### PR TITLE
[Ldap][SecurityBundle] Add an option to check only LDAP users against the LDAP server

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Add `allowed_time_drift` option to the OIDC token handler configuration
  * Allow disabling the redirection on successful logout by passing `null` to the `target` option
  * Deprecate the `remember_me` option of the `form_login`, `json_login`, `login_link`, and `access_token` authenticators, as it has no effect
+ * Add the `ldap_users_only` option to the LDAP authenticators, to bind only `LdapUser` instances against the LDAP server
 
 8.1
 ---

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/FormLoginLdapFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/FormLoginLdapFactory.php
@@ -36,6 +36,7 @@ class FormLoginLdapFactory extends FormLoginFactory
                 ->scalarNode('query_string')->end()
                 ->scalarNode('search_dn')->defaultValue('')->end()
                 ->scalarNode('search_password')->defaultValue('')->end()
+                ->booleanNode('ldap_users_only')->defaultFalse()->info('Only bind users of class "Symfony\\Component\\Ldap\\Security\\LdapUser" against the LDAP server, and leave any other user to the regular password checker.')->end()
             ->end()
         ;
     }

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/HttpBasicLdapFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/HttpBasicLdapFactory.php
@@ -81,6 +81,7 @@ class HttpBasicLdapFactory extends HttpBasicFactory
                 ->scalarNode('query_string')->end()
                 ->scalarNode('search_dn')->defaultValue('')->end()
                 ->scalarNode('search_password')->defaultValue('')->end()
+                ->booleanNode('ldap_users_only')->defaultFalse()->info('Only bind users of class "Symfony\\Component\\Ldap\\Security\\LdapUser" against the LDAP server, and leave any other user to the regular password checker.')->end()
             ->end()
         ;
     }

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/JsonLoginLdapFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/JsonLoginLdapFactory.php
@@ -33,6 +33,7 @@ class JsonLoginLdapFactory extends JsonLoginFactory
                 ->scalarNode('query_string')->end()
                 ->scalarNode('search_dn')->defaultValue('')->end()
                 ->scalarNode('search_password')->defaultValue('')->end()
+                ->booleanNode('ldap_users_only')->defaultFalse()->info('Only bind users of class "Symfony\\Component\\Ldap\\Security\\LdapUser" against the LDAP server, and leave any other user to the regular password checker.')->end()
             ->end()
         ;
     }

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/LdapFactoryTrait.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/LdapFactoryTrait.php
@@ -12,11 +12,16 @@
 namespace Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory;
 
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Ldap\Security\CheckLdapCredentialsListener;
 use Symfony\Component\Ldap\Security\LdapAuthenticator;
+use Symfony\Component\Ldap\Security\LdapUser;
+use Symfony\Component\Ldap\Security\LdapUserProvider;
+use Symfony\Component\Security\Core\User\ChainUserProvider;
 
 /**
  * A trait decorating the authenticator with LDAP functionality.
@@ -51,9 +56,20 @@ trait LdapFactoryTrait
 
         $authenticatorId = $decoratedId;
 
+        if ($config['ldap_users_only']) {
+            if (!property_exists(CheckLdapCredentialsListener::class, 'ldapUsersOnly')) {
+                throw new InvalidConfigurationException('Using "ldap_users_only" requires symfony/ldap 8.2 or higher, the installed version would ignore it.');
+            }
+
+            if (false === self::providesLdapUsers($container, $userProviderId)) {
+                throw new InvalidConfigurationException(\sprintf('Using "ldap_users_only" on the "%s" firewall requires a user provider that returns "%s" instances, but none of the providers it uses does.', $firewallName, LdapUser::class));
+            }
+        }
+
         $container->setDefinition('security.listener.'.$key.'.'.$firewallName, new Definition(CheckLdapCredentialsListener::class))
             ->addTag('kernel.event_subscriber', ['dispatcher' => 'security.event_dispatcher.'.$firewallName])
             ->addArgument(new Reference('security.ldap_locator'))
+            ->addArgument($config['ldap_users_only'])
         ;
 
         $ldapAuthenticatorId = 'security.authenticator.'.$key.'.'.$firewallName;
@@ -75,5 +91,62 @@ trait LdapFactoryTrait
         }
 
         return $ldapAuthenticatorId;
+    }
+
+    /**
+     * Returns null when a provider class cannot be determined, so a setup we cannot read is never rejected.
+     */
+    private static function providesLdapUsers(ContainerBuilder $container, string $userProviderId): ?bool
+    {
+        if (!$container->hasDefinition($userProviderId) || !$class = self::resolveClass($container, $userProviderId)) {
+            return null;
+        }
+
+        if (is_a($class, LdapUserProvider::class, true)) {
+            return true;
+        }
+
+        if (!is_a($class, ChainUserProvider::class, true)) {
+            return false;
+        }
+
+        $legs = $container->findDefinition($userProviderId)->getArguments()[0] ?? null;
+
+        if (!$legs instanceof IteratorArgument) {
+            return null;
+        }
+
+        $unknown = false;
+        foreach ($legs->getValues() as $leg) {
+            if (!$leg instanceof Reference) {
+                return null;
+            }
+
+            if (true === $legProvidesLdapUsers = self::providesLdapUsers($container, (string) $leg)) {
+                return true;
+            }
+
+            $unknown = $unknown || null === $legProvidesLdapUsers;
+        }
+
+        return $unknown ? null : false;
+    }
+
+    /**
+     * User providers are child definitions, whose class only gets resolved by a later pass.
+     */
+    private static function resolveClass(ContainerBuilder $container, string $id): ?string
+    {
+        while (true) {
+            $definition = $container->findDefinition($id);
+
+            if ($class = $definition->getClass()) {
+                return $class;
+            }
+
+            if (!$definition instanceof ChildDefinition || !$container->hasDefinition($id = $definition->getParent())) {
+                return null;
+            }
+        }
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
@@ -32,6 +32,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestMatcher\PathRequestMatcher;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Ldap\Ldap;
+use Symfony\Component\Ldap\Security\CheckLdapCredentialsListener;
 use Symfony\Component\PasswordHasher\PasswordHasherInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
@@ -67,6 +68,101 @@ class SecurityExtensionTest extends TestCase
         $decorated = $container->getDefinition('security.authenticator.form_login_ldap.main')->getArgument(0);
         $this->assertSame('security.authenticator.form_login_ldap.main.inner', (string) $decorated);
         $this->assertSame('/login_check_ldap', $container->getDefinition((string) $decorated)->getArgument(4)['check_path']);
+    }
+
+    public function testLdapUsersOnlyReachesTheCredentialsListener()
+    {
+        if (!property_exists(CheckLdapCredentialsListener::class, 'ldapUsersOnly')) {
+            $this->markTestSkipped('symfony/ldap 8.2 is required.');
+        }
+
+        $container = $this->getRawContainer();
+        $container->register('Symfony\\Component\\Ldap\\Ldap', Ldap::class)->addTag('ldap');
+        $container->loadFromExtension('security', [
+            'providers' => ['default' => ['id' => 'foo']],
+            'firewalls' => [
+                'main' => [
+                    'form_login_ldap' => [
+                        'service' => 'Symfony\\Component\\Ldap\\Ldap',
+                        'ldap_users_only' => true,
+                    ],
+                ],
+            ],
+        ]);
+        $container->compile();
+
+        $listener = $container->getDefinition('security.listener.form_login_ldap.main');
+        $this->assertTrue($listener->getArgument(1));
+    }
+
+    public function testLdapUsersOnlyIsRejectedWithoutAnLdapUserProvider()
+    {
+        if (!property_exists(CheckLdapCredentialsListener::class, 'ldapUsersOnly')) {
+            $this->markTestSkipped('symfony/ldap 8.2 is required.');
+        }
+
+        $container = $this->getRawContainer();
+        $container->register('Symfony\\Component\\Ldap\\Ldap', Ldap::class)->addTag('ldap');
+        $container->loadFromExtension('security', [
+            'providers' => ['default' => ['memory' => ['users' => ['bob' => ['password' => 'x']]]]],
+            'firewalls' => [
+                'main' => [
+                    'form_login_ldap' => [
+                        'service' => 'Symfony\\Component\\Ldap\\Ldap',
+                        'ldap_users_only' => true,
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('Using "ldap_users_only" on the "main" firewall requires a user provider that returns "Symfony\Component\Ldap\Security\LdapUser" instances, but none of the providers it uses does.');
+
+        $container->compile();
+    }
+
+    public function testLdapUsersOnlyIsAcceptedWithAnLdapLegInAChainProvider()
+    {
+        if (!property_exists(CheckLdapCredentialsListener::class, 'ldapUsersOnly')) {
+            $this->markTestSkipped('symfony/ldap 8.2 is required.');
+        }
+
+        $container = $this->getRawContainer();
+        $container->register('Symfony\\Component\\Ldap\\Ldap', Ldap::class)->addTag('ldap');
+        $container->loadFromExtension('security', [
+            'providers' => [
+                'local' => ['memory' => ['users' => ['bob' => ['password' => 'x']]]],
+                'directory' => ['ldap' => ['service' => 'Symfony\\Component\\Ldap\\Ldap', 'base_dn' => 'dc=example,dc=com']],
+                'chain' => ['chain' => ['providers' => ['local', 'directory']]],
+            ],
+            'firewalls' => [
+                'main' => [
+                    'provider' => 'chain',
+                    'form_login_ldap' => [
+                        'service' => 'Symfony\\Component\\Ldap\\Ldap',
+                        'ldap_users_only' => true,
+                    ],
+                ],
+            ],
+        ]);
+        $container->compile();
+
+        $this->assertTrue($container->getDefinition('security.listener.form_login_ldap.main')->getArgument(1));
+    }
+
+    public function testLdapUsersOnlyDefaultsToCheckingEveryUser()
+    {
+        $container = $this->getRawContainer();
+        $container->register('Symfony\\Component\\Ldap\\Ldap', Ldap::class)->addTag('ldap');
+        $container->loadFromExtension('security', [
+            'providers' => ['default' => ['id' => 'foo']],
+            'firewalls' => [
+                'main' => ['form_login_ldap' => ['service' => 'Symfony\\Component\\Ldap\\Ldap']],
+            ],
+        ]);
+        $container->compile();
+
+        $this->assertFalse($container->getDefinition('security.listener.form_login_ldap.main')->getArgument(1));
     }
 
     public function testInvalidCheckPath()

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/JsonLoginLdapTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/JsonLoginLdapTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
 
+use Psr\Container\ContainerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Ldap\Adapter\AdapterInterface;
@@ -19,6 +20,8 @@ use Symfony\Component\Ldap\Adapter\ConnectionInterface;
 use Symfony\Component\Ldap\Adapter\ExtLdap\Adapter;
 use Symfony\Component\Ldap\Adapter\QueryInterface;
 use Symfony\Component\Ldap\Entry;
+use Symfony\Component\Ldap\Exception\InvalidCredentialsException;
+use Symfony\Component\Ldap\Security\CheckLdapCredentialsListener;
 
 class JsonLoginLdapTest extends AbstractWebTestCase
 {
@@ -66,5 +69,117 @@ class JsonLoginLdapTest extends AbstractWebTestCase
         $this->assertInstanceOf(JsonResponse::class, $response);
         $this->assertSame(200, $response->getStatusCode());
         $this->assertSame(['message' => 'Welcome @spomky!', 'roles' => ['ROLE_SUPER_ADMIN', 'ROLE_USER']], json_decode($response->getContent(), true));
+    }
+
+    public function testLdapUsersOnlyLeavesOtherProvidersToTheRegularPasswordChecker()
+    {
+        if (!property_exists(CheckLdapCredentialsListener::class, 'ldapUsersOnly')) {
+            $this->markTestSkipped('symfony/ldap 8.2 is required.');
+        }
+
+        $client = $this->createClient(['test_case' => 'JsonLoginLdap', 'root_config' => 'ldap_users_only.yml', 'debug' => true]);
+        $checked = $this->mockLdapAdapter($client->getContainer());
+
+        $client->request('POST', '/login', [], [], ['CONTENT_TYPE' => 'application/json'], '{"user": {"login": "bob", "password": "db-pass"}}');
+
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+        $this->assertSame([], $checked->getArrayCopy());
+    }
+
+    public function testLdapUsersOnlyStillRejectsAWrongPasswordFromAnotherProvider()
+    {
+        if (!property_exists(CheckLdapCredentialsListener::class, 'ldapUsersOnly')) {
+            $this->markTestSkipped('symfony/ldap 8.2 is required.');
+        }
+
+        $client = $this->createClient(['test_case' => 'JsonLoginLdap', 'root_config' => 'ldap_users_only.yml', 'debug' => true]);
+        $checked = $this->mockLdapAdapter($client->getContainer());
+
+        $client->request('POST', '/login', [], [], ['CONTENT_TYPE' => 'application/json'], '{"user": {"login": "bob", "password": "nope"}}');
+
+        $this->assertSame(401, $client->getResponse()->getStatusCode());
+        $this->assertSame([], $checked->getArrayCopy());
+    }
+
+    public function testLdapUsersOnlyStillBindsLdapUsers()
+    {
+        if (!property_exists(CheckLdapCredentialsListener::class, 'ldapUsersOnly')) {
+            $this->markTestSkipped('symfony/ldap 8.2 is required.');
+        }
+
+        $client = $this->createClient(['test_case' => 'JsonLoginLdap', 'root_config' => 'ldap_users_only.yml', 'debug' => true]);
+        $checked = $this->mockLdapAdapter($client->getContainer());
+
+        $client->request('POST', '/login', [], [], ['CONTENT_TYPE' => 'application/json'], '{"user": {"login": "spomky", "password": "ldap-pass"}}');
+
+        $this->assertSame(200, $client->getResponse()->getStatusCode());
+        $this->assertSame(['spomky'], $checked->getArrayCopy());
+    }
+
+    /**
+     * Installs a directory holding a single "spomky" entry whose password is "ldap-pass".
+     *
+     * @return \ArrayObject<int, string> the identifiers whose password was checked against it
+     */
+    private function mockLdapAdapter(ContainerInterface $container): \ArrayObject
+    {
+        $checked = new \ArrayObject();
+
+        $connection = new class($checked) implements ConnectionInterface {
+            public function __construct(private \ArrayObject $checked)
+            {
+            }
+
+            public function isBound(): bool
+            {
+                return true;
+            }
+
+            public function bind(?string $dn = null, #[\SensitiveParameter] ?string $password = null): void
+            {
+                if (!preg_match('/^uid=([^,]++),/', (string) $dn, $m)) {
+                    // the search bind, not a credentials check
+                    return;
+                }
+
+                $this->checked[] = $m[1];
+
+                if ('spomky' !== $m[1] || 'ldap-pass' !== $password) {
+                    throw new InvalidCredentialsException();
+                }
+            }
+
+            public function saslBind(?string $dn = null, #[\SensitiveParameter] ?string $password = null, ?string $mech = null, ?string $realm = null, ?string $authcId = null, ?string $authzId = null, ?string $props = null): void
+            {
+            }
+
+            public function whoami(): string
+            {
+                return '';
+            }
+        };
+
+        $adapter = $this->createStub(AdapterInterface::class);
+        $adapter->method('getConnection')->willReturn($connection);
+        $adapter->method('escape')->willReturnArgument(0);
+        $adapter->method('createQuery')->willReturnCallback(function (string $dn, string $query): QueryInterface {
+            $entries = str_contains($query, 'spomky') ? [new Entry('uid=spomky,dc=onfroy,dc=net', ['uid' => ['spomky']])] : [];
+
+            $collection = new class($entries) extends \ArrayObject implements CollectionInterface {
+                public function toArray(): array
+                {
+                    return $this->getArrayCopy();
+                }
+            };
+
+            $queryStub = $this->createStub(QueryInterface::class);
+            $queryStub->method('execute')->willReturn($collection);
+
+            return $queryStub;
+        });
+
+        $container->set(Adapter::class, $adapter);
+
+        return $checked;
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/JsonLoginLdap/ldap_users_only.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/JsonLoginLdap/ldap_users_only.yml
@@ -1,0 +1,22 @@
+imports:
+    - { resource: ./config.yml }
+
+security:
+    providers:
+        local:
+            memory:
+                users:
+                    bob: { password: 'db-pass', roles: [ROLE_USER] }
+        chain:
+            chain:
+                providers: [ldap, local]
+
+    firewalls:
+        main:
+            provider: chain
+            json_login_ldap:
+                dn_string: 'uid={user_identifier},dc=onfroy,dc=net'
+                ldap_users_only: true
+
+    password_hashers:
+        Symfony\Component\Security\Core\User\InMemoryUser: plaintext

--- a/src/Symfony/Component/Ldap/CHANGELOG.md
+++ b/src/Symfony/Component/Ldap/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `$ldapUsersOnly` argument to `CheckLdapCredentialsListener`, to bind only `LdapUser` instances against the LDAP server
+
 8.0
 ---
 

--- a/src/Symfony/Component/Ldap/Security/CheckLdapCredentialsListener.php
+++ b/src/Symfony/Component/Ldap/Security/CheckLdapCredentialsListener.php
@@ -31,6 +31,7 @@ class CheckLdapCredentialsListener implements EventSubscriberInterface
 {
     public function __construct(
         private ContainerInterface $ldapLocator,
+        private bool $ldapUsersOnly = false,
     ) {
     }
 
@@ -55,6 +56,14 @@ class CheckLdapCredentialsListener implements EventSubscriberInterface
         $passwordCredentials = $passport->getBadge(PasswordCredentials::class);
         if ($passwordCredentials->isResolved()) {
             throw new \LogicException('LDAP authentication password verification cannot be completed because something else has already resolved the PasswordCredentials.');
+        }
+
+        if ($this->ldapUsersOnly && !$passport->getUser() instanceof LdapUser) {
+            // the user comes from another provider of the chain, leave the password credentials
+            // for CheckCredentialsListener while still reporting that this listener has run
+            $ldapBadge->markResolved();
+
+            return;
         }
 
         if (!$this->ldapLocator->has($ldapBadge->getLdapServiceId())) {

--- a/src/Symfony/Component/Ldap/Tests/Security/CheckLdapCredentialsListenerTest.php
+++ b/src/Symfony/Component/Ldap/Tests/Security/CheckLdapCredentialsListenerTest.php
@@ -23,6 +23,7 @@ use Symfony\Component\Ldap\Exception\InvalidCredentialsException;
 use Symfony\Component\Ldap\LdapInterface;
 use Symfony\Component\Ldap\Security\CheckLdapCredentialsListener;
 use Symfony\Component\Ldap\Security\LdapBadge;
+use Symfony\Component\Ldap\Security\LdapUser;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
@@ -180,6 +181,61 @@ class CheckLdapCredentialsListenerTest extends TestCase
         $listener->onCheckPassport($this->createEvent('s3cr3t', new LdapBadge('app.ldap', '{user_identifier}', 'elsa', 'test1234A$', '{user_identifier}_test')));
     }
 
+    public function testLdapUsersOnlySkipsTheBindForAUserFromAnotherProvider()
+    {
+        $ldap = $this->createMock(LdapInterface::class);
+        $ldap->expects($this->never())->method('bind');
+
+        $event = $this->createEvent();
+        $this->createListener($ldap, true)->onCheckPassport($event);
+
+        $passport = $event->getPassport();
+        // resolved, so a missing listener still fails closed, but the password is left to
+        // CheckCredentialsListener rather than silently accepted here
+        $this->assertTrue($passport->getBadge(LdapBadge::class)->isResolved());
+        $this->assertFalse($passport->getBadge(PasswordCredentials::class)->isResolved());
+    }
+
+    public function testLdapUsersOnlyStillBindsForAnLdapUser()
+    {
+        $ldap = $this->createMock(LdapInterface::class);
+        $ldap->method('escape')->willReturnArgument(0);
+        $ldap->expects($this->once())->method('bind')->with('Wouter', 's3cr3t');
+
+        $event = new CheckPassportEvent(
+            new TestAuthenticator(),
+            new Passport(
+                new UserBadge('Wouter', static fn () => new LdapUser(new Entry('Wouter'), 'Wouter', null, ['ROLE_USER'])),
+                new PasswordCredentials('s3cr3t'),
+                [new LdapBadge('app.ldap')]
+            )
+        );
+
+        $this->createListener($ldap, true)->onCheckPassport($event);
+
+        $this->assertTrue($event->getPassport()->getBadge(PasswordCredentials::class)->isResolved());
+    }
+
+    public function testLdapUsersOnlyStillRejectsAnEmptyPasswordForAnLdapUser()
+    {
+        $ldap = $this->createMock(LdapInterface::class);
+        $ldap->expects($this->never())->method('bind');
+
+        $event = new CheckPassportEvent(
+            new TestAuthenticator(),
+            new Passport(
+                new UserBadge('Wouter', static fn () => new LdapUser(new Entry('Wouter'), 'Wouter', null, ['ROLE_USER'])),
+                new PasswordCredentials(''),
+                [new LdapBadge('app.ldap')]
+            )
+        );
+
+        $this->expectException(BadCredentialsException::class);
+        $this->expectExceptionMessage('The presented password cannot be empty.');
+
+        $this->createListener($ldap, true)->onCheckPassport($event);
+    }
+
     private function createEvent($password = 's3cr3t', $ldapBadge = null)
     {
         return new CheckPassportEvent(
@@ -188,13 +244,13 @@ class CheckLdapCredentialsListenerTest extends TestCase
         );
     }
 
-    private function createListener(?LdapInterface $ldap = null)
+    private function createListener(?LdapInterface $ldap = null, bool $ldapUsersOnly = false)
     {
         $ldapLocator = new class(['app.ldap' => fn () => $ldap ?? $this->createStub(LdapInterface::class)]) implements ContainerInterface {
             use ServiceLocatorTrait;
         };
 
-        return new CheckLdapCredentialsListener($ldapLocator);
+        return new CheckLdapCredentialsListener($ldapLocator, $ldapUsersOnly);
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | #41892
| License       | MIT

Adds `ldap_users_only` to `form_login_ldap`, `json_login_ldap` and `http_basic_ldap`, defaulting to `false`.

When it is on, `CheckLdapCredentialsListener` binds against the directory only for users loaded as `Symfony\Component\Ldap\Security\LdapUser`, and hands any other user to `CheckCredentialsListener`. That makes a chain provider work: LDAP users are checked against the directory, local users against their stored hash. Today the listener binds every user of the firewall, so a local user's password is sent to the LDAP server and login fails.

The skipped path still marks the `LdapBadge` resolved, so it cannot open a hole: `PasswordCredentials` is left unresolved, and `AuthenticatorManager` refuses any passport with an unresolved badge. Removing `CheckCredentialsListener` from the chain gives `Security badge "PasswordCredentials" is not resolved` rather than a granted login.

Credit to @l-vo, whose #51231 raised the problem.

Added during review:

* **the option is described by what it checks.** The `info()` text, the CHANGELOG and this description said "users loaded by an LDAP user provider", but the code tests `instanceof LdapUser`, and `LdapUser` is `@final`. For a provider that authenticates against LDAP yet returns application entities, the two readings differ, and turning the flag on silently converts an LDAP-authenticated firewall into one that trusts a stale local hash:

  ```
  spomky 'stale-local-pass'  status=200 no bind
  spomky 'ldap-pass'         status=401 no bind
  ```

* **that misconfiguration is now refused at container build**, instead of shipping. `LdapFactoryTrait` inspects the firewall's user provider, following the legs of a `ChainUserProvider`, and throws when none of them is an `LdapUserProvider`:

  ```
  Using "ldap_users_only" on the "main" firewall requires a user provider that returns
  "Symfony\Component\Ldap\Security\LdapUser" instances, but none of the providers it uses does.
  ```

  It stays quiet whenever a provider's class cannot be determined, so an `id:` provider or a custom class is never rejected on a guess. **Worth a second opinion:** a custom provider class that does return `LdapUser` instances, for instance a decorator around `LdapUserProvider`, is not recognised and would be refused. Recognising `LdapUserProvider` subclasses covers the common shape, but not a decorator;

* **a functional test that exercises a real login**, `JsonLoginLdapTest::testLdapUsersOnly*`, on a chain of an LDAP provider and an in-memory one. It asserts the response status and which identifiers were checked against the directory, so it can tell "the flag worked" from "nothing ran". Reverting `CheckLdapCredentialsListener` makes the local user's login fail with 401. The bundle tests that only assert a constructor argument are kept, but they are no longer the only coverage;

* a `CHANGELOG` entry for the Ldap component, which gained a constructor argument on the public `CheckLdapCredentialsListener`;

* **the option is refused when the installed `symfony/ldap` cannot honour it.** SecurityBundle allows `symfony/ldap: ^7.4|^8.0`, and on 7.4 the listener takes one constructor argument, so the extra one was dropped and `ldap_users_only: true` did nothing at all, with no error. A `conflict` entry would have been the usual fix, but 8.2 is unreleased, so it would leave the low-deps job unable to resolve. The factory now checks the installed listener instead, which only affects applications that opt in:

  ```
  Using "ldap_users_only" requires symfony/ldap 8.2 or higher, the installed version would ignore it.
  ```

Two things to know.

**This does not fix #41892.** That issue is `json_login_ldap` chained with `json_login` on the same firewall, and its cause is `LdapFactoryTrait` registering the inner authenticator under the id the standalone authenticator also uses, which #64975 addresses on 6.4. On this branch that setup still fails, the LDAP authenticator never running:

```
config_both_authenticators.yml (ldap_users_only: true)
  spomky 'ldap-pass'  status=401, directory never contacted
```

The supported shape is one `*_ldap` authenticator with a chain provider, which is what this option makes work.

**`ldap_users_only: ~` resolves to `true`.** That is how every boolean node in Symfony behaves, but it is worth stating for a switch that changes which server verifies a password.
