### PR TITLE
[Translation] Fix fuzzy translations and message context in PO files

### DIFF
--- a/src/Symfony/Component/Translation/Dumper/PoFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/PoFileDumper.php
@@ -50,6 +50,9 @@ class PoFileDumper extends FileDumper
             if (isset($metadata['sources'])) {
                 $output .= $this->formatComments(implode(' ', (array) $metadata['sources']), ':');
             }
+            if (isset($metadata['context'])) {
+                $output .= \sprintf('msgctxt "%s"'."\n", $this->escape($metadata['context']));
+            }
 
             // in an ICU domain the pipe is an ordinary character, pluralization is expressed by the message itself
             $sourceRules = $isIntlDomain ? [] : $this->getStandardRules($source);

--- a/src/Symfony/Component/Translation/Loader/PoFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/PoFileLoader.php
@@ -11,12 +11,31 @@
 
 namespace Symfony\Component\Translation\Loader;
 
+use Symfony\Component\Translation\Exception\InvalidResourceException;
+use Symfony\Component\Translation\MessageCatalogue;
+
 /**
  * @copyright Copyright (c) 2010, Union of RAD https://github.com/UnionOfRAD/lithium
  * @copyright Copyright (c) 2012, Clemens Tolboom
  */
 class PoFileLoader extends FileLoader
 {
+    private array $metadata = [];
+    private array $contexts = [];
+
+    public function load(mixed $resource, string $locale, string $domain = 'messages'): MessageCatalogue
+    {
+        $this->metadata = [];
+        $this->contexts = [];
+        $catalogue = parent::load($resource, $locale, $domain);
+
+        foreach ($this->metadata as $id => $metadata) {
+            $catalogue->setMetadata($id, $metadata, $domain);
+        }
+
+        return $catalogue;
+    }
+
     /**
      * Parses portable object (PO) format.
      *
@@ -55,7 +74,8 @@ class PoFileLoader extends FileLoader
      * - No support for comments spanning multiple lines.
      * - Translator and extracted comments are treated as being the same type.
      * - Message IDs are allowed to have other encodings as just US-ASCII.
-     * - Contexts (msgctxt) are parsed but discarded.
+     * - Contexts (msgctxt) are stored in the message metadata but ignored in the
+     *   message key, so reusing a msgid with a different context is not supported.
      *
      * Items with an empty id are ignored.
      */
@@ -86,6 +106,7 @@ class PoFileLoader extends FileLoader
                 }
                 $flags = array_map('trim', explode(',', substr($line, 2)));
             } elseif (str_starts_with($line, 'msgctxt "')) {
+                // msgctxt always precedes its msgid, so the context belongs to the next entry
                 if (null !== $item['translated']) {
                     $this->saveItem($messages, $item, $flags, $defaults);
                 }
@@ -155,7 +176,19 @@ class PoFileLoader extends FileLoader
             $translated += $empties;
             ksort($translated);
 
+            $context = null !== $item['context'] ? stripcslashes($item['context']) : null;
+            if (\array_key_exists($id, $this->contexts) && $context !== $this->contexts[$id]) {
+                throw new InvalidResourceException(null === $context || null === $this->contexts[$id]
+                    ? \sprintf('The "%s" message is defined both with and without a context, which is not supported because contexts are ignored in message keys.', $id)
+                    : \sprintf('The "%s" message is defined twice with different contexts ("%s" and "%s"), which is not supported because contexts are ignored in message keys.', $id, $this->contexts[$id], $context));
+            }
+            $this->contexts[$id] = $context;
+
             $messages[$id] = stripcslashes(implode('|', $translated));
+
+            if (null !== $context) {
+                $this->metadata[$id] = ['context' => $context];
+            }
         }
     }
 }

--- a/src/Symfony/Component/Translation/Tests/Dumper/PoFileDumperTest.php
+++ b/src/Symfony/Component/Translation/Tests/Dumper/PoFileDumperTest.php
@@ -60,6 +60,31 @@ class PoFileDumperTest extends TestCase
         $this->assertStringNotContainsString('msgid_plural', $dump);
     }
 
+    public function testDumpContext()
+    {
+        $catalogue = new MessageCatalogue('en');
+        $catalogue->add(['foo' => 'bar']);
+        $catalogue->setMetadata('foo', ['context' => 'menu']);
+
+        $dumper = new PoFileDumper();
+
+        $expected = <<<'EOF'
+            msgid ""
+            msgstr ""
+            "Content-Type: text/plain; charset=UTF-8\n"
+            "Content-Transfer-Encoding: 8bit\n"
+            "Language: en\n"
+            "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+            msgctxt "menu"
+            msgid "foo"
+            msgstr "bar"
+
+            EOF;
+
+        $this->assertSame($expected, $dumper->formatCatalogue($catalogue, 'messages'));
+    }
+
     public function testDumpPlurals()
     {
         $catalogue = new MessageCatalogue('en');

--- a/src/Symfony/Component/Translation/Tests/Fixtures/contexts-ambiguous.po
+++ b/src/Symfony/Component/Translation/Tests/Fixtures/contexts-ambiguous.po
@@ -1,0 +1,7 @@
+msgctxt "menu"
+msgid "foo"
+msgstr "bar1"
+
+msgctxt "sidebar"
+msgid "foo"
+msgstr "bar2"

--- a/src/Symfony/Component/Translation/Tests/Fixtures/contexts-with-and-without.po
+++ b/src/Symfony/Component/Translation/Tests/Fixtures/contexts-with-and-without.po
@@ -1,0 +1,6 @@
+msgid "foo"
+msgstr "bar1"
+
+msgctxt "menu"
+msgid "foo"
+msgstr "bar2"

--- a/src/Symfony/Component/Translation/Tests/Loader/PoFileLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/PoFileLoaderTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Translation\Tests\Loader;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Resource\FileResource;
+use Symfony\Component\Translation\Exception\InvalidResourceException;
 use Symfony\Component\Translation\Exception\NotFoundResourceException;
 use Symfony\Component\Translation\Loader\PoFileLoader;
 
@@ -118,7 +119,7 @@ class PoFileLoaderTest extends TestCase
         ], $catalogue->all('domain1'));
     }
 
-    public function testContextsAreDiscarded()
+    public function testLoadContextsIntoMetadata()
     {
         $loader = new PoFileLoader();
         $resource = __DIR__.'/../Fixtures/contexts.po';
@@ -129,6 +130,32 @@ class PoFileLoaderTest extends TestCase
             'foo2' => 'bar2',
             'foo3' => 'bar3',
         ], $catalogue->all('domain1'));
+
+        $this->assertEquals(['context' => 'menu'], $catalogue->getMetadata('foo1', 'domain1'));
+        $this->assertNull($catalogue->getMetadata('foo2', 'domain1'));
+        $this->assertEquals(['context' => 'multi-line context'], $catalogue->getMetadata('foo3', 'domain1'));
+    }
+
+    public function testLoadThrowsWhenTheSameMessageHasDifferentContexts()
+    {
+        $loader = new PoFileLoader();
+        $resource = __DIR__.'/../Fixtures/contexts-ambiguous.po';
+
+        $this->expectException(InvalidResourceException::class);
+        $this->expectExceptionMessage('The "foo" message is defined twice with different contexts ("menu" and "sidebar"), which is not supported because contexts are ignored in message keys.');
+
+        $loader->load($resource, 'en', 'domain1');
+    }
+
+    public function testLoadThrowsWhenTheSameMessageIsDefinedWithAndWithoutContext()
+    {
+        $loader = new PoFileLoader();
+        $resource = __DIR__.'/../Fixtures/contexts-with-and-without.po';
+
+        $this->expectException(InvalidResourceException::class);
+        $this->expectExceptionMessage('The "foo" message is defined both with and without a context, which is not supported because contexts are ignored in message keys.');
+
+        $loader->load($resource, 'en', 'domain1');
     }
 
     public function testMissingPlurals()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

This fixes one of the oldest pending TODO in Symfony (from 2012!). Some context: "fuzzy translations" means that the translation might be wrong, stale, etc. The standard gettext behavior (and Symfony tries to follow it too) is to discard them as load time.

The first fix of this PR is that the Symfony parser only honored the fuzzy flag when entries were separated by blank lines. Without blank lines, hitting a new `msgid` saved the previous entry unconditionally and never reset the flags. So, a fuzzy entry was wrongly loaded and the following valid entry was wrongly dropped (which is exactly the opposite of the expected behavior).

The second fix is related to the pending TODO: a multi-line msgctxt corrupted the previous translation by appending its continuation line to it. This is no longer the case.