### PR TITLE
[Messenger] Reject a serialized type name that is another message's class name

### DIFF
--- a/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
+++ b/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
@@ -413,12 +413,24 @@ class MessengerPass implements CompilerPassInterface
             return;
         }
 
+        $taggedIds = $container->findTaggedResourceIds('messenger.message', false);
+
+        // a message with no serialized type name is sent under its own class name, so that name is
+        // taken even though it never enters the map
+        $messageClasses = [];
+        foreach ($taggedIds as $id => $tags) {
+            $messageClasses[$container->getDefinition($id)->getClass()] = true;
+        }
+
         $typeToClassMap = [];
-        foreach ($container->findTaggedResourceIds('messenger.message', false) as $id => $tags) {
+        foreach ($taggedIds as $id => $tags) {
             $class = $container->getDefinition($id)->getClass();
             foreach ($tags as $tag) {
                 if (!isset($tag['serializedTypeName'])) {
                     continue;
+                }
+                if ($tag['serializedTypeName'] !== $class && isset($messageClasses[$tag['serializedTypeName']])) {
+                    throw new RuntimeException(\sprintf('The serialized type name "%s" set on class "%s" is the name of another message class, which uses it as its own serialized type.', $tag['serializedTypeName'], $class));
                 }
                 if (isset($typeToClassMap[$tag['serializedTypeName']])) {
                     throw new RuntimeException(\sprintf('The serialized type name "%s" is already mapped to class "%s", cannot map it to "%s" as well. Each serialized type must be unique.', $tag['serializedTypeName'], $typeToClassMap[$tag['serializedTypeName']], $class));

--- a/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerPassTest.php
+++ b/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerPassTest.php
@@ -1123,6 +1123,51 @@ class MessengerPassTest extends TestCase
         (new MessengerPass())->process($container);
     }
 
+    public function testItThrowsExceptionOnSerializedTypeNameShadowingAnotherMessageClass()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The serialized type name "App\Message\MessageA" set on class "App\Message\MessageB" is the name of another message class, which uses it as its own serialized type.');
+
+        $container = $this->getContainerBuilder('message_bus');
+
+        $container->register('messenger.transport.symfony_serializer', Serializer::class)
+            ->setArguments([null, 'json', [], []]);
+
+        $container
+            ->register('App\Message\MessageA', 'App\Message\MessageA')
+            ->addTag('container.excluded')
+            ->addTag('messenger.message', [])
+        ;
+        $container
+            ->register('App\Message\MessageB', 'App\Message\MessageB')
+            ->addTag('container.excluded')
+            ->addTag('messenger.message', ['serializedTypeName' => 'App\Message\MessageA'])
+        ;
+
+        (new MessengerPass())->process($container);
+    }
+
+    public function testItAllowsAMessageToUseItsOwnClassNameAsSerializedTypeName()
+    {
+        $container = $this->getContainerBuilder('message_bus');
+
+        $container->register('messenger.transport.symfony_serializer', Serializer::class)
+            ->setArguments([null, 'json', [], []]);
+
+        $container
+            ->register('App\Message\MyMessage', 'App\Message\MyMessage')
+            ->addTag('container.excluded')
+            ->addTag('messenger.message', ['serializedTypeName' => 'App\Message\MyMessage'])
+        ;
+
+        (new MessengerPass())->process($container);
+
+        $this->assertSame(
+            ['App\Message\MyMessage' => 'App\Message\MyMessage'],
+            $container->getDefinition('messenger.transport.symfony_serializer')->getArgument(3)
+        );
+    }
+
     public function testItDoesNotFailWhenSerializerServiceIsNotRegistered()
     {
         $container = $this->getContainerBuilder('message_bus');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        |
| License       | MIT

A message with no `serializedTypeName` is sent under its own class name, but that name never enters `$typeToClassMap`. The uniqueness check only looks at the map, so another message could claim that class name as its serialized type and silently steal the wire type:

```php
#[AsMessage]
class LegacyOrderCreated {}

#[AsMessage(serializedTypeName: LegacyOrderCreated::class)]
class Shipped {}
```

Compiles today, producing `['LegacyOrderCreated' => 'Shipped']`. Then, in a single deployment:

```
LegacyOrderCreated encodes as LegacyOrderCreated
decodes back as Shipped
```

With `SigningSerializer` it is worse, since the type is resolved through the same map: a forged unsigned message sent under the shadowed name is accepted, where the same application without the shadowing answers `Message "LegacyOrderCreated" requires a signature but none was found.`

The pass now collects the class of every tagged message first, and rejects a serialized type name that is one of those classes:

```
The serialized type name "LegacyOrderCreated" set on class "Shipped" is the name of another message class, which uses it as its own serialized type.
```

A class using its own class name as its serialized type stays valid, which is how an application pins the name it was already sending before `serializedTypeName` existed. `MessengerPassTest::testItAllowsAMessageToUseItsOwnClassNameAsSerializedTypeName` covers that, and passes both before and after.

This turns a silent wrong-class decode into a container build error, so an application that is currently mis-decoding will fail to boot after the upgrade. That seems right for a mapping that cannot have been doing what its author intended, but it is a behaviour change on a stable branch and worth a second opinion.

Unrelated to the fix, found while checking it, and **not** addressed here because there is no fix that fits a bugfix PR:

`Serializer::getTypeFromEnvelope()` resolves the type by walking `[$class] + class_parents($class) + class_implements($class)`, so a class inherits a `serializedTypeName` from a parent or an interface. `AttributeAutoconfigurationPass` reads attributes on the class alone, so those classes are never tagged and never reach the map. Encode and decode therefore disagree:

```
#[AsMessage(serializedTypeName: 'iface.type')] interface ProbeIface {}
class ProbeImpl implements ProbeIface {}

ProbeImpl encodes as iface.type   ->  decode: MessageDecodingFailedException

#[AsMessage(serializedTypeName: 'parent.type')] class ProbeParent {}
class ProbeChild extends ProbeParent {}

ProbeChild encodes as parent.type ->  decode: ProbeParent    (wrong class, no error)
```

`SerializerTest::testEncodeUsesSerializedTypeNameFromInterfaceAttribute` asserts the encode half only, which is why this has gone unnoticed. It cannot be fixed by adding map entries: several classes inheriting one attribute all encode under one name, and one name can only map back to one class. The options are to stop walking the hierarchy on encode, which changes the wire format, or to make the autoconfiguration walk it, which is a DependencyInjection change. Both need a decision rather than a patch.
