### PR TITLE
[DependencyInjection] Add a $priority argument to the #[Required] attribute

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Allow computing tag attributes per tagged service when using `#[AutoconfigureTag]`, `#[Autoconfigure]` or `_instanceof`: pass a `\Closure` receiving the concrete class-string (requires PHP 8.5), or a `[class-string, method]` callable resolved against each concrete class (works on PHP 8.4)
+ * Call `#[Required]` methods in the order defined by the attribute's `$priority` argument
 
 8.1
 ---

--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowireRequiredMethodsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowireRequiredMethodsPass.php
@@ -36,6 +36,7 @@ class AutowireRequiredMethodsPass extends AbstractRecursivePass
 
         $alreadyCalledMethods = [];
         $withers = [];
+        $setters = [];
 
         foreach ($value->getMethodCalls() as [$method]) {
             $alreadyCalledMethods[strtolower($method)] = true;
@@ -49,11 +50,13 @@ class AutowireRequiredMethodsPass extends AbstractRecursivePass
             }
 
             while (true) {
-                if ($r->getAttributes(Required::class)) {
+                if ($attributes = $r->getAttributes(Required::class)) {
+                    $priority = $attributes[0]->newInstance()->priority ?? 0;
+
                     if ($this->isWither($r, $r->getDocComment() ?: '')) {
-                        $withers[] = [$r->name, [], true];
+                        $withers[] = [$r->name, [], $priority, true];
                     } else {
-                        $value->addMethodCall($r->name, []);
+                        $setters[] = [$r->name, [], $priority];
                     }
                     break;
                 }
@@ -64,11 +67,20 @@ class AutowireRequiredMethodsPass extends AbstractRecursivePass
             }
         }
 
+        usort($setters, static fn ($a, $b) => $b[2] <=> $a[2]);
+        foreach ($setters as $call) {
+            $value->addMethodCall($call[0], $call[1]);
+        }
+
         if ($withers) {
+            usort($withers, static fn ($a, $b) => $b[2] <=> $a[2]);
             // Prepend withers to prevent creating circular loops
-            $setters = $value->getMethodCalls();
-            $value->setMethodCalls($withers);
-            foreach ($setters as $call) {
+            $calls = $value->getMethodCalls();
+            $value->setMethodCalls([]);
+            foreach ($withers as $call) {
+                $value->addMethodCall($call[0], $call[1], $call[3]);
+            }
+            foreach ($calls as $call) {
                 $value->addMethodCall($call[0], $call[1], $call[2] ?? false);
             }
         }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowireRequiredMethodsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowireRequiredMethodsPassTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\DependencyInjection\Compiler\AutowireRequiredMethodsPass;
 use Symfony\Component\DependencyInjection\Compiler\ResolveClassPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\WitherStaticReturnType;
+use Symfony\Contracts\Service\Attribute\Required;
 
 require_once __DIR__.'/../Fixtures/includes/autowiring_classes.php';
 
@@ -60,6 +61,32 @@ class AutowireRequiredMethodsPassTest extends TestCase
             array_column($methodCalls, 0)
         );
         $this->assertEquals([], $methodCalls[0][1]);
+    }
+
+    public function testSetterInjectionWithPriority()
+    {
+        if (!property_exists(Required::class, 'priority')) {
+            $this->markTestSkipped('symfony/service-contracts 3.7+ is required.');
+        }
+
+        $container = new ContainerBuilder();
+        $container->register(Foo::class);
+
+        $container
+            ->register('prioritized_setters', AutowirePrioritizedSetters::class)
+            ->setAutowired(true);
+
+        (new ResolveClassPass())->process($container);
+        (new AutowireRequiredMethodsPass())->process($container);
+
+        $this->assertSame([
+            ['withBar', [], true],
+            ['withFoo', [], true],
+            ['setHigh', []],
+            ['setFoo', []],
+            ['setBar', []],
+            ['setLow', []],
+        ], $container->getDefinition('prioritized_setters')->getMethodCalls());
     }
 
     public function testWitherWithStaticReturnTypeInjection()

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes_80.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes_80.php
@@ -31,6 +31,41 @@ class AutowireWither
     }
 }
 
+class AutowirePrioritizedSetters
+{
+    #[Required(priority: -10)]
+    public function setLow(Foo $foo): void
+    {
+    }
+
+    #[Required]
+    public function setFoo(Foo $foo): void
+    {
+    }
+
+    #[Required]
+    public function setBar(Foo $foo): void
+    {
+    }
+
+    #[Required(priority: 10)]
+    public function setHigh(Foo $foo): void
+    {
+    }
+
+    #[Required]
+    public function withFoo(Foo $foo): static
+    {
+        return $this;
+    }
+
+    #[Required(priority: 10)]
+    public function withBar(Foo $foo): static
+    {
+        return $this;
+    }
+}
+
 class AutowireProperty
 {
     #[Required]

--- a/src/Symfony/Contracts/CHANGELOG.md
+++ b/src/Symfony/Contracts/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 3.7
 ---
 
+ * Add a `$priority` argument to the `Required` attribute to control the order in which required methods are called
  * Add support for the `max_connect_duration` option in `HttpClientInterface`
  * Add support for hooked properties in `ServiceMethodsSubscriberTrait`
  * Add `ContainerProviderInterface`

--- a/src/Symfony/Contracts/Service/Attribute/Required.php
+++ b/src/Symfony/Contracts/Service/Attribute/Required.php
@@ -22,4 +22,11 @@ namespace Symfony\Contracts\Service\Attribute;
 #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY)]
 final class Required
 {
+    /**
+     * @param int $priority The priority of the method call when the class declares several required methods; the higher the sooner it's called
+     */
+    public function __construct(
+        public int $priority = 0,
+    ) {
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #64949
| License       | MIT

The `#[Required]` attribute gains an `int $priority` argument, as suggested by @nicolas-grekas in #64949. When a class declares several required methods, the ones with the higher priority are now called first.

Behavior is unchanged by default: ties keep the current reflection order (the sort is stable), so existing code that does not set a priority is not affected. Withers are still prepended as a group to prevent circular loops, and are sorted by priority within that group.

The pass reads the property with `?? 0`, so the `symfony/service-contracts` requirement stays at `^3.6`: with older contracts every method simply gets priority 0. The new test is skipped when service-contracts < 3.7 is installed (lowest-deps job), as passing the named argument to the attribute would fail there.
