### PR TITLE
[Form][Validator] Review Turkish (tr) translations

### DIFF
--- a/src/Symfony/Component/Form/Resources/translations/validators.tr.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.tr.xlf
@@ -12,7 +12,7 @@
             </trans-unit>
             <trans-unit id="30">
                 <source>The CSRF token is invalid. Please try to resubmit the form.</source>
-                <target>CSRF fişi geçersiz. Formu tekrar göndermeyi deneyin.</target>
+                <target>CSRF token geçersiz. Lütfen formu tekrar göndermeyi deneyin.</target>
             </trans-unit>
             <trans-unit id="99">
                 <source>This value is not a valid HTML5 color.</source>
@@ -52,7 +52,7 @@
             </trans-unit>
             <trans-unit id="108">
                 <source>Please enter a valid date.</source>
-                <target>Lütfen geçerli bir tarih giriniz.</target>
+                <target>Lütfen geçerli bir tarih girin.</target>
             </trans-unit>
             <trans-unit id="109">
                 <source>Please select a valid file.</source>
@@ -80,7 +80,7 @@
             </trans-unit>
             <trans-unit id="115">
                 <source>Please enter a number.</source>
-                <target>Lütfen bir numara giriniz.</target>
+                <target>Lütfen bir sayı girin.</target>
             </trans-unit>
             <trans-unit id="116">
                 <source>The password is invalid.</source>
@@ -104,7 +104,7 @@
             </trans-unit>
             <trans-unit id="121">
                 <source>Please enter a valid URL.</source>
-                <target>Lütfen geçerli bir giriniz URL.</target>
+                <target>Lütfen geçerli bir URL girin.</target>
             </trans-unit>
             <trans-unit id="122">
                 <source>Please enter a valid search term.</source>
@@ -112,7 +112,7 @@
             </trans-unit>
             <trans-unit id="123">
                 <source>Please provide a valid phone number.</source>
-                <target>lütfen geçerli bir telefon numarası sağlayın.</target>
+                <target>Lütfen geçerli bir telefon numarası girin.</target>
             </trans-unit>
             <trans-unit id="124">
                 <source>The checkbox has an invalid value.</source>
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="129">
                 <source>Please enter a valid UUID.</source>
-                <target state="needs-review-translation">Lütfen geçerli bir UUID girin.</target>
+                <target>Lütfen geçerli bir UUID girin.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.tr.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.tr.xlf
@@ -36,23 +36,23 @@
             </trans-unit>
             <trans-unit id="9">
                 <source>This field was not expected.</source>
-                <target>Bu alan beklenen olmadı.</target>
+                <target>Bu alan beklenmiyor.</target>
             </trans-unit>
             <trans-unit id="10">
                 <source>This field is missing.</source>
-                <target>Bu alan, eksiktir</target>
+                <target>Bu alan eksik.</target>
             </trans-unit>
             <trans-unit id="11">
                 <source>This value is not a valid date.</source>
-                <target>Bu değer doğru bir tarih biçimi değildir.</target>
+                <target>Bu değer geçerli bir tarih biçimi değildir.</target>
             </trans-unit>
             <trans-unit id="12">
                 <source>This value is not a valid datetime.</source>
-                <target>Bu değer doğru bir tarihsaat biçimi değildir.</target>
+                <target>Bu değer geçerli bir tarih/saat biçimi değildir.</target>
             </trans-unit>
             <trans-unit id="13">
                 <source>This value is not a valid email address.</source>
-                <target>Bu değer doğru bir e-mail adresi değildir.</target>
+                <target>Bu değer geçerli bir e-mail adresi değildir.</target>
             </trans-unit>
             <trans-unit id="14">
                 <source>The file could not be found.</source>
@@ -72,7 +72,7 @@
             </trans-unit>
             <trans-unit id="18">
                 <source>This value should be {{ limit }} or less.</source>
-                <target>Bu değer {{ limit }} ve altında olmalıdır.</target>
+                <target>Bu değer {{ limit }} veya daha az olmalıdır.</target>
             </trans-unit>
             <trans-unit id="19">
                 <source>This value is too long. It should have {{ limit }} character or less.|This value is too long. It should have {{ limit }} characters or less.</source>
@@ -104,11 +104,11 @@
             </trans-unit>
             <trans-unit id="26">
                 <source>This value is not a valid time.</source>
-                <target>Bu değer doğru bir saat değildir.</target>
+                <target>Bu değer geçerli bir saat değildir.</target>
             </trans-unit>
             <trans-unit id="27">
                 <source>This value is not a valid URL.</source>
-                <target>Bu değer doğru bir URL değildir.</target>
+                <target>Bu değer geçerli bir URL değildir.</target>
             </trans-unit>
             <trans-unit id="31">
                 <source>The two values should be equal.</source>
@@ -140,7 +140,7 @@
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
-                <target>Bu değer geçerli bir lisan değildir.</target>
+                <target>Bu değer geçerli bir dil değildir.</target>
             </trans-unit>
             <trans-unit id="39">
                 <source>This value is not a valid locale.</source>
@@ -152,7 +152,7 @@
             </trans-unit>
             <trans-unit id="41">
                 <source>This value is already used.</source>
-                <target>Bu değer şu anda kullanımda.</target>
+                <target>Bu değer zaten kullanılıyor.</target>
             </trans-unit>
             <trans-unit id="42">
                 <source>The size of the image could not be detected.</source>
@@ -556,19 +556,19 @@
             </trans-unit>
             <trans-unit id="143">
                 <source>This value is not valid XML.</source>
-                <target state="needs-review-translation">Bu değer geçerli bir XML değil.</target>
+                <target>Bu değer geçerli bir XML değildir.</target>
             </trans-unit>
             <trans-unit id="144">
                 <source>This value does not conform to the expected XSD schema.</source>
-                <target state="needs-review-translation">Bu değer beklenen XSD şemasına uymuyor.</target>
+                <target>Bu değer beklenen XSD şemasına uymuyor.</target>
             </trans-unit>
             <trans-unit id="145">
                 <source>This XML payload is too large ({{ size }} bytes): it exceeds the limit of {{ limit }} bytes.</source>
-                <target state="needs-review-translation">Bu XML yükü çok büyük ({{ size }} bayt): {{ limit }} baytlık sınırı aşıyor.</target>
+                <target>Bu XML yükü çok büyük ({{ size }} bayt): {{ limit }} baytlık sınırı aşıyor.</target>
             </trans-unit>
             <trans-unit id="146">
                 <source>This value is not a valid cron expression.</source>
-                <target state="needs-review-translation">Bu değer geçerli bir cron ifadesi değil.</target>
+                <target>Bu değer geçerli bir cron ifadesi değildir.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64520
| License       | MIT

Clears the five `needs-review-translation` markers on the Turkish catalogues, and fixes the pre-existing errors found while reading them.

Every changed unit is listed below, so the diff can be checked line by line.

### The five flagged strings (#64520)

| file | id | source | change |
| --- | --- | --- | --- |
| Form | 129 | Please enter a valid UUID. | text already correct, marker removed |
| Validator | 143 | This value is not valid XML. | `değil` to `değildir`, matching the 33 other units that use it |
| Validator | 144 | This value does not conform to the expected XSD schema. | text already correct, marker removed |
| Validator | 145 | This XML payload is too large ... | text already correct, marker removed |
| Validator | 146 | This value is not a valid cron expression. | `değil` to `değildir` |

### Errors fixed in passing

| file | id | before | after | why |
| --- | --- | --- | --- | --- |
| Form | 30 | CSRF **fişi** geçersiz. Formu ... | CSRF **token** geçersiz. **Lütfen** formu ... | `fiş` is a receipt or a physical token. `Lütfen` restores the source's "Please" |
| Form | 108 | ... tarih **giriniz**. | ... tarih **girin**. | `girin` is used 14 times in the file, `giriniz` twice |
| Form | 115 | Lütfen bir **numara giriniz**. | Lütfen bir **sayı girin**. | a `numara` is a label such as a phone or house number. Id 111 already writes `tam sayı` for "integer" |
| Form | 121 | Lütfen geçerli bir **giriniz URL**. | Lütfen geçerli bir **URL girin**. | the verb came before the noun |
| Form | 123 | **l**ütfen ... **sağlayın**. | **L**ütfen ... **girin**. | the sentence started lowercase |
| Validator | 9 | Bu alan **beklenen olmadı**. | Bu alan **beklenmiyor**. | ungrammatical |
| Validator | 10 | Bu alan**,** eksiktir | Bu alan eksik**.** | stray comma, missing full stop |
| Validator | 11, 12, 13, 26, 27 | **doğru** bir ... | **geçerli** bir ... | the source says "valid", not "correct". 25 other units already use `geçerli` |
| Validator | 12 | **tarihsaat** biçimi | **tarih/saat** biçimi | `tarihsaat` is not a word |
| Validator | 18 | {{ limit }} **ve** altında olmalıdır. | {{ limit }} **veya daha az** olmalıdır. | `ve` means "and", the source says "or". Now mirrors id 20, `veya daha fazla olmalıdır` |
| Validator | 38 | geçerli bir **lisan** | geçerli bir **dil** | `lisan` is archaic, `dil` is the standard modern word |
| Validator | 41 | **şu anda kullanımda** | **zaten kullanılıyor** | the source says "already", not "currently" |

After the patch there are no occurrences left of `giriniz`, `doğru bir` or `lisan`, so each of those three is complete rather than half applied.

### Left alone on purpose

Six strings from the first version of this PR were reverted, because they made the catalogue less consistent than it already was:

* **Form 117**, `yüzde değeri` to `yüzde oranı`. `değer` is the literal match for "value", `oran` means "rate".
* **Validator 19**, `veya daha az` to `veya daha kısa`. Id 21 says `veya daha fazla`, so the too-long and too-short pair stop mirroring each other.
* **Validator 22 and 23**, `bırakılmamalıdır` to `bırakılamaz`. The source says "should not", and id 24 says `boş bırakılmalıdır` for "should be null", so the pair stop mirroring each other.
* **Validator 33**, `Dosya çok büyük` to `Dosya boyutu çok büyük`. Ids 16 and 32 come from the same `File` constraint and both say `Dosya çok büyük`.
* **Validator 36**, `resim` to `görsel`. Ids 43, 45 and 73 all say `resim`, so the headline "not a valid image" message would have used a different word from every other image message.

Ids 22 and 23 still share one target, as they did before this PR. "This value should not be blank." and "This value should not be null." both render as `Bu değer boş bırakılmamalıdır.` Telling them apart is a separate change and needs its own discussion.

A review by a native speaker is still worth having, in particular on id 145, where `baytlık sınırı aşıyor` was kept because `bayt sınırı` reads as the noun compound "byte limit" and leaves the verb without an object.

Both catalogues validate against the XLIFF schema, and `TranslationFilesTest` is green for Form and Validator. The catalogues are byte-identical on 6.4, 7.4, 8.1 and 8.2, and the merge up is conflict free on all three.
