### PR TITLE
[PropertyInfo] Do not report a non-public mutator as writable

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -686,7 +686,7 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
             foreach ($names as $name) {
                 try {
                     $reflectionMethod = new \ReflectionMethod($class, $prefix.$name);
-                    if ($reflectionMethod->isStatic()) {
+                    if ($reflectionMethod->isStatic() || !($reflectionMethod->getModifiers() & $this->methodReflectionFlags)) {
                         continue;
                     }
 

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
@@ -434,6 +434,8 @@ class ReflectionExtractorTest extends TestCase
             ['Id', false],
             ['Guid', true],
             ['guid', false],
+            ['privateMutator', false],
+            ['protectedMutator', false],
         ];
     }
 

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Dummy.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Dummy.php
@@ -272,4 +272,12 @@ class Dummy extends ParentDummy
     public function hasElement(string $element): bool
     {
     }
+
+    private function setPrivateMutator($privateMutator)
+    {
+    }
+
+    protected function setProtectedMutator($protectedMutator)
+    {
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        |
| License       | MIT

`ReflectionExtractor::isWritable()` reports a property as writable when the only mutator is `private` or `protected`, so it claims something that cannot be written:

```
          PropertyInfo::isWritable   PropertyAccessor::isWritable
secret    true                       false      <- private setter
protSet   true                       false      <- protected setter
```

The rest of the class already gets this right. `isReadable()` delegates to `getReadInfo()`, and `getWriteInfo()` returns `TYPE_NONE` for both cases above, because both honour the `$accessFlags` given to the constructor. Only `isWritable()` goes through `getMutatorMethod()`, which matches the method by name and rejects `static`, but never looks at visibility. This aligns it with its neighbours:

```php
if ($reflectionMethod->isStatic() || !($reflectionMethod->getModifiers() & $this->methodReflectionFlags)) {
    continue;
}
```

The same `getModifiers() & $this->methodReflectionFlags` test is already used four times in `getReadInfo()`.

Where it shows up. `ObjectNormalizer::isAllowedAttribute()` asks `isWritable()` during denormalization, so a payload key matching a private setter was allowed through, handed to the property accessor, refused, and the resulting `NoSuchPropertyException` swallowed. The value was dropped with no diagnostic and no way to ask for one. After this, the attribute is simply not allowed, which is the same outcome by default and is now reported by the existing option:

```
default                        OK   known=ok secret=''
ALLOW_EXTRA_ATTRIBUTES=false   ExtraAttributesException: Extra attributes are not allowed ("secret" is unknown).
```

That is what #63783 was working around; it is closed in favour of this.

Deliberately left alone: `isWritable()` also returns `true` for a collection with an adder but no matching remover, which the property accessor equally refuses. `ReflectionExtractorTest::testSingularize` asserts the current answer for `AdderRemoverDummy::$analyses` and `$feet`, so that one is a decision rather than an oversight and does not belong in the same change.

Suites run on 6.4, all green: PropertyInfo 553, PropertyAccess 482, Serializer 1150, Form 4748, Validator 4791.

Branch. The defect is present on every maintained branch, so this targets 6.4. `getMutatorMethod()` has never honoured `$methodReflectionFlags`: on 6.4 and 7.4 it looks the method up with `new \ReflectionMethod($class, ...)`, since 8.1 with `$refClass->getMethod(...)`, and both return non-public methods. Verified on 6.4, where `isWritable()` reports `true` for a private and for a protected setter.

One consequence to weigh before merging. With `ALLOW_EXTRA_ATTRIBUTES => false`, a payload key matching a private setter used to be accepted and is now rejected, so an application relying on that in a patch release would start seeing `ExtraAttributesException`. The default configuration is unaffected.
