### PR TITLE
[ObjectMapper] Fix nested map() reconstructing an existing target

### DIFF
--- a/src/Symfony/Component/ObjectMapper/ObjectMapper.php
+++ b/src/Symfony/Component/ObjectMapper/ObjectMapper.php
@@ -49,18 +49,18 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
     public function map(object $source, object|string|null $target = null): object
     {
         if ($this->objectMap) {
-            return $this->doMap($source, $target, $this->objectMap, false);
+            return $this->doMap($source, $target, $this->objectMap);
         }
 
         $this->objectMap = new \WeakMap();
         try {
-            return $this->doMap($source, $target, $this->objectMap, true);
+            return $this->doMap($source, $target, $this->objectMap);
         } finally {
             $this->objectMap = null;
         }
     }
 
-    private function doMap(object $source, object|string|null $target, \WeakMap $objectMap, bool $rootCall): object
+    private function doMap(object $source, object|string|null $target, \WeakMap $objectMap, bool $constructTarget = false): object
     {
         $metadata = $this->metadataFactory->create($source);
         $map = $this->getMapTarget($metadata, null, $source, null, null === $target);
@@ -103,7 +103,7 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
         $objectMap[$source] = $mappedTarget;
         $ctorArguments = [];
         $targetConstructor = $targetRefl->getConstructor();
-        if (!$mappingToObject || !$rootCall) {
+        if (!$mappingToObject || $constructTarget) {
             foreach ($targetConstructor?->getParameters() ?? [] as $parameter) {
                 $parameterName = $parameter->getName();
 
@@ -200,7 +200,7 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
             }
         }
 
-        if ((!$mappingToObject || !$rootCall) && !$map?->transform && $targetConstructor
+        if ((!$mappingToObject || $constructTarget) && !$map?->transform && $targetConstructor
             && ($ctorArguments || !$targetConstructor->getNumberOfRequiredParameters())
         ) {
             try {
@@ -310,7 +310,10 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
                     $previousMap = $this->objectMap;
                     $this->objectMap = $objectMap;
                     try {
-                        $objectMap[$value] = $mapper->map($value, $target);
+                        // the ghost has not run a constructor yet, unlike a caller-supplied target
+                        $objectMap[$value] = $mapper === $this
+                            ? $this->doMap($value, $target, $objectMap, true)
+                            : $mapper->map($value, $target);
                     } finally {
                         $this->objectMap = $previousMap;
                     }

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MapExistingObject/NestedExistingTagTransformer.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MapExistingObject/NestedExistingTagTransformer.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\MapExistingObject;
+
+use Symfony\Component\ObjectMapper\ObjectMapperAwareInterface;
+use Symfony\Component\ObjectMapper\ObjectMapperInterface;
+use Symfony\Component\ObjectMapper\TransformCallableInterface;
+
+/**
+ * Simulates a repository lookup finding an already-existing entity and
+ * updating it in place via a nested (non-root) map() call.
+ *
+ * @implements TransformCallableInterface<PostDto, Post>
+ */
+final class NestedExistingTagTransformer implements TransformCallableInterface, ObjectMapperAwareInterface
+{
+    private ?ObjectMapperInterface $objectMapper = null;
+
+    public function __construct(
+        private readonly Tag $existingTag,
+    ) {
+    }
+
+    public function withObjectMapper(ObjectMapperInterface $objectMapper): static
+    {
+        $clone = clone $this;
+        $clone->objectMapper = $objectMapper;
+
+        return $clone;
+    }
+
+    public function __invoke(mixed $value, object $source, ?object $target): mixed
+    {
+        return $this->objectMapper->map($value, $this->existingTag);
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MapExistingObject/Post.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MapExistingObject/Post.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\MapExistingObject;
+
+final class Post
+{
+    public ?Tag $tag = null;
+
+    public function __construct(
+        public string $title = '',
+    ) {
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MapExistingObject/PostDto.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MapExistingObject/PostDto.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\MapExistingObject;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(target: Post::class)]
+final class PostDto
+{
+    #[Map]
+    public string $title = 'a post';
+
+    #[Map(transform: NestedExistingTagTransformer::class)]
+    public TagDto $tag;
+
+    public function __construct()
+    {
+        $this->tag = new TagDto();
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MapExistingObject/Tag.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MapExistingObject/Tag.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\MapExistingObject;
+
+final class Tag
+{
+    public int $constructorCalls = 0;
+
+    public function __construct(
+        public string $name = '',
+    ) {
+        ++$this->constructorCalls;
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MapExistingObject/TagDto.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MapExistingObject/TagDto.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\MapExistingObject;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(target: Tag::class)]
+final class TagDto
+{
+    #[Map]
+    public string $name = 'updated name';
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedConstructedTarget/Inner.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedConstructedTarget/Inner.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\NestedConstructedTarget;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(target: InnerMapped::class)]
+final class Inner
+{
+    public function __construct(
+        public string $name,
+    ) {
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedConstructedTarget/InnerMapped.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedConstructedTarget/InnerMapped.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\NestedConstructedTarget;
+
+final class InnerMapped
+{
+    public readonly string $slug;
+
+    public function __construct(
+        public readonly string $name,
+    ) {
+        $this->slug = 'slug-of-'.$name;
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedConstructedTarget/Outer.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedConstructedTarget/Outer.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\NestedConstructedTarget;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(target: OuterMapped::class)]
+final class Outer
+{
+    public function __construct(
+        public Inner $inner,
+    ) {
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedConstructedTarget/OuterMapped.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedConstructedTarget/OuterMapped.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\NestedConstructedTarget;
+
+final class OuterMapped
+{
+    public function __construct(
+        public InnerMapped $inner,
+    ) {
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
@@ -69,6 +69,10 @@ use Symfony\Component\ObjectMapper\Tests\Fixtures\MagicGet\MagicGetUser;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MagicGet\MagicGetUserView;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MapExistingObject\ExistingObjectWithPublicProperty;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MapExistingObject\ExistingObjectWithSetter;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\MapExistingObject\NestedExistingTagTransformer;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\MapExistingObject\Post as MapExistingObjectPost;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\MapExistingObject\PostDto;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\MapExistingObject\Tag;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MapStruct\AToBMapper;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MapStruct\MapStructMapperMetadataFactory;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MapStruct\Source;
@@ -82,6 +86,9 @@ use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargetProperty\C as Mu
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargets\A as MultipleTargetsA;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargets\C as MultipleTargetsC;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MyProxy;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\NestedConstructedTarget\Inner;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\NestedConstructedTarget\InnerMapped;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\NestedConstructedTarget\Outer;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMappingWithClassTransformer\ChildWithClassTransformTarget;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMappingWithClassTransformer\ChildWithoutClassTransformerTarget;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMappingWithClassTransformer\ParentSource;
@@ -224,6 +231,25 @@ final class ObjectMapperTest extends TestCase
         $mapped = $mapper->map($ab);
         $this->assertInstanceOf(Dto::class, $mapped);
         $this->assertSame($mapped, $mapped->dto);
+    }
+
+    public function testNestedMapCallDoesNotReconstructExistingTarget()
+    {
+        $existingTag = new Tag('original name');
+        $this->assertSame(1, $existingTag->constructorCalls);
+
+        $mapper = new ObjectMapper(
+            transformCallableLocator: $this->getServiceLocator([
+                NestedExistingTagTransformer::class => new NestedExistingTagTransformer($existingTag),
+            ]),
+        );
+
+        $post = $mapper->map(new PostDto(), MapExistingObjectPost::class);
+
+        $this->assertInstanceOf(MapExistingObjectPost::class, $post);
+        $this->assertSame($existingTag, $post->tag);
+        $this->assertSame('updated name', $existingTag->name);
+        $this->assertSame(1, $existingTag->constructorCalls);
     }
 
     public function testDeeperRecursion()
@@ -1016,5 +1042,16 @@ final class ObjectMapperTest extends TestCase
         // source, otherwise the #[Map(source: ...)] property is read as null and the transform receives null
         $this->assertInstanceOf(TransformSourcePropertyTarget::class, $target);
         $this->assertSame('ABC', $target->targetProperty);
+    }
+
+    public function testNestedTargetIsConstructed()
+    {
+        $mapper = new ObjectMapper();
+        $mapped = $mapper->map(new Outer(new Inner('bar')));
+
+        $this->assertInstanceOf(InnerMapped::class, $mapped->inner);
+        $this->assertSame('bar', $mapped->inner->name);
+        // computed by the constructor, so it can only be set if the constructor ran
+        $this->assertSame('slug-of-bar', $mapped->inner->slug);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64967
| License       | MIT

Calling `map()` on a target that already exists, from inside a `#[Map(transform:)]` callable, ran that target's constructor a second time. `ObjectMapperTest::testNestedMapCallDoesNotReconstructExistingTarget` fails on 7.4 with `Failed asserting that 2 is identical to 1`.

Changed during review, because the first version of the fix traded this bug for a worse one:

**`$rootCall` was not only gating cycle detection.** The `\WeakMap` reinitialisation is gated by `if ($this->objectMap)` in `map()`; `$rootCall` had exactly one job, which was to let the constructor run for the lazy ghost that `getSourceValue()` builds for a nested object property. That ghost comes from `newLazyGhost()`, so no constructor has run, and it reaches `map()` as an object, which makes `$mappingToObject` true. Dropping `!$rootCall` from the two guards therefore treated it like a caller-supplied instance and never constructed it.

On PHP >= 8.4, which is where `getSourceValue()` takes the lazy-ghost branch, that meant every nested object target silently stopped being constructed:

| | before this PR | first version of the fix |
|---|---|---|
| nested target with a readonly promoted property | works | fatal `Error` |
| nested target whose constructor computes a field | `slug-of-bar` | unset |
| nested target with a constructor side effect | ran once | never ran |
| same source object in two properties | 2 constructor calls | 0 |

The readonly case is a straight re-break of `94ec07b4f07`.

So the flag is replaced rather than removed. `doMap()` now takes `$constructTarget`, meaning "the mapper created this target itself", and the lazy-ghost initialiser is the one caller that passes `true`:

```php
$objectMap[$value] = $mapper === $this
    ? $this->doMap($value, $target, $objectMap, true)
    : $mapper->map($value, $target);
```

The `$mapper === $this` check leaves the decorated-mapper path (`withObjectMapper()`) exactly as it is today.

**A fixture that would have caught this.** The regression passed CI's 8.4, 8.5 and 8.6 legs because nothing covered a nested target whose constructor matters: the `ReadOnlyPromotedProperty*` fixtures are misnamed, their promoted properties are plain `public`, so the direct property write in the mapping loop covered for the missing constructor. `Fixtures/NestedConstructedTarget` adds a nested target with a genuinely `readonly` promoted property and a constructor-computed field, and `testNestedTargetIsConstructed` asserts on it. It passes on unmodified 7.4 and fails with `Cannot modify protected(set) readonly property` against the first version of the fix.

Note for the merge-up: `ObjectMapper.php` has moved on 8.2 (72 insertions, 28 deletions against 7.4), so this will not apply cleanly there and wants a look rather than a straight merge. The bug and the regression both reproduce on 8.2, so the same shape of fix is needed.

Suite: 75 tests, 185 assertions, green.
