### PR TITLE
[Mailer] Fix fatal TypeError when sending a RawMessage via an API transport

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesApiAsyncAwsTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesApiAsyncAwsTransportTest.php
@@ -18,10 +18,12 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Mailer\Bridge\Amazon\Transport\SesApiAsyncAwsTransport;
+use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Exception\HttpTransportException;
 use Symfony\Component\Mailer\Header\MetadataHeader;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
+use Symfony\Component\Mime\RawMessage;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class SesApiAsyncAwsTransportTest extends TestCase
@@ -148,5 +150,24 @@ class SesApiAsyncAwsTransportTest extends TestCase
         $this->expectException(HttpTransportException::class);
         $this->expectExceptionMessage('Unable to send an email: i\'m a teapot (code 418).');
         $transport->send($mail);
+    }
+
+    public function testSendRawMessage()
+    {
+        $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
+            $content = json_decode($options['body'], true);
+
+            $this->assertSame("Subject: Hello!\r\n\r\nHello There!", base64_decode($content['Content']['Raw']['Data']));
+            $this->assertSame(['saif.gmati@symfony.com'], $content['Destination']['ToAddresses']);
+
+            return new MockResponse('{"MessageId": "foobar"}', ['http_code' => 200]);
+        });
+
+        $transport = new SesApiAsyncAwsTransport(new SesClient(Configuration::create(['sharedConfigFile' => false]), new NullProvider(), $client));
+
+        $envelope = new Envelope(new Address('fabpot@symfony.com'), [new Address('saif.gmati@symfony.com')]);
+        $message = $transport->send(new RawMessage("Subject: Hello!\r\n\r\nHello There!"), $envelope);
+
+        $this->assertSame('foobar', $message->getMessageId());
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesApiAsyncAwsTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesApiAsyncAwsTransport.php
@@ -21,6 +21,7 @@ use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
 use Symfony\Component\Mime\Header\Headers;
+use Symfony\Component\Mime\Message;
 use Symfony\Component\Mime\MessageConverter;
 
 /**
@@ -43,8 +44,15 @@ class SesApiAsyncAwsTransport extends SesHttpAsyncAwsTransport
 
     protected function getRequest(SentMessage $message): SendEmailRequest
     {
+        $originalMessage = $message->getOriginalMessage();
+
+        if (!$originalMessage instanceof Message) {
+            // the raw endpoint takes the message as-is, the same way an email with attachments does
+            return parent::getRequest($message);
+        }
+
         try {
-            $email = MessageConverter::toEmail($message->getOriginalMessage());
+            $email = MessageConverter::toEmail($originalMessage);
         } catch (\Exception $e) {
             throw new RuntimeException(\sprintf('Unable to send message with the "%s" transport: ', __CLASS__).$e->getMessage(), 0, $e);
         }

--- a/src/Symfony/Component/Mailer/Tests/Transport/AbstractApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/AbstractApiTransportTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Tests\Transport;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\Mailer\Envelope;
+use Symfony\Component\Mailer\Exception\RuntimeException;
+use Symfony\Component\Mailer\SentMessage;
+use Symfony\Component\Mailer\Transport\AbstractApiTransport;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\Email;
+use Symfony\Component\Mime\Message;
+use Symfony\Component\Mime\RawMessage;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+class AbstractApiTransportTest extends TestCase
+{
+    public function testSendThrowsWhenTheOriginalMessageIsNotAMimeMessage()
+    {
+        $transport = new class(new MockHttpClient()) extends AbstractApiTransport {
+            protected function doSendApi(SentMessage $sentMessage, Email $email, Envelope $envelope): ResponseInterface
+            {
+                throw new \BadMethodCallException('This method should never be called.');
+            }
+
+            public function __toString(): string
+            {
+                return 'api://test';
+            }
+        };
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage(\sprintf('Unable to send message with the "%s" transport: the message must be an instance of "%s" (got "%s"). An API transport builds its payload from the message fields; use an SMTP transport to send a raw message.', $transport::class, Message::class, RawMessage::class));
+
+        $transport->send(new RawMessage('Raw email content'), new Envelope(new Address('fabien@symfony.com'), [new Address('helene@symfony.com')]));
+    }
+}

--- a/src/Symfony/Component/Mailer/Transport/AbstractApiTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/AbstractApiTransport.php
@@ -16,6 +16,7 @@ use Symfony\Component\Mailer\Exception\RuntimeException;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
+use Symfony\Component\Mime\Message;
 use Symfony\Component\Mime\MessageConverter;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
@@ -28,10 +29,15 @@ abstract class AbstractApiTransport extends AbstractHttpTransport
 
     protected function doSendHttp(SentMessage $message): ResponseInterface
     {
+        $originalMessage = $message->getOriginalMessage();
+        if (!$originalMessage instanceof Message) {
+            throw new RuntimeException(\sprintf('Unable to send message with the "%s" transport: the message must be an instance of "%s" (got "%s"). An API transport builds its payload from the message fields; use an SMTP transport to send a raw message.', static::class, Message::class, get_debug_type($originalMessage)));
+        }
+
         try {
-            $email = MessageConverter::toEmail($message->getOriginalMessage());
+            $email = MessageConverter::toEmail($originalMessage);
         } catch (\Exception $e) {
-            throw new RuntimeException(\sprintf('Unable to send message with the "%s" transport: ', __CLASS__).$e->getMessage(), 0, $e);
+            throw new RuntimeException(\sprintf('Unable to send message with the "%s" transport: ', static::class).$e->getMessage(), 0, $e);
         }
 
         return $this->doSendApi($message, $email, $message->getEnvelope());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Part of #64964
| License       | MIT

Sending a `RawMessage` through an API transport died with a `TypeError` out of `MessageConverter::toEmail()`, which is an `\Error` and so escapes `catch (\Exception)` and `catch (ExceptionInterface)` around `Mailer::send()`. That is how a spooled raw message takes an application down instead of being reported.

`AbstractApiTransport::doSendHttp()` now checks the original message before converting, and throws `Mailer\Exception\RuntimeException` instead, which is catchable through the usual interfaces.

Added during review:

* **`ses+api://` is covered too.** `SesApiAsyncAwsTransport` extends `AbstractTransport`, not `AbstractApiTransport`, so the guard above never applied to it, and it kept the identical unguarded call at `getRequest()`:

  ```
  transport: ses+api://AK@eu-west-1
  is AbstractApiTransport: no
  TypeError: ... must be of type Message, RawMessage given, called in SesApiAsyncAwsTransport.php on line 47
  ```

  For SES the raw message can simply be sent rather than refused: `getRequest()` already falls back to the SES `Content.Raw.Data` endpoint when an email carries attachments, and that path takes the message as-is. So a `RawMessage` now takes the same fallback, and `SesApiAsyncAwsTransportTest::testSendRawMessage` covers it. Without this the PR title would only be true for the twelve `AbstractApiTransport` subclasses;

* **the exception says what to do instead.** It now ends with "An API transport builds its payload from the message fields; use an SMTP transport to send a raw message", rather than only naming the type it wanted;

* **the exception names the transport the user configured.** `__CLASS__` inside the abstract class always printed `Symfony\Component\Mailer\Transport\AbstractApiTransport`, so someone on `sendgrid+api://` read a class name they had never heard of. Both `sprintf()` calls now use `static::class` and print `SendgridApiTransport`. The pre-existing conversion-failure message had the same wart, and the new test asserted on it, so it was worth settling before that assertion shipped.

Deliberately left alone: the `+https` transports. `MailgunHttpTransport` and `MandrillHttpTransport` also extend `AbstractHttpTransport` directly, but they build their payload from `$message->toString()`, so they already accept a `RawMessage`. Putting the guard one level up in `AbstractHttpTransport` would have broken them.

The Message-ID half of #64964 is untouched, so that issue stays open.

Suites: Mailer 165, plus all 14 mailer bridges, green.
