### PR TITLE
[HttpKernel] Fix the curl command when a cookie holds an array

### DIFF
--- a/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
@@ -521,12 +521,12 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
             $command[] = '--header '.escapeshellarg(ucwords($name, '-').': '.implode(', ', $values));
         }
 
-        if ($request->cookies->all()) {
-            $cookies = [];
-            foreach ($request->cookies->all() as $name => $value) {
-                $cookies[] = urlencode($name).'='.urlencode($value);
-            }
-            $command[] = '--cookie '.escapeshellarg(implode('; ', $cookies));
+        if ($cookies = $this->flattenCookieArrayForCurl($request->cookies->all())) {
+            $command[] = '--cookie '.escapeshellarg(implode('; ', array_map(
+                static fn ($name, $value) => $name.'='.$value,
+                array_keys($cookies),
+                $cookies
+            )));
         }
 
         if ($content && \in_array($method, [Request::METHOD_POST, Request::METHOD_PUT, Request::METHOD_PATCH, Request::METHOD_DELETE], true)) {
@@ -554,5 +554,28 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
         }
 
         return "'".str_replace("'", "'\\''", $payload)."'";
+    }
+
+    /**
+     * @param array<array-key, mixed> $data
+     *
+     * @return array<array-key, string>
+     */
+    private function flattenCookieArrayForCurl(array $data, string $prefix = ''): array
+    {
+        $pairs = [];
+
+        foreach ($data as $key => $value) {
+            $key = rawurlencode((string) $key);
+            $name = '' === $prefix ? $key : $prefix.'['.$key.']';
+
+            if (\is_array($value)) {
+                $pairs += $this->flattenCookieArrayForCurl($value, $name);
+            } else {
+                $pairs[$name] = rawurlencode((string) $value);
+            }
+        }
+
+        return $pairs;
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/RequestDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/RequestDataCollectorTest.php
@@ -518,7 +518,7 @@ class RequestDataCollectorTest extends TestCase
 
     public function testCurlCommandWithCookies()
     {
-        $request = Request::create('http://test.com/foo', 'GET', [], ['session' => 'abc123', 'lang' => 'en']);
+        $request = Request::create('http://test.com/foo', 'GET', [], ['session' => 'abc123', 'lang' => 'en', 'note' => 'hello world', 'prefs' => ['setting1' => 'value1', 'setting2' => 'value2', 'setting3' => ['listItem1', 'listItem2']]]);
 
         $c = new RequestDataCollector();
         $c->collect($request, $this->createResponse());
@@ -527,6 +527,22 @@ class RequestDataCollectorTest extends TestCase
         $this->assertStringContainsString('--cookie', $curlCommand);
         $this->assertStringContainsString('session=abc123', $curlCommand);
         $this->assertStringContainsString('lang=en', $curlCommand);
+        $this->assertStringContainsString('prefs[setting1]=value1', $curlCommand);
+        $this->assertStringContainsString('prefs[setting2]=value2', $curlCommand);
+        $this->assertStringContainsString('prefs[setting3][0]=listItem1', $curlCommand);
+        $this->assertStringContainsString('prefs[setting3][1]=listItem2', $curlCommand);
+        // a cookie is not form data, so a space is "%20" and "+" stays a literal plus
+        $this->assertStringContainsString('note=hello%20world', $curlCommand);
+    }
+
+    public function testCurlCommandWithCookieHoldingAnEmptyArray()
+    {
+        $request = Request::create('http://test.com/foo', 'GET', [], ['prefs' => []]);
+
+        $c = new RequestDataCollector();
+        $c->collect($request, $this->createResponse());
+
+        $this->assertStringNotContainsString('--cookie', $c->getCurlCommand());
     }
 
     public function testCurlCommandPutWithBody()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

PHP turns a `name[key]=value` cookie into a nested array, so `$request->cookies->all()` can hold arrays. The profiler's "copy as curl" feature passed those straight to `urlencode()`:

```
TypeError: urlencode(): Argument #1 ($string) must be of type string, array given
  RequestDataCollector.php:527
```

Nested cookies are now flattened into the `name[key]` form that produced them, at any depth:

```
prefs[setting1]=value1; prefs[setting3][0]=listItem1; d[e][f][g]=deep
```

Each segment is encoded before the brackets are added, so a cookie literally named `a[b]` renders as `a%5Bb%5D=` and stays distinct from a nested `a` holding a `b`.

Changed during review:

* **the encoding of a space changed, and that is deliberate.** The rewrite moved from `urlencode()` to `rawurlencode()`, which is correct here and was worth stating rather than leaving as a side effect:

  | cookie | before | after |
  | --- | --- | --- |
  | `note` = `hello world` | `note=hello+world` | `note=hello%20world` |

  `+` means a space only in form encoding. A cookie is not form data, so the old output was ambiguous for any value containing a literal `+`. `testCurlCommandWithCookies` now asserts it;

* **a cookie holding an empty array produced an empty header.** `['prefs' => []]` left the outer `$request->cookies->all()` check true while the flattened list came out empty, so the command ended with `--cookie ''`. The check now tests the flattened list, which also removes the duplicate `all()` call. Covered by `testCurlCommandWithCookieHoldingAnEmptyArray`;

* the component prefix moved from `[WebProfiler]` to `[HttpKernel]`, which is where the whole diff lives.

Suite: HttpKernel `DataCollector` 96 tests, green. Reverting the source and keeping the tests reproduces the reported `TypeError`, so the coverage proves the fix rather than restating it.
