### PR TITLE
[Lock] Add DoctrineDbalMysqlStore for advisory locking

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -274,5 +274,6 @@ jobs:
           POSTGRES_HOST: localhost
           PGBOUNCER_HOST: localhost:6432
           MYSQL_DSN: mysql:host=localhost
+          MYSQL_HOST: 127.0.0.1
           MYSQL_USERNAME: root
           MYSQL_PASSWORD: root

--- a/src/Symfony/Component/Lock/CHANGELOG.md
+++ b/src/Symfony/Component/Lock/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.2
 ---
 
+ * Add `DoctrineDbalMysqlStore` based on MySQL `GET_LOCK()` functionality, usable with the `mysql+advisory://` DSN
  * Add `MysqlStore` based on MySQL `GET_LOCK()` functionality, usable with the `mysql+advisory:` DSN
 
 8.1

--- a/src/Symfony/Component/Lock/Store/DoctrineDbalMysqlStore.php
+++ b/src/Symfony/Component/Lock/Store/DoctrineDbalMysqlStore.php
@@ -1,0 +1,220 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Lock\Store;
+
+use Doctrine\DBAL\Configuration;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
+use Doctrine\DBAL\Schema\DefaultSchemaManagerFactory;
+use Doctrine\DBAL\Tools\DsnParser;
+use Symfony\Component\Lock\BlockingStoreInterface;
+use Symfony\Component\Lock\Exception\InvalidArgumentException;
+use Symfony\Component\Lock\Exception\LockAcquiringException;
+use Symfony\Component\Lock\Exception\LockConflictedException;
+use Symfony\Component\Lock\Key;
+use Symfony\Component\Lock\SharedLockStoreInterface;
+
+/**
+ * DoctrineDbalMysqlStore is a PersistingStoreInterface implementation using
+ * MySQL advisory locks with a Doctrine DBAL Connection.
+ *
+ * The advisory locking functions used by this class are supported by both MySQL and MariaDB.
+ * It requires MySQL 5.7.5 or MariaDB 10.0.2, the versions that let a session hold several
+ * named locks at once. On older servers, acquiring a lock releases the previous one.
+ *
+ * Shared and read locks are not supported: MySQL has no equivalent of pg_advisory_lock_shared,
+ * so Lock::acquireRead() silently gives an exclusive lock instead of failing.
+ *
+ * The connection should be dedicated to locking: advisory locks are bound to the session, so
+ * RELEASE_ALL_LOCKS(), EntityManager::close(), a wait_timeout expiration or a transparent DBAL
+ * reconnection release every lock held, and nothing detects it.
+ *
+ * @author Ryan Pon <me@ryanpon.com>
+ */
+class DoctrineDbalMysqlStore implements BlockingStoreInterface
+{
+    private Connection $conn;
+
+    /**
+     * You can either pass an existing database connection a Doctrine DBAL Connection
+     * or a URL that will be used to connect to the database.
+     *
+     * @throws InvalidArgumentException When first argument is not Connection nor string
+     */
+    public function __construct(#[\SensitiveParameter] Connection|string $connOrUrl)
+    {
+        if ($connOrUrl instanceof Connection) {
+            if (!$connOrUrl->getDatabasePlatform() instanceof AbstractMySQLPlatform) {
+                throw new InvalidArgumentException(\sprintf('The adapter "%s" does not support the "%s" platform.', __CLASS__, $connOrUrl->getDatabasePlatform()::class));
+            }
+            $this->conn = $connOrUrl;
+        } else {
+            if (!class_exists(DriverManager::class)) {
+                throw new InvalidArgumentException('Failed to parse DSN. Try running "composer require doctrine/dbal".');
+            }
+            $params = (new DsnParser([
+                'db2' => 'ibm_db2',
+                'mssql' => 'pdo_sqlsrv',
+                'mysql' => 'pdo_mysql',
+                'mysql2' => 'pdo_mysql',
+                'postgres' => 'pdo_pgsql',
+                'postgresql' => 'pdo_pgsql',
+                'pgsql' => 'pdo_pgsql',
+                'sqlite' => 'pdo_sqlite',
+                'sqlite3' => 'pdo_sqlite',
+            ]))->parse($this->filterDsn($connOrUrl));
+
+            $config = new Configuration();
+            $config->setSchemaManagerFactory(new DefaultSchemaManagerFactory());
+
+            $this->conn = DriverManager::getConnection($params, $config);
+        }
+    }
+
+    public function save(Key $key): void
+    {
+        // timeout 0 means no waiting
+        $this->saveWithTimeout($key, 0);
+    }
+
+    public function waitAndSave(Key $key): void
+    {
+        // timeout -1 will wait forever
+        $this->saveWithTimeout($key, -1);
+    }
+
+    public function putOffExpiration(Key $key, float $ttl): void
+    {
+        // mysql locks forever.
+        // check if lock still exists
+        if (!$this->exists($key)) {
+            throw new LockConflictedException();
+        }
+    }
+
+    public function delete(Key $key): void
+    {
+        // prevent deleting locks owned by another key in the same connection
+        if ($this->exists($key)) {
+            $this->unlock($key);
+        }
+
+        // the internal store is cleared even when the server already dropped the lock,
+        // otherwise the resource would stay taken for the rest of the process
+        $this->getInternalStore()->delete($key);
+    }
+
+    public function exists(Key $key): bool
+    {
+        $sql = 'SELECT IS_USED_LOCK(:key) = CONNECTION_ID()';
+        $result = $this->conn->executeQuery($sql, [
+            'key' => $this->getHashedKey($key),
+        ])->fetchOne();
+
+        if (1 === (int) $result) {
+            return $this->getInternalStore()->exists($key);
+        }
+
+        return false;
+    }
+
+    private function saveWithTimeout(Key $key, int $timeout): void
+    {
+        // prevent concurrency within the same connection
+        $this->getInternalStore()->save($key);
+
+        $lockAcquired = false;
+
+        try {
+            $hashedKey = $this->getHashedKey($key);
+            $sql = 'SELECT IF(IS_USED_LOCK(:key) = CONNECTION_ID(), -1, GET_LOCK(:key, :timeout))';
+            $maybeResult = $this->conn->executeQuery(
+                $sql,
+                ['key' => $hashedKey, 'timeout' => $timeout],
+                ['timeout' => ParameterType::INTEGER],
+            )->fetchOne();
+            if (null === $maybeResult) {
+                throw new LockAcquiringException('Failed to acquire lock due to mysql error.');
+            }
+
+            $result = (int) $maybeResult;
+
+            // 1 means lock was acquired, -1 means it was already acquired on this conn
+            if (1 === $result || -1 === $result) {
+                $key->markUnserializable();
+                $lockAcquired = true;
+
+                return;
+            }
+
+            if (0 === $result) {
+                throw new LockConflictedException('Lock already acquired by other connection.');
+            }
+
+            // we only expect to receive 1, 0, -1
+            throw new LockAcquiringException('Failed to acquire lock due to mysql error.');
+        } finally {
+            if (!$lockAcquired) {
+                $this->getInternalStore()->delete($key);
+            }
+        }
+    }
+
+    /**
+     * Returns a hashed version of the key.
+     */
+    private function getHashedKey(Key $key): string
+    {
+        // mysql limits lock name length to 64 chars
+        // mariadb compares locks in a case insensitive fashion
+        // we mostly get around these limitations by always hashing the key
+        return hash('sha256', (string) $key);
+    }
+
+    private function unlock(Key $key): void
+    {
+        $sql = 'DO RELEASE_LOCK(:key)';
+        $this->conn->executeQuery($sql, [
+            'key' => $this->getHashedKey($key),
+        ]);
+    }
+
+    /**
+     * Check driver and remove scheme extension from DSN.
+     * From mysql+advisory://server/ to mysql://server/.
+     *
+     * @throws InvalidArgumentException when driver is not supported
+     */
+    private function filterDsn(#[\SensitiveParameter] string $dsn): string
+    {
+        if (!str_contains($dsn, '://')) {
+            throw new InvalidArgumentException('DSN is invalid for Doctrine DBAL.');
+        }
+
+        [$scheme, $rest] = explode(':', $dsn, 2);
+        $driver = substr($scheme, 0, strpos($scheme, '+') ?: null);
+        if (!\in_array($driver, ['mysql', 'mysql2'], true)) {
+            throw new InvalidArgumentException(\sprintf('The adapter "%s" does not support the "%s" driver.', __CLASS__, $driver));
+        }
+
+        return \sprintf('%s:%s', $driver, $rest);
+    }
+
+    private function getInternalStore(): SharedLockStoreInterface
+    {
+        static $storeRegistry = new \WeakMap();
+
+        return $storeRegistry[$this->conn] ??= new InMemoryStore();
+    }
+}

--- a/src/Symfony/Component/Lock/Store/MysqlStore.php
+++ b/src/Symfony/Component/Lock/Store/MysqlStore.php
@@ -11,11 +11,11 @@
 
 namespace Symfony\Component\Lock\Store;
 
+use Symfony\Component\Lock\BlockingStoreInterface;
 use Symfony\Component\Lock\Exception\InvalidArgumentException;
 use Symfony\Component\Lock\Exception\LockAcquiringException;
 use Symfony\Component\Lock\Exception\LockConflictedException;
 use Symfony\Component\Lock\Key;
-use Symfony\Component\Lock\PersistingStoreInterface;
 use Symfony\Component\Lock\SharedLockStoreInterface;
 
 /**
@@ -25,11 +25,18 @@ use Symfony\Component\Lock\SharedLockStoreInterface;
  * It requires MySQL 5.7.5 or MariaDB 10.0.2, the versions that let a session hold several
  * named locks at once. On older servers, acquiring a lock releases the previous one.
  *
+ * Shared and read locks are not supported: MySQL has no equivalent of pg_advisory_lock_shared,
+ * so Lock::acquireRead() silently gives an exclusive lock instead of failing.
+ *
+ * The connection should be dedicated to locking: advisory locks are bound to the session, so
+ * RELEASE_ALL_LOCKS(), EntityManager::close(), a wait_timeout expiration or a transparent
+ * reconnection release every lock held, and nothing detects it.
+ *
  * @author Ryan Pon <me@ryanpon.com>
  * @author rtek
  * @author Jérôme TAMARELLE <jerome@tamarelle.net>
  */
-class MysqlStore implements PersistingStoreInterface
+class MysqlStore implements BlockingStoreInterface
 {
     private \PDO $conn;
 
@@ -75,15 +82,70 @@ class MysqlStore implements PersistingStoreInterface
 
     public function save(Key $key): void
     {
+        // timeout 0 means no waiting
+        $this->saveWithTimeout($key, 0);
+    }
+
+    public function waitAndSave(Key $key): void
+    {
+        // timeout -1 will wait forever
+        $this->saveWithTimeout($key, -1);
+    }
+
+    public function putOffExpiration(Key $key, float $ttl): void
+    {
+        // mysql locks forever.
+        // check if lock still exists
+        if (!$this->exists($key)) {
+            throw new LockConflictedException();
+        }
+    }
+
+    public function delete(Key $key): void
+    {
+        // prevent deleting locks owned by another key in the same connection
+        if ($this->exists($key)) {
+            $stmt = $this->deleteStmt ??
+                $this->deleteStmt = $this->getConnection()->prepare('DO RELEASE_LOCK(:name)');
+
+            $stmt->execute(['name' => self::getHashedKey($key)]);
+        }
+
+        // the internal store is cleared even when the server already dropped the lock,
+        // otherwise the resource would stay taken for the rest of the process
+        $this->getInternalStore()->delete($key);
+    }
+
+    public function exists(Key $key): bool
+    {
+        $stmt = $this->existsStmt ??
+            $this->existsStmt = $this->getConnection()->prepare('SELECT IS_USED_LOCK(:name) = CONNECTION_ID()');
+
+        $stmt->execute(['name' => self::getHashedKey($key)]);
+        $result = (int) $stmt->fetchColumn();
+
+        if (1 === $result) {
+            return $this->getInternalStore()->exists($key);
+        }
+
+        return false;
+    }
+
+    private function saveWithTimeout(Key $key, int $timeout): void
+    {
         $this->getInternalStore()->save($key);
 
         $lockAcquired = false;
 
         try {
+            // the lock name is bound twice because native prepared statements reject a repeated placeholder
             $stmt = $this->saveStmt ??
-                $this->saveStmt = $this->getConnection()->prepare('SELECT IF(IS_USED_LOCK(:name1) = CONNECTION_ID(), -1, GET_LOCK(:name2, 0))');
+                $this->saveStmt = $this->getConnection()->prepare('SELECT IF(IS_USED_LOCK(:name1) = CONNECTION_ID(), -1, GET_LOCK(:name2, :timeout))');
             $name = self::getHashedKey($key);
-            $stmt->execute(['name1' => $name, 'name2' => $name]);
+            $stmt->bindValue('name1', $name);
+            $stmt->bindValue('name2', $name);
+            $stmt->bindValue('timeout', $timeout, \PDO::PARAM_INT);
+            $stmt->execute();
             $maybeResult = $stmt->fetchColumn();
             if (null === $maybeResult) {
                 throw new LockAcquiringException('Failed to acquire lock due to mysql error.');
@@ -110,45 +172,6 @@ class MysqlStore implements PersistingStoreInterface
                 $this->getInternalStore()->delete($key);
             }
         }
-    }
-
-    public function putOffExpiration(Key $key, float $ttl): void
-    {
-        // mysql locks forever.
-        // check if lock still exists
-        if (!$this->exists($key)) {
-            throw new LockConflictedException();
-        }
-    }
-
-    public function delete(Key $key): void
-    {
-        // Prevent deleting locks own by an other key in the same connection
-        if ($this->exists($key)) {
-            $stmt = $this->deleteStmt ??
-                $this->deleteStmt = $this->getConnection()->prepare('DO RELEASE_LOCK(:name)');
-
-            $stmt->execute(['name' => self::getHashedKey($key)]);
-        }
-
-        // the internal store is cleared even when the server already dropped the lock,
-        // otherwise the resource would stay taken for the rest of the process
-        $this->getInternalStore()->delete($key);
-    }
-
-    public function exists(Key $key): bool
-    {
-        $stmt = $this->existsStmt ??
-            $this->existsStmt = $this->getConnection()->prepare('SELECT IS_USED_LOCK(:name) = CONNECTION_ID()');
-
-        $stmt->execute(['name' => self::getHashedKey($key)]);
-        $result = (int) $stmt->fetchColumn();
-
-        if (1 === $result) {
-            return $this->getInternalStore()->exists($key);
-        }
-
-        return false;
     }
 
     private function getConnection(): \PDO

--- a/src/Symfony/Component/Lock/Store/StoreFactory.php
+++ b/src/Symfony/Component/Lock/Store/StoreFactory.php
@@ -119,7 +119,9 @@ class StoreFactory
                 return new PostgreSqlStore(preg_replace('/^([^:+]+)\+advisory/', '$1', $connection));
 
             case str_starts_with($connection, 'mysql+advisory://'):
-                throw new InvalidArgumentException('The "mysql+advisory://" scheme is not supported, use a PDO DSN such as "mysql+advisory:host=localhost;dbname=app".');
+            case str_starts_with($connection, 'mysql2+advisory://'):
+                return new DoctrineDbalMysqlStore($connection);
+
             case str_starts_with($connection, 'mysql+advisory:'):
                 return new MysqlStore(preg_replace('/^([^:+]+)\+advisory/', '$1', $connection));
 

--- a/src/Symfony/Component/Lock/Tests/Store/DoctrineDbalMysqlStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/DoctrineDbalMysqlStoreTest.php
@@ -1,0 +1,338 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Lock\Tests\Store;
+
+use Doctrine\DBAL\Configuration;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Exception as DBALException;
+use Doctrine\DBAL\Platforms\MariaDBPlatform;
+use Doctrine\DBAL\Schema\DefaultSchemaManagerFactory;
+use Doctrine\DBAL\Tools\DsnParser;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+use Symfony\Component\Lock\Exception\InvalidArgumentException;
+use Symfony\Component\Lock\Exception\LockConflictedException;
+use Symfony\Component\Lock\Key;
+use Symfony\Component\Lock\PersistingStoreInterface;
+use Symfony\Component\Lock\Store\DoctrineDbalMysqlStore;
+use Symfony\Component\Lock\Test\AbstractStoreTestCase;
+
+/**
+ * @author Ryan Pon <me@ryanpon.com>
+ */
+#[RequiresPhpExtension('pdo_mysql')]
+#[Group('integration')]
+class DoctrineDbalMysqlStoreTest extends AbstractStoreTestCase
+{
+    use BlockingStoreTestTrait;
+
+    public function createMysqlConnection(array $driverOptions = []): Connection
+    {
+        return self::getDbalConnection(self::getMysqlDsn('pdo-mysql'), $driverOptions);
+    }
+
+    public function getStore(): PersistingStoreInterface
+    {
+        $conn = $this->createMysqlConnection();
+
+        return new DoctrineDbalMysqlStore($conn);
+    }
+
+    #[RequiresPhpExtension('pdo_sqlite')]
+    #[DataProvider('getInvalidDrivers')]
+    public function testInvalidDriver($connOrDsn)
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The adapter "Symfony\Component\Lock\Store\DoctrineDbalMysqlStore" does not support');
+
+        $store = new DoctrineDbalMysqlStore($connOrDsn);
+        $store->exists(new Key('foo'));
+    }
+
+    public static function getInvalidDrivers()
+    {
+        yield ['sqlite:///tmp/foo.db'];
+        yield [self::getDbalConnection('sqlite:///tmp/foo.db')];
+    }
+
+    #[DataProvider('getSupportedServerVersions')]
+    public function testSupportedPlatforms(string $serverVersion)
+    {
+        $this->expectNotToPerformAssertions();
+
+        new DoctrineDbalMysqlStore(DriverManager::getConnection(['driver' => 'pdo_mysql', 'serverVersion' => $serverVersion]));
+    }
+
+    public static function getSupportedServerVersions()
+    {
+        yield 'MySQL' => ['8.0.0'];
+        yield 'MariaDB' => ['10.6.0-MariaDB'];
+    }
+
+    public function testSaveAfterConflict()
+    {
+        $store1 = $this->getStore();
+        $store2 = $this->getStore();
+
+        $key = new Key(__METHOD__);
+
+        $store1->save($key);
+        $this->assertTrue($store1->exists($key));
+
+        $lockConflicted = false;
+        try {
+            $store2->save($key);
+        } catch (LockConflictedException $lockConflictedException) {
+            $lockConflicted = true;
+        }
+
+        $this->assertTrue($lockConflicted);
+        $this->assertFalse($store2->exists($key));
+
+        $store1->delete($key);
+
+        $store2->save($key);
+        $this->assertTrue($store2->exists($key));
+    }
+
+    public function testWaitAndSaveAfterConflictReleasesLockFromInternalStore()
+    {
+        $store1 = $this->getStore();
+        $conn = $this->createMysqlConnection();
+        $store2 = new DoctrineDbalMysqlStore($conn);
+
+        $store1Key = new Key(__METHOD__);
+
+        $store1->save($store1Key);
+
+        // set a low time out then try to wait and save, which will fail
+        // because the key is already set above.
+        self::setStatementTimeout($conn, 0.001);
+        $waitSaveError = null;
+        try {
+            $store2->waitAndSave(new Key(__METHOD__));
+        } catch (DBALException $waitSaveError) {
+        }
+        $this->assertInstanceOf(DBALException::class, $waitSaveError, 'waitAndSave should have thrown');
+        self::setStatementTimeout($conn, 0);
+
+        $store1->delete($store1Key);
+        $this->assertFalse($store1->exists($store1Key));
+
+        $store2Key = new Key(__METHOD__);
+        $lockConflicted = false;
+        try {
+            $store2->waitAndSave($store2Key);
+        } catch (LockConflictedException $lockConflictedException) {
+            $lockConflicted = true;
+        }
+
+        $this->assertFalse($lockConflicted, 'lock should be available now that its been remove from $store1');
+        $this->assertTrue($store2->exists($store2Key));
+    }
+
+    public function testOtherConnConflictException()
+    {
+        $storeA = $this->getStore();
+        $storeB = $this->getStore();
+
+        $key = new Key('foo');
+        $storeA->save($key);
+
+        $this->assertFalse($storeB->exists($key));
+
+        try {
+            $storeB->save($key);
+            $this->fail('Expected exception: '.LockConflictedException::class);
+        } catch (LockConflictedException $e) {
+            $this->assertStringContainsString('acquired by other', $e->getMessage());
+        }
+    }
+
+    public function testExistsOnKeyClone()
+    {
+        $store = $this->getStore();
+
+        $key = new Key('foo');
+        $store->save($key);
+
+        $this->assertTrue($store->exists($key));
+        $this->assertTrue($store->exists(clone $key));
+    }
+
+    public function testDeleteKeyWhileNotOwned()
+    {
+        $store = $this->getStore();
+
+        $keyA = new Key('foo');
+        $keyB = new Key('foo');
+
+        $store->save($keyA); // OK
+        try {
+            $store->save($keyB); // Conflict
+            $this->fail('The store shouldn\'t save the second key');
+        } catch (LockConflictedException $e) {
+        }
+
+        $store->delete($keyB);
+        $this->assertTrue($store->exists($keyA));
+        $this->assertFalse($store->exists($keyB));
+    }
+
+    public function testStoresAreStateless()
+    {
+        $conn = $this->createMysqlConnection();
+
+        $storeA = new DoctrineDbalMysqlStore($conn);
+        $storeB = new DoctrineDbalMysqlStore($conn);
+        $key = new Key('foo');
+
+        $storeA->save($key);
+        $this->assertTrue($storeA->exists($key));
+        $this->assertTrue($storeB->exists($key));
+
+        $storeB->delete($key);
+        $this->assertFalse($storeB->exists($key));
+        $this->assertFalse($storeA->exists($key));
+    }
+
+    public function testDsnConstructor()
+    {
+        $this->expectNotToPerformAssertions();
+
+        $store = new DoctrineDbalMysqlStore(self::getMysqlDsn('mysql+advisory'));
+        $store->save(new Key('foo'));
+    }
+
+    public function testStringifiedFetches()
+    {
+        $conn = $this->createMysqlConnection([\PDO::ATTR_STRINGIFY_FETCHES => true]);
+        $store = new DoctrineDbalMysqlStore($conn);
+
+        $key = new Key('foo');
+        $store->save($key);
+        $this->assertTrue($store->exists($key));
+        $store->delete($key);
+        $this->assertFalse($store->exists($key));
+    }
+
+    public function testNativePreparedStatements()
+    {
+        $conn = $this->createMysqlConnection([\PDO::ATTR_EMULATE_PREPARES => false]);
+        $store = new DoctrineDbalMysqlStore($conn);
+
+        $key = new Key('foo');
+        $store->save($key);
+        $this->assertTrue($store->exists($key));
+        $store->delete($key);
+        $this->assertFalse($store->exists($key));
+    }
+
+    public function testPutOffExpirationWhenLockIsLost()
+    {
+        $conn = $this->createMysqlConnection();
+        $store = new DoctrineDbalMysqlStore($conn);
+
+        $key = new Key('foo');
+        $store->save($key);
+
+        $conn->executeStatement(\sprintf("DO RELEASE_LOCK('%s')", hash('sha256', (string) $key)));
+
+        $this->expectException(LockConflictedException::class);
+        $store->putOffExpiration($key, 300.0);
+    }
+
+    public function testDeleteReleasesTheResourceWhenLockIsLost()
+    {
+        $conn = $this->createMysqlConnection();
+        $store = new DoctrineDbalMysqlStore($conn);
+
+        $key = new Key('foo');
+        $store->save($key);
+
+        $conn->executeStatement(\sprintf("DO RELEASE_LOCK('%s')", hash('sha256', (string) $key)));
+        $store->delete($key);
+
+        $newKey = new Key('foo');
+        $store->save($newKey);
+
+        $this->assertTrue($store->exists($newKey));
+    }
+
+    public function testResourcesDifferingOnlyByCase()
+    {
+        $store = $this->getStore();
+
+        $keyLower = new Key('foo');
+        $keyUpper = new Key('FOO');
+
+        $store->save($keyLower);
+
+        $store->save($keyUpper);
+        $this->assertTrue($store->exists($keyUpper));
+        $store->delete($keyUpper);
+
+        $this->assertFalse($store->exists($keyUpper));
+        $this->assertTrue($store->exists($keyLower));
+
+        $storeB = $this->getStore();
+        try {
+            $storeB->save(new Key('foo'));
+            $this->fail('The lock held by $keyLower was released by another key');
+        } catch (LockConflictedException) {
+            $this->addToAssertionCount(1);
+        }
+    }
+
+    private static function getMysqlDsn(string $scheme): string
+    {
+        if (!$host = getenv('MYSQL_HOST')) {
+            self::markTestSkipped('Missing MYSQL_HOST env variable');
+        }
+
+        if (!$user = getenv('MYSQL_USERNAME')) {
+            self::markTestSkipped('Missing MYSQL_USERNAME env variable');
+        }
+
+        if (!$pass = getenv('MYSQL_PASSWORD')) {
+            self::markTestSkipped('Missing MYSQL_PASSWORD env variable');
+        }
+
+        return \sprintf('%s://%s:%s@%s', $scheme, $user, $pass, $host);
+    }
+
+    /**
+     * MySQL expresses the statement timeout in milliseconds, MariaDB in seconds.
+     */
+    private static function setStatementTimeout(Connection $conn, float $seconds): void
+    {
+        if ($conn->getDatabasePlatform() instanceof MariaDBPlatform) {
+            $conn->executeStatement(\sprintf('SET SESSION max_statement_time=%F', $seconds));
+        } else {
+            $conn->executeStatement(\sprintf('SET SESSION max_execution_time=%d', 1000 * $seconds));
+        }
+    }
+
+    private static function getDbalConnection(string $dsn, array $driverOptions = []): Connection
+    {
+        $params = (new DsnParser(['sqlite' => 'pdo_sqlite']))->parse($dsn);
+        if ($driverOptions) {
+            $params['driverOptions'] = $driverOptions;
+        }
+        $config = new Configuration();
+        $config->setSchemaManagerFactory(new DefaultSchemaManagerFactory());
+
+        return DriverManager::getConnection($params, $config);
+    }
+}

--- a/src/Symfony/Component/Lock/Tests/Store/MysqlStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/MysqlStoreTest.php
@@ -24,6 +24,8 @@ use Symfony\Component\Lock\Test\AbstractStoreTestCase;
 #[Group('integration')]
 class MysqlStoreTest extends AbstractStoreTestCase
 {
+    use BlockingStoreTestTrait;
+
     protected function getEnv(): array
     {
         if (!$dsn = getenv('MYSQL_DSN')) {

--- a/src/Symfony/Component/Lock/Tests/Store/StoreFactoryTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/StoreFactoryTest.php
@@ -19,7 +19,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Cache\Adapter\AbstractAdapter;
 use Symfony\Component\Cache\Adapter\MemcachedAdapter;
 use Symfony\Component\Lock\Bridge\DynamoDb\Store\DynamoDbStore;
-use Symfony\Component\Lock\Exception\InvalidArgumentException;
+use Symfony\Component\Lock\Store\DoctrineDbalMysqlStore;
 use Symfony\Component\Lock\Store\DoctrineDbalPostgreSqlStore;
 use Symfony\Component\Lock\Store\DoctrineDbalStore;
 use Symfony\Component\Lock\Store\FlockStore;
@@ -44,14 +44,6 @@ class StoreFactoryTest extends TestCase
         $store = StoreFactory::createStore($connection);
 
         $this->assertInstanceOf($expectedStoreClass, $store);
-    }
-
-    public function testCreateStoreRejectsMysqlAdvisoryUrl()
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The "mysql+advisory://" scheme is not supported, use a PDO DSN such as "mysql+advisory:host=localhost;dbname=app".');
-
-        StoreFactory::createStore('mysql+advisory://user:pass@localhost:3306/test');
     }
 
     #[RequiresPhpExtension('sysvsem')]
@@ -107,6 +99,8 @@ class StoreFactoryTest extends TestCase
             yield ['sqlite3:///tmp/test', DoctrineDbalStore::class];
             yield ['oci8://server.com/test', DoctrineDbalStore::class];
             yield ['mssql://server.com/test', DoctrineDbalStore::class];
+            yield ['mysql+advisory://server.com/test', DoctrineDbalMysqlStore::class];
+            yield ['mysql2+advisory://server.com/test', DoctrineDbalMysqlStore::class];
             yield ['pgsql+advisory://server.com/test', DoctrineDbalPostgreSqlStore::class];
             yield ['postgres+advisory://server.com/test', DoctrineDbalPostgreSqlStore::class];
             yield ['postgresql+advisory://server.com/test', DoctrineDbalPostgreSqlStore::class];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Adds `DoctrineDbalMysqlStore`, a lock store that uses MySQL advisory locks (`GET_LOCK()`, `RELEASE_LOCK()`, `IS_USED_LOCK()`) through a Doctrine DBAL `Connection`, and gives the existing PDO-based `MysqlStore` the same blocking capability so that both MySQL stores expose the same feature set.

### What the store does

The lock is a named lock held by the database session. `save()` calls `GET_LOCK()` with a timeout of `0`, so it fails immediately when another session holds the lock. `waitAndSave()` calls it with `-1`, so it blocks until the lock becomes free. `delete()` calls `RELEASE_LOCK()`, and `exists()` compares `IS_USED_LOCK()` against `CONNECTION_ID()` to tell "held by me" from "held by someone else".

Resource names are hashed with SHA-256 before being sent to the server, which works around the 64-character limit MySQL puts on lock names and the case-insensitive comparison MariaDB applies to them. An in-memory store, keyed on the DBAL connection through a `WeakMap`, keeps the per-connection bookkeeping so that two `Key` objects for the same resource on the same connection still conflict with each other, the way callers expect.

Locks never expire on the server, so `putOffExpiration()` only checks that the lock is still held and throws `LockConflictedException` when it is not.

### DSN schemes

`StoreFactory::createStore()` routes to the new store for the two URL-style schemes:

- `mysql+advisory://user:pass@host/db`
- `mysql2+advisory://user:pass@host/db` (`mysql2` is the Amazon RDS alias already accepted elsewhere in the component)

The PDO-style DSN `mysql+advisory:host=localhost;dbname=app` keeps routing to `MysqlStore`, exactly like the PostgreSQL pair, where `pgsql+advisory://...` reaches `DoctrineDbalPostgreSqlStore` and `pgsql+advisory:host=...` reaches `PostgreSqlStore`. Before this change the URL form threw an `InvalidArgumentException` telling the user to switch to a PDO DSN.

### Differences from the neighbouring stores

Compared to `MysqlStore`, this one takes a Doctrine DBAL `Connection` (or a URL that DBAL can parse) instead of a `\PDO` instance, so an application already using DBAL can hand over its own connection. The SQL is identical apart from parameter binding: DBAL allows the same named placeholder twice, PDO does not once `ATTR_EMULATE_PREPARES` is off, which is why the PDO version binds the lock name under two names.

Compared to `DoctrineDbalPostgreSqlStore`, this store implements `BlockingStoreInterface` only, not `BlockingSharedLockStoreInterface`. MySQL has no equivalent of `pg_advisory_lock_shared`, so there is nothing to build read locks on.

`MysqlStore` gains `waitAndSave()` in this PR and now implements `BlockingStoreInterface` as well, so the choice between PDO and DBAL is no longer a choice between blocking and non-blocking acquisition. `MysqlStore` is unreleased (it landed on 8.2 too), so this is not a BC concern.

### Caveats

**No shared or read locks.** Since neither MySQL store implements `SharedLockStoreInterface`, `Lock::acquireRead()` silently degrades to an exclusive lock instead of failing. Code that relies on readers not blocking readers needs a different store.

**Use a connection dedicated to locking.** Advisory locks are scoped to the database session. `RELEASE_ALL_LOCKS()`, `EntityManager::close()`, a `wait_timeout` expiration or a transparent DBAL reconnection all drop every lock the session holds, and nothing in the store detects it. Sharing the application's main connection with the lock store is asking for silently lost locks.

### Version requirements

MySQL 5.7.5 or MariaDB 10.0.2 and later. Those are the versions where a session can hold several named locks at once; on older servers acquiring a lock releases the previous one, which breaks the store. Both stores are documented and tested against MySQL and MariaDB. The class accepts any DBAL `AbstractMySQLPlatform`, which covers both `MySQLPlatform` and `MariaDBPlatform`.

### Documentation

A symfony-docs pull request should cover, alongside the existing `MysqlStore` page (symfony-docs 22440):

- the `mysql+advisory://` and `mysql2+advisory://` DSN schemes and which store each DSN form reaches
- passing an existing DBAL `Connection` instead of a DSN
- the MySQL 5.7.5 / MariaDB 10.0.2 minimum
- that shared and read locks are not supported, and that `acquireRead()` therefore returns an exclusive lock
- that the connection should be dedicated to locking, with the session-scoped caveat spelled out
- that `MysqlStore` now supports blocking acquisition
