### PR TITLE
[Messenger] Add AMQP transport keepalive support

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Amqp/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Implement the `KeepaliveReceiverInterface` to enable asynchronously notifying AMQP that the job is still being processed, in order to avoid timeouts
+
 8.1
 ---
 

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpReceiverTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpReceiverTest.php
@@ -21,6 +21,7 @@ use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
 use Symfony\Component\Messenger\Exception\TransportException;
 use Symfony\Component\Messenger\Stamp\TransportMessageIdStamp;
+use Symfony\Component\Messenger\Transport\Receiver\KeepaliveReceiverInterface;
 use Symfony\Component\Messenger\Transport\Serialization\Serializer;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 use Symfony\Component\Serializer as SerializerComponent;
@@ -106,6 +107,33 @@ class AmqpReceiverTest extends TestCase
 
         $receiver = new AmqpReceiver($connection, $serializer);
         $receiver->reject(new Envelope(new \stdClass(), [new AmqpReceivedStamp($amqpEnvelope, 'queueName')]));
+    }
+
+    public function testItSupportsKeepalive()
+    {
+        $this->assertInstanceOf(KeepaliveReceiverInterface::class, new AmqpReceiver($this->createStub(Connection::class)));
+    }
+
+    public function testItKeepsReceivedMessageAlive()
+    {
+        $amqpEnvelope = $this->createAMQPEnvelope();
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->once())->method('keepalive');
+
+        $receiver = new AmqpReceiver($connection, $this->createStub(SerializerInterface::class));
+        $receiver->keepalive(new Envelope(new \stdClass(), [new AmqpReceivedStamp($amqpEnvelope, 'queueName')]));
+    }
+
+    public function testItThrowsATransportExceptionIfItCannotKeepMessageAlive()
+    {
+        $this->expectException(TransportException::class);
+
+        $amqpEnvelope = $this->createAMQPEnvelope();
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->once())->method('keepalive')->willThrowException(new \AMQPException());
+
+        $receiver = new AmqpReceiver($connection, $this->createStub(SerializerInterface::class));
+        $receiver->keepalive(new Envelope(new \stdClass(), [new AmqpReceivedStamp($amqpEnvelope, 'queueName')]));
     }
 
     public function testTransportMessageIdStampIsCreatedWhenMessageIdIsSet()

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpTransportTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpTransportTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Messenger\Bridge\Amqp\Tests\Transport;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Bridge\Amqp\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Messenger\Bridge\Amqp\Transport\AmqpReceivedStamp;
 use Symfony\Component\Messenger\Bridge\Amqp\Transport\AmqpTransport;
 use Symfony\Component\Messenger\Bridge\Amqp\Transport\Connection;
 use Symfony\Component\Messenger\Envelope;
@@ -49,6 +50,18 @@ class AmqpTransportTest extends TestCase
 
         $envelopes = iterator_to_array($transport->get());
         $this->assertSame($decodedMessage, $envelopes[0]->getMessage());
+    }
+
+    public function testKeepalive()
+    {
+        $transport = $this->getTransport(
+            null,
+            $connection = $this->createMock(Connection::class),
+        );
+
+        $connection->expects($this->once())->method('keepalive');
+
+        $transport->keepalive(new Envelope(new DummyMessage('foo'), [new AmqpReceivedStamp($this->createStub(\AMQPEnvelope::class), 'queueName')]));
     }
 
     private function getTransport(?SerializerInterface $serializer = null, ?Connection $connection = null): AmqpTransport

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/ConnectionTest.php
@@ -530,6 +530,21 @@ class ConnectionTest extends TestCase
         $connection->publish('body');
     }
 
+    public function testItKeepsConnectionAlive()
+    {
+        $factory = new TestAmqpFactory(
+            $this->createStub(\AMQPConnection::class),
+            $amqpChannel = $this->createMock(\AMQPChannel::class),
+            $this->createStub(\AMQPQueue::class),
+            $this->createStub(\AMQPExchange::class)
+        );
+
+        $amqpChannel->expects($this->once())->method('qos')->with(0, 0);
+
+        $connection = Connection::fromDsn('amqp://localhost', [], $factory);
+        $connection->keepalive();
+    }
+
     public function testAutoSetupWithDelayDeclaresExchangeQueuesAndDelay()
     {
         $amqpConnection = $this->createStub(\AMQPConnection::class);
@@ -662,7 +677,6 @@ class ConnectionTest extends TestCase
 
         $connection->publish('{}', ['x-some-headers' => 'foo'], 5000);
     }
-
 
     public function testItDelaysTheMessageWithADifferentRoutingKeyAndTTLs()
     {

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpReceiver.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpReceiver.php
@@ -16,6 +16,7 @@ use Symfony\Component\Messenger\Exception\LogicException;
 use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
 use Symfony\Component\Messenger\Exception\TransportException;
 use Symfony\Component\Messenger\Stamp\TransportMessageIdStamp;
+use Symfony\Component\Messenger\Transport\Receiver\KeepaliveReceiverInterface;
 use Symfony\Component\Messenger\Transport\Receiver\MessageCountAwareInterface;
 use Symfony\Component\Messenger\Transport\Receiver\QueueReceiverInterface;
 use Symfony\Component\Messenger\Transport\Serialization\PhpSerializer;
@@ -26,7 +27,7 @@ use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
  *
  * @author Samuel Roze <samuel.roze@gmail.com>
  */
-class AmqpReceiver implements QueueReceiverInterface, MessageCountAwareInterface
+class AmqpReceiver implements QueueReceiverInterface, KeepaliveReceiverInterface, MessageCountAwareInterface
 {
     private SerializerInterface $serializer;
 
@@ -151,6 +152,21 @@ class AmqpReceiver implements QueueReceiverInterface, MessageCountAwareInterface
             $stamp->getAmqpEnvelope(),
             $stamp->getQueueName()
         );
+    }
+
+    /**
+     * AMQP has no per-message deadline to extend, so $seconds is not used: the
+     * frame sent here only tells the broker that the connection is still alive.
+     */
+    public function keepalive(Envelope $envelope, ?int $seconds = null): void
+    {
+        try {
+            $this->findAmqpStamp($envelope);
+
+            $this->connection->keepalive();
+        } catch (\AMQPException $e) {
+            throw new TransportException($e->getMessage(), 0, $e);
+        }
     }
 
     public function getMessageCount(): int

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpTransport.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpTransport.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Messenger\Bridge\Amqp\Transport;
 
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Transport\CloseableTransportInterface;
+use Symfony\Component\Messenger\Transport\Receiver\KeepaliveReceiverInterface;
 use Symfony\Component\Messenger\Transport\Receiver\MessageCountAwareInterface;
 use Symfony\Component\Messenger\Transport\Receiver\QueueReceiverInterface;
 use Symfony\Component\Messenger\Transport\Serialization\PhpSerializer;
@@ -23,7 +24,7 @@ use Symfony\Component\Messenger\Transport\TransportInterface;
 /**
  * @author Nicolas Grekas <p@tchwork.com>
  */
-class AmqpTransport implements QueueReceiverInterface, TransportInterface, SetupableTransportInterface, CloseableTransportInterface, MessageCountAwareInterface
+class AmqpTransport implements QueueReceiverInterface, TransportInterface, SetupableTransportInterface, CloseableTransportInterface, KeepaliveReceiverInterface, MessageCountAwareInterface
 {
     private SerializerInterface $serializer;
     private AmqpReceiver $receiver;
@@ -64,6 +65,11 @@ class AmqpTransport implements QueueReceiverInterface, TransportInterface, Setup
     public function reject(Envelope $envelope): void
     {
         $this->getReceiver()->reject($envelope);
+    }
+
+    public function keepalive(Envelope $envelope, ?int $seconds = null): void
+    {
+        $this->getReceiver()->keepalive($envelope, $seconds);
     }
 
     public function send(Envelope $envelope): Envelope

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
@@ -486,6 +486,13 @@ class Connection
         }
     }
 
+    public function keepalive(): void
+    {
+        // qos() with no limit changes nothing on the channel, it is sent for the traffic it generates
+        $this->channel()->qos(0, 0);
+        $this->lastActivityTime = time();
+    }
+
     public function setup(): void
     {
         $this->setupExchangeAndQueues();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #64554
| License       | MIT

The AMQP transport now implements `KeepaliveReceiverInterface`, so `messenger:consume --keepalive` works with it, like it already does with the Doctrine, Beanstalkd, Redis and Amazon SQS transports:

```
php bin/console messenger:consume async --keepalive
```

While a handler runs, the worker periodically calls `keepalive()` on the transport. For AMQP that sends a frame on the channel, which tells the broker the connection is still in use. Without it, a handler slower than the broker's own timeout can have its connection closed under it, and the message is redelivered.

Note that AMQP has no per-message deadline to extend, unlike Beanstalkd or Amazon SQS. The `$seconds` argument is therefore not used: the call keeps the connection alive, not the message reservation. Setting `--keepalive=30` still controls how often the worker calls it.

Points for the documentation:

* the AMQP transport can now be listed among the transports supporting `--keepalive`
* for AMQP the option keeps the connection alive, it does not extend a per-message deadline
* it addresses brokers closing idle connections during long running handlers, RabbitMQ's `consumer_timeout` being the usual case
