### PR TITLE
[PropertyInfo] Do not trigger legacy Type deprecation on getType()

### DIFF
--- a/src/Symfony/Component/PropertyInfo/PropertyInfoCacheExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyInfoCacheExtractor.php
@@ -67,7 +67,7 @@ class PropertyInfoCacheExtractor implements PropertyInfoExtractorInterface, Prop
                 return $this->propertyInfoExtractor->getType($class, $property, $context);
             }
 
-            return LegacyTypeConverter::toTypeInfoType($this->propertyInfoExtractor->getTypes($class, $property, $context));
+            return LegacyTypeConverter::fromLegacy(fn () => $this->propertyInfoExtractor->getTypes($class, $property, $context));
         }
 
         // Calling rawurlencode escapes special characters not allowed in PSR-6's keys
@@ -86,7 +86,7 @@ class PropertyInfoCacheExtractor implements PropertyInfoExtractorInterface, Prop
         if (method_exists($this->propertyInfoExtractor, 'getType')) {
             $value = $this->propertyInfoExtractor->getType($class, $property, $context);
         } else {
-            $value = LegacyTypeConverter::toTypeInfoType($this->propertyInfoExtractor->getTypes($class, $property, $context));
+            $value = LegacyTypeConverter::fromLegacy(fn () => $this->propertyInfoExtractor->getTypes($class, $property, $context));
         }
 
         $item->set($value);

--- a/src/Symfony/Component/PropertyInfo/PropertyInfoExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyInfoExtractor.php
@@ -58,10 +58,10 @@ class PropertyInfoExtractor implements PropertyInfoExtractorInterface, PropertyI
     {
         foreach ($this->typeExtractors as $extractor) {
             if (!method_exists($extractor, 'getType')) {
-                $legacyTypes = $extractor->getTypes($class, $property, $context);
-
-                if (null !== $legacyTypes) {
-                    return LegacyTypeConverter::toTypeInfoType($legacyTypes);
+                // BC layer for PropertyTypeExtractorInterface::getTypes().
+                // Can be removed as soon as PropertyTypeExtractorInterface::getTypes() is removed (8.0).
+                if (null !== $value = LegacyTypeConverter::fromLegacy(static fn () => $extractor->getTypes($class, $property, $context))) {
+                    return $value;
                 }
 
                 continue;

--- a/src/Symfony/Component/PropertyInfo/Tests/PropertyInfoExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/PropertyInfoExtractorTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\ParentDummy;
+use Symfony\Component\PropertyInfo\Type as LegacyType;
 use Symfony\Component\TypeInfo\Type;
 
 /**
@@ -83,5 +84,38 @@ class PropertyInfoExtractorTest extends AbstractPropertyInfoExtractorTest
         yield ['noDocBlock', null];
         yield ['listOfStrings', Type::array(Type::string(), Type::int())];
         yield ['parentAnnotation', Type::object(ParentDummy::class)];
+    }
+
+    public function testGetTypeConvertsTypesFromGetTypesOnlyExtractor()
+    {
+        $propertyInfoExtractor = new PropertyInfoExtractor([], [new class implements PropertyTypeExtractorInterface {
+            public function getTypes(string $class, string $property, array $context = []): ?array
+            {
+                return [new LegacyType(LegacyType::BUILTIN_TYPE_STRING)];
+            }
+        }]);
+
+        $deprecations = [];
+        set_error_handler(static function (int $type, string $message) use (&$deprecations): bool {
+            if (\E_USER_DEPRECATED === $type) {
+                $deprecations[] = $message;
+            }
+
+            return true;
+        });
+
+        try {
+            $type = $propertyInfoExtractor->getType(Dummy::class, 'bar');
+            $deprecationsAfterExtraction = $deprecations;
+
+            // a direct use must still be reported
+            new LegacyType(LegacyType::BUILTIN_TYPE_INT);
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertEquals(Type::string(), $type);
+        $this->assertSame([], $deprecationsAfterExtraction);
+        $this->assertCount(1, $deprecations);
     }
 }

--- a/src/Symfony/Component/PropertyInfo/Tests/Util/LegacyTypeConverterTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Util/LegacyTypeConverterTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Tests\Util;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\PropertyInfo\Type as LegacyType;
+use Symfony\Component\PropertyInfo\Util\LegacyTypeConverter;
+use Symfony\Component\TypeInfo\Type;
+
+class LegacyTypeConverterTest extends TestCase
+{
+    public function testFromLegacyConvertsProvidedLegacyTypes()
+    {
+        $this->assertEquals(
+            Type::string(),
+            LegacyTypeConverter::fromLegacy(static fn () => [new LegacyType(LegacyType::BUILTIN_TYPE_STRING)]),
+        );
+    }
+
+    public function testFromLegacyReturnsNullWhenProviderReturnsNull()
+    {
+        $this->assertNull(LegacyTypeConverter::fromLegacy(static fn () => null));
+    }
+
+    public function testFromLegacySilencesLegacyTypeClassDeprecation()
+    {
+        $deprecations = [];
+        $prev = set_error_handler(static function ($type, $message) use (&$deprecations) {
+            if (\E_USER_DEPRECATED === $type) {
+                $deprecations[] = $message;
+            }
+
+            return true;
+        });
+
+        try {
+            LegacyTypeConverter::fromLegacy(static fn () => [new LegacyType(LegacyType::BUILTIN_TYPE_INT)]);
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertSame([], $deprecations);
+    }
+
+    public function testFromLegacyForwardsUnrelatedDeprecations()
+    {
+        $deprecations = [];
+        $prev = set_error_handler(static function ($type, $message) use (&$deprecations) {
+            if (\E_USER_DEPRECATED === $type) {
+                $deprecations[] = $message;
+            }
+
+            return true;
+        });
+
+        try {
+            LegacyTypeConverter::fromLegacy(static function () {
+                @trigger_error('Some unrelated deprecation.', \E_USER_DEPRECATED);
+
+                return [new LegacyType(LegacyType::BUILTIN_TYPE_INT)];
+            });
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertSame(['Some unrelated deprecation.'], $deprecations);
+    }
+}

--- a/src/Symfony/Component/PropertyInfo/Type.php
+++ b/src/Symfony/Component/PropertyInfo/Type.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Component\PropertyInfo;
 
-trigger_deprecation('symfony/property-info', '7.3', 'The "%s" class is deprecated. Use "%s" class from "symfony/type-info" instead.', Type::class, \Symfony\Component\TypeInfo\Type::class);
-
 /**
  * Type value object (immutable).
  *
@@ -84,6 +82,8 @@ class Type
         array|self|null $collectionKeyType = null,
         array|self|null $collectionValueType = null,
     ) {
+        trigger_deprecation('symfony/property-info', '7.3', 'The "%s" class is deprecated. Use "%s" class from "symfony/type-info" instead.', self::class, \Symfony\Component\TypeInfo\Type::class);
+
         if (!\in_array($builtinType, self::$builtinTypes, true)) {
             throw new \InvalidArgumentException(\sprintf('"%s" is not a valid PHP type.', $builtinType));
         }

--- a/src/Symfony/Component/PropertyInfo/Util/LegacyTypeConverter.php
+++ b/src/Symfony/Component/PropertyInfo/Util/LegacyTypeConverter.php
@@ -20,6 +20,28 @@ use Symfony\Component\TypeInfo\Type;
 class LegacyTypeConverter
 {
     /**
+     * Silences the legacy Type deprecation while the bridge builds types the caller never asked for.
+     *
+     * @param callable():(LegacyType[]|null) $legacyTypesProvider
+     */
+    public static function fromLegacy(callable $legacyTypesProvider): ?Type
+    {
+        $prevErrorHandler = set_error_handler(static function ($type, $message, $file, $line) use (&$prevErrorHandler) {
+            if (\E_USER_DEPRECATED === $type && str_contains($message, '"'.LegacyType::class.'" class is deprecated')) {
+                return true;
+            }
+
+            return $prevErrorHandler ? $prevErrorHandler($type, $message, $file, $line) : false;
+        });
+
+        try {
+            return self::toTypeInfoType($legacyTypesProvider());
+        } finally {
+            restore_error_handler();
+        }
+    }
+
+    /**
      * @param LegacyType[]|null $legacyTypes
      */
     public static function toTypeInfoType(?array $legacyTypes): ?Type


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64969
| License       | MIT

An application that registers a property type extractor implementing only the deprecated `getTypes()` was told that `Symfony\Component\PropertyInfo\Type` is deprecated, even though it never touched that class. The deprecated call is made by Symfony's own BC bridge inside `PropertyInfoExtractor::getType()`, so there is nothing for the reader to fix.

`LegacyTypeConverter::fromLegacy()` now wraps that bridge and silences the class deprecation while the legacy types are built and converted. Any other deprecation is forwarded to the previous handler.

Changed during review:

* **the deprecation was silenced for the whole process, not just for the bridge.** `trigger_deprecation()` sat at file scope in `Type.php`, so it fired once, when the class was first autoloaded. Whichever code path reached the class first decided whether the process ever saw the notice. If the bridge won that race, an application that genuinely uses `PropertyInfo\Type` was never told to migrate:

  | | 7.4 | first version of the fix | now |
  | --- | --- | --- | --- |
  | bridge call, then the application builds a `Type` itself | 1 notice | **0** | 0, then 1 |
  | application builds a `Type`, then a bridge call | 1 | 1 | 1 |

  Which row an application landed on depended on autoloader order, so the notice became a coin flip. The trigger moved into `Type::__construct()`, which is what the suppression window in `fromLegacy()` actually corresponds to: types the bridge built, rather than the one-shot class load. Building a `Type` directly reports again.

  The non-deprecated path is unaffected: `ReflectionExtractor`, `PhpDocExtractor` and `PhpStanExtractor` never construct a legacy `Type` from `getType()`, and a `getType()` call on a modern extractor does not even load the class;

* **the test proved nothing.** `testGetTypeConvertsTypesFromGetTypesOnlyExtractor()` asserted only the converted value, so it passed unchanged on 7.4. It now asserts the notices on both sides, and fails on each broken state for its own reason:

  ```
  7.4                          Failed asserting that two arrays are identical.
  first version of the fix     Failed asserting that actual size 0 matches expected size 1.
  ```

* **the converter test faked the deprecation** with `trigger_error()`, so it exercised the message filter rather than the behaviour. It builds a real legacy `Type` now;

* dropped the issue link from the test docblock, per the contribution rules on referencing issues in code.

Suites: PropertyInfo 1053, Serializer 1396, Validator 5369, Doctrine bridge 478, all green.

Note for the merge up: `Type.php`, `LegacyTypeConverter` and the `getTypes()` bridges were all removed in 8.0, so nothing here applies above 7.4.
