### PR TITLE
[String] Add missing coverage for negative offsets in indexOfLast()

### DIFF
--- a/src/Symfony/Component/String/Tests/AbstractUnicodeTestCase.php
+++ b/src/Symfony/Component/String/Tests/AbstractUnicodeTestCase.php
@@ -202,9 +202,14 @@ END'],
                 [null, '한국어', '', 0],
                 [1, '한국어', '국', 0],
                 [5, '한국어어어어국국', '어', 0],
-                // see https://bugs.php.net/bug.php?id=74264
+                // these test the fix done in bugs.php.net/74264
                 [15, 'abcdéf12é45abcdéf', 'é', 0],
                 [8, 'abcdéf12é45abcdéf', 'é', -4],
+                // multi-grapheme needle with overlapping matches: ICU still resolves these
+                // too far left without the offset correction in UnicodeString::indexOfLast()
+                [1, 'ééé', 'éé', -1],
+                [1, 'ééé', 'éé', -2],
+                [1, 'éééé', 'éé', -3],
             ]
         );
     }
@@ -223,11 +228,15 @@ END'],
                 [2, 'DÉJÀÀÀÀ', 'jà', 0],
                 [2, 'DÉJÀÀÀÀ', 'jà', -5],
                 [6, 'DÉJÀÀÀÀ!', 'à', -2],
-                // see https://bugs.php.net/bug.php?id=74264
+                // these test the fix done in bugs.php.net/74264
                 [5, 'DÉJÀÀÀÀ', 'à', -2],
                 [15, 'abcdéf12é45abcdéf', 'é', 0],
                 [8, 'abcdéf12é45abcdéf', 'é', -4],
                 [1, 'aςσb', 'ΣΣ', 0],
+                // multi-grapheme needle with overlapping matches: ICU still resolves these
+                // too far left without the offset correction in UnicodeString::indexOfLast()
+                [1, 'ééé', 'éé', -1],
+                [1, 'éééé', 'éé', -3],
             ]
         );
     }

--- a/src/Symfony/Component/String/UnicodeString.php
+++ b/src/Symfony/Component/String/UnicodeString.php
@@ -177,7 +177,9 @@ class UnicodeString extends AbstractUnicodeString
         $string = $this->string;
 
         if (0 > $offset) {
-            // workaround https://bugs.php.net/74264
+            // ICU's grapheme_strrpos() disagrees with mb_strrpos() for multi-grapheme needles at
+            // negative offsets: it truncates the haystack instead of bounding the match start, so
+            // overlapping matches resolve too far left. bugs.php.net/74264 only fixed the single-grapheme case
             if (0 > $offset += grapheme_strlen($needle)) {
                 $string = grapheme_substr($string, 0, $offset);
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The bugs.php.net/74264 that this comment refers to was fixed in PHP 7.4.22 (https://www.php.net/ChangeLog-7.php#7.4.22), so I was thinking about removing the comment and the workaround. Tests would have pass ... but apparently, that fix only solved it for single-grapheme needles. So, after adding more tests for multi-grapheme needles, the workaround must still be present, although with an updated comment to explain why.
