### PR TITLE
[String] Consistently return null for out-of-range offsets

### DIFF
--- a/src/Symfony/Component/String/ByteString.php
+++ b/src/Symfony/Component/String/ByteString.php
@@ -178,7 +178,11 @@ class ByteString extends AbstractString
             return null;
         }
 
-        $i = $this->ignoreCase ? stripos($this->string, $needle, $offset) : strpos($this->string, $needle, $offset);
+        try {
+            $i = $this->ignoreCase ? stripos($this->string, $needle, $offset) : strpos($this->string, $needle, $offset);
+        } catch (\ValueError) {
+            return null;
+        }
 
         return false === $i ? null : $i;
     }
@@ -195,7 +199,11 @@ class ByteString extends AbstractString
             return null;
         }
 
-        $i = $this->ignoreCase ? strripos($this->string, $needle, $offset) : strrpos($this->string, $needle, $offset);
+        try {
+            $i = $this->ignoreCase ? strripos($this->string, $needle, $offset) : strrpos($this->string, $needle, $offset);
+        } catch (\ValueError) {
+            return null;
+        }
 
         return false === $i ? null : $i;
     }

--- a/src/Symfony/Component/String/CodePointString.php
+++ b/src/Symfony/Component/String/CodePointString.php
@@ -126,7 +126,11 @@ class CodePointString extends AbstractUnicodeString
             return null;
         }
 
-        $i = $this->ignoreCase ? mb_stripos($this->string, $needle, $offset, 'UTF-8') : mb_strpos($this->string, $needle, $offset, 'UTF-8');
+        try {
+            $i = $this->ignoreCase ? mb_stripos($this->string, $needle, $offset, 'UTF-8') : mb_strpos($this->string, $needle, $offset, 'UTF-8');
+        } catch (\ValueError) {
+            return null;
+        }
 
         return false === $i ? null : $i;
     }
@@ -143,7 +147,11 @@ class CodePointString extends AbstractUnicodeString
             return null;
         }
 
-        $i = $this->ignoreCase ? mb_strripos($this->string, $needle, $offset, 'UTF-8') : mb_strrpos($this->string, $needle, $offset, 'UTF-8');
+        try {
+            $i = $this->ignoreCase ? mb_strripos($this->string, $needle, $offset, 'UTF-8') : mb_strrpos($this->string, $needle, $offset, 'UTF-8');
+        } catch (\ValueError) {
+            return null;
+        }
 
         return false === $i ? null : $i;
     }

--- a/src/Symfony/Component/String/Tests/AbstractAsciiTestCase.php
+++ b/src/Symfony/Component/String/Tests/AbstractAsciiTestCase.php
@@ -223,6 +223,8 @@ abstract class AbstractAsciiTestCase extends TestCase
             [2, 'abc', 'c', 1],
             [4, 'abacabab', 'ab', 1],
             [4, '123abc', 'b', -3],
+            [null, 'abc', 'b', 10],
+            [null, 'abc', 'b', -10],
         ];
     }
 
@@ -255,6 +257,8 @@ abstract class AbstractAsciiTestCase extends TestCase
             [2, 'ABC', 'c', 2],
             [4, 'ABACaBAB', 'Ab', 1],
             [4, '123abc', 'B', -3],
+            [null, 'ABC', 'b', 10],
+            [null, 'ABC', 'b', -10],
         ];
     }
 
@@ -282,6 +286,8 @@ abstract class AbstractAsciiTestCase extends TestCase
             [57, 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, amet sagittis felis.', 'amet', 0],
             [57, 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, amet sagittis felis.', 'amet', -10],
             [22, 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, amet sagittis felis.', 'amet', -30],
+            [null, 'abc', 'b', 10],
+            [null, 'abc', 'b', -10],
         ];
     }
 
@@ -313,6 +319,8 @@ abstract class AbstractAsciiTestCase extends TestCase
             [57, 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, amet sagittis felis.', 'AmeT', 0],
             [57, 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, amet sagittis felis.', 'aMEt', -10],
             [22, 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, amet sagittis felis.', 'AMET', -30],
+            [null, 'ABC', 'b', 10],
+            [null, 'ABC', 'b', -10],
         ];
     }
 

--- a/src/Symfony/Component/String/UnicodeString.php
+++ b/src/Symfony/Component/String/UnicodeString.php
@@ -180,7 +180,11 @@ class UnicodeString extends AbstractUnicodeString
             $offset = 0;
         }
 
-        $i = $this->ignoreCase ? grapheme_strripos($string, $needle, $offset) : grapheme_strrpos($string, $needle, $offset);
+        try {
+            $i = $this->ignoreCase ? grapheme_strripos($string, $needle, $offset) : grapheme_strrpos($string, $needle, $offset);
+        } catch (\ValueError) {
+            return null;
+        }
 
         return false === $i ? null : $i;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`indexOf()` and `indexOfLast()` disagreed across the three string classes when the offset fell outside the string. Some returned `null`, others threw a `ValueError`:

```php
(new ByteString('abc'))->indexOf('b', 10);       // ValueError
(new CodePointString('abc'))->indexOf('b', 10);  // ValueError
(new UnicodeString('abc'))->indexOf('b', 10);    // null
```

Before:

|                                          | `ByteString` | `CodePointString` | `UnicodeString` |
| ---------------------------------------- | ------------ | ----------------- | --------------- |
| `indexOf()`, offset past the end         | `ValueError` | `ValueError`      | `null`          |
| `indexOf()`, offset before the start     | `ValueError` | `ValueError`      | `null`          |
| `indexOfLast()`, offset past the end     | `ValueError` | `ValueError`      | `ValueError`    |
| `indexOfLast()`, offset before the start | `ValueError` | `ValueError`      | `null`          |

After, every cell is `null`: an offset outside the string means "not found", which is what the `?int` return type already promised.

The cause is an incomplete PHP 8 migration. On PHP 7 these functions returned `false` for an out-of-range offset; PHP 8 made them throw. #38128 and #38144 taught `UnicodeString::indexOf()` and `slice()` to catch that and keep reporting "not found", but the other five call sites were left alone. They now do the same.

The four data providers in `AbstractAsciiTestCase` gained the two out-of-range cases, so all three implementations are asserted through the shared test case rather than one of them.
