### PR TITLE
[DependencyInjection] Dump container interface stub

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.2
 ---
 
+ * Generate a `stub/ContainerInterface.php` file in the container build directory to help static analysis tools infer public service types
  * Allow computing tag attributes per tagged service when using `#[AutoconfigureTag]`, `#[Autoconfigure]` or `_instanceof`: pass a `\Closure` receiving the concrete class-string (requires PHP 8.5), or a `[class-string, method]` callable resolved against each concrete class (works on PHP 8.4)
  * Call `#[Required]` methods in the order defined by the attribute's `$priority` argument
 

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -124,6 +124,7 @@ class PhpDumper extends Dumper
      *  * base_class: The base class name
      *  * namespace:  The class namespace
      *  * as_files:   To split the container in several files
+     *  * container_stub: To dump a ContainerInterface static analysis stub
      *
      * @return string|array A PHP class representing the service container or an array of PHP files if the "as_files" option is set
      *
@@ -141,6 +142,7 @@ class PhpDumper extends Dumper
             'base_class' => 'Container',
             'namespace' => '',
             'as_files' => false,
+            'container_stub' => false,
             'debug' => true,
             'hot_path_tag' => 'container.hot_path',
             'preload_tags' => ['container.preload', 'container.no_preload'],
@@ -354,6 +356,10 @@ class PhpDumper extends Dumper
                     EOF;
             }
 
+            if ($options['container_stub']) {
+                $code['stub/ContainerInterface.php'] = $this->generateContainerInterfaceStub();
+            }
+
             $code[$options['class'].'.php'] = <<<EOF
                 <?php
                 {$namespaceLine}
@@ -405,6 +411,106 @@ class PhpDumper extends Dumper
         }
 
         return $code;
+    }
+
+    private function generateContainerInterfaceStub(): string
+    {
+        $types = [];
+
+        foreach ($this->container->getDefinitions() as $id => $definition) {
+            if (!$definition->isPublic() || $definition->isSynthetic() || $definition->isAbstract()) {
+                continue;
+            }
+
+            if (null !== $type = $this->getContainerStubServiceType($definition)) {
+                $types[$id] = $type;
+            }
+        }
+
+        foreach ($this->container->getAliases() as $alias => $target) {
+            if (!$target->isPublic() || $target->isDeprecated()) {
+                continue;
+            }
+
+            if (null !== $type = $this->getContainerStubServiceType($this->container->findDefinition($alias))) {
+                $types[$alias] = $type;
+            }
+        }
+
+        ksort($types);
+
+        $shape = 'array{}';
+        if ($types) {
+            $shape = "array{\n";
+            foreach ($types as $id => $type) {
+                $shape .= \sprintf(" *     '%s': %s,\n", str_replace(['\\', "'"], ['\\\\', "\\'"], $id), $type);
+            }
+            $shape .= ' * }';
+        }
+
+        return <<<EOF
+            <?php
+
+            namespace Symfony\Component\DependencyInjection;
+
+            use Psr\Container\ContainerInterface as PsrContainerInterface;
+            use Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException;
+            use Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException;
+            use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
+
+            /**
+             * @phpstan-type Services {$shape}
+             * @psalm-type Services = {$shape}
+             * @type Services = {$shape}
+             */
+            interface ContainerInterface extends PsrContainerInterface
+            {
+                public const RUNTIME_EXCEPTION_ON_INVALID_REFERENCE = 0;
+                public const EXCEPTION_ON_INVALID_REFERENCE = 1;
+                public const NULL_ON_INVALID_REFERENCE = 2;
+                public const IGNORE_ON_INVALID_REFERENCE = 3;
+                public const IGNORE_ON_UNINITIALIZED_REFERENCE = 4;
+
+                public function set(string \$id, ?object \$service): void;
+
+                /**
+                 * @template T of string
+                 *
+                 * @param T \$id
+                 *
+                 * @return (T is key-of<Services> ? Services[T] : object|null)
+                 *
+                 * @throws ServiceCircularReferenceException
+                 * @throws ServiceNotFoundException
+                 */
+                public function get(string \$id, int \$invalidBehavior = self::EXCEPTION_ON_INVALID_REFERENCE): ?object;
+
+                public function has(string \$id): bool;
+
+                public function initialized(string \$id): bool;
+
+                /**
+                 * @throws ParameterNotFoundException
+                 */
+                public function getParameter(string \$name): array|bool|string|int|float|\UnitEnum|null;
+
+                public function hasParameter(string \$name): bool;
+
+                public function setParameter(string \$name, array|bool|string|int|float|\UnitEnum|null \$value): void;
+            }
+
+            EOF;
+    }
+
+    private function getContainerStubServiceType(Definition $definition): ?string
+    {
+        $class = $this->container->getParameterBag()->resolveValue($definition->getClass());
+
+        if (!\is_string($class) || '' === $class || str_contains($class, '%')) {
+            return null;
+        }
+
+        return '\\'.ltrim($class, '\\');
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Kernel/KernelTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Kernel/KernelTrait.php
@@ -373,6 +373,7 @@ trait KernelTrait
             'base_class' => $baseClass,
             'file' => $cache->getPath(),
             'as_files' => true,
+            'container_stub' => true,
             'debug' => $this->debug,
             'inline_factories' => $buildParameters['.container.dumper.inline_factories'] ?? false,
             'inline_class_loader' => $buildParameters['.container.dumper.inline_class_loader'] ?? $this->debug,

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -2530,6 +2530,24 @@ class PhpDumperTest extends TestCase
         $this->assertStringNotContainsString("'container.build_time' => 0", $dump);
     }
 
+    public function testDumpAsFilesGeneratesContainerInterfaceStub()
+    {
+        $container = new ContainerBuilder();
+        $container->register('foo', \stdClass::class)->setPublic(true);
+        $container->register('private_foo', FooClass::class);
+        $container->setAlias('bar', 'foo')->setPublic(true);
+        $container->compile();
+
+        $dumper = new PhpDumper($container);
+        $dump = $dumper->dump(['as_files' => true, 'container_stub' => true, 'file' => __DIR__]);
+
+        $this->assertArrayHasKey('stub/ContainerInterface.php', $dump);
+        $this->assertStringContainsString("'bar': \\stdClass,", $dump['stub/ContainerInterface.php']);
+        $this->assertStringContainsString("'foo': \\stdClass,", $dump['stub/ContainerInterface.php']);
+        $this->assertStringNotContainsString('private_foo', $dump['stub/ContainerInterface.php']);
+        $this->assertStringContainsString('@return (T is key-of<Services> ? Services[T] : object|null)', $dump['stub/ContainerInterface.php']);
+    }
+
     private static function assertStringEqualsGeneratedFile(string $expectedFile, string $dumpedCode): void
     {
         $expectedFile = self::$fixturesPath.'/php/'.$expectedFile;

--- a/src/Symfony/Component/DependencyInjection/Tests/Kernel/ContainerInterfaceStubTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Kernel/ContainerInterfaceStubTest.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Kernel;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Kernel\AbstractKernel;
+use Symfony\Component\DependencyInjection\Kernel\KernelTrait;
+use Symfony\Component\Filesystem\Filesystem;
+
+class ContainerInterfaceStubTest extends TestCase
+{
+    private string $varDir;
+
+    protected function setUp(): void
+    {
+        $this->varDir = sys_get_temp_dir().'/sf_container_interface_stub_test';
+    }
+
+    protected function tearDown(): void
+    {
+        (new Filesystem())->remove($this->varDir);
+    }
+
+    public function testBootDumpsContainerInterfaceStub()
+    {
+        $kernel = new ContainerStubKernel('test', true, $this->varDir);
+        $kernel->boot();
+
+        $stub = $kernel->getContainer()->getParameter('kernel.build_dir').'/stub/ContainerInterface.php';
+
+        $this->assertFileExists($stub);
+        $contents = file_get_contents($stub);
+        $this->assertStringContainsString("'bar': \\stdClass,", $contents);
+        $this->assertStringContainsString("'foo': \\stdClass,", $contents);
+        $this->assertStringNotContainsString('private_foo', $contents);
+    }
+}
+
+class ContainerStubKernel extends AbstractKernel
+{
+    use KernelTrait {
+        registerBundles as public;
+    }
+
+    public function __construct(string $env, bool $debug, private string $dir)
+    {
+        parent::__construct($env, $debug);
+    }
+
+    public function getProjectDir(): string
+    {
+        return $this->dir;
+    }
+
+    protected function build(ContainerBuilder $container): void
+    {
+        $container->register('foo', \stdClass::class)->setPublic(true);
+        $container->register('private_foo', \stdClass::class);
+        $container->setAlias('bar', 'foo')->setPublic(true);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #64913
| License       | MIT

This adds an opt-in `PhpDumper` option to dump `stub/ContainerInterface.php` next to generated container files, and enables it for kernels so Symfony applications get the stub in their build directory.

The generated stub exposes public, non-synthetic, non-abstract service ids and public aliases as a `Services` array shape for static analysis tools, while keeping private services out of the shape.