### PR TITLE
[DependencyInjection] Allow configuring tags kept by decorators

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.1
 ---
 
+ * Add `$tagsToKeep` argument to `DecoratorServicePass`
  * Support autowiring env vars as closures or `Stringable` when using `#[Autowire(env: 'FOO')]`
  * Add `EnvClosureArgument` and `!env_closure` YAML tag to inject env vars as closures or `Stringable` arguments
  * Add `AddBehaviorDescribingTagsPass` to allow bundles to extend the list of behavior-describing tags

--- a/src/Symfony/Component/DependencyInjection/Compiler/DecoratorServicePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/DecoratorServicePass.php
@@ -27,7 +27,25 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class DecoratorServicePass extends AbstractRecursivePass
 {
+    private const TAGS_TO_KEEP = [
+        'proxy',
+        'container.do_not_inline',
+        'container.service_locator',
+        'container.service_subscriber',
+        'container.service_subscriber.locator',
+    ];
+
     protected bool $skipScalars = true;
+
+    private array $tagsToKeep;
+
+    /**
+     * @param list<string> $tagsToKeep Tags that describe the service instance and must stay on the decorated service
+     */
+    public function __construct(array $tagsToKeep = [])
+    {
+        $this->tagsToKeep = [...self::TAGS_TO_KEEP, ...$tagsToKeep];
+    }
 
     public function process(ContainerBuilder $container): void
     {
@@ -45,7 +63,7 @@ class DecoratorServicePass extends AbstractRecursivePass
 
         // These tags describe how the container wires a concrete service and must stay on the
         // decorated service; role-describing tags (e.g. "kernel.event_listener") move to its decorators.
-        $tagsToKeep = ['proxy', 'container.do_not_inline', 'container.service_locator', 'container.service_subscriber', 'container.service_subscriber.locator'];
+        $tagsToKeep = $this->tagsToKeep;
 
         foreach ($definitions as [$id, $definition]) {
             $decoratedService = $definition->getDecoratedService();

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/DecoratorServicePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/DecoratorServicePassTest.php
@@ -281,6 +281,29 @@ class DecoratorServicePassTest extends TestCase
         $this->assertEquals(['bar' => ['attr' => 'baz'], 'foobar' => ['attr' => 'bar'], 'container.decorator' => [['id' => 'foo', 'inner' => 'baz.inner']]], $container->getDefinition('baz')->getTags());
     }
 
+    public function testProcessLeavesCustomTagsOnOriginalDefinition()
+    {
+        $container = new ContainerBuilder();
+        $container
+            ->register('foo')
+            ->setTags(['logger_aware' => [['method' => 'setLogger']], 'bar' => ['attr' => 'baz']])
+        ;
+        $container
+            ->register('baz')
+            ->setTags(['foobar' => ['attr' => 'bar']])
+            ->setDecoratedService('foo')
+        ;
+
+        (new DecoratorServicePass(['logger_aware']))->process($container);
+
+        $this->assertEquals(['logger_aware' => [['method' => 'setLogger']]], $container->getDefinition('baz.inner')->getTags());
+        $this->assertEquals([
+            'bar' => ['attr' => 'baz'],
+            'foobar' => ['attr' => 'bar'],
+            'container.decorator' => [['id' => 'foo', 'inner' => 'baz.inner']],
+        ], $container->getDefinition('baz')->getTags());
+    }
+
     public function testProcessIgnoresBehaviorDescribingTagsParameter()
     {
         $container = new ContainerBuilder();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64970
| License       | MIT

This adds an optional `$tagsToKeep` argument to `DecoratorServicePass` so standalone container builders can keep custom instance-describing tags on the decorated service.

The default behavior remains unchanged: `container.behavior_describing_tags` is still ignored by this pass, and only explicitly provided tags are merged with the built-in tags kept on the original definition.

Lowest affected branch checked: `6.4`, `7.4`, and `8.0` still read `container.behavior_describing_tags` in `DecoratorServicePass`; `8.1` hardcodes the tags after #64572, so this PR targets `8.1`.
