### PR TITLE
[Notifier][LinkedIn] Add organization author support via DSN option

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/LinkedIn/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/LinkedIn/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add support for posting as a LinkedIn organization via the DSN `author` option
+
 5.3
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/LinkedIn/LinkedInAuthorType.php
+++ b/src/Symfony/Component/Notifier/Bridge/LinkedIn/LinkedInAuthorType.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\LinkedIn;
+
+use Symfony\Component\Notifier\Exception\InvalidArgumentException;
+
+/**
+ * LinkedIn UGC author entity type (person profile or company page).
+ *
+ * @author Mathieu Ledru <matyo91@gmail.com>
+ */
+enum LinkedInAuthorType: string
+{
+    case Person = 'person';
+    case Organization = 'organization';
+
+    public static function fromDsnOption(?string $value): self
+    {
+        if (null === $value || '' === $value) {
+            return self::Person;
+        }
+
+        return self::tryFrom($value) ?? throw new InvalidArgumentException(\sprintf('Invalid LinkedIn DSN author option "%s". Supported values: "person", "organization".', $value));
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/LinkedIn/LinkedInTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/LinkedIn/LinkedInTransport.php
@@ -37,13 +37,19 @@ final class LinkedInTransport extends AbstractTransport
         private string $accountId,
         ?HttpClientInterface $client = null,
         ?EventDispatcherInterface $dispatcher = null,
+        private LinkedInAuthorType $authorType = LinkedInAuthorType::Person,
     ) {
         parent::__construct($client, $dispatcher);
     }
 
     public function __toString(): string
     {
-        return \sprintf('linkedin://%s', $this->getEndpoint());
+        $query = [];
+        if (LinkedInAuthorType::Person !== $this->authorType) {
+            $query['author'] = $this->authorType->value;
+        }
+
+        return \sprintf('linkedin://%s%s', $this->getEndpoint(), $query ? '?'.http_build_query($query) : '');
     }
 
     public function supports(MessageInterface $message): bool
@@ -66,7 +72,7 @@ final class LinkedInTransport extends AbstractTransport
 
         if (!$options && $notification = $message->getNotification()) {
             $options = LinkedInOptions::fromNotification($notification);
-            $options->author(new AuthorShare($this->accountId));
+            $options->author(new AuthorShare($this->accountId, $this->authorType->value));
         }
 
         $endpoint = \sprintf('https://%s/v2/ugcPosts', $this->getEndpoint());
@@ -89,8 +95,8 @@ final class LinkedInTransport extends AbstractTransport
 
         $result = $response->toArray(false);
 
-        if (!$result['id']) {
-            throw new TransportException(\sprintf('Unable to post the Linkedin message: "%s".', $result['error']), $response);
+        if (!isset($result['id']) || '' === $result['id']) {
+            throw new TransportException(\sprintf('Unable to post the Linkedin message: "%s".', $result['error'] ?? 'missing post id'), $response);
         }
 
         $sentMessage = new SentMessage($message, (string) $this);
@@ -115,7 +121,7 @@ final class LinkedInTransport extends AbstractTransport
                 'com.linkedin.ugc.MemberNetworkVisibility' => 'PUBLIC',
             ],
             'lifecycleState' => 'PUBLISHED',
-            'author' => \sprintf('urn:li:person:%s', $this->accountId),
+            'author' => \sprintf('urn:li:%s:%s', $this->authorType->value, $this->accountId),
         ];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/LinkedIn/LinkedInTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/LinkedIn/LinkedInTransportFactory.php
@@ -30,10 +30,12 @@ final class LinkedInTransportFactory extends AbstractTransportFactory
 
         $authToken = $this->getUser($dsn);
         $accountId = $this->getPassword($dsn);
+        $author = $dsn->getOption('author');
+        $authorType = LinkedInAuthorType::fromDsnOption(\is_string($author) ? $author : null);
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new LinkedInTransport($authToken, $accountId, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new LinkedInTransport($authToken, $accountId, $this->client, $this->dispatcher, $authorType))->setHost($host)->setPort($port);
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/LinkedIn/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/LinkedIn/README.md
@@ -12,7 +12,15 @@ LINKEDIN_DSN=linkedin://ACCESS_TOKEN:USER_ID@default
 
 where:
  - `ACCESS_TOKEN` is your LinkedIn access token
- - `USER_ID` is your LinkedIn user id
+ - `USER_ID` is your LinkedIn user id (or organization id when posting as a company page)
+
+To post as a LinkedIn organization (company page), set the optional `author` query parameter:
+
+```
+LINKEDIN_DSN=linkedin://ACCESS_TOKEN:ORGANIZATION_ID@default?author=organization
+```
+
+Supported `author` values are `person` (default) and `organization`.
 
 Sponsor
 -------

--- a/src/Symfony/Component/Notifier/Bridge/LinkedIn/Tests/LinkedInTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/LinkedIn/Tests/LinkedInTransportFactoryTest.php
@@ -12,8 +12,10 @@
 namespace Symfony\Component\Notifier\Bridge\LinkedIn\Tests;
 
 use Symfony\Component\Notifier\Bridge\LinkedIn\LinkedInTransportFactory;
+use Symfony\Component\Notifier\Exception\InvalidArgumentException;
 use Symfony\Component\Notifier\Test\AbstractTransportFactoryTestCase;
 use Symfony\Component\Notifier\Test\IncompleteDsnTestTrait;
+use Symfony\Component\Notifier\Transport\Dsn;
 
 final class LinkedInTransportFactoryTest extends AbstractTransportFactoryTestCase
 {
@@ -29,6 +31,16 @@ final class LinkedInTransportFactoryTest extends AbstractTransportFactoryTestCas
         yield [
             'linkedin://host.test',
             'linkedin://accessToken:UserId@host.test',
+        ];
+
+        yield 'with organization author' => [
+            'linkedin://host.test?author=organization',
+            'linkedin://accessToken:OrganizationId@host.test?author=organization',
+        ];
+
+        yield 'with person author' => [
+            'linkedin://host.test',
+            'linkedin://accessToken:UserId@host.test?author=person',
         ];
     }
 
@@ -46,5 +58,13 @@ final class LinkedInTransportFactoryTest extends AbstractTransportFactoryTestCas
     public static function unsupportedSchemeProvider(): iterable
     {
         yield ['somethingElse://accessToken:UserId@default'];
+    }
+
+    public function testInvalidAuthorOptionThrows()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid LinkedIn DSN author option "company". Supported values: "person", "organization".');
+
+        $this->createFactory()->create(new Dsn('linkedin://accessToken:UserId@default?author=company'));
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/LinkedIn/Tests/LinkedInTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/LinkedIn/Tests/LinkedInTransportTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Notifier\Bridge\LinkedIn\Tests;
 
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\Notifier\Bridge\LinkedIn\LinkedInAuthorType;
 use Symfony\Component\Notifier\Bridge\LinkedIn\LinkedInTransport;
 use Symfony\Component\Notifier\Exception\LogicException;
 use Symfony\Component\Notifier\Exception\TransportException;
@@ -27,14 +28,15 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 
 final class LinkedInTransportTest extends TransportTestCase
 {
-    public static function createTransport(?HttpClientInterface $client = null): LinkedInTransport
+    public static function createTransport(?HttpClientInterface $client = null, string $authorType = 'person'): LinkedInTransport
     {
-        return (new LinkedInTransport('AuthToken', 'AccountId', $client ?? new MockHttpClient()))->setHost('host.test');
+        return (new LinkedInTransport('AuthToken', 'AccountId', $client ?? new MockHttpClient(), null, LinkedInAuthorType::from($authorType)))->setHost('host.test');
     }
 
     public static function toStringProvider(): iterable
     {
         yield ['linkedin://host.test', self::createTransport()];
+        yield ['linkedin://host.test?author=organization', self::createTransport(authorType: 'organization')];
     }
 
     public static function supportedMessagesProvider(): iterable
@@ -139,6 +141,39 @@ final class LinkedInTransportTest extends TransportTestCase
         $transport = self::createTransport($client);
 
         $transport->send($chatMessage);
+    }
+
+    public function testSendWithOrganizationAuthor()
+    {
+        $message = 'testMessage';
+
+        $expectedBody = json_encode([
+            'specificContent' => [
+                'com.linkedin.ugc.ShareContent' => [
+                    'shareCommentary' => [
+                        'attributes' => [],
+                        'text' => 'testMessage',
+                    ],
+                    'shareMediaCategory' => 'NONE',
+                ],
+            ],
+            'visibility' => [
+                'com.linkedin.ugc.MemberNetworkVisibility' => 'PUBLIC',
+            ],
+            'lifecycleState' => 'PUBLISHED',
+            'author' => 'urn:li:organization:AccountId',
+        ]);
+
+        $client = new MockHttpClient(function (string $method, string $url, array $options = []) use (
+            $expectedBody
+        ): ResponseInterface {
+            $this->assertSame($expectedBody, $options['body']);
+
+            return new MockResponse(json_encode(['id' => '42']), ['http_code' => 201]);
+        });
+        $transport = self::createTransport($client, 'organization');
+
+        $transport->send(new ChatMessage($message));
     }
 
     public function testSendWithInvalidOptions()


### PR DESCRIPTION
Allow posting as a company page with ?author=organization while keeping person as the default for backward compatibility.

| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

Allow posting LinkedIn UGC shares as a company page via an optional DSN `author` query parameter.

Today the transport always uses `urn:li:person:…`.
Organization posting was already possible via `AuthorShare`, but not configurable from the DSN.

person (default, unchanged)
`linkedin://ACCESS_TOKEN:USER_ID@default`

organization / company page
`linkedin://ACCESS_TOKEN:ORGANIZATION_ID@default?author=organization`