### PR TITLE
[DependencyInjection] Restore reading "container.behavior_describing_tags" in DecoratorServicePass

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/DecoratorServicePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/DecoratorServicePass.php
@@ -43,9 +43,13 @@ class DecoratorServicePass extends AbstractRecursivePass
         $decoratingDefinitions = [];
         $decoratedIds = [];
 
-        // These tags describe how the container wires a concrete service and must stay on the
-        // decorated service; role-describing tags (e.g. "kernel.event_listener") move to its decorators.
-        $tagsToKeep = ['proxy', 'container.do_not_inline', 'container.service_locator', 'container.service_subscriber', 'container.service_subscriber.locator'];
+        // Behavior-describing tags must stay on the decorated service;
+        // role-describing tags (e.g. "kernel.event_listener") move to its decorators.
+        // The parameter is consumed and removed by ResolveInstanceofConditionalsPass, which runs
+        // before this pass; it's read here for container builders that keep it around.
+        $tagsToKeep = $container->hasParameter('container.behavior_describing_tags')
+            ? $container->getParameter('container.behavior_describing_tags')
+            : ['proxy', 'container.do_not_inline', 'container.service_locator', 'container.service_subscriber', 'container.service_subscriber.locator'];
 
         foreach ($definitions as [$id, $definition]) {
             $decoratedService = $definition->getDecoratedService();

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/DecoratorServicePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/DecoratorServicePassTest.php
@@ -281,10 +281,9 @@ class DecoratorServicePassTest extends TestCase
         $this->assertEquals(['bar' => ['attr' => 'baz'], 'foobar' => ['attr' => 'bar'], 'container.decorator' => [['id' => 'foo', 'inner' => 'baz.inner']]], $container->getDefinition('baz')->getTags());
     }
 
-    public function testProcessIgnoresBehaviorDescribingTagsParameter()
+    public function testProcessMovesRoleDescribingTagsWithoutBehaviorDescribingTagsParameter()
     {
         $container = new ContainerBuilder();
-        $container->setParameter('container.behavior_describing_tags', ['container.service_locator', 'kernel.event_listener']);
         $container
             ->register('foo')
             ->setTags(['container.service_locator' => [0 => []], 'kernel.event_listener' => [['event' => 'foo']]])
@@ -297,6 +296,25 @@ class DecoratorServicePassTest extends TestCase
         $this->process($container);
 
         $this->assertEquals(['container.service_locator' => [0 => []]], $container->getDefinition('baz.inner')->getTags());
+        $this->assertEquals(['kernel.event_listener' => [['event' => 'foo']], 'container.decorator' => [['id' => 'foo', 'inner' => 'baz.inner']]], $container->getDefinition('baz')->getTags());
+    }
+
+    public function testProcessLeavesBehaviorDescribingTagsFromParameterOnOriginalDefinition()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('container.behavior_describing_tags', ['container.service_locator', 'logger_aware']);
+        $container
+            ->register('foo')
+            ->setTags(['container.service_locator' => [0 => []], 'logger_aware' => [[]], 'kernel.event_listener' => [['event' => 'foo']]])
+        ;
+        $container
+            ->register('baz')
+            ->setDecoratedService('foo')
+        ;
+
+        $this->process($container);
+
+        $this->assertEquals(['container.service_locator' => [0 => []], 'logger_aware' => [[]]], $container->getDefinition('baz.inner')->getTags());
         $this->assertEquals(['kernel.event_listener' => [['event' => 'foo']], 'container.decorator' => [['id' => 'foo', 'inner' => 'baz.inner']]], $container->getDefinition('baz')->getTags());
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64970
| License       | MIT

#64572 gave `DecoratorServicePass` a fixed list of wiring tags, which removed the ability to declare extra behavior-describing tags that must stay on the decorated service.

This restores reading `container.behavior_describing_tags` in the pass, with the same fallback as before. Doing so doesn't reintroduce #64570 because the other half of #64572 stays: `AddBehaviorDescribingTagsPass` is registered before `ResolveInstanceofConditionalsPass`, which consumes and removes the parameter, so it's gone by the time `DecoratorServicePass` runs and the built-in list applies. Container builders that keep the parameter around get the extension point back.
