### PR TITLE
 Review Italian validator translations

### DIFF
--- a/src/Symfony/Component/Form/Resources/translations/validators.it.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.it.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="129">
                 <source>Please enter a valid UUID.</source>
-                <target state="needs-review-translation">Per favore, inserisci un UUID valido.</target>
+                <target>Per favore, inserisci un UUID valido.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.it.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.it.xlf
@@ -556,19 +556,19 @@
             </trans-unit>
             <trans-unit id="143">
                 <source>This value is not valid XML.</source>
-                <target state="needs-review-translation">Questo valore non è un XML valido.</target>
+                <target>Questo valore non è un XML valido.</target>
             </trans-unit>
             <trans-unit id="144">
                 <source>This value does not conform to the expected XSD schema.</source>
-                <target state="needs-review-translation">Questo valore non è conforme allo schema XSD previsto.</target>
+                <target>Questo valore non è conforme allo schema XSD previsto.</target>
             </trans-unit>
             <trans-unit id="145">
                 <source>This XML payload is too large ({{ size }} bytes): it exceeds the limit of {{ limit }} bytes.</source>
-                <target state="needs-review-translation">Questo payload XML è troppo grande ({{ size }} byte): supera il limite di {{ limit }} byte.</target>
+                <target>Questo payload XML è troppo grande ({{ size }} byte): supera il limite di {{ limit }} byte.</target>
             </trans-unit>
             <trans-unit id="146">
                 <source>This value is not a valid cron expression.</source>
-                <target state="needs-review-translation">Questo valore non è un'espressione cron valida.</target>
+                <target>Questo valore non è un'espressione cron valida.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
Fixes #64501.

The five Italian validator translations reported in the issue were generated automatically and still carried the `state="needs-review-translation"` marker. They have now been reviewed by a native Italian speaker and confirmed to be correct.

This removes the review marker from the UUID, XML, XSD schema, XML payload size, and cron expression messages. The translated text itself is unchanged.

Validation:

- `git diff --check`
- parsed both XLIFF files as XML
- verified that no `needs-review-translation` markers remain in the affected files
- verified that the `{{ size }}` and `{{ limit }}` placeholders are preserved
