### PR TITLE
[HttpFoundation] Fix retry field being dropped across server event streams

### DIFF
--- a/src/Symfony/Component/HttpFoundation/EventStreamResponse.php
+++ b/src/Symfony/Component/HttpFoundation/EventStreamResponse.php
@@ -36,6 +36,8 @@ namespace Symfony\Component\HttpFoundation;
  */
 class EventStreamResponse extends StreamedResponse
 {
+    private ?int $lastRetry = null;
+
     /**
      * @param int|null $retry The number of milliseconds the client should wait
      *                        before reconnecting in case of network failure
@@ -82,8 +84,10 @@ class EventStreamResponse extends StreamedResponse
      */
     public function sendEvent(ServerEvent $event): static
     {
-        if ($this->retry > 0 && !$event->getRetry()) {
-            $event->setRetry($this->retry);
+        if (($retry = $event->getRetry()) > 0) {
+            $this->lastRetry = $retry;
+        } elseif ($this->retry > 0 && $this->retry !== $this->lastRetry) {
+            $event->setRetry($this->lastRetry = $this->retry);
         }
 
         foreach ($event as $part) {

--- a/src/Symfony/Component/HttpFoundation/ServerEvent.php
+++ b/src/Symfony/Component/HttpFoundation/ServerEvent.php
@@ -115,8 +115,6 @@ class ServerEvent implements \IteratorAggregate
      */
     public function getIterator(): \Traversable
     {
-        static $lastRetry = null;
-
         $head = '';
         if ($this->comment) {
             $head .= \sprintf(': %s', $this->comment)."\n";
@@ -124,8 +122,8 @@ class ServerEvent implements \IteratorAggregate
         if ($this->id) {
             $head .= \sprintf('id: %s', $this->id)."\n";
         }
-        if ($this->retry > 0 && $this->retry !== $lastRetry) {
-            $head .= \sprintf('retry: %s', $lastRetry = $this->retry)."\n";
+        if ($this->retry > 0) {
+            $head .= \sprintf('retry: %s', $this->retry)."\n";
         }
         if ($this->type) {
             $head .= \sprintf('event: %s', $this->type)."\n";

--- a/src/Symfony/Component/HttpFoundation/Tests/EventStreamResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/EventStreamResponseTest.php
@@ -115,6 +115,35 @@ class EventStreamResponseTest extends TestCase
         $this->assertSameResponseContent($expected, $response);
     }
 
+    public function testRetryIsNotSharedBetweenServerEvents()
+    {
+        $first = new ServerEvent('foo', retry: 3000);
+        $second = new ServerEvent('bar', retry: 3000);
+
+        $this->assertSame("retry: 3000\ndata: foo\n\n", implode('', iterator_to_array($first)));
+        $this->assertSame("retry: 3000\ndata: bar\n\n", implode('', iterator_to_array($second)));
+    }
+
+    public function testRetryIsNotSharedBetweenStreams()
+    {
+        $callback = static function () {
+            yield new ServerEvent('foo');
+            yield new ServerEvent('bar');
+        };
+
+        $expected = <<<STR
+            retry: 2000
+            data: foo
+
+            data: bar
+
+
+            STR;
+
+        $this->assertSameResponseContent($expected, new EventStreamResponse($callback, retry: 2000));
+        $this->assertSameResponseContent($expected, new EventStreamResponse($callback, retry: 2000));
+    }
+
     public function testStreamEventWithSendMethod()
     {
         $response = new EventStreamResponse(static function (EventStreamResponse $response) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`ServerEvent::getIterator()` used a function-level static to avoid repeating the `retry:` field. A static local in a method is shared by every instance of the class for the whole process, not scoped to one response or one stream:

```php
$a = new ServerEvent('first',  retry: 3000);
$b = new ServerEvent('second', retry: 3000);
echo implode('', iterator_to_array($a));   // retry: 3000 \n data: first \n\n
echo implode('', iterator_to_array($b));   //              data: second \n\n   <- retry lost
```

Under PHP-FPM this is mostly invisible because the process handles one request. On persistent worker runtimes (FrankenPHP worker mode, RoadRunner, Swoole, ReactPHP), every stream after the first that uses the same retry value never tells the client its reconnection delay, so the browser silently falls back to its own default. It also makes the class order-dependent and awkward to test.

The suppression exists so that a response-level `retry` is not repeated on every event of one stream, so the state belongs to the stream. It now lives on `EventStreamResponse`, which is the object that drives the events of a single stream: it remembers the last retry it sent and only applies its fallback `retry` when it differs. `ServerEvent` becomes stateless and always emits `retry:` when one is set, which is also what a standalone event should do.

An explicit `retry` on a `ServerEvent` is now always emitted, even if the previous event of the stream carried the same value. That is the value the user explicitly asked to send, repeating it is valid SSE, and any other behaviour would require the response to mutate and restore the user's event object.
