### PR TITLE
[JsonPath] Fix evaluating filter expressions wrapped in several parentheses

### DIFF
--- a/src/Symfony/Component/JsonPath/JsonCrawler.php
+++ b/src/Symfony/Component/JsonPath/JsonCrawler.php
@@ -543,30 +543,9 @@ final class JsonCrawler implements JsonCrawlerInterface
 
     private function evaluateFilterExpression(string $expr, mixed $context): bool
     {
-        $expr = JsonPathUtils::normalizeWhitespace($expr);
+        $expr = $this->stripWrappingParentheses(JsonPathUtils::normalizeWhitespace($expr));
 
-        // remove outer parentheses if they wrap the entire expression
-        if (str_starts_with($expr, '(') && str_ends_with($expr, ')')) {
-            $depth = 0;
-            $isWrapped = true;
-            $i = -1;
-            while (null !== $char = $expr[++$i] ?? null) {
-                if ('(' === $char) {
-                    ++$depth;
-                } elseif (')' === $char && 0 === --$depth && isset($expr[$i + 1])) {
-                    $isWrapped = false;
-                    break;
-                }
-            }
-            if ($isWrapped) {
-                $expr = trim(substr($expr, 1, -1));
-            }
-        }
-
-        if (str_starts_with($expr, '!')) {
-            return !$this->evaluateFilterExpression(trim(substr($expr, 1)), $context);
-        }
-
+        // logical operators bind less tightly than the negation
         if ($logicalOp = $this->findRightmostLogicalOperator($expr)) {
             $left = trim(substr($expr, 0, $logicalOp['position']));
             $right = trim(substr($expr, $logicalOp['position'] + \strlen($logicalOp['operator'])));
@@ -576,6 +555,10 @@ final class JsonCrawler implements JsonCrawlerInterface
             }
 
             return $this->evaluateFilterExpression($left, $context) && $this->evaluateFilterExpression($right, $context);
+        }
+
+        if (str_starts_with($expr, '!')) {
+            return !$this->evaluateFilterExpression(trim(substr($expr, 1)), $context);
         }
 
         foreach (self::COMPARISON_OPERATORS as $op => $len) {
@@ -624,6 +607,29 @@ final class JsonCrawler implements JsonCrawlerInterface
         }
 
         return false;
+    }
+
+    /**
+     * Removes the outer parentheses as long as they wrap the whole expression,
+     * e.g. `((@.a == 1))` becomes `@.a == 1` while `(@.a == 1) && (@.b == 2)` is left untouched.
+     */
+    private function stripWrappingParentheses(string $expr): string
+    {
+        while (str_starts_with($expr, '(') && str_ends_with($expr, ')')) {
+            $depth = 0;
+            $i = -1;
+            while (null !== $char = $expr[++$i] ?? null) {
+                if ('(' === $char) {
+                    ++$depth;
+                } elseif (')' === $char && 0 === --$depth && isset($expr[$i + 1])) {
+                    return $expr;
+                }
+            }
+
+            $expr = trim(substr($expr, 1, -1));
+        }
+
+        return $expr;
     }
 
     private function findRightmostLogicalOperator(string $expr): ?array
@@ -1007,9 +1013,17 @@ final class JsonCrawler implements JsonCrawlerInterface
 
     private function validateFilterExpression(string $expr): void
     {
+        $expr = $this->stripWrappingParentheses($expr);
+
         if ($logicalOp = $this->findRightmostLogicalOperator($expr)) {
             $this->validateFilterExpression(trim(substr($expr, 0, $logicalOp['position']))); // left
             $this->validateFilterExpression(trim(substr($expr, $logicalOp['position'] + \strlen($logicalOp['operator'])))); // right
+
+            return;
+        }
+
+        if (str_starts_with($expr, '!')) {
+            $this->validateFilterExpression(trim(substr($expr, 1)));
 
             return;
         }

--- a/src/Symfony/Component/JsonPath/Tests/JsonCrawlerTest.php
+++ b/src/Symfony/Component/JsonPath/Tests/JsonCrawlerTest.php
@@ -362,6 +362,63 @@ class JsonCrawlerTest extends TestCase
         $this->assertSame('Sayings of the Century', $result[0]['title']);
     }
 
+    #[DataProvider('provideNestedParenthesesFilters')]
+    public function testFilterWithNestedParentheses(string $path, array $expected)
+    {
+        $crawler = new JsonCrawler('[{"a": 1, "b": 2}, {"a": 2, "b": 2}, {"a": 3, "b": 4}]');
+
+        $this->assertSame($expected, $crawler->find($path));
+    }
+
+    public static function provideNestedParenthesesFilters(): iterable
+    {
+        $first = ['a' => 1, 'b' => 2];
+        $second = ['a' => 2, 'b' => 2];
+        $third = ['a' => 3, 'b' => 4];
+
+        yield 'no parentheses' => ['$[?@.a == 1]', [$first]];
+        yield 'one pair' => ['$[?(@.a == 1)]', [$first]];
+        yield 'two pairs' => ['$[?((@.a == 1))]', [$first]];
+        yield 'three pairs' => ['$[?(((@.a == 1)))]', [$first]];
+        yield 'four pairs' => ['$[?((((@.a == 1))))]', [$first]];
+        yield 'five pairs' => ['$[?(((((@.a == 1)))))]', [$first]];
+
+        yield 'sibling groups' => ['$[?((@.a == 1) && (@.b == 2))]', [$first]];
+        yield 'sibling groups with or' => ['$[?((@.a == 1) || (@.a == 3))]', [$first, $third]];
+        yield 'wrapped sibling groups' => ['$[?(((@.a == 1) && (@.b == 2)))]', [$first]];
+        yield 'nested sibling groups' => ['$[?(((@.a == 1)) && ((@.b == 2)))]', [$first]];
+        yield 'sibling groups with nested or' => ['$[?(((@.a == 1) || (@.a == 2)) && (@.b == 2))]', [$first, $second]];
+
+        yield 'negated group' => ['$[?(!(@.a == 1))]', [$second, $third]];
+        yield 'negated nested group' => ['$[?(!((@.a == 1)))]', [$second, $third]];
+        yield 'negated deeply nested group' => ['$[?(!(((@.a == 1))))]', [$second, $third]];
+        yield 'wrapped negated group' => ['$[?((!(@.a == 1)))]', [$second, $third]];
+        yield 'negated group with and' => ['$[?(!((@.a == 1)) && (@.b == 2))]', [$second]];
+        yield 'negation binds tighter than and' => ['$[?(!(@.a == 1) && (@.b == 2))]', [$second]];
+        yield 'negation binds tighter than or' => ['$[?(!(@.b == 2) || (@.a == 1))]', [$first, $third]];
+        yield 'negation of a whole group' => ['$[?(!((@.a == 1) && (@.b == 2)))]', [$second, $third]];
+
+        yield 'nested function call' => ['$[?((length(@) == 2))]', [$first, $second, $third]];
+    }
+
+    #[DataProvider('provideNestedParenthesesNonSingularFilters')]
+    public function testNonSingularQueryIsRejectedWhateverTheNesting(string $path)
+    {
+        $this->expectException(JsonCrawlerException::class);
+        $this->expectExceptionMessageMatches('/non-singular query/i');
+
+        (new JsonCrawler('[{"a": 1}]'))->find($path);
+    }
+
+    public static function provideNestedParenthesesNonSingularFilters(): iterable
+    {
+        yield ['$[?(@.* == 1)]'];
+        yield ['$[?((@.* == 1))]'];
+        yield ['$[?(((@.* == 1)))]'];
+        yield ['$[?(!(@.* == 1))]'];
+        yield ['$[?((@.* == 1) && (@.a == 1))]'];
+    }
+
     public function testEmptyResult()
     {
         $result = self::getBookstoreCrawler()->find('$.store.book[?(@.price > 1000)]');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`evaluateFilterExpression()` removed at most one wrapping parenthesis pair per call, then fell through to the operator scan instead of unwrapping again. A filter expression wrapped in three or more parentheses was therefore silently mis-evaluated, with no error raised. Against `[{"a":1},{"a":2}]`:

```
$[?(@.a == 1)]        => [{"a":1}]
$[?((@.a == 1))]      => [{"a":1}]
$[?(((@.a == 1)))]    => []          wrong
$[?((((@.a == 1))))]  => []          wrong
```

The unwrapping is now a loop in a dedicated `stripWrappingParentheses()` method, which keeps the depth tracking that tells `((@.a == 1))` (wrapped) apart from `(@.a == 1) && (@.b == 2)` (not wrapped).

`validateFilterExpression()` was affected too: it never unwrapped at all and relied on its caller having stripped exactly one pair. Any extra pair made the comparison operator invisible to it, so its checks were silently skipped, e.g. `$[?(@.* == 1)]` correctly reported a non-singular query while `$[?((@.* == 1))]` did not.

Two more cases showed up while covering the negation, both fixed here since they belong to the same silently-wrong-filter family: `!` was handled before the logical operator scan in both methods, so `!(@.a == 1) && (@.b == 2)` was parsed as `!((@.a == 1) && (@.b == 2))`, and the operand of a `!` was never validated.

The RFC 9535 compliance test suite stays green.
