### PR TITLE
[String] Add AbstractString::screamingSnake()

### DIFF
--- a/src/Symfony/Component/String/AbstractString.php
+++ b/src/Symfony/Component/String/AbstractString.php
@@ -446,6 +446,11 @@ abstract class AbstractString implements \Stringable, \JsonSerializable
         return $this->camel()->title();
     }
 
+    public function screamingSnake(): static
+    {
+        return $this->snake()->upper();
+    }
+
     abstract public function splice(string $replacement, int $start = 0, ?int $length = null): static;
 
     /**

--- a/src/Symfony/Component/String/CHANGELOG.md
+++ b/src/Symfony/Component/String/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add `AbstractString::screamingSnake()` method to convert a string to SCREAMING_SNAKE_CASE
+
 8.0
 ---
 

--- a/src/Symfony/Component/String/Tests/AbstractAsciiTestCase.php
+++ b/src/Symfony/Component/String/Tests/AbstractAsciiTestCase.php
@@ -1084,6 +1084,32 @@ abstract class AbstractAsciiTestCase extends TestCase
         ];
     }
 
+    #[DataProvider('provideScreamingSnake')]
+    public function testScreamingSnake(string $expectedString, string $origin)
+    {
+        $instance = static::createFromString($origin)->screamingSnake();
+
+        $this->assertEquals(static::createFromString($expectedString), $instance);
+        $this->assertNotSame($origin, $instance, 'Strings should be immutable');
+    }
+
+    public static function provideScreamingSnake(): array
+    {
+        return [
+            ['', ''],
+            ['X_Y', 'x_y'],
+            ['X_Y', 'X_Y'],
+            ['XU_YO', 'xu_yo'],
+            ['SYMFONY_IS_GREAT', 'symfonyIsGreat'],
+            ['SYMFONY123_IS_GREAT', 'symfony123IsGreat'],
+            ['SYMFONY_IS_GREAT', 'Symfony is great'],
+            ['SYMFONY_IS_A_GREAT_FRAMEWORK', 'symfonyIsAGreatFramework'],
+            ['SYMFONY_IS_GREAT', 'symfonyIsGREAT'],
+            ['SYMFONY_IS_REALLY_GREAT', 'symfonyIsREALLYGreat'],
+            ['SYMFONY', 'SYMFONY'],
+        ];
+    }
+
     #[DataProvider('provideStartsWith')]
     public function testStartsWith(bool $expected, string $origin, $prefix, ?int $form = null)
     {


### PR DESCRIPTION
Add a screamingSnake() case converter producing SCREAMING_SNAKE_CASE (a.k.a. CONSTANT_CASE), the natural counterpart to the existing snake(), kebab(), pascal() and camel() helpers. Useful for deriving constant names, environment variable keys or enum case names from arbitrary labels.

Like kebab() and pascal(), it is a thin wrapper over existing helpers (snake()->upper()), so it works for ByteString, CodePointString and UnicodeString without further changes.

| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

Adds a screamingSnake() case converter to the String component, producing SCREAMING_SNAKE_CASE (a.k.a. CONSTANT_CASE / upper snake). It is the natural counterpart to the existing snake(), kebab(), pascal() and camel() helpers and is handy for deriving constant names, environment variable keys or enum case names from arbitrary labels.

u('symfonyIsGreat')->screamingSnake();   // SYMFONY_IS_GREAT
u('Symfony is great')->screamingSnake(); // SYMFONY_IS_GREAT
Like kebab() and pascal(), it is a thin wrapper over existing helpers (snake()->upper()), so it works for ByteString, CodePointString and UnicodeString without any further changes. No BC break, no deprecation, no new dependency.

Tests were added in AbstractAsciiTestCase (so they run against all three string implementations) mirroring the existing provideKebab/providePascal data sets, and a CHANGELOG entry was added under 8.2.
