### PR TITLE
[HttpClient] Don't send the original Host header on cross-authority redirects

### DIFF
--- a/src/Symfony/Component/HttpClient/CurlHttpClient.php
+++ b/src/Symfony/Component/HttpClient/CurlHttpClient.php
@@ -411,7 +411,7 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
             $redirectHeaders['with_auth'] = $redirectHeaders['no_auth'] = array_filter($options['headers'], static fn ($h) => 0 !== stripos($h, 'Host:'));
 
             if (isset($options['normalized_headers']['authorization'][0]) || isset($options['normalized_headers']['cookie'][0])) {
-                $redirectHeaders['no_auth'] = array_filter($options['headers'], static fn ($h) => 0 !== stripos($h, 'Authorization:') && 0 !== stripos($h, 'Cookie:'));
+                $redirectHeaders['no_auth'] = array_filter($redirectHeaders['no_auth'], static fn ($h) => 0 !== stripos($h, 'Authorization:') && 0 !== stripos($h, 'Cookie:'));
             }
         }
 

--- a/src/Symfony/Component/HttpClient/Tests/AmpHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/AmpHttpClientTest.php
@@ -40,6 +40,16 @@ class AmpHttpClientTest extends HttpClientTestCase
         return new AmpHttpClient(['verify_peer' => false, 'verify_host' => false, 'timeout' => 5]);
     }
 
+    public static function getRedirectWithHostHeaderTests()
+    {
+        // unlike curl and the native client, amphp keeps the user-provided Host header when the authority doesn't change
+        return [
+            'same host and port' => ['url' => 'http://localhost:8057/custom', 'redirectWithAuth' => true, 'expectedHost' => 'foo.example.com'],
+            'other port' => ['url' => 'http://localhost:8067/custom', 'redirectWithAuth' => false, 'expectedHost' => 'localhost:8057'],
+            'other host' => ['url' => 'http://127.0.0.1:8057/custom', 'redirectWithAuth' => false, 'expectedHost' => 'localhost:8057'],
+        ];
+    }
+
     public function testProxy()
     {
         $this->markTestSkipped('A real proxy server would be needed.');

--- a/src/Symfony/Component/HttpClient/Tests/HttpClientTestCase.php
+++ b/src/Symfony/Component/HttpClient/Tests/HttpClientTestCase.php
@@ -635,6 +635,50 @@ abstract class HttpClientTestCase extends BaseHttpClientTestCase
         ];
     }
 
+    /**
+     * @dataProvider getRedirectWithHostHeaderTests
+     */
+    public function testRedirectWithHostHeader(string $url, bool $redirectWithAuth, string $expectedHost)
+    {
+        $p = TestHttpServer::start(8067);
+
+        try {
+            $client = $this->getHttpClient(__FUNCTION__);
+
+            $response = $client->request('GET', $url, [
+                'query' => [
+                    'status' => 302,
+                    'headers' => ['Location: http://localhost:8057/'],
+                ],
+                'headers' => [
+                    'Host' => 'foo.example.com',
+                    'Authorization' => 'Basic Zm9vOmJhcg==',
+                ],
+            ]);
+            $body = $response->toArray();
+        } finally {
+            $p->stop();
+        }
+
+        $this->assertSame('http://localhost:8057/', $response->getInfo('url'));
+        $this->assertSame($expectedHost, $body['HTTP_HOST']);
+
+        if ($redirectWithAuth) {
+            $this->assertSame('Basic Zm9vOmJhcg==', $body['HTTP_AUTHORIZATION']);
+        } else {
+            $this->assertArrayNotHasKey('HTTP_AUTHORIZATION', $body);
+        }
+    }
+
+    public static function getRedirectWithHostHeaderTests()
+    {
+        return [
+            'same host and port' => ['url' => 'http://localhost:8057/custom', 'redirectWithAuth' => true, 'expectedHost' => 'localhost:8057'],
+            'other port' => ['url' => 'http://localhost:8067/custom', 'redirectWithAuth' => false, 'expectedHost' => 'localhost:8057'],
+            'other host' => ['url' => 'http://127.0.0.1:8057/custom', 'redirectWithAuth' => false, 'expectedHost' => 'localhost:8057'],
+        ];
+    }
+
     public function testDefaultContentType()
     {
         $client = $this->getHttpClient(__FUNCTION__);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`CurlHttpClient::createRedirectResolver()` builds the header set used after a redirect twice. The first assignment filters out a user-supplied `Host:` header:

```php
$redirectHeaders['with_auth'] = $redirectHeaders['no_auth'] = array_filter($options['headers'], static fn ($h) => 0 !== stripos($h, 'Host:'));

if (isset($options['normalized_headers']['authorization'][0]) || isset($options['normalized_headers']['cookie'][0])) {
    $redirectHeaders['no_auth'] = array_filter($options['headers'], ...);
}
```

The second one rebuilds `no_auth` from the raw `$options['headers']`, which drops that `Host:` filter. So a user-supplied `Host:` header is kept when following a redirect to a different authority, while it is correctly removed on a same-authority redirect. `NativeHttpClient` does not have this asymmetry: it filters `$redirectHeaders['no_auth']` rather than the raw headers.

In practice the observable case is narrow, because libcurl drops a custom `Host:` header itself when a redirect changes the host name. What remains is a redirect that changes Symfony's notion of the authority while leaving libcurl's notion of the host unchanged, that is a port-only or scheme-only change on the same host name. Verified with plain libcurl 8.5.0 that the custom `Host:` survives a port-only redirect, so this filter is the only control there.

The fix is to filter the already filtered set instead of the raw headers, so both branches agree.

Test coverage is added to the shared `HttpClientTestCase` with same-authority, other-port and other-host rows. Before the fix exactly one row failed, the curl "other port" case, which received `foo.example.com` instead of the real authority.

Note that `AmpHttpClient` keeps a user-supplied `Host:` header on same-authority redirects, where curl and native always drop it. That pre-existing difference is left alone here and encoded in an overridden data provider.
