### PR TITLE
[JsonPath] Reject non-singular queries in filter comparisons

### DIFF
--- a/src/Symfony/Component/JsonPath/JsonCrawler.php
+++ b/src/Symfony/Component/JsonPath/JsonCrawler.php
@@ -393,25 +393,9 @@ final class JsonCrawler implements JsonCrawlerInterface
             }
 
             $needsParentheses = true;
-            if (str_starts_with($filterExpr, '(') && str_ends_with($filterExpr, ')')) {
-                $depth = 0;
-                $isWrapped = true;
-                $filterLen = \strlen($filterExpr);
-
-                for ($i = 0; $i < $filterLen; ++$i) {
-                    $char = $filterExpr[$i];
-                    if ('(' === $char) {
-                        ++$depth;
-                    } elseif (')' === $char && 0 === --$depth && $i < $filterLen - 1) {
-                        $isWrapped = false;
-                        break;
-                    }
-                }
-
-                if ($isWrapped) {
-                    $needsParentheses = false;
-                    $filterExpr = trim(substr($filterExpr, 1, -1));
-                }
+            if (str_starts_with($filterExpr, '(') && str_ends_with($filterExpr, ')') && $this->isWrappedInParentheses($filterExpr)) {
+                $needsParentheses = false;
+                $filterExpr = trim(substr($filterExpr, 1, -1));
             }
 
             if ($needsParentheses && !str_starts_with($filterExpr, '(')) {
@@ -615,17 +599,7 @@ final class JsonCrawler implements JsonCrawlerInterface
      */
     private function stripWrappingParentheses(string $expr): string
     {
-        while (str_starts_with($expr, '(') && str_ends_with($expr, ')')) {
-            $depth = 0;
-            $i = -1;
-            while (null !== $char = $expr[++$i] ?? null) {
-                if ('(' === $char) {
-                    ++$depth;
-                } elseif (')' === $char && 0 === --$depth && isset($expr[$i + 1])) {
-                    return $expr;
-                }
-            }
-
+        while (str_starts_with($expr, '(') && str_ends_with($expr, ')') && $this->isWrappedInParentheses($expr)) {
             $expr = trim(substr($expr, 1, -1));
         }
 
@@ -985,6 +959,86 @@ final class JsonCrawler implements JsonCrawlerInterface
         return preg_match('/@\[.*,.*]/', $expr) || '@.*' === $expr || preg_match('/@\[.*:.*]/', $expr);
     }
 
+    /**
+     * A singular query is made of a leading "@" or "$" followed by name and index selectors only.
+     *
+     * @see https://www.rfc-editor.org/rfc/rfc9535.html#name-comparisons
+     */
+    private function isSingularQuery(string $expr): bool
+    {
+        $expr = trim($expr);
+        $length = \strlen($expr);
+
+        if (!$length || ('@' !== $expr[0] && '$' !== $expr[0])) {
+            return false;
+        }
+
+        $i = 1;
+        while ($i < $length) {
+            if (' ' === $expr[$i] || "\t" === $expr[$i] || "\n" === $expr[$i] || "\r" === $expr[$i]) {
+                ++$i;
+                continue;
+            }
+
+            if ('.' === $expr[$i]) {
+                if ('.' === ($expr[$i + 1] ?? '')) {
+                    return false;
+                }
+
+                $start = ++$i;
+                while ($i < $length && !\in_array($expr[$i], ['.', '[', ' ', "\t", "\n", "\r"], true)) {
+                    ++$i;
+                }
+
+                if (!preg_match('/^[A-Za-z_\x{80}-\x{10FFFF}][A-Za-z0-9_\x{80}-\x{10FFFF}]*+$/u', substr($expr, $start, $i - $start))) {
+                    return false;
+                }
+
+                continue;
+            }
+
+            if ('[' !== $expr[$i]) {
+                return false;
+            }
+
+            $start = ++$i;
+            $quote = null;
+            while ($i < $length) {
+                $char = $expr[$i];
+
+                if (null !== $quote) {
+                    if ('\\' === $char) {
+                        ++$i;
+                    } elseif ($char === $quote) {
+                        $quote = null;
+                    }
+                } elseif ('"' === $char || "'" === $char) {
+                    $quote = $char;
+                } elseif (']' === $char) {
+                    break;
+                }
+
+                ++$i;
+            }
+
+            if ($i >= $length) {
+                return false;
+            }
+
+            $selector = trim(substr($expr, $start, $i - $start));
+            ++$i;
+
+            if (!preg_match('/^-?+\d++$/', $selector)
+                && !preg_match('/^\'(?:[^\'\\\\]|\\\\.)*+\'$/s', $selector)
+                && !preg_match('/^"(?:[^"\\\\]|\\\\.)*+"$/s', $selector)
+            ) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     private function findOperatorPosition(string $expr, string $op): int|false
     {
         $bracketDepth = 0;
@@ -1011,9 +1065,25 @@ final class JsonCrawler implements JsonCrawlerInterface
         return false;
     }
 
+    private function isWrappedInParentheses(string $expr): bool
+    {
+        $depth = 0;
+        $length = \strlen($expr);
+
+        for ($i = 0; $i < $length; ++$i) {
+            if ('(' === $expr[$i]) {
+                ++$depth;
+            } elseif (')' === $expr[$i] && 0 === --$depth && $i < $length - 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     private function validateFilterExpression(string $expr): void
     {
-        $expr = $this->stripWrappingParentheses($expr);
+        $expr = $this->stripWrappingParentheses(trim($expr));
 
         if ($logicalOp = $this->findRightmostLogicalOperator($expr)) {
             $this->validateFilterExpression(trim(substr($expr, 0, $logicalOp['position']))); // left
@@ -1045,8 +1115,8 @@ final class JsonCrawler implements JsonCrawlerInterface
                 }
 
                 if (
-                    str_starts_with($left, '@') && $this->isNonSingularRelativeQuery($left)
-                    || str_starts_with($right, '@') && $this->isNonSingularRelativeQuery($right)
+                    str_starts_with($left, '@') && !$this->isSingularQuery($left)
+                    || str_starts_with($right, '@') && !$this->isSingularQuery($right)
                 ) {
                     throw new JsonCrawlerException($left, 'non-singular query is not comparable');
                 }

--- a/src/Symfony/Component/JsonPath/Tests/JsonCrawlerTest.php
+++ b/src/Symfony/Component/JsonPath/Tests/JsonCrawlerTest.php
@@ -508,12 +508,12 @@ class JsonCrawlerTest extends TestCase
         $this->assertSame('Sword of Honour', $result[0]['title']);
     }
 
-    public function testWildcardInFilter()
+    public function testWildcardInFilterComparisonThrows()
     {
-        $result = self::getBookstoreCrawler()->find('$.store.book[?(@.publisher.* == "my-publisher")]');
+        $this->expectException(JsonCrawlerException::class);
+        $this->expectExceptionMessageMatches('/non-singular query is not comparable/');
 
-        $this->assertCount(1, $result);
-        $this->assertSame('Sword of Honour', $result[0]['title']);
+        self::getBookstoreCrawler()->find('$.store.book[?(@.publisher.* == "my-publisher")]');
     }
 
     public function testWildcardInFunction()
@@ -614,6 +614,62 @@ class JsonCrawlerTest extends TestCase
         $this->expectExceptionMessage('invalid function "unknown"');
 
         self::getBookstoreCrawler()->find('$.store.book[?unknown(@.extra) != 0]');
+    }
+
+    #[DataProvider('provideNonSingularComparisonOperands')]
+    public function testNonSingularQueryInComparisonThrows(string $jsonPath)
+    {
+        $this->expectException(JsonCrawlerException::class);
+        $this->expectExceptionMessageMatches('/[Nn]on-singular query is not comparable/');
+
+        (new JsonCrawler('[{"a": 1, "b": {"a": 1}}, {"a": 2}]'))->find($jsonPath);
+    }
+
+    public static function provideNonSingularComparisonOperands(): iterable
+    {
+        foreach ([
+            '@..a',
+            '@[*]',
+            '@.*',
+            '@.b.*',
+            '@.b[*]',
+            '@.b..a',
+            '@[0,1]',
+            '@[0:1]',
+            '@[?@.a]',
+            '@.b[*].a',
+        ] as $operand) {
+            yield [\sprintf('$[?%s == 1]', $operand)];
+            yield [\sprintf('$[?(%s == 1)]', $operand)];
+            yield [\sprintf('$[?1 == %s]', $operand)];
+            yield [\sprintf('$[?(1 == %s)]', $operand)];
+        }
+    }
+
+    #[DataProvider('provideSingularComparisonOperands')]
+    public function testSingularQueryInComparisonIsAccepted(string $jsonPath, array $expected)
+    {
+        $this->assertSame($expected, (new JsonCrawler('[{"a": 1, "b": {"a": 1}}, {"a": 2}]'))->find($jsonPath));
+    }
+
+    public static function provideSingularComparisonOperands(): iterable
+    {
+        yield ['$[?@.a == 1]', [['a' => 1, 'b' => ['a' => 1]]]];
+        yield ['$[?(@.a == 1)]', [['a' => 1, 'b' => ['a' => 1]]]];
+        yield ['$[?@["a"] == 1]', [['a' => 1, 'b' => ['a' => 1]]]];
+        yield ['$[?(@[\'a\'] == 1)]', [['a' => 1, 'b' => ['a' => 1]]]];
+        yield ['$[?@.b.a == 1]', [['a' => 1, 'b' => ['a' => 1]]]];
+        yield ['$[?(@.b["a"] == 1)]', [['a' => 1, 'b' => ['a' => 1]]]];
+        yield ['$[?@.a == 2]', [['a' => 2]]];
+        yield ['$[?@ == 1]', []];
+    }
+
+    public function testNonSingularQueryAsFunctionArgumentIsStillAllowed()
+    {
+        $crawler = new JsonCrawler('[{"a": 1, "b": {"a": 1}}, {"a": 2}]');
+
+        $this->assertSame([['a' => 1, 'b' => ['a' => 1]]], $crawler->find('$[?count(@..a) == 2]'));
+        $this->assertSame([['a' => 1, 'b' => ['a' => 1]]], $crawler->find('$[?(count(@[*]) == 2)]'));
     }
 
     public function testAcceptsJsonPath()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

RFC 9535 [§2.3.5.2](https://www.rfc-editor.org/rfc/rfc9535.html#name-comparisons) requires both operands of a comparison inside a filter selector to be *singular queries*: queries whose segments consist only of name selectors and index selectors. Anything else is a syntax error, not a query that evaluates to nothing.

`JsonCrawler::isNonSingularRelativeQuery()` enforced this with a three-pattern negative heuristic:

```php
return preg_match('/@\[.*,.*]/', $expr) || '@.*' === $expr || preg_match('/@\[.*:.*]/', $expr);
```

It catches unions and slices, and the wildcard only by exact string equality. Against the document `[{"a":1,"b":{"a":1}},{"a":2}]` it misses at least these three shapes, which returned results instead of throwing:

```
$[?(@..a == 1)]     descendant segment
$[?(@[*] == 1)]     bracket wildcard
$[?(@.b.* == 1)]    wildcard below the top level
```

The compliance test suite already contains two of them, `filter, non-singular query in comparison, all children` (`$[?@[*]==0]`) and `filter, non-singular query in comparison, descendants` (`$[?@..a==0]`), and the suite was green. They passed only by accident: the bare, unparenthesised spelling is rejected by a separate heuristic in `JsonPathTokenizer::validateFilterExpression()`, which bails out unless the filter expression starts with `@`. Add parentheses and the rejection disappears:

```
$[?@..a==1]     => throws
$[?(@..a==1)]   => returns results
```

The same asymmetry existed for every bare filter, in the other direction: `evaluateBracket()` wraps an unparenthesised filter expression in parentheses *before* handing it to `JsonCrawler::validateFilterExpression()`, where `findOperatorPosition()` then refuses to match an operator at parenthesis depth 1. So for bare filters the crawler-side validation never ran at all and only the tokenizer heuristic applied.

Instead of adding two more regexes, this PR replaces the negative heuristic with a positive check that the operand *is* a singular query: after the leading `@` or `$`, the only permitted segments are name selectors (`.name`, `['name']`, `["name"]`) and index selectors (`[0]`, `[-1]`). Descendant segments, wildcards, unions, slices and nested filters are all rejected, including shapes nobody has enumerated yet. `@` on its own stays valid, and `validateFilterExpression()` now strips a wrapping parenthesis pair so bare and parenthesised filters are validated identically.

Function arguments are untouched: `count()` and friends legitimately take non-singular queries, and `validateFunctionArguments()` keeps its existing behaviour for `length`/`match`/`search`.

**This is a behaviour change.** Queries such as `$[?(@.publisher.* == "x")]` previously returned results and now throw a `JsonCrawlerException`. That is the specified behaviour: RFC 9535 classifies a non-singular query in a comparison as invalid syntax, so the selector never had a defined result set and the values it returned were arbitrary, depending on which node of the nodelist happened to be picked. Returning something plausible for an invalid selector is worse than failing, because it hides the mistake and encourages selectors that no other RFC 9535 implementation accepts. One existing test asserted the old result and is updated accordingly.

The compliance suite (1159 cases, 247 of them invalid-selector cases) stays green, and the full component suite passes with 1394 tests / 1622 assertions.

Note that #65002 touches the same validation routine, so a textual conflict is possible depending on merge order. This fix is independent of it and improves matters on its own.
