### PR TITLE
[HttpKernel] Fix curl command generation on Windows

### DIFF
--- a/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
@@ -22,7 +22,6 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
-use Symfony\Component\Process\Process;
 use Symfony\Component\VarDumper\Cloner\Data;
 
 /**
@@ -511,18 +510,18 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
             $command[] = \sprintf('--request %s', $method);
         }
 
-        $command[] = \sprintf('--url %s', escapeshellarg($request->getUri()));
+        $command[] = \sprintf('--url %s', $this->escapeArgument($request->getUri()));
 
         foreach ($request->headers->all() as $name => $values) {
             if (\in_array(strtolower($name), ['host', 'cookie'], true)) {
                 continue;
             }
 
-            $command[] = '--header '.escapeshellarg(ucwords($name, '-').': '.implode(', ', $values));
+            $command[] = '--header '.$this->escapeArgument(ucwords($name, '-').': '.implode(', ', $values));
         }
 
         if ($cookies = $this->flattenCookieArrayForCurl($request->cookies->all())) {
-            $command[] = '--cookie '.escapeshellarg(implode('; ', array_map(
+            $command[] = '--cookie '.$this->escapeArgument(implode('; ', array_map(
                 static fn ($name, $value) => $name.'='.$value,
                 array_keys($cookies),
                 $cookies
@@ -530,7 +529,7 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
         }
 
         if ($content && \in_array($method, [Request::METHOD_POST, Request::METHOD_PUT, Request::METHOD_PATCH, Request::METHOD_DELETE], true)) {
-            $command[] = '--data-raw '.$this->escapePayload($content);
+            $command[] = '--data-raw '.$this->escapeArgument($content);
         }
 
         return implode(" \\\n  ", $command);
@@ -541,19 +540,22 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
         return $this->data['curlCommand'] ?? '';
     }
 
-    private function escapePayload(string $payload): string
+    /**
+     * Quotes a value as a single argument for the displayed curl command.
+     *
+     * escapeshellarg() cannot be used here: on Windows it replaces "%" with a
+     * space to neutralize environment variable expansion, which corrupts
+     * percent-encoded values such as cookies (e.g. "hello%20world"). A simple
+     * manual quoting is used instead so the command stays readable and
+     * copy-pasteable while leaving "%" untouched.
+     */
+    private function escapeArgument(string $value): string
     {
-        static $useProcess;
-
-        if ($useProcess ??= \function_exists('proc_open') && class_exists(Process::class)) {
-            return substr((new Process(['', $payload]))->getCommandLine(), 3);
-        }
-
         if ('\\' === \DIRECTORY_SEPARATOR) {
-            return '"'.str_replace('"', '""', $payload).'"';
+            return '"'.str_replace('"', '""', $value).'"';
         }
 
-        return "'".str_replace("'", "'\\''", $payload)."'";
+        return "'".str_replace("'", "'\\''", $value)."'";
     }
 
     /**


### PR DESCRIPTION
The generated curl command escaped its arguments with escapeshellarg(), which on Windows replaces "%" with a space to neutralize environment variable expansion. This corrupted percent-encoded values, most notably cookies: "note=hello%20world" became "note=hello 20world".

Route every argument (url, headers, cookies and payload) through the Process component, which escapes arguments correctly on every platform, with the previous manual escaping kept as a fallback. The dedicated escaping helper is renamed accordingly since it is no longer specific to the request payload.

| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no 
| Issues        | Fix #... <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

The RequestDataCollector::getCurlCommand() feature (new in 8.2) escaped its arguments with escapeshellarg(). On Windows, escapeshellarg() replaces % with a space to neutralize environment variable expansion, which corrupts percent-encoded values — most visibly cookies:

note=hello%20world   →   note=hello 20world
This is what makes RequestDataCollectorTest::testCurlCommandWithCookies fail on the Windows CI jobs (the assertion note=hello%20world never matches).

This PR replaces escapeshellarg() with a simple, readable manual quoting applied to every argument (--url, --header, --cookie, --data-raw): double quotes on Windows (doubling any embedded double quote), single quotes elsewhere. This keeps % intact and produces a copy-pasteable command on every platform.

The Process component is intentionally not used here: it escapes for execution and would inject caret escaping such as "^%" on Windows, which is unreadable and still would not contain the plain %20 the profiler displays.

On non-Windows platforms the output is unchanged (values are still wrapped in single quotes), so the existing assertions keep passing. The already-present testCurlCommandWithCookies covers the regression: it now passes on Windows too.