### PR TITLE
[HttpKernel] Fix the escaping of the generated curl command

### DIFF
--- a/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
@@ -22,7 +22,6 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
-use Symfony\Component\Process\Process;
 use Symfony\Component\VarDumper\Cloner\Data;
 
 /**
@@ -511,18 +510,18 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
             $command[] = \sprintf('--request %s', $method);
         }
 
-        $command[] = \sprintf('--url %s', escapeshellarg($request->getUri()));
+        $command[] = \sprintf('--url %s', $this->escapeArgument($request->getUri()));
 
         foreach ($request->headers->all() as $name => $values) {
             if (\in_array(strtolower($name), ['host', 'cookie'], true)) {
                 continue;
             }
 
-            $command[] = '--header '.escapeshellarg(ucwords($name, '-').': '.implode(', ', $values));
+            $command[] = '--header '.$this->escapeArgument(ucwords($name, '-').': '.implode(', ', $values));
         }
 
         if ($cookies = $this->flattenCookieArrayForCurl($request->cookies->all())) {
-            $command[] = '--cookie '.escapeshellarg(implode('; ', array_map(
+            $command[] = '--cookie '.$this->escapeArgument(implode('; ', array_map(
                 static fn ($name, $value) => $name.'='.$value,
                 array_keys($cookies),
                 $cookies
@@ -530,7 +529,7 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
         }
 
         if ($content && \in_array($method, [Request::METHOD_POST, Request::METHOD_PUT, Request::METHOD_PATCH, Request::METHOD_DELETE], true)) {
-            $command[] = '--data-raw '.$this->escapePayload($content);
+            $command[] = '--data-raw '.$this->escapeArgument($content);
         }
 
         return implode(" \\\n  ", $command);
@@ -541,19 +540,14 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
         return $this->data['curlCommand'] ?? '';
     }
 
-    private function escapePayload(string $payload): string
+    /**
+     * The command joins its arguments with "\" line continuations, so it targets a POSIX
+     * shell on every platform. escapeshellarg() cannot be used: it drops bytes that are
+     * not valid in the current locale, and turns "%" into a space on Windows.
+     */
+    private function escapeArgument(string $value): string
     {
-        static $useProcess;
-
-        if ($useProcess ??= \function_exists('proc_open') && class_exists(Process::class)) {
-            return substr((new Process(['', $payload]))->getCommandLine(), 3);
-        }
-
-        if ('\\' === \DIRECTORY_SEPARATOR) {
-            return '"'.str_replace('"', '""', $payload).'"';
-        }
-
-        return "'".str_replace("'", "'\\''", $payload)."'";
+        return "'".str_replace("'", "'\\''", $value)."'";
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/RequestDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/RequestDataCollectorTest.php
@@ -472,7 +472,7 @@ class RequestDataCollectorTest extends TestCase
 
         $curlCommand = $c->getCurlCommand();
         $this->assertStringStartsWith("curl \\\n  --compressed", $curlCommand);
-        $this->assertStringContainsString('--url '.('\\' === \DIRECTORY_SEPARATOR ? '"http://test.com/foo?bar=baz"' : "'http://test.com/foo?bar=baz'"), $curlCommand);
+        $this->assertStringContainsString("--url 'http://test.com/foo?bar=baz'", $curlCommand);
         $this->assertStringNotContainsString('--request', $curlCommand);
     }
 
@@ -486,7 +486,7 @@ class RequestDataCollectorTest extends TestCase
         $curlCommand = $c->getCurlCommand();
         $this->assertStringContainsString('--request POST', $curlCommand);
         $this->assertStringContainsString('--data-raw', $curlCommand);
-        $this->assertStringContainsString('\\' === \DIRECTORY_SEPARATOR ? '"{""key"":""value""}"' : '\'{"key":"value"}\'', $curlCommand);
+        $this->assertStringContainsString('\'{"key":"value"}\'', $curlCommand);
     }
 
     public function testCurlCommandHead()
@@ -511,8 +511,8 @@ class RequestDataCollectorTest extends TestCase
         $c->collect($request, $this->createResponse());
 
         $curlCommand = $c->getCurlCommand();
-        $this->assertStringContainsString('--header '.('\\' === \DIRECTORY_SEPARATOR ? '"Accept: application/json"' : "'Accept: application/json'"), $curlCommand);
-        $this->assertStringContainsString('--header '.('\\' === \DIRECTORY_SEPARATOR ? '"X-Custom-Header: custom-value"' : "'X-Custom-Header: custom-value'"), $curlCommand);
+        $this->assertStringContainsString("--header 'Accept: application/json'", $curlCommand);
+        $this->assertStringContainsString("--header 'X-Custom-Header: custom-value'", $curlCommand);
         $this->assertStringNotContainsString('Host:', $curlCommand);
     }
 
@@ -533,6 +533,21 @@ class RequestDataCollectorTest extends TestCase
         $this->assertStringContainsString('prefs[setting3][1]=listItem2', $curlCommand);
         // a cookie is not form data, so a space is "%20" and "+" stays a literal plus
         $this->assertStringContainsString('note=hello%20world', $curlCommand);
+    }
+
+    public function testCurlCommandEscapesArgumentsForAPosixShell()
+    {
+        $request = Request::create('http://test.com/foo', 'POST', [], [], [], [], "it's `id` \$(id) & echo");
+        $request->headers->set('X-Shell', 'a`id`b $(id) & echo');
+        $request->headers->set('X-Binary', "a\xffb");
+
+        $c = new RequestDataCollector();
+        $c->collect($request, $this->createResponse());
+
+        $curlCommand = $c->getCurlCommand();
+        $this->assertStringContainsString("--header 'X-Shell: a`id`b \$(id) & echo'", $curlCommand);
+        $this->assertStringContainsString("--header 'X-Binary: a\xffb'", $curlCommand);
+        $this->assertStringContainsString("--data-raw 'it'\\''s `id` \$(id) & echo'", $curlCommand);
     }
 
     public function testCurlCommandWithCookieHoldingAnEmptyArray()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The "Copy as cURL" command shown in the profiler is built by quoting each argument with `escapeshellarg()`, except the body. That function has two behaviors that do not fit a command meant to be read and pasted by a human:

 * it silently drops every byte that is not valid in the current locale, so a header carrying a non-UTF-8 value loses those bytes: `a\xffb` is rendered as `ab`;
 * on Windows it replaces `"`, `%` and `!` with a space, so any percent-encoded value is corrupted: the cookie `note=hello%20world` is rendered as `note=hello 20world`.

The second one turns the Windows jobs red, since `RequestDataCollectorTest::testCurlCommandWithCookies` asserts on `note=hello%20world`.

The command joins its arguments with `\` line continuations, which is POSIX shell syntax on every platform. This quotes each argument for a POSIX shell accordingly, `'` included, and drops the platform branch. Single quoting is also the only one of the candidate schemes that is safe: with the previous double-quote branch, a header value of `` a$(id)b `id` `` pasted into git-bash or WSL executes `id`.

The output is unchanged on Linux and macOS for every value that `escapeshellarg()` did not mangle, so this only affects Windows and non-UTF-8 payloads.

Note that this does not try to produce a `cmd.exe` command line. That would need caret escaping and a different line continuation, and it would render `hello%20world` as `hello%^20world`, which is what Chrome DevTools does in its "Copy as cURL (cmd)" entry. Chrome offers "Copy as cURL (bash)" next to it and lets the user pick; adding that here would be a feature, not a bug fix.

Supersedes #65006, which found the Windows failure.

`HttpClientDataCollector::getCurlCommand()` has the same defect down to 6.4, fixed separately.
