### PR TITLE
[HttpClient] Fix the escaping of the generated curl command

### DIFF
--- a/src/Symfony/Component/HttpClient/DataCollector/HttpClientDataCollector.php
+++ b/src/Symfony/Component/HttpClient/DataCollector/HttpClientDataCollector.php
@@ -18,7 +18,6 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\DataCollector\DataCollector;
 use Symfony\Component\HttpKernel\DataCollector\LateDataCollectorInterface;
-use Symfony\Component\Process\Process;
 use Symfony\Component\VarDumper\Caster\ImgStub;
 
 /**
@@ -189,7 +188,7 @@ final class HttpClientDataCollector extends DataCollector implements LateDataCol
             $port = parse_url($url, \PHP_URL_PORT) ?: (str_starts_with('http:', $url) ? 80 : 443);
             foreach ($trace['options']['resolve'] as $host => $ip) {
                 if (null !== $ip) {
-                    $command[] = '--resolve '.escapeshellarg("$host:$port:$ip");
+                    $command[] = '--resolve '.$this->escapeArgument("$host:$port:$ip");
                 }
             }
         }
@@ -197,10 +196,10 @@ final class HttpClientDataCollector extends DataCollector implements LateDataCol
         $dataArg = [];
 
         if ($json = $trace['options']['json'] ?? null) {
-            $dataArg[] = '--data-raw '.$this->escapePayload(self::jsonEncode($json));
+            $dataArg[] = '--data-raw '.$this->escapeArgument(self::jsonEncode($json));
         } elseif ($body = $trace['options']['body'] ?? null) {
             if (\is_string($body)) {
-                $dataArg[] = '--data-raw '.$this->escapePayload($body);
+                $dataArg[] = '--data-raw '.$this->escapeArgument($body);
             } elseif (\is_array($body)) {
                 try {
                     $body = self::normalizeBody($body);
@@ -211,7 +210,7 @@ final class HttpClientDataCollector extends DataCollector implements LateDataCol
                     return null;
                 }
                 foreach (explode('&', $body) as $value) {
-                    $dataArg[] = '--data-raw '.$this->escapePayload(urldecode($value));
+                    $dataArg[] = '--data-raw '.$this->escapeArgument(urldecode($value));
                 }
             } else {
                 return null;
@@ -239,11 +238,11 @@ final class HttpClientDataCollector extends DataCollector implements LateDataCol
 
             if (preg_match('/^> ([A-Z]+)/', $line, $match)) {
                 $command[] = \sprintf('--request %s', $match[1]);
-                $command[] = \sprintf('--url %s', escapeshellarg($url));
+                $command[] = \sprintf('--url %s', $this->escapeArgument($url));
                 continue;
             }
 
-            $command[] = '--header '.escapeshellarg($line);
+            $command[] = '--header '.$this->escapeArgument($line);
         }
 
         if (null !== $dataArg) {
@@ -253,18 +252,13 @@ final class HttpClientDataCollector extends DataCollector implements LateDataCol
         return implode(" \\\n  ", $command);
     }
 
-    private function escapePayload(string $payload): string
+    /**
+     * The command joins its arguments with "\" line continuations, so it targets a POSIX
+     * shell on every platform. escapeshellarg() cannot be used: it drops bytes that are
+     * not valid in the current locale, and turns "%" into a space on Windows.
+     */
+    private function escapeArgument(string $value): string
     {
-        static $useProcess;
-
-        if ($useProcess ??= \function_exists('proc_open') && class_exists(Process::class)) {
-            return substr((new Process(['', $payload]))->getCommandLine(), 3);
-        }
-
-        if ('\\' === \DIRECTORY_SEPARATOR) {
-            return '"'.str_replace('"', '""', $payload).'"';
-        }
-
-        return "'".str_replace("'", "'\\''", $payload)."'";
+        return "'".str_replace("'", "'\\''", $value)."'";
     }
 }

--- a/src/Symfony/Component/HttpClient/Tests/DataCollector/HttpClientDataCollectorTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/DataCollector/HttpClientDataCollectorTest.php
@@ -325,7 +325,7 @@ class HttpClientDataCollectorTest extends TestCase
                             'foo' => [
                                 'bar' => 'baz',
                                 'qux' => [1.10, 1.0],
-                                'fred' => ['<foo>', "'bar'", '"baz"', '&blong&'],
+                                'fred' => ['<foo>', "'bar'", '"baz"', '&belong&'],
                             ],
                         ],
                     ],
@@ -336,12 +336,37 @@ class HttpClientDataCollectorTest extends TestCase
   --url http://localhost:8057/json \\
   --header Content-Type: application/json \\
   --header Accept: */* \\
-  --header Content-Length: 120 \\
+  --header Content-Length: 121 \\
   --header Accept-Encoding: gzip \\
   --header User-Agent: Symfony HttpClient (Native) \\
-  --data-raw {"foo":{"bar":"baz","qux":[1.1,1.0],"fred":["\u003Cfoo\u003E","\u0027bar\u0027","\u0022baz\u0022","\u0026blong\u0026"]}}',
+  --data-raw {"foo":{"bar":"baz","qux":[1.1,1.0],"fred":["\u003Cfoo\u003E","\u0027bar\u0027","\u0022baz\u0022","\u0026belong\u0026"]}}',
             ];
         }
+    }
+
+    public function testItEscapesCurlCommandArgumentsForAPosixShell()
+    {
+        $sut = new HttpClientDataCollector();
+        $sut->registerClient('http_client', $this->httpClientThatHasTracedRequests([
+            [
+                'method' => 'POST',
+                'url' => 'http://localhost:8057/json',
+                'options' => [
+                    'headers' => [
+                        'X-Shell' => 'a`id`b $(id) & echo',
+                        'X-Binary' => "a\xffb",
+                    ],
+                    'body' => "it's `id` \$(id)",
+                ],
+            ],
+        ]));
+        $sut->lateCollect();
+        $collectedData = $sut->getClients();
+        $curlCommand = $collectedData['http_client']['traces'][0]['curlCommand'];
+
+        self::assertStringContainsString("--header 'X-Shell: a`id`b \$(id) & echo'", $curlCommand);
+        self::assertStringContainsString("--header 'X-Binary: a\xffb'", $curlCommand);
+        self::assertStringContainsString("--data-raw 'it'\\''s `id` \$(id)'", $curlCommand);
     }
 
     public function testItDoesNotFollowRedirectionsWhenGeneratingCurlCommands()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Same defect as #65008, in the HttpClient panel of the profiler.

`--resolve`, `--url` and `--header` are quoted with `escapeshellarg()`, which:

 * silently drops every byte that is not valid in the current locale, so a header carrying a non-UTF-8 value loses those bytes: `X-Binary: a\xffb` is rendered as `X-Binary: ab`;
 * replaces `"`, `%` and `!` with a space on Windows, so any percent-encoded URL is corrupted.

The command joins its arguments with `\` line continuations, which is POSIX shell syntax on every platform, so this quotes each argument for a POSIX shell and drops the platform branch that `--data-raw` used. Single quoting is also the only safe scheme here: the previous double-quote branch left `` ` `` and `$` live, so a header value of `` a$(id)b `id` `` executed `id` when pasted into git-bash or WSL.

The existing curl assertions strip `"` and `'` before comparing, which is why they never caught this. The new test asserts the quoting itself.
