### PR TITLE
[HttpKernel] Remove an unused dev dependency on symfony/process

### DIFF
--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -35,7 +35,6 @@
         "symfony/expression-language": "^5.4|^6.0|^7.0",
         "symfony/finder": "^5.4|^6.0|^7.0",
         "symfony/http-client-contracts": "^2.5|^3",
-        "symfony/process": "^5.4|^6.0|^7.0",
         "symfony/property-access": "^5.4.5|^6.0.5|^7.0",
         "symfony/routing": "^5.4|^6.0|^7.0",
         "symfony/serializer": "^6.4.4|^7.0.4",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Nothing in the HttpKernel component references the Process component, on any branch from 6.4 to 8.0. On 8.1 the single reference left is removed by #65008.
