### PR TITLE
[Cache] Add support for relay 0.40

### DIFF
--- a/src/Symfony/Component/Cache/Traits/Relay/Relay40Trait.php
+++ b/src/Symfony/Component/Cache/Traits/Relay/Relay40Trait.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Traits\Relay;
+
+if (version_compare(phpversion('relay'), '0.40.0', '>=')) {
+    /**
+     * @internal
+     */
+    trait Relay40Trait
+    {
+        public function blmovem($srckey, $dstkey, $srcpos, $dstpos, $timeout, $options = null): \Relay\Relay|array|false
+        {
+            return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->blmovem(...\func_get_args());
+        }
+
+        public function lmovem($srckey, $dstkey, $srcpos, $dstpos, $options = null): \Relay\Relay|array|false
+        {
+            return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lmovem(...\func_get_args());
+        }
+
+        public function sdiffcard($keys, $options = null): \Relay\Relay|false|int
+        {
+            return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sdiffcard(...\func_get_args());
+        }
+
+        public function sunioncard($keys, $options = null): \Relay\Relay|false|int
+        {
+            return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sunioncard(...\func_get_args());
+        }
+    }
+} else {
+    /**
+     * @internal
+     */
+    trait Relay40Trait
+    {
+    }
+}

--- a/src/Symfony/Component/Cache/Traits/RelayProxy.php
+++ b/src/Symfony/Component/Cache/Traits/RelayProxy.php
@@ -29,6 +29,7 @@ use Symfony\Component\Cache\Traits\Relay\Relay20Trait;
 use Symfony\Component\Cache\Traits\Relay\Relay21Trait;
 use Symfony\Component\Cache\Traits\Relay\Relay22Trait;
 use Symfony\Component\Cache\Traits\Relay\Relay30Trait;
+use Symfony\Component\Cache\Traits\Relay\Relay40Trait;
 use Symfony\Component\Cache\Traits\Relay\SwapdbTrait;
 use Symfony\Component\VarExporter\LazyObjectInterface;
 use Symfony\Component\VarExporter\LazyProxyTrait;
@@ -66,6 +67,7 @@ class RelayProxy extends \Relay\Relay implements ResetInterface, LazyObjectInter
     use Relay21Trait;
     use Relay22Trait;
     use Relay30Trait;
+    use Relay40Trait;
     use SwapdbTrait;
 
     private const LAZY_OBJECT_PROPERTY_SCOPES = [];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

CI is red on all branches since relay 0.40 got released: `RedisProxiesTest::testRelayProxy` fails because the extension now exposes `blmovem`, `lmovem`, `sdiffcard` and `sunioncard`, which `RelayProxy` doesn't declare.

This adds them in a version-gated `Relay40Trait`, following the existing pattern.