### PR TITLE
[Notifier] Support multiline Telegram inline keyboards

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Telegram/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add support for passing multiple inline keyboard rows to `InlineKeyboardMarkup`
+
 8.1
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/Reply/Markup/InlineKeyboardMarkup.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/Reply/Markup/InlineKeyboardMarkup.php
@@ -26,15 +26,21 @@ final class InlineKeyboardMarkup extends AbstractTelegramReplyMarkup
     }
 
     /**
-     * @param InlineKeyboardButton[] $buttons
+     * @param InlineKeyboardButton[]|InlineKeyboardButton[][] $buttons
      *
      * @return $this
      */
     public function inlineKeyboard(array $buttons): static
     {
-        $buttons = array_map(static fn (InlineKeyboardButton $button) => $button->toArray(), $buttons);
+        $rows = $buttons;
 
-        $this->options['inline_keyboard'][] = $buttons;
+        if ([] === $buttons || $buttons[array_key_first($buttons)] instanceof InlineKeyboardButton) {
+            $rows = [$buttons];
+        }
+
+        foreach ($rows as $buttons) {
+            $this->options['inline_keyboard'][] = array_map(static fn (InlineKeyboardButton $button) => $button->toArray(), $buttons);
+        }
 
         return $this;
     }

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/Tests/TelegramOptionsTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/Tests/TelegramOptionsTest.php
@@ -141,6 +141,45 @@ final class TelegramOptionsTest extends TestCase
         $this->assertSame($expected, $options->toArray());
     }
 
+    public function testWithMultilineInlineKeyboard()
+    {
+        $firstRowButton = new InlineKeyboardButton('Button 1');
+        $firstRowButton->callbackData('callback_1');
+
+        $secondRowButton1 = new InlineKeyboardButton('Button 2');
+        $secondRowButton1->callbackData('callback_2');
+
+        $secondRowButton2 = new InlineKeyboardButton('Button 3');
+        $secondRowButton2->callbackData('callback_3');
+
+        $markup = new InlineKeyboardMarkup();
+        $markup->inlineKeyboard([
+            [$firstRowButton],
+            [$secondRowButton1, $secondRowButton2],
+        ]);
+
+        $options = (new TelegramOptions())
+            ->chatId('123456')
+            ->replyMarkup($markup);
+
+        $expected = [
+            'chat_id' => '123456',
+            'reply_markup' => [
+                'inline_keyboard' => [
+                    [
+                        ['text' => 'Button 1', 'callback_data' => 'callback_1'],
+                    ],
+                    [
+                        ['text' => 'Button 2', 'callback_data' => 'callback_2'],
+                        ['text' => 'Button 3', 'callback_data' => 'callback_3'],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->assertSame($expected, $options->toArray());
+    }
+
     public function testOptionsChaining()
     {
         $options = new TelegramOptions();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #64958
| License       | MIT

`InlineKeyboardMarkup::inlineKeyboard()` only accepted one flat row of `InlineKeyboardButton` instances. Telegram's native `inline_keyboard` payload is an array of button rows, so this allows passing multiple rows in one call while keeping the existing flat-row call working.

## Test verification (RED → GREEN)

RED on `upstream/8.2` with the new test before the production change:

```text
There was 1 error:

1) Symfony\Component\Notifier\Bridge\Telegram\Tests\TelegramOptionsTest::testWithMultilineInlineKeyboard
TypeError: Symfony\Component\Notifier\Bridge\Telegram\Reply\Markup\InlineKeyboardMarkup::{closure:Symfony\Component\Notifier\Bridge\Telegram\Reply\Markup\InlineKeyboardMarkup::inlineKeyboard():35}(): Argument #1 ($button) must be of type Symfony\Component\Notifier\Bridge\Telegram\Reply\Markup\Button\InlineKeyboardButton, array given

ERRORS!
Tests: 1, Assertions: 0, Errors: 1.
```

GREEN after the change:

```text
PHPUnit 13.2.6 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.5.8
Configuration: /app/phpunit.xml.dist

.                                                                   1 / 1 (100%)

OK (1 test, 1 assertion)
```

Local CI replay:

```text
Baseline upstream/8.2: OK (77 tests, 169 assertions)
Final branch: OK (78 tests, 170 assertions)
```
