### PR TITLE
[PropertyAccess] Add collection suffix adder remover convention

### DIFF
--- a/src/Symfony/Component/PropertyAccess/CHANGELOG.md
+++ b/src/Symfony/Component/PropertyAccess/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add support for using a `Collection` suffix to derive adder and remover method names
+
 8.1
 ---
 

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -57,6 +57,7 @@ class PropertyAccessor implements PropertyAccessorInterface
     private const CACHE_PREFIX_READ = 'r';
     private const CACHE_PREFIX_WRITE = 'w';
     private const CACHE_PREFIX_PROPERTY_PATH = 'p';
+    private const COLLECTION_SUFFIX = 'Collection';
     private const RESULT_PROTO = [self::VALUE => null];
 
     private bool $ignoreInvalidIndices;
@@ -617,6 +618,19 @@ class PropertyAccessor implements PropertyAccessorInterface
             'enable_constructor_extraction' => false,
             'enable_adder_remover_extraction' => $useAdderAndRemover,
         ]);
+
+        if ($useAdderAndRemover && PropertyWriteInfo::TYPE_NONE === $mutator->getType() && str_ends_with($property, self::COLLECTION_SUFFIX) && self::COLLECTION_SUFFIX !== $property) {
+            $collectionMutator = $this->writeInfoExtractor->getWriteInfo($class, substr($property, 0, -\strlen(self::COLLECTION_SUFFIX)), [
+                'enable_getter_setter_extraction' => true,
+                'enable_magic_methods_extraction' => $this->magicMethodsFlags,
+                'enable_constructor_extraction' => false,
+                'enable_adder_remover_extraction' => true,
+            ]);
+
+            if ($collectionMutator && PropertyWriteInfo::TYPE_ADDER_AND_REMOVER === $collectionMutator->getType()) {
+                $mutator = $collectionMutator;
+            }
+        }
 
         if (isset($item)) {
             $this->cacheItemPool->save($item->set($mutator));

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorCollectionTestCase.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorCollectionTestCase.php
@@ -100,6 +100,37 @@ class PropertyAccessorCollectionTestCase_CarStructure
     }
 }
 
+class PropertyAccessorCollectionTestCase_Publication
+{
+    private array $comments;
+
+    public function __construct(array $comments)
+    {
+        $this->comments = $comments;
+    }
+
+    public function addComment(string $comment): void
+    {
+        $this->comments[] = $comment;
+    }
+
+    public function removeComment(string $comment): void
+    {
+        foreach ($this->comments as $key => $value) {
+            if ($value === $comment) {
+                unset($this->comments[$key]);
+
+                return;
+            }
+        }
+    }
+
+    public function getCommentCollection(): array
+    {
+        return $this->comments;
+    }
+}
+
 abstract class PropertyAccessorCollectionTestCase extends PropertyAccessorArrayAccessTestCase
 {
     public function testSetValueCallsAdderAndRemoverForCollections()
@@ -152,6 +183,15 @@ abstract class PropertyAccessorCollectionTestCase extends PropertyAccessorArrayA
         ;
 
         $this->propertyAccessor->setValue($car, 'structure.axes', $axesAfter);
+    }
+
+    public function testSetValueUsesCollectionSuffixForAdderAndRemoverConvention()
+    {
+        $publication = new PropertyAccessorCollectionTestCase_Publication(['second', 'fourth']);
+
+        $this->propertyAccessor->setValue($publication, 'commentCollection', ['first', 'second', 'third']);
+
+        $this->assertSame(['second', 2 => 'first', 3 => 'third'], $publication->getCommentCollection());
     }
 
     public function testSetValueFailsIfNoAdderNorRemoverFound()

--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -42,6 +42,8 @@ use Symfony\Component\TypeInfo\TypeResolver\TypeResolverInterface;
  */
 class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTypeExtractorInterface, PropertyAccessExtractorInterface, PropertyInitializableExtractorInterface, PropertyReadInfoExtractorInterface, PropertyWriteInfoExtractorInterface, ConstructorArgumentTypeExtractorInterface
 {
+    private const COLLECTION_SUFFIX = 'Collection';
+
     /**
      * @internal
      */
@@ -688,7 +690,17 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
         [$addPrefix, $removePrefix] = $this->arrayMutatorPrefixes;
         $errors = [];
 
+        $singulars = [];
+
+        if (str_ends_with($property, self::COLLECTION_SUFFIX) && self::COLLECTION_SUFFIX !== $property) {
+            $singulars[] = substr($property, 0, -\strlen(self::COLLECTION_SUFFIX));
+        }
+
         foreach ($this->inflector->singularize($property) as $singular) {
+            $singulars[] = $singular;
+        }
+
+        foreach (array_unique($singulars) as $singular) {
             $addMethod = $addPrefix.$singular;
             $removeMethod = $removePrefix.$singular;
 

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\PropertyInfo\PropertyReadInfo;
 use Symfony\Component\PropertyInfo\PropertyWriteInfo;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\AdderRemoverDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\AsymmetricVisibility;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\CollectionSuffixAdderRemoverDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\ConstructorDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\DefaultValue;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy;
@@ -476,6 +477,7 @@ class ReflectionExtractorTest extends TestCase
             [SnakeCaseDummy::class, 'snake_property', false, true, PropertyWriteInfo::TYPE_METHOD, 'setSnakeProperty', null, null, PropertyWriteInfo::VISIBILITY_PUBLIC, false],
             [SnakeCaseDummy::class, 'snake_method', false, true, PropertyWriteInfo::TYPE_METHOD, 'setSnake_method', null, null, PropertyWriteInfo::VISIBILITY_PUBLIC, false],
             [SnakeCaseDummy::class, 'snake_readonly', false, false, PropertyWriteInfo::TYPE_NONE, null, null, null, null, null],
+            [CollectionSuffixAdderRemoverDummy::class, 'commentCollection', false, true, PropertyWriteInfo::TYPE_ADDER_AND_REMOVER, null, 'addComment', 'removeComment', PropertyWriteInfo::VISIBILITY_PUBLIC, false],
         ];
     }
 

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/CollectionSuffixAdderRemoverDummy.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/CollectionSuffixAdderRemoverDummy.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
+
+class CollectionSuffixAdderRemoverDummy
+{
+    public function addComment(string $comment)
+    {
+    }
+
+    public function removeComment(string $comment)
+    {
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #52809
| License       | MIT
| Doc PR        | Not needed

This adds a deterministic `Collection` suffix convention for collection-valued properties handled through adder/remover pairs.

With this change, a property path such as `commentCollection` can be written through:

```php
getCommentCollection()
addComment()
removeComment()
```

The existing English inflector fallback is preserved.

Prior-art audit:

* Read #52809 body and all comments.
* `issue-available.sh` reported no open PRs, no fork-internal PRs, and no prior closed PRs for #52809.
* The thread suggested either a deterministic convention or configurable inflector; this PR keeps scope to the deterministic convention requested in the issue.

RED:

```text
Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException:
Could not determine access type for property "commentCollection"

ERRORS!
Tests: 1, Assertions: 0, Errors: 1.
```

GREEN:

```text
OK (1 test, 1 assertion)
```

Local CI:

```text
Baseline upstream/8.2:
OK (1071 tests, 1478 assertions)

Final:
OK (1074 tests, 1481 assertions)
```
