### PR TITLE
[Routing] Add snake case aliases for generated route names

### DIFF
--- a/src/Symfony/Component/Routing/CHANGELOG.md
+++ b/src/Symfony/Component/Routing/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add snake_case aliases for automatically generated attribute route names with camelCase segments
+
 8.1
 ---
 

--- a/src/Symfony/Component/Routing/Loader/AttributeClassLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AttributeClassLoader.php
@@ -148,8 +148,15 @@ abstract class AttributeClassLoader implements LoaderInterface
             return;
         }
 
-        $name = $attr->name ?? $this->getDefaultRouteName($class, $method);
+        $defaultAliasName = null;
+        if (null === $attr->name) {
+            $name = $this->getDefaultRouteName($class, $method);
+            $defaultAliasName = $this->getDefaultRouteAliasName($class, $method, $this->defaultRouteIndex - 1);
+        } else {
+            $name = $attr->name;
+        }
         $name = $globals['name'].$name;
+        $defaultAliasName = null === $defaultAliasName ? null : $globals['name'].$defaultAliasName;
 
         $requirements = $attr->requirements;
 
@@ -226,6 +233,17 @@ abstract class AttributeClassLoader implements LoaderInterface
             }
         }
 
+        if (null !== $defaultAliasName && $defaultAliasName !== $name) {
+            foreach (array_keys($paths) as $locale) {
+                $suffix = 0 !== $locale ? '.'.$locale : '';
+                $aliasName = $defaultAliasName.$suffix;
+
+                if (!$collection->get($aliasName) && !$collection->getAlias($aliasName)) {
+                    $collection->addAlias($aliasName, $name.$suffix);
+                }
+            }
+        }
+
         foreach ($attr->aliases as $aliasAttribute) {
             $aliasName = $aliasAttribute instanceof DeprecatedAlias ? $aliasAttribute->aliasName : $aliasAttribute;
 
@@ -271,6 +289,24 @@ abstract class AttributeClassLoader implements LoaderInterface
         ++$this->defaultRouteIndex;
 
         return $name;
+    }
+
+    private function getDefaultRouteAliasName(\ReflectionClass $class, \ReflectionMethod $method, int $defaultRouteIndex): string
+    {
+        $namespace = $class->getNamespaceName();
+        $name = ('' === $namespace ? '' : str_replace('\\', '_', $namespace).'_')
+            .$this->camelCaseToSnakeCase($class->getShortName()).'_'.$this->camelCaseToSnakeCase($method->name);
+        $name = \function_exists('mb_strtolower') && preg_match('//u', $name) ? mb_strtolower($name, 'UTF-8') : strtolower($name);
+        if ($defaultRouteIndex > 0) {
+            $name .= '_'.$defaultRouteIndex;
+        }
+
+        return $name;
+    }
+
+    private function camelCaseToSnakeCase(string $name): string
+    {
+        return preg_replace('/(?<=[\p{Ll}\p{N}])(\p{Lu})/u', '_$1', $name) ?? $name;
     }
 
     /**

--- a/src/Symfony/Component/Routing/Tests/Fixtures/AttributeFixtures/CamelCaseDefaultRouteNameController.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AttributeFixtures/CamelCaseDefaultRouteNameController.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Symfony\Component\Routing\Tests\Fixtures\AttributeFixtures;
+
+use Symfony\Component\Routing\Attribute\Route;
+
+class CamelCaseDefaultRouteNameController
+{
+    #[Route('/change-password')]
+    public function changePassword()
+    {
+    }
+}

--- a/src/Symfony/Component/Routing/Tests/Loader/AttributeClassLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AttributeClassLoaderTest.php
@@ -22,6 +22,7 @@ use Symfony\Component\Routing\Tests\Fixtures\AttributeFixtures\AliasInvokableCon
 use Symfony\Component\Routing\Tests\Fixtures\AttributeFixtures\AliasLocalizedRouteController;
 use Symfony\Component\Routing\Tests\Fixtures\AttributeFixtures\AliasRouteController;
 use Symfony\Component\Routing\Tests\Fixtures\AttributeFixtures\BazClass;
+use Symfony\Component\Routing\Tests\Fixtures\AttributeFixtures\CamelCaseDefaultRouteNameController;
 use Symfony\Component\Routing\Tests\Fixtures\AttributeFixtures\DefaultValueController;
 use Symfony\Component\Routing\Tests\Fixtures\AttributeFixtures\DeprecatedAliasCustomMessageRouteController;
 use Symfony\Component\Routing\Tests\Fixtures\AttributeFixtures\DeprecatedAliasRouteController;
@@ -192,6 +193,16 @@ class AttributeClassLoaderTest extends TestCase
         $this->assertEquals('/the/path', $routes->get('post')->getPath());
         $this->assertEquals(new Alias('post'), $routes->getAlias('Symfony\Component\Routing\Tests\Fixtures\AttributeFixtures\MethodActionControllers::post'));
         $this->assertEquals(new Alias('put'), $routes->getAlias('Symfony\Component\Routing\Tests\Fixtures\AttributeFixtures\MethodActionControllers::put'));
+    }
+
+    public function testCamelCaseDefaultRouteNameHasSnakeCaseAlias()
+    {
+        $routes = $this->loader->load(CamelCaseDefaultRouteNameController::class);
+        $routeName = 'symfony_component_routing_tests_fixtures_attributefixtures_camelcasedefaultroutenamecontroller_changepassword';
+        $aliasName = 'symfony_component_routing_tests_fixtures_attributefixtures_camel_case_default_route_name_controller_change_password';
+
+        $this->assertArrayHasKey($routeName, $routes->all());
+        $this->assertEquals(new Alias($routeName), $routes->getAlias($aliasName));
     }
 
     public function testInvokableClassRouteLoadWithMethodAttribute()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #53237
| License       | MIT
| Doc PR        | Not needed

This keeps the existing automatically generated route name unchanged, and adds a snake_case alias when the generated name contains camelCase segments.

That avoids the BC break called out on the previous PR while making the requested `changePassword` / `change_password` style name resolvable.

Prior-art audit:

* Read #53237 body and comments.
* Read closed PR #53982.
* #53982 changed the primary generated route name and was closed as a BC break.
* This PR follows the alternative mentioned there: add an alias instead of changing the existing route name.

RED:

```text
null does not match expected type "object".

FAILURES!
Tests: 1, Assertions: 2, Failures: 1.
```

GREEN:

```text
OK (1 test, 2 assertions)
```

Local CI:

```text
Baseline upstream/8.2:
OK (1183 tests, 2288 assertions)

Final:
OK (1184 tests, 2290 assertions)
```
