### PR TITLE
[Lock] Allow advisory locks when reusing a PDO/DBAL connection in StoreFactory

### DIFF
--- a/src/Symfony/Component/Lock/CHANGELOG.md
+++ b/src/Symfony/Component/Lock/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 7.4
 ---
 
+ * Add an `$options` argument to `StoreFactory::createStore()` with an `advisory` flag to use PostgreSQL advisory locks when reusing an existing `\PDO` or Doctrine DBAL `Connection`
  * Add `LockKeyNormalizer`
 
 7.3

--- a/src/Symfony/Component/Lock/Store/StoreFactory.php
+++ b/src/Symfony/Component/Lock/Store/StoreFactory.php
@@ -26,8 +26,15 @@ use Symfony\Component\Lock\PersistingStoreInterface;
  */
 class StoreFactory
 {
-    public static function createStore(#[\SensitiveParameter] object|string $connection): PersistingStoreInterface
+    /**
+     * @param array{advisory?: bool} $options Set "advisory" to true to use PostgreSQL advisory locks when reusing
+     *                                        an existing \PDO or Doctrine DBAL Connection instead of the default,
+     *                                        table-based store
+     */
+    public static function createStore(#[\SensitiveParameter] object|string $connection, array $options = []): PersistingStoreInterface
     {
+        $advisory = $options['advisory'] ?? false;
+
         switch (true) {
             case $connection instanceof DynamoDbClient:
                 self::requireBridgeClass(DynamoDbStore::class, 'symfony/amazon-dynamo-db-lock');
@@ -48,10 +55,10 @@ class StoreFactory
                 return new MongoDbStore($connection);
 
             case $connection instanceof \PDO:
-                return new PdoStore($connection);
+                return $advisory ? new PostgreSqlStore($connection) : new PdoStore($connection);
 
             case $connection instanceof Connection:
-                return new DoctrineDbalStore($connection);
+                return $advisory ? new DoctrineDbalPostgreSqlStore($connection) : new DoctrineDbalStore($connection);
 
             case $connection instanceof \Zookeeper:
                 return new ZookeeperStore($connection);

--- a/src/Symfony/Component/Lock/Store/StoreFactory.php
+++ b/src/Symfony/Component/Lock/Store/StoreFactory.php
@@ -138,7 +138,7 @@ class StoreFactory
     private static function requireBridgeClass(string $class, string $package): void
     {
         if (!class_exists($class)) {
-            throw new \LogicException(\sprintf('Class "%s" is missing. Try running "composer require %s" to install the lock store package.', $class, $package));
+            throw new \LogicException(\sprintf('Class "%s" is missing. Try running composer require "%s" to install the lock store package.', $class, $package));
         }
     }
 }

--- a/src/Symfony/Component/Lock/Tests/Store/StoreFactoryTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/StoreFactoryTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Lock\Tests\Store;
 
 use AsyncAws\DynamoDb\DynamoDbClient;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Cache\Adapter\AbstractAdapter;
@@ -99,5 +100,56 @@ class StoreFactoryTest extends TestCase
         yield ['flock://'.sys_get_temp_dir(), FlockStore::class];
 
         yield ['null', NullStore::class];
+    }
+
+    /**
+     * @requires extension pdo_sqlite
+     */
+    public function testCreateStoreForPdoConnectionWithoutAdvisory()
+    {
+        $store = StoreFactory::createStore(new \PDO('sqlite::memory:'));
+
+        $this->assertInstanceOf(PdoStore::class, $store);
+    }
+
+    /**
+     * @requires extension pdo_sqlite
+     */
+    public function testCreateAdvisoryStoreForPdoConnectionRoutesToPostgreSqlStore()
+    {
+        $pdo = new \PDO('sqlite::memory:');
+        $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+
+        // PostgreSqlStore rejects non-pgsql drivers in its constructor, which proves the
+        // factory routed the connection to the advisory store rather than PdoStore.
+        $this->expectException(\Symfony\Component\Lock\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage(PostgreSqlStore::class);
+
+        StoreFactory::createStore($pdo, ['advisory' => true]);
+    }
+
+    public function testCreateStoreForDbalConnectionWithoutAdvisory()
+    {
+        if (!class_exists(Connection::class)) {
+            $this->markTestSkipped('The "doctrine/dbal" package is required.');
+        }
+
+        $store = StoreFactory::createStore($this->createStub(Connection::class));
+
+        $this->assertInstanceOf(DoctrineDbalStore::class, $store);
+    }
+
+    public function testCreateAdvisoryStoreForDbalConnectionRoutesToDoctrineDbalPostgreSqlStore()
+    {
+        if (!class_exists(Connection::class) || !class_exists(PostgreSQLPlatform::class)) {
+            $this->markTestSkipped('The "doctrine/dbal" package with the PostgreSQL platform is required.');
+        }
+
+        $connection = $this->createStub(Connection::class);
+        $connection->method('getDatabasePlatform')->willReturn(new PostgreSQLPlatform());
+
+        $store = StoreFactory::createStore($connection, ['advisory' => true]);
+
+        $this->assertInstanceOf(DoctrineDbalPostgreSqlStore::class, $store);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #64775
| License       | MIT

`StoreFactory::createStore()` always returned the table-based `PdoStore` or
`DoctrineDbalStore` when given an existing `\PDO` or Doctrine DBAL `Connection`
object. There was no way to request PostgreSQL advisory locks the way the
`pgsql+advisory://` DSN already allows — so an application that wants to **reuse**
its existing connection couldn't opt into advisory locking.

This adds an `$options` argument with an `advisory` flag:

```php
// Reuse an existing connection, with advisory locks
$store = StoreFactory::createStore($pdo, ['advisory' => true]);                 // -> PostgreSqlStore
$store = StoreFactory::createStore($dbalConnection, ['advisory' => true]);      // -> DoctrineDbalPostgreSqlStore

// Unchanged default behavior
$store = StoreFactory::createStore($pdo);                                       // -> PdoStore
$store = StoreFactory::createStore($dbalConnection);                            // -> DoctrineDbalStore