### PR TITLE
[HttpKernel] Add a $skipInvalidFields argument to #[MapQueryString]

### DIFF
--- a/src/Symfony/Component/HttpKernel/Attribute/MapQueryString.php
+++ b/src/Symfony/Component/HttpKernel/Attribute/MapQueryString.php
@@ -34,6 +34,7 @@ class MapQueryString extends ValueResolver
      * @param string|Expression|GroupSequence|GroupResolver|array<string>|null $validationGroups           The validation groups to use when validating the query string mapping
      * @param class-string                                                     $resolver                   The class name of the resolver to use
      * @param int                                                              $validationFailedStatusCode The HTTP code to return if the validation fails
+     * @param bool                                                             $skipInvalidFields          Whether to ignore query parameters that cannot be denormalized and fall back to the mapped object's default values instead of failing
      */
     public function __construct(
         public readonly array $serializationContext = [],
@@ -42,6 +43,7 @@ class MapQueryString extends ValueResolver
         public readonly int $validationFailedStatusCode = Response::HTTP_NOT_FOUND,
         public readonly ?string $key = null,
         public bool $mapWhenEmpty = false,
+        public readonly bool $skipInvalidFields = false,
     ) {
         parent::__construct($resolver);
     }

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.2
 ---
 
+ * Add the `$skipInvalidFields` argument to `#[MapQueryString]` to ignore query parameters that cannot be denormalized and fall back to the mapped object's default values
  * Add `#[AsControllerAttributeListener]` attribute to declare event listeners for controller attributes
  * Add the `$expiration` argument to `FragmentUriGenerator::__construct()` and sign fragment URIs with a 5-year expiration by default
  * Add `hasDump()` method to `Profile` to track profiles with dump

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestPayloadValueResolver.php
@@ -222,7 +222,63 @@ class RequestPayloadValueResolver implements ValueResolverInterface, EventSubscr
             return null;
         }
 
-        return $this->serializer->denormalize($data, $argument->getType(), 'csv', $attribute->serializationContext + self::CONTEXT_DENORMALIZE + ['filter_bool' => true]);
+        $context = $attribute->serializationContext + self::CONTEXT_DENORMALIZE + ['filter_bool' => true];
+
+        if (!$attribute->skipInvalidFields) {
+            return $this->serializer->denormalize($data, $argument->getType(), 'csv', $context);
+        }
+
+        // When skipping invalid fields, drop every query parameter that cannot be denormalized and
+        // retry, so the mapped object falls back to its own default values for those fields while
+        // keeping the valid ones. Retrying is needed because a single invalid constructor argument
+        // otherwise prevents the constructor (and thus its defaults) from being applied at all.
+        while (true) {
+            try {
+                return $this->serializer->denormalize($data, $argument->getType(), 'csv', $context);
+            } catch (PartialDenormalizationException $e) {
+                $errors = method_exists($e, 'getNotNormalizableValueErrors') ? $e->getNotNormalizableValueErrors() : $e->getErrors();
+                $strippedSomething = false;
+                foreach ($errors as $error) {
+                    if (null !== ($path = $error->getPath()) && $this->unsetPath($data, $path)) {
+                        $strippedSomething = true;
+                    }
+                }
+
+                if (!$strippedSomething) {
+                    // Nothing left to strip (e.g. a missing required field); let the caller report it.
+                    throw $e;
+                }
+            }
+        }
+    }
+
+    /**
+     * Removes the value at the given dot-separated path from the data array.
+     *
+     * @param array<array-key, mixed> $data
+     *
+     * @return bool Whether a value was actually removed
+     */
+    private function unsetPath(array &$data, string $path): bool
+    {
+        $keys = explode('.', $path);
+        $lastKey = array_pop($keys);
+        $cursor = &$data;
+
+        foreach ($keys as $key) {
+            if (!\is_array($cursor) || !\array_key_exists($key, $cursor)) {
+                return false;
+            }
+            $cursor = &$cursor[$key];
+        }
+
+        if (!\is_array($cursor) || !\array_key_exists($lastKey, $cursor)) {
+            return false;
+        }
+
+        unset($cursor[$lastKey]);
+
+        return true;
     }
 
     private function mapRequestPayload(Request $request, ArgumentMetadata $argument, MapRequestPayload $attribute): object|array|null

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/RequestPayloadValueResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/RequestPayloadValueResolverTest.php
@@ -51,6 +51,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationList;
 use Symfony\Component\Validator\Exception\ValidationFailedException;
+use Symfony\Component\Validator\Validation;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Component\Validator\ValidatorBuilder;
 
@@ -596,6 +597,129 @@ class RequestPayloadValueResolverTest extends TestCase
             $validationFailedException = $e->getPrevious();
             $this->assertInstanceOf(ValidationFailedException::class, $validationFailedException);
             $this->assertSame('This value should be of type float.', $validationFailedException->getViolations()[0]->getMessage());
+        }
+    }
+
+    public function testQueryStringSkipInvalidFieldsFallsBackToDefaults()
+    {
+        $query = ['text' => 'hello', 'page' => 'not an int'];
+
+        $normalizer = new ObjectNormalizer(null, null, null, new ReflectionExtractor());
+        $serializer = new Serializer([$normalizer], ['json' => new JsonEncoder()]);
+
+        $validator = $this->createMock(ValidatorInterface::class);
+        $validator->expects($this->once())
+            ->method('validate')
+            ->willReturn(new ConstraintViolationList());
+
+        $resolver = new RequestPayloadValueResolver($serializer, $validator);
+
+        $argument = new ArgumentMetadata('search', SearchQuery::class, false, false, null, false, [
+            MapQueryString::class => new MapQueryString(skipInvalidFields: true),
+        ]);
+
+        $request = Request::create('/', 'GET', $query);
+
+        $kernel = $this->createStub(HttpKernelInterface::class);
+        $arguments = $resolver->resolve($request, $argument);
+        $event = new ControllerArgumentsEvent($kernel, static function () {}, $arguments, $request, HttpKernelInterface::MAIN_REQUEST);
+
+        $resolver->onKernelControllerArguments($event);
+
+        $payload = $event->getArguments()[0];
+        $this->assertInstanceOf(SearchQuery::class, $payload);
+        $this->assertSame('hello', $payload->text);
+        $this->assertSame(1, $payload->page);
+    }
+
+    public function testQueryStringSkipInvalidFieldsWithoutValidator()
+    {
+        $query = ['text' => 'hello', 'page' => 'not an int'];
+
+        $normalizer = new ObjectNormalizer(null, null, null, new ReflectionExtractor());
+        $serializer = new Serializer([$normalizer], ['json' => new JsonEncoder()]);
+
+        $resolver = new RequestPayloadValueResolver($serializer);
+
+        $argument = new ArgumentMetadata('search', SearchQuery::class, false, false, null, false, [
+            MapQueryString::class => new MapQueryString(skipInvalidFields: true),
+        ]);
+
+        $request = Request::create('/', 'GET', $query);
+
+        $kernel = $this->createStub(HttpKernelInterface::class);
+        $arguments = $resolver->resolve($request, $argument);
+        $event = new ControllerArgumentsEvent($kernel, static function () {}, $arguments, $request, HttpKernelInterface::MAIN_REQUEST);
+
+        $resolver->onKernelControllerArguments($event);
+
+        $payload = $event->getArguments()[0];
+        $this->assertInstanceOf(SearchQuery::class, $payload);
+        $this->assertSame('hello', $payload->text);
+        $this->assertSame(1, $payload->page);
+    }
+
+    public function testQueryStringSkipInvalidFieldsWithNestedObject()
+    {
+        $query = ['text' => 'hello', 'page' => 'invalid', 'filters' => ['start' => 'invalid', 'length' => '25']];
+
+        $normalizer = new ObjectNormalizer(null, null, null, new ReflectionExtractor());
+        $serializer = new Serializer([$normalizer], ['json' => new JsonEncoder()]);
+
+        $resolver = new RequestPayloadValueResolver($serializer);
+
+        $argument = new ArgumentMetadata('search', SearchQuery::class, false, false, null, false, [
+            MapQueryString::class => new MapQueryString(skipInvalidFields: true),
+        ]);
+
+        $request = Request::create('/', 'GET', $query);
+
+        $kernel = $this->createStub(HttpKernelInterface::class);
+        $arguments = $resolver->resolve($request, $argument);
+        $event = new ControllerArgumentsEvent($kernel, static function () {}, $arguments, $request, HttpKernelInterface::MAIN_REQUEST);
+
+        $resolver->onKernelControllerArguments($event);
+
+        $payload = $event->getArguments()[0];
+        $this->assertInstanceOf(SearchQuery::class, $payload);
+        $this->assertSame('hello', $payload->text);
+        $this->assertSame(1, $payload->page);
+        // Only the invalid nested field falls back to its default; the valid sibling is kept.
+        $this->assertSame(0, $payload->filters->start);
+        $this->assertSame(25, $payload->filters->length);
+    }
+
+    public function testQueryStringSkipInvalidFieldsStillRunsValidationConstraints()
+    {
+        // "page" is a valid int but violates the #[Assert\Positive] constraint,
+        // so skipInvalidFields must not suppress validation of well-typed values.
+        $query = ['page' => '-5'];
+
+        $normalizer = new ObjectNormalizer(null, null, null, new ReflectionExtractor());
+        $serializer = new Serializer([$normalizer], ['json' => new JsonEncoder()]);
+
+        $validator = Validation::createValidatorBuilder()
+            ->enableAttributeMapping()
+            ->getValidator();
+
+        $resolver = new RequestPayloadValueResolver($serializer, $validator);
+
+        $argument = new ArgumentMetadata('search', SearchQuery::class, false, false, null, false, [
+            MapQueryString::class => new MapQueryString(skipInvalidFields: true, validationFailedStatusCode: 422),
+        ]);
+
+        $request = Request::create('/', 'GET', $query);
+
+        $kernel = $this->createStub(HttpKernelInterface::class);
+        $arguments = $resolver->resolve($request, $argument);
+        $event = new ControllerArgumentsEvent($kernel, static function () {}, $arguments, $request, HttpKernelInterface::MAIN_REQUEST);
+
+        try {
+            $resolver->onKernelControllerArguments($event);
+            $this->fail(\sprintf('Expected "%s" to be thrown.', HttpException::class));
+        } catch (HttpException $e) {
+            $this->assertSame(422, $e->getStatusCode());
+            $this->assertInstanceOf(ValidationFailedException::class, $e->getPrevious());
         }
     }
 
@@ -1527,6 +1651,26 @@ class QueryPayload
 {
     public function __construct(public readonly float $page)
     {
+    }
+}
+
+class SearchQuery
+{
+    public function __construct(
+        public readonly string $text = '',
+        #[Assert\Positive]
+        public readonly int $page = 1,
+        public readonly SearchFilters $filters = new SearchFilters(),
+    ) {
+    }
+}
+
+class SearchFilters
+{
+    public function __construct(
+        public readonly int $start = 0,
+        public readonly int $length = 10,
+    ) {
     }
 }
 


### PR DESCRIPTION
When enabled, query parameters that cannot be denormalized are dropped and the mapped object falls back to its own default values for those fields while keeping the valid ones, instead of failing the request.

Closes #64776

| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no 
| Issues        | Fix #64776
| License       | MIT

When mapping the query string to a typed object with `#[MapQueryString]`, a single
query parameter that cannot be denormalized (e.g. `?page=hello` where an `int` is
expected) currently fails the whole request. This is inconvenient for search/filter
pages, where a bad parameter should simply be ignored rather than break the page.

This PR adds a `$skipInvalidFields` argument to `#[MapQueryString]`:

```php
public function search(
    #[MapQueryString(skipInvalidFields: true)] SearchQuery $query,
): Response {
    // ...
}
When enabled, query parameters that cannot be denormalized are dropped, and the
mapped object falls back to its own default values for those fields while keeping
the valid ones. Given /search?text=hello&page=invalid&filters[start]=invalid&filters[length]=25
and:

class SearchQuery
{
    public function __construct(
        public readonly string $text = '',
        public readonly int $page = 1,
        public readonly SearchFilters $filters = new SearchFilters(),
    ) {
    }
}
the controller receives text: "hello", page: 1 (default), filters.start: 0
(default), filters.length: 25 (kept).

Validation constraints still run on the resulting object, so well-typed but invalid
values (e.g. a negative page with #[Assert\Positive]) are still rejected — only
denormalization (type) errors are skipped, not validation.

The feature is limited to #[MapQueryString] and does not affect #[MapRequestPayload].
