### PR TITLE
[HttpFoundation] Fix newline handling in server event fields

### DIFF
--- a/src/Symfony/Component/HttpFoundation/ServerEvent.php
+++ b/src/Symfony/Component/HttpFoundation/ServerEvent.php
@@ -117,27 +117,44 @@ class ServerEvent implements \IteratorAggregate
     {
         $head = '';
         if ($this->comment) {
-            $head .= \sprintf(': %s', $this->comment)."\n";
+            $head .= self::field(': ', $this->comment);
         }
         if ($this->id) {
-            $head .= \sprintf('id: %s', $this->id)."\n";
+            $head .= \sprintf('id: %s', self::singleLine($this->id))."\n";
         }
         if ($this->retry > 0) {
             $head .= \sprintf('retry: %s', $this->retry)."\n";
         }
         if ($this->type) {
-            $head .= \sprintf('event: %s', $this->type)."\n";
+            $head .= \sprintf('event: %s', self::singleLine($this->type))."\n";
         }
         yield $head;
 
         if (is_iterable($this->data)) {
             foreach ($this->data as $data) {
-                yield \sprintf('data: %s', $data)."\n";
+                yield self::field('data: ', $data);
             }
         } elseif ('' !== $this->data) {
-            yield \sprintf('data: %s', $this->data)."\n";
+            yield self::field('data: ', $this->data);
         }
 
         yield "\n";
+    }
+
+    /**
+     * Renders a multi-line value as one prefixed line per line of the value.
+     */
+    private static function field(string $prefix, string $value): string
+    {
+        return $prefix.implode("\n".$prefix, preg_split("/\r\n|[\r\n]/", $value))."\n";
+    }
+
+    /**
+     * Removes the line terminators that would end the field early, as the
+     * SSE specification defines these fields as single-line only.
+     */
+    private static function singleLine(string $value): string
+    {
+        return str_replace(["\r", "\n"], '', $value);
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/EventStreamResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/EventStreamResponseTest.php
@@ -175,6 +175,90 @@ class EventStreamResponseTest extends TestCase
         $this->assertSameResponseContent("\n", $response);
     }
 
+    public function testStreamEventWithMultilineStringData()
+    {
+        $response = new EventStreamResponse(static function () {
+            yield new ServerEvent(
+                data: "first line\nsecond line\rthird line\r\nfourth line",
+            );
+        });
+
+        $expected = <<<STR
+            data: first line
+            data: second line
+            data: third line
+            data: fourth line
+
+
+            STR;
+
+        $this->assertSameResponseContent($expected, $response);
+    }
+
+    public function testStreamEventWithMultilineIterableData()
+    {
+        $response = new EventStreamResponse(static function () {
+            yield new ServerEvent(
+                data: ['first line', "second line\nthird line"],
+            );
+        });
+
+        $expected = <<<STR
+            data: first line
+            data: second line
+            data: third line
+
+
+            STR;
+
+        $this->assertSameResponseContent($expected, $response);
+    }
+
+    public function testStreamEventCannotInjectFieldsThroughData()
+    {
+        $response = new EventStreamResponse(static function () {
+            yield new ServerEvent(
+                data: "legit\nevent: adminAlert\ndata: hijacked",
+                type: 'message',
+            );
+        });
+
+        $expected = <<<STR
+            event: message
+            data: legit
+            data: event: adminAlert
+            data: data: hijacked
+
+
+            STR;
+
+        $this->assertSameResponseContent($expected, $response);
+    }
+
+    public function testStreamEventCannotInjectFieldsThroughIdTypeAndComment()
+    {
+        $response = new EventStreamResponse(static function () {
+            yield new ServerEvent(
+                data: 'foo',
+                type: "message\nretry: 1",
+                id: "1\revent: adminAlert",
+                comment: "bla\r\nbla",
+            );
+        });
+
+        $expected = <<<STR
+            : bla
+            : bla
+            id: 1event: adminAlert
+            event: messageretry: 1
+            data: foo
+
+
+            STR;
+
+        $this->assertSameResponseContent($expected, $response);
+    }
+
     private function assertSameResponseContent(string $expected, EventStreamResponse $response): void
     {
         ob_start();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`ServerEvent::getIterator()` interpolates the `data`, `id`, `type` and `comment` values into SSE field lines terminated by `"\n"`, without accounting for line terminators inside the values.

SSE delimits fields by line, so a newline inside a value ends that field early and everything after it is parsed by the client as a *new field*. The component already handles multi-line data correctly when `data` is iterable, emitting one `data:` line per item, but a single string containing a newline is emitted verbatim:

```php
$event = new ServerEvent(data: "legit\nevent: adminAlert\ndata: hijacked", type: 'message');
foreach ($event as $chunk) { echo $chunk; }
```

```
event: message
data: legit
event: adminAlert      <- parsed as a second, separate event
data: hijacked
```

The same applies to an *item* of an iterable `data` value, which is interpolated into its line without splitting either, so `new ServerEvent(['ok', "bad\nevent: pwn"])` behaves identically. `id`, `event` and comments are single-line-only per the specification, with nothing enforcing it, so a newline in `id` can emit a `retry:` field or a second `id:`.

Changes:

- a string `data` value is split on line terminators into multiple `data:` lines, matching what the iterable branch already does and what the SSE specification defines as the representation of multi-line data
- items of an iterable `data` value are split the same way
- `comment` is rendered as one `: ` line per line of the value, which is lossless since a comment carries no meaning beyond being ignored
- `"\r"` and `"\n"` are removed from `id` and `type`, which have no correct multi-line rendering

Splitting uses `preg_split("/\r\n|[\r\n]/", ...)`, so `"\r\n"` produces one break rather than two. The client parser splits on a lone `"\r"` as well, which is easy to miss when eyeballing output because such a line looks normal in a terminal.

`id` and `type` strip rather than throw, deliberately. `ServerEvent` instances are normally built and rendered inside the streamed callback, which runs after the headers are sent, so an exception there aborts a `200 text/event-stream` mid-body with no way to produce an error response. Adding that failure mode on a maintenance branch is worse than dropping characters that were never renderable in a single-line field. Validation happens at render time, so `getId()` and `getType()` still return exactly what the caller set.

`EventStreamResponse` needs no change: it only echoes the chunks `ServerEvent` yields, and the one field it sets itself, `retry`, is an `int`.
