### PR TITLE
[Lock] Allow advisory locks when reusing a PDO/DBAL connection in StoreFactory

### DIFF
--- a/UPGRADE-8.2.md
+++ b/UPGRADE-8.2.md
@@ -30,6 +30,11 @@ HttpFoundation
 
  * Add argument `$version` to `UriSigner::sign()`, `UriSigner::check()`, `UriSigner::checkRequest()`, and `UriSigner::verify()`
 
+Lock
+----
+
+ * Add argument `$advisory` to `StoreFactory::createStore()`
+
 Loco Translation Provider
 -------------------------
 

--- a/src/Symfony/Component/Lock/CHANGELOG.md
+++ b/src/Symfony/Component/Lock/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.2
 ---
 
+ * Add argument `$advisory` to `StoreFactory::createStore()` to use advisory locks when reusing an existing `\PDO` or Doctrine DBAL `Connection`
  * Add `DoctrineDbalMysqlStore` based on MySQL `GET_LOCK()` functionality, usable with the `mysql+advisory://` DSN
  * Add `MysqlStore` based on MySQL `GET_LOCK()` functionality, usable with the `mysql+advisory:` DSN
 

--- a/src/Symfony/Component/Lock/Store/StoreFactory.php
+++ b/src/Symfony/Component/Lock/Store/StoreFactory.php
@@ -13,6 +13,8 @@ namespace Symfony\Component\Lock\Store;
 
 use AsyncAws\DynamoDb\DynamoDbClient;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Relay\Relay;
 use Symfony\Component\Cache\Adapter\AbstractAdapter;
 use Symfony\Component\Lock\Bridge\DynamoDb\Store\DynamoDbStore;
@@ -26,8 +28,21 @@ use Symfony\Component\Lock\PersistingStoreInterface;
  */
 class StoreFactory
 {
-    public static function createStore(#[\SensitiveParameter] object|string $connection): PersistingStoreInterface
+    /**
+     * Advisory locks are held by the database session, not by a table: a reconnection, an explicit
+     * close or the server's idle timeout releases every lock the application holds, and nothing
+     * detects it. Prefer a connection dedicated to locking.
+     *
+     * With a Doctrine DBAL connection, the platform selects the advisory store, so a connection
+     * configured without a "serverVersion" parameter connects to the database to resolve it.
+     *
+     * @param bool $advisory Whether to use advisory locks (PostgreSQL or MySQL) instead of the default
+     *                       table-based store when reusing an existing \PDO or DBAL connection
+     */
+    public static function createStore(#[\SensitiveParameter] object|string $connection/* , bool $advisory = false */): PersistingStoreInterface
     {
+        $advisory = 1 < \func_num_args() ? func_get_arg(1) : false;
+
         switch (true) {
             case $connection instanceof DynamoDbClient:
                 self::requireBridgeClass(DynamoDbStore::class, 'symfony/amazon-dynamo-db-lock');
@@ -48,10 +63,28 @@ class StoreFactory
                 return new MongoDbStore($connection);
 
             case $connection instanceof \PDO:
-                return new PdoStore($connection);
+                if (!$advisory) {
+                    return new PdoStore($connection);
+                }
+
+                return match ($driver = $connection->getAttribute(\PDO::ATTR_DRIVER_NAME)) {
+                    'pgsql' => new PostgreSqlStore($connection),
+                    'mysql' => new MysqlStore($connection),
+                    default => throw new InvalidArgumentException(\sprintf('The "%s" PDO driver does not support advisory locks.', $driver)),
+                };
 
             case $connection instanceof Connection:
-                return new DoctrineDbalStore($connection);
+                if (!$advisory) {
+                    return new DoctrineDbalStore($connection);
+                }
+
+                $platform = $connection->getDatabasePlatform();
+
+                return match (true) {
+                    $platform instanceof PostgreSQLPlatform => new DoctrineDbalPostgreSqlStore($connection),
+                    $platform instanceof AbstractMySQLPlatform => new DoctrineDbalMysqlStore($connection),
+                    default => throw new InvalidArgumentException(\sprintf('The "%s" platform does not support advisory locks.', $platform::class)),
+                };
 
             case $connection instanceof \Zookeeper:
                 return new ZookeeperStore($connection);

--- a/src/Symfony/Component/Lock/Tests/Store/StoreFactoryTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/StoreFactoryTest.php
@@ -13,12 +13,14 @@ namespace Symfony\Component\Lock\Tests\Store;
 
 use AsyncAws\DynamoDb\DynamoDbClient;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DriverManager;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Cache\Adapter\AbstractAdapter;
 use Symfony\Component\Cache\Adapter\MemcachedAdapter;
 use Symfony\Component\Lock\Bridge\DynamoDb\Store\DynamoDbStore;
+use Symfony\Component\Lock\Exception\InvalidArgumentException;
 use Symfony\Component\Lock\Store\DoctrineDbalMysqlStore;
 use Symfony\Component\Lock\Store\DoctrineDbalPostgreSqlStore;
 use Symfony\Component\Lock\Store\DoctrineDbalStore;
@@ -44,6 +46,93 @@ class StoreFactoryTest extends TestCase
         $store = StoreFactory::createStore($connection);
 
         $this->assertInstanceOf($expectedStoreClass, $store);
+    }
+
+    #[RequiresPhpExtension('pdo_sqlite')]
+    public function testCreateStoreForPdoConnectionWithoutAdvisory()
+    {
+        $store = StoreFactory::createStore(new \PDO('sqlite::memory:'));
+
+        $this->assertInstanceOf(PdoStore::class, $store);
+    }
+
+    #[RequiresPhpExtension('pdo_sqlite')]
+    public function testCreateAdvisoryStoreRejectsUnsupportedPdoDriver()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "sqlite" PDO driver does not support advisory locks.');
+
+        StoreFactory::createStore(new \PDO('sqlite::memory:'), true);
+    }
+
+    public function testCreateAdvisoryStoreForPgsqlPdoConnection()
+    {
+        // the connection is never used, only its driver name is read to route to the advisory store
+        $store = StoreFactory::createStore($this->createPdoStub('pgsql'), true);
+
+        $this->assertInstanceOf(PostgreSqlStore::class, $store);
+    }
+
+    public function testCreateAdvisoryStoreForMysqlPdoConnection()
+    {
+        $store = StoreFactory::createStore($this->createPdoStub('mysql'), true);
+
+        $this->assertInstanceOf(MysqlStore::class, $store);
+    }
+
+    public function testCreateStoreForDbalConnectionWithoutAdvisory()
+    {
+        if (!class_exists(Connection::class)) {
+            $this->markTestSkipped('The "doctrine/dbal" package is required.');
+        }
+
+        $store = StoreFactory::createStore($this->createStub(Connection::class));
+
+        $this->assertInstanceOf(DoctrineDbalStore::class, $store);
+    }
+
+    #[DataProvider('advisoryDbalPlatforms')]
+    public function testCreateAdvisoryStoreForDbalConnection(string $driver, string $serverVersion, string $expectedStoreClass)
+    {
+        if (!class_exists(Connection::class)) {
+            $this->markTestSkipped('The "doctrine/dbal" package is required.');
+        }
+
+        $connection = DriverManager::getConnection(['driver' => $driver, 'serverVersion' => $serverVersion]);
+
+        $this->assertInstanceOf($expectedStoreClass, StoreFactory::createStore($connection, true));
+    }
+
+    public static function advisoryDbalPlatforms(): \Generator
+    {
+        yield 'PostgreSQL' => ['pdo_pgsql', '16.0', DoctrineDbalPostgreSqlStore::class];
+        yield 'MySQL' => ['pdo_mysql', '8.0.0', DoctrineDbalMysqlStore::class];
+        yield 'MariaDB' => ['pdo_mysql', '10.6.0-MariaDB', DoctrineDbalMysqlStore::class];
+    }
+
+    public function testCreateAdvisoryStoreRejectsUnsupportedDbalPlatform()
+    {
+        if (!class_exists(Connection::class)) {
+            $this->markTestSkipped('The "doctrine/dbal" package is required.');
+        }
+
+        $connection = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'memory' => true]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(\sprintf('The "%s" platform does not support advisory locks.', $connection->getDatabasePlatform()::class));
+
+        StoreFactory::createStore($connection, true);
+    }
+
+    private function createPdoStub(string $driver): \PDO
+    {
+        $pdo = $this->createStub(\PDO::class);
+        $pdo->method('getAttribute')->willReturnMap([
+            [\PDO::ATTR_DRIVER_NAME, $driver],
+            [\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION],
+        ]);
+
+        return $pdo;
     }
 
     #[RequiresPhpExtension('sysvsem')]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Refs #64775
| License       | MIT

`StoreFactory::createStore()` maps a DSN string such as `pgsql+advisory:` or `mysql+advisory://` to an advisory-lock store, but when it is handed an already open `\PDO` or Doctrine DBAL `Connection` it always returns the table-based `PdoStore` or `DoctrineDbalStore`. An application that wants to reuse the connection it already has, instead of opening a second one, had no way to ask for advisory locks.

This adds a second argument to `createStore()`:

```php
// unchanged defaults
StoreFactory::createStore($pdo);                       // PdoStore
StoreFactory::createStore($dbalConnection);            // DoctrineDbalStore

// opt in to advisory locks on the very same connection
StoreFactory::createStore($pdo, true);
StoreFactory::createStore($dbalConnection, true);
```

`StoreFactory` is neither final nor internal and `createStore()` is public static, so declaring the parameter would break every child class that overrides the method. The argument follows the usual pattern for a minor branch instead: it stays in a trailing comment in the parameter list, is described by `@param` in the docblock and is read with `func_num_args()`, exactly like `UriSigner::check()` or `Cookie::create()`. It must therefore be passed positionally; `advisory: true` as a named argument does not work.

```php
public static function createStore(#[\SensitiveParameter] object|string $connection/* , bool $advisory = false */): PersistingStoreInterface
```

### Routing

With `$advisory` left to `false`, nothing changes: object connections and DSN strings behave exactly as before.

With `$advisory` set to `true`, a `\PDO` is routed on `PDO::ATTR_DRIVER_NAME`:

| driver | store |
| --- | --- |
| `pgsql` | `PostgreSqlStore` |
| `mysql` | `MysqlStore` |
| anything else | `InvalidArgumentException`: `The "sqlite" PDO driver does not support advisory locks.` |

and a DBAL `Connection` is routed on its platform:

| platform | store |
| --- | --- |
| `PostgreSQLPlatform` and subclasses | `DoctrineDbalPostgreSqlStore` |
| `AbstractMySQLPlatform` and subclasses, so MySQL and MariaDB alike | `DoctrineDbalMysqlStore` |
| anything else | `InvalidArgumentException`: `The "Doctrine\DBAL\Platforms\SQLitePlatform" platform does not support advisory locks.` |

The MySQL side of the DBAL branch only became possible with #64987, which added `DoctrineDbalMysqlStore`. The check is on `AbstractMySQLPlatform` and not on `MySQLPlatform` because DBAL declares `MariaDBPlatform` as a sibling of `MySQLPlatform`, not as a subclass; narrowing it would silently push MariaDB into the unsupported branch. A test covers that case.

Routing on the platform rather than delegating to the store also means the error message names the platform the caller passed, instead of `The adapter "…\DoctrineDbalPostgreSqlStore" does not support the "MySQL80Platform" platform.`, which mentioned a class the caller never asked for.

### Caveats worth knowing before opting in

Advisory locks are held by the database session, not by a table. Reconnecting, calling `EntityManager::close()`, or letting the server's idle timeout fire releases every lock the application holds, and nothing detects it. A connection dedicated to locking stays the safer choice; reusing the request connection is a convenience with a real trade-off, which is why it is opt-in.

Resolving the platform of a DBAL connection whose parameters carry no `serverVersion` connects to the database. Passing such a connection therefore turns this factory call into a database round trip, which matters when the call happens while a container is being built.

### Not included on purpose

#64775 asks for a FrameworkBundle knob, along the lines of `lock: { named_lock: { service_id: '@doctrine.dbal.default_connection', advisory: true } }`. This PR is the component-level half only. `Configuration::addLockSection()` still types every resource as a bare string and `FrameworkExtension` still calls the factory with a single argument, so a user coming from that issue through the bundle sees no change yet. Wiring the bundle is a separate PR, and it needs its own config-format discussion.

### Documentation

A symfony-docs PR should cover:

* the new `$advisory` argument of `StoreFactory::createStore()`, passed positionally;
* the routing table above, including that MariaDB maps to `DoctrineDbalMysqlStore`;
* the session scope of advisory locks and what silently releases them;
* the eager connection when a DBAL connection has no `serverVersion`;
* a note that MySQL advisory locks have no shared/read mode, so `Lock::acquireRead()` degrades to an exclusive lock.
