### PR TITLE
[HttpFoundation] Don't crash on a non-string signature in UriSigner

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Tests/UriSignerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/UriSignerTest.php
@@ -41,6 +41,23 @@ class UriSignerTest extends TestCase
         $this->assertSame($signer->sign('http://example.com/foo?foo=bar&bar=foo'), $signer->sign('http://example.com/foo?bar=foo&foo=bar'));
     }
 
+    public function testCheckWithNonStringHash()
+    {
+        $signer = new UriSigner('foobar');
+
+        $this->assertFalse($signer->check('http://example.com/foo?_hash[]=y'));
+        $this->assertFalse($signer->check('http://example.com/foo?_hash[k]=y'));
+        $this->assertFalse($signer->check('http://example.com/foo?foo=bar&_hash[]='));
+    }
+
+    public function testCheckRequestWithNonStringHash()
+    {
+        $signer = new UriSigner('foobar');
+
+        $this->assertFalse($signer->checkRequest(Request::create('http://example.com/foo?_path=x&_hash[]=y')));
+        $this->assertFalse($signer->checkRequest(Request::create('http://example.com/foo?_hash[k]=y')));
+    }
+
     public function testCheckWithDifferentArgSeparator()
     {
         $this->iniSet('arg_separator.output', '&amp;');

--- a/src/Symfony/Component/HttpFoundation/UriSigner.php
+++ b/src/Symfony/Component/HttpFoundation/UriSigner.php
@@ -65,11 +65,10 @@ class UriSigner
             parse_str($url['query'], $params);
         }
 
-        if (empty($params[$this->parameter])) {
+        if (!\is_string($hash = $params[$this->parameter] ?? null) || '' === $hash) {
             return false;
         }
 
-        $hash = $params[$this->parameter];
         unset($params[$this->parameter]);
 
         return hash_equals($this->computeHash($this->buildUrl($url, $params)), $hash);

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/FragmentListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/FragmentListenerTest.php
@@ -73,6 +73,17 @@ class FragmentListenerTest extends TestCase
         $listener->onKernelRequest($event);
     }
 
+    public function testAccessDeniedWithNonStringSignature()
+    {
+        $this->expectException(AccessDeniedHttpException::class);
+        $request = Request::create('http://example.com/_fragment?_path=x&_hash[]=y', 'GET', [], [], [], ['REMOTE_ADDR' => '10.0.0.1']);
+
+        $listener = new FragmentListener(new UriSigner('foo'));
+        $event = $this->createRequestEvent($request);
+
+        $listener->onKernelRequest($event);
+    }
+
     public function testWithSignature()
     {
         $signer = new UriSigner('foo');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`UriSigner` reads the hash query parameter straight out of `parse_str()` output and passes it to `hash_equals()` without checking its type. Query strings can produce arrays, so sending the parameter with array syntax raises an uncaught `TypeError`:

```php
(new UriSigner('foobar'))->check('http://example.com/foo?_hash[]=y');
```

```
TypeError: hash_equals(): Argument #2 ($user_string) must be of type string, array given
```

The former guard was `if (empty($params[$this->parameter]))`, and an array is not `empty()`, so it went right through to the comparison.

The same happens via `checkRequest()`, which is what `FragmentListener::validateRequest()` calls. It expects `checkRequest()` to return `false` so that it can throw an `AccessDeniedHttpException`, so a request like `/_fragment?_path=x&_hash[]=y` ends up as an uncaught error instead of the intended 403.

The fix is a single guard at the top of `check()`, which is the only place that reads the parameter and the one both public entry points funnel through (`checkRequest()` delegates to `check()`):

```php
if (!\is_string($hash = $params[$this->parameter] ?? null) || '' === $hash) {
    return false;
}
```

A non-string or empty hash is now treated the same as a missing signature, so the check keeps failing closed and callers get their normal `false`.

The only behavioral difference versus `empty()` is the literal hash `"0"`: it used to short-circuit here and now reaches `hash_equals()`. The result is `false` in both cases.

Note that `Symfony\Component\HttpKernel\UriSigner` needs no change: on this branch it is only the deprecated `class_alias` shim over the HttpFoundation class.

Tests are added for the array hash through both entry points (`UriSignerTest::testCheckWithNonStringHash`, `testCheckRequestWithNonStringHash`) and through the listener (`FragmentListenerTest::testAccessDeniedWithNonStringSignature`). All three error out with the `TypeError` before the fix.

```
$ ./phpunit src/Symfony/Component/HttpFoundation
OK, but incomplete, skipped, or risky tests!
Tests: 1684, Assertions: 3256, Skipped: 42.

$ ./phpunit src/Symfony/Component/HttpKernel
OK (1215 tests, 2950 assertions)
```
