### PR TITLE
[HttpFoundation] Validate the characters allowed in a cookie path and domain

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Cookie.php
+++ b/src/Symfony/Component/HttpFoundation/Cookie.php
@@ -39,6 +39,9 @@ class Cookie
     private const RESERVED_CHARS_FROM = ['=', ',', ';', ' ', "\t", "\r", "\n", "\v", "\f"];
     private const RESERVED_CHARS_TO = ['%3D', '%2C', '%3B', '%20', '%09', '%0D', '%0A', '%0B', '%0C'];
 
+    // same list as above minus "=", which PHP allows in the path and domain attributes
+    private const RESERVED_ATTR_CHARS_LIST = ",; \t\r\n\v\f";
+
     /**
      * Creates cookie from raw header string.
      */
@@ -108,6 +111,9 @@ class Cookie
             throw new \InvalidArgumentException('The cookie name cannot be empty.');
         }
 
+        self::validateAttribute('path', $path);
+        self::validateAttribute('domain', $domain);
+
         $this->name = $name;
         $this->value = $value;
         $this->domain = $domain;
@@ -136,6 +142,8 @@ class Cookie
      */
     public function withDomain(?string $domain): static
     {
+        self::validateAttribute('domain', $domain);
+
         $cookie = clone $this;
         $cookie->domain = $domain;
 
@@ -173,10 +181,22 @@ class Cookie
     }
 
     /**
+     * Rejects the characters that PHP's setcookie() also rejects in the path and domain attributes.
+     */
+    private static function validateAttribute(string $attribute, ?string $value): void
+    {
+        if (null !== $value && false !== strpbrk($value, self::RESERVED_ATTR_CHARS_LIST)) {
+            throw new \InvalidArgumentException(\sprintf('The cookie %s "%s" contains invalid characters.', $attribute, $value));
+        }
+    }
+
+    /**
      * Creates a cookie copy with a new path on the server in which the cookie will be available on.
      */
     public function withPath(string $path): static
     {
+        self::validateAttribute('path', $path);
+
         $cookie = clone $this;
         $cookie->path = '' === $path ? '/' : $path;
 

--- a/src/Symfony/Component/HttpFoundation/Tests/CookieTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/CookieTest.php
@@ -70,6 +70,106 @@ class CookieTest extends TestCase
         Cookie::create('');
     }
 
+    public static function pathsAndDomainsWithSpecialCharacters()
+    {
+        return [
+            ['/p,q'],
+            ['/p;q'],
+            ['/p q'],
+            ["/p\tq"],
+            ["/p\rq"],
+            ["/p\nq"],
+            ["/p\013q"],
+            ["/p\014q"],
+            ['/p; SameSite=None; Secure'],
+            ['victim.com; secure'],
+        ];
+    }
+
+    /**
+     * @dataProvider pathsAndDomainsWithSpecialCharacters
+     */
+    public function testInstantiationThrowsExceptionIfPathContainsSpecialCharacters($path)
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        Cookie::create('MyCookie', 'MyValue', 0, $path);
+    }
+
+    /**
+     * @dataProvider pathsAndDomainsWithSpecialCharacters
+     */
+    public function testInstantiationThrowsExceptionIfDomainContainsSpecialCharacters($domain)
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        Cookie::create('MyCookie', 'MyValue', 0, '/', $domain);
+    }
+
+    /**
+     * @dataProvider pathsAndDomainsWithSpecialCharacters
+     */
+    public function testWithPathThrowsExceptionIfPathContainsSpecialCharacters($path)
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        Cookie::create('MyCookie')->withPath($path);
+    }
+
+    /**
+     * @dataProvider pathsAndDomainsWithSpecialCharacters
+     */
+    public function testWithDomainThrowsExceptionIfDomainContainsSpecialCharacters($domain)
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        Cookie::create('MyCookie')->withDomain($domain);
+    }
+
+    public function testFromStringThrowsExceptionIfPathContainsSpecialCharacters()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        Cookie::fromString('foo=bar; path="/p; SameSite=None"');
+    }
+
+    public static function validPathsAndDomains()
+    {
+        return [
+            ['/'],
+            ['/foo'],
+            ['/foo/bar'],
+            ['/foo=bar'],
+            ['/foo%20bar'],
+            ['.myfoodomain.com'],
+            ['myfoodomain.com'],
+        ];
+    }
+
+    /**
+     * @dataProvider validPathsAndDomains
+     */
+    public function testOrdinaryPathsAndDomainsAreAccepted($value)
+    {
+        $cookie = Cookie::create('MyCookie', 'MyValue', 0, $value, $value);
+
+        $this->assertSame($value, $cookie->getPath());
+        $this->assertSame($value, $cookie->getDomain());
+
+        $cookie = Cookie::create('MyCookie')->withPath($value)->withDomain($value);
+
+        $this->assertSame($value, $cookie->getPath());
+        $this->assertSame($value, $cookie->getDomain());
+    }
+
+    public function testNullAndEmptyPathsAndDomainsAreAccepted()
+    {
+        $cookie = Cookie::create('MyCookie', 'MyValue', 0, null, null);
+
+        $this->assertSame('/', $cookie->getPath());
+        $this->assertNull($cookie->getDomain());
+
+        $cookie = Cookie::create('MyCookie', 'MyValue', 0, '', null)->withDomain(null);
+
+        $this->assertSame('/', $cookie->getPath());
+        $this->assertNull($cookie->getDomain());
+    }
+
     public function testInvalidExpiration()
     {
         $this->expectException(\InvalidArgumentException::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`Cookie::__toString()` writes the `path` and `domain` attributes into the `Set-Cookie` string verbatim, while the name goes through `RESERVED_CHARS_FROM`/`RESERVED_CHARS_TO` and the value through `rawurlencode()`. Neither attribute is validated anywhere: not in `__construct()`, not in `withPath()`, not in `withDomain()`.

Native `setcookie()` rejects these characters outright:

```
$ php -r 'setcookie("x", "v", ["path" => "/p; SameSite=None"]);'
ValueError: setcookie(): "path" option cannot contain ",", ";", " ", "\t", "\r", "\n", "\013", or "\014"
```

Symfony builds the header itself instead of calling `setcookie()`, so the same value goes straight through:

```
$ php -r 'echo (string) new Cookie("sess", "v", 0, "/p; SameSite=None; Secure", "good.com");'
sess=v; path=/p; SameSite=None; Secure; domain=good.com; httponly; samesite=lax
```

The `; SameSite=None; Secure` embedded in the path becomes two extra cookie attributes, landing before the component's own `samesite=lax`, so they win. `withDomain('victim.com; secure')` behaves the same way. That is a plain bug: the header the component emits is not the header its author described.

This PR validates `path` and `domain` at the three entry points that set them (`__construct()`, `withPath()`, `withDomain()`) and throws `\InvalidArgumentException` on a rejected value, the same exception type and message shape as the existing cookie-name check. `fromString()` needs no separate handling since it builds the cookie through `new static(...)`.

Two points worth a reviewer's attention:

**The character set is PHP's own, and it deliberately excludes `=`.** The obvious move is to reuse `RESERVED_CHARS_LIST` (`"=,; \t\r\n\v\f"`), the list used for the name. That would be wrong here. PHP's check on these two attributes is `",; \t\r\n\013\014"`, with no `=`, and `=` is genuinely valid in a path:

```
$ php -r 'setcookie("x", "v", ["path" => "/p=q"]);'   # accepted, no ValueError
```

Rejecting `=` would break working applications for no benefit, since `=` cannot introduce a new attribute on its own. So the new `RESERVED_ATTR_CHARS_LIST` constant is `RESERVED_CHARS_LIST` minus `=`, byte for byte PHP's list. Parity with `setcookie()` is the whole justification for the change, so the set is exactly what parity dictates.

**This is a behaviour change on a stable branch.** Input that used to be accepted now throws. I judge the risk acceptable: every rejected character already produced a malformed or attribute-injecting header, so no cookie built from such a value ever behaved as its author intended, and the plain-PHP equivalent already threw on the same input. Excluding `=` removes the one realistic false positive. The residual risk is an application passing a stray space in a value it never relied on, which now sees an exception where it previously saw a subtly wrong cookie. Surfacing that loudly is the point, but it is a real behaviour change and should be weighed as one.

Tests added to `CookieTest.php` cover each rejected character against the constructor, `withPath()` and `withDomain()`, a `fromString()` case with a quoted path smuggling a `;`, and a provider of ordinary values that must keep working (`/`, `/foo`, `/foo/bar`, `/foo=bar`, `/foo%20bar`, `myfoodomain.com`, `.myfoodomain.com`), plus `null`/empty path and domain still normalising to `/` and `null`.

```
$ ./phpunit src/Symfony/Component/HttpFoundation
OK, but incomplete, skipped, or risky tests!
Tests: 1731, Assertions: 3324, Skipped: 42.

$ ./phpunit src/Symfony/Component/HttpKernel
OK (1214 tests, 2949 assertions)
```

`HttpKernel` is covered too because `AbstractSessionListener` builds session cookies through `Cookie::create()`.
