### PR TITLE
[SecurityBundle] Always constrain redirect targets to the current host, even without sessions

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/AddSessionDomainConstraintPass.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/AddSessionDomainConstraintPass.php
@@ -26,11 +26,12 @@ class AddSessionDomainConstraintPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        if (!$container->hasParameter('session.storage.options') || !$container->has('security.http_utils')) {
+        if (!$container->has('security.http_utils')) {
             return;
         }
 
-        $sessionOptions = $container->getParameter('session.storage.options');
+        // Without sessions, fall back to restricting redirections to the current host
+        $sessionOptions = $container->hasParameter('session.storage.options') ? $container->getParameter('session.storage.options') : [];
         $domainRegexp = empty($sessionOptions['cookie_domain']) ? '%%s' : \sprintf('(?:%%%%s|(?:.+\.)?%s)', preg_quote(trim($sessionOptions['cookie_domain'], '.')));
 
         if ('auto' === ($sessionOptions['cookie_secure'] ?? null)) {

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/AddSessionDomainConstraintPassTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/AddSessionDomainConstraintPassTest.php
@@ -21,6 +21,7 @@ use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Http\HttpUtils;
 
 class AddSessionDomainConstraintPassTest extends TestCase
 {
@@ -92,12 +93,23 @@ class AddSessionDomainConstraintPassTest extends TestCase
         $utils = $container->get('security.http_utils');
         $request = Request::create('/', 'get');
 
-        $this->assertTrue($utils->createRedirectResponse($request, 'https://symfony.com/blog')->isRedirect('https://symfony.com/blog'));
-        $this->assertTrue($utils->createRedirectResponse($request, 'https://www.symfony.com/blog')->isRedirect('https://www.symfony.com/blog'));
+        $this->assertTrue($utils->createRedirectResponse($request, 'https://symfony.com/blog')->isRedirect('http://localhost/'));
+        $this->assertTrue($utils->createRedirectResponse($request, 'https://www.symfony.com/blog')->isRedirect('http://localhost/'));
         $this->assertTrue($utils->createRedirectResponse($request, 'https://localhost/foo')->isRedirect('https://localhost/foo'));
-        $this->assertTrue($utils->createRedirectResponse($request, 'https://www.localhost/foo')->isRedirect('https://www.localhost/foo'));
-        $this->assertTrue($utils->createRedirectResponse($request, 'http://symfony.com/blog')->isRedirect('http://symfony.com/blog'));
-        $this->assertTrue($utils->createRedirectResponse($request, 'http://pirate.com/foo')->isRedirect('http://pirate.com/foo'));
+        $this->assertTrue($utils->createRedirectResponse($request, 'http://localhost/foo')->isRedirect('http://localhost/foo'));
+        $this->assertTrue($utils->createRedirectResponse($request, 'https://www.localhost/foo')->isRedirect('http://localhost/'));
+        $this->assertTrue($utils->createRedirectResponse($request, 'http://symfony.com/blog')->isRedirect('http://localhost/'));
+        $this->assertTrue($utils->createRedirectResponse($request, 'http://pirate.com/foo')->isRedirect('http://localhost/'));
+    }
+
+    public function testNoSessionInjectsCurrentHostConstraint()
+    {
+        $container = new ContainerBuilder();
+        $container->register('security.http_utils', HttpUtils::class);
+
+        (new AddSessionDomainConstraintPass())->process($container);
+
+        $this->assertSame(['{^https?://%%s$}i', null], $container->getDefinition('security.http_utils')->getArguments());
     }
 
     public function testSessionAutoSecure()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`HttpUtils::createRedirectResponse()` only checks the redirection target when it has been given a domain regexp, and the constructor defaults that argument to `null`. In a full-stack application, `AddSessionDomainConstraintPass` is what supplies the regexp: it derives it from the session cookie options and appends it to the `security.http_utils` definition.

That pass used to return early when the `session.storage.options` container parameter was missing. That parameter is only registered by `FrameworkExtension::registerSessionConfiguration()`, which is only reached when `framework.session` is enabled. So with `framework.session: false` the constraint was never injected, `HttpUtils` kept its unconstrained default, and absolute URLs pointing at any host were handed back as-is.

The point here is not that some particular application is exploitable, it is that a compiler pass belonging to a security component bailed out silently. The developer got no signal that a protection they reasonably assume is active was in fact off, and a security component should fail safe rather than fail open. A session-less application should get the same constraint a session-enabled one does.

So the pass no longer bails out. It treats a missing `session.storage.options` as an empty array and runs its existing logic unchanged. With empty options that logic already produces `{^https?://%%s$}i`, the "current host, http or https" constraint, which is exactly what a session-enabled application gets when it configures neither `cookie_domain` nor `cookie_secure`. The no-session case now behaves like the plain-session case instead of being unconstrained.

I fixed this in the bundle rather than by making `HttpUtils` fall back to `Request::getHttpHost()` when `$domainRegexp` is `null`. That `null` default is documented behaviour of a standalone component constructor that third parties instantiate directly, and redefining what `null` means there would silently change behaviour for every direct consumer of the component, including code outside Symfony. Injecting the constraint from the bundle keeps the component contract intact.

Two things reviewers should weigh:

* The existing test `AddSessionDomainConstraintPassTest::testNoSession` asserted the old behaviour explicitly: it asserted that `createRedirectResponse($request, 'http://pirate.com/foo')` returns a redirect to `http://pirate.com/foo`. This PR inverts those assertions. The previous behaviour was therefore deliberate at some point, and this is a behaviour change rather than the correction of a sloppy test.
* BC surface: applications using SecurityBundle with sessions disabled that redirect to an absolute off-host URL through `security.http_utils`, for example an external logout endpoint or an identity provider endpoint used as `default_target_path`. Those targets now get rewritten to `/`, exactly as they already are in session-enabled applications. Such an application now has to pass an explicit `$domainRegexp`, same as a session-enabled one has always had to. No public signature changed.

On the test side, `testNoSession` was updated to the new expectations and `testNoSessionInjectsCurrentHostConstraint` was added to check that the constraint arguments really do land on the `security.http_utils` definition when the session parameter is absent. Both suites are green on this branch:

```
$ ./phpunit src/Symfony/Bundle/SecurityBundle
Tests: 360, Assertions: 1104, Skipped: 1.

$ ./phpunit src/Symfony/Component/Security/Http
OK (525 tests, 985 assertions)
```
