### PR TITLE
[Serializer] Check the denormalized class is a Mime part in MimeMessageNormalizer

### DIFF
--- a/src/Symfony/Component/Mime/Tests/MessageTest.php
+++ b/src/Symfony/Component/Mime/Tests/MessageTest.php
@@ -18,17 +18,24 @@ use Symfony\Component\Mime\Header\Headers;
 use Symfony\Component\Mime\Header\MailboxListHeader;
 use Symfony\Component\Mime\Header\UnstructuredHeader;
 use Symfony\Component\Mime\Message;
+use Symfony\Component\Mime\Part\AbstractPart;
 use Symfony\Component\Mime\Part\DataPart;
 use Symfony\Component\Mime\Part\Multipart\AlternativePart;
 use Symfony\Component\Mime\Part\Multipart\MixedPart;
 use Symfony\Component\Mime\Part\TextPart;
 use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
 use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
 use Symfony\Component\Serializer\Normalizer\MimeMessageNormalizer;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Symfony\Component\Serializer\Normalizer\PropertyNormalizer;
 use Symfony\Component\Serializer\Serializer;
+
+class MessageTestForeignClass
+{
+    public string $marker = '';
+}
 
 class MessageTest extends TestCase
 {
@@ -285,6 +292,42 @@ class MessageTest extends TestCase
 
         $serialized = $serializer->serialize($e, 'json');
         $this->assertStringMatchesFormat($expectedJson, json_encode(json_decode($serialized), \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
+    }
+
+    public function testSymfonySerializePartRoundTrip()
+    {
+        $serializer = $this->createMimeSerializer();
+
+        $part = new TextPart('Text content');
+        $part->getHeaders()->addHeader('foo', 'bar');
+
+        $normalized = $serializer->normalize($part);
+        $this->assertSame(TextPart::class, $normalized['class']);
+
+        $this->assertEquals($part, $serializer->denormalize($normalized, AbstractPart::class));
+    }
+
+    public function testSymfonyDenormalizeRejectsForeignClassInPart()
+    {
+        $serializer = $this->createMimeSerializer();
+
+        $this->expectException(NotNormalizableValueException::class);
+        $this->expectExceptionMessage('Expected a subclass of "Symfony\Component\Mime\Part\AbstractPart", got "Symfony\Component\Mime\Tests\MessageTestForeignClass".');
+
+        $serializer->denormalize(['class' => MessageTestForeignClass::class, 'marker' => 'foo', 'headers' => []], AbstractPart::class);
+    }
+
+    private function createMimeSerializer(): Serializer
+    {
+        $extractor = new PhpDocExtractor();
+        $propertyNormalizer = new PropertyNormalizer(null, null, $extractor);
+
+        return new Serializer([
+            new ArrayDenormalizer(),
+            new MimeMessageNormalizer($propertyNormalizer),
+            new ObjectNormalizer(null, null, null, $extractor),
+            $propertyNormalizer,
+        ], [new JsonEncoder()]);
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Normalizer/MimeMessageNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/MimeMessageNormalizer.php
@@ -19,6 +19,7 @@ use Symfony\Component\Mime\Message;
 use Symfony\Component\Mime\Part\AbstractPart;
 use Symfony\Component\Mime\RawMessage;
 use Symfony\Component\Serializer\Exception\LogicException;
+use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
 use Symfony\Component\Serializer\SerializerAwareInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 
@@ -103,7 +104,13 @@ final class MimeMessageNormalizer implements NormalizerInterface, DenormalizerIn
         }
 
         if (AbstractPart::class === $type) {
-            $type = $data['class'];
+            $class = $data['class'] ?? null;
+
+            if (!\is_string($class) || !is_a($class, AbstractPart::class, true)) {
+                throw NotNormalizableValueException::createForUnexpectedDataType(\sprintf('Expected a subclass of "%s", got "%s".', AbstractPart::class, \is_string($class) ? $class : get_debug_type($class)), $data, [AbstractPart::class], $context['deserialization_path'] ?? null);
+            }
+
+            $type = $class;
             unset($data['class']);
             $data['headers'] = $this->serializer->denormalize($data['headers'], Headers::class, $format, $context);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`MimeMessageNormalizer::denormalize()` ignores the type the caller asked for and re-derives the class to instantiate from the payload itself, from the `class` key that `normalize()` writes. Nothing checks that the resulting class is a Mime part, so a caller doing the safe-looking thing, denormalizing into the fixed and trusted `AbstractPart::class`, still ends up with whatever class the payload names, constructed and populated by the wrapped `PropertyNormalizer`:

```php
$extractor = new PhpDocExtractor();
$propertyNormalizer = new PropertyNormalizer(null, null, $extractor);
$serializer = new Serializer([
    new ArrayDenormalizer(),
    new MimeMessageNormalizer($propertyNormalizer),
    new ObjectNormalizer(null, null, null, $extractor),
    $propertyNormalizer,
], []);

$part = $serializer->denormalize([
    'class' => SomeUnrelatedClass::class,
    'headers' => [],
], AbstractPart::class);

// before: SomeUnrelatedClass, even though AbstractPart::class was requested
// after:  NotNormalizableValueException
var_dump($part::class);
```

This patch validates the class named by the payload before anything is instantiated: the payload is rejected unless the `class` key is a string and `is_a($class, AbstractPart::class, true)` holds. `is_a()` with `$allow_string = true` also covers the non-autoloadable case, so no separate `class_exists()` call is needed. The nested `headers` denormalization now runs only after the class has been accepted.

`NotNormalizableValueException` is what the Serializer expects from a denormalizer handed an unusable payload: it is the type collected by `COLLECT_DENORMALIZATION_ERRORS`, and it keeps the rejection reportable per deserialization path instead of fatal.

The guard is BC safe: `normalize()` writes the `class` key from `$object::class` on an `AbstractPart` instance, so any legitimate round-trip satisfies `is_a(..., AbstractPart::class, true)` by construction. One cosmetic detail, a payload naming `AbstractPart` itself passes the guard, since `is_a()` is true for the class itself, and then fails slightly later with `Error: Cannot instantiate abstract class`. That is the same outcome as before the patch, so it is left as is.

On the test side, a round-trip test for a real `TextPart` and a test that a non-part class named in the payload is refused were added next to the existing `testSymfonySerialize()`. The second one fails without the patch. Both suites are green on this branch:

```
$ ./phpunit src/Symfony/Component/Mime
Tests: 396, Assertions: 1586, Skipped: 1.

$ ./phpunit src/Symfony/Component/Serializer
Tests: 1147, Assertions: 2308, Skipped: 11.
```
