### PR TITLE
[JsonStreamer] Drop the unbounded process-global key cache in Splitter

### DIFF
--- a/src/Symfony/Component/JsonStreamer/Read/Splitter.php
+++ b/src/Symfony/Component/JsonStreamer/Read/Splitter.php
@@ -26,13 +26,6 @@ final class Splitter
     private static ?Lexer $lexer = null;
 
     /**
-     * @var array{key: array<string, string>}
-     */
-    private static array $cache = [
-        'key' => [],
-    ];
-
-    /**
      * @param resource $stream
      */
     public static function splitList($stream, int $offset = 0, ?int $length = null): ?\Iterator
@@ -171,7 +164,7 @@ final class Splitter
             }
 
             if (null === $key) {
-                $key = self::$cache['key'][$value] ??= json_decode($value);
+                $key = json_decode($value);
             }
         }
 

--- a/src/Symfony/Component/JsonStreamer/Tests/Read/SplitterTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Read/SplitterTest.php
@@ -40,6 +40,40 @@ class SplitterTest extends TestCase
         $this->assertDictBoundaries(['k' => [5, 4]], '{"k":[10]}');
     }
 
+    public function testSplitDictDoesNotRetainKeys()
+    {
+        $countRetainedValues = static function (): int {
+            $count = 0;
+
+            foreach ((new \ReflectionClass(Splitter::class))->getStaticProperties() as $value) {
+                if (\is_array($value)) {
+                    array_walk_recursive($value, static function () use (&$count): void {
+                        ++$count;
+                    });
+                }
+            }
+
+            return $count;
+        };
+
+        $splitUniqueKeys = static function (int $batch): void {
+            for ($i = 0; $i < 100; ++$i) {
+                $resource = fopen('php://temp', 'w');
+                fwrite($resource, \sprintf('{"key_%d_%d":1}', $batch, $i));
+                rewind($resource);
+
+                iterator_to_array((new Splitter())->splitDict($resource));
+            }
+        };
+
+        $splitUniqueKeys(1);
+        $retainedAfterFirstBatch = $countRetainedValues();
+
+        $splitUniqueKeys(2);
+
+        $this->assertSame($retainedAfterFirstBatch, $countRetainedValues());
+    }
+
     #[DataProvider('splitDictInvalidDataProvider')]
     public function testSplitDictInvalidThrowException(string $expectedMessage, string $content)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`Symfony\Component\JsonStreamer\Read\Splitter` holds a `private static array $cache` that memoises every JSON object key it has ever parsed, keyed on the raw key token, with no size bound and no eviction:

```php
$key = self::$cache['key'][$value] ??= json_decode($value);
```

`Splitter` is `final`, exposes only `static` methods, is not registered as a service and does not implement `ResetInterface`, so nothing ever clears that array. It is also filled while computing element boundaries, before any property matching happens downstream, so keys that no target class declares end up cached too.

The result is process-global state, keyed on input, that is never reset and grows for the lifetime of the process. Under classic PHP-FPM this is self-limiting since the memory is reclaimed at the end of each request, but on persistent worker runtimes such as FrankenPHP worker mode, RoadRunner, Swoole or ReactPHP the process outlives the request and the array only ever grows. Reading a stream carrying 2000 distinct keys ten times in a row adds a steady 2001 entries per read, with the heap going from +0.68 MB to +3.24 MB. With the cache removed the heap stays flat at 0.45 to 0.47 MB.

This PR drops the cache and decodes the key directly.

### Why remove it rather than bound it

A reviewer will reasonably ask what this costs. Measured on PHP 8.5 over 4M operations with 20 realistic key names:

```
static cache hit :   25.6 ns/key
json_decode      :  134.9 ns/key
```

So a cache hit saves about 109 ns per key. But that has to be read against the pipeline it sits in. The lexer is a byte-at-a-time loop with a `preg_match` per token and costs about 4184 ns per key end to end. The `json_decode` call is therefore about 3.2% of the per-key cost, and dropping the cache costs about 2.6% of per-key splitting time in the worst case where every single key is a repeat. Against stream I/O and object hydration downstream it is not measurable.

Bounding the cache or turning it into an LRU would keep bookkeeping in the hot loop, would still retain input-derived strings up to the cap, and would require inventing a tuning constant that is really a guess about workload. Removing the shared mutable state is the smaller and more predictable change.

### Why this is safe

The key token is already validated upstream: `Read/Lexer.php` rejects any dict key that does not match `KEY_REGEX` before the splitter ever sees it. By the time `createDictBoundaries()` calls `json_decode($value)` the token is a well-formed JSON string by construction, so the decode cannot fail and the cached value was never doing anything the direct call does not.

Only a private static property is removed, so there is no public API change.

### Tests

A regression test is added as `SplitterTest::testSplitDictDoesNotRetainKeys`. It splits two batches of 100 dicts with keys unique to each batch and asserts that the number of values retained across all of `Splitter`'s static array properties is the same after both batches. It is written against `getStaticProperties()` rather than against the `cache` property by name, so it keeps working if retained state is ever reintroduced under a different name. Without the fix it fails with `Failed asserting that 201 is identical to 101.`

`Splitter` is also used by `JsonPath\JsonPathUtils`, which means `JsonPath\JsonCrawler` reading from a stream was feeding the very same global cache, so both components are tested here:

```
$ ./phpunit src/Symfony/Component/JsonStreamer
OK, but some tests were skipped!
Tests: 457, Assertions: 863, Skipped: 3.

$ ./phpunit src/Symfony/Component/JsonPath
OK (1419 tests, 1652 assertions)
```

The 3 skipped tests are pre-existing and unrelated, they require PHP < 8.4. On `7.4` without this patch the same suite reports `Tests: 456, Assertions: 862, Skipped: 3.`
