### PR TITLE
[HttpFoundation] Handle newlines in server event field values

### DIFF
--- a/src/Symfony/Component/HttpFoundation/ServerEvent.php
+++ b/src/Symfony/Component/HttpFoundation/ServerEvent.php
@@ -117,27 +117,44 @@ class ServerEvent implements \IteratorAggregate
     {
         $head = '';
         if ($this->comment) {
-            $head .= \sprintf(': %s', $this->comment)."\n";
+            $head .= self::field(': ', $this->comment);
         }
         if ($this->id) {
-            $head .= \sprintf('id: %s', $this->id)."\n";
+            $head .= \sprintf('id: %s', self::singleLine($this->id))."\n";
         }
         if ($this->retry > 0) {
             $head .= \sprintf('retry: %s', $this->retry)."\n";
         }
         if ($this->type) {
-            $head .= \sprintf('event: %s', $this->type)."\n";
+            $head .= \sprintf('event: %s', self::singleLine($this->type))."\n";
         }
         yield $head;
 
         if (is_iterable($this->data)) {
             foreach ($this->data as $data) {
-                yield \sprintf('data: %s', $data)."\n";
+                yield self::field('data: ', $data);
             }
         } elseif ('' !== $this->data) {
-            yield \sprintf('data: %s', $this->data)."\n";
+            yield self::field('data: ', $this->data);
         }
 
         yield "\n";
+    }
+
+    /**
+     * Renders a multi-line value as one prefixed line per line of the value.
+     */
+    private static function field(string $prefix, string $value): string
+    {
+        return $prefix.implode("\n".$prefix, preg_split("/\r\n|[\r\n]/", $value))."\n";
+    }
+
+    /**
+     * Removes the line terminators that would end the field early, as the
+     * SSE specification defines these fields as single-line only.
+     */
+    private static function singleLine(string $value): string
+    {
+        return str_replace(["\r", "\n"], '', $value);
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/EventStreamResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/EventStreamResponseTest.php
@@ -175,6 +175,90 @@ class EventStreamResponseTest extends TestCase
         $this->assertSameResponseContent("\n", $response);
     }
 
+    public function testStreamEventWithMultilineStringData()
+    {
+        $response = new EventStreamResponse(static function () {
+            yield new ServerEvent(
+                data: "first line\nsecond line\rthird line\r\nfourth line",
+            );
+        });
+
+        $expected = <<<STR
+            data: first line
+            data: second line
+            data: third line
+            data: fourth line
+
+
+            STR;
+
+        $this->assertSameResponseContent($expected, $response);
+    }
+
+    public function testStreamEventWithMultilineIterableData()
+    {
+        $response = new EventStreamResponse(static function () {
+            yield new ServerEvent(
+                data: ['first line', "second line\nthird line"],
+            );
+        });
+
+        $expected = <<<STR
+            data: first line
+            data: second line
+            data: third line
+
+
+            STR;
+
+        $this->assertSameResponseContent($expected, $response);
+    }
+
+    public function testStreamEventWithFieldLikeContentInData()
+    {
+        $response = new EventStreamResponse(static function () {
+            yield new ServerEvent(
+                data: "legit\nevent: adminAlert\ndata: hijacked",
+                type: 'message',
+            );
+        });
+
+        $expected = <<<STR
+            event: message
+            data: legit
+            data: event: adminAlert
+            data: data: hijacked
+
+
+            STR;
+
+        $this->assertSameResponseContent($expected, $response);
+    }
+
+    public function testStreamEventWithNewlinesInIdTypeAndComment()
+    {
+        $response = new EventStreamResponse(static function () {
+            yield new ServerEvent(
+                data: 'foo',
+                type: "message\nretry: 1",
+                id: "1\revent: adminAlert",
+                comment: "bla\r\nbla",
+            );
+        });
+
+        $expected = <<<STR
+            : bla
+            : bla
+            id: 1event: adminAlert
+            event: messageretry: 1
+            data: foo
+
+
+            STR;
+
+        $this->assertSameResponseContent($expected, $response);
+    }
+
     private function assertSameResponseContent(string $expected, EventStreamResponse $response): void
     {
         ob_start();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`ServerEvent::getIterator()` builds each SSE field line by interpolating the field value and appending `"\n"`, without handling the line terminators the value may itself contain. SSE delimits fields by line, so a terminator inside a value ends the field early and everything after it is parsed by the client as a new field.

Multi-line data is a normal case in the SSE specification, and the component already renders it correctly when `data` is iterable: one `data:` line per item. The string branch just never got the same treatment, so it is simply incomplete. Symmetrically, `id`, `event` and `retry` are single-line-only per the specification, and nothing enforces it.

Reproduction on 7.4:

```php
use Symfony\Component\HttpFoundation\ServerEvent;

$cases = [
    'multi-line string data' => new ServerEvent(
        data: "first line\nsecond line",
        type: 'message',
    ),
    'multi-line item in iterable data' => new ServerEvent(
        data: ['first line', "second line\nthird line"],
    ),
    'newlines in id, type and comment' => new ServerEvent(
        data: 'foo',
        type: "message\nretry: 1",
        id: "1\revent: other",
        comment: "bla\r\nbla",
    ),
];

foreach ($cases as $label => $event) {
    echo "--- $label ---\n";
    echo implode('', iterator_to_array($event, false));
}
```

Before, piped through `cat -A` so the terminators are visible:

```
--- multi-line string data ---$
event: message$
data: first line$
second line$
$
--- multi-line item in iterable data ---$
data: first line$
data: second line$
third line$
$
--- newlines in id, type and comment ---$
: bla^M$
bla$
id: 1^Mevent: other$
event: message$
retry: 1$
data: foo$
$
```

Every continuation line above is read by the client as a field of its own: `second line` and `third line` are dropped as unknown fields instead of being part of the data, `retry: 1` becomes an actual retry directive, and the lone `"\r"` in `id` splits the line for the client parser while not even being visible in a naive read of the output.

After:

```
--- multi-line string data ---$
event: message$
data: first line$
data: second line$
$
--- multi-line item in iterable data ---$
data: first line$
data: second line$
data: third line$
$
--- newlines in id, type and comment ---$
: bla$
: bla$
id: 1event: other$
event: messageretry: 1$
data: foo$
$
```

Every line the iterator emits now starts with a prefix chosen by the component, whatever the values contain:

- `data` as a string is split on line terminators and rendered as one `data:` line per line of the value, which is what the iterable branch already did per item and what the specification defines as the representation of a multi-line payload. This is lossless: the client re-joins the `data:` lines with `"\n"` and reconstructs the original value.
- `data` as an iterable puts each item through the same splitting, so a multi-line item is no longer a hole either. That case was missed originally: the iterable branch was only correct for items that happened to be single-line already. Single-line items render exactly as before, which is what the existing tests assert.
- `comment` renders as one `: ` line per line of the value. A comment has no meaning to the client beyond being ignored, so several comment lines are a faithful rendering, and it keeps the whole value instead of silently dropping part of it.
- `id` and `type` have carriage returns and newlines removed. These two are single-line-only by specification, so a newline in them has no correct rendering to preserve, unlike `data` and `comment`.

All three terminators are handled: the split uses `preg_split("/\r\n|[\r\n]/", ...)` so a CRLF yields one break rather than two, and the stripping removes both characters individually. Matching only `"\n"` would have left the lone-`"\r"` case above unhandled.

Stripping rather than throwing, for `id` and `type`: a `ServerEvent` is normally constructed and rendered from inside the streamed response callback, since `EventStreamResponse::setCallback()` iterates the events the callback yields and `sendEvent()` echoes each chunk. That runs during `send()`, after the headers have gone out. An exception thrown there cannot be turned into an error response; it aborts a `200 text/event-stream` mid-body and leaves the client with a truncated stream. Introducing that failure mode in a patch release, on a value an application may have been passing through for two minor versions, is worse than the alternative, and the alternative loses nothing renderable. Validation is applied at render time rather than in the constructor and setters, so `getId()` and `getType()` keep returning what the caller set.

`EventStreamResponse` needs no change to stay consistent: it only echoes the chunks `ServerEvent` yields, and the one field it sets itself, `retry`, is an `int`.

Four tests are added to `EventStreamResponseTest`, covering a multi-line string `data` mixing the three terminators, a multi-line item inside an iterable `data`, field-like content inside `data`, and newlines in `id`, `type` and `comment` at once. The existing assertions on single-line iterable data, `'0'` data and empty-string data are unchanged and still pass, which is the regression guard on the iterable behaviour.

```
$ ./phpunit src/Symfony/Component/HttpFoundation
OK, but some tests were skipped!
Tests: 1800, Assertions: 3434, Skipped: 49.
```

The 49 skips are pre-existing environment-dependent tests: the suite reports the same count on the same tree without this change.
