### PR TITLE
[HttpClient] Fail when an https proxy is configured but libcurl cannot use it

### DIFF
--- a/src/Symfony/Component/HttpClient/CurlHttpClient.php
+++ b/src/Symfony/Component/HttpClient/CurlHttpClient.php
@@ -94,6 +94,8 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
         $host = parse_url($authority, \PHP_URL_HOST);
         $port = parse_url($authority, \PHP_URL_PORT) ?: ('http:' === $scheme ? 80 : 443);
         $proxy = self::getProxyUrl($options['proxy'], $url);
+        $noProxy = $options['no_proxy'] ?? $_SERVER['no_proxy'] ?? $_SERVER['NO_PROXY'] ?? '';
+        self::checkHttpsProxySupport($proxy, $url, $noProxy);
         $url = implode('', $url);
 
         if (!isset($options['normalized_headers']['user-agent'])) {
@@ -109,8 +111,9 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
             \CURLOPT_MAXREDIRS => 0 < $options['max_redirects'] ? $options['max_redirects'] : 0,
             \CURLOPT_COOKIEFILE => '', // Keep track of cookies during redirects
             \CURLOPT_TIMEOUT => 0,
-            \CURLOPT_PROXY => $proxy,
-            \CURLOPT_NOPROXY => $options['no_proxy'] ?? $_SERVER['no_proxy'] ?? $_SERVER['NO_PROXY'] ?? '',
+            // Always set, so that curl doesn't resolve the proxy from its own environment
+            \CURLOPT_PROXY => $proxy ?? '',
+            \CURLOPT_NOPROXY => $noProxy,
             \CURLOPT_SSL_VERIFYPEER => $options['verify_peer'],
             \CURLOPT_SSL_VERIFYHOST => $options['verify_host'] ? 2 : 0,
             \CURLOPT_CAINFO => $options['cafile'],
@@ -324,7 +327,7 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
             }
         }
 
-        return $pushedResponse ?? new CurlResponse($this->multi, $ch, $options, $this->logger, $method, self::createRedirectResolver($options, $authority), CurlClientState::$curlVersion['version_number'], $url, $ntlmOriginKey);
+        return $pushedResponse ?? new CurlResponse($this->multi, $ch, $options, $this->logger, $method, self::createRedirectResolver($options, $authority, $noProxy), CurlClientState::$curlVersion['version_number'], $url, $ntlmOriginKey);
     }
 
     public function stream(ResponseInterface|iterable $responses, ?float $timeout = null): ResponseStreamInterface
@@ -403,7 +406,7 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
      *
      * Work around CVE-2018-1000007: Authorization, Cookie and Proxy-Authorization headers should not follow redirects - fixed in Curl 7.64
      */
-    private static function createRedirectResolver(array $options, string $authority): \Closure
+    private static function createRedirectResolver(array $options, string $authority, string $noProxy): \Closure
     {
         $redirectHeaders = [];
         if (0 < $options['max_redirects']) {
@@ -415,7 +418,7 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
             }
         }
 
-        return static function ($ch, string $location, bool $noContent) use (&$redirectHeaders, $options) {
+        return static function ($ch, string $location, bool $noContent) use (&$redirectHeaders, $options, $noProxy) {
             try {
                 $location = self::parseUrl($location);
                 $url = self::parseUrl(curl_getinfo($ch, \CURLINFO_EFFECTIVE_URL));
@@ -437,10 +440,40 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
                 curl_setopt($ch, \CURLOPT_HTTPHEADER, $redirectHeaders['with_auth']);
             }
 
-            curl_setopt($ch, \CURLOPT_PROXY, self::getProxyUrl($options['proxy'], $url));
+            $proxy = self::getProxyUrl($options['proxy'], $url);
+            self::checkHttpsProxySupport($proxy, $url, $noProxy);
+            curl_setopt($ch, \CURLOPT_PROXY, $proxy ?? '');
 
             return implode('', $url);
         };
+    }
+
+    /**
+     * Rejects "https://" proxies that curl cannot connect to over TLS.
+     *
+     * Curl older than 7.50.2 connects to them in cleartext instead, leaking the proxy
+     * credentials and the CONNECT metadata on the wire.
+     */
+    private static function checkHttpsProxySupport(?string $proxy, array $url, string $noProxy): void
+    {
+        if (null === $proxy || 0 !== stripos($proxy, 'https://')) {
+            return;
+        }
+
+        if (CurlClientState::$curlVersion['features'] & (\defined('CURL_VERSION_HTTPS_PROXY') ? \CURL_VERSION_HTTPS_PROXY : 1 << 21)) {
+            return;
+        }
+
+        $host = parse_url($url['authority'], \PHP_URL_HOST);
+
+        // Matching "no_proxy" should follow the behavior of curl
+        foreach (preg_split('/[\s,]+/', $noProxy, -1, \PREG_SPLIT_NO_EMPTY) as $rule) {
+            if ('*' === $rule || $host === $rule || str_ends_with($host, '.'.ltrim($rule, '.'))) {
+                return;
+            }
+        }
+
+        throw new TransportException('Cannot use an "https://" proxy: the installed curl does not support HTTPS proxies and could connect to it in cleartext; curl 7.52 or higher is required.');
     }
 
     private function findConstantName(int $opt): ?string

--- a/src/Symfony/Component/HttpClient/Response/CurlResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/CurlResponse.php
@@ -431,7 +431,17 @@ final class CurlResponse implements ResponseInterface, StreamableInterface
                 curl_setopt($ch, \CURLOPT_CUSTOMREQUEST, $info['http_method']);
             }
 
-            if (null === $info['redirect_url'] = $resolveRedirect($ch, $location, $noContent)) {
+            try {
+                $info['redirect_url'] = $resolveRedirect($ch, $location, $noContent);
+            } catch (TransportException $e) {
+                // Exceptions must be reported through the response, they cannot escape a curl callback
+                $multi->handlesActivity[$id][] = null;
+                $multi->handlesActivity[$id][] = $e;
+
+                return 0;
+            }
+
+            if (null === $info['redirect_url']) {
                 $options['max_redirects'] = curl_getinfo($ch, \CURLINFO_REDIRECT_COUNT);
                 curl_setopt($ch, \CURLOPT_FOLLOWLOCATION, false);
                 curl_setopt($ch, \CURLOPT_MAXREDIRS, $options['max_redirects']);

--- a/src/Symfony/Component/HttpClient/Tests/CurlHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/CurlHttpClientTest.php
@@ -13,6 +13,8 @@ namespace Symfony\Component\HttpClient\Tests;
 
 use Symfony\Component\HttpClient\CurlHttpClient;
 use Symfony\Component\HttpClient\Exception\InvalidArgumentException;
+use Symfony\Component\HttpClient\Exception\TransportException;
+use Symfony\Component\HttpClient\Internal\CurlClientState;
 
 /**
  * @requires extension curl
@@ -21,6 +23,8 @@ use Symfony\Component\HttpClient\Exception\InvalidArgumentException;
  */
 class CurlHttpClientTest extends HttpClientTestCase
 {
+    private const HTTPS_PROXY_ERROR = 'Cannot use an "https://" proxy: the installed curl does not support HTTPS proxies and could connect to it in cleartext; curl 7.52 or higher is required.';
+
     protected function getHttpClient(string $testCase): CurlHttpClient
     {
         if (!str_contains($testCase, 'Push')) {
@@ -137,6 +141,82 @@ class CurlHttpClientTest extends HttpClientTestCase
                 ],
             ],
         ]);
+    }
+
+    public function testHttpsProxyIsRejectedWhenCurlLacksSupport()
+    {
+        $client = $this->getHttpClient(__FUNCTION__);
+
+        $this->withProxyEnvironment([], [], false, function () use ($client) {
+            $this->expectException(TransportException::class);
+            $this->expectExceptionMessage(self::HTTPS_PROXY_ERROR);
+
+            $client->request('GET', 'http://127.0.0.1:8057/', ['proxy' => 'https://127.0.0.1:8057']);
+        });
+    }
+
+    public function testHttpsProxyFromServerVarsIsRejectedWhenCurlLacksSupport()
+    {
+        $client = $this->getHttpClient(__FUNCTION__);
+
+        $this->withProxyEnvironment(['https_proxy' => 'https://127.0.0.1:8057'], [], false, function () use ($client) {
+            $this->expectException(TransportException::class);
+            $this->expectExceptionMessage(self::HTTPS_PROXY_ERROR);
+
+            $client->request('GET', 'https://127.0.0.1:8057/');
+        });
+    }
+
+    public function testProxyFromProcessEnvIsNotUsed()
+    {
+        $client = $this->getHttpClient(__FUNCTION__);
+
+        // Only curl reads the process environment, and it must not do so behind our back
+        $this->withProxyEnvironment([], ['http_proxy' => 'http://127.0.0.1:9'], true, function () use ($client) {
+            $response = $client->request('GET', 'http://127.0.0.1:8057/');
+
+            $this->assertSame(200, $response->getStatusCode());
+        });
+    }
+
+    public function testHttpsProxyIsRejectedOnRedirectWhenCurlLacksSupport()
+    {
+        $client = $this->getHttpClient(__FUNCTION__);
+
+        $this->withProxyEnvironment(['https_proxy' => 'https://127.0.0.1:8057'], [], false, function () use ($client) {
+            $response = $client->request('GET', 'http://127.0.0.1:8057/302?location=https://127.0.0.1:8057/');
+
+            $this->expectException(TransportException::class);
+            $this->expectExceptionMessage(self::HTTPS_PROXY_ERROR);
+
+            $response->getStatusCode();
+        });
+    }
+
+    public function testHttpsProxyIsNotRejectedWhenNoProxyMatches()
+    {
+        $client = $this->getHttpClient(__FUNCTION__);
+
+        $this->withProxyEnvironment([], [], false, function () use ($client) {
+            $response = $client->request('GET', 'http://127.0.0.1:8057/', [
+                'proxy' => 'https://127.0.0.1:8057',
+                'no_proxy' => '127.0.0.1',
+            ]);
+
+            $this->assertSame(200, $response->getStatusCode());
+        });
+    }
+
+    public function testHttpsProxyIsNotRejectedWhenCurlSupportsIt()
+    {
+        $client = $this->getHttpClient(__FUNCTION__);
+
+        $this->withProxyEnvironment([], [], true, function () use ($client) {
+            $response = $client->request('GET', 'http://127.0.0.1:8057/', ['proxy' => 'https://127.0.0.1:8057']);
+            $response->cancel();
+
+            $this->addToAssertionCount(1);
+        });
     }
 
     public function testKeepAuthorizationHeaderOnRedirectToSameHostWithConfiguredHostToIpAddressMapping()
@@ -275,6 +355,48 @@ class CurlHttpClientTest extends HttpClientTestCase
                 $response->getContent();
 
                 self::assertSame($expectedResult[$i], str_contains($response->getInfo('debug'), 'Re-using existing connection'));
+            }
+        }
+    }
+
+    /**
+     * Runs $test with a controlled proxy environment and a curl that pretends to support HTTPS proxies or not.
+     */
+    private function withProxyEnvironment(array $server, array $env, bool $httpsProxySupport, \Closure $test): void
+    {
+        $backup = [];
+
+        foreach (['http_proxy', 'HTTP_PROXY', 'https_proxy', 'HTTPS_PROXY', 'all_proxy', 'ALL_PROXY', 'no_proxy', 'NO_PROXY'] as $name) {
+            $backup[$name] = [\array_key_exists($name, $_SERVER) ? $_SERVER[$name] : null, getenv($name, true)];
+            unset($_SERVER[$name]);
+            putenv($name);
+        }
+
+        foreach ($server as $name => $value) {
+            $_SERVER[$name] = $value;
+        }
+
+        foreach ($env as $name => $value) {
+            putenv($name.'='.$value);
+        }
+
+        $curlVersion = CurlClientState::$curlVersion ?? curl_version();
+        $httpsProxyFeature = \defined('CURL_VERSION_HTTPS_PROXY') ? \CURL_VERSION_HTTPS_PROXY : 1 << 21;
+        CurlClientState::$curlVersion = ['features' => $httpsProxySupport ? $curlVersion['features'] | $httpsProxyFeature : $curlVersion['features'] & ~$httpsProxyFeature] + $curlVersion;
+
+        try {
+            $test();
+        } finally {
+            CurlClientState::$curlVersion = $curlVersion;
+
+            foreach ($backup as $name => [$serverValue, $envValue]) {
+                if (null === $serverValue) {
+                    unset($_SERVER[$name]);
+                } else {
+                    $_SERVER[$name] = $serverValue;
+                }
+
+                false === $envValue ? putenv($name) : putenv($name.'='.$envValue);
             }
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`CurlHttpClient` hands the resolved proxy URL straight to `CURLOPT_PROXY` without looking at its scheme. HTTPS-proxy support landed in libcurl 7.52.0. Older libcurl cannot establish the client-to-proxy TLS connection: 7.50.2 through 7.51.x reject the scheme at connect time with an opaque error, and versions older than 7.50.2 silently treat `https://` as plaintext `http://` and connect in the clear. A 7.52+ build compiled without the feature also fails rather than downgrades.

`https://` proxy support is first-class client configuration, so it should fail loudly rather than silently degrade to plaintext depending on what the linked libcurl happens to be capable of. This adds an up-front check that throws a `TransportException` when the effective proxy is an `https://` one and `curl_version()` does not report `CURL_VERSION_HTTPS_PROXY`.

Spotted from the equivalent work in Guzzle, https://github.com/guzzle/guzzle/pull/3626. Credit to Graham Campbell for identifying the pattern.

## The patch

**`CURLOPT_PROXY` is now always set**, to `$proxy ?? ''`, so that Symfony's proxy resolution is authoritative. An empty string tells libcurl to use no proxy and to not look for one, which is exactly what "we resolved no proxy" means.

**`checkHttpsProxySupport()`** then runs before the handle is configured and before any byte goes on the wire, both in `request()` and in the redirect resolver. It short-circuits on the cheap capability bit first (`CurlClientState::$curlVersion['features'] & CURL_VERSION_HTTPS_PROXY`, falling back to `1 << 21` since the constant is undefined when ext/curl is built against a libcurl older than 7.52), and only then scans `no_proxy`. `CurlClientState::$curlVersion` is the already-cached `curl_version()` the client uses for its other capability checks.

`no_proxy` is honoured before the exception is thrown, using the same string that is handed to `CURLOPT_NOPROXY` and the same matching rules as `NativeHttpClient` and `AmpClientState` (`*`, exact host, dot-suffix). A request that libcurl would not have proxied in the first place must not be refused.

The guard runs on redirects too, because the proxy is re-selected on each hop and an `http://` to `https://` redirect can pull in an `https_proxy` that did not apply to the initial request.

## Two findings that shaped this

**libcurl was doing its own proxy lookup in the process environment on the initial request.** `CurlHttpClient` skips `curl_setopt()` for `null` values, so when `getProxyUrl()` resolved nothing, `CURLOPT_PROXY` was never set at all and libcurl fell back to its own `getenv()` lookup. Verified with a script that sets `http_proxy` through `putenv()` only, absent from `$_SERVER`: the request failed with `Failed to connect to 127.0.0.1 port 9`, so libcurl had used it. That only ever happened on the first hop, since the redirect resolver calls `curl_setopt()` unconditionally and `null` lands as `''` there, which disables the proxy.

An earlier revision of this patch made the guard replicate libcurl's own lookup instead: the per-scheme variables, the uppercase versus lowercase precedence, libcurl's httpoxy-driven refusal to honour an uppercase `HTTP_PROXY`, the `all_proxy` fallback. Always setting `CURLOPT_PROXY` removes the need for any of it, and there is no longer a second proxy resolution to predict.

This is a behaviour change worth calling out: a proxy configured only through a runtime `putenv()` call is no longer used on the first request. Real exported environment variables are unaffected, since they show up in both `$_SERVER` and `getenv()`, and `getProxyUrl()` reads them from `$_SERVER`. It removes an inconsistency rather than creating one, since such a proxy was already ignored on every redirect hop, meaning a request could be proxied on its first hop and go direct on the next one. It also aligns the three transports, as `NativeHttpClient` and `AmpHttpClient` never consult `getenv()`.

`CURLOPT_NOPROXY` was already set unconditionally, so `no_proxy` handling is untouched. `CURLOPT_PROXY` is in the `$curloptsToConfig` map, so `extra.curl` already refuses it with "use option proxy instead"; there is no user-supplied value to conflict with.

**An exception thrown from a cURL callback escapes straight out of `curl_multi_exec()`.** Verified with a standalone script using a `CURLOPT_HEADERFUNCTION` that throws: the exception surfaces from `curl_multi_exec()` while `curl_multi_info_read()` reports `result=0 (No error)`. Letting it escape from the redirect resolver would bypass the whole `curl_multi_info_read()` loop in `CurlResponse::perform()`, leave the handle in the multi handle, and surface the error on whichever response happens to be waiting rather than on the offending one. So the redirect path catches `TransportException` around the `$resolveRedirect()` call, reports it through `$multi->handlesActivity`, and returns `0` to abort the transfer. That is the same pattern already used by the write and progress callbacks a few lines above in that file.

## Tests

`./phpunit src/Symfony/Component/HttpClient` gives `OK, but incomplete, skipped, or risky tests! Tests: 994, Assertions: 2234, Skipped: 43.`

Six tests in `CurlHttpClientTest` cover the `proxy` option, `$_SERVER`-provided proxies, the redirect path, the `no_proxy` bypass, the absence of rejection when the feature bit is present, and the fact that a `putenv()`-only proxy is not used on the first hop. The shared `testProxy` from `HttpClientTestCase`, which exercises a real proxy including the `$_SERVER['http_proxy']` path, still passes unchanged.

Coverage limit, stated plainly: no ancient libcurl is available here, so the tests do not observe a real downgrade. They flip the `CURL_VERSION_HTTPS_PROXY` bit in `CurlClientState::$curlVersion`, the same value the production code reads, around each case and restore it afterwards along with the proxy environment. That exercises the guard, the bypass logic and the redirect reporting path exactly as production code runs them, but the underlying libcurl behaviour being protected against is taken from libcurl's own history rather than reproduced here.

One thing deliberately not adopted from the Guzzle patch: CIDR `no_proxy` matching. libcurl only accepts CIDR rules in `NOPROXY` since 7.86.0, six years past HTTPS-proxy support, so for any libcurl that can actually downgrade the CIDR branch is unused code, and leaving it out keeps the guard aligned with the `no_proxy` semantics the other Symfony transports implement.
