### PR TITLE
[JsonPath] Add limits for filter expression length and depth in JsonCrawler

### DIFF
--- a/src/Symfony/Component/JsonPath/JsonCrawler.php
+++ b/src/Symfony/Component/JsonPath/JsonCrawler.php
@@ -42,6 +42,9 @@ final class JsonCrawler implements JsonCrawlerInterface
 
     private const REGEX_BACKTRACK_LIMIT = 10000;
 
+    private const MAX_FILTER_EXPRESSION_LENGTH = 10000;
+    private const MAX_FILTER_EXPRESSION_DEPTH = 100;
+
     /**
      * Comparison operators and their corresponding lengths.
      */
@@ -525,9 +528,15 @@ final class JsonCrawler implements JsonCrawlerInterface
         return $result;
     }
 
-    private function evaluateFilterExpression(string $expr, mixed $context): bool
+    private function evaluateFilterExpression(string $expr, mixed $context, int $depth = 0): bool
     {
-        $expr = $this->stripWrappingParentheses(JsonPathUtils::normalizeWhitespace($expr));
+        $expr = JsonPathUtils::normalizeWhitespace($expr);
+
+        if ($depth > self::MAX_FILTER_EXPRESSION_DEPTH || \strlen($expr) > self::MAX_FILTER_EXPRESSION_LENGTH) {
+            throw new JsonCrawlerException($expr, 'filter expression is too long or too deeply nested');
+        }
+
+        $expr = $this->stripWrappingParentheses($expr);
 
         // logical operators bind less tightly than the negation
         if ($logicalOp = $this->findRightmostLogicalOperator($expr)) {
@@ -535,14 +544,14 @@ final class JsonCrawler implements JsonCrawlerInterface
             $right = trim(substr($expr, $logicalOp['position'] + \strlen($logicalOp['operator'])));
 
             if ('||' === $logicalOp['operator']) {
-                return $this->evaluateFilterExpression($left, $context) || $this->evaluateFilterExpression($right, $context);
+                return $this->evaluateFilterExpression($left, $context, $depth + 1) || $this->evaluateFilterExpression($right, $context, $depth + 1);
             }
 
-            return $this->evaluateFilterExpression($left, $context) && $this->evaluateFilterExpression($right, $context);
+            return $this->evaluateFilterExpression($left, $context, $depth + 1) && $this->evaluateFilterExpression($right, $context, $depth + 1);
         }
 
         if (str_starts_with($expr, '!')) {
-            return !$this->evaluateFilterExpression(trim(substr($expr, 1)), $context);
+            return !$this->evaluateFilterExpression(trim(substr($expr, 1)), $context, $depth + 1);
         }
 
         foreach (self::COMPARISON_OPERATORS as $op => $len) {
@@ -1081,19 +1090,25 @@ final class JsonCrawler implements JsonCrawlerInterface
         return true;
     }
 
-    private function validateFilterExpression(string $expr): void
+    private function validateFilterExpression(string $expr, int $depth = 0): void
     {
-        $expr = $this->stripWrappingParentheses(trim($expr));
+        $expr = trim($expr);
+
+        if ($depth > self::MAX_FILTER_EXPRESSION_DEPTH || \strlen($expr) > self::MAX_FILTER_EXPRESSION_LENGTH) {
+            throw new JsonCrawlerException($expr, 'filter expression is too long or too deeply nested');
+        }
+
+        $expr = $this->stripWrappingParentheses($expr);
 
         if ($logicalOp = $this->findRightmostLogicalOperator($expr)) {
-            $this->validateFilterExpression(trim(substr($expr, 0, $logicalOp['position']))); // left
-            $this->validateFilterExpression(trim(substr($expr, $logicalOp['position'] + \strlen($logicalOp['operator'])))); // right
+            $this->validateFilterExpression(trim(substr($expr, 0, $logicalOp['position'])), $depth + 1); // left
+            $this->validateFilterExpression(trim(substr($expr, $logicalOp['position'] + \strlen($logicalOp['operator']))), $depth + 1); // right
 
             return;
         }
 
         if (str_starts_with($expr, '!')) {
-            $this->validateFilterExpression(trim(substr($expr, 1)));
+            $this->validateFilterExpression(trim(substr($expr, 1)), $depth + 1);
 
             return;
         }

--- a/src/Symfony/Component/JsonPath/Tests/JsonCrawlerTest.php
+++ b/src/Symfony/Component/JsonPath/Tests/JsonCrawlerTest.php
@@ -500,6 +500,16 @@ class JsonCrawlerTest extends TestCase
         $this->assertLessThan(1.0, $elapsed, 'ReDoS pattern must not stall preg_match');
     }
 
+    public function testDeeplyNestedFilterExpressionIsRejected()
+    {
+        // a hostile query of nested logical-NOT operators would otherwise drive
+        // unbounded recursion while validating the filter and exhaust memory (CWE-674)
+        $this->expectException(JsonCrawlerException::class);
+        $this->expectExceptionMessage('filter expression is too long or too deeply nested');
+
+        (new JsonCrawler('[1]'))->find('$[?'.str_repeat('!', 1000).'@.a]');
+    }
+
     public function testDeepExpressionInFilter()
     {
         $result = self::getBookstoreCrawler()->find('$.store.book[?(@.publisher.address.city == "Springfield")]');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

This patch is authored by @alexandre-daubois. I am only rebasing it onto current `7.4` and forwarding it, the design and the constants are his.

### The problem

`JsonCrawler` parses a filter expression by recursive descent: `validateFilterExpression()` and `evaluateFilterExpression()` peel one operator off the expression and call themselves on the remainder. Neither the length of the expression nor the recursion depth was bounded, so the cost is driven entirely by the query string and is paid *before* the document is ever examined. A one-element document such as `[1]` is enough to trigger it.

Two shapes:

* A chain of logical-NOT operators, `$[?!!!!!...@.a]`. Each `!` adds a stack frame plus a copy of the remaining string, so a roughly 15 KB query allocates on the order of *n²* bytes of live substrings and exhausts a 128 MB memory limit.
* A chain of `&&`, `$[?@.a&&@.a&&...]`. `findRightmostLogicalOperator()` rescans the whole expression at every level, which makes parsing quadratic in CPU. Measured on the unpatched branch against `[1]`:

  | operators | query size | time |
  | --- | --- | --- |
  | 250 | 1.2 KB | 0.07s |
  | 500 | 2.5 KB | 0.28s |
  | 1000 | 5.0 KB | 1.07s |
  | 2000 | 10.0 KB | 2.37s |

Part of the value here is the failure *mode*, not only the cost. On the unpatched branch the first shape dies with a fatal `E_ERROR`:

```
PHP Fatal error:  Allowed memory size of 134217728 bytes exhausted ... in JsonCrawler.php on line 1096
#0 JsonCrawler.php(1096): Symfony\Component\JsonPath\JsonCrawler->validateFilterExpression()
#1 JsonCrawler.php(1096): Symfony\Component\JsonPath\JsonCrawler->validateFilterExpression()
...
```

That is not catchable, so the component's own `JsonCrawlerException` handling cannot intercept it and the process is simply gone. After this patch both shapes raise an ordinary `JsonCrawlerException`, which callers can already handle.

### The fix

Two constants, `MAX_FILTER_EXPRESSION_LENGTH = 10000` and `MAX_FILTER_EXPRESSION_DEPTH = 100`, checked at the top of both recursive routines before any further work, with a `$depth` counter threaded through every recursive call.

### Rebase notes for reviewers

This commit predates two changes that rewrote the very routines it guards, so it did not apply cleanly and I had to resolve a conflict in `JsonCrawler.php`. Both upstream behaviours are preserved in full, nothing was dropped:

* #65002 extracted `stripWrappingParentheses()` (repeated unwrapping) and moved the `!` handling *after* the scan for logical operators, so that logical operators bind less tightly than negation.
* #65005 added `isSingularQuery()` as a positive check on comparison operands, plus `trim()` before the paren-stripping loop in `validateFilterExpression()`.

Resolution:

* `evaluateFilterExpression()`: keeps `stripWrappingParentheses()` and keeps the reordered `!` branch. The limit check sits between `normalizeWhitespace()` and `stripWrappingParentheses()`, matching the position it had in the original commit, so the length is measured before any unwrapping work happens.
* `validateFilterExpression()`: keeps `trim()` + `stripWrappingParentheses()` and the `isSingularQuery()` operand checks, with the limit check inserted between the `trim()` and the strip.
* The `!` recursion branch that #65002 added to `validateFilterExpression()` did not exist when this commit was written, so it also had to be given `$depth + 1`. Without that the `!` chain still recursed unbounded during validation, which is exactly where the fatal error above is raised.

### Verification

`./phpunit src/Symfony/Component/JsonPath` after the rebase:

```
OK (1420 tests, 1654 assertions)
```

The RFC 9535 compliance suite on its own is green too: `OK (1159 tests, 1159 assertions)`.

Both attack shapes were re-checked against the rebased code rather than assumed. Under `php -d memory_limit=128M`, against the document `[1]`:

| query | before | after |
| --- | --- | --- |
| `'$[?'.str_repeat('!', 15000).'@.a]'` | fatal `E_ERROR`, 128 MB exhausted | `JsonCrawlerException` in 0.008s |
| `'$[?@.a'.str_repeat('&&@.a', 2000).']'` | completes, 4.4s of CPU | `JsonCrawlerException` in 0.010s |

Shorter chains that stay under the length limit are caught by the depth limit instead. Ordinary nested filter expressions still evaluate correctly, including the two upstream behaviours: `$.store.book[?(((@.price < 10)))]`, `$.store.book[?((@.price < 10 && @.category == "fiction") || @.category == "reference")]` and `$.store.book[?(!!(@.price < 10))]` all return the expected matches, and a non-singular comparison such as `$[?@.* == 1]` is still rejected as before.

### Observation on the constants, not a proposed change

While checking that the limits could not reject anything legitimate, I measured the compliance test suite. Of its 703 cases, 377 carry a filter selector, and across all of them:

* longest filter-bearing selector: **43 bytes**, `$.values[?length(@.a)==length(value($..c))]`
* deepest parenthesis nesting: **2**
* most logical operators in a single expression: **4**, `$[?@.a && @.b && @.c && @.d && @.e]`

So the configured 10000 bytes and depth 100 leave a very wide margin over anything RFC 9535 exercises. Recording this only as calibration evidence that the limits are safe. The constants are left exactly as authored.
