### PR TITLE
[HttpKernel] Minor performance improvement when resolving arguments

### DIFF
--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/ServiceValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/ServiceValueResolver.php
@@ -48,12 +48,12 @@ final class ServiceValueResolver implements ValueResolverInterface
             $controller = substr($controller, 0, $i).strtolower(substr($controller, $i));
         }
 
-        if (!$this->container->has($controller) || !$this->container->get($controller)->has($argument->getName())) {
+        if (!$this->container->has($controller) || !($locator = $this->container->get($controller))->has($argument->getName())) {
             return [];
         }
 
         try {
-            return [$this->container->get($controller)->get($argument->getName())];
+            return [$locator->get($argument->getName())];
         } catch (RuntimeException $e) {
             $what = 'argument $'.$argument->getName();
             $message = str_replace(\sprintf('service "%s"', $argument->getName()), $what, $e->getMessage());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`ServiceValueResolver::resolve()` calls `$this->container->get($controller)` twice per resolved argument. This code runs on every request for each service-backed controller argument (in `prod` too), so let's optimize this.

This PR stores the locator in a local variable and reuses it, which is exactly what the related class in Console already does:

https://github.com/symfony/symfony/blob/fdd57039973475deb7f106e68b76967dbf397dfa/src/Symfony/Component/Console/ArgumentResolver/ValueResolver/ServiceValueResolver.php#L38