### PR TITLE
[Messenger] Add failed message id range options

### DIFF
--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.2
 ---
 
+ * Add `--from` and `--until` options to `messenger:failed:retry` and `messenger:failed:remove` to process a range of failed message ids
  * Add `$serializedTypeNameAliases` parameter to `#[AsMessage]` to accept alternate serialized type names when decoding
 
 8.1

--- a/src/Symfony/Component/Messenger/Command/AbstractFailedMessagesCommand.php
+++ b/src/Symfony/Component/Messenger/Command/AbstractFailedMessagesCommand.php
@@ -14,7 +14,9 @@ namespace Symfony\Component\Messenger\Command;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Completion\CompletionInput;
 use Symfony\Component\Console\Completion\CompletionSuggestions;
+use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Helper\Dumper;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Question\ChoiceQuestion;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\ErrorHandler\Exception\FlattenException;
@@ -45,6 +47,9 @@ use Symfony\Contracts\Service\ServiceProviderInterface;
 abstract class AbstractFailedMessagesCommand extends Command
 {
     protected const DEFAULT_TRANSPORT_OPTION = 'choose';
+    protected const FIRST_MESSAGE_ID_OPTION = 'from';
+    protected const LAST_MESSAGE_ID_OPTION = 'until';
+    private const MIN_MESSAGE_ID = 1;
 
     public function __construct(
         private ?string $globalFailureReceiverName,
@@ -67,6 +72,34 @@ abstract class AbstractFailedMessagesCommand extends Command
         $stamp = $envelope->last(TransportMessageIdStamp::class);
 
         return $stamp?->getId();
+    }
+
+    protected function getMessageIds(InputInterface $input): array
+    {
+        $ids = (array) $input->getArgument('id');
+        $firstId = $input->getOption(self::FIRST_MESSAGE_ID_OPTION);
+        $lastId = $input->getOption(self::LAST_MESSAGE_ID_OPTION);
+
+        if (null === $firstId && null === $lastId) {
+            return $ids;
+        }
+
+        if ($ids) {
+            throw new RuntimeException(\sprintf('You cannot specify message ids when using the "--%s" and "--%s" options.', self::FIRST_MESSAGE_ID_OPTION, self::LAST_MESSAGE_ID_OPTION));
+        }
+
+        if (null === $firstId || null === $lastId) {
+            throw new RuntimeException(\sprintf('The "--%s" and "--%s" options must be used together.', self::FIRST_MESSAGE_ID_OPTION, self::LAST_MESSAGE_ID_OPTION));
+        }
+
+        $firstId = $this->parseMessageIdRangeBound($firstId, self::FIRST_MESSAGE_ID_OPTION);
+        $lastId = $this->parseMessageIdRangeBound($lastId, self::LAST_MESSAGE_ID_OPTION);
+
+        if ($firstId > $lastId) {
+            throw new RuntimeException(\sprintf('The "--%s" option must be lower than or equal to the "--%s" option.', self::FIRST_MESSAGE_ID_OPTION, self::LAST_MESSAGE_ID_OPTION));
+        }
+
+        return array_map('strval', range($firstId, $lastId));
     }
 
     protected function displaySingleMessage(Envelope $envelope, SymfonyStyle $io, ?SymfonyStyle $errorIo = null): void
@@ -171,6 +204,15 @@ abstract class AbstractFailedMessagesCommand extends Command
         }]);
 
         return $cloner;
+    }
+
+    private function parseMessageIdRangeBound(mixed $id, string $optionName): int
+    {
+        if (false === filter_var($id, \FILTER_VALIDATE_INT, ['options' => ['min_range' => self::MIN_MESSAGE_ID]])) {
+            throw new RuntimeException(\sprintf('The "--%s" option expects a positive integer.', $optionName));
+        }
+
+        return (int) $id;
     }
 
     protected function printWarningAvailableFailureTransports(SymfonyStyle $io, ?string $failureTransportName): void

--- a/src/Symfony/Component/Messenger/Command/FailedMessagesRemoveCommand.php
+++ b/src/Symfony/Component/Messenger/Command/FailedMessagesRemoveCommand.php
@@ -34,6 +34,8 @@ class FailedMessagesRemoveCommand extends AbstractFailedMessagesCommand
                 new InputArgument('id', InputArgument::OPTIONAL | InputArgument::IS_ARRAY, 'Specific message id(s) to remove'),
                 new InputOption('all', null, InputOption::VALUE_NONE, 'Remove all failed messages from the transport'),
                 new InputOption('force', null, InputOption::VALUE_NONE, 'Force the operation without confirmation'),
+                new InputOption(self::FIRST_MESSAGE_ID_OPTION, null, InputOption::VALUE_REQUIRED, 'First message id to remove'),
+                new InputOption(self::LAST_MESSAGE_ID_OPTION, null, InputOption::VALUE_REQUIRED, 'Last message id to remove'),
                 new InputOption('transport', null, InputOption::VALUE_REQUIRED, 'Use a specific failure transport', self::DEFAULT_TRANSPORT_OPTION),
                 new InputOption('show-messages', null, InputOption::VALUE_NONE, 'Display messages before removing it (if multiple ids are given)'),
                 new InputOption('class-filter', null, InputOption::VALUE_REQUIRED, 'Filter by a specific class name'),
@@ -48,6 +50,10 @@ class FailedMessagesRemoveCommand extends AbstractFailedMessagesCommand
                 You can remove all failed messages from the failure transport by using the "--all" option:
 
                     <info>php %command.full_name% --all</info>
+
+                Or pass an inclusive id range:
+
+                    <info>php %command.full_name% --from={firstId} --until={lastId}</info>
                 EOF
             )
         ;
@@ -66,7 +72,7 @@ class FailedMessagesRemoveCommand extends AbstractFailedMessagesCommand
         $receiver = $this->getReceiver($failureTransportName);
 
         $shouldForce = $input->getOption('force');
-        $ids = (array) $input->getArgument('id');
+        $ids = $this->getMessageIds($input);
         $shouldDeleteAllMessages = $input->getOption('all');
 
         $idsCount = \count($ids);

--- a/src/Symfony/Component/Messenger/Command/FailedMessagesRetryCommand.php
+++ b/src/Symfony/Component/Messenger/Command/FailedMessagesRetryCommand.php
@@ -63,6 +63,8 @@ class FailedMessagesRetryCommand extends AbstractFailedMessagesCommand implement
             ->setDefinition([
                 new InputArgument('id', InputArgument::IS_ARRAY, 'Specific message id(s) to retry'),
                 new InputOption('force', null, InputOption::VALUE_NONE, 'Force action without confirmation'),
+                new InputOption(self::FIRST_MESSAGE_ID_OPTION, null, InputOption::VALUE_REQUIRED, 'First message id to retry'),
+                new InputOption(self::LAST_MESSAGE_ID_OPTION, null, InputOption::VALUE_REQUIRED, 'Last message id to retry'),
                 new InputOption('transport', null, InputOption::VALUE_REQUIRED, 'Use a specific failure transport', self::DEFAULT_TRANSPORT_OPTION),
                 new InputOption('keepalive', null, InputOption::VALUE_REQUIRED, 'Whether to use the transport\'s keepalive mechanism if implemented', self::DEFAULT_KEEPALIVE_INTERVAL),
             ])
@@ -82,6 +84,10 @@ class FailedMessagesRetryCommand extends AbstractFailedMessagesCommand implement
                 Or pass multiple ids at once to process multiple messages:
 
                 <info>php %command.full_name% {id1} {id2} {id3}</info>
+
+                Or pass an inclusive id range:
+
+                <info>php %command.full_name% --from={firstId} --until={lastId}</info>
 
                 EOF
             )
@@ -121,7 +127,7 @@ class FailedMessagesRetryCommand extends AbstractFailedMessagesCommand implement
         $io->writeln(\sprintf('To retry all the messages, run <comment>messenger:consume %s</comment>', $failureTransportName));
 
         $shouldForce = $input->getOption('force');
-        $ids = $input->getArgument('id');
+        $ids = $this->getMessageIds($input);
         if (0 === \count($ids)) {
             if (!$input->isInteractive()) {
                 throw new RuntimeException('Message id must be passed when in non-interactive mode.');

--- a/src/Symfony/Component/Messenger/Tests/Command/FailedMessagesRemoveCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/FailedMessagesRemoveCommandTest.php
@@ -162,6 +162,40 @@ class FailedMessagesRemoveCommandTest extends TestCase
         $this->assertStringContainsString('Message with id 30 removed.', $tester->getDisplay());
     }
 
+    public function testRemoveMessagesByIdRange()
+    {
+        $globalFailureReceiverName = 'failure_receiver';
+        $receiver = $this->createMock(ListableReceiverInterface::class);
+
+        $series = [
+            [['20'], new Envelope(new \stdClass())],
+            [['21'], new Envelope(new \stdClass())],
+            [['22'], new Envelope(new \stdClass())],
+        ];
+
+        $receiver->expects($this->exactly(3))->method('find')
+            ->willReturnCallback(function (...$args) use (&$series) {
+                [$expectedArgs, $return] = array_shift($series);
+                $this->assertSame($expectedArgs, $args);
+
+                return $return;
+            })
+        ;
+        $receiver->expects($this->exactly(3))->method('reject');
+
+        $command = new FailedMessagesRemoveCommand(
+            $globalFailureReceiverName,
+            new ServiceLocator([$globalFailureReceiverName => static fn () => $receiver])
+        );
+
+        $tester = new CommandTester($command);
+        $tester->execute(['--from' => '20', '--until' => '22', '--force' => true]);
+
+        $this->assertStringContainsString('Message with id 20 removed.', $tester->getDisplay());
+        $this->assertStringContainsString('Message with id 21 removed.', $tester->getDisplay());
+        $this->assertStringContainsString('Message with id 22 removed.', $tester->getDisplay());
+    }
+
     public function testRemoveMessagesFilteredByClassMessage()
     {
         $globalFailureReceiverName = 'failure_receiver';

--- a/src/Symfony/Component/Messenger/Tests/Command/FailedMessagesRetryCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/FailedMessagesRetryCommandTest.php
@@ -137,6 +137,41 @@ class FailedMessagesRetryCommandTest extends TestCase
         $this->assertStringContainsString('[OK]', $tester->getDisplay());
     }
 
+    public function testRetryMessagesByIdRange()
+    {
+        $series = [
+            [['20'], new Envelope(new \stdClass())],
+            [['21'], new Envelope(new \stdClass())],
+            [['22'], new Envelope(new \stdClass())],
+        ];
+
+        $receiver = $this->createMock(ListableReceiverInterface::class);
+        $receiver->expects($this->exactly(3))->method('find')
+            ->willReturnCallback(function (...$args) use (&$series) {
+                [$expectedArgs, $return] = array_shift($series);
+                $this->assertSame($expectedArgs, $args);
+
+                return $return;
+            })
+        ;
+        $receiver->expects($this->exactly(3))->method('ack');
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects($this->exactly(3))->method('dispatch')->willReturn(new Envelope(new \stdClass()));
+
+        $command = new FailedMessagesRetryCommand(
+            'failure_receiver',
+            new ServiceLocator(['failure_receiver' => static fn () => $receiver]),
+            $bus,
+            new EventDispatcher()
+        );
+
+        $tester = new CommandTester($command);
+        $tester->execute(['--from' => '20', '--until' => '22', '--force' => true]);
+
+        $this->assertStringContainsString('[OK]', $tester->getDisplay());
+    }
+
     public function testCompletingTransport()
     {
         $globalFailureReceiverName = 'failure_receiver';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #63924
| License       | MIT

This adds inclusive `--from` and `--until` options to `messenger:failed:retry` and `messenger:failed:remove`.

The range is expanded into explicit message ids and then uses the same `ListableReceiverInterface::find()` flow as existing id-based retry/remove handling. This keeps the feature transport-agnostic for listable failure receivers while avoiding a new transport contract.

## Test verification (RED -> GREEN)

RED on `upstream/8.2` with the new tests only:

```text
Symfony\Component\Messenger\Tests\Command\FailedMessagesRetryCommandTest::testRetryMessagesByIdRange
Symfony\Component\Console\Exception\InvalidOptionException: The "--from" option does not exist.

Symfony\Component\Messenger\Tests\Command\FailedMessagesRemoveCommandTest::testRemoveMessagesByIdRange
Symfony\Component\Console\Exception\InvalidOptionException: The "--from" option does not exist.
```

GREEN on the final branch:

```text
PHPUnit 13.3-dev by Sebastian Bergmann and contributors.

Runtime:       PHP 8.4.23
Configuration: /w/src/Symfony/Component/Messenger/phpunit.xml.dist

..............................                                    30 / 30 (100%)

OK (30 tests, 109 assertions)
```

Local CI replay:

```text
Baseline upstream/8.2: OK (28 tests, 96 assertions)
Final branch:          OK (30 tests, 109 assertions)
```
