### PR TITLE
[JsonStreamer] Fix escaping, float precision and error reporting when writing JSON

### DIFF
--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/Model/DummyWithSpecialCharacterNamedProperties.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/Model/DummyWithSpecialCharacterNamedProperties.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Symfony\Component\JsonStreamer\Tests\Fixtures\Model;
+
+use Symfony\Component\JsonStreamer\Attribute\StreamedName;
+
+class DummyWithSpecialCharacterNamedProperties
+{
+    #[StreamedName('https://symfony.com/école')]
+    public int $url = 1;
+
+    #[StreamedName("line\u{2028}separator")]
+    public int $lineSeparator = 2;
+}

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/backed_enum.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/backed_enum.php
@@ -5,7 +5,7 @@
  */
 return static function (mixed $data, \Psr\Container\ContainerInterface $valueTransformers, array $options): \Traversable {
     try {
-        yield \json_encode($data->value, \JSON_THROW_ON_ERROR, 512);
+        yield \json_encode($data->value, \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE, 512);
     } catch (\JsonException $e) {
         throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);
     }

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/bool_list.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/bool_list.php
@@ -5,7 +5,7 @@
  */
 return static function (mixed $data, \Psr\Container\ContainerInterface $valueTransformers, array $options): \Traversable {
     try {
-        yield \json_encode($data, \JSON_THROW_ON_ERROR, 512);
+        yield \json_encode($data, \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE, 512);
     } catch (\JsonException $e) {
         throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);
     }

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/dict.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/dict.php
@@ -5,7 +5,7 @@
  */
 return static function (mixed $data, \Psr\Container\ContainerInterface $valueTransformers, array $options): \Traversable {
     try {
-        yield \json_encode($data, \JSON_THROW_ON_ERROR, 512);
+        yield \json_encode($data, \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE, 512);
     } catch (\JsonException $e) {
         throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);
     }

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/double_nested_array.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/double_nested_array.php
@@ -13,31 +13,31 @@ return static function (mixed $data, \Psr\Container\ContainerInterface $valueTra
             yield "{";
             $prefix3 = '';
             foreach ($value1->dummies as $key2 => $value2) {
-                $key2 = is_int($key2) ? $key2 : \substr(\json_encode($key2), 1, -1);
+                $key2 = is_int($key2) ? $key2 : \substr(\json_encode($key2, \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE), 1, -1);
                 $prefix4 = '';
                 yield "{$prefix3}\"{$key2}\":{{$prefix4}\"dummies\":";
                 yield "{";
                 $prefix5 = '';
                 foreach ($value2->dummies as $key3 => $value3) {
-                    $key3 = is_int($key3) ? $key3 : \substr(\json_encode($key3), 1, -1);
+                    $key3 = is_int($key3) ? $key3 : \substr(\json_encode($key3, \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE), 1, -1);
                     $prefix6 = '';
                     yield "{$prefix5}\"{$key3}\":{{$prefix6}\"id\":";
-                    yield \json_encode($value3->id, \JSON_THROW_ON_ERROR, 506);
+                    yield \json_encode($value3->id, \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE, 506);
                     $prefix6 = ',';
                     yield "{$prefix6}\"name\":";
-                    yield \json_encode($value3->name, \JSON_THROW_ON_ERROR, 506);
+                    yield \json_encode($value3->name, \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE, 506);
                     yield "}";
                     $prefix5 = ',';
                 }
                 $prefix4 = ',';
                 yield "}{$prefix4}\"customProperty\":";
-                yield \json_encode($value2->customProperty, \JSON_THROW_ON_ERROR, 508);
+                yield \json_encode($value2->customProperty, \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE, 508);
                 yield "}";
                 $prefix3 = ',';
             }
             $prefix2 = ',';
             yield "}{$prefix2}\"stringProperty\":";
-            yield \json_encode($value1->stringProperty, \JSON_THROW_ON_ERROR, 510);
+            yield \json_encode($value1->stringProperty, \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE, 510);
             yield "}";
             $prefix1 = ',';
         }

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/double_nested_list.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/double_nested_list.php
@@ -20,22 +20,22 @@ return static function (mixed $data, \Psr\Container\ContainerInterface $valueTra
                 foreach ($value2->dummies as $value3) {
                     $prefix6 = '';
                     yield "{$prefix5}{{$prefix6}\"id\":";
-                    yield \json_encode($value3->id, \JSON_THROW_ON_ERROR, 506);
+                    yield \json_encode($value3->id, \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE, 506);
                     $prefix6 = ',';
                     yield "{$prefix6}\"name\":";
-                    yield \json_encode($value3->name, \JSON_THROW_ON_ERROR, 506);
+                    yield \json_encode($value3->name, \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE, 506);
                     yield "}";
                     $prefix5 = ',';
                 }
                 $prefix4 = ',';
                 yield "]{$prefix4}\"customProperty\":";
-                yield \json_encode($value2->customProperty, \JSON_THROW_ON_ERROR, 508);
+                yield \json_encode($value2->customProperty, \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE, 508);
                 yield "}";
                 $prefix3 = ',';
             }
             $prefix2 = ',';
             yield "]{$prefix2}\"stringProperty\":";
-            yield \json_encode($value1->stringProperty, \JSON_THROW_ON_ERROR, 510);
+            yield \json_encode($value1->stringProperty, \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE, 510);
             yield "}";
             $prefix1 = ',';
         }

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/iterable.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/iterable.php
@@ -5,7 +5,7 @@
  */
 return static function (mixed $data, \Psr\Container\ContainerInterface $valueTransformers, array $options): \Traversable {
     try {
-        yield \json_encode($data, \JSON_THROW_ON_ERROR, 512);
+        yield \json_encode($data, \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE, 512);
     } catch (\JsonException $e) {
         throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);
     }

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/list.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/list.php
@@ -5,7 +5,7 @@
  */
 return static function (mixed $data, \Psr\Container\ContainerInterface $valueTransformers, array $options): \Traversable {
     try {
-        yield \json_encode($data, \JSON_THROW_ON_ERROR, 512);
+        yield \json_encode($data, \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE, 512);
     } catch (\JsonException $e) {
         throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);
     }

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/mixed.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/mixed.php
@@ -5,7 +5,7 @@
  */
 return static function (mixed $data, \Psr\Container\ContainerInterface $valueTransformers, array $options): \Traversable {
     try {
-        yield \json_encode($data, \JSON_THROW_ON_ERROR, 512);
+        yield \json_encode($data, \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE, 512);
     } catch (\JsonException $e) {
         throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);
     }

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/nested_array.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/nested_array.php
@@ -13,19 +13,19 @@ return static function (mixed $data, \Psr\Container\ContainerInterface $valueTra
             yield "{";
             $prefix3 = '';
             foreach ($value1->dummies as $key2 => $value2) {
-                $key2 = is_int($key2) ? $key2 : \substr(\json_encode($key2), 1, -1);
+                $key2 = is_int($key2) ? $key2 : \substr(\json_encode($key2, \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE), 1, -1);
                 $prefix4 = '';
                 yield "{$prefix3}\"{$key2}\":{{$prefix4}\"id\":";
-                yield \json_encode($value2->id, \JSON_THROW_ON_ERROR, 508);
+                yield \json_encode($value2->id, \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE, 508);
                 $prefix4 = ',';
                 yield "{$prefix4}\"name\":";
-                yield \json_encode($value2->name, \JSON_THROW_ON_ERROR, 508);
+                yield \json_encode($value2->name, \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE, 508);
                 yield "}";
                 $prefix3 = ',';
             }
             $prefix2 = ',';
             yield "}{$prefix2}\"customProperty\":";
-            yield \json_encode($value1->customProperty, \JSON_THROW_ON_ERROR, 510);
+            yield \json_encode($value1->customProperty, \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE, 510);
             yield "}";
             $prefix1 = ',';
         }

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/nested_list.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/nested_list.php
@@ -15,16 +15,16 @@ return static function (mixed $data, \Psr\Container\ContainerInterface $valueTra
             foreach ($value1->dummies as $value2) {
                 $prefix4 = '';
                 yield "{$prefix3}{{$prefix4}\"id\":";
-                yield \json_encode($value2->id, \JSON_THROW_ON_ERROR, 508);
+                yield \json_encode($value2->id, \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE, 508);
                 $prefix4 = ',';
                 yield "{$prefix4}\"name\":";
-                yield \json_encode($value2->name, \JSON_THROW_ON_ERROR, 508);
+                yield \json_encode($value2->name, \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE, 508);
                 yield "}";
                 $prefix3 = ',';
             }
             $prefix2 = ',';
             yield "]{$prefix2}\"customProperty\":";
-            yield \json_encode($value1->customProperty, \JSON_THROW_ON_ERROR, 510);
+            yield \json_encode($value1->customProperty, \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE, 510);
             yield "}";
             $prefix1 = ',';
         }

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/null_list.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/null_list.php
@@ -5,7 +5,7 @@
  */
 return static function (mixed $data, \Psr\Container\ContainerInterface $valueTransformers, array $options): \Traversable {
     try {
-        yield \json_encode($data, \JSON_THROW_ON_ERROR, 512);
+        yield \json_encode($data, \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE, 512);
     } catch (\JsonException $e) {
         throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);
     }

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/nullable_backed_enum.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/nullable_backed_enum.php
@@ -6,7 +6,7 @@
 return static function (mixed $data, \Psr\Container\ContainerInterface $valueTransformers, array $options): \Traversable {
     try {
         if ($data instanceof \Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum) {
-            yield \json_encode($data->value, \JSON_THROW_ON_ERROR, 512);
+            yield \json_encode($data->value, \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE, 512);
         } elseif (null === $data) {
             yield "null";
         } else {

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/nullable_object.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/nullable_object.php
@@ -8,10 +8,10 @@ return static function (mixed $data, \Psr\Container\ContainerInterface $valueTra
         if ($data instanceof \Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes) {
             $prefix1 = '';
             yield "{{$prefix1}\"@id\":";
-            yield \json_encode($data->id, \JSON_THROW_ON_ERROR, 511);
+            yield \json_encode($data->id, \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE, 511);
             $prefix1 = ',';
             yield "{$prefix1}\"name\":";
-            yield \json_encode($data->name, \JSON_THROW_ON_ERROR, 511);
+            yield \json_encode($data->name, \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE, 511);
             yield "}";
         } elseif (null === $data) {
             yield "null";

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/nullable_object_dict.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/nullable_object_dict.php
@@ -9,13 +9,13 @@ return static function (mixed $data, \Psr\Container\ContainerInterface $valueTra
             yield "{";
             $prefix1 = '';
             foreach ($data as $key1 => $value1) {
-                $key1 = \substr(\json_encode($key1), 1, -1);
+                $key1 = \substr(\json_encode($key1, \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE), 1, -1);
                 $prefix2 = '';
                 yield "{$prefix1}\"{$key1}\":{{$prefix2}\"@id\":";
-                yield \json_encode($value1->id, \JSON_THROW_ON_ERROR, 510);
+                yield \json_encode($value1->id, \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE, 510);
                 $prefix2 = ',';
                 yield "{$prefix2}\"name\":";
-                yield \json_encode($value1->name, \JSON_THROW_ON_ERROR, 510);
+                yield \json_encode($value1->name, \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE, 510);
                 yield "}";
                 $prefix1 = ',';
             }

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/nullable_object_list.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/nullable_object_list.php
@@ -11,10 +11,10 @@ return static function (mixed $data, \Psr\Container\ContainerInterface $valueTra
             foreach ($data as $value1) {
                 $prefix2 = '';
                 yield "{$prefix1}{{$prefix2}\"@id\":";
-                yield \json_encode($value1->id, \JSON_THROW_ON_ERROR, 510);
+                yield \json_encode($value1->id, \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE, 510);
                 $prefix2 = ',';
                 yield "{$prefix2}\"name\":";
-                yield \json_encode($value1->name, \JSON_THROW_ON_ERROR, 510);
+                yield \json_encode($value1->name, \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE, 510);
                 yield "}";
                 $prefix1 = ',';
             }

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object.php
@@ -7,10 +7,10 @@ return static function (mixed $data, \Psr\Container\ContainerInterface $valueTra
     try {
         $prefix1 = '';
         yield "{{$prefix1}\"@id\":";
-        yield \json_encode($data->id, \JSON_THROW_ON_ERROR, 511);
+        yield \json_encode($data->id, \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE, 511);
         $prefix1 = ',';
         yield "{$prefix1}\"name\":";
-        yield \json_encode($data->name, \JSON_THROW_ON_ERROR, 511);
+        yield \json_encode($data->name, \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE, 511);
         yield "}";
     } catch (\JsonException $e) {
         throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_dict.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_dict.php
@@ -8,13 +8,13 @@ return static function (mixed $data, \Psr\Container\ContainerInterface $valueTra
         yield "{";
         $prefix1 = '';
         foreach ($data as $key1 => $value1) {
-            $key1 = \substr(\json_encode($key1), 1, -1);
+            $key1 = \substr(\json_encode($key1, \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE), 1, -1);
             $prefix2 = '';
             yield "{$prefix1}\"{$key1}\":{{$prefix2}\"@id\":";
-            yield \json_encode($value1->id, \JSON_THROW_ON_ERROR, 510);
+            yield \json_encode($value1->id, \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE, 510);
             $prefix2 = ',';
             yield "{$prefix2}\"name\":";
-            yield \json_encode($value1->name, \JSON_THROW_ON_ERROR, 510);
+            yield \json_encode($value1->name, \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE, 510);
             yield "}";
             $prefix1 = ',';
         }

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_in_object.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_in_object.php
@@ -7,22 +7,22 @@ return static function (mixed $data, \Psr\Container\ContainerInterface $valueTra
     try {
         $prefix1 = '';
         yield "{{$prefix1}\"name\":";
-        yield \json_encode($data->name, \JSON_THROW_ON_ERROR, 511);
+        yield \json_encode($data->name, \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE, 511);
         $prefix1 = ',';
         yield "{$prefix1}\"otherDummyOne\":";
         $prefix2 = '';
         yield "{{$prefix2}\"@id\":";
-        yield \json_encode($data->otherDummyOne->id, \JSON_THROW_ON_ERROR, 510);
+        yield \json_encode($data->otherDummyOne->id, \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE, 510);
         $prefix2 = ',';
         yield "{$prefix2}\"name\":";
-        yield \json_encode($data->otherDummyOne->name, \JSON_THROW_ON_ERROR, 510);
+        yield \json_encode($data->otherDummyOne->name, \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE, 510);
         yield "}{$prefix1}\"otherDummyTwo\":";
         $prefix2 = '';
         yield "{{$prefix2}\"id\":";
-        yield \json_encode($data->otherDummyTwo->id, \JSON_THROW_ON_ERROR, 510);
+        yield \json_encode($data->otherDummyTwo->id, \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE, 510);
         $prefix2 = ',';
         yield "{$prefix2}\"name\":";
-        yield \json_encode($data->otherDummyTwo->name, \JSON_THROW_ON_ERROR, 510);
+        yield \json_encode($data->otherDummyTwo->name, \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE, 510);
         yield "}}";
     } catch (\JsonException $e) {
         throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_iterable.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_iterable.php
@@ -8,13 +8,13 @@ return static function (mixed $data, \Psr\Container\ContainerInterface $valueTra
         yield "{";
         $prefix1 = '';
         foreach ($data as $key1 => $value1) {
-            $key1 = is_int($key1) ? $key1 : \substr(\json_encode($key1), 1, -1);
+            $key1 = is_int($key1) ? $key1 : \substr(\json_encode($key1, \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE), 1, -1);
             $prefix2 = '';
             yield "{$prefix1}\"{$key1}\":{{$prefix2}\"id\":";
-            yield \json_encode($value1->id, \JSON_THROW_ON_ERROR, 510);
+            yield \json_encode($value1->id, \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE, 510);
             $prefix2 = ',';
             yield "{$prefix2}\"name\":";
-            yield \json_encode($value1->name, \JSON_THROW_ON_ERROR, 510);
+            yield \json_encode($value1->name, \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE, 510);
             yield "}";
             $prefix1 = ',';
         }

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_list.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_list.php
@@ -10,10 +10,10 @@ return static function (mixed $data, \Psr\Container\ContainerInterface $valueTra
         foreach ($data as $value1) {
             $prefix2 = '';
             yield "{$prefix1}{{$prefix2}\"@id\":";
-            yield \json_encode($value1->id, \JSON_THROW_ON_ERROR, 510);
+            yield \json_encode($value1->id, \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE, 510);
             $prefix2 = ',';
             yield "{$prefix2}\"name\":";
-            yield \json_encode($value1->name, \JSON_THROW_ON_ERROR, 510);
+            yield \json_encode($value1->name, \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE, 510);
             yield "}";
             $prefix1 = ',';
         }

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_with_nested_dict_self.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_with_nested_dict_self.php
@@ -13,7 +13,7 @@ return static function (mixed $data, \Psr\Container\ContainerInterface $valueTra
         yield "{";
         $prefix2 = '';
         foreach ($data->dummies as $key1 => $value1) {
-            $key1 = \substr(\json_encode($key1), 1, -1);
+            $key1 = \substr(\json_encode($key1, \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE), 1, -1);
             yield "{$prefix2}\"{$key1}\":";
             yield from $generators['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNestedDictDummies']($value1, $depth + 1);
             $prefix2 = ',';

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_with_nested_list_self.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_with_nested_list_self.php
@@ -13,7 +13,7 @@ return static function (mixed $data, \Psr\Container\ContainerInterface $valueTra
         yield "{";
         $prefix2 = '';
         foreach ($data->dummies as $key1 => $value1) {
-            $key1 = is_int($key1) ? $key1 : \substr(\json_encode($key1), 1, -1);
+            $key1 = is_int($key1) ? $key1 : \substr(\json_encode($key1, \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE), 1, -1);
             yield "{$prefix2}\"{$key1}\":";
             yield from $generators['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNestedListDummies']($value1, $depth + 1);
             $prefix2 = ',';

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_with_synthetic_properties.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_with_synthetic_properties.php
@@ -7,7 +7,7 @@ return static function (mixed $data, \Psr\Container\ContainerInterface $valueTra
     try {
         $prefix1 = '';
         yield "{{$prefix1}\"synthetic\":";
-        yield \json_encode(Symfony\Component\JsonStreamer\Tests\Fixtures\Mapping\SyntheticPropertyMetadataLoader::true(null, ['_current_object' => $data] + $options), \JSON_THROW_ON_ERROR, 511);
+        yield \json_encode(Symfony\Component\JsonStreamer\Tests\Fixtures\Mapping\SyntheticPropertyMetadataLoader::true(null, ['_current_object' => $data] + $options), \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE, 511);
         yield "}";
     } catch (\JsonException $e) {
         throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_with_union.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_with_union.php
@@ -13,9 +13,9 @@ return static function (mixed $data, \Psr\Container\ContainerInterface $valueTra
         if (null !== $data->value) {
             yield "{$prefix1}\"value\":";
             if ($data->value instanceof \Symfony\Component\JsonStreamer\Tests\Fixtures\Enum\DummyBackedEnum) {
-                yield \json_encode($data->value->value, \JSON_THROW_ON_ERROR, 511);
+                yield \json_encode($data->value->value, \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE, 511);
             } elseif (\is_string($data->value)) {
-                yield \json_encode($data->value, \JSON_THROW_ON_ERROR, 511);
+                yield \json_encode($data->value, \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE, 511);
             } else {
                 throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value.', \get_debug_type($data->value)));
             }

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_with_value_transformer.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/object_with_value_transformer.php
@@ -7,14 +7,14 @@ return static function (mixed $data, \Psr\Container\ContainerInterface $valueTra
     try {
         $prefix1 = '';
         yield "{{$prefix1}\"id\":";
-        yield \json_encode($valueTransformers->get('Symfony\Component\JsonStreamer\Tests\Fixtures\ValueTransformer\DoubleIntAndCastToStringValueTransformer')->transform($data->id, ['_current_object' => $data] + $options), \JSON_THROW_ON_ERROR, 511);
+        yield \json_encode($valueTransformers->get('Symfony\Component\JsonStreamer\Tests\Fixtures\ValueTransformer\DoubleIntAndCastToStringValueTransformer')->transform($data->id, ['_current_object' => $data] + $options), \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE, 511);
         $prefix1 = ',';
         yield "{$prefix1}\"active\":";
-        yield \json_encode($valueTransformers->get('Symfony\Component\JsonStreamer\Tests\Fixtures\ValueTransformer\BooleanToStringValueTransformer')->transform($data->active, ['_current_object' => $data] + $options), \JSON_THROW_ON_ERROR, 511);
+        yield \json_encode($valueTransformers->get('Symfony\Component\JsonStreamer\Tests\Fixtures\ValueTransformer\BooleanToStringValueTransformer')->transform($data->active, ['_current_object' => $data] + $options), \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE, 511);
         yield "{$prefix1}\"name\":";
-        yield \json_encode(strtolower($data->name), \JSON_THROW_ON_ERROR, 511);
+        yield \json_encode(strtolower($data->name), \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE, 511);
         yield "{$prefix1}\"range\":";
-        yield \json_encode(Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithValueTransformerAttributes::concatRange($data->range, ['_current_object' => $data] + $options), \JSON_THROW_ON_ERROR, 511);
+        yield \json_encode(Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithValueTransformerAttributes::concatRange($data->range, ['_current_object' => $data] + $options), \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE, 511);
         yield "}";
     } catch (\JsonException $e) {
         throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/scalar.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/scalar.php
@@ -5,7 +5,7 @@
  */
 return static function (mixed $data, \Psr\Container\ContainerInterface $valueTransformers, array $options): \Traversable {
     try {
-        yield \json_encode($data, \JSON_THROW_ON_ERROR, 512);
+        yield \json_encode($data, \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE, 512);
     } catch (\JsonException $e) {
         throw new \Symfony\Component\JsonStreamer\Exception\NotEncodableValueException($e->getMessage(), 0, $e);
     }

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/self_referencing_object_dict.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/self_referencing_object_dict.php
@@ -13,7 +13,7 @@ return static function (mixed $data, \Psr\Container\ContainerInterface $valueTra
         yield "{";
         $prefix2 = '';
         foreach ($data->items as $key1 => $value1) {
-            $key1 = \substr(\json_encode($key1), 1, -1);
+            $key1 = \substr(\json_encode($key1, \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE), 1, -1);
             yield "{$prefix2}\"{$key1}\":";
             yield from $generators['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\SelfReferencingDummyDict']($value1, $depth + 1);
             $prefix2 = ',';

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/self_referencing_object_list.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/self_referencing_object_list.php
@@ -13,7 +13,7 @@ return static function (mixed $data, \Psr\Container\ContainerInterface $valueTra
         yield "{";
         $prefix2 = '';
         foreach ($data->items as $key1 => $value1) {
-            $key1 = is_int($key1) ? $key1 : \substr(\json_encode($key1), 1, -1);
+            $key1 = is_int($key1) ? $key1 : \substr(\json_encode($key1, \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE), 1, -1);
             yield "{$prefix2}\"{$key1}\":";
             yield from $generators['Symfony\Component\JsonStreamer\Tests\Fixtures\Model\SelfReferencingDummyList']($value1, $depth + 1);
             $prefix2 = ',';

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/union.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/stream_writer/union.php
@@ -10,20 +10,20 @@ return static function (mixed $data, \Psr\Container\ContainerInterface $valueTra
             $prefix1 = '';
             foreach ($data as $value1) {
                 yield "{$prefix1}";
-                yield \json_encode($value1->value, \JSON_THROW_ON_ERROR, 511);
+                yield \json_encode($value1->value, \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE, 511);
                 $prefix1 = ',';
             }
             yield "]";
         } elseif ($data instanceof \Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes) {
             $prefix1 = '';
             yield "{{$prefix1}\"@id\":";
-            yield \json_encode($data->id, \JSON_THROW_ON_ERROR, 511);
+            yield \json_encode($data->id, \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE, 511);
             $prefix1 = ',';
             yield "{$prefix1}\"name\":";
-            yield \json_encode($data->name, \JSON_THROW_ON_ERROR, 511);
+            yield \json_encode($data->name, \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE, 511);
             yield "}";
         } elseif (\is_int($data)) {
-            yield \json_encode($data, \JSON_THROW_ON_ERROR, 512);
+            yield \json_encode($data, \JSON_THROW_ON_ERROR | \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE, 512);
         } else {
             throw new \Symfony\Component\JsonStreamer\Exception\UnexpectedValueException(\sprintf('Unexpected "%s" value.', \get_debug_type($data)));
         }

--- a/src/Symfony/Component/JsonStreamer/Tests/JsonStreamWriterTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/JsonStreamWriterTest.php
@@ -32,6 +32,7 @@ use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNestedListDummi
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNullableProperties;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithPhpDoc;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithSelfReferencingDummy;
+use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithSpecialCharacterNamedProperties;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithSyntheticProperties;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithUnionProperties;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithValueTransformerAttributes;
@@ -76,6 +77,39 @@ class JsonStreamWriterTest extends TestCase
         $this->assertWritten('[{"foo":1,"bar":2},{"foo":3}]', [['foo' => 1, 'bar' => 2], ['foo' => 3]], Type::list());
         $this->assertWritten('{"foo":"bar"}', (object) ['foo' => 'bar'], Type::object());
         $this->assertWritten('1', DummyBackedEnum::ONE, Type::enum(DummyBackedEnum::class));
+    }
+
+    public function testWriteReadableJsonByDefault()
+    {
+        $this->assertWritten('{"url":"https://symfony.com/école","ratio":1.0}', ['url' => 'https://symfony.com/école', 'ratio' => 1.0], Type::dict());
+    }
+
+    public function testWriteReadableDictionaryKeysByDefault()
+    {
+        $this->assertWritten(
+            '{"https://symfony.com/école":{"id":1,"name":"dummy"}}',
+            ['https://symfony.com/école' => new ClassicDummy()],
+            Type::dict(Type::object(ClassicDummy::class)),
+        );
+    }
+
+    public function testWriteReadablePropertyNamesByDefault()
+    {
+        $this->assertWritten(
+            '{"https://symfony.com/école":1,"line\\u2028separator":2}',
+            new DummyWithSpecialCharacterNamedProperties(),
+            Type::object(DummyWithSpecialCharacterNamedProperties::class),
+        );
+    }
+
+    public function testThrowWhenDictionaryKeyCannotBeEncoded()
+    {
+        $writer = JsonStreamWriter::create(streamWritersDir: $this->streamWritersDir);
+
+        $this->expectException(NotEncodableValueException::class);
+        $this->expectExceptionMessage('Malformed UTF-8 characters, possibly incorrectly encoded');
+
+        (string) $writer->write(["invalid\xB1key" => new ClassicDummy()], Type::dict(Type::object(ClassicDummy::class)));
     }
 
     public function testWriteUnion()

--- a/src/Symfony/Component/JsonStreamer/Tests/Write/StreamWriterGeneratorTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Write/StreamWriterGeneratorTest.php
@@ -13,8 +13,10 @@ namespace Symfony\Component\JsonStreamer\Tests\Write;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\JsonStreamer\Exception\RuntimeException;
 use Symfony\Component\JsonStreamer\Exception\UnsupportedException;
 use Symfony\Component\JsonStreamer\Mapping\GenericTypePropertyMetadataLoader;
+use Symfony\Component\JsonStreamer\Mapping\PropertyMetadata;
 use Symfony\Component\JsonStreamer\Mapping\PropertyMetadataLoader;
 use Symfony\Component\JsonStreamer\Mapping\PropertyMetadataLoaderInterface;
 use Symfony\Component\JsonStreamer\Mapping\Write\AttributePropertyMetadataLoader;
@@ -158,6 +160,21 @@ class StreamWriterGeneratorTest extends TestCase
         $this->expectExceptionMessage(\sprintf('"%s" type is not supported.', DummyEnum::class));
 
         $generator->generate(Type::enum(DummyEnum::class));
+    }
+
+    public function testThrowWhenStreamedNameCannotBeEncoded()
+    {
+        $streamedName = "invalid\xB1name";
+
+        $propertyMetadataLoader = $this->createStub(PropertyMetadataLoaderInterface::class);
+        $propertyMetadataLoader->method('load')->willReturn([$streamedName => new PropertyMetadata('id', Type::int())]);
+
+        $generator = new StreamWriterGenerator($propertyMetadataLoader, $this->streamWritersDir);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage(\sprintf('Cannot encode "%s"', $streamedName));
+
+        $generator->generate(Type::object(ClassicDummy::class));
     }
 
     public function testCallPropertyMetadataLoaderWithProperContext()

--- a/src/Symfony/Component/JsonStreamer/Write/PhpGenerator.php
+++ b/src/Symfony/Component/JsonStreamer/Write/PhpGenerator.php
@@ -38,6 +38,10 @@ use Symfony\Component\TypeInfo\TypeIdentifier;
  */
 final class PhpGenerator
 {
+    private const JSON_ENCODE_FLAGS = \JSON_PRESERVE_ZERO_FRACTION | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE;
+    private const THROWING_JSON_ENCODE_FLAGS_EXPRESSION = '\\JSON_THROW_ON_ERROR | \\JSON_PRESERVE_ZERO_FRACTION | \\JSON_UNESCAPED_SLASHES | \\JSON_UNESCAPED_UNICODE';
+    private const MAX_DEPTH = 512;
+
     private string $yieldBuffer = '';
 
     /**
@@ -120,7 +124,7 @@ final class PhpGenerator
 
             $generators = [
                 $node->getIdentifier() => $this->line('$generators[\''.$node->getIdentifier().'\'] = static function ($data, $depth) use ($valueTransformers, $options, &$generators) {', $context)
-                    .$this->line('    if ($depth >= 512) {', $context)
+                    .$this->line('    if ($depth >= '.self::MAX_DEPTH.') {', $context)
                     .$this->line('        throw new \\'.NotEncodableValueException::class.'(\'Maximum stack depth exceeded\');', $context)
                     .$this->line('    }', $context)
                     .$yields
@@ -155,7 +159,7 @@ final class PhpGenerator
             return $this->yield($this->encode($accessor, $context), $context);
         }
 
-        if ($context['depth'] >= 512) {
+        if ($context['depth'] >= self::MAX_DEPTH) {
             return $this->line('throw new '.NotEncodableValueException::class.'(\'Maximum stack depth exceeded\');', $context);
         }
 
@@ -220,8 +224,8 @@ final class PhpGenerator
             $keyAccessor = $dataModelNode->getKeyNode()->getAccessor();
 
             $escapedKey = $dataModelNode->getType()->getCollectionKeyType()->isIdentifiedBy(TypeIdentifier::INT)
-                ? "$keyAccessor = is_int($keyAccessor) ? $keyAccessor : \substr(\json_encode($keyAccessor), 1, -1);"
-                : "$keyAccessor = \substr(\json_encode($keyAccessor), 1, -1);";
+                ? "$keyAccessor = is_int($keyAccessor) ? $keyAccessor : \substr(\json_encode($keyAccessor, ".self::THROWING_JSON_ENCODE_FLAGS_EXPRESSION.'), 1, -1);'
+                : "$keyAccessor = \substr(\json_encode($keyAccessor, ".self::THROWING_JSON_ENCODE_FLAGS_EXPRESSION.'), 1, -1);';
 
             $php = $this->yieldInterpolatedString('{', $context)
                 .$this->flushYieldBuffer($context)
@@ -258,7 +262,7 @@ final class PhpGenerator
             $prefixIsCommaForSure = false;
 
             foreach ($dataModelNode->getProperties() as $name => $propertyNode) {
-                $encodedName = json_encode($name);
+                $encodedName = json_encode($name, self::JSON_ENCODE_FLAGS);
                 if (false === $encodedName) {
                     throw new RuntimeException(\sprintf('Cannot encode "%s"', $name));
                 }
@@ -336,7 +340,7 @@ final class PhpGenerator
      */
     private function encode(string $value, array $context): string
     {
-        return "\json_encode($value, \\JSON_THROW_ON_ERROR, ". 512 - $context['depth'].')';
+        return "\json_encode($value, ".self::THROWING_JSON_ENCODE_FLAGS_EXPRESSION.', '.(self::MAX_DEPTH - $context['depth']).')';
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63102
| License       | MIT

The flags passed to `json_encode()` when writing were wrong in three ways. The output was escaped more aggressively than users of `json_encode()` expect, with forward slashes written as `\/` and every non-ASCII character as a `\uXXXX` sequence. Floats lost a zero fraction, so `1.0` was written as `1`, which also put the component at odds with the Serializer's `JsonEncode`. And a dictionary key that could not be encoded was emitted as an empty key instead of raising, which is covered below.

`JSON_PRESERVE_ZERO_FRACTION | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE` are now applied on every path where the component turns a PHP value into JSON:

* the `json_encode()` calls in the generated stream writers, used for scalars, for backed enum values and for whole subtrees that can be encoded in a single call;
* the `json_encode()` call the generated code makes on each dictionary key;
* the `json_encode()` call the generator itself makes on property names while writing them into the generated PHP.

`JSON_UNESCAPED_LINE_TERMINATORS` is deliberately left out, so U+2028 and U+2029 keep being escaped and the output stays safe to embed in a `<script>` block.

### Behaviour change on dictionary keys that cannot be encoded

Dictionary keys used to be escaped with `json_encode($key)`, with no flags at all. A key that cannot be encoded, an invalid UTF-8 string for instance, made that call return `false`; `substr(false, 1, -1)` then yielded an empty string, and the writer silently emitted an empty key. Two such keys in the same dictionary collided into `{"":{...},"":{...}}`.

Those calls now carry `JSON_THROW_ON_ERROR`, like the other `json_encode()` calls of the generated code, so the failure surfaces as a `NotEncodableValueException` instead of producing corrupt output. This is the one behaviour change beyond the escaping itself.

The property-name call is the exception: it runs while the PHP code is being generated, not at write time, so it keeps no `JSON_THROW_ON_ERROR` and keeps returning `false`, which the generator already turns into a `RuntimeException`.

### About #63102

The issue asked for a way to configure the flags. The resolution is different from the request: the defaults are made readable for everybody instead of adding a configuration option, which is why the issue is closed here rather than implemented as filed.

### Merge-ups

On 8.1 and 8.2, this change additionally requires `JsonStreamWriterTest::testWriteObjectWithDateTimeZones()` to be updated, since it asserts `'{"timezone":"Asia\/Tokyo"}'` on both branches, and `Tests/Fixtures/stream_writer/object_with_value_object.php` to be regenerated. Neither exists on 7.4.

