### PR TITLE
[Mailer][Resend] Handle the email.failed and email.suppressed webhook events

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Resend/RemoteEvent/ResendPayloadConverter.php
+++ b/src/Symfony/Component/Mailer/Bridge/Resend/RemoteEvent/ResendPayloadConverter.php
@@ -21,15 +21,19 @@ final class ResendPayloadConverter implements PayloadConverterInterface
 {
     public function convert(array $payload): AbstractMailerEvent
     {
-        if (\in_array($payload['type'], ['email.sent', 'email.delivered', 'email.delivery_delayed', 'email.bounced'], true)) {
+        if (\in_array($payload['type'], ['email.sent', 'email.delivered', 'email.delivery_delayed', 'email.bounced', 'email.failed', 'email.suppressed'], true)) {
             $name = match ($payload['type']) {
                 'email.sent' => MailerDeliveryEvent::RECEIVED,
                 'email.delivered' => MailerDeliveryEvent::DELIVERED,
                 'email.delivery_delayed' => MailerDeliveryEvent::DEFERRED,
                 'email.bounced' => MailerDeliveryEvent::BOUNCE,
+                'email.failed', 'email.suppressed' => MailerDeliveryEvent::DROPPED,
             };
 
             $event = new MailerDeliveryEvent($name, $payload['data']['email_id'], $payload);
+            if (MailerDeliveryEvent::DROPPED === $name) {
+                $event->setReason($payload['data']['failed']['reason'] ?? $payload['data']['suppressed']['message'] ?? '');
+            }
         } else {
             $name = match ($payload['type']) {
                 'email.clicked' => MailerEngagementEvent::CLICK,

--- a/src/Symfony/Component/Mailer/Bridge/Resend/Tests/RemoteEvent/ResendPayloadConverterTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Resend/Tests/RemoteEvent/ResendPayloadConverterTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\Resend\Tests\RemoteEvent;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Mailer\Bridge\Resend\RemoteEvent\ResendPayloadConverter;
+use Symfony\Component\RemoteEvent\Event\Mailer\MailerDeliveryEvent;
+
+class ResendPayloadConverterTest extends TestCase
+{
+    private const SUPPRESSION_MESSAGE = 'Resend has suppressed sending to this address because it is on the account-level suppression list.';
+
+    #[DataProvider('provideDroppedEvents')]
+    public function testDroppedEvent(string $type, array $extraData, string $expectedReason)
+    {
+        $converter = new ResendPayloadConverter();
+
+        $event = $converter->convert([
+            'type' => $type,
+            'created_at' => '2024-04-08T09:43:09.500Z',
+            'data' => [
+                'created_at' => '2024-04-08T09:43:09.438Z',
+                'email_id' => '172c41ce-ba6d-4281-8a7a-541faa725748',
+                'from' => 'test@resend.com',
+                'to' => ['test@example.com'],
+                'subject' => 'Test subject',
+            ] + $extraData,
+        ]);
+
+        $this->assertInstanceOf(MailerDeliveryEvent::class, $event);
+        $this->assertSame(MailerDeliveryEvent::DROPPED, $event->getName());
+        $this->assertSame('172c41ce-ba6d-4281-8a7a-541faa725748', $event->getId());
+        $this->assertSame($expectedReason, $event->getReason());
+        $this->assertSame('test@example.com', $event->getRecipientEmail());
+    }
+
+    public static function provideDroppedEvents(): iterable
+    {
+        yield 'email.failed' => [
+            'email.failed',
+            ['failed' => ['reason' => 'reached_daily_quota']],
+            'reached_daily_quota',
+        ];
+
+        yield 'email.suppressed' => [
+            'email.suppressed',
+            ['suppressed' => ['message' => self::SUPPRESSION_MESSAGE, 'type' => 'OnAccountSuppressionList']],
+            self::SUPPRESSION_MESSAGE,
+        ];
+    }
+
+    public function testDeliveryEventWithoutFailureCarriesNoReason()
+    {
+        $converter = new ResendPayloadConverter();
+
+        $event = $converter->convert([
+            'type' => 'email.delivered',
+            'created_at' => '2024-04-08T09:43:09.500Z',
+            'data' => [
+                'created_at' => '2024-04-08T09:43:09.438Z',
+                'email_id' => '172c41ce-ba6d-4281-8a7a-541faa725748',
+                'from' => 'test@resend.com',
+                'to' => ['test@example.com'],
+                'subject' => 'Test subject',
+            ],
+        ]);
+
+        $this->assertInstanceOf(MailerDeliveryEvent::class, $event);
+        $this->assertSame(MailerDeliveryEvent::DELIVERED, $event->getName());
+        $this->assertSame('', $event->getReason());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Resend sends 11 email webhook events. `ResendPayloadConverter` handles 7 of them, and any other one reaches the `default` arm and throws a `ParseException`, which `ResendRequestParser` turns into a 406 response. Two of the missing ones are sent to existing applications today:

* `email.failed`, when Resend could not send the message at all, for instance after `reached_daily_quota`;
* `email.suppressed`, when the address is on the account suppression list.

Both are now mapped to `MailerDeliveryEvent::DROPPED`, which is what the other bridges use for the same semantics: AhaSend for `message.suppressed`, Brevo for `invalid_email`, `blocked` and `error`, Mailgun for `rejected`, Sendgrid for `dropped`, Mailtrap for `suspension` and `reject`. Neither is a bounce: the remote server never rejected the message, Resend stopped it before delivery.

The reason reported by Resend is exposed through `MailerDeliveryEvent::getReason()`, which was empty until now, taken from `data.failed.reason` or `data.suppressed.message` depending on the event.

The two remaining unhandled events are left alone on purpose. `email.scheduled` is not a delivery outcome, and `email.received` belongs to inbound email, which this converter does not cover.
