### PR TITLE
[HttpClient] Revert " Strip Proxy-Authorization on cross-authority redirects"

### DIFF
--- a/src/Symfony/Component/HttpClient/CurlHttpClient.php
+++ b/src/Symfony/Component/HttpClient/CurlHttpClient.php
@@ -404,7 +404,7 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
     /**
      * Resolves relative URLs on redirects and deals with authentication headers.
      *
-     * Work around CVE-2018-1000007: Authorization, Cookie and Proxy-Authorization headers should not follow redirects - fixed in Curl 7.64
+     * Work around CVE-2018-1000007: Authorization and Cookie headers should not follow redirects - fixed in Curl 7.64
      */
     private static function createRedirectResolver(array $options, string $authority, string $noProxy): \Closure
     {
@@ -413,8 +413,8 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
             $redirectHeaders['authority'] = $authority;
             $redirectHeaders['with_auth'] = $redirectHeaders['no_auth'] = array_filter($options['headers'], static fn ($h) => 0 !== stripos($h, 'Host:'));
 
-            if (isset($options['normalized_headers']['authorization'][0]) || isset($options['normalized_headers']['cookie'][0]) || isset($options['normalized_headers']['proxy-authorization'][0])) {
-                $redirectHeaders['no_auth'] = array_filter($redirectHeaders['no_auth'], static fn ($h) => 0 !== stripos($h, 'Authorization:') && 0 !== stripos($h, 'Cookie:') && 0 !== stripos($h, 'Proxy-Authorization:'));
+            if (isset($options['normalized_headers']['authorization'][0]) || isset($options['normalized_headers']['cookie'][0])) {
+                $redirectHeaders['no_auth'] = array_filter($redirectHeaders['no_auth'], static fn ($h) => 0 !== stripos($h, 'Authorization:') && 0 !== stripos($h, 'Cookie:'));
             }
         }
 

--- a/src/Symfony/Component/HttpClient/NativeHttpClient.php
+++ b/src/Symfony/Component/HttpClient/NativeHttpClient.php
@@ -372,8 +372,8 @@ final class NativeHttpClient implements HttpClientInterface, LoggerAwareInterfac
             $redirectHeaders = ['authority' => $authority];
             $redirectHeaders['with_auth'] = $redirectHeaders['no_auth'] = array_filter($options['headers'], static fn ($h) => 0 !== stripos($h, 'Host:'));
 
-            if (isset($options['normalized_headers']['authorization']) || isset($options['normalized_headers']['cookie']) || isset($options['normalized_headers']['proxy-authorization'])) {
-                $redirectHeaders['no_auth'] = array_filter($redirectHeaders['no_auth'], static fn ($h) => 0 !== stripos($h, 'Authorization:') && 0 !== stripos($h, 'Cookie:') && 0 !== stripos($h, 'Proxy-Authorization:'));
+            if (isset($options['normalized_headers']['authorization']) || isset($options['normalized_headers']['cookie'])) {
+                $redirectHeaders['no_auth'] = array_filter($redirectHeaders['no_auth'], static fn ($h) => 0 !== stripos($h, 'Authorization:') && 0 !== stripos($h, 'Cookie:'));
             }
         }
 
@@ -427,7 +427,7 @@ final class NativeHttpClient implements HttpClientInterface, LoggerAwareInterfac
             [$host, $port] = self::parseHostPort($url, $info);
 
             if ($locationHasHost) {
-                // Authorization, Cookie and Proxy-Authorization headers MUST NOT follow except for the initial authority name
+                // Authorization and Cookie headers MUST NOT follow except for the initial authority name
                 $requestHeaders = $redirectHeaders['authority'] === $url['authority'] ? $redirectHeaders['with_auth'] : $redirectHeaders['no_auth'];
                 $requestHeaders[] = 'Host: '.$host.$port;
                 $dnsResolve = !self::configureHeadersAndProxy($context, $host, $requestHeaders, $proxy, 'https:' === $url['scheme']);

--- a/src/Symfony/Component/HttpClient/NoPrivateNetworkHttpClient.php
+++ b/src/Symfony/Component/HttpClient/NoPrivateNetworkHttpClient.php
@@ -102,8 +102,8 @@ final class NoPrivateNetworkHttpClient implements HttpClientInterface, LoggerAwa
         $options['max_redirects'] = 0;
         $redirectHeaders['with_auth'] = $redirectHeaders['no_auth'] = $options['headers'];
 
-        if (isset($options['normalized_headers']['host']) || isset($options['normalized_headers']['authorization']) || isset($options['normalized_headers']['cookie']) || isset($options['normalized_headers']['proxy-authorization'])) {
-            $redirectHeaders['no_auth'] = array_filter($redirectHeaders['no_auth'], static fn ($h) => 0 !== stripos($h, 'Host:') && 0 !== stripos($h, 'Authorization:') && 0 !== stripos($h, 'Cookie:') && 0 !== stripos($h, 'Proxy-Authorization:'));
+        if (isset($options['normalized_headers']['host']) || isset($options['normalized_headers']['authorization']) || isset($options['normalized_headers']['cookie'])) {
+            $redirectHeaders['no_auth'] = array_filter($redirectHeaders['no_auth'], static fn ($h) => 0 !== stripos($h, 'Host:') && 0 !== stripos($h, 'Authorization:') && 0 !== stripos($h, 'Cookie:'));
         }
 
         return new AsyncResponse($this->client, $method, $url, $options, static function (ChunkInterface $chunk, AsyncContext $context) use (&$method, &$options, $maxRedirects, &$redirectHeaders, $subnets, $ipFlags, $dnsCache): \Generator {
@@ -140,7 +140,7 @@ final class NoPrivateNetworkHttpClient implements HttpClientInterface, LoggerAwa
                 }
             }
 
-            // Authorization, Cookie and Proxy-Authorization headers MUST NOT follow except for the initial host name
+            // Authorization and Cookie headers MUST NOT follow except for the initial host name
             $port = parse_url($url, \PHP_URL_PORT);
             $options['headers'] = $redirectHeaders['host'] === $host && ($redirectHeaders['port'] ?? null) === $port ? $redirectHeaders['with_auth'] : $redirectHeaders['no_auth'];
 

--- a/src/Symfony/Component/HttpClient/Response/AmpResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/AmpResponse.php
@@ -353,7 +353,6 @@ final class AmpResponse implements ResponseInterface, StreamableInterface
             if ($request->getUri()->getAuthority() !== $originRequest->getUri()->getAuthority()) {
                 $request->removeHeader('authorization');
                 $request->removeHeader('cookie');
-                $request->removeHeader('proxy-authorization');
                 $request->removeHeader('host');
             }
 

--- a/src/Symfony/Component/HttpClient/Tests/AmpHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/AmpHttpClientTest.php
@@ -54,16 +54,4 @@ class AmpHttpClientTest extends HttpClientTestCase
     {
         $this->markTestSkipped('A real proxy server would be needed.');
     }
-
-    /**
-     * @dataProvider getRedirectWithAuthTests
-     */
-    public function testRedirectWithProxyAuthorization(string $url, bool $redirectWithAuth)
-    {
-        if ($redirectWithAuth) {
-            $this->markTestSkipped('AmpHttpClient never forwards Proxy-Authorization to the target host.');
-        }
-
-        parent::testRedirectWithProxyAuthorization($url, $redirectWithAuth);
-    }
 }

--- a/src/Symfony/Component/HttpClient/Tests/HttpClientTestCase.php
+++ b/src/Symfony/Component/HttpClient/Tests/HttpClientTestCase.php
@@ -679,33 +679,6 @@ abstract class HttpClientTestCase extends BaseHttpClientTestCase
         ];
     }
 
-    /**
-     * @dataProvider getRedirectWithAuthTests
-     */
-    public function testRedirectWithProxyAuthorization(string $url, bool $redirectWithAuth)
-    {
-        $p = TestHttpServer::start(8067);
-
-        try {
-            $client = $this->getHttpClient(__FUNCTION__);
-
-            $response = $client->request('GET', $url, [
-                'headers' => [
-                    'proxy-authorization' => 'Basic Zm9vOmJhcg==',
-                ],
-            ]);
-            $body = $response->toArray();
-        } finally {
-            $p->stop();
-        }
-
-        if ($redirectWithAuth) {
-            $this->assertSame('Basic Zm9vOmJhcg==', $body['HTTP_PROXY_AUTHORIZATION'] ?? null);
-        } else {
-            $this->assertArrayNotHasKey('HTTP_PROXY_AUTHORIZATION', $body);
-        }
-    }
-
     public function testDefaultContentType()
     {
         $client = $this->getHttpClient(__FUNCTION__);

--- a/src/Symfony/Component/HttpClient/Tests/NoPrivateNetworkHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/NoPrivateNetworkHttpClientTest.php
@@ -197,32 +197,6 @@ class NoPrivateNetworkHttpClientTest extends TestCase
         $this->assertEquals($content, $response->getContent());
     }
 
-    public function testAuthHeadersAreStrippedOnCrossAuthorityRedirect()
-    {
-        $content = 'foo';
-
-        $callback = function ($method, $url, $options) use ($content): MockResponse {
-            $this->assertNotContains('Authorization: Basic Zm9vOmJhcg==', $options['headers']);
-            $this->assertNotContains('Proxy-Authorization: Basic Zm9vOmJhcg==', $options['headers']);
-            $this->assertNotContains('Cookie: foo=bar', $options['headers']);
-            $this->assertContains('foo: bar', $options['headers']);
-
-            return new MockResponse($content);
-        };
-        $responses = [
-            new MockResponse('', ['http_code' => 302, 'redirect_url' => 'http://104.26.14.7/']),
-            $callback,
-        ];
-        $client = new NoPrivateNetworkHttpClient(new MockHttpClient($responses));
-        $response = $client->request('GET', 'http://104.26.14.6/', ['headers' => [
-            'foo' => 'bar',
-            'authorization' => 'Basic Zm9vOmJhcg==',
-            'proxy-authorization' => 'Basic Zm9vOmJhcg==',
-            'cookie' => 'foo=bar',
-        ]]);
-        $this->assertSame($content, $response->getContent());
-    }
-
     private function getMockHttpClient(string $ipAddr, string $content)
     {
         return new MockHttpClient(new MockResponse($content, ['primary_ip' => $ipAddr]));


### PR DESCRIPTION
Reverts symfony/symfony#65019 because stripping the proxy-authorization header is a bug, breaking things for people using proxies. That header is intended only for proxies, and never to go to the origin, so a change in origin authority is not a reason to strip this.