### PR TITLE
[RemoteEvent] Add SMS engagement events

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Sweego/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Sweego/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.2
 ---
 
+ * Add support for the `sms_clicked` and `sms_stop` webhook events
  * Allow updating region in SweegoOptions
 
 7.2

--- a/src/Symfony/Component/Notifier/Bridge/Sweego/Tests/Webhook/Fixtures/clicked.json
+++ b/src/Symfony/Component/Notifier/Bridge/Sweego/Tests/Webhook/Fixtures/clicked.json
@@ -1,0 +1,15 @@
+{
+  "event_type": "sms_clicked",
+  "timestamp": "2024-09-02T17:35:43",
+  "swg_uid": "03-f237cd16-a013-4e35-a279-c9eaa994e82b",
+  "event_id": "a5ccc627-6e43-4012-bb29-f1bfe3a3e",
+  "channel": "sms",
+  "client_id": "de1bbe6f-4103-47b1-8f69-94856aaba3fc",
+  "country_code": "FR",
+  "phone_number": "0033612345678",
+  "sender_id": "38082",
+  "sms_type": "transactional",
+  "url": "https://symfony.com",
+  "campaign_id": null,
+  "test_mode": false
+}

--- a/src/Symfony/Component/Notifier/Bridge/Sweego/Tests/Webhook/Fixtures/clicked.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sweego/Tests/Webhook/Fixtures/clicked.php
@@ -1,0 +1,8 @@
+<?php
+
+use Symfony\Component\RemoteEvent\Event\Sms\SmsEvent;
+
+$wh = new SmsEvent('clicked', '03-f237cd16-a013-4e35-a279-c9eaa994e82b', json_decode(file_get_contents(str_replace('.php', '.json', __FILE__)), true, flags: \JSON_THROW_ON_ERROR));
+$wh->setRecipientPhone('0033612345678');
+
+return $wh;

--- a/src/Symfony/Component/Notifier/Bridge/Sweego/Tests/Webhook/Fixtures/stop.json
+++ b/src/Symfony/Component/Notifier/Bridge/Sweego/Tests/Webhook/Fixtures/stop.json
@@ -1,0 +1,14 @@
+{
+  "event_type": "sms_stop",
+  "timestamp": "2024-09-02T17:45:43",
+  "swg_uid": "03-f237cd16-a013-4e35-a279-c9eaa994e82b",
+  "event_id": "a5ccc627-6e43-4012-bb29-f1bfe3a3f",
+  "channel": "sms",
+  "client_id": "de1bbe6f-4103-47b1-8f69-94856aaba3fc",
+  "country_code": "FR",
+  "phone_number": "0033612345678",
+  "sender_id": "38082",
+  "sms_type": "transactional",
+  "campaign_id": null,
+  "test_mode": false
+}

--- a/src/Symfony/Component/Notifier/Bridge/Sweego/Tests/Webhook/Fixtures/stop.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sweego/Tests/Webhook/Fixtures/stop.php
@@ -1,0 +1,8 @@
+<?php
+
+use Symfony\Component\RemoteEvent\Event\Sms\SmsEvent;
+
+$wh = new SmsEvent('unsubscribed', '03-f237cd16-a013-4e35-a279-c9eaa994e82b', json_decode(file_get_contents(str_replace('.php', '.json', __FILE__)), true, flags: \JSON_THROW_ON_ERROR));
+$wh->setRecipientPhone('0033612345678');
+
+return $wh;

--- a/src/Symfony/Component/Notifier/Bridge/Sweego/Tests/Webhook/SweegoRequestParserTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sweego/Tests/Webhook/SweegoRequestParserTest.php
@@ -18,6 +18,9 @@ use Symfony\Component\Webhook\Test\AbstractRequestParserTestCase;
 
 class SweegoRequestParserTest extends AbstractRequestParserTestCase
 {
+    private const WEBHOOK_ID = 'a5ccc627-6e43-4012-bb29-f1bfe3a3d13e';
+    private const WEBHOOK_TIMESTAMP = '1725290740';
+
     protected function createRequestParser(): RequestParserInterface
     {
         return new SweegoRequestParser();
@@ -27,9 +30,9 @@ class SweegoRequestParserTest extends AbstractRequestParserTestCase
     {
         return Request::create('/', 'POST', [], [], [], [
             'Content-Type' => 'application/json',
-            'HTTP_webhook-id' => 'a5ccc627-6e43-4012-bb29-f1bfe3a3d13e',
-            'HTTP_webhook-timestamp' => '1725290740',
-            'HTTP_webhook-signature' => 'k7SwzHXZqVKNvCpp6HwGS/5aDZ6NraYnKmVkBdx7MHE=',
+            'HTTP_webhook-id' => self::WEBHOOK_ID,
+            'HTTP_webhook-timestamp' => self::WEBHOOK_TIMESTAMP,
+            'HTTP_webhook-signature' => base64_encode(hash_hmac('sha256', \sprintf('%s.%s.%s', self::WEBHOOK_ID, self::WEBHOOK_TIMESTAMP, $payload), '', true)),
         ], $payload);
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Sweego/Webhook/SweegoRequestParser.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sweego/Webhook/SweegoRequestParser.php
@@ -49,7 +49,9 @@ final class SweegoRequestParser extends AbstractRequestParser
 
         $name = match ($payload['event_type']) {
             'sms_sent' => SmsEvent::DELIVERED,
-            default => throw new RejectWebhookException(406, \sprintf('Unsupported event "%s".', $payload['event'])),
+            'sms_clicked' => SmsEvent::CLICKED,
+            'sms_stop' => SmsEvent::UNSUBSCRIBED,
+            default => throw new RejectWebhookException(406, \sprintf('Unsupported event "%s".', $payload['event_type'])),
         };
 
         $event = new SmsEvent($name, $payload['swg_uid'], $payload);

--- a/src/Symfony/Component/Notifier/Bridge/Sweego/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Sweego/composer.json
@@ -24,7 +24,8 @@
         "symfony/webhook": "^7.4|^8.0"
     },
     "conflict": {
-        "symfony/http-foundation": "<7.4"
+        "symfony/http-foundation": "<7.4",
+        "symfony/remote-event": "<8.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Sweego\\": "" },

--- a/src/Symfony/Component/RemoteEvent/CHANGELOG.md
+++ b/src/Symfony/Component/RemoteEvent/CHANGELOG.md
@@ -3,6 +3,8 @@ CHANGELOG
 
 8.2
 ---
+
+ * Add `clicked` and `unsubscribed` SMS event names
  * Allow repeating `AsRemoteEventConsumer` attribute
 
 6.4

--- a/src/Symfony/Component/RemoteEvent/Event/Sms/SmsEvent.php
+++ b/src/Symfony/Component/RemoteEvent/Event/Sms/SmsEvent.php
@@ -20,6 +20,8 @@ final class SmsEvent extends RemoteEvent
 {
     public const FAILED = 'failed';
     public const DELIVERED = 'delivered';
+    public const CLICKED = 'clicked';
+    public const UNSUBSCRIBED = 'unsubscribed';
 
     private string $phone = '';
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #61558
| License       | MIT

This adds `clicked` and `unsubscribed` SMS event names to `SmsEvent`, then maps Sweego's `sms_clicked` and `sms_stop` webhooks to those names.

The Sweego parser already handled SMS delivery events, so this keeps the first provider mapping narrow and covered by signed webhook fixtures. It also fixes the unsupported-event error message to read the existing `event_type` field.

## Test verification (RED -> GREEN)

RED on `upstream/8.2` with only the new Sweego webhook fixtures added:

```text
There were 2 errors:

1) Symfony\Component\Notifier\Bridge\Sweego\Tests\Webhook\SweegoRequestParserTest::testParse with clicked.json
Symfony\Component\Webhook\Exception\RejectWebhookException: Unsupported event "".

2) Symfony\Component\Notifier\Bridge\Sweego\Tests\Webhook\SweegoRequestParserTest::testParse with stop.json
Symfony\Component\Webhook\Exception\RejectWebhookException: Unsupported event "".

2 tests triggered 1 PHP warning:
Undefined array key "event"

ERRORS!
Tests: 3, Assertions: 1, Errors: 2, Warnings: 1.
```

GREEN after the review follow-up on this branch:

```text
No syntax errors detected in src/Symfony/Component/RemoteEvent/Event/Sms/SmsEvent.php
No syntax errors detected in src/Symfony/Component/RemoteEvent/Tests/Event/Sms/SmsEventTest.php
No syntax errors detected in src/Symfony/Component/Notifier/Bridge/Sweego/Webhook/SweegoRequestParser.php
No syntax errors detected in src/Symfony/Component/Notifier/Bridge/Sweego/Tests/Webhook/Fixtures/clicked.php
No syntax errors detected in src/Symfony/Component/Notifier/Bridge/Sweego/Tests/Webhook/Fixtures/stop.php

RemoteEvent + Sweego webhook: OK (4 tests, 4 assertions)
```

Baseline on the reviewed PR head before the follow-up:

```text
RemoteEvent + Sweego webhook: OK (5 tests, 8 assertions)
```
