### PR TITLE
[TwigBridge] Add normalize filter

### DIFF
--- a/src/Symfony/Bridge/Twig/CHANGELOG.md
+++ b/src/Symfony/Bridge/Twig/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add the `logout_form()` function to build a form that logs the user out with a POST
+ * Add the `normalize` filter to normalize values with the Serializer component
 
 8.1
 ---

--- a/src/Symfony/Bridge/Twig/Extension/SerializerExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/SerializerExtension.php
@@ -22,6 +22,7 @@ final class SerializerExtension extends AbstractExtension
     public function getFilters(): array
     {
         return [
+            new TwigFilter('normalize', [SerializerRuntime::class, 'normalize']),
             new TwigFilter('serialize', [SerializerRuntime::class, 'serialize']),
         ];
     }

--- a/src/Symfony/Bridge/Twig/Extension/SerializerRuntime.php
+++ b/src/Symfony/Bridge/Twig/Extension/SerializerRuntime.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bridge\Twig\Extension;
 
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 use Twig\Extension\RuntimeExtensionInterface;
 
@@ -20,12 +21,25 @@ use Twig\Extension\RuntimeExtensionInterface;
 final class SerializerRuntime implements RuntimeExtensionInterface
 {
     public function __construct(
-        private SerializerInterface $serializer,
+        private SerializerInterface|NormalizerInterface $serializer,
     ) {
+    }
+
+    public function normalize(mixed $data, ?string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null
+    {
+        if (!$this->serializer instanceof NormalizerInterface) {
+            throw new \LogicException(\sprintf('The "normalize" filter requires a serializer implementing "%s", but "%s" does not.', NormalizerInterface::class, get_debug_type($this->serializer)));
+        }
+
+        return $this->serializer->normalize($data, $format, $context);
     }
 
     public function serialize(mixed $data, string $format = 'json', array $context = []): string
     {
+        if (!$this->serializer instanceof SerializerInterface) {
+            throw new \LogicException(\sprintf('The "serialize" filter requires a serializer implementing "%s", but "%s" does not.', SerializerInterface::class, get_debug_type($this->serializer)));
+        }
+
         return $this->serializer->serialize($data, $format, $context);
     }
 }

--- a/src/Symfony/Bridge/Twig/Tests/Extension/SerializerExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/SerializerExtensionTest.php
@@ -21,8 +21,10 @@ use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Encoder\YamlEncoder;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
 use Symfony\Component\Serializer\Mapping\Loader\AttributeLoader;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Symfony\Component\Serializer\Serializer;
+use Symfony\Component\Serializer\SerializerInterface;
 use Twig\Environment;
 use Twig\Loader\ArrayLoader;
 use Twig\RuntimeLoader\ContainerRuntimeLoader;
@@ -45,6 +47,78 @@ class SerializerExtensionTest extends TestCase
         yield ['{{ object|serialize }}', '{&quot;name&quot;:&quot;howdy&quot;,&quot;title&quot;:&quot;fixture&quot;}'];
         yield ['{{ object|serialize(\'yaml\') }}', '{ name: howdy, title: fixture }'];
         yield ['{{ object|serialize(\'yaml\', {groups: \'read\'}) }}', '{ name: howdy }'];
+    }
+
+    #[DataProvider('normalizerDataProvider')]
+    public function testNormalizeFilter(string $template, string $expectedResult)
+    {
+        $twig = $this->getTwig($template);
+
+        self::assertSame($expectedResult, $twig->render('template', ['object' => new SerializerModelFixture()]));
+    }
+
+    public static function normalizerDataProvider(): \Generator
+    {
+        yield ['{{ (object|normalize).name }} {{ (object|normalize).title }}', 'howdy fixture'];
+        yield ['{{ object|normalize(\'json\', {groups: \'read\'})|keys|join(\',\') }}', 'name'];
+    }
+
+    public function testNormalizeWithoutFormatByDefault()
+    {
+        $normalizer = new class implements NormalizerInterface {
+            public string|false|null $format = false;
+
+            public function normalize(mixed $data, ?string $format = null, array $context = []): array
+            {
+                $this->format = $format;
+
+                return [];
+            }
+
+            public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+            {
+                return true;
+            }
+
+            public function getSupportedTypes(?string $format): array
+            {
+                return ['*' => true];
+            }
+        };
+
+        (new SerializerRuntime($normalizer))->normalize(new SerializerModelFixture());
+
+        self::assertNull($normalizer->format);
+    }
+
+    public function testNormalizeRequiresANormalizer()
+    {
+        $runtime = new SerializerRuntime(new class implements SerializerInterface {
+            public function serialize(mixed $data, string $format, array $context = []): string
+            {
+                return '';
+            }
+
+            public function deserialize(mixed $data, string $type, string $format, array $context = []): mixed
+            {
+                return null;
+            }
+        });
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage(\sprintf('The "normalize" filter requires a serializer implementing "%s"', NormalizerInterface::class));
+
+        $runtime->normalize(new SerializerModelFixture());
+    }
+
+    public function testSerializeRequiresASerializer()
+    {
+        $runtime = new SerializerRuntime(new ObjectNormalizer());
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage(\sprintf('The "serialize" filter requires a serializer implementing "%s"', SerializerInterface::class));
+
+        $runtime->serialize(new SerializerModelFixture());
     }
 
     private function getTwig(string $template): Environment

--- a/src/Symfony/Bridge/Twig/UndefinedCallableHandler.php
+++ b/src/Symfony/Bridge/Twig/UndefinedCallableHandler.php
@@ -26,6 +26,7 @@ class UndefinedCallableHandler
         'emojify' => 'emoji',
         'humanize' => 'form',
         'form_encode_currency' => 'form',
+        'normalize' => 'serializer',
         'serialize' => 'serializer',
         'trans' => 'translation',
         'sanitize_html' => 'html-sanitizer',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #63911
| License       | MIT

This adds a `normalize` Twig filter, backed by the Serializer component. It mirrors the `serialize` filter but returns normalized data instead of an encoded string:

```twig
{{ object|normalize }}                                {# an array, not a JSON string #}
{{ object|normalize('json', {groups: 'read'}) }}      {# format and context, as for |serialize #}

<div {{ vue_component('MyComponent', {data: object|normalize}) }}></div>
```

The filter takes the same two optional arguments as `serialize`: a format and a serialization context. The format defaults to `null`, the same default as `NormalizerInterface::normalize()`, since nothing is encoded here and only format aware normalizers care about it.

It answers the double encoding problem from #63911: passing `object|serialize` to a helper that encodes on its own, such as `vue_component` or any UX component prop, produces a JSON string inside JSON. `object|normalize` gives that helper the data it expects.

The runtime now accepts `SerializerInterface|NormalizerInterface`, so a serializer that only implements one of them is still valid, and each filter throws a `LogicException` naming the missing interface when it is used with a service that cannot answer it. `symfony/serializer` ships `Serializer`, which implements both, so the framework wiring is unaffected.

Documentation points, for the symfony-docs pull request:

 * the filter name, its two optional arguments and their defaults, next to the existing `serialize` filter
 * when to reach for `normalize` rather than `serialize`: whenever the consumer encodes on its own (UX component props, `vue_component`, `json_encode` in a template helper)
 * the error a project gets when the `serializer` service is replaced by an implementation that cannot normalize
