### PR TITLE
[Validator] Fix File constraint skipping the mime type check when extensions and mimeTypes have no common value

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/FileValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/FileValidator.php
@@ -210,7 +210,9 @@ class FileValidator extends ConstraintValidator
                     $v = $mimeTypesHelper->getMimeTypes($k);
                 }
 
-                $mimeTypes = $mimeTypes ? array_intersect($v, $mimeTypes) : (array) $v;
+                // when the configured mime types share none with the ones of the matched
+                // extension, keep the configured ones so that the file is still checked
+                $mimeTypes = $mimeTypes ? (array_intersect($v, $mimeTypes) ?: $mimeTypes) : (array) $v;
                 break;
             }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTestCase.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTestCase.php
@@ -637,6 +637,32 @@ abstract class FileValidatorTestCase extends ConstraintValidatorTestCase
             ->assertRaised();
     }
 
+    public function testExtensionsAndMimeTypesWithoutCommonValue()
+    {
+        $path = __DIR__.'/Fixtures/test.gif';
+        $file = new \Symfony\Component\HttpFoundation\File\File($path);
+
+        try {
+            $file->getMimeType();
+        } catch (\LogicException $e) {
+            $this->markTestSkipped('Guessing the mime type is not possible');
+        }
+
+        $constraint = new File(mimeTypes: ['application/pdf'], mimeTypesMessage: 'myMessage', extensions: ['gif']);
+
+        $this->validator->validate($file, $constraint);
+
+        $this->buildViolation('myMessage')
+            ->setParameters([
+                '{{ file }}' => '"'.$path.'"',
+                '{{ name }}' => '"test.gif"',
+                '{{ type }}' => '"image/gif"',
+                '{{ types }}' => '"application/pdf"',
+            ])
+            ->setCode(File::INVALID_MIME_TYPE_ERROR)
+            ->assertRaised();
+    }
+
     public function testUploadedFileExtensions()
     {
         $file = new UploadedFile(__DIR__.'/Fixtures/bar', 'bar.txt', 'text/plain', \UPLOAD_ERR_OK, true);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Refs #61713, #63984
| License       | MIT

When the `File` constraint is given both `extensions` and `mimeTypes`, the validator intersects the mime types configured by the user with the ones of the matched extension:

```php
$mimeTypes = $mimeTypes ? array_intersect($v, $mimeTypes) : (array) $v;
```

When the two lists have no value in common, the intersection is empty, and an empty list makes the mime type check below it be skipped entirely. Adding an extension allow-list therefore removes a check that was passing before:

```php
// image/gif file named test.gif

new File(mimeTypes: ['application/pdf'])
// INVALID: The mime type of the file is invalid ("image/gif"). Allowed mime types are "application/pdf".

new File(extensions: ['gif'], mimeTypes: ['application/pdf'])
// VALID
```

This keeps the configured mime types when the intersection comes out empty, so the file is still checked and the violation reports the mime types the user asked for.

The only combination whose result changes is the one where the two lists are disjoint, which no file could ever satisfy. Every other combination behaves as before, including the case reported in #61713.
