### PR TITLE
[Mailer] Exclude ./Bridge from the source map to avoid a PHPUnit crash

### DIFF
--- a/src/Symfony/Component/Mailer/phpunit.xml.dist
+++ b/src/Symfony/Component/Mailer/phpunit.xml.dist
@@ -31,6 +31,7 @@
         <exclude>
             <directory>./Tests</directory>
             <directory>./vendor</directory>
+            <directory>./Bridge</directory>
         </exclude>
     </source>
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

The Mailer `phpunit.xml.dist` `<source>` config includes `./`, so PHPUnit 13's
`SourceMapper` walks into every mailer bridge — including each bridge's own
`vendor/` directory. During CI, a bridge's isolated composer install
materializes transient `vendor/composer/<hash>/...` symlinks; when one is
removed while `SourceMapper` is still iterating, `RecursiveDirectoryIterator`
throws and aborts the whole run:
