### PR TITLE
[VarExporter] Detect the null byte rendering instead of pinning a PHP version

### DIFF
--- a/src/Symfony/Component/VarExporter/Tests/ProxyHelperTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/ProxyHelperTest.php
@@ -40,7 +40,7 @@ class ProxyHelperTest extends TestCase
             $expected = str_replace('self', '\\'.TestForProxyHelper::class, $expected);
             $expected = str_replace('= [namespace\M_PI, new M_PI()]', '= [\M_PI, new \Symfony\Component\VarExporter\Tests\M_PI()]', $expected);
 
-            if (\PHP_VERSION_ID >= 80600) {
+            if (self::hasOctalControlChars()) {
                 $expected = str_replace('"a\0b"', '"a\000b"', $expected);
             }
 
@@ -260,6 +260,18 @@ class ProxyHelperTest extends TestCase
         $proxyCode = ProxyHelper::generateLazyProxy(new \ReflectionClass(Hooked::class));
         self::assertStringContainsString("'backed' => [parent::class, 'backed', null, 7],", $proxyCode);
         self::assertStringContainsString("'notBacked' => [parent::class, 'notBacked', null, 2055],", $proxyCode);
+    }
+
+    /**
+     * Whether the running PHP renders control chars in exported default values as octal
+     * escapes rather than as raw bytes. Feature-detected because the change was backported
+     * to several branches, so no single version boundary describes it. Only defaults kept
+     * as an AST go through the export that changed, hence reflecting the very method the
+     * expectations are built from.
+     */
+    private static function hasOctalControlChars(): bool
+    {
+        return str_contains((string) (new \ReflectionMethod(TestForProxyHelper::class, 'foo5'))->getParameters()[0], '\000');
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`ProxyHelperTest` currently gates the expected null byte rendering on `\PHP_VERSION_ID >= 80600`, from when the change first appeared in PHP 8.6. php-src has since backported it to the 8.4 and 8.5 branches, so 8.4.24 and 8.5.9 render the new way while the guard still says "8.6 only". The `Unit Tests (8.4)` and `Unit Tests (8.5)` jobs are red on every maintained branch as a result, while 8.2, 8.3 and 8.6 stay green.

Upstream, `zend_ast_export_quoted_str()` now exports a string containing any byte below `0x20` as a double-quoted literal with `\n`, `\r`, `\t`, `\f`, `\v`, `\e` and `\0NN` escapes, where it previously emitted a single-quoted literal with the raw bytes. So `Reflection*::__toString()` renders the default value of

```php
public function foo5($b = new \stdClass([0 => 123]).Bar.Bar::BAR."a\0b")
```

as `"a\000b"` instead of `'a<NUL>b'`, and `ProxyHelper::exportSignature()` passes the double-quoted literal through untouched rather than building one itself. The generated proxy is correct either way, only its text differs.

Since the change was backported, no single version boundary describes it, and 8.2 and 8.3 may well get it too. This replaces the version pin with a probe of the actual rendering:

```php
private static function hasOctalControlChars(): bool
{
    return str_contains((string) new \ReflectionParameter(static fn ($a = "\0") => null, 0), '\000');
}
```

Verified green on 8.1.34, 8.2.32, 8.3.32, 8.4.23 and 8.5.8, which all still use the old rendering. For the new one I ported `zend_ast_export_quoted_str()`/`zend_ast_export_qstr()` and ran the result through the literal-splitting regex from `ProxyHelper`: it yields `"a\000b"` and the probe returns `true`, matching what CI reports.

7.4 and up carry the same stale guard a second time, in `testGenerateLazyProxy`; it needs the same treatment when merging up.
