### PR TITLE
[VarExporter] cache result of hasOctalControlChars

### DIFF
--- a/src/Symfony/Component/VarExporter/Tests/ProxyHelperTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/ProxyHelperTest.php
@@ -32,6 +32,7 @@ class ProxyHelperTest extends TestCase
     {
         $methods = (new \ReflectionClass(TestForProxyHelper::class))->getMethods();
         $source = file(__FILE__);
+        $hasOctalControlChars = self::hasOctalControlChars();
 
         foreach ($methods as $method) {
             $expected = substr($source[$method->getStartLine() - 1], $method->isAbstract() ? 13 : 4, -(1 + $method->isAbstract()));
@@ -40,7 +41,7 @@ class ProxyHelperTest extends TestCase
             $expected = str_replace('self', '\\'.TestForProxyHelper::class, $expected);
             $expected = str_replace('= [namespace\M_PI, new M_PI()]', '= [\M_PI, new \Symfony\Component\VarExporter\Tests\M_PI()]', $expected);
 
-            if (self::hasOctalControlChars()) {
+            if ($hasOctalControlChars) {
                 $expected = str_replace('"a\0b"', '"a\000b"', $expected);
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Related to PR GH-65046
| License       | MIT

This value can be computed once instead of 10 times.
