### PR TITLE
[Translation] Do not split ICU messages on pipes in PoFileDumper

### DIFF
--- a/src/Symfony/Component/Translation/Dumper/PoFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/PoFileDumper.php
@@ -30,6 +30,8 @@ class PoFileDumper extends FileDumper
         $output .= "\n";
 
         $newLine = false;
+        $isIntlDomain = str_ends_with($domain, MessageCatalogue::INTL_DOMAIN_SUFFIX);
+
         foreach ($messages->all($domain) as $source => $target) {
             if ($newLine) {
                 $output .= "\n";
@@ -48,8 +50,9 @@ class PoFileDumper extends FileDumper
                 $output .= $this->formatComments(implode(' ', (array) $metadata['sources']), ':');
             }
 
-            $sourceRules = $this->getStandardRules($source);
-            $targetRules = $this->getStandardRules($target);
+            // in an ICU domain the pipe is an ordinary character, pluralization is expressed by the message itself
+            $sourceRules = $isIntlDomain ? [] : $this->getStandardRules($source);
+            $targetRules = $isIntlDomain ? [] : $this->getStandardRules($target);
             if (2 == \count($sourceRules) && [] !== $targetRules) {
                 $output .= \sprintf('msgid "%s"'."\n", $this->escape($sourceRules[0]));
                 $output .= \sprintf('msgid_plural "%s"'."\n", $this->escape($sourceRules[1]));

--- a/src/Symfony/Component/Translation/Tests/Dumper/PoFileDumperTest.php
+++ b/src/Symfony/Component/Translation/Tests/Dumper/PoFileDumperTest.php
@@ -46,6 +46,19 @@ class PoFileDumperTest extends TestCase
         $this->assertStringEqualsFile(__DIR__.'/../Fixtures/resources.po', $dumper->formatCatalogue($catalogue, 'messages'));
     }
 
+    public function testDumpIntlDomainKeepsPipes()
+    {
+        $id = '{{subject}} must not be an instance of {{class|quote}}';
+        $catalogue = new MessageCatalogue('en');
+        $catalogue->set($id, $id, 'messages'.MessageCatalogue::INTL_DOMAIN_SUFFIX);
+
+        $dumper = new PoFileDumper();
+        $dump = $dumper->formatCatalogue($catalogue, 'messages'.MessageCatalogue::INTL_DOMAIN_SUFFIX);
+
+        $this->assertStringContainsString(\sprintf('msgid "%s"', $id), $dump);
+        $this->assertStringNotContainsString('msgid_plural', $dump);
+    }
+
     public function testDumpPlurals()
     {
         $catalogue = new MessageCatalogue('en');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Refs #64585
| License       | MIT

`PoFileDumper` treats a message whose id contains a single pipe as a legacy plural and writes it as a `msgid`/`msgid_plural` pair. It does that for every domain, including the ICU ones, where the pipe carries no such meaning: an `+intl-icu` message expresses plurals inside the message itself and a pipe there is an ordinary character.

So an ICU message holding a pipe is dumped cut in half:

```php
$id = '{{subject}} must not be an instance of {{class|quote}}';
$catalogue->set($id, $id, 'validators'.MessageCatalogue::INTL_DOMAIN_SUFFIX);
```

```po
msgid "{{subject}} must not be an instance of {{class"
msgid_plural "quote}}"
msgstr[0] "{{subject}} must not be an instance of {{class"
msgstr[1] "quote}}"
```

The id no longer matches the one the application asks for, so the translation is never found.

This skips the legacy plural detection for ICU domains, which leaves the message whole:

```po
msgid "{{subject}} must not be an instance of {{class|quote}}"
msgstr "{{subject}} must not be an instance of {{class|quote}}"
```

Nothing changes for other domains: only the two ICU rows of this matrix differ, the legacy plural syntax keeps working where it is meaningful.

| Case | `msgid_plural` before | after |
| --- | --- | --- |
| plain domain, pipe in the id | yes | yes |
| plain domain, `apple\|apples` | yes | yes |
| ICU domain, pipe in the id | yes | no |
| ICU domain, ICU plural message | no | no |

Note this does not make pipes usable as ordinary characters in a plain domain, which is what #64585 asks for. There the pipe is Symfony's own plural separator and the ambiguity is by design, so that part of the issue is not something we can fix. `MoFileDumper` is unaffected either way: it never splits on pipes.
