### PR TITLE
 Release v8.0.16

### DIFF
--- a/CHANGELOG-8.0.md
+++ b/CHANGELOG-8.0.md
@@ -7,6 +7,10 @@ in 8.0 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v8.0.0...v8.0.1
 
+* 8.0.16 (2026-07-29)
+
+ * bug #65036 [HttpClient] Revert " Strip Proxy-Authorization on cross-authority redirects" (GrahamCampbell)
+
 * 8.0.15 (2026-07-29)
 
  * bug #65029 [JsonPath] Add limits for filter expression length and depth in JsonCrawler (alexandre-daubois)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -72,12 +72,12 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
      */
     private static array $freshCache = [];
 
-    public const VERSION = '8.0.16-DEV';
+    public const VERSION = '8.0.16';
     public const VERSION_ID = 80016;
     public const MAJOR_VERSION = 8;
     public const MINOR_VERSION = 0;
     public const RELEASE_VERSION = 16;
-    public const EXTRA_VERSION = 'DEV';
+    public const EXTRA_VERSION = '';
 
     public const END_OF_MAINTENANCE = '07/2026';
     public const END_OF_LIFE = '07/2026';


### PR DESCRIPTION
**Changelog** (https://github.com/symfony/symfony/compare/v8.0.15...v8.0.16)

 * bug #65036 [HttpClient] Revert " Strip Proxy-Authorization on cross-authority redirects" (@GrahamCampbell)
