### PR TITLE
 Release v8.1.3

### DIFF
--- a/CHANGELOG-8.1.md
+++ b/CHANGELOG-8.1.md
@@ -7,6 +7,10 @@ in 8.1 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v8.1.0...v8.1.1
 
+* 8.1.3 (2026-07-29)
+
+ * bug #65036 [HttpClient] Revert " Strip Proxy-Authorization on cross-authority redirects" (GrahamCampbell)
+
 * 8.1.2 (2026-07-29)
 
  * bug #65029 [JsonPath] Add limits for filter expression length and depth in JsonCrawler (alexandre-daubois)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -45,12 +45,12 @@ abstract class Kernel extends AbstractKernel implements KernelInterface, Reboota
     private bool $resetServices = false;
     private bool $handlingHttpCache = false;
 
-    public const VERSION = '8.1.3-DEV';
+    public const VERSION = '8.1.3';
     public const VERSION_ID = 80103;
     public const MAJOR_VERSION = 8;
     public const MINOR_VERSION = 1;
     public const RELEASE_VERSION = 3;
-    public const EXTRA_VERSION = 'DEV';
+    public const EXTRA_VERSION = '';
 
     public const END_OF_MAINTENANCE = '01/2027';
     public const END_OF_LIFE = '01/2027';


### PR DESCRIPTION
**Changelog** (https://github.com/symfony/symfony/compare/v8.1.2...v8.1.3)

 * bug #65036 [HttpClient] Revert " Strip Proxy-Authorization on cross-authority redirects" (@GrahamCampbell)
