### PR TITLE
[SecurityBundle] Deprecate access control rules voting on many attributes

### DIFF
--- a/UPGRADE-8.2.md
+++ b/UPGRADE-8.2.md
@@ -96,6 +96,8 @@ SecurityBundle
 --------------
 
  * Deprecate the `remember_me` option of the `form_login`, `json_login`, `login_link`, and `access_token` authenticators, as it has no effect
+ * Deprecate configuring an access control rule with many `roles`, use `allow_if` or role hierarchy instead
+ * Deprecate configuring both an access control rule `allow_if` and `roles`, update `allow_if` instead
 
 Serializer
 ----------

--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -11,6 +11,8 @@ CHANGELOG
  * Show the deauthentication reason and the responsible user providers in the security profiler panel
  * Serve the CSRF token id of a firewall through the `csrf_token_manager` it configures, so that `csrf_token()` no longer mints a token the firewall rejects
  * Add `path`, `enable_csrf`, `csrf_token_id`, `csrf_parameter` and `csrf_token_manager` options to the `switch_user` firewall configuration to restrict user switching to a dedicated (POST-only) route protected by a CSRF token
+ * Deprecate configuring an access control rule with many `roles`, use `allow_if` or role hierarchy instead
+ * Deprecate configuring both an access control rule `allow_if` and `roles`, update `allow_if` instead
 
 8.1
 ---

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
@@ -130,6 +130,16 @@ class MainConfiguration implements ConfigurationInterface
                 ->arrayNode('access_control', 'rule')
                     ->cannotBeOverwritten()
                     ->prototype('array')
+                        ->beforeNormalization()
+                            ->ifArray()
+                            ->then(static function (array $v) {
+                                if (isset($v['roles'], $v['allow_if']) || isset($v['role'], $v['allow_if'])) {
+                                    trigger_deprecation('symfony/security-bundle', '8.2', 'Configuring both an access control rule "allow_if" and "roles" is deprecated, update "allow_if" instead.');
+                                }
+
+                                return $v;
+                            })
+                        ->end()
                         ->children()
                             ->scalarNode('request_matcher')->defaultNull()->end()
                             ->scalarNode('requires_channel')->defaultNull()->end()
@@ -154,11 +164,17 @@ class MainConfiguration implements ConfigurationInterface
                                 ->prototype('scalar')->end()
                             ->end()
                             ->scalarNode('allow_if')->defaultNull()->end()
-                        ->end()
-                        ->children()
                             ->arrayNode('roles', 'role')
                                 ->beforeNormalization()->ifString()->then(static fn ($v) => preg_split('/\s*,\s*/', $v))->end()
                                 ->prototype('scalar')->end()
+                                ->validate()
+                                    ->ifTrue(static fn (array $v) => \count($v) > 1)
+                                    ->then(static function (array $v) {
+                                        trigger_deprecation('symfony/security-bundle', '8.2', 'Configuring an access control rule with many "roles" is deprecated, use "allow_if" or role hierarchy instead.');
+
+                                        return $v;
+                                    })
+                                ->end()
                             ->end()
                         ->end()
                     ->end()

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -253,9 +253,7 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
                 $roles[] = $this->createExpression($container, $access['allow_if']);
             }
 
-            $emptyAccess = 0 === \count(array_filter($access));
-
-            if ($emptyAccess) {
+            if (!array_filter($access)) {
                 throw new InvalidConfigurationException('One or more access control items are empty. Did you accidentally add lines only containing a "-" under "security.access_control"?');
             }
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTestCase.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTestCase.php
@@ -331,8 +331,7 @@ abstract class CompleteConfigurationTestCase extends TestCase
                 $this->assertSame(PathRequestMatcher::class, $def->getClass());
                 $this->assertSame('/blog/.*', $def->getArgument(0));
             } elseif (3 === $i) {
-                $this->assertEquals('IS_AUTHENTICATED_ANONYMOUSLY', $attributes[0]);
-                $expression = $container->getDefinition((string) $attributes[1])->getArgument(0);
+                $expression = $container->getDefinition((string) $attributes[0])->getArgument(0);
                 $this->assertEquals("token.getUserIdentifier() matches '/^admin/'", $expression);
             } elseif (4 === $i) {
                 $this->assertEquals(['ROLE_ADMIN'], $attributes);

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/container1.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/container1.php
@@ -95,7 +95,7 @@ $container->loadFromExtension('security', [
     'access_control' => [
         ['path' => '/blog/524', 'role' => 'ROLE_USER', 'requires_channel' => 'https', 'methods' => ['get', 'POST'], 'port' => 8000],
         ['path' => '/blog/.*', 'role' => 'IS_AUTHENTICATED_ANONYMOUSLY'],
-        ['path' => '/blog/524', 'role' => 'IS_AUTHENTICATED_ANONYMOUSLY', 'allow_if' => "token.getUserIdentifier() matches '/^admin/'"],
+        ['path' => '/blog/524', 'allow_if' => "token.getUserIdentifier() matches '/^admin/'"],
         ['role' => 'ROLE_ADMIN', 'attributes' => ['_controller' => 'AdminController::index'], 'route' => 'admin'],
     ],
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/container1.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/container1.yml
@@ -79,8 +79,6 @@ security:
 
     access_control:
         - { path: /blog/524, role: ROLE_USER, requires_channel: https, methods: [get, POST], port: 8000}
-        -
-            path: /blog/.*
-            role: IS_AUTHENTICATED_ANONYMOUSLY
-        - { path: /blog/524, role: IS_AUTHENTICATED_ANONYMOUSLY, allow_if: "token.getUserIdentifier() matches '/^admin/'" }
+        - { path: /blog/.*, role: IS_AUTHENTICATED_ANONYMOUSLY }
+        - { path: /blog/524, allow_if: "token.getUserIdentifier() matches '/^admin/'" }
         - { role: ROLE_ADMIN, attributes: { _controller: 'AdminController::index' }, route: 'admin' }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/MainConfigurationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/MainConfigurationTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectUserDeprecationMessageTrait;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\MainConfiguration;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\AuthenticatorFactoryInterface;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
@@ -23,6 +24,8 @@ use Symfony\Component\Security\Http\Authentication\ExposeSecurityLevel;
 
 class MainConfigurationTest extends TestCase
 {
+    use ExpectUserDeprecationMessageTrait;
+
     /**
      * The minimal, required config needed to not have any required validation
      * issues.
@@ -340,6 +343,51 @@ class MainConfigurationTest extends TestCase
         $configuration = new MainConfiguration([], []);
 
         $this->expectException(InvalidConfigurationException::class);
+
+        $processor->processConfiguration($configuration, [$config]);
+    }
+
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
+    #[DataProvider('provideAccessControlRuleRoles')]
+    public function testConfiguringManyAccessControlRuleRolesIsDeprecated(array|string $roles, array $resultingRoles)
+    {
+        $config = array_merge(static::$minimalConfig, [
+            'access_control' => [['path' => '/', 'roles' => $roles]],
+        ]);
+
+        $processor = new Processor();
+        $configuration = new MainConfiguration([], []);
+
+        $this->expectUserDeprecationMessage('Since symfony/security-bundle 8.2: Configuring an access control rule with many "roles" is deprecated, use "allow_if" or role hierarchy instead.');
+
+        $processedConfig = $processor->processConfiguration($configuration, [$config]);
+
+        $this->assertEqualsCanonicalizing($resultingRoles, $processedConfig['access_control'][0]['roles']);
+    }
+
+    public static function provideAccessControlRuleRoles(): iterable
+    {
+        yield [['ROLE_ADMIN', 'ROLE_USER'], ['ROLE_ADMIN', 'ROLE_USER']];
+        yield ['ROLE_ADMIN, ROLE_USER', ['ROLE_ADMIN', 'ROLE_USER']];
+    }
+
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
+    public function testConfiguringAccessControlRuleRolesAndAllowIfIsDeprecated()
+    {
+        $config = array_merge(static::$minimalConfig, [
+            'access_control' => [[
+                'path' => '/',
+                'roles' => 'ROLE_USER',
+                'allow_if' => 'is_granted("ROLE_ADMIN")',
+            ]],
+        ]);
+
+        $processor = new Processor();
+        $configuration = new MainConfiguration([], []);
+
+        $this->expectUserDeprecationMessage('Since symfony/security-bundle 8.2: Configuring both an access control rule "allow_if" and "roles" is deprecated, update "allow_if" instead.');
 
         $processor->processConfiguration($configuration, [$config]);
     }

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -22,6 +22,7 @@
         "symfony/clock": "^7.4|^8.0",
         "symfony/config": "^7.4|^8.0",
         "symfony/dependency-injection": "^7.4|^8.0",
+        "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/event-dispatcher": "^7.4|^8.0",
         "symfony/http-kernel": "^7.4|^8.0",
         "symfony/http-foundation": "^7.4|^8.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Issues        | N/A
| License       | MIT

Follow-up of #33584.

This should allow removing `AccessDecisionManager::decide()`’s `$allowMultipleAttributes` parameter in the future, thus solving #54060.