### PR TITLE
[PropertyAccess] Fix caching of null read info

### DIFF
--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -482,7 +482,8 @@ class PropertyAccessor implements PropertyAccessorInterface
     {
         $key = str_replace('\\', '.', $class).'..'.$property;
 
-        if (isset($this->readPropertyCache[$key])) {
+        // don't use isset() here, the cached value can be null
+        if (\array_key_exists($key, $this->readPropertyCache)) {
             return $this->readPropertyCache[$key];
         }
 

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
@@ -42,6 +42,7 @@ use Symfony\Component\PropertyAccess\Tests\Fixtures\TypeHinted;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\UninitializedObjectProperty;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\UninitializedPrivateProperty;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\UninitializedProperty;
+use Symfony\Component\PropertyInfo\PropertyReadInfoExtractorInterface;
 use Symfony\Component\VarExporter\ProxyHelper;
 
 class PropertyAccessorTest extends TestCase
@@ -717,6 +718,23 @@ class PropertyAccessorTest extends TestCase
         $propertyAccessor->setValue($obj, 'publicGetSetter', 'bar');
         $propertyAccessor->setValue($obj, 'publicGetSetter', 'baz');
         $this->assertEquals('baz', $propertyAccessor->getValue($obj, 'publicGetSetter'));
+    }
+
+    public function testNullReadInfoIsCached()
+    {
+        $obj = new \stdClass();
+        $obj->foo = 'bar';
+
+        $extractor = $this->createMock(PropertyReadInfoExtractorInterface::class);
+        $extractor->expects($this->once())
+            ->method('getReadInfo')
+            ->with(\stdClass::class, 'foo')
+            ->willReturn(null);
+
+        $propertyAccessor = new PropertyAccessor(PropertyAccessor::DISALLOW_MAGIC_METHODS, PropertyAccessor::THROW_ON_INVALID_PROPERTY_PATH, null, $extractor);
+
+        $this->assertSame('bar', $propertyAccessor->getValue($obj, 'foo'));
+        $this->assertSame('bar', $propertyAccessor->getValue($obj, 'foo'));
     }
 
     public function testAttributeWithSpecialChars()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`PropertyAccessor::getReadInfo()` caches the extractor result in `$this->readPropertyCache`, but it looks for a hit with `isset()`. The extractor returns `null` for every property it cannot resolve, so those entries never hit: reading such a property runs the full `ReflectionExtractor::getReadInfo()` again on every call, and when a PSR-6 cache pool is configured, it also does a `getItem()` round-trip on every call.

This PR looks up the cache with `array_key_exists()`, so `null` results are cached like any other value. Since PHP 7.4, `array_key_exists()` compiles to a dedicated VM opcode, so the common getter/setter path is not affected.

Properties with no read info are the dynamic ones (`stdClass`, `#[AllowDynamicProperties]`, objects created by `json_decode()`) and any property the extractor cannot resolve, so `isReadable()` returning `false` and reads that ignore invalid properties get the same benefit.

Benchmark, 200k reads on PHP 8.5:

| case | before | after |
| --- | --- | --- |
| dynamic property, no cache pool | 480 ms | 126 ms |
| dynamic property, ArrayAdapter pool | 356 ms | 127 ms |
| public getter, no cache pool | 134 ms | 129 ms |

Reads through a getter and writes through a setter are unchanged. In the context of a full HTTP request this change alone is insignificant, but code that reads many dynamic properties in a loop, for example mapping objects created with `json_decode()`, can notice it.

The write path is not affected: `PropertyAccessor::getWriteInfo()` has a non-nullable return type, and `ReflectionExtractor` returns a `TYPE_NONE` instance instead of `null`, so a `null` never reaches that cache. Same for `getPropertyPath()`.
