### PR TITLE
[Translation] Fix fuzzy translations and multi-line msgctxt in PO files

### DIFF
--- a/src/Symfony/Component/Translation/Loader/PoFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/PoFileLoader.php
@@ -55,6 +55,7 @@ class PoFileLoader extends FileLoader
      * - No support for comments spanning multiple lines.
      * - Translator and extracted comments are treated as being the same type.
      * - Message IDs are allowed to have other encodings as just US-ASCII.
+     * - Contexts (msgctxt) are parsed but discarded.
      *
      * Items with an empty id are ignored.
      */
@@ -65,6 +66,7 @@ class PoFileLoader extends FileLoader
         $defaults = [
             'ids' => [],
             'translated' => null,
+            'context' => null,
         ];
 
         $messages = [];
@@ -76,23 +78,28 @@ class PoFileLoader extends FileLoader
 
             if ('' === $line) {
                 // Whitespace indicated current item is done
-                if (!\in_array('fuzzy', $flags)) {
-                    $this->addMessage($messages, $item);
-                }
-                $item = $defaults;
-                $flags = [];
+                $this->saveItem($messages, $item, $flags, $defaults);
             } elseif (str_starts_with($line, '#,')) {
+                // flags belong to the next entry, so the previous one ends here
+                if (null !== $item['translated']) {
+                    $this->saveItem($messages, $item, $flags, $defaults);
+                }
                 $flags = array_map('trim', explode(',', substr($line, 2)));
+            } elseif (str_starts_with($line, 'msgctxt "')) {
+                if (null !== $item['translated']) {
+                    $this->saveItem($messages, $item, $flags, $defaults);
+                }
+                $item['context'] = substr($line, 9, -1);
             } elseif (str_starts_with($line, 'msgid "')) {
                 // We start a new msg so save previous
-                // TODO: this fails when comments or contexts are added
-                $this->addMessage($messages, $item);
-                $item = $defaults;
+                if ($item['ids']) {
+                    $this->saveItem($messages, $item, $flags, $defaults);
+                }
                 $item['ids']['singular'] = substr($line, 7, -1);
             } elseif (str_starts_with($line, 'msgstr "')) {
                 $item['translated'] = substr($line, 8, -1);
             } elseif ('"' === $line[0]) {
-                $continues = isset($item['translated']) ? 'translated' : 'ids';
+                $continues = isset($item['translated']) ? 'translated' : ($item['ids'] ? 'ids' : 'context');
 
                 if (\is_array($item[$continues])) {
                     end($item[$continues]);
@@ -108,12 +115,19 @@ class PoFileLoader extends FileLoader
             }
         }
         // save last item
-        if (!\in_array('fuzzy', $flags)) {
-            $this->addMessage($messages, $item);
-        }
+        $this->saveItem($messages, $item, $flags, $defaults);
         fclose($stream);
 
         return $messages;
+    }
+
+    private function saveItem(array &$messages, array &$item, array &$flags, array $defaults): void
+    {
+        if (!\in_array('fuzzy', $flags, true)) {
+            $this->addMessage($messages, $item);
+        }
+        $item = $defaults;
+        $flags = [];
     }
 
     /**

--- a/src/Symfony/Component/Translation/Tests/Fixtures/contexts.po
+++ b/src/Symfony/Component/Translation/Tests/Fixtures/contexts.po
@@ -1,0 +1,10 @@
+msgctxt "menu"
+msgid "foo1"
+msgstr "bar1"
+
+msgid "foo2"
+msgstr "bar2"
+msgctxt "multi-line "
+"context"
+msgid "foo3"
+msgstr "bar3"

--- a/src/Symfony/Component/Translation/Tests/Fixtures/fuzzy-translations-no-blank-lines.po
+++ b/src/Symfony/Component/Translation/Tests/Fixtures/fuzzy-translations-no-blank-lines.po
@@ -1,0 +1,11 @@
+#, fuzzy
+msgid "foo1"
+msgstr "fuzzy bar1"
+msgid "foo2"
+msgstr "bar2"
+# translator comment
+msgid "foo3"
+msgstr "bar3"
+#, fuzzy
+msgid "foo4"
+msgstr "fuzzy bar4"

--- a/src/Symfony/Component/Translation/Tests/Loader/PoFileLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/PoFileLoaderTest.php
@@ -107,6 +107,31 @@ class PoFileLoaderTest extends TestCase
         $this->assertArrayHasKey('foo3', $messages);
     }
 
+    public function testSkipFuzzyTranslationsWithoutBlankLines()
+    {
+        $loader = new PoFileLoader();
+        $resource = __DIR__.'/../Fixtures/fuzzy-translations-no-blank-lines.po';
+        $catalogue = $loader->load($resource, 'en', 'domain1');
+
+        $this->assertEquals([
+            'foo2' => 'bar2',
+            'foo3' => 'bar3',
+        ], $catalogue->all('domain1'));
+    }
+
+    public function testContextsAreDiscarded()
+    {
+        $loader = new PoFileLoader();
+        $resource = __DIR__.'/../Fixtures/contexts.po';
+        $catalogue = $loader->load($resource, 'en', 'domain1');
+
+        $this->assertEquals([
+            'foo1' => 'bar1',
+            'foo2' => 'bar2',
+            'foo3' => 'bar3',
+        ], $catalogue->all('domain1'));
+    }
+
     public function testMissingPlurals()
     {
         $loader = new PoFileLoader();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

This is the bugfix half of #64977 by @javiereguiluz, cherry-picked for the maintained branches. His commit and authorship are preserved; the rest of that PR stays on 8.2 because it adds behaviour.

Two defects in `PoFileLoader`, both present since the loader was written.

The fuzzy flag was only honoured when entries were separated by a blank line. Reaching a new `msgid` saved the previous entry unconditionally and never reset the flags, so a fuzzy entry was kept and the valid entry after it was dropped, the exact opposite of what gettext does:

```php
$po = <<<'EOF'
#, fuzzy
msgid "stale"
msgstr "STALE"
msgid "good"
msgstr "GOOD"
EOF;

(new PoFileLoader())->load($file, 'en', 'messages')->all('messages');
// before: ["stale" => "STALE"]
// after:  ["good" => "GOOD"]
```

A multi-line `msgctxt` also corrupted the entry before it, because its continuation lines were appended to the previous translation instead of to the context.

Saving an entry is now done in one place, which is what makes both cases behave the same whether or not blank lines separate the entries.
