### PR TITLE
[TwigBridge][WebProfilerBundle] Fix compatibility with Twig 4

### DIFF
--- a/src/Symfony/Bridge/Twig/Tests/NodeVisitor/TwigNodeProvider.php
+++ b/src/Symfony/Bridge/Twig/Tests/NodeVisitor/TwigNodeProvider.php
@@ -19,6 +19,7 @@ use Twig\Node\EmptyNode;
 use Twig\Node\Expression\ArrayExpression;
 use Twig\Node\Expression\ConstantExpression;
 use Twig\Node\Expression\FilterExpression;
+use Twig\Node\MacrosNode;
 use Twig\Node\ModuleNode;
 use Twig\Node\Node;
 use Twig\Node\Nodes;
@@ -35,7 +36,7 @@ class TwigNodeProvider
             new BodyNode([new ConstantExpression($content, 0)]),
             null,
             $emptyNodeExists ? new EmptyNode() : new ArrayExpression([], 0),
-            $emptyNodeExists ? new EmptyNode() : new ArrayExpression([], 0),
+            class_exists(MacrosNode::class) ? new MacrosNode() : ($emptyNodeExists ? new EmptyNode() : new ArrayExpression([], 0)),
             $emptyNodeExists ? new EmptyNode() : new ArrayExpression([], 0),
             $emptyNodeExists ? new EmptyNode() : null,
             new Source('', '')

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
@@ -411,7 +411,7 @@
     </div>
 {% endblock %}
 
-{% macro set_handler(controller, route, method) %}
+{% macro set_handler(controller, route = null, method = null) %}
     {% if controller.class is defined -%}
         {%- if method|default(false) %}<span class="sf-toolbar-status sf-toolbar-redirection-method">{{ method }}</span>{% endif -%}
         {%- set link = controller.file|file_link(controller.line) %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Twig 4.x removed the deprecation shims added in 3.29 by "Redesign macro calls and argument handling", which turns two long-standing patterns here into hard errors. `Unit Tests` and `Windows` are red on every maintained branch, with `KO src/Symfony/Bridge/Twig` and `KO src/Symfony/Bundle/WebProfilerBundle`.

**`ModuleNode` macros argument.** 3.29 deprecated passing anything but a `MacrosNode` as the fourth constructor argument; 4.0 makes it a `TypeError`:

```
Twig\Node\ModuleNode::__construct(): Argument #4 ($macros) must be of type
Twig\Node\MacrosNode, Twig\Node\EmptyNode given
```

`TwigNodeProvider::getModule()` passes an `EmptyNode`. Since the bridge supports `^2.13|^3.0.4|^4.0` and `MacrosNode` only exists from 3.29, this extends the compatibility ladder already in place for `EmptyNode` rather than hard-coding the new class.

**Required macro arguments.** 4.0 throws when a macro argument that has no default receives no value:

```
Value for argument "route" is required for macro "set_handler" in
"@WebProfiler/Collector/request.html.twig" at line 130
```

`set_handler(controller, route, method)` is called with a single argument at four of its five call sites. The body already treats both extra arguments as optional (`route|default(false)`, `method|default(false)`, `route|default(controller)`), so they get explicit `null` defaults; behaviour is unchanged and the syntax works on Twig 2 and 3 as well.

Verified against a checkout of Twig's `4.x` branch shadowing the vendored copy, since a partial `composer update twig/twig` cannot resolve against the monorepo's lock. Both failures reproduce byte for byte before the change. After it, `Bridge/Twig/Tests/NodeVisitor` is 12/12 and `WebProfilerBundle` 137/137 on Twig 4 and on the currently vendored Twig alike.
