### PR TITLE
[Mime] Fix corrupted CID references when one is a prefix of another

### DIFF
--- a/src/Symfony/Component/Mime/Email.php
+++ b/src/Symfony/Component/Mime/Email.php
@@ -497,6 +497,7 @@ class Email extends Message
         }
 
         $otherParts = $relatedParts = [];
+        $cidReplacements = [];
         foreach ($this->attachments as $part) {
             foreach ($names as $name) {
                 if ($name !== $part->getName() && (!$part->hasContentId() || $name !== $part->getContentId())) {
@@ -506,9 +507,7 @@ class Email extends Message
                     continue 2;
                 }
 
-                if ($name !== $part->getContentId()) {
-                    $html = str_replace('cid:'.$name, 'cid:'.$part->getContentId(), $html);
-                }
+                $cidReplacements['cid:'.$name] = 'cid:'.$part->getContentId();
                 $relatedParts[$name] = $part;
                 $part->setName($part->getName() ?? $part->getContentId())->asInline();
 
@@ -516,6 +515,11 @@ class Email extends Message
             }
 
             $otherParts[] = $part;
+        }
+        if ($cidReplacements) {
+            // all references are replaced at once as strtr() matches the longest name first and
+            // never replaces inside already substituted text, unlike successive str_replace() calls
+            $html = strtr($html, $cidReplacements);
         }
         if (null !== $htmlPart) {
             $htmlPart = new TextPart($html, $this->htmlCharset, 'html');

--- a/src/Symfony/Component/Mime/Tests/EmailTest.php
+++ b/src/Symfony/Component/Mime/Tests/EmailTest.php
@@ -527,6 +527,67 @@ class EmailTest extends TestCase
         $this->assertStringNotContainsString('name='.$inlinePart->getContentId(), $headers);
     }
 
+    public function testGenerateBodyWithInlinedImagesWhoseCidNamesArePrefixesOfEachOther()
+    {
+        // "logo" is a strict prefix of "logo_2", the shorter one is added first
+        $e = (new Email())->from('me@example.com')->to('you@example.com');
+        $e->html('html content <img src="cid:logo"> <img src="cid:logo_2">');
+        $e->addPart((new DataPart(fopen(__DIR__.'/Fixtures/mimetypes/test.gif', 'r'), 'logo'))->asInline());
+        $e->addPart((new DataPart(fopen(__DIR__.'/Fixtures/mimetypes/test.gif', 'r'), 'logo_2'))->asInline());
+        $this->assertInlinedImagesAreReferencedViaTheirContentId($e, 2);
+
+        // same pair, the longer one is added first
+        $e = (new Email())->from('me@example.com')->to('you@example.com');
+        $e->html('html content <img src="cid:logo"> <img src="cid:logo_2">');
+        $e->addPart((new DataPart(fopen(__DIR__.'/Fixtures/mimetypes/test.gif', 'r'), 'logo_2'))->asInline());
+        $e->addPart((new DataPart(fopen(__DIR__.'/Fixtures/mimetypes/test.gif', 'r'), 'logo'))->asInline());
+        $this->assertInlinedImagesAreReferencedViaTheirContentId($e, 2);
+    }
+
+    public function testGenerateBodyWithInlinedImagesWhoseCidNamesAreNested()
+    {
+        $e = (new Email())->from('me@example.com')->to('you@example.com');
+        $e->html('html content <img src="cid:logo"> <img src="cid:logo_2"> <img src="cid:logo_2_3">');
+        $e->addPart((new DataPart(fopen(__DIR__.'/Fixtures/mimetypes/test.gif', 'r'), 'logo'))->asInline());
+        $e->addPart((new DataPart(fopen(__DIR__.'/Fixtures/mimetypes/test.gif', 'r'), 'logo_2'))->asInline());
+        $e->addPart((new DataPart(fopen(__DIR__.'/Fixtures/mimetypes/test.gif', 'r'), 'logo_2_3'))->asInline());
+        $this->assertInlinedImagesAreReferencedViaTheirContentId($e, 3);
+    }
+
+    public function testGenerateBodyWithInlinedImagesWhoseCidNamesDoNotCollide()
+    {
+        $e = (new Email())->from('me@example.com')->to('you@example.com');
+        $e->html('html content <img src="cid:one.gif"> <img src="cid:two.gif">');
+        $e->addPart((new DataPart(fopen(__DIR__.'/Fixtures/mimetypes/test.gif', 'r'), 'one.gif'))->asInline());
+        $e->addPart((new DataPart(fopen(__DIR__.'/Fixtures/mimetypes/test.gif', 'r'), 'two.gif'))->asInline());
+        $this->assertInlinedImagesAreReferencedViaTheirContentId($e, 2);
+    }
+
+    public function testGenerateBodyWithInlinedImageReferencedByAContentIdPrefixedByAnotherName()
+    {
+        $e = (new Email())->from('me@example.com')->to('you@example.com');
+        $e->html('html content <img src="cid:logo"> <img src="cid:logo@example.com">');
+        $e->addPart((new DataPart(fopen(__DIR__.'/Fixtures/mimetypes/test.gif', 'r'), 'logo'))->asInline());
+        $e->addPart((new DataPart(fopen(__DIR__.'/Fixtures/mimetypes/test.gif', 'r')))->setContentId('logo@example.com')->asInline());
+        $this->assertInlinedImagesAreReferencedViaTheirContentId($e, 2);
+    }
+
+    private function assertInlinedImagesAreReferencedViaTheirContentId(Email $e, int $expectedImages): void
+    {
+        $body = $e->getBody();
+        $this->assertInstanceOf(RelatedPart::class, $body);
+        $parts = $body->getParts();
+        $htmlPart = array_shift($parts);
+        $this->assertCount($expectedImages, $parts);
+
+        $contentIds = array_map(static fn (DataPart $part) => $part->getContentId(), $parts);
+        $this->assertSame($expectedImages, preg_match_all('/cid:([^"\s>]++)/', $htmlPart->getBody(), $matches));
+        foreach ($matches[1] as $contentId) {
+            $this->assertContains($contentId, $contentIds, \sprintf('"cid:%s" does not reference any related part.', $contentId));
+        }
+        $this->assertCount($expectedImages, array_unique($matches[1]), 'Several references point to the same related part.');
+    }
+
     private function generateSomeParts(): array
     {
         $text = new TextPart('text content');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65061
| License       | MIT

`Email::prepareParts()` rewrites the `cid:` references of the inlined parts so that each one points at the Content-ID of its part. It did so one part at a time with `str_replace()`, each call applied to the result of the previous one. When one reference is a strict prefix of another, replacing the shorter one first also rewrites that prefix inside the longer reference, which has not been processed yet.

Two shapes are affected. With parts named `logo` and `logo_2`, `cid:logo_2` became `cid:<content-id-of-logo>_2`, a Content-ID that no part of the message carries. With a part named `logo` and another one referenced by an explicit Content-ID `logo@example.com`, the same clipping produced `cid:<content-id-of-logo>@example.com`. In both cases the affected image does not resolve in the mail client. Adding the parts in the opposite order happened to produce the correct result, so the outcome depended on the order the parts were added in.

The replacements are now collected in an array and applied in a single `strtr()` call. `strtr()` matches the longest key first at each offset and never replaces inside already substituted text, so both the clipping and the order dependence disappear. Every reference is queued, including the ones that map to themselves, which is what keeps a Content-ID reference from being clipped by a shorter part name. Names that are not in a prefix relation are unaffected.

Regression tests cover a prefix pair in both add orders, a three-level nested chain (`logo` / `logo_2` / `logo_2_3`, two broken references before the fix), a Content-ID prefixed by another part's name, and a non-colliding control pair. They assert that every `cid:` reference in the generated HTML resolves to the Content-ID of a part inside the `RelatedPart`, and that no two references point at the same part.
