### PR TITLE
[FrameworkBundle] Reject combining framework.cache.app with default_provider

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -1425,6 +1425,22 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('cache')
                     ->info('Cache configuration')
                     ->addDefaultsIfNotSet()
+                    // "app" is checked before normalization so that setting it explicitly is told apart from
+                    // its default value, and after merging so that the two options cannot come from two files
+                    ->beforeNormalization()
+                        ->ifArray()
+                        ->then(static function ($v) {
+                            if (isset($v['app'], $v['default_provider'])) {
+                                throw new InvalidConfigurationException('The "framework.cache.app" and "framework.cache.default_provider" options cannot be used together, the adapter is deduced from the DSN.');
+                            }
+
+                            return $v;
+                        })
+                    ->end()
+                    ->validate()
+                        ->ifTrue(static fn ($v) => isset($v['default_provider']) && 'cache.adapter.filesystem' !== $v['app'])
+                        ->thenInvalid('The "framework.cache.app" and "framework.cache.default_provider" options cannot be used together, the adapter is deduced from the DSN.')
+                    ->end()
                     ->children()
                         ->scalarNode('prefix_seed')
                             ->info('Used to namespace cache keys when using several apps with the same shared backend.')
@@ -1432,7 +1448,7 @@ class Configuration implements ConfigurationInterface
                             ->example('my-application-name/%kernel.environment%')
                         ->end()
                         ->scalarNode('app')
-                            ->info('App related cache pools configuration.')
+                            ->info('App related cache pools configuration. Cannot be combined with "default_provider".')
                             ->defaultValue('cache.adapter.filesystem')
                         ->end()
                         ->scalarNode('system')
@@ -1441,7 +1457,7 @@ class Configuration implements ConfigurationInterface
                         ->end()
                         ->scalarNode('directory')->defaultValue('%kernel.share_dir%/pools/app')->end()
                         ->scalarNode('default_provider')
-                            ->info('DSN of the backend to use for "cache.app"; the adapter is deduced from it.')
+                            ->info('DSN of the backend to use for "cache.app"; the adapter is deduced from it. Replaces "app", which cannot be set alongside it.')
                             ->example('%env(APP_CACHE_DSN)%')
                         ->end()
                         ->scalarNode('default_psr6_provider')->end()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -62,6 +62,53 @@ class ConfigurationTest extends TestCase
         ];
     }
 
+    public function testCacheAppAndDefaultProviderCannotBeCombined()
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('The "framework.cache.app" and "framework.cache.default_provider" options cannot be used together, the adapter is deduced from the DSN.');
+
+        (new Processor())->processConfiguration(new Configuration(true), [[
+            'cache' => ['app' => 'cache.adapter.redis', 'default_provider' => 'redis://localhost'],
+        ]]);
+    }
+
+    public function testCacheAppAndDefaultProviderCannotBeCombinedAcrossFiles()
+    {
+        $this->expectException(InvalidConfigurationException::class);
+
+        (new Processor())->processConfiguration(new Configuration(true), [
+            ['cache' => ['app' => 'cache.adapter.redis']],
+            ['cache' => ['default_provider' => 'redis://localhost']],
+        ]);
+    }
+
+    public function testCacheAppSetToItsDefaultValueStillConflictsWithDefaultProvider()
+    {
+        $this->expectException(InvalidConfigurationException::class);
+
+        (new Processor())->processConfiguration(new Configuration(true), [[
+            'cache' => ['app' => 'cache.adapter.filesystem', 'default_provider' => 'redis://localhost'],
+        ]]);
+    }
+
+    public function testCacheDefaultProviderAloneIsAllowed()
+    {
+        $config = (new Processor())->processConfiguration(new Configuration(true), [[
+            'cache' => ['default_provider' => 'redis://localhost'],
+        ]]);
+
+        $this->assertSame('redis://localhost', $config['cache']['default_provider']);
+    }
+
+    public function testCacheAppAloneIsAllowed()
+    {
+        $config = (new Processor())->processConfiguration(new Configuration(true), [[
+            'cache' => ['app' => 'cache.adapter.redis'],
+        ]]);
+
+        $this->assertSame('cache.adapter.redis', $config['cache']['app']);
+    }
+
     #[DataProvider('getTestInvalidSessionName')]
     public function testInvalidSessionName($sessionName)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Follow up to #65045, after @alexander-schranz noticed that `framework.cache.app` still advertises a default while `default_provider` now decides the adapter.

Setting both used to leave `app` silently ignored:

```yaml
framework:
    cache:
        app: cache.adapter.redis
        default_provider: '%env(APP_CACHE_DSN)%'   # app was discarded, with no warning
```

It now fails, with the two options documented as mutually exclusive:

```
The "framework.cache.app" and "framework.cache.default_provider" options cannot be used together, the adapter is deduced from the DSN.
```

The check is in two places because neither hook covers everything on its own. `beforeNormalization()` runs on the raw array, so it can tell an explicitly configured `app` from its default value, but it runs per configuration file, before they are merged. `validate()` sees the merged result, so it catches the two options coming from two different files, but by then `app` is filled in and can only be compared against its default value. Together they cover:

| Configuration | Caught by |
| --- | --- |
| `app` and `default_provider` in the same file | both |
| `app: cache.adapter.filesystem` and `default_provider` in the same file | `beforeNormalization()` |
| `app` in one file, `default_provider` in another | `validate()` |

The normalization uses `ifArray()` rather than `ifTrue()` on purpose: `ifTrue()` with a closure registers the node as accepting `any`, which widens the shape that `ArrayShapeGenerator` produces for `framework.cache` (see #64695). `ifArray()` registers `array`, which the generator already excludes for an array node:

```
with ifTrue : any, array
with ifArray: array
```

One case stays allowed on purpose: `app` explicitly set to `cache.adapter.filesystem` in one file and `default_provider` in another. Detecting it would need to know that `app` was written down rather than defaulted, which is not available once the files are merged.