### PR TITLE
[Console] Fix column widths when a row spans columns

### DIFF
--- a/src/Symfony/Component/Console/Helper/Table.php
+++ b/src/Symfony/Component/Console/Helper/Table.php
@@ -49,6 +49,7 @@ class Table
     private TableStyle $style;
     private array $columnStyles = [];
     private array $columnWidths = [];
+    private array $configuredColumnWidths = [];
     private array $columnMaxWidths = [];
     private bool $rendered = false;
     private string $displayOrientation = self::DISPLAY_ORIENTATION_DEFAULT;
@@ -138,6 +139,7 @@ class Table
     public function setColumnWidth(int $columnIndex, int $width): static
     {
         $this->columnWidths[$columnIndex] = $width;
+        $this->configuredColumnWidths[$columnIndex] = $width;
 
         return $this;
     }
@@ -150,6 +152,7 @@ class Table
     public function setColumnWidths(array $widths): static
     {
         $this->columnWidths = [];
+        $this->configuredColumnWidths = [];
         foreach ($widths as $index => $width) {
             $this->setColumnWidth($index, $width);
         }
@@ -704,13 +707,18 @@ class Table
                             $this->columnWidths[$item['column']] = $minWidthColumn;
                             $columnsMinWidthProcessed[$item['column']] = true;
                             $cellWidth -= $minWidthColumn + $lengthColumnBorder;
+                        } elseif ('min' === $item['type'] && ($this->configuredColumnWidths[$item['column']] ?? 0) > 0) {
+                            // this column already covers part of the cell, so share only the rest
+                            $columnsMinWidthProcessed[$item['column']] = true;
+                            $cellWidth -= $this->configuredColumnWidths[$item['column']] + $lengthColumnBorder;
                         }
                     }
                     for ($i = $column; $i < ($column + $colspan); ++$i) {
                         if (isset($columnsMinWidthProcessed[$i])) {
                             continue;
                         }
-                        $this->columnWidths[$i] = $cellWidth + $lengthColumnBorder;
+                        // a width set through setColumnWidth() is a minimum, unlike one computed for an earlier row
+                        $this->columnWidths[$i] = max($this->configuredColumnWidths[$i] ?? 0, $cellWidth + $lengthColumnBorder);
                     }
                 }
                 if (!str_contains($cell ?? '', "\n")) {

--- a/src/Symfony/Component/Console/Tests/Helper/TableTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/TableTest.php
@@ -1154,6 +1154,89 @@ class TableTest extends TestCase
         $this->assertEquals($expected, $this->getOutputContent($output));
     }
 
+    public function testColumnWidthIsKeptWhenARowSpansColumns()
+    {
+        $table = new Table($output = $this->getOutputStream());
+        $table
+            ->setHeaders(['ISBN', 'Author'])
+            ->setRows([
+                ['9971-5-0210-0', 'Dante Alighieri'],
+                [new TableCell('span', ['colspan' => 2])],
+            ])
+            ->setColumnWidth(0, 20);
+
+        $table->render();
+
+        $expected =
+            <<<TABLE
+                +----------------------+-----------------+
+                | ISBN                 | Author          |
+                +----------------------+-----------------+
+                | 9971-5-0210-0        | Dante Alighieri |
+                | span                                   |
+                +----------------------------------------+
+
+                TABLE;
+
+        $this->assertEquals($expected, $this->getOutputContent($output));
+    }
+
+    public function testColumnMinWidthDoesNotInflateSiblingColumns()
+    {
+        $table = new Table($output = $this->getOutputStream());
+        $table
+            ->setHeaders(['A', 'B'])
+            ->setRows([
+                ['x', 'y'],
+                [new TableCell('short span', ['colspan' => 2])],
+            ])
+            ->setColumnWidth(0, 20);
+
+        $table->render();
+
+        $expected =
+            <<<TABLE
+                +----------------------+-------+
+                | A                    | B     |
+                +----------------------+-------+
+                | x                    | y     |
+                | short span                   |
+                +------------------------------+
+
+                TABLE;
+
+        $this->assertEquals($expected, $this->getOutputContent($output));
+    }
+
+    public function testColumnWidthComputedForASpanningRowIsNotReusedByTheNextOne()
+    {
+        $table = new Table($output = $this->getOutputStream());
+        $table
+            ->setHeaders(['H0', 'H1'])
+            ->setRows([
+                ['value0', 'value1'],
+                [new TableCell('zzzzz', ['colspan' => 2])],
+                [new TableCell('qq', ['colspan' => 2])],
+            ])
+            ->setColumnMaxWidth(1, 6);
+
+        $table->render();
+
+        $expected =
+            <<<TABLE
+                +--------+--------+
+                | H0     | H1     |
+                +--------+--------+
+                | value0 | value1 |
+                | zzzzz           |
+                | qq              |
+                +-----------------+
+
+                TABLE;
+
+        $this->assertEquals($expected, $this->getOutputContent($output));
+    }
+
     public function testSectionOutput()
     {
         $sections = [];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65064
| License       | MIT

`setColumnWidth()` sets a minimum column width. It works fine, until one row uses a `colspan` cell. Then two things go wrong at once (both described in #65064):

* the configured minimum is thrown away and the column shrinks to its content;
* the *other* spanned column becomes wider than it is without that minimum.

Both come from the same block in `Table::buildTableRows()` that shares a `colspan` cell over the columns it covers and writes into the same `$columnWidths` array `setColumnWidth()` uses. A configured column is now kept as a floor, and its width is subtracted before the rest of the cell is shared out — the same "pin and subtract" the maximum-width branch just above already does.

```php
(new Table($output))
    ->setStyle('box')
    ->setColumnWidth(0, 20)
    ->setRows([
        ['x', 'y'],
        [new TableCell('short span', ['colspan' => 2])],
    ])
    ->render();
```

Before (column A is 13 wide instead of 20, and column B is 13 too):

```
┌───────────────┬───────────────┐
│ x             │ y             │
│ short span                    │
└───────────────────────────────┘
```

After (column A keeps its minimum of 20; column B is 5, the same width it has when no minimum is set on column A):

```
┌──────────────────────┬───────┐
│ x                    │ y     │
│ short span                   │
└──────────────────────────────┘
```

Without the `colspan` row the minimum is already honored and column B stays small, so both problems only show up when a row spans columns.
