### PR TITLE
[Mailer] Fix rewriting cid references of inline parts for Mailgun

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Transport/MailgunApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Transport/MailgunApiTransportTest.php
@@ -22,6 +22,7 @@ use Symfony\Component\Mailer\Header\MetadataHeader;
 use Symfony\Component\Mailer\Header\TagHeader;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
+use Symfony\Component\Mime\Part\DataPart;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class MailgunApiTransportTest extends TestCase
@@ -178,6 +179,37 @@ class MailgunApiTransportTest extends TestCase
         $message = $transport->send($mail);
 
         $this->assertSame('foobar2', $message->getMessageId());
+    }
+
+    public function testSendWithInlineAttachmentsSharingANamePrefix()
+    {
+        $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
+            $content = '';
+            while ($chunk = $options['body']()) {
+                $content .= $chunk;
+            }
+
+            $this->assertStringContainsString("name=\"inline[0]\"; filename=\"b\"\r\n", $content);
+            $this->assertStringContainsString("name=\"inline[1]\"; filename=\"c\"\r\n", $content);
+            $this->assertStringContainsString("\r\n\r\n<img src=\"cid:b\"><img src=\"cid:c\">\r\n", $content);
+
+            return new JsonMockResponse(['id' => 'foobar'], [
+                'http_code' => 200,
+            ]);
+        });
+        $transport = new MailgunApiTransport('ACCESS_KEY', 'symfony', 'us-east-1', $client);
+
+        $mail = new Email();
+        $mail->subject('Hello!')
+            ->to(new Address('saif.gmati@symfony.com', 'Saif Eddin'))
+            ->from(new Address('fabpot@symfony.com', 'Fabien'))
+            ->html('<img src="cid:a/b"><img src="cid:a/b/c">')
+            ->addPart((new DataPart('image', 'a/b', 'image/png'))->asInline())
+            ->addPart((new DataPart('nested-image', 'a/b/c', 'image/png'))->asInline());
+
+        $message = $transport->send($mail);
+
+        $this->assertSame('foobar', $message->getMessageId());
     }
 
     public function testSendThrowsForErrorResponse()

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunApiTransport.php
@@ -152,7 +152,7 @@ class MailgunApiTransport extends AbstractApiTransport
 
     private function prepareAttachments(Email $email, ?string $html): array
     {
-        $attachments = $inlines = [];
+        $attachments = $inlines = $replacements = [];
         foreach ($email->getAttachments() as $attachment) {
             $headers = $attachment->getPreparedHeaders();
             if ('inline' === $headers->getHeaderBody('Content-Disposition')) {
@@ -160,7 +160,7 @@ class MailgunApiTransport extends AbstractApiTransport
                 if ($html) {
                     $filename = $headers->getHeaderParameter('Content-Disposition', 'filename');
                     $new = basename($filename);
-                    $html = str_replace('cid:'.$filename, 'cid:'.$new, $html);
+                    $replacements['cid:'.$filename] = 'cid:'.$new;
                     $p = new \ReflectionProperty($attachment, 'filename');
                     $p->setValue($attachment, $new);
                 }
@@ -170,7 +170,8 @@ class MailgunApiTransport extends AbstractApiTransport
             }
         }
 
-        return [$attachments, $inlines, $html];
+        // strtr() replaces the longest match first and never rewrites what it already replaced
+        return [$attachments, $inlines, $replacements ? strtr($html, $replacements) : $html];
     }
 
     private function getEndpoint(): ?string


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`MailgunApiTransport::prepareAttachments()` rewrites `cid:<name>` into `cid:<basename>` because a bare file name is the only form Mailgun accepts. It did so with one `str_replace()` per inline part, each applied to the result of the previous one, so a part whose name is a path prefix of another part's name corrupted the other reference.

With two inline parts named `a/b` and `a/b/c`, and an HTML body referencing both, the first pass turned `cid:a/b/c` into `cid:b/c`. The second pass then looked for `cid:a/b/c`, which no longer existed, and did nothing. The payload went out with `cid:b/c` while the part itself was sent as `c`, so the image did not resolve. Adding the same two parts in the opposite order happens to produce the correct result, which is why this is rarely noticed.

The replacements are now collected and applied in a single `strtr()` call, which matches the longest name first and never rewrites what it already replaced. Parts whose names are not in a prefix relation are unaffected.

Same defect and same fix as #65062, which addresses the equivalent loop in `Mime\Email::prepareParts()`.
