### PR TITLE
[DependencyInjection] Remove the deprecation about default index/priority methods

### DIFF
--- a/UPGRADE-8.1.md
+++ b/UPGRADE-8.1.md
@@ -25,7 +25,6 @@ DependencyInjection
 -------------------
 
  * Deprecate configuring options `alias`, `parent`, `synthetic`, `file`, `arguments`, `properties`, `configurator` or `calls` when using `from_callable`
- * Deprecate default index/priority methods when defining tagged locators/iterators; use the `#[AsTaggedItem]` attribute instead
  * Deprecate named autowiring aliases that don't use `#[Target]`
    ```diff
     use Symfony\Component\DependencyInjection\Attribute\Target;

--- a/src/Symfony/Component/DependencyInjection/Argument/TaggedIteratorArgument.php
+++ b/src/Symfony/Component/DependencyInjection/Argument/TaggedIteratorArgument.php
@@ -43,7 +43,6 @@ class TaggedIteratorArgument extends IteratorArgument
 
         if (\func_num_args() > 5 || !\is_bool($needsIndexes) || !\is_array($exclude) || !\is_bool($excludeSelf)) {
             [, , $defaultIndexMethod, $needsIndexes, $defaultPriorityMethod, $exclude, $excludeSelf] = \func_get_args() + [2 => null, false, null, [], true];
-            trigger_deprecation('symfony/dependency-injection', '8.1', 'The $defaultIndexMethod and $defaultPriorityMethod arguments of tagged locators and iterators are deprecated, use the #[AsTaggedItem] attribute instead. (tag: "%s")', $tag);
         } else {
             $defaultIndexMethod = $defaultPriorityMethod = false;
         }
@@ -70,15 +69,8 @@ class TaggedIteratorArgument extends IteratorArgument
         return $this->indexAttribute;
     }
 
-    /**
-     * @deprecated since Symfony 8.1, use the #[AsTaggedItem] attribute instead of default methods
-     */
-    public function getDefaultIndexMethod(/* bool $triggerDeprecation = true */): ?string
+    public function getDefaultIndexMethod(): ?string
     {
-        if (!\func_num_args() || func_get_arg(0)) {
-            trigger_deprecation('symfony/dependency-injection', '8.1', 'The "%s()" method is deprecated, use the #[AsTaggedItem] attribute instead of default methods.', __METHOD__);
-        }
-
         return $this->defaultIndexMethod;
     }
 
@@ -87,15 +79,8 @@ class TaggedIteratorArgument extends IteratorArgument
         return $this->needsIndexes;
     }
 
-    /**
-     * @deprecated since Symfony 8.1, use the #[AsTaggedItem] attribute instead of default methods
-     */
-    public function getDefaultPriorityMethod(/* bool $triggerDeprecation = true */): ?string
+    public function getDefaultPriorityMethod(): ?string
     {
-        if (!\func_num_args() || func_get_arg(0)) {
-            trigger_deprecation('symfony/dependency-injection', '8.1', 'The "%s()" method is deprecated, use the #[AsTaggedItem] attribute instead of default methods.', __METHOD__);
-        }
-
         return $this->defaultPriorityMethod;
     }
 

--- a/src/Symfony/Component/DependencyInjection/Attribute/AutowireLocator.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/AutowireLocator.php
@@ -59,9 +59,6 @@ class AutowireLocator extends Autowire
 
             return;
         }
-        if (false !== $defaultIndexMethod || false !== $defaultPriorityMethod) {
-            trigger_deprecation('symfony/dependency-injection', '8.1', 'The $defaultIndexMethod and $defaultPriorityMethod arguments of tagged locators and iterators attributes are deprecated, use the #[AsTaggedItem] attribute instead of default methods.');
-        }
 
         $references = [];
 

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -13,7 +13,6 @@ CHANGELOG
  * Add support for decorating all services with a specific tag using the `container.tag_decorator` resource tag or `#[AsTagDecorator]`
  * Add support for `SOURCE_DATE_EPOCH` environment variable
  * Deprecate configuring options `alias`, `parent`, `synthetic`, `file`, `arguments`, `properties`, `configurator` or `calls` when using `from_callable`
- * Deprecate default index/priority methods when defining tagged locators/iterators; use the `#[AsTaggedItem]` attribute instead
  * Allow environment variables with `.` in them
  * Add argument `exclude` to `ContainerConfigurator::import()`
  * Add `target` parameter to `#[AsAlias]` to create target-specific autowiring aliases

--- a/src/Symfony/Component/DependencyInjection/Compiler/PriorityTaggedServiceTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PriorityTaggedServiceTrait.php
@@ -43,9 +43,9 @@ trait PriorityTaggedServiceTrait
 
         if ($tagName instanceof TaggedIteratorArgument) {
             $indexAttribute = $tagName->getIndexAttribute();
-            $defaultIndexMethod = $tagName->getDefaultIndexMethod(false);
+            $defaultIndexMethod = $tagName->getDefaultIndexMethod();
             $needsIndexes = $tagName->needsIndexes();
-            $defaultPriorityMethod = $tagName->getDefaultPriorityMethod(false) ?? 'getDefaultPriority';
+            $defaultPriorityMethod = $tagName->getDefaultPriorityMethod() ?? 'getDefaultPriority';
             $exclude = array_merge($exclude, $tagName->getExclude());
             $tagName = $tagName->getTag();
         }
@@ -186,8 +186,6 @@ class PriorityTaggedServiceUtil
         if (!$rm->isPublic()) {
             throw new InvalidArgumentException(implode('be public', $message));
         }
-
-        trigger_deprecation('symfony/dependency-injection', '8.1', 'Calling "%s::%s()" to get the "%s" index is deprecated, use the #[AsTaggedItem] attribute instead.', $class, $defaultMethod, $indexAttribute);
 
         $default = $rm->invoke(null);
 

--- a/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
@@ -325,11 +325,11 @@ class XmlDumper extends Dumper
 
                     $defaultPrefix = 'getDefault'.str_replace(' ', '', ucwords(preg_replace('/[^a-zA-Z0-9\x7f-\xff]++/', ' ', $tag->getIndexAttribute())));
 
-                    if ($tag->getDefaultIndexMethod(false) !== $defaultPrefix.'Name') {
-                        $xmlAttr .= \sprintf(' default-index-method="%s"', $this->encode($tag->getDefaultIndexMethod(false)));
+                    if ($tag->getDefaultIndexMethod() !== $defaultPrefix.'Name') {
+                        $xmlAttr .= \sprintf(' default-index-method="%s"', $this->encode($tag->getDefaultIndexMethod()));
                     }
-                    if ($tag->getDefaultPriorityMethod(false) !== $defaultPrefix.'Priority') {
-                        $xmlAttr .= \sprintf(' default-priority-method="%s"', $this->encode($tag->getDefaultPriorityMethod(false)));
+                    if ($tag->getDefaultPriorityMethod() !== $defaultPrefix.'Priority') {
+                        $xmlAttr .= \sprintf(' default-priority-method="%s"', $this->encode($tag->getDefaultPriorityMethod()));
                     }
                 }
                 if (1 === \count($excludes = $tag->getExclude())) {

--- a/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
@@ -278,11 +278,11 @@ class YamlDumper extends Dumper
 
                     $defaultPrefix = 'getDefault'.str_replace(' ', '', ucwords(preg_replace('/[^a-zA-Z0-9\x7f-\xff]++/', ' ', $tag->getIndexAttribute())));
 
-                    if (!\in_array($tag->getDefaultIndexMethod(false), [null, $defaultPrefix.'Name'], true)) {
-                        $content['default_index_method'] = $tag->getDefaultIndexMethod(false);
+                    if (!\in_array($tag->getDefaultIndexMethod(), [null, $defaultPrefix.'Name'], true)) {
+                        $content['default_index_method'] = $tag->getDefaultIndexMethod();
                     }
-                    if (!\in_array($tag->getDefaultPriorityMethod(false), [null, $defaultPrefix.'Priority'], true)) {
-                        $content['default_priority_method'] = $tag->getDefaultPriorityMethod(false);
+                    if (!\in_array($tag->getDefaultPriorityMethod(), [null, $defaultPrefix.'Priority'], true)) {
+                        $content['default_priority_method'] = $tag->getDefaultPriorityMethod();
                     }
                 }
                 if ($excludes = $tag->getExclude()) {

--- a/src/Symfony/Component/DependencyInjection/Tests/Argument/TaggedIteratorArgumentTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Argument/TaggedIteratorArgumentTest.php
@@ -12,8 +12,6 @@
 namespace Symfony\Component\DependencyInjection\Tests\Argument;
 
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 
@@ -25,9 +23,9 @@ class TaggedIteratorArgumentTest extends TestCase
 
         $this->assertSame('foo', $taggedIteratorArgument->getTag());
         $this->assertNull($taggedIteratorArgument->getIndexAttribute());
-        $this->assertNull($taggedIteratorArgument->getDefaultIndexMethod(false));
+        $this->assertNull($taggedIteratorArgument->getDefaultIndexMethod());
         $this->assertFalse($taggedIteratorArgument->needsIndexes());
-        $this->assertNull($taggedIteratorArgument->getDefaultPriorityMethod(false));
+        $this->assertNull($taggedIteratorArgument->getDefaultPriorityMethod());
     }
 
     public function testOnlyTagWithNeedsIndexes()
@@ -36,8 +34,8 @@ class TaggedIteratorArgumentTest extends TestCase
 
         $this->assertSame('foo', $taggedIteratorArgument->getTag());
         $this->assertSame('foo', $taggedIteratorArgument->getIndexAttribute());
-        $this->assertSame('getDefaultFooName', $taggedIteratorArgument->getDefaultIndexMethod(false));
-        $this->assertSame('getDefaultFooPriority', $taggedIteratorArgument->getDefaultPriorityMethod(false));
+        $this->assertSame('getDefaultFooName', $taggedIteratorArgument->getDefaultIndexMethod());
+        $this->assertSame('getDefaultFooPriority', $taggedIteratorArgument->getDefaultPriorityMethod());
     }
 
     public function testOnlyTagWithNeedsIndexesAndDotTag()
@@ -46,8 +44,8 @@ class TaggedIteratorArgumentTest extends TestCase
 
         $this->assertSame('foo.bar', $taggedIteratorArgument->getTag());
         $this->assertSame('bar', $taggedIteratorArgument->getIndexAttribute());
-        $this->assertSame('getDefaultBarName', $taggedIteratorArgument->getDefaultIndexMethod(false));
-        $this->assertSame('getDefaultBarPriority', $taggedIteratorArgument->getDefaultPriorityMethod(false));
+        $this->assertSame('getDefaultBarName', $taggedIteratorArgument->getDefaultIndexMethod());
+        $this->assertSame('getDefaultBarPriority', $taggedIteratorArgument->getDefaultPriorityMethod());
     }
 
     public function testOnlyTagWithNeedsIndexesAndDotsTag()
@@ -56,13 +54,11 @@ class TaggedIteratorArgumentTest extends TestCase
 
         $this->assertSame('foo.bar.baz.qux', $taggedIteratorArgument->getTag());
         $this->assertSame('qux', $taggedIteratorArgument->getIndexAttribute());
-        $this->assertSame('getDefaultQuxName', $taggedIteratorArgument->getDefaultIndexMethod(false));
-        $this->assertSame('getDefaultQuxPriority', $taggedIteratorArgument->getDefaultPriorityMethod(false));
+        $this->assertSame('getDefaultQuxName', $taggedIteratorArgument->getDefaultIndexMethod());
+        $this->assertSame('getDefaultQuxPriority', $taggedIteratorArgument->getDefaultPriorityMethod());
     }
 
     #[DataProvider('defaultIndexMethodProvider')]
-    #[IgnoreDeprecations]
-    #[Group('legacy')]
     public function testDefaultIndexMethod(?string $indexAttribute, ?string $defaultIndexMethod, ?string $expectedDefaultIndexMethod)
     {
         $taggedIteratorArgument = new TaggedIteratorArgument('foo', $indexAttribute, $defaultIndexMethod);
@@ -110,8 +106,6 @@ class TaggedIteratorArgumentTest extends TestCase
     }
 
     #[DataProvider('defaultPriorityMethodProvider')]
-    #[IgnoreDeprecations]
-    #[Group('legacy')]
     public function testDefaultPriorityIndexMethod(?string $indexAttribute, ?string $defaultPriorityMethod, ?string $expectedDefaultPriorityMethod)
     {
         $taggedIteratorArgument = new TaggedIteratorArgument('foo', $indexAttribute, null, false, $defaultPriorityMethod);

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/IntegrationTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/IntegrationTest.php
@@ -12,8 +12,6 @@
 namespace Symfony\Component\DependencyInjection\Tests\Compiler;
 
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\Config\FileLocator;
@@ -345,8 +343,6 @@ class IntegrationTest extends TestCase
         ];
     }
 
-    #[IgnoreDeprecations]
-    #[Group('legacy')]
     public function testTaggedServiceWithIndexAttribute()
     {
         $container = new ContainerBuilder();
@@ -371,8 +367,6 @@ class IntegrationTest extends TestCase
         $this->assertSame(['bar' => $container->get(BarTagClass::class), 'foo_tag_class' => $container->get(FooTagClass::class)], $param);
     }
 
-    #[IgnoreDeprecations]
-    #[Group('legacy')]
     public function testTaggedServiceWithIndexAttributeAndDefaultMethod()
     {
         $container = new ContainerBuilder();
@@ -424,8 +418,6 @@ class IntegrationTest extends TestCase
         self::assertSame('foo', $s->locator->get('subscribed1'));
     }
 
-    #[IgnoreDeprecations]
-    #[Group('legacy')]
     public function testTaggedServiceWithIndexAttributeAndDefaultMethodConfiguredViaAttribute()
     {
         $container = new ContainerBuilder();
@@ -450,8 +442,6 @@ class IntegrationTest extends TestCase
         $this->assertSame(['bar_tab_class_with_defaultmethod' => $container->get(BarTagClass::class), 'foo' => $container->get(FooTagClass::class)], $param);
     }
 
-    #[IgnoreDeprecations]
-    #[Group('legacy')]
     public function testTaggedIteratorWithDefaultIndexMethodConfiguredViaAttribute()
     {
         $container = new ContainerBuilder();
@@ -476,8 +466,6 @@ class IntegrationTest extends TestCase
         $this->assertSame(['bar_tag_class' => $container->get(BarTagClass::class), 'foo_tag_class' => $container->get(FooTagClass::class)], $param);
     }
 
-    #[IgnoreDeprecations]
-    #[Group('legacy')]
     public function testTaggedIteratorWithDefaultPriorityMethodConfiguredViaAttribute()
     {
         $container = new ContainerBuilder();
@@ -502,8 +490,6 @@ class IntegrationTest extends TestCase
         $this->assertSame([0 => $container->get(FooTagClass::class), 1 => $container->get(BarTagClass::class)], $param);
     }
 
-    #[IgnoreDeprecations]
-    #[Group('legacy')]
     public function testTaggedIteratorWithDefaultIndexMethodAndWithDefaultPriorityMethodConfiguredViaAttribute()
     {
         $container = new ContainerBuilder();
@@ -528,8 +514,6 @@ class IntegrationTest extends TestCase
         $this->assertSame(['foo_tag_class' => $container->get(FooTagClass::class), 'bar_tag_class' => $container->get(BarTagClass::class)], $param);
     }
 
-    #[IgnoreDeprecations]
-    #[Group('legacy')]
     public function testTaggedLocatorConfiguredViaAttribute()
     {
         $container = new ContainerBuilder();
@@ -556,8 +540,6 @@ class IntegrationTest extends TestCase
         self::assertSame($container->get(FooTagClass::class), $locator->get('foo'));
     }
 
-    #[IgnoreDeprecations]
-    #[Group('legacy')]
     public function testTaggedLocatorConfiguredViaAttributeWithoutIndex()
     {
         $container = new ContainerBuilder();
@@ -584,8 +566,6 @@ class IntegrationTest extends TestCase
         self::assertSame($container->get(FooTagClass::class), $locator->get(FooTagClass::class));
     }
 
-    #[IgnoreDeprecations]
-    #[Group('legacy')]
     public function testTaggedLocatorWithDefaultIndexMethodConfiguredViaAttribute()
     {
         $container = new ContainerBuilder();
@@ -612,8 +592,6 @@ class IntegrationTest extends TestCase
         self::assertSame($container->get(FooTagClass::class), $locator->get('foo_tag_class'));
     }
 
-    #[IgnoreDeprecations]
-    #[Group('legacy')]
     public function testTaggedLocatorWithDefaultPriorityMethodConfiguredViaAttribute()
     {
         $container = new ContainerBuilder();
@@ -643,8 +621,6 @@ class IntegrationTest extends TestCase
         self::assertSame([FooTagClass::class, BarTagClass::class], array_keys($factories->getValue($locator)));
     }
 
-    #[IgnoreDeprecations]
-    #[Group('legacy')]
     public function testTaggedLocatorWithDefaultIndexMethodAndWithDefaultPriorityMethodConfiguredViaAttribute()
     {
         $container = new ContainerBuilder();
@@ -676,8 +652,6 @@ class IntegrationTest extends TestCase
         self::assertSame($container->get(FooTagClass::class), $locator->get('foo_tag_class'));
     }
 
-    #[IgnoreDeprecations]
-    #[Group('legacy')]
     public function testNestedDefinitionWithAutoconfiguredConstructorArgument()
     {
         $container = new ContainerBuilder();
@@ -725,8 +699,6 @@ class IntegrationTest extends TestCase
         self::assertSame($container->get(FooTagClass::class), $locator->get('my_service'));
     }
 
-    #[IgnoreDeprecations]
-    #[Group('legacy')]
     public function testTaggedServiceWithDefaultPriorityMethod()
     {
         $container = new ContainerBuilder();
@@ -751,8 +723,6 @@ class IntegrationTest extends TestCase
         $this->assertSame([$container->get(FooTagClass::class), $container->get(BarTagClass::class)], $param);
     }
 
-    #[IgnoreDeprecations]
-    #[Group('legacy')]
     public function testTaggedServiceLocatorWithIndexAttribute()
     {
         $container = new ContainerBuilder();
@@ -784,8 +754,6 @@ class IntegrationTest extends TestCase
         $this->assertSame(['bar' => $container->get('bar_tag'), 'foo_tag_class' => $container->get('foo_tag')], $same);
     }
 
-    #[IgnoreDeprecations]
-    #[Group('legacy')]
     public function testTaggedServiceLocatorWithMultipleIndexAttribute()
     {
         $container = new ContainerBuilder();
@@ -820,8 +788,6 @@ class IntegrationTest extends TestCase
         $this->assertSame(['bar' => $container->get('bar_tag'), 'bar_duplicate' => $container->get('bar_tag'), 'foo_tag_class' => $container->get('foo_tag')], $same);
     }
 
-    #[IgnoreDeprecations]
-    #[Group('legacy')]
     public function testTaggedServiceLocatorWithIndexAttributeAndDefaultMethod()
     {
         $container = new ContainerBuilder();

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/PriorityTaggedServiceTraitTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/PriorityTaggedServiceTraitTest.php
@@ -12,8 +12,6 @@
 namespace Symfony\Component\DependencyInjection\Tests\Compiler;
 
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\Attribute\AsTaggedItem;
@@ -117,8 +115,6 @@ class PriorityTaggedServiceTraitTest extends TestCase
         $this->assertEquals($expected, $priorityTaggedServiceTraitImplementation->test('my_custom_tag', $container));
     }
 
-    #[IgnoreDeprecations]
-    #[Group('legacy')]
     public function testOnlyTheIndexedTagsAreListed()
     {
         $container = new ContainerBuilder();
@@ -145,8 +141,6 @@ class PriorityTaggedServiceTraitTest extends TestCase
         $this->assertEquals($expected, $priorityTaggedServiceTraitImplementation->test($tag, $container));
     }
 
-    #[IgnoreDeprecations]
-    #[Group('legacy')]
     public function testTheIndexedTagsByDefaultIndexMethod()
     {
         $container = new ContainerBuilder();
@@ -179,8 +173,6 @@ class PriorityTaggedServiceTraitTest extends TestCase
     }
 
     #[DataProvider('provideInvalidDefaultMethods')]
-    #[IgnoreDeprecations]
-    #[Group('legacy')]
     public function testTheIndexedTagsByDefaultIndexMethodFailure(string $defaultIndexMethod, ?string $indexAttribute, string $expectedExceptionMessage)
     {
         $this->expectException(InvalidArgumentException::class);
@@ -206,8 +198,6 @@ class PriorityTaggedServiceTraitTest extends TestCase
         yield ['getMethodShouldBePublicInsteadPrivate', 'foo', \sprintf('Either method "%s::getMethodShouldBePublicInsteadPrivate()" should be public or tag "my_custom_tag" on service "service1" is missing attribute "foo".', FooTaggedForInvalidDefaultMethodClass::class)];
     }
 
-    #[IgnoreDeprecations]
-    #[Group('legacy')]
     public function testTaggedItemAttributes()
     {
         $container = new ContainerBuilder();
@@ -250,8 +240,6 @@ class PriorityTaggedServiceTraitTest extends TestCase
         $this->assertEquals($expected, $priorityTaggedServiceTraitImplementation->test($tag, $container));
     }
 
-    #[IgnoreDeprecations]
-    #[Group('legacy')]
     public function testResolveIndexedTags()
     {
         $container = new ContainerBuilder();
@@ -280,8 +268,6 @@ class PriorityTaggedServiceTraitTest extends TestCase
         $this->assertEquals($expected, $priorityTaggedServiceTraitImplementation->test($tag, $container));
     }
 
-    #[IgnoreDeprecations]
-    #[Group('legacy')]
     public function testAttributesAreMergedWithTags()
     {
         $container = new ContainerBuilder();
@@ -307,8 +293,6 @@ class PriorityTaggedServiceTraitTest extends TestCase
         $this->assertEquals($expected, $services);
     }
 
-    #[IgnoreDeprecations]
-    #[Group('legacy')]
     public function testAttributesAreFallbacks()
     {
         $container = new ContainerBuilder();
@@ -326,8 +310,6 @@ class PriorityTaggedServiceTraitTest extends TestCase
         $this->assertEquals(['z' => new TypedReference('service_attr_first', MultiTagHelloNamedService::class)], $services);
     }
 
-    #[IgnoreDeprecations]
-    #[Group('legacy')]
     public function testTaggedIteratorWithDefaultNameMethod()
     {
         $container = new ContainerBuilder();
@@ -340,8 +322,6 @@ class PriorityTaggedServiceTraitTest extends TestCase
         $this->assertEquals([new Reference('service')], $services);
     }
 
-    #[IgnoreDeprecations]
-    #[Group('legacy')]
     public function testIndexedIteratorUsesTagAttributeOverDefaultMethod()
     {
         $container = new ContainerBuilder();
@@ -359,8 +339,6 @@ class PriorityTaggedServiceTraitTest extends TestCase
         $this->assertSame('service.a', (string) $services['from_tag']);
     }
 
-    #[IgnoreDeprecations]
-    #[Group('legacy')]
     public function testIndexedIteratorUsesDefaultMethodAsFallback()
     {
         $container = new ContainerBuilder();
@@ -377,8 +355,6 @@ class PriorityTaggedServiceTraitTest extends TestCase
         $this->assertInstanceOf(TypedReference::class, $services['from_static_method']);
     }
 
-    #[IgnoreDeprecations]
-    #[Group('legacy')]
     public function testIndexedIteratorUsesTagIndexAndDefaultPriorityMethod()
     {
         $container = new ContainerBuilder();
@@ -400,8 +376,6 @@ class PriorityTaggedServiceTraitTest extends TestCase
         $this->assertSame(['tag_index', 'another_index'], array_keys($services));
     }
 
-    #[IgnoreDeprecations]
-    #[Group('legacy')]
     public function testTaggedLocatorWithProvidedIndexAttributeAndNonStaticDefaultIndexMethod()
     {
         $container = new ContainerBuilder();
@@ -415,8 +389,6 @@ class PriorityTaggedServiceTraitTest extends TestCase
         $this->assertEquals(['foo' => new TypedReference('service', NonStaticDefaultIndexClass::class)], $services);
     }
 
-    #[IgnoreDeprecations]
-    #[Group('legacy')]
     public function testTaggedLocatorWithoutIndexAttributeAndNonStaticDefaultIndexMethod()
     {
         $this->expectException(InvalidArgumentException::class);
@@ -448,8 +420,6 @@ class PriorityTaggedServiceTraitTest extends TestCase
         $this->assertEquals(['bar' => new TypedReference('service', AsTaggedItemClassWithBusinessMethod::class)], $services);
     }
 
-    #[IgnoreDeprecations]
-    #[Group('legacy')]
     public function testPriorityFallbackWithoutIndexAndStaticPriorityMethod()
     {
         $container = new ContainerBuilder();
@@ -463,8 +433,6 @@ class PriorityTaggedServiceTraitTest extends TestCase
         $this->assertEquals([new Reference('service')], $services);
     }
 
-    #[IgnoreDeprecations]
-    #[Group('legacy')]
     public function testMultiTagsWithMixedAttributesAndNonStaticDefault()
     {
         $container = new ContainerBuilder();

--- a/src/Symfony/Component/DependencyInjection/Tests/CrossCheckTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/CrossCheckTest.php
@@ -12,8 +12,6 @@
 namespace Symfony\Component\DependencyInjection\Tests;
 
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -33,8 +31,6 @@ class CrossCheckTest extends TestCase
     }
 
     #[DataProvider('crossCheckYamlLoadersDumpers')]
-    #[IgnoreDeprecations]
-    #[Group('legacy')]
     public function testYamlCrossCheck($fixture)
     {
         $tmp = tempnam(sys_get_temp_dir(), 'sf');

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/XmlDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/XmlDumperTest.php
@@ -12,8 +12,6 @@
 namespace Symfony\Component\DependencyInjection\Tests\Dumper;
 
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Argument\AbstractArgument;
 use Symfony\Component\DependencyInjection\Argument\EnvClosureArgument;
@@ -232,8 +230,6 @@ class XmlDumperTest extends TestCase
         $this->assertXmlStringEqualsGeneratedXmlFile('services_with_tagged_arguments.xml', $dumper->dump());
     }
 
-    #[IgnoreDeprecations]
-    #[Group('legacy')]
     public function testLegacyTaggedArguments()
     {
         $taggedIterator = new TaggedIteratorArgument('foo_tag', 'barfoo', 'foobar', false, 'getPriority');

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/YamlDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/YamlDumperTest.php
@@ -12,8 +12,6 @@
 namespace Symfony\Component\DependencyInjection\Tests\Dumper;
 
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Argument\AbstractArgument;
@@ -139,8 +137,6 @@ class YamlDumperTest extends TestCase
         $this->assertStringEqualsGeneratedFile('services_with_tagged_argument.yml', $dumper->dump());
     }
 
-    #[IgnoreDeprecations]
-    #[Group('legacy')]
     public function testDeprecatedTaggedArguments()
     {
         $taggedIterator = new TaggedIteratorArgument('foo', 'barfoo', 'foobar', false, 'getPriority');

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TaggedIteratorConsumerWithDefaultIndexMethod.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TaggedIteratorConsumerWithDefaultIndexMethod.php
@@ -4,9 +4,6 @@ namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
 
 use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 
-/**
- * @deprecated since Symfony 8.1
- */
 final class TaggedIteratorConsumerWithDefaultIndexMethod
 {
     public function __construct(

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TaggedIteratorConsumerWithDefaultIndexMethodAndWithDefaultPriorityMethod.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TaggedIteratorConsumerWithDefaultIndexMethodAndWithDefaultPriorityMethod.php
@@ -4,9 +4,6 @@ namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
 
 use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 
-/**
- * @deprecated since Symfony 8.1
- */
 final class TaggedIteratorConsumerWithDefaultIndexMethodAndWithDefaultPriorityMethod
 {
     public function __construct(

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TaggedIteratorConsumerWithDefaultPriorityMethod.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TaggedIteratorConsumerWithDefaultPriorityMethod.php
@@ -4,9 +4,6 @@ namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
 
 use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 
-/**
- * @deprecated since Symfony 8.1
- */
 final class TaggedIteratorConsumerWithDefaultPriorityMethod
 {
     public function __construct(

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TaggedLocatorConsumerWithDefaultIndexMethod.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TaggedLocatorConsumerWithDefaultIndexMethod.php
@@ -5,9 +5,6 @@ namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\DependencyInjection\Attribute\AutowireLocator;
 
-/**
- * @deprecated since Symfony 8.1
- */
 final class TaggedLocatorConsumerWithDefaultIndexMethod
 {
     public function __construct(

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TaggedLocatorConsumerWithDefaultIndexMethodAndWithDefaultPriorityMethod.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TaggedLocatorConsumerWithDefaultIndexMethodAndWithDefaultPriorityMethod.php
@@ -5,9 +5,6 @@ namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\DependencyInjection\Attribute\AutowireLocator;
 
-/**
- * @deprecated since Symfony 8.1
- */
 final class TaggedLocatorConsumerWithDefaultIndexMethodAndWithDefaultPriorityMethod
 {
     public function __construct(

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TaggedLocatorConsumerWithDefaultPriorityMethod.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TaggedLocatorConsumerWithDefaultPriorityMethod.php
@@ -5,9 +5,6 @@ namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\DependencyInjection\Attribute\AutowireLocator;
 
-/**
- * @deprecated since Symfony 8.1
- */
 final class TaggedLocatorConsumerWithDefaultPriorityMethod
 {
     public function __construct(

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/Configurator/ContainerConfiguratorTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/Configurator/ContainerConfiguratorTest.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Component\DependencyInjection\Tests\Loader\Configurator;
 
-use PHPUnit\Framework\Attributes\Group;
-use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
@@ -86,25 +84,21 @@ class ContainerConfiguratorTest extends TestCase
         $this->assertTrue($argument->excludeSelf());
     }
 
-    #[IgnoreDeprecations]
-    #[Group('legacy')]
     public function testTaggedIteratorBcDetectsNullPositionalDefaultPriorityMethod()
     {
         $argument = tagged_iterator('foo', 'idx', 'fetchId', null);
 
         $this->assertInstanceOf(TaggedIteratorArgument::class, $argument);
-        $this->assertSame('fetchId', $argument->getDefaultIndexMethod(false));
+        $this->assertSame('fetchId', $argument->getDefaultIndexMethod());
         $this->assertSame([], $argument->getExclude());
     }
 
-    #[IgnoreDeprecations]
-    #[Group('legacy')]
     public function testTaggedLocatorBcDetectsNullPositionalDefaultPriorityMethod()
     {
         $argument = tagged_locator('foo', 'idx', 'fetchId', null);
 
         $this->assertInstanceOf(ServiceLocatorArgument::class, $argument);
-        $this->assertSame('fetchId', $argument->getTaggedIteratorArgument()->getDefaultIndexMethod(false));
+        $this->assertSame('fetchId', $argument->getTaggedIteratorArgument()->getDefaultIndexMethod());
         $this->assertSame([], $argument->getTaggedIteratorArgument()->getExclude());
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -442,8 +442,6 @@ class YamlFileLoaderTest extends TestCase
         $this->assertEquals(new ServiceLocatorArgument($taggedIterator), $container->getDefinition('bar_service_tagged_locator')->getArgument(0));
     }
 
-    #[IgnoreDeprecations]
-    #[Group('legacy')]
     public function testDeprecatedTaggedArguments()
     {
         $container = new ContainerBuilder();
@@ -561,8 +559,6 @@ class YamlFileLoaderTest extends TestCase
         $loader->load('tag_name_no_string.yml');
     }
 
-    #[IgnoreDeprecations]
-    #[Group('legacy')]
     public function testParsesIteratorArgument()
     {
         $container = new ContainerBuilder();
@@ -1029,8 +1025,6 @@ class YamlFileLoaderTest extends TestCase
         $this->assertSame([['interface' => 'SomeInterface']], $definition->getTag('proxy'));
     }
 
-    #[IgnoreDeprecations]
-    #[Group('legacy')]
     public function testServiceWithSameNameAsInterfaceAndFactoryIsNotTagged()
     {
         $container = new ContainerBuilder();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no (removes one)
| Issues        | Fix #65057
| License       | MIT

Symfony 8.1 deprecated the *default index/priority methods* for tagged
iterators/locators in favor of the `#[AsTaggedItem]` attribute (#62339). In
practice that deprecation is triggered **once per matching tagged service on
every container compile**, so it floods the logs and makes debugging painful.

Since #64652 restored the ability to compute tag attributes dynamically
(closures / `[class-string, method]` callables, plus YAML `_instanceof`
support), the original reason to push people off default methods is largely
addressed. As 8.1 has not been released yet, this removes the deprecation
rather than shipping it as noise, as suggested in #65057.

This removes the four `trigger_deprecation()` calls:

 * `TaggedIteratorArgument` — the constructor and both `getDefault*Method()` getters
 * `PriorityTaggedServiceUtil::getDefault()` — the per-service one, the main source of noise
 * `AutowireLocator`

The default-methods feature itself keeps working exactly as before — only the
deprecation notices are gone.

Note: dropping the deprecation lets the `$triggerDeprecation` pseudo-argument of
`getDefaultIndexMethod()` / `getDefaultPriorityMethod()` go away too, since it
only ever existed to suppress the notice being removed. These getters are
effectively internal (used by the trait and the dumpers), and all internal
callers are updated accordingly.

The CHANGELOG/UPGRADE-8.1 entries for the deprecation are removed, and the
tests that only carried `#[IgnoreDeprecations]` / `#[Group('legacy')]` (and the
`@deprecated` docblocks on the related fixtures) for this deprecation are
cleaned up. Unrelated deprecations are left untouched.

The full `DependencyInjection` test suite passes with
`SYMFONY_DEPRECATIONS_HELPER=max` (1720 tests, 0 deprecations).