### PR TITLE
[Notifier][Telegram] Document how to build a multi-row inline keyboard

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Telegram/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/README.md
@@ -47,6 +47,28 @@ $chatMessage->options($telegramOptions);
 $chatter->send($chatMessage);
 ```
 
+An inline keyboard is a list of button rows. Every call to `inlineKeyboard()`
+appends one row, so call it once per row to spread the buttons over several
+lines:
+
+```php
+$telegramOptions = (new TelegramOptions())
+    ->chatId('@symfonynotifierdev')
+    ->replyMarkup((new InlineKeyboardMarkup())
+        ->inlineKeyboard([
+            (new InlineKeyboardButton('Yes'))->callbackData('yes'),
+            (new InlineKeyboardButton('No'))->callbackData('no'),
+        ])
+        ->inlineKeyboard([
+            (new InlineKeyboardButton('Visit symfony.com'))
+                ->url('https://symfony.com/'),
+        ])
+    );
+```
+
+The keyboard above shows "Yes" and "No" side by side on the first row, and the
+link alone on the second one.
+
 Adding files to a Message
 -------------------------
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64958
| License       | MIT

`InlineKeyboardMarkup::inlineKeyboard()` appends a row to the keyboard, so a keyboard with several rows is built by calling it once per row. Both examples in the README call it a single time, which reads as if a keyboard could only ever have one row. That is what #64958 reports.

This adds a short example showing two rows. No code change: the behavior has been there since the bridge was added.

Replaces #65012, which proposed accepting a nested array in the same argument.
