### PR TITLE
[Serializer] Add a "skip_invalid_attributes" denormalization option

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.2
 ---
 
+ * Add `AbstractNormalizer::SKIP_INVALID_ATTRIBUTES` to denormalize the attributes whose value cannot be used as if they were absent from the input
  * Allow passing an associative array to `CsvEncoder::HEADERS_KEY` to map and reorder columns when encoding
  * Use the discriminator property of an object to pick its type when several types map to the same class; the first declared type is used when the property is unset or unknown
  * Trigger a deprecation when denormalizing an array that is not a list into a `list`-typed property

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -130,6 +130,19 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
     public const FILTER_BOOL = 'filter_bool';
 
     /**
+     * While denormalizing, ignore the attributes whose value cannot be used.
+     *
+     * Such an attribute is handled as if it were absent from the input: a
+     * constructor argument falls back to DEFAULT_CONSTRUCTOR_ARGUMENTS, then to
+     * its default value, then to null when it is nullable; any other attribute
+     * is left untouched. No error is reported for it.
+     *
+     * Where ALLOW_EXTRA_ATTRIBUTES covers the attributes the class does not
+     * know about, this one covers the attributes it cannot use.
+     */
+    public const SKIP_INVALID_ATTRIBUTES = 'skip_invalid_attributes';
+
+    /**
      * @internal
      */
     protected const CIRCULAR_REFERENCE_LIMIT_COUNTERS = 'circular_reference_limit_counters';
@@ -336,6 +349,7 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
             $params = [];
             $unsetKeys = [];
             $collectedErrorCountBeforeConstructor = \count($context['not_normalizable_value_exceptions'] ?? []);
+            $skipInvalidAttributes = $context[self::SKIP_INVALID_ATTRIBUTES] ?? $this->defaultContext[self::SKIP_INVALID_ATTRIBUTES] ?? false;
 
             foreach ($constructorParameters as $constructorParameter) {
                 $paramName = $constructorParameter->name;
@@ -344,8 +358,10 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
 
                 $allowed = false === $allowedAttributes || \in_array($paramName, $allowedAttributes, true);
                 $ignored = !$this->isAllowedAttribute($class, $paramName, $format, $context);
+                $provided = $allowed && !$ignored && (isset($data[$key]) || \array_key_exists($key, $data));
+
                 if ($constructorParameter->isVariadic()) {
-                    if ($allowed && !$ignored && (isset($data[$key]) || \array_key_exists($key, $data))) {
+                    if ($provided) {
                         if (!\is_array($data[$key])) {
                             throw new RuntimeException(\sprintf('Cannot create an instance of "%s" from serialized data because the variadic parameter "%s" can only accept an array.', $class, $constructorParameter->name));
                         }
@@ -355,6 +371,10 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
                             try {
                                 $variadicParameters[$parameterKey] = $this->denormalizeParameter($reflectionClass, $constructorParameter, $paramName, $parameterData, $attributeContext, $format);
                             } catch (NotNormalizableValueException $exception) {
+                                if ($skipInvalidAttributes) {
+                                    continue;
+                                }
+
                                 if (!isset($context['not_normalizable_value_exceptions'])) {
                                     throw $exception;
                                 }
@@ -367,7 +387,11 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
                         $params = array_merge(array_values($params), $variadicParameters);
                         $unsetKeys[] = $key;
                     }
-                } elseif ($allowed && !$ignored && (isset($data[$key]) || \array_key_exists($key, $data))) {
+
+                    continue;
+                }
+
+                if ($provided) {
                     $parameterData = $data[$key];
                     if (null === $parameterData && $constructorParameter->allowsNull()) {
                         $params[$paramName] = null;
@@ -376,19 +400,28 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
                         continue;
                     }
 
+                    $unsetKeys[] = $key;
+                    $skipped = false;
+
                     try {
                         $params[$paramName] = $this->denormalizeParameter($reflectionClass, $constructorParameter, $paramName, $parameterData, $attributeContext, $format);
                     } catch (NotNormalizableValueException $exception) {
-                        if (!isset($context['not_normalizable_value_exceptions'])) {
+                        if ($skipInvalidAttributes) {
+                            $skipped = true;
+                        } elseif (!isset($context['not_normalizable_value_exceptions'])) {
                             throw $exception;
+                        } else {
+                            $context['not_normalizable_value_exceptions'][] = $exception;
+                            $params[$paramName] = $parameterData;
                         }
-
-                        $context['not_normalizable_value_exceptions'][] = $exception;
-                        $params[$paramName] = $parameterData;
                     }
 
-                    $unsetKeys[] = $key;
-                } elseif (\array_key_exists($key, $context[static::DEFAULT_CONSTRUCTOR_ARGUMENTS][$class] ?? [])) {
+                    if (!$skipped) {
+                        continue;
+                    }
+                }
+
+                if (\array_key_exists($key, $context[static::DEFAULT_CONSTRUCTOR_ARGUMENTS][$class] ?? [])) {
                     $params[$paramName] = $context[static::DEFAULT_CONSTRUCTOR_ARGUMENTS][$class][$key];
                 } elseif (\array_key_exists($key, $this->defaultContext[self::DEFAULT_CONSTRUCTOR_ARGUMENTS][$class] ?? [])) {
                     $params[$paramName] = $this->defaultContext[self::DEFAULT_CONSTRUCTOR_ARGUMENTS][$class][$key];

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -358,6 +358,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
         $originalNormalizedData = $normalizedData;
         $object = $this->instantiateObject($normalizedData, $mappedClass, $context, new \ReflectionClass($mappedClass), $allowedAttributes, $format);
         $resolvedClass = ($this->objectClassResolver)($object);
+        $skipInvalidAttributes = $context[self::SKIP_INVALID_ATTRIBUTES] ?? $this->defaultContext[self::SKIP_INVALID_ATTRIBUTES] ?? false;
 
         foreach ($normalizedData as $attribute => $value) {
             if ($this->nameConverter) {
@@ -415,6 +416,9 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                 try {
                     $value = $this->validateAndDenormalize($type, $resolvedClass, $attribute, $value, $format, $attributeContext);
                 } catch (NotNormalizableValueException $exception) {
+                    if ($skipInvalidAttributes) {
+                        continue;
+                    }
                     if (isset($context['not_normalizable_value_exceptions'])) {
                         $context['not_normalizable_value_exceptions'][] = $exception;
                         continue;
@@ -428,6 +432,9 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
             try {
                 $this->setAttributeValue($object, $attribute, $value, $format, $attributeContext);
             } catch (NotNormalizableValueException $exception) {
+                if ($skipInvalidAttributes) {
+                    continue;
+                }
                 if (isset($context['not_normalizable_value_exceptions'])) {
                     $context['not_normalizable_value_exceptions'][] = $exception;
                     continue;

--- a/src/Symfony/Component/Serializer/Tests/SkipInvalidAttributesTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SkipInvalidAttributesTest.php
@@ -1,0 +1,262 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
+use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
+use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
+use Symfony\Component\Serializer\Attribute\SerializedName;
+use Symfony\Component\Serializer\Exception\MissingConstructorArgumentsException;
+use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
+use Symfony\Component\Serializer\Exception\PartialDenormalizationException;
+use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
+use Symfony\Component\Serializer\Mapping\Loader\AttributeLoader;
+use Symfony\Component\Serializer\NameConverter\MetadataAwareNameConverter;
+use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
+use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
+use Symfony\Component\Serializer\Normalizer\BackedEnumNormalizer;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
+use Symfony\Component\Serializer\Serializer;
+use Symfony\Component\Serializer\Tests\Fixtures\StringBackedEnumDummy;
+
+class SkipInvalidAttributesTest extends TestCase
+{
+    private const SKIP = [AbstractNormalizer::SKIP_INVALID_ATTRIBUTES => true];
+
+    public function testConstructorArgumentFallsBackToItsDefault()
+    {
+        $dummy = $this->createSerializer()->denormalize(['page' => 'nope', 'query' => 'foo'], SkipInvalidDummy::class, null, self::SKIP);
+
+        $this->assertSame(1, $dummy->page);
+        $this->assertSame('foo', $dummy->query);
+    }
+
+    public function testConstructorArgumentInsideACollectionFallsBackToItsDefault()
+    {
+        $basket = $this->createSerializer()->denormalize(['lines' => [['quantity' => 'nope'], ['quantity' => 3]]], SkipInvalidBasket::class, null, self::SKIP);
+
+        $this->assertCount(2, $basket->lines);
+        $this->assertSame(0, $basket->lines[0]->quantity);
+        $this->assertSame(3, $basket->lines[1]->quantity);
+    }
+
+    public function testRenamedConstructorArgumentFallsBackToItsDefault()
+    {
+        $dummy = $this->createSerializer()->denormalize(['p' => 'nope'], SkipInvalidRenamedDummy::class, null, self::SKIP);
+
+        $this->assertSame(7, $dummy->page);
+    }
+
+    public function testConstructorArgumentFallsBackToTheDefaultConstructorArgumentsOption()
+    {
+        $dummy = $this->createSerializer()->denormalize(['page' => 'nope'], SkipInvalidDummy::class, null, self::SKIP + [
+            AbstractNormalizer::DEFAULT_CONSTRUCTOR_ARGUMENTS => [SkipInvalidDummy::class => ['page' => 42]],
+        ]);
+
+        $this->assertSame(42, $dummy->page);
+    }
+
+    public function testNullableConstructorArgumentWithoutDefaultFallsBackToNull()
+    {
+        $dummy = $this->createSerializer()->denormalize(['page' => 'nope'], SkipInvalidNullableDummy::class, null, self::SKIP);
+
+        $this->assertNull($dummy->page);
+    }
+
+    public function testRequiredConstructorArgumentIsReportedAsMissing()
+    {
+        $this->expectException(MissingConstructorArgumentsException::class);
+        $this->expectExceptionMessage('Cannot create an instance of "'.SkipInvalidRequiredDummy::class.'" from serialized data because its constructor requires the following parameters to be present : "$page".');
+
+        $this->createSerializer()->denormalize(['page' => 'nope'], SkipInvalidRequiredDummy::class, null, self::SKIP);
+    }
+
+    public function testAbsentRequiredConstructorArgumentIsUnaffected()
+    {
+        $this->expectException(MissingConstructorArgumentsException::class);
+        $this->expectExceptionMessage('Cannot create an instance of "'.SkipInvalidRequiredDummy::class.'" from serialized data because its constructor requires the following parameters to be present : "$page".');
+
+        $this->createSerializer()->denormalize([], SkipInvalidRequiredDummy::class, null, self::SKIP);
+    }
+
+    public function testInvalidVariadicArgumentIsDropped()
+    {
+        $dummy = $this->createSerializer()->denormalize(['methods' => ['GET', 'nope', 'OPTIONS']], SkipInvalidVariadicDummy::class, null, self::SKIP);
+
+        $this->assertSame([StringBackedEnumDummy::GET, StringBackedEnumDummy::OPTIONS], $dummy->methods);
+    }
+
+    public function testPropertyKeepsItsDefault()
+    {
+        $dummy = $this->createSerializer()->denormalize(['page' => 'nope', 'query' => 'foo'], SkipInvalidPropertyDummy::class, null, self::SKIP);
+
+        $this->assertSame(1, $dummy->page);
+        $this->assertSame('foo', $dummy->query);
+    }
+
+    public function testPropertyWithoutDefaultStaysUninitialized()
+    {
+        $dummy = $this->createSerializer()->denormalize(['page' => 'nope'], SkipInvalidTypedPropertyDummy::class, null, self::SKIP);
+
+        $this->assertFalse((new \ReflectionProperty($dummy, 'page'))->isInitialized($dummy));
+    }
+
+    public function testValidValuesAreUnaffected()
+    {
+        $serializer = $this->createSerializer();
+
+        $dummy = $serializer->denormalize(['page' => 5, 'query' => 'foo'], SkipInvalidDummy::class, null, self::SKIP);
+        $this->assertSame(5, $dummy->page);
+        $this->assertSame('foo', $dummy->query);
+
+        $dummy = $serializer->denormalize(['page' => 5, 'query' => 'foo'], SkipInvalidPropertyDummy::class, null, self::SKIP);
+        $this->assertSame(5, $dummy->page);
+        $this->assertSame('foo', $dummy->query);
+    }
+
+    public function testNoPartialDenormalizationExceptionIsThrown()
+    {
+        $serializer = $this->createSerializer();
+
+        $this->assertInstanceOf(SkipInvalidDummy::class, $serializer->denormalize(['page' => 'nope'], SkipInvalidDummy::class, null, self::SKIP));
+        $this->assertInstanceOf(SkipInvalidPropertyDummy::class, $serializer->denormalize(['page' => 'nope'], SkipInvalidPropertyDummy::class, null, self::SKIP));
+    }
+
+    public function testSkippedValuesAreNotCollectedAsErrors()
+    {
+        $dummy = $this->createSerializer()->denormalize(['page' => 'nope', 'query' => 'foo'], SkipInvalidDummy::class, null, self::SKIP + [
+            DenormalizerInterface::COLLECT_DENORMALIZATION_ERRORS => true,
+        ]);
+
+        $this->assertSame(1, $dummy->page);
+        $this->assertSame('foo', $dummy->query);
+    }
+
+    public function testRemainingErrorsAreStillCollected()
+    {
+        try {
+            $this->createSerializer()->denormalize(['page' => 'nope'], SkipInvalidRequiredDummy::class, null, self::SKIP + [
+                DenormalizerInterface::COLLECT_DENORMALIZATION_ERRORS => true,
+            ]);
+
+            $this->fail(\sprintf('Expected a "%s" to be thrown.', PartialDenormalizationException::class));
+        } catch (PartialDenormalizationException $e) {
+            $errors = $e->getNotNormalizableValueErrors();
+        }
+
+        $this->assertCount(1, $errors);
+        $this->assertSame('Failed to create object because the class misses the "page" property.', $errors[0]->getMessage());
+    }
+
+    public function testErrorsAreReportedWithoutTheOption()
+    {
+        $this->expectException(NotNormalizableValueException::class);
+
+        $this->createSerializer()->denormalize(['page' => 'nope'], SkipInvalidDummy::class);
+    }
+
+    public function testOptionCanBeSetInTheDefaultContext()
+    {
+        $serializer = $this->createSerializer(self::SKIP);
+
+        $this->assertSame(1, $serializer->denormalize(['page' => 'nope'], SkipInvalidDummy::class)->page);
+        $this->assertSame(1, $serializer->denormalize(['page' => 'nope'], SkipInvalidPropertyDummy::class)->page);
+    }
+
+    private function createSerializer(array $defaultContext = []): Serializer
+    {
+        $classMetadataFactory = new ClassMetadataFactory(new AttributeLoader());
+        $extractor = new PropertyInfoExtractor([], [new PhpDocExtractor(), new ReflectionExtractor()]);
+
+        return new Serializer([
+            new ArrayDenormalizer(),
+            new BackedEnumNormalizer(),
+            new ObjectNormalizer($classMetadataFactory, new MetadataAwareNameConverter($classMetadataFactory), null, $extractor, null, null, $defaultContext),
+        ]);
+    }
+}
+
+class SkipInvalidDummy
+{
+    public function __construct(
+        public int $page = 1,
+        public string $query = '',
+    ) {
+    }
+}
+
+class SkipInvalidLine
+{
+    public function __construct(
+        public int $quantity = 0,
+    ) {
+    }
+}
+
+class SkipInvalidBasket
+{
+    /**
+     * @param SkipInvalidLine[] $lines
+     */
+    public function __construct(
+        public array $lines = [],
+    ) {
+    }
+}
+
+class SkipInvalidRenamedDummy
+{
+    public function __construct(
+        #[SerializedName('p')]
+        public int $page = 7,
+    ) {
+    }
+}
+
+class SkipInvalidNullableDummy
+{
+    public function __construct(
+        public ?int $page,
+    ) {
+    }
+}
+
+class SkipInvalidRequiredDummy
+{
+    public function __construct(
+        public int $page,
+    ) {
+    }
+}
+
+class SkipInvalidVariadicDummy
+{
+    public array $methods;
+
+    public function __construct(StringBackedEnumDummy ...$methods)
+    {
+        $this->methods = $methods;
+    }
+}
+
+class SkipInvalidPropertyDummy
+{
+    public int $page = 1;
+    public string $query = '';
+}
+
+class SkipInvalidTypedPropertyDummy
+{
+    public int $page;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #64776
| License       | MIT

Denormalizing user-supplied input is all or nothing today: one value of the wrong type aborts the whole object, even when the target declares a perfectly good default for it. That is why `#[MapQueryString]` answers a 404 as soon as someone edits `?page=2` into `?page=foo` in the URL bar.

This PR adds a `skip_invalid_attributes` denormalization option to do the obvious thing instead.

## What it does

An attribute whose value cannot be used is denormalized **as if its key were absent from the input**. That single rule covers every case:

* a constructor argument goes through the regular fallback chain, in order: the `default_constructor_arguments` context option, then the argument's default value, then `null` when the argument is nullable and `require_all_properties` is off;
* any other attribute is left untouched, so it keeps whatever the constructor gave it;
* nothing is reported for it, so no `PartialDenormalizationException` is thrown because of a skipped value;
* an invalid entry of a variadic argument is dropped from the list.

Two consequences follow from that rule and are deliberate:

* a required non-nullable constructor argument with no default still fails, with the same `MissingConstructorArgumentsException` an absent key produces today;
* a typed property with no default and no constructor argument stays uninitialized, exactly as if the input had not mentioned it.

Valid values are untouched, and so is the behavior when the option is off.

```php
class SearchQuery
{
    public function __construct(
        public int $page = 1,
        public string $sort = 'date',
    ) {
    }
}

$query = $serializer->denormalize(['page' => 'foo'], SearchQuery::class, null, [
    AbstractNormalizer::SKIP_INVALID_ATTRIBUTES => true,
]);
// SearchQuery { page: 1, sort: 'date' }
```

## With `collect_denormalization_errors`

The two options compose. Skipped attributes are not collected, so they never reach `PartialDenormalizationException::getNotNormalizableValueErrors()`, while everything else is still collected and reported as usual. Used together, they let you accept the values a client got right, apply the declared defaults for the ones it got wrong, and still report what could not be recovered.

## Motivating use case

```php
public function search(
    #[MapQueryString(serializationContext: ['skip_invalid_attributes' => true])]
    SearchQuery $query,
): Response {
    // ?page=foo no longer 404s, $query->page is 1
}
```

## Why here and not in HttpKernel

This replaces the approach of #65017, which reconstructed a mapping from the collected errors back to the input keys inside `RequestPayloadValueResolver`, then removed the offending keys and denormalized a second time. That mapping cannot be rebuilt reliably from the outside: it silently no-ops for a value nested in a collection, and for a property renamed with `#[SerializedName]`, since the error path and the input key differ. The Serializer is also the only layer that knows the declared default of the target, which is precisely what makes the fallback meaningful. Handling it here fixes the nested and renamed cases for free, and every normalizer built on `AbstractObjectNormalizer` gets it at once.

## Naming

The constant is declared on `AbstractNormalizer`, next to the other context options, since it serves both `AbstractNormalizer::instantiateObject()` and `AbstractObjectNormalizer::denormalize()`.

"Attributes" is the vocabulary this component already uses for mapped members: `allow_extra_attributes`, `ignored_attributes`, `attributes`. The existing `skip_null_values` and `skip_uninitialized_values` are normalization-side options, so reusing "values" here would have been misleading. The name also reads as the counterpart of `allow_extra_attributes`: one covers the attributes the class does not know about, this one covers the attributes it cannot use.

## Documentation

A symfony-docs PR should carry:

* the new option in the serializer context options reference, with a `versionadded 8.2` directive;
* the "invalid value is treated as an absent key" rule, and the constructor fallback order it goes through;
* the two deliberate consequences above: a required non-nullable argument with no default still fails, and a typed property with no default stays uninitialized;
* the fact that skipped attributes are never collected, and how the option composes with `collect_denormalization_errors`;
* the `#[MapQueryString(serializationContext: ['skip_invalid_attributes' => true])]` recipe in the "Mapping Query Parameters" section, as the answer to "how do I keep my defaults when the query string is wrong".
