### PR TITLE
[FrameworkBundle] Remove unused code from legacy controller notation in DelegatingLoader

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Routing/DelegatingLoader.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Routing/DelegatingLoader.php
@@ -19,9 +19,6 @@ use Symfony\Component\Routing\RouteCollection;
 /**
  * DelegatingLoader delegates route loading to other loaders using a loader resolver.
  *
- * This implementation resolves the _controller attribute from the short notation
- * to the fully-qualified form (from a:b:c to class::method).
- *
  * @author Fabien Potencier <fabien@symfony.com>
  *
  * @final
@@ -67,22 +64,15 @@ class DelegatingLoader extends BaseDelegatingLoader
             $this->loading = false;
         }
 
-        foreach ($collection->all() as $route) {
-            if ($this->defaultOptions) {
-                $route->setOptions($route->getOptions() + $this->defaultOptions);
+        if ($this->defaultOptions || $this->defaultRequirements) {
+            foreach ($collection->all() as $route) {
+                if ($this->defaultOptions) {
+                    $route->setOptions($route->getOptions() + $this->defaultOptions);
+                }
+                if ($this->defaultRequirements) {
+                    $route->setRequirements($route->getRequirements() + $this->defaultRequirements);
+                }
             }
-            if ($this->defaultRequirements) {
-                $route->setRequirements($route->getRequirements() + $this->defaultRequirements);
-            }
-            if (!\is_string($controller = $route->getDefault('_controller'))) {
-                continue;
-            }
-
-            if (str_contains($controller, '::')) {
-                continue;
-            }
-
-            $route->setDefault('_controller', $controller);
         }
 
         return $collection;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The `bundle:controller:action` (`a:b:c`) short notation was deprecated in Symfony 4.1 (#26085) and removed for 5.0 in #31702. That removal left some code in `DelegatingLoader::load()`: for each loaded route it reads `_controller`, skips non-strings and `Class::method` strings, and then re-sets `_controller` to the exact value it just read: a no-op `getDefault()` + `setDefault()` per route.

This PR:

* removes the unused code block: the `defaultOptions` / `defaultRequirements` merges are the only real work left in the loop;
* removes the stale class docblock paragraph claiming the loader still resolves the `a:b:c` notation to `class::method`;
* skips the loop entirely when both `defaultOptions` and `defaultRequirements` are empty (the common case), so route loading no longer iterates the whole collection for nothing.