### PR TITLE
[Routing] Allow defining default query parameters

### DIFF
--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Add the `$expiration` argument to `FragmentUriGenerator::__construct()` and sign fragment URIs with a 5-year expiration by default
  * Add `hasDump()` method to `Profile` to track profiles with dump
  * Dispatch `RateLimitExceededEvent` from `RateLimitAttributeListener` when the `#[RateLimit]` attribute rejects a request
+ * Seed the query bag from the `_query` route default when a route is matched
 
 8.1
 ---

--- a/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
@@ -23,6 +23,7 @@ use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Routing\Exception\InvalidParameterException;
 use Symfony\Component\Routing\Exception\MethodNotAllowedException;
 use Symfony\Component\Routing\Exception\NoConfigurationException;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
@@ -144,7 +145,19 @@ class RouterListener implements EventSubscriberInterface
             }
 
             $request->attributes->add($attributes);
-            unset($parameters['_route'], $parameters['_controller']);
+
+            // the route may declare query parameters it always carries, the request wins over them
+            if (!\is_array($query = $attributes['_query'] ?? [])) {
+                throw new InvalidParameterException(\sprintf('Default "_query" must be an array of query parameters for route "%s".', $parameters['_route'] ?? ''));
+            }
+
+            if ($query = array_filter($query, static fn ($value) => null !== $value)) {
+                // going through the query string gives the same values a real one would have parsed to
+                parse_str(http_build_query($query, '', '&', \PHP_QUERY_RFC3986), $query);
+                $request->query->add(array_diff_key($query, $request->query->all()));
+            }
+
+            unset($parameters['_route'], $parameters['_controller'], $parameters['_query']);
             $request->attributes->set('_route_params', $parameters);
         } catch (ResourceNotFoundException $e) {
             $message = \sprintf('No route found for "%s %s"', $request->getMethod(), $request->getUriForPath($request->getPathInfo()));

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/RouterListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/RouterListenerTest.php
@@ -30,6 +30,7 @@ use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\HttpKernel;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\Routing\Exception\InvalidParameterException;
 use Symfony\Component\Routing\Exception\MethodNotAllowedException;
 use Symfony\Component\Routing\Exception\NoConfigurationException;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
@@ -265,6 +266,72 @@ class RouterListenerTest extends TestCase
 
         $listener = new RouterListener($urlMatcher, new RequestStack());
         $listener->onKernelRequest($event);
+    }
+
+    public function testDefaultQueryParametersSeedTheQueryBag()
+    {
+        $request = $this->dispatchWithMatchedParameters(
+            'http://localhost/user',
+            ['_route' => 'user', '_query' => ['page' => 1, 'sort' => 'name']],
+        );
+
+        $this->assertSame('1', $request->query->get('page'));
+        $this->assertSame('name', $request->query->get('sort'));
+    }
+
+    public function testDefaultQueryParametersDoNotOverrideTheRequestQueryString()
+    {
+        $request = $this->dispatchWithMatchedParameters(
+            'http://localhost/user?page=2',
+            ['_route' => 'user', '_query' => ['page' => 1, 'sort' => 'name']],
+        );
+
+        $this->assertSame('2', $request->query->get('page'));
+        $this->assertSame('name', $request->query->get('sort'));
+    }
+
+    public function testDefaultQueryParametersDoNotConflictWithAQueryParameterNamedQuery()
+    {
+        $request = $this->dispatchWithMatchedParameters(
+            'http://localhost/user?_query[page]=2',
+            ['_route' => 'user', '_query' => ['page' => 1, 'sort' => 'name']],
+        );
+
+        $this->assertSame(['page' => '2'], $request->query->all('_query'));
+        $this->assertSame('1', $request->query->get('page'));
+        $this->assertSame('name', $request->query->get('sort'));
+    }
+
+    public function testDefaultQueryParametersAreNotExposedAsRouteParams()
+    {
+        $request = $this->dispatchWithMatchedParameters(
+            'http://localhost/user',
+            ['_route' => 'user', '_query' => ['page' => 1]],
+        );
+
+        $this->assertSame([], $request->attributes->get('_route_params'));
+    }
+
+    public function testDefaultQueryParametersMustBeAnArray()
+    {
+        $this->expectException(InvalidParameterException::class);
+        $this->expectExceptionMessage('Default "_query" must be an array of query parameters for route "user".');
+
+        $this->dispatchWithMatchedParameters('http://localhost/user', ['_route' => 'user', '_query' => 'page=1']);
+    }
+
+    private function dispatchWithMatchedParameters(string $uri, array $parameters): Request
+    {
+        $kernel = $this->createStub(HttpKernelInterface::class);
+        $request = Request::create($uri);
+        $event = new RequestEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST);
+
+        $requestMatcher = $this->createStub(RequestMatcherInterface::class);
+        $requestMatcher->method('matchRequest')->willReturn($parameters);
+
+        (new RouterListener($requestMatcher, new RequestStack(), new RequestContext()))->onKernelRequest($event);
+
+        return $request;
     }
 
     #[DataProvider('provideRouteMapping')]

--- a/src/Symfony/Component/Routing/CHANGELOG.md
+++ b/src/Symfony/Component/Routing/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Allow defining default query parameters with the `_query` route default
+
 8.1
 ---
 
@@ -352,7 +357,7 @@ CHANGELOG
    "../parent-file" and "//example.com/dir/file". The third parameter in
    `UrlGeneratorInterface::generate($name, $parameters = [], $referenceType = self::ABSOLUTE_PATH)`
    now accepts more values and you should use the constants defined in `UrlGeneratorInterface` for
-   claritiy. The old method calls with a Boolean parameter will continue to work because they
+   clarity. The old method calls with a Boolean parameter will continue to work because they
    equal the signature using the constants.
 
 2.1.0

--- a/src/Symfony/Component/Routing/Generator/UrlGenerator.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGenerator.php
@@ -143,6 +143,12 @@ class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInt
      */
     protected function doGenerate(array $variables, array $defaults, array $requirements, array $tokens, array $parameters, string $name, int $referenceType, array $hostTokens, array $requiredSchemes = []): string
     {
+        $defaultQuery = $defaults['_query'] ?? [];
+
+        if (!\is_array($defaultQuery)) {
+            throw new InvalidParameterException(\sprintf('Default "_query" must be an array of query parameters for route "%s".', $name));
+        }
+
         $queryParameters = [];
 
         if (isset($parameters['_query'])) {
@@ -277,7 +283,7 @@ class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInt
 
         // add a query string if needed
         $extra = array_udiff_assoc(array_diff_key($parameters, $variables), $defaults, static fn ($a, $b) => $a == $b ? 0 : 1);
-        $extra = array_replace($extra, $queryParameters);
+        $extra = array_replace($defaultQuery, $extra, $queryParameters);
 
         $seen = [];
         array_walk_recursive($extra, $caster = static function (&$v) use (&$caster, &$seen, $name) {

--- a/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
@@ -1116,6 +1116,73 @@ class UrlGeneratorTest extends TestCase
         $this->assertSame('/app.php/user/john?a=123&b=bar&c=baz&d=789', $url);
     }
 
+    public function testQueryParametersDefinedAsDefaultsAreAddedToTheUrl()
+    {
+        $routes = $this->getRoutes('user', new Route('/user', [
+            '_query' => [
+                'page' => 1,
+                'sort' => 'name',
+            ],
+        ]));
+
+        $this->assertSame('/app.php/user?page=1&sort=name', $this->getGenerator($routes)->generate('user'));
+    }
+
+    public function testQueryParametersCanBeDefinedAsDefaults()
+    {
+        $routes = $this->getRoutes('user', new Route('/user', [
+            '_query' => [
+                'page' => 1,
+                'sort' => 'name',
+            ],
+        ]));
+
+        $url = $this->getGenerator($routes)->generate('user', [
+            '_query' => [
+                'page' => 2,
+            ],
+        ]);
+
+        $this->assertSame('/app.php/user?page=2&sort=name', $url);
+    }
+
+    public function testQueryParametersDefinedAsDefaultsAreOverriddenByParameters()
+    {
+        $routes = $this->getRoutes('user', new Route('/user', [
+            '_query' => [
+                'page' => 1,
+                'sort' => 'name',
+            ],
+        ]));
+
+        $url = $this->getGenerator($routes)->generate('user', ['page' => 2]);
+
+        $this->assertSame('/app.php/user?page=2&sort=name', $url);
+    }
+
+    public function testQueryParametersDefinedAsDefaultsCanBeRemoved()
+    {
+        $routes = $this->getRoutes('user', new Route('/user', [
+            '_query' => [
+                'page' => 1,
+            ],
+        ]));
+
+        $url = $this->getGenerator($routes)->generate('user', ['_query' => ['page' => null]]);
+
+        $this->assertSame('/app.php/user', $url);
+    }
+
+    public function testQueryParametersDefinedAsDefaultsMustBeAnArray()
+    {
+        $routes = $this->getRoutes('user', new Route('/user', ['_query' => 'page=1']));
+
+        $this->expectException(InvalidParameterException::class);
+        $this->expectExceptionMessage('Default "_query" must be an array of query parameters for route "user".');
+
+        $this->getGenerator($routes)->generate('user');
+    }
+
     public function testRouteHostParameterAndQueryParameterWithSameName()
     {
         $routes = $this->getRoutes('admin_stats', new Route('/admin/stats', requirements: ['domain' => '.+'], host: '{siteCode}.{domain}'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #63280
| License       | MIT

A route can now declare query parameters it should always carry, through a `_query` route default:

```php
new Route('/user', ['_query' => ['page' => 1, 'sort' => 'name']]);
```

```php
$urlGenerator->generate('user');
// /user?page=1&sort=name
```

It works through every loader, since it rides on the generic `defaults` of a route:

```yaml
user:
    path: /user
    defaults:
        _query: { page: 1, sort: name }
```

### Precedence

From lowest to highest: the route default, then the parameters passed to `generate()`, then an explicit `_query` parameter. A caller always wins over the route.

```php
$urlGenerator->generate('user', ['page' => 2]);                  // /user?page=2&sort=name
$urlGenerator->generate('user', ['_query' => ['page' => 2]]);    // /user?page=2&sort=name
```

Passing `null` for a key drops it from the generated URL:

```php
$urlGenerator->generate('user', ['_query' => ['page' => null]]); // /user?sort=name
```

A `_query` default that is not an array throws `InvalidParameterException`, naming the route, both when generating and when matching. That matches how a non-array `_query` *parameter* has behaved since 8.0.

### Matching

When a route is matched, `RouterListener` seeds the query bag from the same default for every key the request does not already carry, so a controller reads them like any other query parameter:

```php
#[Route('/user', defaults: ['_query' => ['page' => 1]])]
public function list(#[MapQueryParameter] int $page): Response
{
    // $page is 1 for /user, and 2 for /user?page=2
}
```

The values go through the query string before being added, so they end up with the types a real query string would have parsed to: `page` reads as `"1"`, not `1`. A `null` value is skipped rather than seeded.

The seeding fills `Request::$query` only. `Request::getQueryString()` and `Request::getUri()` keep returning what the client sent, so a URL built from the current request does not gain the declared defaults.

### Documentation

Points a symfony-docs pull request should carry:

- The `_query` route default, its shape, and that it works in every loader through `defaults`.
- The precedence order, and that `null` removes an inherited key.
- That the default also applies when matching, filling `Request::$query` for keys the request omits, and that the request always wins.
- That the matched defaults do not show up in `Request::getQueryString()` or `Request::getUri()`.
- That `_query` has been reserved as a generator parameter since 7.3, so an application already using it as an ordinary default will now see those values appended to generated URLs.
