### PR TITLE
[AssetMapper] Allow requiring raw ESM packages

### DIFF
--- a/UPGRADE-8.2.md
+++ b/UPGRADE-8.2.md
@@ -8,6 +8,11 @@ Read more about this in the [Symfony documentation](https://symfony.com/doc/8.2/
 
 If you're upgrading from a version below 8.1, follow the [8.1 upgrade guide](UPGRADE-8.1.md) first.
 
+AssetMapper
+-----------
+
+ * Add argument `$useEsm` to `ImportMapConfigReader::createRemoteEntry()`
+
 Crowdin Translation Provider
 ----------------------------
 

--- a/src/Symfony/Component/AssetMapper/CHANGELOG.md
+++ b/src/Symfony/Component/AssetMapper/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add a `--no-esm` option to `importmap:require` and an `esm` option to importmap entries
+
 8.0
 ---
 

--- a/src/Symfony/Component/AssetMapper/Command/ImportMapRequireCommand.php
+++ b/src/Symfony/Component/AssetMapper/Command/ImportMapRequireCommand.php
@@ -47,6 +47,7 @@ final class ImportMapRequireCommand extends Command
             ->addArgument('packages', InputArgument::IS_ARRAY | InputArgument::REQUIRED, 'The packages to add')
             ->addOption('entrypoint', null, InputOption::VALUE_NONE, 'Make the packages an entrypoint?')
             ->addOption('path', null, InputOption::VALUE_REQUIRED, 'The local path where the package lives relative to the project root')
+            ->addOption('no-esm', null, InputOption::VALUE_NONE, 'Download raw package files instead of using jsDelivr\'s ESM resolver?')
             ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Simulate the installation of the packages')
             ->setHelp(<<<'EOT'
                 The <info>%command.name%</info> command adds packages to <comment>importmap.php</comment> usually
@@ -76,6 +77,12 @@ final class ImportMapRequireCommand extends Command
 
                     <info>php %command.full_name% "any_module_name" --path=./assets/some_file.js</info>
 
+                Remote packages are downloaded as the ESM build jsDelivr generates for them. When that build
+                is broken for a package, use the <info>--no-esm</info> option to download the files the package
+                publishes instead. The path to the file is then required:
+
+                    <info>php %command.full_name% "fullcalendar/index.global.js=fullcalendar" --no-esm</info>
+
                 To simulate the installation, use the <info>--dry-run</info> option:
 
                     <info>php %command.full_name% "any_module_name" --dry-run -v</info>
@@ -100,6 +107,12 @@ final class ImportMapRequireCommand extends Command
             }
 
             $path = $input->getOption('path');
+
+            if ($input->getOption('no-esm')) {
+                $io->error('The "--no-esm" option cannot be used with "--path": a local package is never downloaded from jsDelivr.');
+
+                return Command::FAILURE;
+            }
         }
 
         if ($input->getOption('dry-run')) {
@@ -121,6 +134,7 @@ final class ImportMapRequireCommand extends Command
                 $parts['alias'] ?? null,
                 $path,
                 $input->getOption('entrypoint'),
+                !$input->getOption('no-esm'),
             );
         }
 

--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapConfigReader.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapConfigReader.php
@@ -48,7 +48,7 @@ class ImportMapConfigReader
 
         $entries = new ImportMapEntries();
         foreach ($importMapConfig as $importName => $data) {
-            $validKeys = ['path', 'version', 'type', 'entrypoint', 'package_specifier'];
+            $validKeys = ['path', 'version', 'type', 'entrypoint', 'package_specifier', 'esm'];
             if ($invalidKeys = array_diff(array_keys($data), $validKeys)) {
                 throw new \InvalidArgumentException(\sprintf('The following keys are not valid for the importmap entry "%s": "%s". Valid keys are: "%s".', $importName, implode('", "', $invalidKeys), implode('", "', $validKeys)));
             }
@@ -76,7 +76,7 @@ class ImportMapConfigReader
             }
 
             $packageModuleSpecifier = $data['package_specifier'] ?? $importName;
-            $entries->add($this->createRemoteEntry($importName, $type, $version, $packageModuleSpecifier, $isEntrypoint));
+            $entries->add($this->createRemoteEntry($importName, $type, $version, $packageModuleSpecifier, $isEntrypoint, $data['esm'] ?? true));
         }
 
         return $this->rootImportMapEntries = $entries;
@@ -93,6 +93,9 @@ class ImportMapConfigReader
                 $config['version'] = $entry->version;
                 if ($entry->packageModuleSpecifier !== $entry->importName) {
                     $config['package_specifier'] = $entry->packageModuleSpecifier;
+                }
+                if (!$entry->useEsm) {
+                    $config['esm'] = false;
                 }
             } else {
                 $config['path'] = $entry->path;
@@ -131,6 +134,7 @@ class ImportMapConfigReader
              *     package_specifier?: string, // Remote "package-name/path" specifier, defaults to the import name
              *     type?: 'js'|'css'|'json',
              *     entrypoint?: bool,
+             *     esm?: bool,                 // Whether jsDelivr's ESM build is used, defaults to true
              * }>
              */
             return $map;
@@ -145,11 +149,15 @@ class ImportMapConfigReader
         return $entries->has($moduleName) ? $entries->get($moduleName) : null;
     }
 
-    public function createRemoteEntry(string $importName, ImportMapType $type, string $version, string $packageModuleSpecifier, bool $isEntrypoint): ImportMapEntry
+    /**
+     * @param bool $useEsm Whether jsDelivr's ESM build is used instead of the raw package files
+     */
+    public function createRemoteEntry(string $importName, ImportMapType $type, string $version, string $packageModuleSpecifier, bool $isEntrypoint /* , bool $useEsm = true */): ImportMapEntry
     {
+        $useEsm = 5 < \func_num_args() ? func_get_arg(5) : true;
         $path = $this->remotePackageStorage->getDownloadPath($packageModuleSpecifier, $type);
 
-        return ImportMapEntry::createRemote($importName, $type, $path, $version, $packageModuleSpecifier, $isEntrypoint);
+        return ImportMapEntry::createRemote($importName, $type, $path, $version, $packageModuleSpecifier, $isEntrypoint, $useEsm);
     }
 
     /**

--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapEntry.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapEntry.php
@@ -34,17 +34,18 @@ final class ImportMapEntry
          * The full "package-name/path" (remote only).
          */
         public readonly ?string $packageModuleSpecifier,
+        public readonly bool $useEsm,
     ) {
     }
 
     public static function createLocal(string $importName, ImportMapType $importMapType, string $path, bool $isEntrypoint): self
     {
-        return new self($importName, $importMapType, $path, $isEntrypoint, null, null);
+        return new self($importName, $importMapType, $path, $isEntrypoint, null, null, true);
     }
 
-    public static function createRemote(string $importName, ImportMapType $importMapType, string $path, string $version, string $packageModuleSpecifier, bool $isEntrypoint): self
+    public static function createRemote(string $importName, ImportMapType $importMapType, string $path, string $version, string $packageModuleSpecifier, bool $isEntrypoint, bool $useEsm = true): self
     {
-        return new self($importName, $importMapType, $path, $isEntrypoint, $version, $packageModuleSpecifier);
+        return new self($importName, $importMapType, $path, $isEntrypoint, $version, $packageModuleSpecifier, $useEsm);
     }
 
     public function getPackageName(): string

--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapManager.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapManager.php
@@ -114,6 +114,7 @@ class ImportMapManager
                     $importName,
                     null,
                     $entry->isEntrypoint,
+                    $entry->useEsm,
                 );
 
                 // remove it: then it will be re-added
@@ -185,6 +186,7 @@ class ImportMapManager
                 $resolvedPackage->version,
                 $resolvedPackage->requireOptions->packageModuleSpecifier,
                 $resolvedPackage->requireOptions->entrypoint,
+                $resolvedPackage->requireOptions->useEsm,
             );
             $importMapEntries->add($newEntry);
             $addedEntries[] = $newEntry;

--- a/src/Symfony/Component/AssetMapper/ImportMap/PackageRequireOptions.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/PackageRequireOptions.php
@@ -29,6 +29,7 @@ final class PackageRequireOptions
         ?string $importName = null,
         public readonly ?string $path = null,
         public readonly bool $entrypoint = false,
+        public readonly bool $useEsm = true,
     ) {
         $this->importName = $importName ?: $packageModuleSpecifier;
     }

--- a/src/Symfony/Component/AssetMapper/ImportMap/Resolver/JsDelivrEsmResolver.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/Resolver/JsDelivrEsmResolver.php
@@ -32,6 +32,7 @@ final class JsDelivrEsmResolver implements PackageResolverInterface
 
     public const IMPORT_REGEX = '#(?:import\s*(?:[\w$]+,)?(?:(?:\{[^}]*\}|[\w$]+|\*\s*as\s+[\w$]+)\s*\bfrom\s*)?|export\s*(?:\{[^}]*\}|\*)\s*from\s*|await\simport\()("/npm/((?:@[^/]+/)?[^@]+?)(?:@([^/]+))?((?:/[^/]+)*?)/\+esm")(?:\)*)#';
 
+    private const RELATIVE_IMPORT_REGEX = '#(?:import\s*(?:[\w$]+,)?(?:(?:\{[^}]*\}|[\w$]+|\*\s*as\s+[\w$]+)\s*\bfrom\s*)?|export\s*(?:\{[^}]*\}|\*)\s*from\s*|await\simport\()([\'"](\.{1,2}/[^\'"]+)[\'"])(?:\)*)#';
     private const ES_MODULE_SHIMS = 'es-module-shims';
 
     private readonly HttpClientInterface $httpClient;
@@ -60,6 +61,12 @@ final class JsDelivrEsmResolver implements PackageResolverInterface
 
             [$packageName, $filePath] = ImportMapEntry::splitPackageNameAndFilePath($packageSpecifier);
 
+            if (!$options->useEsm && !$filePath) {
+                // relative imports inside the raw file are resolved against its directory, which is unknown
+                // as long as jsDelivr is the one picking the file from the package "main" entry
+                throw new RuntimeException(\sprintf('The package "%s" must be required with the path to the file to download, e.g. "%s/dist/index.js", when the jsDelivr ESM build is not used.', $packageName, $packageName));
+            }
+
             $versionUrl = \sprintf(self::URL_PATTERN_VERSION, $packageName);
             if (null !== $options->versionConstraint) {
                 $versionUrl .= '?specifier='.urlencode($options->versionConstraint);
@@ -82,7 +89,7 @@ final class JsDelivrEsmResolver implements PackageResolverInterface
                 throw new RuntimeException(\sprintf('Unable to find the latest version for package "%s" - try specifying the version manually.', $packageName));
             }
 
-            $pattern = $this->resolveUrlPattern($packageName, $filePath);
+            $pattern = $this->resolveUrlPattern($packageName, $filePath, useEsm: $options->useEsm);
             $requiredPackages[$i][1] = $this->httpClient->request('GET', \sprintf($pattern, $packageName, $version, $filePath));
             $requiredPackages[$i][4] = $version;
 
@@ -178,6 +185,7 @@ final class JsDelivrEsmResolver implements PackageResolverInterface
                 $entry->getPackageName(),
                 $entry->getPackagePathString(),
                 $entry->type,
+                $entry->useEsm,
             );
             $url = \sprintf($pattern, $entry->getPackageName(), $entry->version, $entry->getPackagePathString());
 
@@ -200,7 +208,7 @@ final class JsDelivrEsmResolver implements PackageResolverInterface
             $dependencies = [];
             $extraFiles = [];
             $contents[$package] = [
-                'content' => $this->makeImportsBare($response->getContent(), $dependencies, $extraFiles, $entry->type, $entry->getPackagePathString()),
+                'content' => $this->makeImportsBare($response->getContent(), $dependencies, $extraFiles, $entry->type, $entry->getPackagePathString(), $entry->useEsm),
                 'dependencies' => $dependencies,
                 'extraFiles' => [],
             ];
@@ -237,11 +245,15 @@ final class JsDelivrEsmResolver implements PackageResolverInterface
                     continue;
                 }
 
+                $dependencies = [];
                 $extraFiles = [];
 
                 $content = $response->getContent();
+                // only rewrite what can carry imports: an extra file can also be a font, an image or a source map
                 if (str_ends_with($extraFile, '.css')) {
-                    $content = $this->makeImportsBare($content, $dependencies, $extraFiles, ImportMapType::CSS, $extraFile);
+                    $content = $this->makeImportsBare($content, $dependencies, $extraFiles, ImportMapType::CSS, $extraFile, false);
+                } elseif (str_ends_with($extraFile, '.js') || str_ends_with($extraFile, '.mjs')) {
+                    $content = $this->makeImportsBare($content, $dependencies, $extraFiles, ImportMapType::JS, $extraFile, false);
                 }
                 $contents[$package]['extraFiles'][$extraFile] = $content;
 
@@ -299,16 +311,23 @@ final class JsDelivrEsmResolver implements PackageResolverInterface
      *
      * Replaces those with normal import "package/name" statements.
      */
-    private function makeImportsBare(string $content, array &$dependencies, array &$extraFiles, ImportMapType $type, string $sourceFilePath): string
+    private function makeImportsBare(string $content, array &$dependencies, array &$extraFiles, ImportMapType $type, string $sourceFilePath, bool $useEsm = true): string
     {
         if (ImportMapType::JS === $type) {
-            $content = preg_replace_callback(self::IMPORT_REGEX, static function ($matches) use (&$dependencies) {
-                $packageName = $matches[2].$matches[4]; // add the path if any
-                $dependencies[] = $packageName;
+            if ($useEsm) {
+                $content = preg_replace_callback(self::IMPORT_REGEX, static function ($matches) use (&$dependencies) {
+                    $packageName = $matches[2].$matches[4]; // add the path if any
+                    $dependencies[] = $packageName;
 
-                // replace the "/npm/package@version/+esm" with "package@version"
-                return str_replace($matches[1], \sprintf('"%s"', $packageName), $matches[0]);
-            }, $content);
+                    // replace the "/npm/package@version/+esm" with "package@version"
+                    return str_replace($matches[1], \sprintf('"%s"', $packageName), $matches[0]);
+                }, $content);
+            } else {
+                preg_match_all(self::RELATIVE_IMPORT_REGEX, $content, $matches);
+                foreach ($matches[2] as $path) {
+                    $extraFiles[] = $this->resolveRelativePackagePath($sourceFilePath, $path);
+                }
+            }
 
             // source maps are not also downloaded - so remove the sourceMappingURL
             // remove the final one only (in case sourceMappingURL is used in the code)
@@ -335,15 +354,22 @@ final class JsDelivrEsmResolver implements PackageResolverInterface
         return preg_replace('{/\*# sourceMappingURL=[^ ]*+ \*/}', '', $content);
     }
 
+    private function resolveRelativePackagePath(string $sourceFilePath, string $path): string
+    {
+        $path = substr($path, 0, strcspn($path, '?#'));
+
+        return Path::canonicalize(Path::join(\dirname('/'.$sourceFilePath), $path));
+    }
+
     /**
      * Determine the URL pattern to be used by the HTTP Client.
      */
-    private function resolveUrlPattern(string $packageName, string $path, ?ImportMapType $type = null): string
+    private function resolveUrlPattern(string $packageName, string $path, ?ImportMapType $type = null, bool $useEsm = true): string
     {
         // The URL for the es-module-shims polyfill package uses the CSS pattern to
         // prevent a syntax error in the browser console, so check the package name
         // as part of the condition.
-        if (self::ES_MODULE_SHIMS === $packageName || str_ends_with($path, '.css') || ImportMapType::CSS === $type) {
+        if (!$useEsm || self::ES_MODULE_SHIMS === $packageName || str_ends_with($path, '.css') || ImportMapType::CSS === $type) {
             return self::URL_PATTERN_DIST_CSS;
         }
 

--- a/src/Symfony/Component/AssetMapper/Tests/Command/ImportMapRequireCommandTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/Command/ImportMapRequireCommandTest.php
@@ -15,11 +15,14 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\AssetMapper\Command\ImportMapRequireCommand;
+use Symfony\Component\AssetMapper\ImportMap\ImportMapEntries;
 use Symfony\Component\AssetMapper\ImportMap\ImportMapEntry;
 use Symfony\Component\AssetMapper\ImportMap\ImportMapManager;
 use Symfony\Component\AssetMapper\ImportMap\ImportMapType;
 use Symfony\Component\AssetMapper\ImportMap\ImportMapVersionChecker;
+use Symfony\Component\AssetMapper\ImportMap\PackageRequireOptions;
 use Symfony\Component\AssetMapper\Tests\Fixtures\ImportMapTestAppKernel;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Filesystem\Filesystem;
@@ -202,6 +205,61 @@ class ImportMapRequireCommandTest extends KernelTestCase
         $fs->remove($projectDir.'/var');
 
         static::$kernel->shutdown();
+    }
+
+    public function testNoEsmOptionRequiresRawPackage()
+    {
+        $importMapManager = $this->createMock(ImportMapManager::class);
+        $importMapManager
+            ->expects($this->once())
+            ->method('requirePackages')
+            ->with($this->callback(function (array $packages) {
+                $this->assertCount(1, $packages);
+                $this->assertInstanceOf(PackageRequireOptions::class, $packages[0]);
+                $this->assertSame('fullcalendar/index.js', $packages[0]->packageModuleSpecifier);
+                $this->assertSame('fullcalendar', $packages[0]->importName);
+                $this->assertFalse($packages[0]->useEsm);
+
+                return true;
+            }), $this->isInstanceOf(ImportMapEntries::class))
+            ->willReturn([self::createRemoteEntry('fullcalendar', '7.0.0', 'assets/vendor/fullcalendar/fullcalendar.js')]);
+
+        $command = new ImportMapRequireCommand(
+            $importMapManager,
+            $this->createStub(ImportMapVersionChecker::class),
+            '/path/to/project/dir',
+        );
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([
+            'packages' => ['fullcalendar/index.js=fullcalendar'],
+            '--dry-run' => true,
+            '--no-esm' => true,
+        ]);
+
+        $commandTester->assertCommandIsSuccessful();
+    }
+
+    public function testNoEsmOptionCannotBeUsedWithPath()
+    {
+        $importMapManager = $this->createMock(ImportMapManager::class);
+        $importMapManager->expects($this->never())->method('requirePackages');
+
+        $command = new ImportMapRequireCommand(
+            $importMapManager,
+            $this->createStub(ImportMapVersionChecker::class),
+            '/path/to/project/dir',
+        );
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([
+            'packages' => ['any_module_name'],
+            '--path' => './assets/some_file.js',
+            '--no-esm' => true,
+        ]);
+
+        $this->assertSame(Command::FAILURE, $commandTester->getStatusCode());
+        $this->assertStringContainsString('The "--no-esm" option cannot be used with "--path"', $commandTester->getDisplay());
     }
 
     private static function createRemoteEntry(string $importName, string $version, ?string $path = null): ImportMapEntry

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapConfigReaderTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapConfigReaderTest.php
@@ -60,6 +60,10 @@ class ImportMapConfigReaderTest extends TestCase
                 'package/with_file.js' => [
                     'version' => '1.0.0',
                 ],
+                'raw_esm_package' => [
+                    'version' => '2.0.0',
+                    'esm' => false,
+                ],
             ];
             EOF;
         file_put_contents(__DIR__.'/../Fixtures/importmap_config_reader/importmap.php', $importMap);
@@ -76,7 +80,7 @@ class ImportMapConfigReaderTest extends TestCase
         $this->assertInstanceOf(ImportMapEntries::class, $entries);
         /** @var ImportMapEntry[] $allEntries */
         $allEntries = iterator_to_array($entries);
-        $this->assertCount(5, $allEntries);
+        $this->assertCount(6, $allEntries);
 
         $remotePackageEntry = $allEntries[0];
         $this->assertSame('remote_package', $remotePackageEntry->importName);
@@ -95,6 +99,9 @@ class ImportMapConfigReaderTest extends TestCase
 
         $packageWithFileEntry = $allEntries[4];
         $this->assertSame('package/with_file.js', $packageWithFileEntry->packageModuleSpecifier);
+
+        $rawEsmEntry = $allEntries[5];
+        $this->assertFalse($rawEsmEntry->useEsm);
 
         // now save the original raw data from importmap.php and delete the file
         $originalImportMapData = (static fn () => eval('?>'.file_get_contents(__DIR__.'/../Fixtures/importmap_config_reader/importmap.php')))();
@@ -209,5 +216,16 @@ class ImportMapConfigReaderTest extends TestCase
 
         $this->assertCount(1, $entries);
         $this->assertSame('no-scope', $entries[0]->path);
+    }
+
+    public function testCreateRemoteEntryUsesEsmByDefault()
+    {
+        $reader = new ImportMapConfigReader(__DIR__.'/../Fixtures/importmap.php', new RemotePackageStorage(sys_get_temp_dir()));
+
+        $this->assertTrue($reader->createRemoteEntry('lodash', ImportMapType::JS, '1.2.3', 'lodash', false)->useEsm);
+        $this->assertFalse($reader->createRemoteEntry('lodash', ImportMapType::JS, '1.2.3', 'lodash', false, false)->useEsm);
+
+        // the class is not final, so declaring the extra parameter would break every child that overrides the method
+        $this->assertSame(5, (new \ReflectionMethod(ImportMapConfigReader::class, 'createRemoteEntry'))->getNumberOfParameters());
     }
 }

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapManagerTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapManagerTest.php
@@ -418,6 +418,45 @@ class ImportMapManagerTest extends TestCase
         $manager->update();
     }
 
+    public function testUpdatePreservesUseEsm()
+    {
+        $this->packageResolver = $this->createMock(PackageResolverInterface::class);
+        $manager = $this->createImportMapManager();
+
+        $this->mockImportMap([
+            self::createRemoteEntry('esm_lib', version: '1.0.0'),
+            self::createRemoteEntry('raw_lib', version: '2.0.0', useEsm: false),
+        ]);
+
+        $this->packageResolver->expects($this->once())
+            ->method('resolvePackages')
+            ->with($this->callback(function (array $packages) {
+                $useEsmByName = [];
+                foreach ($packages as $package) {
+                    $useEsmByName[$package->importName] = $package->useEsm;
+                }
+                $this->assertTrue($useEsmByName['esm_lib']);
+                $this->assertFalse($useEsmByName['raw_lib'], 'useEsm=false lost when rebuilding options for importmap:update');
+
+                return true;
+            }))
+            ->willReturn([
+                self::resolvedPackage('esm_lib', '1.0.1'),
+                self::resolvedPackage('raw_lib', '2.1.0', useEsm: false),
+            ]);
+
+        $this->configReader->expects($this->once())
+            ->method('writeEntries')
+            ->with($this->callback(function (ImportMapEntries $entries) {
+                $this->assertTrue($entries->get('esm_lib')->useEsm);
+                $this->assertFalse($entries->get('raw_lib')->useEsm, 'useEsm=false lost when re-creating the entry during importmap:update');
+
+                return true;
+            }));
+
+        $manager->update();
+    }
+
     private function createImportMapManager(): ImportMapManager
     {
         $this->assetMapper = $this->createStub(AssetMapperInterface::class);
@@ -428,10 +467,10 @@ class ImportMapManagerTest extends TestCase
         // mock this to behave like normal
         $this->configReader
             ->method('createRemoteEntry')
-            ->willReturnCallback(static function (string $importName, ImportMapType $type, string $version, string $packageModuleSpecifier, bool $isEntrypoint) {
+            ->willReturnCallback(static function (string $importName, ImportMapType $type, string $version, string $packageModuleSpecifier, bool $isEntrypoint, bool $useEsm = true) {
                 $path = '/path/to/vendor/'.$packageModuleSpecifier.'.js';
 
-                return ImportMapEntry::createRemote($importName, $type, $path, $version, $packageModuleSpecifier, $isEntrypoint);
+                return ImportMapEntry::createRemote($importName, $type, $path, $version, $packageModuleSpecifier, $isEntrypoint, $useEsm);
             });
 
         return new ImportMapManager(
@@ -442,10 +481,10 @@ class ImportMapManagerTest extends TestCase
         );
     }
 
-    private static function resolvedPackage(string $packageName, string $version, ImportMapType $type = ImportMapType::JS, bool $isEntrypoint = false)
+    private static function resolvedPackage(string $packageName, string $version, ImportMapType $type = ImportMapType::JS, bool $isEntrypoint = false, bool $useEsm = true)
     {
         return new ResolvedImportMapPackage(
-            new PackageRequireOptions($packageName, entrypoint: $isEntrypoint),
+            new PackageRequireOptions($packageName, entrypoint: $isEntrypoint, useEsm: $useEsm),
             $version,
             $type,
         );
@@ -469,11 +508,11 @@ class ImportMapManagerTest extends TestCase
         return ImportMapEntry::createLocal($importName, $type, $path, $isEntrypoint);
     }
 
-    private static function createRemoteEntry(string $importName, string $version, ?string $path = null, ImportMapType $type = ImportMapType::JS, ?string $packageSpecifier = null, bool $isEntrypoint = false): ImportMapEntry
+    private static function createRemoteEntry(string $importName, string $version, ?string $path = null, ImportMapType $type = ImportMapType::JS, ?string $packageSpecifier = null, bool $isEntrypoint = false, bool $useEsm = true): ImportMapEntry
     {
         $packageSpecifier ??= $importName;
         $path ??= '/vendor/any-path.js';
 
-        return ImportMapEntry::createRemote($importName, $type, $path, $version, $packageSpecifier, $isEntrypoint);
+        return ImportMapEntry::createRemote($importName, $type, $path, $version, $packageSpecifier, $isEntrypoint, $useEsm);
     }
 }

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/Resolver/JsDelivrEsmResolverTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/Resolver/JsDelivrEsmResolverTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\AssetMapper\Tests\ImportMap\Resolver;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\AssetMapper\Exception\RuntimeException;
 use Symfony\Component\AssetMapper\ImportMap\ImportMapEntry;
 use Symfony\Component\AssetMapper\ImportMap\ImportMapType;
 use Symfony\Component\AssetMapper\ImportMap\PackageRequireOptions;
@@ -52,6 +53,16 @@ class JsDelivrEsmResolverTest extends TestCase
         }
 
         $this->assertSame(\count($expectedRequests), $httpClient->getRequestsCount());
+    }
+
+    public function testResolveRawPackageWithoutFilePath()
+    {
+        $resolver = new JsDelivrEsmResolver(new MockHttpClient());
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The package "fullcalendar" must be required with the path to the file to download, e.g. "fullcalendar/dist/index.js", when the jsDelivr ESM build is not used.');
+
+        $resolver->resolvePackages([new PackageRequireOptions('fullcalendar', useEsm: false)]);
     }
 
     public static function provideResolvePackagesTests(): iterable
@@ -262,6 +273,24 @@ class JsDelivrEsmResolverTest extends TestCase
                 ],
             ],
         ];
+
+        yield 'require raw ESM package' => [
+            'packages' => [new PackageRequireOptions('fullcalendar/index.js', '^7', 'fullcalendar', useEsm: false)],
+            'expectedRequests' => [
+                [
+                    'url' => '/v1/packages/npm/fullcalendar/resolved?specifier=%5E7',
+                    'response' => ['body' => ['version' => '7.0.0']],
+                ],
+                [
+                    'url' => '/fullcalendar@7.0.0/index.js',
+                ],
+            ],
+            'expectedResolvedPackages' => [
+                'fullcalendar' => [
+                    'version' => '7.0.0',
+                ],
+            ],
+        ];
     }
 
     #[DataProvider('provideDownloadPackagesTests')]
@@ -387,6 +416,52 @@ class JsDelivrEsmResolverTest extends TestCase
                     'content' => 'import{Color as t}from"@kurkle/color";function e(){}const i=(()=',
                     'dependencies' => ['@kurkle/color'],
                     'extraFiles' => [],
+                ],
+            ],
+        ];
+
+        yield 'raw ESM package downloads relative imports' => [
+            ['fullcalendar' => self::createRemoteEntry('fullcalendar', version: '7.0.0', packageSpecifier: 'fullcalendar/index.js', useEsm: false)],
+            [
+                [
+                    'url' => '/fullcalendar@7.0.0/index.js',
+                    'body' => 'import { Calendar } from "./chunk/calendar.js"; export { Calendar };',
+                ],
+                [
+                    'url' => '/fullcalendar@7.0.0/chunk/calendar.js',
+                    'body' => 'export class Calendar {}',
+                ],
+            ],
+            [
+                'fullcalendar' => [
+                    'content' => 'import { Calendar } from "./chunk/calendar.js"; export { Calendar };',
+                    'dependencies' => [],
+                    'extraFiles' => [
+                        '/chunk/calendar.js' => 'export class Calendar {}',
+                    ],
+                ],
+            ],
+        ];
+
+        yield 'extra file that is neither JS nor CSS is downloaded untouched' => [
+            ['bootstrap/dist/bootstrap.css' => self::createRemoteEntry('bootstrap/dist/bootstrap.css', version: '5.3.3', type: ImportMapType::CSS)],
+            [
+                [
+                    'url' => '/bootstrap@5.3.3/dist/bootstrap.css',
+                    'body' => '@font-face { src: url("./icons.svg"); }',
+                ],
+                [
+                    'url' => '/bootstrap@5.3.3/dist/icons.svg',
+                    'body' => "<svg></svg>\n//# sourceMappingURL=icons.svg.map\n",
+                ],
+            ],
+            [
+                'bootstrap/dist/bootstrap.css' => [
+                    'content' => '@font-face { src: url("./icons.svg"); }',
+                    'dependencies' => [],
+                    'extraFiles' => [
+                        '/dist/icons.svg' => "<svg></svg>\n//# sourceMappingURL=icons.svg.map\n",
+                    ],
                 ],
             ],
         ];
@@ -696,10 +771,10 @@ class JsDelivrEsmResolverTest extends TestCase
         ];
     }
 
-    private static function createRemoteEntry(string $importName, string $version, ImportMapType $type = ImportMapType::JS, ?string $packageSpecifier = null): ImportMapEntry
+    private static function createRemoteEntry(string $importName, string $version, ImportMapType $type = ImportMapType::JS, ?string $packageSpecifier = null, bool $useEsm = true): ImportMapEntry
     {
         $packageSpecifier ??= $importName;
 
-        return ImportMapEntry::createRemote($importName, $type, 'does not matter', $version, $packageSpecifier, false);
+        return ImportMapEntry::createRemote($importName, $type, 'does not matter', $version, $packageSpecifier, false, $useEsm);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #64553
| License       | MIT

A remote package is downloaded as the ESM build jsDelivr generates for it, by appending `/+esm` to the package URL. That build is broken for some packages, and until now there was no way to get the files the package actually publishes instead.

```
php bin/console importmap:require "fullcalendar/index.global.js=fullcalendar" --no-esm
```

writes into `importmap.php`:

```php
'fullcalendar' => [
    'version' => '7.0.0',
    'package_specifier' => 'fullcalendar/index.global.js',
    'esm' => false,
],
```

and downloads `https://cdn.jsdelivr.net/npm/fullcalendar@7.0.0/index.global.js` as published, instead of `.../+esm`.

The file is stored untouched. The relative imports it declares are downloaded next to it as extra files, and AssetMapper adds each one to the rendered import map, so `import "./chunk/calendar.js"` inside the package keeps working:

```
fullcalendar                                  => /assets/vendor/fullcalendar/index-aYqn6H0.js
/assets/vendor/fullcalendar/chunk/calendar.js => /assets/vendor/fullcalendar/chunk/calendar-LNPGw9E.js
```

Things to know when using it:

* The path to the file is required. `--no-esm fullcalendar` is refused, because relative imports inside the file are resolved against its directory, and that directory is unknown while jsDelivr is the one choosing the file from the package `main` entry.
* `--no-esm` cannot be combined with `--path`, which declares a local file that is never downloaded.
* Bare imports inside a raw file, such as `import { h } from "preact"`, are not resolved. The ESM build rewrites those into further jsDelivr URLs that AssetMapper follows; a raw file is taken as it is. Require those packages yourself.
* The `esm` key is only written when it is `false`, so existing `importmap.php` files are untouched, and an entry without the key behaves exactly as before.
* `importmap:update` preserves the flag.

Public API added: the `--no-esm` option on `importmap:require`, the `esm` key in `importmap.php`, `PackageRequireOptions::$useEsm` and `ImportMapEntry::$useEsm`.

For symfony-docs: the option and the config key, when to reach for them (a package whose `/+esm` build is broken), the requirement to pass the file path, and the bare-import limitation above.
