### PR TITLE
[DomCrawler] Use native HTML selectors

### DIFF
--- a/src/Symfony/Component/DomCrawler/CHANGELOG.md
+++ b/src/Symfony/Component/DomCrawler/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Use native HTML selector methods when crawling HTML documents
+
 8.1
 ---
 

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -22,6 +22,8 @@ use Symfony\Component\CssSelector\CssSelectorConverter;
  */
 class Crawler implements \Countable, \IteratorAggregate
 {
+    private const CSS_SELECTOR_FALLBACK_PSEUDO_CLASSES = '#:(?:checked|contains|disabled|enabled|link)\b#i';
+
     /**
      * The default namespace prefix to be used with XPath and CSS expressions.
      */
@@ -44,6 +46,21 @@ class Crawler implements \Countable, \IteratorAggregate
     private ?string $baseHref;
 
     private ?\DOMDocument $document = null;
+
+    /**
+     * Keeps native HTML nodes alive for selector lookups while exposing legacy DOM nodes.
+     */
+    private ?\Dom\HTMLDocument $html5Document = null;
+
+    /**
+     * @var \WeakMap<\DOMNode, \Dom\Node>|null
+     */
+    private ?\WeakMap $domToHtml5Nodes = null;
+
+    /**
+     * @var \WeakMap<\Dom\Node, \DOMNode>|null
+     */
+    private ?\WeakMap $html5ToDomNodes = null;
 
     /**
      * @var list<\DOMNode>
@@ -92,6 +109,9 @@ class Crawler implements \Countable, \IteratorAggregate
     {
         $this->nodes = [];
         $this->document = null;
+        $this->html5Document = null;
+        $this->domToHtml5Nodes = null;
+        $this->html5ToDomNodes = null;
         $this->cachedNamespaces = new \ArrayObject();
     }
 
@@ -385,6 +405,10 @@ class Crawler implements \Countable, \IteratorAggregate
             return false;
         }
 
+        if (null !== $matches = $this->matchesNativeHtmlSelector($this->getNode(0), $selector)) {
+            return $matches;
+        }
+
         $converter = $this->createCssSelectorConverter();
         $xpath = $converter->toXPath($selector, 'self::');
 
@@ -405,6 +429,9 @@ class Crawler implements \Countable, \IteratorAggregate
         }
 
         $domNode = $this->getNode(0);
+        if (null !== $closest = $this->closestNativeHtmlSelector($domNode, $selector)) {
+            return $closest;
+        }
 
         while (null !== $domNode && \XML_ELEMENT_NODE === $domNode->nodeType) {
             $node = $this->createSubCrawler($domNode);
@@ -482,6 +509,10 @@ class Crawler implements \Countable, \IteratorAggregate
         }
 
         if (null !== $selector) {
+            if (null !== $crawler = $this->childrenNativeHtmlSelector($selector)) {
+                return $crawler;
+            }
+
             $converter = $this->createCssSelectorConverter();
             $xpath = $converter->toXPath($selector, 'child::');
 
@@ -710,6 +741,10 @@ class Crawler implements \Countable, \IteratorAggregate
      */
     public function filter(string $selector): static
     {
+        if (null !== $crawler = $this->filterNativeHtmlSelector($selector)) {
+            return $crawler;
+        }
+
         $converter = $this->createCssSelectorConverter();
 
         // The CssSelector already prefixes the selector with descendant-or-self::
@@ -1063,6 +1098,9 @@ class Crawler implements \Countable, \IteratorAggregate
         libxml_use_internal_errors($internalErrors);
 
         $dom = new \DOMDocument('1.0', $document->inputEncoding);
+        $this->html5Document = $document;
+        $this->domToHtml5Nodes = new \WeakMap();
+        $this->html5ToDomNodes = new \WeakMap();
         $this->copyFromHtml5ToDom($document->documentElement, $dom);
 
         return $dom;
@@ -1145,10 +1183,132 @@ class Crawler implements \Countable, \IteratorAggregate
         $crawler = new static($nodes, $this->uri, $this->baseHref);
         $crawler->isHtml = $this->isHtml;
         $crawler->document = $this->document;
+        $crawler->html5Document = $this->html5Document;
+        $crawler->domToHtml5Nodes = $this->domToHtml5Nodes;
+        $crawler->html5ToDomNodes = $this->html5ToDomNodes;
         $crawler->namespaces = $this->namespaces;
         $crawler->cachedNamespaces = $this->cachedNamespaces;
 
         return $crawler;
+    }
+
+    private function filterNativeHtmlSelector(string $selector): ?static
+    {
+        if (!$this->isHtml || null === $this->domToHtml5Nodes || null === $this->html5ToDomNodes || $this->requiresCssSelectorFallback($selector)) {
+            return null;
+        }
+
+        $nodes = [];
+        foreach ($this->nodes as $node) {
+            $html5Node = $this->domToHtml5Nodes[$node] ?? null;
+            if (!$html5Node instanceof \Dom\Element && !$html5Node instanceof \Dom\Document) {
+                return null;
+            }
+
+            try {
+                if ($html5Node instanceof \Dom\Element && $html5Node->matches($selector)) {
+                    $this->addNativeHtmlNode($html5Node, $nodes);
+                }
+
+                foreach ($html5Node->querySelectorAll($selector) as $matchedNode) {
+                    $this->addNativeHtmlNode($matchedNode, $nodes);
+                }
+            } catch (\DOMException) {
+                return null;
+            }
+        }
+
+        return $this->createSubCrawler($nodes);
+    }
+
+    private function matchesNativeHtmlSelector(\DOMNode $node, string $selector): ?bool
+    {
+        if (!$this->isHtml || null === $this->domToHtml5Nodes || $this->requiresCssSelectorFallback($selector)) {
+            return null;
+        }
+
+        $html5Node = $this->domToHtml5Nodes[$node] ?? null;
+        if (!$html5Node instanceof \Dom\Element) {
+            return null;
+        }
+
+        try {
+            return $html5Node->matches($selector);
+        } catch (\DOMException) {
+            return null;
+        }
+    }
+
+    private function closestNativeHtmlSelector(\DOMNode $node, string $selector): ?static
+    {
+        if (!$this->isHtml || null === $this->domToHtml5Nodes || null === $this->html5ToDomNodes || !$node->isConnected || $this->requiresCssSelectorFallback($selector)) {
+            return null;
+        }
+
+        $html5Node = $this->domToHtml5Nodes[$node] ?? null;
+        if (!$html5Node instanceof \Dom\Element) {
+            return null;
+        }
+
+        try {
+            $closestNode = $html5Node->closest($selector);
+        } catch (\DOMException) {
+            return null;
+        }
+
+        if (null === $closestNode) {
+            return null;
+        }
+
+        $domNode = $this->html5ToDomNodes[$closestNode] ?? null;
+
+        return $domNode instanceof \DOMNode ? $this->createSubCrawler($domNode) : null;
+    }
+
+    private function childrenNativeHtmlSelector(string $selector): ?static
+    {
+        if (!$this->isHtml || null === $this->domToHtml5Nodes || $this->requiresCssSelectorFallback($selector)) {
+            return null;
+        }
+
+        $nodes = [];
+        $node = $this->getNode(0)->firstChild;
+        while ($node) {
+            if (\XML_ELEMENT_NODE === $node->nodeType) {
+                $html5Node = $this->domToHtml5Nodes[$node] ?? null;
+                if (!$html5Node instanceof \Dom\Element) {
+                    return null;
+                }
+
+                try {
+                    if ($html5Node->matches($selector)) {
+                        $nodes[] = $node;
+                    }
+                } catch (\DOMException) {
+                    return null;
+                }
+            }
+
+            $node = $node->nextSibling;
+        }
+
+        return $this->createSubCrawler($nodes);
+    }
+
+    /**
+     * @param list<\DOMNode> $nodes
+     */
+    private function addNativeHtmlNode(\Dom\Node $html5Node, array &$nodes): void
+    {
+        $domNode = $this->html5ToDomNodes[$html5Node] ?? null;
+        if ($domNode instanceof \DOMNode && !\in_array($domNode, $nodes, true)) {
+            $nodes[] = $domNode;
+        }
+    }
+
+    private function requiresCssSelectorFallback(string $selector): bool
+    {
+        return 1 === preg_match(self::CSS_SELECTOR_FALLBACK_PSEUDO_CLASSES, $selector);
     }
 
     /**
@@ -1173,12 +1333,16 @@ class Crawler implements \Countable, \IteratorAggregate
 
             foreach ($children as $source) {
                 if ($source instanceof \Dom\CharacterData) {
-                    $parent->appendChild(match (true) {
+                    $node = match (true) {
                         $source instanceof \Dom\Text => $target->createTextNode($source->data),
                         $source instanceof \Dom\Comment => $target->createComment($source->data),
                         $source instanceof \Dom\CDATASection => $target->createCDATASection($source->data),
                         $source instanceof \Dom\ProcessingInstruction => $target->createProcessingInstruction($source->target, $source->data),
-                    });
+                    };
+
+                    $parent->appendChild($node);
+                    $this->domToHtml5Nodes[$node] = $source;
+                    $this->html5ToDomNodes[$source] = $node;
                     continue;
                 }
 
@@ -1204,6 +1368,8 @@ class Crawler implements \Countable, \IteratorAggregate
                 }
 
                 $parent->appendChild($element);
+                $this->domToHtml5Nodes[$element] = $source;
+                $this->html5ToDomNodes[$source] = $element;
 
                 $stack[] = [$source->childNodes, $element];
             }

--- a/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
@@ -22,6 +22,8 @@ use Symfony\Component\DomCrawler\Link;
 
 class CrawlerTest extends TestCase
 {
+    private const NATIVE_HTML_SELECTOR = 'li:nth-child(-n+2 of .enabled)';
+
     public static function getDoctype(): string
     {
         return '<!DOCTYPE html>';
@@ -665,6 +667,43 @@ class CrawlerTest extends TestCase
         $this->assertCount(6, $crawler->filter('li'), '->filter() filters the node list with the CSS selector');
     }
 
+    public function testFilterUsesNativeHtmlSelectors()
+    {
+        $crawler = $this->createCrawler($this->getDoctype().<<<'HTML'
+            <html lang="en">
+            <body>
+                <ul id="menu">
+                    <li class="enabled">One</li>
+                    <li>Two</li>
+                    <li class="enabled">Three</li>
+                    <li class="enabled">Four</li>
+                </ul>
+            </body>
+            </html>
+            HTML);
+
+        $items = $crawler->filter('#menu')->filter(self::NATIVE_HTML_SELECTOR);
+
+        $this->assertCount(2, $items);
+        $this->assertSame('One', $items->eq(0)->text());
+        $this->assertSame('Three', $items->eq(1)->text());
+    }
+
+    public function testFilterKeepsCssSelectorFallbackPseudoClasses()
+    {
+        $crawler = $this->createCrawler($this->getDoctype().<<<'HTML'
+            <html lang="en">
+            <body>
+                <form>
+                    <input type="checkbox" name="rememberMe" checked>
+                </form>
+            </body>
+            </html>
+            HTML);
+
+        $this->assertCount(1, $crawler->filter('input[name="rememberMe"]:checked'));
+    }
+
     public function testFilterWithDefaultNamespace()
     {
         $crawler = $this->createTestXmlCrawler()->filter('default|entry default|id');
@@ -1058,6 +1097,26 @@ class CrawlerTest extends TestCase
         $this->assertNull($notFound);
     }
 
+    public function testClosestUsesNativeHtmlSelectors()
+    {
+        $crawler = $this->createCrawler($this->getDoctype().<<<'HTML'
+            <html lang="en">
+            <body>
+                <section>
+                    <article class="published">
+                        <p id="content">Content</p>
+                    </article>
+                </section>
+            </body>
+            </html>
+            HTML);
+
+        $article = $crawler->filter('#content')->closest('article:nth-child(odd of .published)');
+
+        $this->assertInstanceOf(Crawler::class, $article);
+        $this->assertSame('published', $article->attr('class'));
+    }
+
     public function testClosestWithOrphanedNode()
     {
         $html = <<<'HTML'
@@ -1196,6 +1255,27 @@ class CrawlerTest extends TestCase
         $this->assertEquals(1, $foo->children('span')->count());
         $this->assertEquals(1, $foo->children('span.ipsum')->count());
         $this->assertEquals(1, $foo->children('.ipsum')->count());
+    }
+
+    public function testChildrenUsesNativeHtmlSelectors()
+    {
+        $crawler = $this->createCrawler($this->getDoctype().<<<'HTML'
+            <html lang="en">
+            <body>
+                <ul id="menu">
+                    <li class="enabled">One</li>
+                    <li>Two</li>
+                    <li class="enabled">Three</li>
+                </ul>
+            </body>
+            </html>
+            HTML);
+
+        $items = $crawler->filter('#menu')->children(self::NATIVE_HTML_SELECTOR);
+
+        $this->assertCount(2, $items);
+        $this->assertSame('One', $items->eq(0)->text());
+        $this->assertSame('Three', $items->eq(1)->text());
     }
 
     public function testAncestors()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #57605
| License       | MIT

This allows DomCrawler to use PHP native HTML selector methods when crawling HTML documents.

The native path keeps DomCrawler's public legacy `DOM*` nodes while retaining the parsed `Dom\HTMLDocument` internally for selector lookups. It is used for `filter()`, `matches()`, `closest()`, and filtered `children()`, with the existing CssSelector/XPath path kept as fallback for unsupported selectors, XML documents, and namespace-aware queries.

Tests cover native selector syntax such as `:nth-child(... of ...)`, which is supported by PHP's native selector engine but not by CssSelector.