### PR TITLE
[RateLimiter] Add clock support

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/rate_limiter.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/rate_limiter.php
@@ -26,6 +26,7 @@ return static function (ContainerConfigurator $container) {
                 abstract_arg('config'),
                 abstract_arg('storage'),
                 null,
+                service('clock')->nullOnInvalid(),
             ])
 
         ->set('rate_limiter.attribute_listener', RateLimitAttributeListener::class)

--- a/src/Symfony/Component/RateLimiter/CHANGELOG.md
+++ b/src/Symfony/Component/RateLimiter/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add an optional `$clock` argument to rate limiter implementations and factories
+
 8.1
 ---
 

--- a/src/Symfony/Component/RateLimiter/Policy/FixedWindowLimiter.php
+++ b/src/Symfony/Component/RateLimiter/Policy/FixedWindowLimiter.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\RateLimiter\Policy;
 
+use Psr\Clock\ClockInterface;
 use Symfony\Component\Lock\LockInterface;
 use Symfony\Component\RateLimiter\Exception\MaxWaitDurationExceededException;
 use Symfony\Component\RateLimiter\LimiterInterface;
@@ -46,6 +47,7 @@ final class FixedWindowLimiter implements LimiterInterface
         StorageInterface $storage,
         ?LockInterface $lock = null,
         private readonly ?\DateTimeImmutable $anchorAt = null,
+        private readonly ?ClockInterface $clock = null,
     ) {
         if ($limit < 1) {
             throw new \InvalidArgumentException(\sprintf('Cannot set the limit of "%s" to 0, as that would never accept any hit.', __CLASS__));
@@ -71,7 +73,7 @@ final class FixedWindowLimiter implements LimiterInterface
         $this->lock?->acquire(true);
 
         try {
-            $now = microtime(true);
+            $now = $this->now();
             $window = $this->storage->fetch($this->id);
 
             if (null !== $this->anchorAt) {
@@ -81,7 +83,7 @@ final class FixedWindowLimiter implements LimiterInterface
                     $window = new CalendarAlignedWindow($this->id, $this->limit, $periodStart, $periodEnd);
                 }
             } elseif (!$window instanceof Window) {
-                $window = new Window($this->id, $this->intervalInSeconds, $this->limit);
+                $window = new Window($this->id, $this->intervalInSeconds, $this->limit, $now);
             }
 
             $availableTokens = $window->getAvailableTokens($now);
@@ -158,5 +160,10 @@ final class FixedWindowLimiter implements LimiterInterface
         }
 
         return [$periodStart, $periodEnd];
+    }
+
+    private function now(): float
+    {
+        return null === $this->clock ? microtime(true) : (float) $this->clock->now()->format('U.u');
     }
 }

--- a/src/Symfony/Component/RateLimiter/Policy/SlidingWindow.php
+++ b/src/Symfony/Component/RateLimiter/Policy/SlidingWindow.php
@@ -28,19 +28,21 @@ final class SlidingWindow implements LimiterStateInterface
     public function __construct(
         private string $id,
         private int $intervalInSeconds,
+        ?float $now = null,
     ) {
         if ($intervalInSeconds < 1) {
             throw new InvalidIntervalException(\sprintf('The interval must be positive integer, "%d" given.', $intervalInSeconds));
         }
-        $this->windowEndAt = microtime(true) + $intervalInSeconds;
+        $this->windowEndAt = ($now ?? microtime(true)) + $intervalInSeconds;
     }
 
-    public static function createFromPreviousWindow(self $window, int $intervalInSeconds): self
+    public static function createFromPreviousWindow(self $window, int $intervalInSeconds, ?float $now = null): self
     {
-        $new = new self($window->id, $intervalInSeconds);
+        $now ??= microtime(true);
+        $new = new self($window->id, $intervalInSeconds, $now);
         $windowEndAt = $window->windowEndAt + $intervalInSeconds;
 
-        if (microtime(true) < $windowEndAt) {
+        if ($now < $windowEndAt) {
             $new->hitCountForLastWindow = $window->hitCount;
             $new->windowEndAt = $windowEndAt;
         }
@@ -56,14 +58,14 @@ final class SlidingWindow implements LimiterStateInterface
     /**
      * Returns the remaining of this timeframe and the next one.
      */
-    public function getExpirationTime(): int
+    public function getExpirationTime(?float $now = null): int
     {
-        return (int) ($this->windowEndAt + $this->intervalInSeconds - microtime(true));
+        return (int) ($this->windowEndAt + $this->intervalInSeconds - ($now ?? microtime(true)));
     }
 
-    public function isExpired(): bool
+    public function isExpired(?float $now = null): bool
     {
-        return microtime(true) > $this->windowEndAt;
+        return ($now ?? microtime(true)) > $this->windowEndAt;
     }
 
     public function add(int $hits = 1): void
@@ -74,24 +76,24 @@ final class SlidingWindow implements LimiterStateInterface
     /**
      * Calculates the sliding window number of request.
      */
-    public function getHitCount(): int
+    public function getHitCount(?float $now = null): int
     {
         $startOfWindow = $this->windowEndAt - $this->intervalInSeconds;
-        $percentOfCurrentTimeFrame = min((microtime(true) - $startOfWindow) / $this->intervalInSeconds, 1);
+        $percentOfCurrentTimeFrame = min((($now ?? microtime(true)) - $startOfWindow) / $this->intervalInSeconds, 1);
 
         return (int) floor($this->hitCountForLastWindow * (1 - $percentOfCurrentTimeFrame) + $this->hitCount);
     }
 
-    public function calculateTimeForTokens(int $maxSize, int $tokens): float
+    public function calculateTimeForTokens(int $maxSize, int $tokens, ?float $now = null): float
     {
-        $remaining = $maxSize - $this->getHitCount();
+        $now ??= microtime(true);
+        $remaining = $maxSize - $this->getHitCount($now);
         if ($remaining >= $tokens) {
             return 0;
         }
 
-        $time = microtime(true);
         $startOfWindow = $this->windowEndAt - $this->intervalInSeconds;
-        $timePassed = $time - $startOfWindow;
+        $timePassed = $now - $startOfWindow;
         $windowPassed = min($timePassed / $this->intervalInSeconds, 1);
         $releasable = max(1, $maxSize - floor($this->hitCountForLastWindow * (1 - $windowPassed)));
         $remainingWindow = $this->intervalInSeconds - $timePassed;
@@ -101,7 +103,7 @@ final class SlidingWindow implements LimiterStateInterface
             return $needed * ($remainingWindow / max(1, $releasable));
         }
 
-        return ($this->windowEndAt - $time) + ($needed - $releasable) * ($this->intervalInSeconds / $maxSize);
+        return ($this->windowEndAt - $now) + ($needed - $releasable) * ($this->intervalInSeconds / $maxSize);
     }
 
     public function __serialize(): array

--- a/src/Symfony/Component/RateLimiter/Policy/SlidingWindowLimiter.php
+++ b/src/Symfony/Component/RateLimiter/Policy/SlidingWindowLimiter.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\RateLimiter\Policy;
 
+use Psr\Clock\ClockInterface;
 use Symfony\Component\Lock\LockInterface;
 use Symfony\Component\RateLimiter\Exception\MaxWaitDurationExceededException;
 use Symfony\Component\RateLimiter\LimiterInterface;
@@ -42,6 +43,7 @@ final class SlidingWindowLimiter implements LimiterInterface
         \DateInterval $interval,
         StorageInterface $storage,
         ?LockInterface $lock = null,
+        private readonly ?ClockInterface $clock = null,
     ) {
         $this->storage = $storage;
         $this->lock = $lock;
@@ -58,18 +60,18 @@ final class SlidingWindowLimiter implements LimiterInterface
         $this->lock?->acquire(true);
 
         try {
+            $now = $this->now();
             $window = $this->storage->fetch($this->id);
             if (!$window instanceof SlidingWindow) {
-                $window = new SlidingWindow($this->id, $this->interval);
-            } elseif ($window->isExpired()) {
-                $window = SlidingWindow::createFromPreviousWindow($window, $this->interval);
+                $window = new SlidingWindow($this->id, $this->interval, $now);
+            } elseif ($window->isExpired($now)) {
+                $window = SlidingWindow::createFromPreviousWindow($window, $this->interval, $now);
             }
 
-            $now = microtime(true);
-            $hitCount = $window->getHitCount();
+            $hitCount = $window->getHitCount($now);
             $availableTokens = $this->getAvailableTokens($hitCount);
             if (0 === $tokens) {
-                $resetDuration = $window->calculateTimeForTokens($this->limit, $window->getHitCount());
+                $resetDuration = $window->calculateTimeForTokens($this->limit, $window->getHitCount($now), $now);
                 $resetTime = \DateTimeImmutable::createFromFormat('U', $availableTokens ? floor($now) : floor($now + $resetDuration));
 
                 return new Reservation($now, new RateLimit($availableTokens, $resetTime, true, $this->limit));
@@ -79,21 +81,21 @@ final class SlidingWindowLimiter implements LimiterInterface
 
                 $retryAfter = $now;
                 if ($availableTokens === $tokens) {
-                    $retryAfter += $window->calculateTimeForTokens($this->limit, $window->getHitCount());
+                    $retryAfter += $window->calculateTimeForTokens($this->limit, $window->getHitCount($now), $now);
                 }
 
-                $reservation = new Reservation($now, new RateLimit($this->getAvailableTokens($window->getHitCount()), \DateTimeImmutable::createFromFormat('U', floor($retryAfter)), true, $this->limit));
+                $reservation = new Reservation($now, new RateLimit($this->getAvailableTokens($window->getHitCount($now)), \DateTimeImmutable::createFromFormat('U', floor($retryAfter)), true, $this->limit));
             } else {
-                $waitDuration = $window->calculateTimeForTokens($this->limit, $tokens);
+                $waitDuration = $window->calculateTimeForTokens($this->limit, $tokens, $now);
 
                 if (null !== $maxTime && $waitDuration > $maxTime) {
                     // process needs to wait longer than set interval
-                    throw new MaxWaitDurationExceededException(\sprintf('The rate limiter wait time ("%d" seconds) is longer than the provided maximum time ("%d" seconds).', $waitDuration, $maxTime), new RateLimit($this->getAvailableTokens($window->getHitCount()), \DateTimeImmutable::createFromFormat('U', floor($now + $waitDuration)), false, $this->limit));
+                    throw new MaxWaitDurationExceededException(\sprintf('The rate limiter wait time ("%d" seconds) is longer than the provided maximum time ("%d" seconds).', $waitDuration, $maxTime), new RateLimit($this->getAvailableTokens($window->getHitCount($now)), \DateTimeImmutable::createFromFormat('U', floor($now + $waitDuration)), false, $this->limit));
                 }
 
                 $window->add($tokens);
 
-                $reservation = new Reservation($now + $waitDuration, new RateLimit($this->getAvailableTokens($window->getHitCount()), \DateTimeImmutable::createFromFormat('U', floor($now + $waitDuration)), false, $this->limit));
+                $reservation = new Reservation($now + $waitDuration, new RateLimit($this->getAvailableTokens($window->getHitCount($now)), \DateTimeImmutable::createFromFormat('U', floor($now + $waitDuration)), false, $this->limit));
             }
 
             if (0 !== $tokens) {
@@ -118,5 +120,10 @@ final class SlidingWindowLimiter implements LimiterInterface
     private function getAvailableTokens(int $hitCount): int
     {
         return $this->limit - $hitCount;
+    }
+
+    private function now(): float
+    {
+        return null === $this->clock ? microtime(true) : (float) $this->clock->now()->format('U.u');
     }
 }

--- a/src/Symfony/Component/RateLimiter/Policy/TokenBucketLimiter.php
+++ b/src/Symfony/Component/RateLimiter/Policy/TokenBucketLimiter.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\RateLimiter\Policy;
 
+use Psr\Clock\ClockInterface;
 use Symfony\Component\Lock\LockInterface;
 use Symfony\Component\RateLimiter\Exception\MaxWaitDurationExceededException;
 use Symfony\Component\RateLimiter\LimiterInterface;
@@ -31,6 +32,7 @@ final class TokenBucketLimiter implements LimiterInterface
         private Rate $rate,
         StorageInterface $storage,
         ?LockInterface $lock = null,
+        private readonly ?ClockInterface $clock = null,
     ) {
         $this->id = $id;
         $this->storage = $storage;
@@ -59,12 +61,12 @@ final class TokenBucketLimiter implements LimiterInterface
         $this->lock?->acquire(true);
 
         try {
+            $now = $this->now();
             $bucket = $this->storage->fetch($this->id);
             if (!$bucket instanceof TokenBucket) {
-                $bucket = new TokenBucket($this->id, $this->maxBurst, $this->rate);
+                $bucket = new TokenBucket($this->id, $this->maxBurst, $this->rate, $now);
             }
 
-            $now = microtime(true);
             $availableTokens = $bucket->getAvailableTokens($now);
 
             if ($availableTokens > $this->maxBurst) {
@@ -116,5 +118,10 @@ final class TokenBucketLimiter implements LimiterInterface
         } catch (MaxWaitDurationExceededException $e) {
             return $e->getRateLimit();
         }
+    }
+
+    private function now(): float
+    {
+        return null === $this->clock ? microtime(true) : (float) $this->clock->now()->format('U.u');
     }
 }

--- a/src/Symfony/Component/RateLimiter/RateLimiterFactory.php
+++ b/src/Symfony/Component/RateLimiter/RateLimiterFactory.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\RateLimiter;
 
+use Psr\Clock\ClockInterface;
 use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -32,6 +33,7 @@ final class RateLimiterFactory implements RateLimiterFactoryInterface
         array $config,
         private StorageInterface $storage,
         private ?LockFactory $lockFactory = null,
+        private readonly ?ClockInterface $clock = null,
     ) {
         $options = new OptionsResolver();
         self::configureOptions($options);
@@ -45,9 +47,9 @@ final class RateLimiterFactory implements RateLimiterFactoryInterface
         $lock = $this->lockFactory?->createLock($id);
 
         return match ($this->config['policy']) {
-            'token_bucket' => new TokenBucketLimiter($id, $this->config['limit'], $this->config['rate'], $this->storage, $lock),
-            'fixed_window' => new FixedWindowLimiter($id, $this->config['limit'], $this->config['interval'], $this->storage, $lock, $this->config['anchor_at']),
-            'sliding_window' => new SlidingWindowLimiter($id, $this->config['limit'], $this->config['interval'], $this->storage, $lock),
+            'token_bucket' => new TokenBucketLimiter($id, $this->config['limit'], $this->config['rate'], $this->storage, $lock, $this->clock),
+            'fixed_window' => new FixedWindowLimiter($id, $this->config['limit'], $this->config['interval'], $this->storage, $lock, $this->config['anchor_at'], $this->clock),
+            'sliding_window' => new SlidingWindowLimiter($id, $this->config['limit'], $this->config['interval'], $this->storage, $lock, $this->clock),
             'no_limit' => new NoLimiter(),
             default => throw new \LogicException(\sprintf('Limiter policy "%s" does not exists, it must be either "token_bucket", "sliding_window", "fixed_window" or "no_limit".', $this->config['policy'])),
         };

--- a/src/Symfony/Component/RateLimiter/Tests/Policy/FixedWindowLimiterTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/Policy/FixedWindowLimiterTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\PhpUnit\ClockMock;
+use Symfony\Component\Clock\MockClock;
 use Symfony\Component\RateLimiter\Policy\CalendarAlignedWindow;
 use Symfony\Component\RateLimiter\Policy\FixedWindowLimiter;
 use Symfony\Component\RateLimiter\Policy\Window;
@@ -73,6 +74,17 @@ class FixedWindowLimiterTest extends TestCase
             \DateTimeImmutable::createFromFormat('U', $now + 60),
             $rateLimit->getRetryAfter()
         );
+    }
+
+    public function testConsumeUsesConfiguredClock()
+    {
+        $limiter = $this->createLimiter(clock: new MockClock('@1000'));
+
+        $rateLimit = $limiter->consume(10);
+
+        $this->assertSame(0, $rateLimit->getRemainingTokens());
+        $this->assertTrue($rateLimit->isAccepted());
+        $this->assertSame(1060, $rateLimit->getRetryAfter()->getTimestamp());
     }
 
     #[DataProvider('provideConsumeOutsideInterval')]
@@ -520,8 +532,8 @@ class FixedWindowLimiterTest extends TestCase
         yield ['P1Y'];
     }
 
-    private function createLimiter(string $dateIntervalString = 'PT1M'): FixedWindowLimiter
+    private function createLimiter(string $dateIntervalString = 'PT1M', ?MockClock $clock = null): FixedWindowLimiter
     {
-        return new FixedWindowLimiter('test', 10, new \DateInterval($dateIntervalString), $this->storage);
+        return new FixedWindowLimiter('test', 10, new \DateInterval($dateIntervalString), $this->storage, clock: $clock);
     }
 }

--- a/src/Symfony/Component/RateLimiter/Tests/Policy/SlidingWindowLimiterTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/Policy/SlidingWindowLimiterTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\RateLimiter\Tests\Policy;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\PhpUnit\ClockMock;
+use Symfony\Component\Clock\MockClock;
 use Symfony\Component\RateLimiter\Policy\SlidingWindowLimiter;
 use Symfony\Component\RateLimiter\RateLimit;
 use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
@@ -83,6 +84,17 @@ class SlidingWindowLimiterTest extends TestCase
         );
     }
 
+    public function testConsumeUsesConfiguredClock()
+    {
+        $limiter = $this->createLimiter(new MockClock('@1000'));
+
+        $rateLimit = $limiter->consume(10);
+
+        $this->assertSame(0, $rateLimit->getRemainingTokens());
+        $this->assertTrue($rateLimit->isAccepted());
+        $this->assertSame(1012, $rateLimit->getRetryAfter()->getTimestamp());
+    }
+
     public function testReserve()
     {
         $limiter = $this->createLimiter();
@@ -140,8 +152,8 @@ class SlidingWindowLimiterTest extends TestCase
         }
     }
 
-    private function createLimiter(): SlidingWindowLimiter
+    private function createLimiter(?MockClock $clock = null): SlidingWindowLimiter
     {
-        return new SlidingWindowLimiter('test', 10, new \DateInterval('PT12S'), $this->storage);
+        return new SlidingWindowLimiter('test', 10, new \DateInterval('PT12S'), $this->storage, clock: $clock);
     }
 }

--- a/src/Symfony/Component/RateLimiter/Tests/Policy/TokenBucketLimiterTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/Policy/TokenBucketLimiterTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\RateLimiter\Tests\Policy;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\PhpUnit\ClockMock;
+use Symfony\Component\Clock\MockClock;
 use Symfony\Component\RateLimiter\Exception\MaxWaitDurationExceededException;
 use Symfony\Component\RateLimiter\Policy\Rate;
 use Symfony\Component\RateLimiter\Policy\TokenBucket;
@@ -113,6 +114,19 @@ class TokenBucketLimiterTest extends TestCase
         $this->assertSame(0, $rateLimit->getRemainingTokens());
         $this->assertTrue($rateLimit->isAccepted());
         $this->assertEqualsWithDelta(time(), $rateLimit->getRetryAfter()->getTimestamp(), 10);
+    }
+
+    public function testConsumeUsesConfiguredClock()
+    {
+        $clock = new MockClock('@1000');
+        $rate = Rate::perSecond(1);
+        $limiter = $this->createLimiter(10, $rate, $clock);
+
+        $rateLimit = $limiter->consume(10);
+
+        $this->assertSame(0, $rateLimit->getRemainingTokens());
+        $this->assertTrue($rateLimit->isAccepted());
+        $this->assertSame(1001, $rateLimit->getRetryAfter()->getTimestamp());
     }
 
     public function testConsumeZeroTokens()
@@ -256,8 +270,8 @@ class TokenBucketLimiterTest extends TestCase
         $this->assertEquals(10, $limiter->reserve(1)->getWaitDuration());
     }
 
-    private function createLimiter($initialTokens = 10, ?Rate $rate = null)
+    private function createLimiter($initialTokens = 10, ?Rate $rate = null, ?MockClock $clock = null)
     {
-        return new TokenBucketLimiter('test', $initialTokens, $rate ?? Rate::perSecond(10), $this->storage);
+        return new TokenBucketLimiter('test', $initialTokens, $rate ?? Rate::perSecond(10), $this->storage, clock: $clock);
     }
 }

--- a/src/Symfony/Component/RateLimiter/Tests/RateLimiterFactoryTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/RateLimiterFactoryTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\PhpUnit\ClockMock;
+use Symfony\Component\Clock\MockClock;
 use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
 use Symfony\Component\RateLimiter\Policy\FixedWindowLimiter;
 use Symfony\Component\RateLimiter\Policy\NoLimiter;
@@ -142,6 +143,22 @@ class RateLimiterFactoryTest extends TestCase
             'interval' => '5 seconds',
             'anchor_at' => '2024-01-05 00:00:00 UTC',
         ], new InMemoryStorage());
+    }
+
+    public function testCreatePassesClockToLimiter()
+    {
+        $factory = new RateLimiterFactory([
+            'policy' => 'token_bucket',
+            'id' => 'test',
+            'limit' => 5,
+            'rate' => [
+                'interval' => '5 seconds',
+            ],
+        ], new InMemoryStorage(), clock: new MockClock('@1000'));
+
+        $rateLimit = $factory->create('key')->consume(5);
+
+        $this->assertSame(1005, $rateLimit->getRetryAfter()->getTimestamp());
     }
 
     #[Group('time-sensitive')]

--- a/src/Symfony/Component/RateLimiter/composer.json
+++ b/src/Symfony/Component/RateLimiter/composer.json
@@ -17,10 +17,12 @@
     ],
     "require": {
         "php": ">=8.4.1",
+        "psr/clock": "^1.0",
         "symfony/options-resolver": "^7.4|^8.0"
     },
     "require-dev": {
         "psr/cache": "^1.0|^2.0|^3.0",
+        "symfony/clock": "^7.4|^8.0",
         "symfony/lock": "^7.4|^8.0"
     },
     "autoload": {

--- a/src/Symfony/Component/RateLimiter/composer.json
+++ b/src/Symfony/Component/RateLimiter/composer.json
@@ -17,7 +17,6 @@
     ],
     "require": {
         "php": ">=8.4.1",
-        "psr/clock": "^1.0",
         "symfony/options-resolver": "^7.4|^8.0"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #47999
| License       | MIT

This makes the RateLimiter time source explicit by adding an optional PSR clock to `RateLimiterFactory` and to the built-in limiter implementations.

I read the previous closed attempt in #49222 before implementing this. This version keeps limiter state/value objects free of services and only passes the current timestamp into them where needed.

RED/GREEN:

* RED before implementation, keeping the new tests: `TokenBucketLimiterTest::testConsumeUsesConfiguredClock`, `FixedWindowLimiterTest::testConsumeUsesConfiguredClock`, `SlidingWindowLimiterTest::testConsumeUsesConfiguredClock`, and `RateLimiterFactoryTest::testCreatePassesClockToLimiter` all failed with `Unknown named parameter $clock`.
* GREEN after implementation: `./run-ci.sh`
  * `OK (98 tests, 324 assertions)` for `src/Symfony/Component/RateLimiter/Tests`
  * `OK (1 test, 16 assertions)` for `ConfigurationTest --filter RateLimiter`
  * `OK (11 tests, 36 assertions)` for `PhpFrameworkExtensionTest --filter RateLimiter`
* `git diff --check` passes.

I could not run `composer validate src/Symfony/Component/RateLimiter/composer.json --strict --no-check-lock` locally because `composer` is not installed in this shell.
