### PR TITLE
[Messenger] Stop the PostgreSQL transport from blocking the worker loop

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/PostgreSqlConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/PostgreSqlConnectionTest.php
@@ -17,7 +17,13 @@ use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\DBAL\Result;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Clock\MockClock;
+use Symfony\Component\Messenger\Bridge\Doctrine\Transport\DoctrineReceiver;
 use Symfony\Component\Messenger\Bridge\Doctrine\Transport\PostgreSqlConnection;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
+use Symfony\Component\Messenger\Worker;
 
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>
@@ -72,11 +78,11 @@ class PostgreSqlConnectionTest extends TestCase
         $driverConnection->method('executeStatement')->willReturn(1);
 
         $wrappedConnection = new class {
-            public int $notifyCalls = 0;
+            public array $notifyTimeouts = [];
 
-            public function getNotify()
+            public function getNotify(int $fetchMode = \PDO::FETCH_ASSOC, int|float $timeoutMs = 0)
             {
-                ++$this->notifyCalls;
+                $this->notifyTimeouts[] = $timeoutMs;
 
                 return false;
             }
@@ -89,16 +95,83 @@ class PostgreSqlConnectionTest extends TestCase
 
         $connection = new PostgreSqlConnection(['table_name' => 'queue_table'], $driverConnection);
 
-        $result = $connection->waitForNotify(1000);
+        $result = $connection->waitForNotify(60000);
 
         $this->assertFalse($result);
         $this->assertTrue($connection->isListening());
-        $this->assertSame(1, $wrappedConnection->notifyCalls);
+        $this->assertSame([60000], $wrappedConnection->notifyTimeouts);
     }
 
-    public function testGetBlocksOnNotifyWhenNoExternalListenerIsActive()
+    public function testGetCollectsNotificationsWithoutWaitingWhenNoExternalListenerIsActive()
     {
-        $driverConnection = $this->createMock(Connection::class);
+        [$connection, $wrappedConnection] = $this->createConnectionWithNotifyTimeoutCapture([
+            'table_name' => 'queue_table',
+        ]);
+
+        // first get(): queueEmptiedAt === null -> parent::get(), sets queueEmptiedAt
+        $connection->get();
+        // second/third get(): queueEmptiedAt !== null -> collects pending notifications
+        $connection->get();
+        $connection->get();
+
+        $this->assertTrue($connection->isListening());
+        $this->assertSame([0, 0], $wrappedConnection->notifyTimeouts);
+    }
+
+    public function testGetDoesNotWaitForNotifyWhenTimeoutIsSetToZero()
+    {
+        [$connection, $wrappedConnection] = $this->createConnectionWithNotifyTimeoutCapture([
+            'table_name' => 'queue_table',
+            'get_notify_timeout' => 0,
+        ]);
+
+        $connection->get();
+        $connection->get();
+
+        $this->assertSame([0], $wrappedConnection->notifyTimeouts);
+    }
+
+    public function testWorkerKeepsPollingItsOtherReceiversWhileThePostgreSqlQueueIsEmpty()
+    {
+        $clock = new MockClock();
+        $startedAt = $clock->now()->getTimestamp();
+
+        // a blocking getNotify() would move the clock forward
+        [$connection] = $this->createConnectionWithNotifyTimeoutCapture(['table_name' => 'queue_table'], $clock);
+
+        $otherReceiver = new class implements ReceiverInterface {
+            public int $calls = 0;
+
+            public function get(): iterable
+            {
+                ++$this->calls;
+
+                return [];
+            }
+
+            public function ack(Envelope $envelope): void
+            {
+            }
+
+            public function reject(Envelope $envelope): void
+            {
+            }
+        };
+
+        $worker = new Worker([
+            'pgsql' => new DoctrineReceiver($connection),
+            'other' => $otherReceiver,
+        ], $this->createStub(MessageBusInterface::class), clock: $clock);
+
+        $worker->run(['sleep' => 1000000, 'time_limit' => 5]);
+
+        $this->assertSame(5, $otherReceiver->calls);
+        $this->assertSame(5, $clock->now()->getTimestamp() - $startedAt);
+    }
+
+    private function createConnectionWithNotifyTimeoutCapture(array $configuration, ?MockClock $clock = null): array
+    {
+        $driverConnection = $this->createStub(Connection::class);
         $driverConnection->method('executeStatement')->willReturn(1);
 
         $driverConnection
@@ -109,19 +182,23 @@ class PostgreSqlConnectionTest extends TestCase
             ->method('createQueryBuilder')
             ->willReturn(new QueryBuilder($driverConnection));
 
-        $wrappedConnection = new class {
-            public int $notifyCalls = 0;
+        $wrappedConnection = new class($clock) {
+            public array $notifyTimeouts = [];
 
-            public function getNotify()
+            public function __construct(private ?MockClock $clock)
             {
-                ++$this->notifyCalls;
+            }
+
+            public function getNotify(int $fetchMode = \PDO::FETCH_ASSOC, int|float $timeoutMs = 0)
+            {
+                $this->notifyTimeouts[] = $timeoutMs;
+                $this->clock?->sleep($timeoutMs / 1000);
 
                 return false;
             }
         };
 
         $driverConnection
-            ->expects(self::exactly(2))
             ->method('getNativeConnection')
             ->willReturn($wrappedConnection);
 
@@ -132,16 +209,7 @@ class PostgreSqlConnectionTest extends TestCase
             ->method('executeQuery')
             ->willReturn(new Result($driverResult, $driverConnection));
 
-        $connection = new PostgreSqlConnection(['table_name' => 'queue_table'], $driverConnection);
-
-        // first get(): queueEmptiedAt === null -> parent::get(), sets queueEmptiedAt
-        $connection->get();
-        // second/third get(): queueEmptiedAt !== null -> blocks on getNotify
-        $connection->get();
-        $connection->get();
-
-        $this->assertTrue($connection->isListening());
-        $this->assertSame(2, $wrappedConnection->notifyCalls);
+        return [new PostgreSqlConnection($configuration, $driverConnection), $wrappedConnection];
     }
 
     public function testGetSkipsBlockingWhenListenCalledExternally()

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/PostgreSqlConnection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/PostgreSqlConnection.php
@@ -29,7 +29,8 @@ final class PostgreSqlConnection extends Connection
 
     /**
      * * check_delayed_interval: The interval to check for delayed messages, in milliseconds. Set to 0 to disable checks. Default: 60000 (1 minute)
-     * * get_notify_timeout: The maximum time to wait for a NOTIFY, in milliseconds. Default: 60000 (1 minute).
+     * * get_notify_timeout: The maximum time PostgreSqlNotifyOnIdleListener waits for a NOTIFY while the worker is idle,
+     *                       in milliseconds. Set to 0 to disable waiting. Default: 60000 (1 minute).
      */
     protected const DEFAULT_OPTIONS = parent::DEFAULT_OPTIONS + [
         'check_delayed_interval' => 60000,
@@ -68,8 +69,10 @@ final class PostgreSqlConnection extends Connection
             return parent::get($fetchSize);
         }
 
-        // Fallback: when no external listener handles LISTEN/NOTIFY,
-        // block here until a notification arrives or timeout expires
+        // Fallback: when no external listener handles LISTEN/NOTIFY, only collect the
+        // notifications that already arrived. Waiting for one is up to
+        // PostgreSqlNotifyOnIdleListener, which knows how long the worker can afford to
+        // block, while get() is called for a single receiver of that worker.
 
         // This is secure because the table name must be a valid identifier:
         // https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
@@ -79,16 +82,16 @@ final class PostgreSqlConnection extends Connection
 
         /** @var \PDO $nativeConnection */
         $nativeConnection = $this->driverConnection->getNativeConnection();
-        $timeout = $this->configuration['check_delayed_interval'] - (microtime(true) * 1000 - $this->queueEmptiedAt);
-        $timeout = max(0, ceil(min($this->configuration['get_notify_timeout'] ?: $timeout, $timeout)));
 
-        $notification = $nativeConnection->getNotify(\PDO::FETCH_ASSOC, $timeout);
+        $notification = $nativeConnection->getNotify(\PDO::FETCH_ASSOC, 0);
         if (
             // no notifications, or for another table or queue
             (false === $notification || $notification['message'] !== $this->configuration['table_name'] || $notification['payload'] !== $this->configuration['queue_name'])
             // delayed messages
             && (microtime(true) * 1000 - $this->queueEmptiedAt < $this->configuration['check_delayed_interval'])
         ) {
+            usleep(1000);
+
             return null;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65079
| License       | MIT

`PostgreSqlConnection::get()` stops waiting for a `NOTIFY`. It still issues the `LISTEN` and still collects the notifications that already arrived, but with a zero timeout, so it hands control back to the worker immediately. Waiting while the worker is idle remains the job of `PostgreSqlNotifyOnIdleListener`, whose `waitForNotify()` is untouched. This is the shape the method has on 6.4, 7.4 and 8.0.

### Why the connection cannot own the wait

`get()` is called for a single receiver of a worker that may consume several transports. It does not know:

* how many transports the worker consumes, so it cannot tell whether parking the loop starves the others;
* the worker's `--sleep`, so it cannot pick a bound that respects the requested polling rate;
* the worker's `--time-limit`, so its wait can outlive the deadline.

`PostgreSqlNotifyOnIdleListener` knows all three: it receives `WorkerStartedEvent`, caps its wait to the idle timeout when non-PostgreSQL transports are consumed, caps it to the worker deadline, and caps it to the earliest delayed message. Any bound computed inside `get()` is a lesser copy of that.

Since 8.1, `get()` waited up to `get_notify_timeout` (default `60000`), bounded by the time left before the next delayed-message check. For a worker whose idle listener is not wired, that parks the whole receiver loop for up to a minute per idle cycle.

Measured with a real `Worker`, a real `DoctrineReceiver` over a stubbed DBAL connection whose `getNotify()` sleeps for the requested timeout, and a second, counting receiver:

|            | sibling receiver polled | `--time-limit=5` returned after |
| ---------- | ----------------------- | ------------------------------- |
| 8.1 today  | every 56.9 s            | 56.9 s                          |
| this PR    | every 1.0 s (`--sleep`) | 5.0 s                           |

The same harness with `--sleep 0.1 --time-limit 3` polls the sibling receiver 29 times with this patch. Merely capping the wait in `get()` to 1 s instead of removing it yields 6 polls: a bound chosen by the connection overrides the polling rate the user asked for.

### What users without the idle listener should expect

DoctrineBundle registers `PostgreSqlNotifyOnIdleListener` since 3.3.0, so applications running that version or later never took this path and are not affected either way.

Without the listener, the PostgreSQL transport is polled at the worker's `--sleep` interval instead of being pushed by `NOTIFY`. A message published while the worker sleeps is picked up on the next poll, and delayed messages are picked up on the first poll after `check_delayed_interval` has elapsed rather than exactly at that instant. This is the 8.0 behaviour.

`get_notify_timeout` now only takes effect where it can be honoured, in the idle listener, and the docblock says so. Setting it to `0` disables the idle wait and no longer falls back to `check_delayed_interval` inside `get()`.

### symfony-docs

`messenger.rst` still documents `get_notify_timeout` with its pre-8.1 default of `0` and its pre-8.1 meaning ("the length of time to wait for a response when calling `PDO::pgsqlGetNotify`"). That needs a separate docs PR: the default is `60000` since 8.1, and the option bounds the wait performed by the idle listener while the worker is idle, `0` disabling it.
