### PR TITLE
 Tell dependabot to ignore the 8.0 branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,18 +32,6 @@ updates:
 
     - package-ecosystem: 'github-actions'
       directory: '/'
-      target-branch: '8.0'
-      schedule:
-          interval: 'weekly'
-      groups:
-          github-actions:
-              patterns:
-                  - '*'
-      cooldown:
-          default-days: 9
-
-    - package-ecosystem: 'github-actions'
-      directory: '/'
       target-branch: '8.1'
       schedule:
           interval: 'weekly'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

The 8.0 branch is EOL. Dependabot should not bother updating anything there.