### PR TITLE
[Mailer] Fix low-deps tests for Mailgun

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Transport/MailgunApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Transport/MailgunApiTransportTest.php
@@ -199,13 +199,21 @@ class MailgunApiTransportTest extends TestCase
         });
         $transport = new MailgunApiTransport('ACCESS_KEY', 'symfony', 'us-east-1', $client);
 
+        $addPart = method_exists(Email::class, 'addPart')
+            ? static function (Email $email, string $body, string $filename, string $contentType): void {
+                $email->addPart((new DataPart($body, $filename, $contentType))->asInline());
+            } : static function (Email $email, string $body, string $filename, string $contentType): void {
+                $email->embed($body, $filename, $contentType);
+            };
+
         $mail = new Email();
         $mail->subject('Hello!')
             ->to(new Address('saif.gmati@symfony.com', 'Saif Eddin'))
             ->from(new Address('fabpot@symfony.com', 'Fabien'))
-            ->html('<img src="cid:a/b"><img src="cid:a/b/c">')
-            ->addPart((new DataPart('image', 'a/b', 'image/png'))->asInline())
-            ->addPart((new DataPart('nested-image', 'a/b/c', 'image/png'))->asInline());
+            ->html('<img src="cid:a/b"><img src="cid:a/b/c">');
+
+        $addPart($mail, 'image', 'a/b', 'image/png');
+        $addPart($mail, 'nested-image', 'a/b/c', 'image/png');
 
         $message = $transport->send($mail);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

Low-deps tests currently fail because the `addPart()` method does not exist on Mailer 5.4. This change should be reverted when merging up to 6.4.