### PR TITLE
[Translation] Make `FilteringProvider::read()` return early if no locales or domains match the configured ones

### DIFF
--- a/UPGRADE-8.2.md
+++ b/UPGRADE-8.2.md
@@ -59,3 +59,8 @@ Serializer
 ----------
 
  * Deprecate denormalizing an array that is not a list into a `list`-typed property, in version 9.0 a `Symfony\Component\Serializer\Exception\NotNormalizableValueException` will be thrown when the input does not satisfy `array_is_list()`
+
+Translation
+-----------
+
+ * `FilteringProvider::read()` now returns an empty `TranslatorBag` when none of the requested locales match the configured ones, and a bag of empty catalogues when no requested domain matches, instead of delegating to the wrapped provider

--- a/src/Symfony/Component/Translation/Provider/FilteringProvider.php
+++ b/src/Symfony/Component/Translation/Provider/FilteringProvider.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Translation\Provider;
 
+use Symfony\Component\Translation\MessageCatalogue;
 use Symfony\Component\Translation\TranslatorBag;
 use Symfony\Component\Translation\TranslatorBagInterface;
 
@@ -41,8 +42,19 @@ class FilteringProvider implements ProviderInterface
 
     public function read(array $domains, array $locales): TranslatorBag
     {
-        $domains = !$this->domains ? $domains : array_intersect($this->domains, $domains);
-        $locales = array_intersect($this->locales, $locales);
+        if ($this->locales && !$locales = $locales ? array_intersect($this->locales, $locales) : $this->locales) {
+            return new TranslatorBag();
+        }
+
+        if ($this->domains && !$domains = $domains ? array_intersect($this->domains, $domains) : $this->domains) {
+            $translatorBag = new TranslatorBag();
+
+            foreach ($locales as $locale) {
+                $translatorBag->addCatalogue(new MessageCatalogue($locale));
+            }
+
+            return $translatorBag;
+        }
 
         return $this->provider->read($domains, $locales);
     }

--- a/src/Symfony/Component/Translation/Tests/Provider/FilteringProviderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Provider/FilteringProviderTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Translation\Tests\Provider;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Translation\MessageCatalogue;
 use Symfony\Component\Translation\Provider\FilteringProvider;
 use Symfony\Component\Translation\Provider\ProviderInterface;
 use Symfony\Component\Translation\TranslatorBag;
@@ -53,5 +54,157 @@ class FilteringProviderTest extends TestCase
         );
 
         $filteringProvider->read(['bar'], ['en']);
+    }
+
+    public function testReadNoLocalesWithoutConfiguredLocales()
+    {
+        $innerProvider = $this->createMock(ProviderInterface::class);
+        $innerProvider->expects($this->once())
+            ->method('read')
+            ->with(['messages'], [])
+            ->willReturn(new TranslatorBag());
+
+        $filteringProvider = new FilteringProvider(
+            $innerProvider,
+            [],
+            ['messages']
+        );
+
+        $filteringProvider->read(['messages'], []);
+    }
+
+    public function testReadNoLocalesFallsBackToConfiguredLocales()
+    {
+        $innerProvider = $this->createMock(ProviderInterface::class);
+        $innerProvider->expects($this->once())
+            ->method('read')
+            ->with(['messages'], ['en', 'fr'])
+            ->willReturn(new TranslatorBag());
+
+        $filteringProvider = new FilteringProvider(
+            $innerProvider,
+            ['en', 'fr'],
+            ['messages']
+        );
+
+        $filteringProvider->read(['messages'], []);
+    }
+
+    public function testReadNoMatchingLocales()
+    {
+        $innerProvider = $this->createMock(ProviderInterface::class);
+        $innerProvider->expects($this->never())->method('read');
+
+        $filteringProvider = new FilteringProvider(
+            $innerProvider,
+            ['en'],
+            ['messages']
+        );
+
+        $this->assertCount(0, $filteringProvider->read(['messages'], ['fr'])->getCatalogues());
+    }
+
+    public function testReadNoDomainsWithoutConfiguredDomains()
+    {
+        $innerProvider = $this->createMock(ProviderInterface::class);
+        $innerProvider->expects($this->once())
+            ->method('read')
+            ->with([], ['en'])
+            ->willReturn(new TranslatorBag());
+
+        $filteringProvider = new FilteringProvider(
+            $innerProvider,
+            ['en'],
+            []
+        );
+
+        $filteringProvider->read([], ['en']);
+    }
+
+    public function testReadNoDomainsFallsBackToConfiguredDomains()
+    {
+        $innerProvider = $this->createMock(ProviderInterface::class);
+        $innerProvider->expects($this->once())
+            ->method('read')
+            ->with(['messages', 'validators'], ['en'])
+            ->willReturn(new TranslatorBag());
+
+        $filteringProvider = new FilteringProvider(
+            $innerProvider,
+            ['en'],
+            ['messages', 'validators']
+        );
+
+        $filteringProvider->read([], ['en']);
+    }
+
+    public function testReadNoMatchingDomains()
+    {
+        $innerProvider = $this->createMock(ProviderInterface::class);
+        $innerProvider->expects($this->never())->method('read');
+
+        $filteringProvider = new FilteringProvider(
+            $innerProvider,
+            ['en'],
+            ['messages']
+        );
+
+        $translatorBag = $filteringProvider->read(['validators'], ['en']);
+
+        $this->assertCount(1, $translatorBag->getCatalogues());
+        $this->assertCount(0, $translatorBag->getCatalogue('en')->getDomains());
+    }
+
+    public function testReadRequestedLocalesWithoutConfiguredLocales()
+    {
+        $innerProvider = $this->createMock(ProviderInterface::class);
+        $innerProvider->expects($this->once())
+            ->method('read')
+            ->with(['messages'], ['fr'])
+            ->willReturn(new TranslatorBag());
+
+        $filteringProvider = new FilteringProvider(
+            $innerProvider,
+            [],
+            ['messages']
+        );
+
+        $filteringProvider->read(['messages'], ['fr']);
+    }
+
+    public function testReadKeepsRequestedLocalesThatAreConfigured()
+    {
+        $innerProvider = $this->createMock(ProviderInterface::class);
+        $innerProvider->expects($this->once())
+            ->method('read')
+            ->with(['messages'], ['fr'])
+            ->willReturn(new TranslatorBag());
+
+        $filteringProvider = new FilteringProvider(
+            $innerProvider,
+            ['fr', 'en'],
+            ['messages']
+        );
+
+        $filteringProvider->read(['messages'], ['fr', 'de']);
+    }
+
+    public function testReadNoMatchingDomainsKeepsMatchingLocalesOnly()
+    {
+        $innerProvider = $this->createMock(ProviderInterface::class);
+        $innerProvider->expects($this->never())->method('read');
+
+        $filteringProvider = new FilteringProvider(
+            $innerProvider,
+            ['fr', 'en'],
+            ['messages']
+        );
+
+        $translatorBag = $filteringProvider->read(['validators'], ['fr', 'de']);
+
+        $this->assertSame(
+            ['fr'],
+            array_map(static fn (MessageCatalogue $catalogue) => $catalogue->getLocale(), $translatorBag->getCatalogues()),
+        );
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

In #64155 I suggested providers should fetch every locale when their `read` method is called without any, and work has been done in this direction. However if a provider has been configured with locales, we don’t want `read` with no matching locales to do that. This PR returns an empty `TranslatorBag` instead.

The same reasoning applies to domains, except that in that case the returned `TranslatorBag` has one empty `MessageCatalogue` per locale.

When no locale (resp. no domain) is requested at all, the configured ones are used, so the inner provider still receives the filters the provider is configured for. `translation:pull` gives its `--locales` option no default and `framework.enabled_locales` has no default value either, so a bare `translation:pull` goes through that path.

It also fixes a second case: locales were intersected even when none are configured, and `array_intersect([], $locales)` is empty whatever was asked, so the requested locales were discarded and a provider reading everything when passed none returned the whole project. `translation:pull --locales=fr` now reaches the inner provider as `fr`.

A possible improvement could be the `translation:pull` command detecting such cases and failing with appropriate feedback, but `FilteringProvider` only exposes a getter for its domains so we cannot check locales yet.

Filed against 8.2 rather than the oldest affected branch because the change is observable: a provider configured with locales or domains, asked for none that match, used to delegate anyway. With Lokalise an empty filter means "no filter", so such a request silently exported the whole project. Applications relying on that will pull fewer files after upgrading, which is why there is an `UPGRADE-8.2.md` entry.
