### PR TITLE
[DoctrineBridge] Close all expired connections in the idle listener

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Middleware/IdleConnection/Listener.php
+++ b/src/Symfony/Bridge/Doctrine/Middleware/IdleConnection/Listener.php
@@ -35,7 +35,8 @@ final class Listener implements EventSubscriberInterface
         }
         $timestamp = time();
 
-        foreach ($this->connectionExpiries as $name => $expiry) {
+        // iterate over a copy: removing the current key would make the iterator skip the next one
+        foreach ($this->connectionExpiries->getArrayCopy() as $name => $expiry) {
             if ($timestamp >= $expiry) {
                 // unset before so that we won't retry in case of any failure
                 $this->connectionExpiries->offsetUnset($name);

--- a/src/Symfony/Bridge/Doctrine/Tests/Middleware/IdleConnection/ListenerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Middleware/IdleConnection/ListenerTest.php
@@ -38,11 +38,42 @@ class ListenerTest extends TestCase
         $this->assertArrayHasKey('connectiontwo', (array) $connectionExpiries);
     }
 
+    public function testOnKernelRequestClosesEveryExpiredConnection()
+    {
+        $connectionExpiries = new \ArrayObject([
+            'connectionone' => time() - 30,
+            'connectiontwo' => time() - 20,
+            'connectionthree' => time() + 40,
+        ]);
+
+        $connectionOneMock = $this->createMock(ConnectionInterface::class);
+        $connectionOneMock->expects($this->once())->method('close');
+
+        $connectionTwoMock = $this->createMock(ConnectionInterface::class);
+        $connectionTwoMock->expects($this->once())->method('close');
+
+        $connectionThreeMock = $this->createMock(ConnectionInterface::class);
+        $connectionThreeMock->expects($this->never())->method('close');
+
+        $container = new Container();
+        $container->set('doctrine.dbal.connectionone_connection', $connectionOneMock);
+        $container->set('doctrine.dbal.connectiontwo_connection', $connectionTwoMock);
+        $container->set('doctrine.dbal.connectionthree_connection', $connectionThreeMock);
+
+        $listener = new Listener($connectionExpiries, $container);
+
+        $listener->onKernelRequest(new RequestEvent($this->createStub(HttpKernelInterface::class), new Request(), HttpKernelInterface::MAIN_REQUEST));
+
+        $this->assertArrayNotHasKey('connectionone', (array) $connectionExpiries);
+        $this->assertArrayNotHasKey('connectiontwo', (array) $connectionExpiries);
+        $this->assertArrayHasKey('connectionthree', (array) $connectionExpiries);
+    }
+
     public function testOnKernelRequestShouldSkipSubrequests()
     {
         self::expectNotToPerformAssertions();
         $arrayObj = $this->createStub(\ArrayObject::class);
-        $arrayObj->method('getIterator')->willThrowException(new \Exception('Invalid behavior'));
+        $arrayObj->method('getArrayCopy')->willThrowException(new \Exception('Invalid behavior'));
         $listener = new Listener($arrayObj, new Container());
 
         $listener->onKernelRequest(new RequestEvent($this->createStub(HttpKernelInterface::class), new Request(), HttpKernelInterface::SUB_REQUEST));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`Listener::onKernelRequest()` iterated the shared `ArrayObject` of connection expiries directly while removing entries from it. `ArrayObject::getIterator()` returns an `ArrayIterator` over the same hashtable, so unsetting the current key advances the internal pointer and the next entry is skipped.

With two connections expiring in the same request, only the first is closed. With four, only the first and the third. The skipped entries keep their stale expiry and are picked up on a later request, so they are not lost forever, but until then the application is handed a connection the listener was supposed to have closed, which is what produces `MySQL server has gone away` on a long running runtime.

Iterating over `getArrayCopy()` leaves the removals to operate on the underlying object without disturbing the traversal. The `ArrayObject` itself stays shared by reference, so an expiry registered while the loop runs is still recorded and simply handled on the next request.

A single connection is unaffected, which is why this went unnoticed.
