### PR TITLE
[Translation] Make `FilteringProvider::read()` return early if no locales or domains match the configured ones

### DIFF
--- a/src/Symfony/Component/Translation/Provider/FilteringProvider.php
+++ b/src/Symfony/Component/Translation/Provider/FilteringProvider.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Translation\Provider;
 
+use Symfony\Component\Translation\MessageCatalogue;
 use Symfony\Component\Translation\TranslatorBag;
 use Symfony\Component\Translation\TranslatorBagInterface;
 
@@ -40,8 +41,19 @@ class FilteringProvider implements ProviderInterface
 
     public function read(array $domains, array $locales): TranslatorBag
     {
-        $domains = !$this->domains ? $domains : array_intersect($this->domains, $domains);
-        $locales = array_intersect($this->locales, $locales);
+        if ($this->locales && !$locales = array_intersect($this->locales, $locales)) {
+            return new TranslatorBag();
+        }
+
+        if ($this->domains && !$domains = array_intersect($this->domains, $domains)) {
+            $translatorBag = new TranslatorBag();
+
+            foreach ($locales as $locale) {
+                $translatorBag->addCatalogue(new MessageCatalogue($locale));
+            }
+
+            return $translatorBag;
+        }
 
         return $this->provider->read($domains, $locales);
     }

--- a/src/Symfony/Component/Translation/Tests/Provider/FilteringProviderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Provider/FilteringProviderTest.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Tests\Provider;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Translation\MessageCatalogue;
+use Symfony\Component\Translation\Provider\FilteringProvider;
+use Symfony\Component\Translation\Provider\ProviderInterface;
+use Symfony\Component\Translation\TranslatorBag;
+
+class FilteringProviderTest extends TestCase
+{
+    public function testReadRequestedLocalesWithoutConfiguredLocales()
+    {
+        $innerProvider = $this->createMock(ProviderInterface::class);
+        $innerProvider->expects($this->once())
+            ->method('read')
+            ->with(['messages'], ['fr'])
+            ->willReturn(new TranslatorBag());
+
+        $filteringProvider = new FilteringProvider(
+            $innerProvider,
+            [],
+            ['messages']
+        );
+
+        $filteringProvider->read(['messages'], ['fr']);
+    }
+
+    public function testReadKeepsRequestedLocalesThatAreConfigured()
+    {
+        $innerProvider = $this->createMock(ProviderInterface::class);
+        $innerProvider->expects($this->once())
+            ->method('read')
+            ->with(['messages'], ['fr'])
+            ->willReturn(new TranslatorBag());
+
+        $filteringProvider = new FilteringProvider(
+            $innerProvider,
+            ['fr', 'en'],
+            ['messages']
+        );
+
+        $filteringProvider->read(['messages'], ['fr', 'de']);
+    }
+
+    public function testReadNoConfiguredLocales()
+    {
+        $innerProvider = $this->createMock(ProviderInterface::class);
+        $innerProvider->expects($this->never())->method('read');
+
+        $filteringProvider = new FilteringProvider(
+            $innerProvider,
+            ['en'],
+            ['messages']
+        );
+
+        $this->assertCount(0, $filteringProvider->read(['messages'], ['fr'])->getCatalogues());
+    }
+
+    public function testReadNoConfiguredDomains()
+    {
+        $innerProvider = $this->createMock(ProviderInterface::class);
+        $innerProvider->expects($this->never())->method('read');
+
+        $filteringProvider = new FilteringProvider(
+            $innerProvider,
+            ['en'],
+            ['messages']
+        );
+
+        $this->assertCount(0, $filteringProvider->read(['validators'], ['en'])->getCatalogue('en')->getDomains());
+    }
+
+    public function testReadNoConfiguredDomainsKeepsConfiguredLocalesOnly()
+    {
+        $innerProvider = $this->createMock(ProviderInterface::class);
+        $innerProvider->expects($this->never())->method('read');
+
+        $filteringProvider = new FilteringProvider(
+            $innerProvider,
+            ['fr', 'en'],
+            ['messages']
+        );
+
+        $translatorBag = $filteringProvider->read(['validators'], ['fr', 'de']);
+
+        $this->assertSame(
+            ['fr'],
+            array_map(static fn (MessageCatalogue $catalogue) => $catalogue->getLocale(), $translatorBag->getCatalogues()),
+        );
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Same patch as #65090, on 7.4, since the flaw looks older than 8.2. The commit is @MatTheCat's work, I only retargeted it and added tests.

`FilteringProvider::read()` intersects the requested locales with the configured ones, and the requested domains with the configured ones, then hands the result to the inner provider. Two cases end up passing an empty array down:

 * nothing intersects, for instance `translation:pull --locales=de` on a provider configured for `en`;
 * no locale is configured at all, in which case `array_intersect([], $locales)` is empty whatever was asked, so `--locales=fr` is discarded.

A provider that treats "no locale" or "no domain" as "everything" then returns the whole project. `LokaliseProvider` does exactly that: `exportFiles()` sends `filter_langs` and `filter_filenames` built from those arrays, so empty filters export every language and every file. `read()` now returns early instead, with an empty `TranslatorBag` when no locale matches, and one empty `MessageCatalogue` per locale when no domain matches.

@MatTheCat could you confirm the Lokalise side from a real project, the same way you checked Loco earlier? What I am after is whether an export with empty `filter_langs` really returns every language, which is what #64155 describes and what makes this a 7.4 bug rather than an 8.2 one. If it does not, this can be closed and #65090 merged on 8.2 instead, where Loco and Crowdin gained that behaviour.

`translation:pull --force` is safe in both branches: with local files in place and a provider whose locales or domains do not match, nothing is written, because a catalogue without domains produces no file.
