### PR TITLE
[WebProfilerBundle] Avoid a flash of unstyled content in the debug toolbar

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
@@ -1,4 +1,9 @@
 <!-- START of Symfony Web Debug Toolbar -->
+{# The stylesheet is loaded before the toolbar markup, and the empty script below makes
+   the parser wait for it, so the toolbar is never painted unstyled. #}
+<link rel="stylesheet"{% if csp_style_nonce %} nonce="{{ csp_style_nonce }}"{% endif %} href="{{ url('_wdt_stylesheet') }}" />
+<script{% if csp_script_nonce is defined and csp_script_nonce %} nonce="{{ csp_script_nonce }}"{% endif %}> </script>
+
 <div class="sf-toolbar sf-toolbar-opened" role="region" aria-label="Symfony Web Debug Toolbar" data-frankenphp-hot-reload-preserve>
     <div id="sfwdt{{ token }}">
         {{ include('@WebProfiler/Profiler/toolbar.html.twig', {
@@ -10,8 +15,6 @@
             profiler_markup_version: 3,
         }) }}
     </div>
-
-    <link rel="stylesheet"{% if csp_style_nonce %} nonce="{{ csp_style_nonce }}"{% endif %} href="{{ url('_wdt_stylesheet') }}" />
 
     {# CAUTION: the contents of this file are processed by Twig before loading
                 them as JavaScript source code. Always use '/*' comments instead


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65094
| License       | MIT

The toolbar markup is injected before `</body>`, and the stylesheet that positions it was fetched from a `link` placed *after* that markup. The browser could therefore paint the toolbar as ordinary in-flow content at the bottom of the page, then move it to `position: fixed; bottom: 0` once `_wdt_stylesheet` arrived. On a slow connection the jump is clearly visible.

The `link` now comes before the toolbar markup, followed by an empty `script`. A parser-inserted script has to wait for the stylesheets that precede it, because it may query computed styles, so the toolbar element is not parsed, let alone painted, until its stylesheet is in. Nothing is hidden and nothing has to be revealed later, so no code path can leave the toolbar invisible.

Both elements carry the nonces the bundle already emits, `csp_style_nonce` on the `link` and `csp_script_nonce` on the `script`, so a strict Content Security Policy does not drop either.

The trade-off is that the page's `DOMContentLoaded` now waits for the toolbar stylesheet. It is served by the same development server that just served the page, and this only ever runs with the toolbar enabled, so the cost is small and confined to development.

Not unit-testable: this is a browser paint-timing property. `WebDebugToolbarListenerTest` mocks the Twig environment to return a literal string, so the template is never rendered, and no functional test exercises `toolbar_js.html.twig`. A test asserting the rendered output contains the new markup would only restate the diff.

For the merger: 8.1 and 8.2 carry `role="toolbar"` where 7.4 has `role="region"` on the same line, so the hunk conflicts trivially on merge-up.
