### PR TITLE
[Messenger] Filter failed messages by class and failure time

### DIFF
--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add `$serializedTypeNameAliases` parameter to `#[AsMessage]` to accept alternate serialized type names when decoding
+ * Add `--failed-after` and `--failed-before` options to the `messenger:failed:retry`, `messenger:failed:remove` and `messenger:failed:show` commands, and a `--class-filter` option to `messenger:failed:retry`
 
 8.1
 ---

--- a/src/Symfony/Component/Messenger/Command/AbstractFailedMessagesCommand.php
+++ b/src/Symfony/Component/Messenger/Command/AbstractFailedMessagesCommand.php
@@ -14,7 +14,9 @@ namespace Symfony\Component\Messenger\Command;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Completion\CompletionInput;
 use Symfony\Component\Console\Completion\CompletionSuggestions;
+use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Helper\Dumper;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Question\ChoiceQuestion;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\ErrorHandler\Exception\FlattenException;
@@ -137,6 +139,63 @@ abstract class AbstractFailedMessagesCommand extends Command
         }
     }
 
+    /**
+     * @param bool $hasIds Whether explicit message ids were given, which the filters cannot be combined with
+     *
+     * @return array{?string, ?\DateTimeImmutable, ?\DateTimeImmutable} The class name, the earliest and the latest failure time to select
+     */
+    protected function getFilters(InputInterface $input, bool $hasIds): array
+    {
+        $classFilter = $input->getOption('class-filter');
+        $failedAfter = $this->getDateOption($input, 'failed-after');
+        $failedBefore = $this->getDateOption($input, 'failed-before');
+
+        if ($hasIds && (null !== $classFilter || null !== $failedAfter || null !== $failedBefore)) {
+            throw new RuntimeException('You cannot specify message ids when using the "--class-filter", "--failed-after" or "--failed-before" options.');
+        }
+
+        return [$classFilter, $failedAfter, $failedBefore];
+    }
+
+    /**
+     * @return list<mixed> The ids of the messages matching every given filter
+     */
+    protected function getMessageIdsByFilter(ListableReceiverInterface $receiver, ?string $classFilter, ?\DateTimeImmutable $failedAfter, ?\DateTimeImmutable $failedBefore): array
+    {
+        $ids = [];
+
+        $this->phpSerializer?->acceptPhpIncompleteClass();
+        try {
+            foreach ($receiver->all() as $envelope) {
+                if ($this->matchesFilter($envelope, $classFilter, $failedAfter, $failedBefore)) {
+                    $ids[] = $this->getMessageId($envelope);
+                }
+            }
+        } finally {
+            $this->phpSerializer?->rejectPhpIncompleteClass();
+        }
+
+        return $ids;
+    }
+
+    protected function matchesFilter(Envelope $envelope, ?string $classFilter, ?\DateTimeImmutable $failedAfter, ?\DateTimeImmutable $failedBefore): bool
+    {
+        if (null !== $classFilter && $classFilter !== $envelope->getMessage()::class) {
+            return false;
+        }
+
+        if (null === $failedAfter && null === $failedBefore) {
+            return true;
+        }
+
+        // messages that were never redelivered have no known failure time, so no time window can select them
+        if (null === $failedAt = $envelope->last(RedeliveryStamp::class)?->getRedeliveredAt()) {
+            return false;
+        }
+
+        return (null === $failedAfter || $failedAt >= $failedAfter) && (null === $failedBefore || $failedAt <= $failedBefore);
+    }
+
     protected function getReceiver(?string $name = null): ReceiverInterface
     {
         if (null === $name ??= $this->globalFailureReceiverName) {
@@ -148,6 +207,19 @@ abstract class AbstractFailedMessagesCommand extends Command
         }
 
         return $this->failureTransports->get($name);
+    }
+
+    private function getDateOption(InputInterface $input, string $option): ?\DateTimeImmutable
+    {
+        if (null === $value = $input->getOption($option)) {
+            return null;
+        }
+
+        try {
+            return new \DateTimeImmutable($value);
+        } catch (\DateMalformedStringException $e) {
+            throw new InvalidArgumentException(\sprintf('The value of the "--%s" option is not a valid date: "%s".', $option, $value), previous: $e);
+        }
     }
 
     private function createCloner(): ?ClonerInterface

--- a/src/Symfony/Component/Messenger/Command/FailedMessagesRemoveCommand.php
+++ b/src/Symfony/Component/Messenger/Command/FailedMessagesRemoveCommand.php
@@ -37,6 +37,8 @@ class FailedMessagesRemoveCommand extends AbstractFailedMessagesCommand
                 new InputOption('transport', null, InputOption::VALUE_REQUIRED, 'Use a specific failure transport', self::DEFAULT_TRANSPORT_OPTION),
                 new InputOption('show-messages', null, InputOption::VALUE_NONE, 'Display messages before removing it (if multiple ids are given)'),
                 new InputOption('class-filter', null, InputOption::VALUE_REQUIRED, 'Filter by a specific class name'),
+                new InputOption('failed-after', null, InputOption::VALUE_REQUIRED, 'Only select messages that failed at or after this date; messages with no known failure time are never selected'),
+                new InputOption('failed-before', null, InputOption::VALUE_REQUIRED, 'Only select messages that failed at or before this date; messages with no known failure time are never selected'),
             ])
             ->setHelp(<<<'EOF'
                 The <info>%command.name%</info> removes given messages that are pending in the failure transport.
@@ -48,6 +50,19 @@ class FailedMessagesRemoveCommand extends AbstractFailedMessagesCommand
                 You can remove all failed messages from the failure transport by using the "--all" option:
 
                     <info>php %command.full_name% --all</info>
+
+                Instead of ids, messages can be selected by class name, by failure time, or by both:
+
+                    <info>php %command.full_name% --class-filter='App\Message\SendEmail'</info>
+                    <info>php %command.full_name% --failed-after='-1 hour'</info>
+                    <info>php %command.full_name% --failed-after='2024-05-01 08:00' --failed-before='2024-05-01 09:30'</info>
+
+                The "--failed-after" and "--failed-before" options accept any expression supported by
+                DateTimeImmutable and both bounds are inclusive. The failure time comes from the message
+                history, so messages that were never redelivered are never selected by these options.
+
+                Filters cannot be combined with message ids nor with the "--all" option, and the number of
+                matching messages is confirmed before anything is removed.
                 EOF
             )
         ;
@@ -58,6 +73,10 @@ class FailedMessagesRemoveCommand extends AbstractFailedMessagesCommand
         $io = new SymfonyStyle($input, $output);
         $errorIo = $io->getErrorStyle();
 
+        $ids = (array) $input->getArgument('id');
+        [$classFilter, $failedAfter, $failedBefore] = $this->getFilters($input, (bool) $ids);
+        $hasFilters = null !== $classFilter || null !== $failedAfter || null !== $failedBefore;
+
         $failureTransportName = $input->getOption('transport');
         if (self::DEFAULT_TRANSPORT_OPTION === $failureTransportName) {
             $failureTransportName = $this->getGlobalFailureReceiverName();
@@ -66,7 +85,6 @@ class FailedMessagesRemoveCommand extends AbstractFailedMessagesCommand
         $receiver = $this->getReceiver($failureTransportName);
 
         $shouldForce = $input->getOption('force');
-        $ids = (array) $input->getArgument('id');
         $shouldDeleteAllMessages = $input->getOption('all');
 
         $idsCount = \count($ids);
@@ -75,8 +93,12 @@ class FailedMessagesRemoveCommand extends AbstractFailedMessagesCommand
             throw new RuntimeException(\sprintf('The "%s" receiver does not support removing specific messages.', $failureTransportName));
         }
 
-        if (!$idsCount && null !== $input->getOption('class-filter')) {
-            $ids = $this->getMessageIdsByClassFilter($input->getOption('class-filter'), $receiver);
+        if ($shouldDeleteAllMessages && $hasFilters) {
+            throw new RuntimeException('You cannot use the "--all" option together with the "--class-filter", "--failed-after" or "--failed-before" options.');
+        }
+
+        if ($hasFilters) {
+            $ids = $this->getMessageIdsByFilter($receiver, $classFilter, $failedAfter, $failedBefore);
             $idsCount = \count($ids);
 
             if (!$idsCount) {
@@ -132,26 +154,6 @@ class FailedMessagesRemoveCommand extends AbstractFailedMessagesCommand
                 $errorIo->note(\sprintf('Message with id %s not removed.', $id));
             }
         }
-    }
-
-    private function getMessageIdsByClassFilter(string $classFilter, ListableReceiverInterface $receiver): array
-    {
-        $ids = [];
-
-        $this->phpSerializer?->acceptPhpIncompleteClass();
-        try {
-            foreach ($receiver->all() as $envelope) {
-                if ($classFilter !== $envelope->getMessage()::class) {
-                    continue;
-                }
-
-                $ids[] = $this->getMessageId($envelope);
-            }
-        } finally {
-            $this->phpSerializer?->rejectPhpIncompleteClass();
-        }
-
-        return $ids;
     }
 
     private function removeAllMessages(ListableReceiverInterface $receiver, SymfonyStyle $io, SymfonyStyle $errorIo, bool $shouldForce, bool $shouldDisplayMessages): void

--- a/src/Symfony/Component/Messenger/Command/FailedMessagesRetryCommand.php
+++ b/src/Symfony/Component/Messenger/Command/FailedMessagesRetryCommand.php
@@ -65,6 +65,9 @@ class FailedMessagesRetryCommand extends AbstractFailedMessagesCommand implement
                 new InputOption('force', null, InputOption::VALUE_NONE, 'Force action without confirmation'),
                 new InputOption('transport', null, InputOption::VALUE_REQUIRED, 'Use a specific failure transport', self::DEFAULT_TRANSPORT_OPTION),
                 new InputOption('keepalive', null, InputOption::VALUE_REQUIRED, 'Whether to use the transport\'s keepalive mechanism if implemented', self::DEFAULT_KEEPALIVE_INTERVAL),
+                new InputOption('class-filter', null, InputOption::VALUE_REQUIRED, 'Filter by a specific class name'),
+                new InputOption('failed-after', null, InputOption::VALUE_REQUIRED, 'Only select messages that failed at or after this date; messages with no known failure time are never selected'),
+                new InputOption('failed-before', null, InputOption::VALUE_REQUIRED, 'Only select messages that failed at or before this date; messages with no known failure time are never selected'),
             ])
             ->setHelp(<<<'EOF'
                 The <info>%command.name%</info> retries message in the failure transport.
@@ -83,6 +86,19 @@ class FailedMessagesRetryCommand extends AbstractFailedMessagesCommand implement
 
                 <info>php %command.full_name% {id1} {id2} {id3}</info>
 
+                Instead of ids, messages can be selected by class name, by failure time, or by both:
+
+                    <info>php %command.full_name% --class-filter='App\Message\SendEmail'</info>
+                    <info>php %command.full_name% --failed-after='-1 hour'</info>
+                    <info>php %command.full_name% --failed-after='2024-05-01 08:00' --failed-before='2024-05-01 09:30'</info>
+
+                The "--failed-after" and "--failed-before" options accept any expression supported by
+                DateTimeImmutable and both bounds are inclusive. The failure time comes from the message
+                history, so messages that were never redelivered are never selected by these options.
+
+                Filters cannot be combined with message ids. Add "--force" to retry every matching message
+                without being asked about each of them.
+
                 EOF
             )
         ;
@@ -97,6 +113,9 @@ class FailedMessagesRetryCommand extends AbstractFailedMessagesCommand implement
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        $ids = $input->getArgument('id');
+        [$classFilter, $failedAfter, $failedBefore] = $this->getFilters($input, (bool) $ids);
+
         $this->eventDispatcher->addSubscriber(new StopWorkerOnMessageLimitListener(1));
 
         $io = new SymfonyStyle($input, $output);
@@ -121,7 +140,19 @@ class FailedMessagesRetryCommand extends AbstractFailedMessagesCommand implement
         $io->writeln(\sprintf('To retry all the messages, run <comment>messenger:consume %s</comment>', $failureTransportName));
 
         $shouldForce = $input->getOption('force');
-        $ids = $input->getArgument('id');
+
+        if (null !== $classFilter || null !== $failedAfter || null !== $failedBefore) {
+            if (!$receiver instanceof ListableReceiverInterface) {
+                throw new RuntimeException(\sprintf('The "%s" receiver does not support filtering messages.', $failureTransportName));
+            }
+
+            $ids = $this->getMessageIdsByFilter($receiver, $classFilter, $failedAfter, $failedBefore);
+
+            if (!$ids) {
+                throw new RuntimeException('No failed messages were found with this filter.');
+            }
+        }
+
         if (0 === \count($ids)) {
             if (!$input->isInteractive()) {
                 throw new RuntimeException('Message id must be passed when in non-interactive mode.');

--- a/src/Symfony/Component/Messenger/Command/FailedMessagesShowCommand.php
+++ b/src/Symfony/Component/Messenger/Command/FailedMessagesShowCommand.php
@@ -37,6 +37,8 @@ class FailedMessagesShowCommand extends AbstractFailedMessagesCommand
                 new InputOption('transport', null, InputOption::VALUE_REQUIRED, 'Use a specific failure transport', self::DEFAULT_TRANSPORT_OPTION),
                 new InputOption('stats', null, InputOption::VALUE_NONE, 'Display the message count by class'),
                 new InputOption('class-filter', null, InputOption::VALUE_REQUIRED, 'Filter by a specific class name'),
+                new InputOption('failed-after', null, InputOption::VALUE_REQUIRED, 'Only select messages that failed at or after this date; messages with no known failure time are never selected'),
+                new InputOption('failed-before', null, InputOption::VALUE_REQUIRED, 'Only select messages that failed at or before this date; messages with no known failure time are never selected'),
             ])
             ->setHelp(<<<'EOF'
                 The <info>%command.name%</info> shows message that are pending in the failure transport.
@@ -46,6 +48,17 @@ class FailedMessagesShowCommand extends AbstractFailedMessagesCommand
                 Or look at a specific message by its id:
 
                     <info>php %command.full_name% {id}</info>
+
+                The listing can be narrowed down by class name, by failure time, or by both:
+
+                    <info>php %command.full_name% --class-filter='App\Message\SendEmail'</info>
+                    <info>php %command.full_name% --failed-after='-1 hour'</info>
+                    <info>php %command.full_name% --failed-after='2024-05-01 08:00' --failed-before='2024-05-01 09:30'</info>
+
+                The "--failed-after" and "--failed-before" options accept any expression supported by
+                DateTimeImmutable and both bounds are inclusive. The failure time is the one shown in the
+                "Failed at" column, so messages that were never redelivered are never selected by these
+                options. Filters cannot be combined with a message id and they also narrow down "--stats".
                 EOF
             )
         ;
@@ -55,6 +68,9 @@ class FailedMessagesShowCommand extends AbstractFailedMessagesCommand
     {
         $io = new SymfonyStyle($input, $output);
         $errorIo = $io->getErrorStyle();
+
+        $id = $input->getArgument('id');
+        [$classFilter, $failedAfter, $failedBefore] = $this->getFilters($input, null !== $id);
 
         $failureTransportName = $input->getOption('transport');
         if (self::DEFAULT_TRANSPORT_OPTION === $failureTransportName) {
@@ -75,9 +91,9 @@ class FailedMessagesShowCommand extends AbstractFailedMessagesCommand
 
         if ($input->getOption('stats')) {
             $max = $input->hasParameterOption(['--max'], true) ? $input->getOption('max') : null;
-            $this->listMessagesPerClass($receiver, $io, $max);
-        } elseif (null === $id = $input->getArgument('id')) {
-            $this->listMessages($receiver, $failureTransportName, $io, $errorIo, $input->getOption('max'), $input->getOption('class-filter'));
+            $this->listMessagesPerClass($receiver, $io, $max, $classFilter, $failedAfter, $failedBefore);
+        } elseif (null === $id) {
+            $this->listMessages($receiver, $failureTransportName, $io, $errorIo, $input->getOption('max'), $classFilter, $failedAfter, $failedBefore);
         } else {
             $this->showMessage($receiver, $failureTransportName, $id, $io, $errorIo);
         }
@@ -85,7 +101,7 @@ class FailedMessagesShowCommand extends AbstractFailedMessagesCommand
         return 0;
     }
 
-    private function listMessages(ListableReceiverInterface $receiver, string $failedTransportName, SymfonyStyle $io, SymfonyStyle $errorIo, int $max, ?string $classFilter = null): void
+    private function listMessages(ListableReceiverInterface $receiver, string $failedTransportName, SymfonyStyle $io, SymfonyStyle $errorIo, int $max, ?string $classFilter, ?\DateTimeImmutable $failedAfter, ?\DateTimeImmutable $failedBefore): void
     {
         $envelopes = $receiver->all($max);
 
@@ -94,13 +110,17 @@ class FailedMessagesShowCommand extends AbstractFailedMessagesCommand
         if ($classFilter) {
             $errorIo->comment(\sprintf('Displaying only \'%s\' messages', $classFilter));
         }
+        if ($failedAfter) {
+            $errorIo->comment(\sprintf('Displaying only messages that failed after %s', $failedAfter->format('Y-m-d H:i:s')));
+        }
+        if ($failedBefore) {
+            $errorIo->comment(\sprintf('Displaying only messages that failed before %s', $failedBefore->format('Y-m-d H:i:s')));
+        }
 
         $this->phpSerializer?->acceptPhpIncompleteClass();
         try {
             foreach ($envelopes as $envelope) {
-                $currentClassName = $envelope->getMessage()::class;
-
-                if ($classFilter && $classFilter !== $currentClassName) {
+                if (!$this->matchesFilter($envelope, $classFilter, $failedAfter, $failedBefore)) {
                     continue;
                 }
 
@@ -109,7 +129,7 @@ class FailedMessagesShowCommand extends AbstractFailedMessagesCommand
 
                 $rows[] = [
                     $this->getMessageId($envelope),
-                    $currentClassName,
+                    $envelope->getMessage()::class,
                     null === $lastRedeliveryStamp ? '' : $lastRedeliveryStamp->getRedeliveredAt()->format('Y-m-d H:i:s'),
                     $lastErrorDetailsStamp?->getExceptionMessage() ?? '',
                 ];
@@ -130,14 +150,14 @@ class FailedMessagesShowCommand extends AbstractFailedMessagesCommand
 
         if ($rowsCount === $max) {
             $errorIo->comment(\sprintf('Showing first %d messages.', $max));
-        } elseif ($classFilter) {
+        } elseif ($classFilter || $failedAfter || $failedBefore) {
             $errorIo->comment(\sprintf('Showing %d message(s).', $rowsCount));
         }
 
         $errorIo->comment(\sprintf('Run <comment>messenger:failed:show {id} --transport=%s -vv</comment> to see message details.', $failedTransportName));
     }
 
-    private function listMessagesPerClass(ListableReceiverInterface $receiver, SymfonyStyle $io, ?int $max): void
+    private function listMessagesPerClass(ListableReceiverInterface $receiver, SymfonyStyle $io, ?int $max, ?string $classFilter, ?\DateTimeImmutable $failedAfter, ?\DateTimeImmutable $failedBefore): void
     {
         $envelopes = $receiver->all($max);
 
@@ -146,6 +166,10 @@ class FailedMessagesShowCommand extends AbstractFailedMessagesCommand
         $this->phpSerializer?->acceptPhpIncompleteClass();
         try {
             foreach ($envelopes as $envelope) {
+                if (!$this->matchesFilter($envelope, $classFilter, $failedAfter, $failedBefore)) {
+                    continue;
+                }
+
                 $c = $envelope->getMessage()::class;
 
                 if (!isset($countPerClass[$c])) {

--- a/src/Symfony/Component/Messenger/Tests/Command/FailedMessagesRemoveCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/FailedMessagesRemoveCommandTest.php
@@ -20,6 +20,7 @@ use Symfony\Component\Messenger\Bridge\Doctrine\Transport\DoctrineReceiver;
 use Symfony\Component\Messenger\Command\FailedMessagesRemoveCommand;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\InvalidArgumentException;
+use Symfony\Component\Messenger\Stamp\RedeliveryStamp;
 use Symfony\Component\Messenger\Stamp\TransportMessageIdStamp;
 use Symfony\Component\Messenger\Transport\Receiver\ListableReceiverInterface;
 
@@ -400,5 +401,187 @@ class FailedMessagesRemoveCommandTest extends TestCase
 
         $this->assertStringNotContainsString('[NOTE]', $stdout);
         $this->assertStringContainsString('Message with id some_id not removed', $stderr);
+    }
+
+    public function testRemoveMessagesFilteredByFailureTime()
+    {
+        $envelopes = [
+            $this->createFailedEnvelope(10, '2024-05-01 10:00:00'),
+            $this->createFailedEnvelope(20, '2024-05-02 10:00:00'),
+            $this->createFailedEnvelope(30, '2024-05-03 10:00:00'),
+        ];
+
+        $tester = $this->createCommandTester($envelopes, [20, 30]);
+        $tester->execute(['--failed-after' => '2024-05-02 00:00:00', '--force' => true]);
+
+        $this->assertStringContainsString('Can you confirm you want to remove 2 messages?', $tester->getDisplay());
+        $this->assertStringContainsString('Message with id 20 removed.', $tester->getDisplay());
+        $this->assertStringContainsString('Message with id 30 removed.', $tester->getDisplay());
+    }
+
+    public function testRemoveMessagesFilteredByRelativeFailureTime()
+    {
+        $envelopes = [
+            $this->createFailedEnvelope(10, '-1 year'),
+            $this->createFailedEnvelope(20, '-1 minute'),
+        ];
+
+        $tester = $this->createCommandTester($envelopes, [20]);
+        $tester->execute(['--failed-after' => '-1 hour', '--force' => true]);
+
+        $this->assertStringContainsString('Message with id 20 removed.', $tester->getDisplay());
+    }
+
+    public function testRemoveMessagesFilteredByClassAndFailureTime()
+    {
+        $anotherClass = new class extends \stdClass {};
+
+        $envelopes = [
+            $this->createFailedEnvelope(10, '2024-05-02 10:00:00'),
+            new Envelope(new $anotherClass(), [new TransportMessageIdStamp(20), new RedeliveryStamp(0, new \DateTimeImmutable('2024-05-02 11:00:00'))]),
+            $this->createFailedEnvelope(30, '2024-05-05 10:00:00'),
+        ];
+
+        $tester = $this->createCommandTester($envelopes, [10]);
+        $tester->execute(['--class-filter' => 'stdClass', '--failed-before' => '2024-05-03 00:00:00', '--force' => true]);
+
+        $this->assertStringContainsString('Can you confirm you want to remove 1 message?', $tester->getDisplay());
+        $this->assertStringContainsString('Message with id 10 removed.', $tester->getDisplay());
+    }
+
+    public function testRemoveExcludesMessagesWithoutRedeliveryStampWhenFilteringByFailureTime()
+    {
+        $envelopes = [
+            new Envelope(new \stdClass(), [new TransportMessageIdStamp(10)]),
+            $this->createFailedEnvelope(20, '2024-05-02 10:00:00'),
+        ];
+
+        $tester = $this->createCommandTester($envelopes, [20]);
+        $tester->execute(['--failed-after' => '2024-05-01 00:00:00', '--force' => true]);
+
+        $this->assertStringContainsString('Can you confirm you want to remove 1 message?', $tester->getDisplay());
+        $this->assertStringContainsString('Message with id 20 removed.', $tester->getDisplay());
+        $this->assertStringNotContainsString('Message with id 10 removed.', $tester->getDisplay());
+    }
+
+    public function testRemoveIncludesMessagesWithoutRedeliveryStampWhenFilteringByClassOnly()
+    {
+        $envelopes = [
+            new Envelope(new \stdClass(), [new TransportMessageIdStamp(10)]),
+            $this->createFailedEnvelope(20, '2024-05-02 10:00:00'),
+        ];
+
+        $tester = $this->createCommandTester($envelopes, [10, 20]);
+        $tester->execute(['--class-filter' => 'stdClass', '--force' => true]);
+
+        $this->assertStringContainsString('Message with id 10 removed.', $tester->getDisplay());
+        $this->assertStringContainsString('Message with id 20 removed.', $tester->getDisplay());
+    }
+
+    public function testRemoveMessagesFilteredByFailureTimeCanBeAborted()
+    {
+        $receiver = $this->createMock(ListableReceiverInterface::class);
+        $receiver->expects($this->once())->method('all')->willReturn([
+            $this->createFailedEnvelope(10, '2024-05-02 10:00:00'),
+        ]);
+        $receiver->expects($this->never())->method('find');
+        $receiver->expects($this->never())->method('reject');
+
+        $command = new FailedMessagesRemoveCommand('failure_receiver', new ServiceLocator(['failure_receiver' => static fn () => $receiver]));
+
+        $tester = new CommandTester($command);
+        $tester->setInputs(['no']);
+        $tester->execute(['--failed-after' => '2024-05-01 00:00:00', '--force' => true]);
+
+        $this->assertSame(0, $tester->getStatusCode());
+        $this->assertStringContainsString('Can you confirm you want to remove 1 message?', $tester->getDisplay());
+    }
+
+    public function testRemoveWithForceDoesNotAskForEachFilteredMessage()
+    {
+        $envelopes = [
+            $this->createFailedEnvelope(10, '2024-05-02 10:00:00'),
+        ];
+
+        $tester = $this->createCommandTester($envelopes, [10]);
+        $tester->execute(['--failed-after' => '2024-05-01 00:00:00', '--force' => true]);
+
+        $this->assertStringNotContainsString('Do you want to permanently remove this message?', $tester->getDisplay());
+        $this->assertStringContainsString('Message with id 10 removed.', $tester->getDisplay());
+    }
+
+    public function testRemoveWithIdsAndFilterThrows()
+    {
+        $globalFailureReceiverName = 'failure_receiver';
+
+        $command = new FailedMessagesRemoveCommand($globalFailureReceiverName, new ServiceLocator([$globalFailureReceiverName => fn () => $this->createStub(ListableReceiverInterface::class)]));
+        $tester = new CommandTester($command);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('You cannot specify message ids when using the "--class-filter", "--failed-after" or "--failed-before" options.');
+        $tester->execute(['id' => [20], '--failed-after' => '2024-05-01 00:00:00']);
+    }
+
+    public function testRemoveWithFilterMatchingNothingThrows()
+    {
+        $receiver = $this->createMock(ListableReceiverInterface::class);
+        $receiver->expects($this->once())->method('all')->willReturn([
+            $this->createFailedEnvelope(10, '2024-05-02 10:00:00'),
+        ]);
+
+        $command = new FailedMessagesRemoveCommand('failure_receiver', new ServiceLocator(['failure_receiver' => static fn () => $receiver]));
+        $tester = new CommandTester($command);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('No failed messages were found with this filter.');
+        $tester->execute(['--failed-after' => '2024-06-01 00:00:00', '--force' => true]);
+    }
+
+    public function testRemoveWithUnparsableFailureTimeThrows()
+    {
+        $globalFailureReceiverName = 'failure_receiver';
+
+        $command = new FailedMessagesRemoveCommand($globalFailureReceiverName, new ServiceLocator([$globalFailureReceiverName => fn () => $this->createStub(ListableReceiverInterface::class)]));
+        $tester = new CommandTester($command);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The value of the "--failed-before" option is not a valid date: "yesterdayish".');
+        $tester->execute(['--failed-before' => 'yesterdayish']);
+    }
+
+    private function createFailedEnvelope(int $id, string $failedAt): Envelope
+    {
+        return new Envelope(new \stdClass(), [
+            new TransportMessageIdStamp($id),
+            new RedeliveryStamp(0, new \DateTimeImmutable($failedAt)),
+        ]);
+    }
+
+    /**
+     * @param Envelope[] $envelopes   the messages listed by the failure transport
+     * @param int[]      $expectedIds the ids expected to be removed, in order
+     */
+    private function createCommandTester(array $envelopes, array $expectedIds): CommandTester
+    {
+        $receiver = $this->createMock(ListableReceiverInterface::class);
+        $receiver->expects($this->once())->method('all')->willReturn($envelopes);
+        $receiver->expects($this->exactly(\count($expectedIds)))->method('find')
+            ->willReturnCallback(function (...$args) use ($envelopes, &$expectedIds) {
+                $this->assertSame([array_shift($expectedIds)], $args);
+
+                foreach ($envelopes as $envelope) {
+                    if ([$envelope->last(TransportMessageIdStamp::class)->getId()] === $args) {
+                        return $envelope;
+                    }
+                }
+
+                return null;
+            })
+        ;
+        $receiver->expects($this->exactly(\count($expectedIds)))->method('reject');
+
+        $command = new FailedMessagesRemoveCommand('failure_receiver', new ServiceLocator(['failure_receiver' => static fn () => $receiver]));
+
+        return new CommandTester($command);
     }
 }

--- a/src/Symfony/Component/Messenger/Tests/Command/FailedMessagesRetryCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/FailedMessagesRetryCommandTest.php
@@ -12,18 +12,22 @@
 namespace Symfony\Component\Messenger\Tests\Command;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Tester\CommandCompletionTester;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Messenger\Command\FailedMessagesRetryCommand;
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\InvalidArgumentException;
 use Symfony\Component\Messenger\MessageBus;
 use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\RedeliveryStamp;
 use Symfony\Component\Messenger\Stamp\SentToFailureTransportStamp;
 use Symfony\Component\Messenger\Stamp\TransportMessageIdStamp;
 use Symfony\Component\Messenger\Transport\Receiver\ListableReceiverInterface;
 use Symfony\Component\Messenger\Transport\Receiver\MessageCountAwareInterface;
+use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
 
 class FailedMessagesRetryCommandTest extends TestCase
 {
@@ -333,5 +337,209 @@ class FailedMessagesRetryCommandTest extends TestCase
 
         $tester->execute(['id' => ['10']]);
         $this->assertStringContainsString('[OK]', $tester->getDisplay());
+    }
+
+    public function testRetryMessagesFilteredByClass()
+    {
+        $anotherClass = new class extends \stdClass {};
+
+        $envelopes = [
+            new Envelope(new \stdClass(), [new TransportMessageIdStamp(10)]),
+            new Envelope(new $anotherClass(), [new TransportMessageIdStamp(20)]),
+            new Envelope(new \stdClass(), [new TransportMessageIdStamp(30)]),
+        ];
+
+        $tester = $this->createCommandTester($envelopes, [10, 30]);
+        $tester->execute(['--class-filter' => 'stdClass', '--force' => true]);
+
+        $this->assertStringContainsString('[OK]', $tester->getDisplay());
+    }
+
+    public function testRetryMessagesFilteredByFailureTime()
+    {
+        $envelopes = [
+            $this->createFailedEnvelope(10, '2024-05-01 10:00:00'),
+            $this->createFailedEnvelope(20, '2024-05-02 10:00:00'),
+            $this->createFailedEnvelope(30, '2024-05-03 10:00:00'),
+        ];
+
+        $tester = $this->createCommandTester($envelopes, [20]);
+        $tester->execute(['--failed-after' => '2024-05-02 00:00:00', '--failed-before' => '2024-05-02 23:59:59', '--force' => true]);
+
+        $this->assertStringContainsString('[OK]', $tester->getDisplay());
+    }
+
+    public function testRetryMessagesFilteredByRelativeFailureTime()
+    {
+        $envelopes = [
+            $this->createFailedEnvelope(10, '-1 year'),
+            $this->createFailedEnvelope(20, '-1 minute'),
+        ];
+
+        $tester = $this->createCommandTester($envelopes, [20]);
+        $tester->execute(['--failed-after' => '-1 hour', '--force' => true]);
+
+        $this->assertStringContainsString('[OK]', $tester->getDisplay());
+    }
+
+    public function testRetryMessagesFilteredByClassAndFailureTime()
+    {
+        $anotherClass = new class extends \stdClass {};
+
+        $envelopes = [
+            $this->createFailedEnvelope(10, '2024-05-02 10:00:00'),
+            new Envelope(new $anotherClass(), [new TransportMessageIdStamp(20), new RedeliveryStamp(0, new \DateTimeImmutable('2024-05-02 11:00:00'))]),
+            $this->createFailedEnvelope(30, '2024-05-05 10:00:00'),
+        ];
+
+        $tester = $this->createCommandTester($envelopes, [10]);
+        $tester->execute(['--class-filter' => 'stdClass', '--failed-before' => '2024-05-03 00:00:00', '--force' => true]);
+
+        $this->assertStringContainsString('[OK]', $tester->getDisplay());
+    }
+
+    public function testRetryExcludesMessagesWithoutRedeliveryStampWhenFilteringByFailureTime()
+    {
+        $envelopes = [
+            new Envelope(new \stdClass(), [new TransportMessageIdStamp(10)]),
+            $this->createFailedEnvelope(20, '2024-05-02 10:00:00'),
+        ];
+
+        $tester = $this->createCommandTester($envelopes, [20]);
+        $tester->execute(['--failed-after' => '2024-05-01 00:00:00', '--force' => true]);
+
+        $this->assertStringContainsString('[OK]', $tester->getDisplay());
+    }
+
+    public function testRetryIncludesMessagesWithoutRedeliveryStampWhenFilteringByClassOnly()
+    {
+        $envelopes = [
+            new Envelope(new \stdClass(), [new TransportMessageIdStamp(10)]),
+            $this->createFailedEnvelope(20, '2024-05-02 10:00:00'),
+        ];
+
+        $tester = $this->createCommandTester($envelopes, [10, 20]);
+        $tester->execute(['--class-filter' => 'stdClass', '--force' => true]);
+
+        $this->assertStringContainsString('[OK]', $tester->getDisplay());
+    }
+
+    public function testRetryWithIdsAndFilterThrows()
+    {
+        $receiver = $this->createStub(ListableReceiverInterface::class);
+
+        $command = new FailedMessagesRetryCommand(
+            'failure_receiver',
+            new ServiceLocator(['failure_receiver' => static fn () => $receiver]),
+            new MessageBus(),
+            new EventDispatcher()
+        );
+
+        $tester = new CommandTester($command);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('You cannot specify message ids when using the "--class-filter", "--failed-after" or "--failed-before" options.');
+        $tester->execute(['id' => [10], '--class-filter' => 'stdClass']);
+    }
+
+    public function testRetryWithFilterMatchingNothingThrows()
+    {
+        $receiver = $this->createMock(ListableReceiverInterface::class);
+        $receiver->expects($this->once())->method('all')->willReturn([
+            $this->createFailedEnvelope(10, '2024-05-02 10:00:00'),
+        ]);
+
+        $command = new FailedMessagesRetryCommand(
+            'failure_receiver',
+            new ServiceLocator(['failure_receiver' => static fn () => $receiver]),
+            new MessageBus(),
+            new EventDispatcher()
+        );
+
+        $tester = new CommandTester($command);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('No failed messages were found with this filter.');
+        $tester->execute(['--failed-after' => '2024-06-01 00:00:00', '--force' => true]);
+    }
+
+    public function testRetryWithFilterOnNonListableReceiverThrows()
+    {
+        $receiver = $this->createStub(ReceiverInterface::class);
+
+        $command = new FailedMessagesRetryCommand(
+            'failure_receiver',
+            new ServiceLocator(['failure_receiver' => static fn () => $receiver]),
+            new MessageBus(),
+            new EventDispatcher()
+        );
+
+        $tester = new CommandTester($command);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The "failure_receiver" receiver does not support filtering messages.');
+        $tester->execute(['--class-filter' => 'stdClass', '--force' => true]);
+    }
+
+    public function testRetryWithUnparsableFailureTimeThrows()
+    {
+        $receiver = $this->createStub(ListableReceiverInterface::class);
+
+        $command = new FailedMessagesRetryCommand(
+            'failure_receiver',
+            new ServiceLocator(['failure_receiver' => static fn () => $receiver]),
+            new MessageBus(),
+            new EventDispatcher()
+        );
+
+        $tester = new CommandTester($command);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The value of the "--failed-after" option is not a valid date: "not a date".');
+        $tester->execute(['--failed-after' => 'not a date']);
+    }
+
+    private function createFailedEnvelope(int $id, string $failedAt): Envelope
+    {
+        return new Envelope(new \stdClass(), [
+            new TransportMessageIdStamp($id),
+            new RedeliveryStamp(0, new \DateTimeImmutable($failedAt)),
+        ]);
+    }
+
+    /**
+     * @param Envelope[] $envelopes   the messages listed by the failure transport
+     * @param int[]      $expectedIds the ids expected to be retried, in order
+     */
+    private function createCommandTester(array $envelopes, array $expectedIds): CommandTester
+    {
+        $receiver = $this->createMock(ListableReceiverInterface::class);
+        $receiver->expects($this->once())->method('all')->willReturn($envelopes);
+        $receiver->expects($this->exactly(\count($expectedIds)))->method('find')
+            ->willReturnCallback(function (...$args) use ($envelopes, &$expectedIds) {
+                $this->assertSame([array_shift($expectedIds)], $args);
+
+                foreach ($envelopes as $envelope) {
+                    if ([$envelope->last(TransportMessageIdStamp::class)->getId()] === $args) {
+                        return $envelope;
+                    }
+                }
+
+                return null;
+            })
+        ;
+        $receiver->expects($this->exactly(\count($expectedIds)))->method('ack');
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects($this->exactly(\count($expectedIds)))->method('dispatch')->willReturn(new Envelope(new \stdClass()));
+
+        $command = new FailedMessagesRetryCommand(
+            'failure_receiver',
+            new ServiceLocator(['failure_receiver' => static fn () => $receiver]),
+            $bus,
+            new EventDispatcher()
+        );
+
+        return new CommandTester($command);
     }
 }

--- a/src/Symfony/Component/Messenger/Tests/Command/FailedMessagesShowCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/FailedMessagesShowCommandTest.php
@@ -13,12 +13,14 @@ namespace Symfony\Component\Messenger\Tests\Command;
 
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Tester\CommandCompletionTester;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\Messenger\Command\FailedMessagesShowCommand;
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\InvalidArgumentException;
 use Symfony\Component\Messenger\Stamp\ErrorDetailsStamp;
 use Symfony\Component\Messenger\Stamp\RedeliveryStamp;
 use Symfony\Component\Messenger\Stamp\SentToFailureTransportStamp;
@@ -516,5 +518,149 @@ class FailedMessagesShowCommandTest extends TestCase
         $this->assertStringContainsString('3', $stdout);
         $this->assertStringContainsString('messages pending', $stdout);
         $this->assertStringNotContainsString('messages pending', $stderr);
+    }
+
+    public function testListMessagesFilteredByFailureTime()
+    {
+        $receiver = $this->createMock(ListableReceiverInterface::class);
+        $receiver->expects($this->once())->method('all')->willReturn([
+            $this->createFailedEnvelope(10, '2024-05-01 10:00:00', 'Older failure'),
+            $this->createFailedEnvelope(20, '2024-05-02 10:00:00', 'Recent failure'),
+            $this->createFailedEnvelope(30, '2024-05-03 10:00:00', 'Newest failure'),
+        ]);
+
+        $command = new FailedMessagesShowCommand('failure_receiver', new ServiceLocator(['failure_receiver' => static fn () => $receiver]));
+
+        $tester = new CommandTester($command);
+        $tester->execute(['--failed-after' => '2024-05-02 00:00:00', '--failed-before' => '2024-05-02 23:59:59']);
+
+        $display = $tester->getDisplay(true);
+        $this->assertStringContainsString('Recent failure', $display);
+        $this->assertStringNotContainsString('Older failure', $display);
+        $this->assertStringNotContainsString('Newest failure', $display);
+        $this->assertStringContainsString('Displaying only messages that failed after 2024-05-02 00:00:00', $display);
+        $this->assertStringContainsString('Displaying only messages that failed before 2024-05-02 23:59:59', $display);
+        $this->assertStringContainsString('Showing 1 message(s).', $display);
+    }
+
+    public function testListMessagesFilteredByClassAndFailureTime()
+    {
+        $anotherClass = new class extends \stdClass {};
+
+        $receiver = $this->createMock(ListableReceiverInterface::class);
+        $receiver->expects($this->once())->method('all')->willReturn([
+            $this->createFailedEnvelope(10, '2024-05-02 10:00:00', 'Matching failure'),
+            new Envelope(new $anotherClass(), [
+                new TransportMessageIdStamp(20),
+                new RedeliveryStamp(0, new \DateTimeImmutable('2024-05-02 11:00:00')),
+                ErrorDetailsStamp::create(new \RuntimeException('Other class failure')),
+            ]),
+            $this->createFailedEnvelope(30, '2024-05-05 10:00:00', 'Out of window failure'),
+        ]);
+
+        $command = new FailedMessagesShowCommand('failure_receiver', new ServiceLocator(['failure_receiver' => static fn () => $receiver]));
+
+        $tester = new CommandTester($command);
+        $tester->execute(['--class-filter' => 'stdClass', '--failed-before' => '2024-05-03 00:00:00']);
+
+        $display = $tester->getDisplay(true);
+        $this->assertStringContainsString('Matching failure', $display);
+        $this->assertStringNotContainsString('Other class failure', $display);
+        $this->assertStringNotContainsString('Out of window failure', $display);
+    }
+
+    public function testListMessagesExcludesMessagesWithoutRedeliveryStampWhenFilteringByFailureTime()
+    {
+        $receiver = $this->createMock(ListableReceiverInterface::class);
+        $receiver->expects($this->exactly(2))->method('all')->willReturn([
+            new Envelope(new \stdClass(), [
+                new TransportMessageIdStamp(10),
+                ErrorDetailsStamp::create(new \RuntimeException('Never redelivered')),
+            ]),
+            $this->createFailedEnvelope(20, '2024-05-02 10:00:00', 'Redelivered once'),
+        ]);
+
+        $command = new FailedMessagesShowCommand('failure_receiver', new ServiceLocator(['failure_receiver' => static fn () => $receiver]));
+
+        $tester = new CommandTester($command);
+        $tester->execute([]);
+
+        $display = $tester->getDisplay(true);
+        $this->assertStringContainsString('Never redelivered', $display);
+        $this->assertStringContainsString('Redelivered once', $display);
+
+        $tester->execute(['--failed-after' => '2024-05-01 00:00:00']);
+
+        $display = $tester->getDisplay(true);
+        $this->assertStringNotContainsString('Never redelivered', $display);
+        $this->assertStringContainsString('Redelivered once', $display);
+    }
+
+    public function testListMessagesPerClassFilteredByFailureTime()
+    {
+        $receiver = $this->createMock(ListableReceiverInterface::class);
+        $receiver->expects($this->once())->method('all')->willReturn([
+            $this->createFailedEnvelope(10, '2024-05-01 10:00:00', 'Older failure'),
+            $this->createFailedEnvelope(20, '2024-05-02 10:00:00', 'Recent failure'),
+            $this->createFailedEnvelope(30, '2024-05-03 10:00:00', 'Newest failure'),
+        ]);
+
+        $command = new FailedMessagesShowCommand('failure_receiver', new ServiceLocator(['failure_receiver' => static fn () => $receiver]));
+
+        $tester = new CommandTester($command);
+        $tester->execute(['--stats' => true, '--failed-after' => '2024-05-02 00:00:00']);
+
+        $this->assertStringContainsString('stdClass   2', $tester->getDisplay(true));
+    }
+
+    public function testListMessagesWithFilterMatchingNothing()
+    {
+        $receiver = $this->createMock(ListableReceiverInterface::class);
+        $receiver->expects($this->once())->method('all')->willReturn([
+            $this->createFailedEnvelope(10, '2024-05-01 10:00:00', 'Older failure'),
+        ]);
+
+        $command = new FailedMessagesShowCommand('failure_receiver', new ServiceLocator(['failure_receiver' => static fn () => $receiver]));
+
+        $tester = new CommandTester($command);
+        $tester->execute(['--failed-after' => '2024-06-01 00:00:00']);
+
+        $this->assertStringContainsString('[OK] No failed messages were found.', $tester->getDisplay(true));
+    }
+
+    public function testShowWithIdAndFilterThrows()
+    {
+        $receiver = $this->createStub(ListableReceiverInterface::class);
+
+        $command = new FailedMessagesShowCommand('failure_receiver', new ServiceLocator(['failure_receiver' => static fn () => $receiver]));
+
+        $tester = new CommandTester($command);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('You cannot specify message ids when using the "--class-filter", "--failed-after" or "--failed-before" options.');
+        $tester->execute(['id' => '10', '--failed-after' => '2024-05-01 00:00:00']);
+    }
+
+    public function testShowWithUnparsableFailureTimeThrows()
+    {
+        $receiver = $this->createStub(ListableReceiverInterface::class);
+
+        $command = new FailedMessagesShowCommand('failure_receiver', new ServiceLocator(['failure_receiver' => static fn () => $receiver]));
+
+        $tester = new CommandTester($command);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The value of the "--failed-after" option is not a valid date: "last thursdayish".');
+        $tester->execute(['--failed-after' => 'last thursdayish']);
+    }
+
+    private function createFailedEnvelope(int $id, string $failedAt, string $error): Envelope
+    {
+        return new Envelope(new \stdClass(), [
+            new TransportMessageIdStamp($id),
+            new SentToFailureTransportStamp('async'),
+            new RedeliveryStamp(0, new \DateTimeImmutable($failedAt)),
+            ErrorDetailsStamp::create(new \RuntimeException($error)),
+        ]);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #63924
| License       | MIT

Recovering from an incident today means either typing every failed message id by hand, or retrying/removing everything. Neither works when a subset of the failure queue is a batch of rate-limited emails that need to go out again, and the rest needs to stay put for investigation.

This adds two ways to select that batch without naming ids: by message class and by failure time.

## New options

| Command | `--class-filter` | `--failed-after` | `--failed-before` |
| --- | --- | --- | --- |
| `messenger:failed:show` | already there | new | new |
| `messenger:failed:remove` | already there | new | new |
| `messenger:failed:retry` | **new** | new | new |

`messenger:failed:retry` was the only one of the three without `--class-filter`, so it gains one too, behaving like the one on `messenger:failed:remove`.

## The time window

`--failed-after` and `--failed-before` take a value that is passed to `new \DateTimeImmutable()`, so both absolute timestamps and relative expressions work:

```
--failed-after='2024-05-01 08:00'
--failed-after='-1 hour'
--failed-before='yesterday 18:00'
```

Both bounds are inclusive. An unparseable value is reported with the option that carried it:

```
The value of the "--failed-after" option is not a valid date: "nonsense".
```

The failure time is read from `RedeliveryStamp::getRedeliveredAt()`, the same value `messenger:failed:show` already prints in its `Failed at` column. That stamp is added by the retry mechanism, so it is present on every transport, but it is not present on a message that was never redelivered. `messenger:failed:show` prints an empty `Failed at` for those.

Since their failure time cannot be established, **messages without a `RedeliveryStamp` are never selected while a time filter is active**. They keep showing up when no time filter is used, and `--class-filter` alone still selects them. The option description states this.

## How the filters compose

The filters are ANDed:

```
messenger:failed:retry --class-filter='App\Message\SendEmail' --failed-after='-2 hours' --force
```

selects the `SendEmail` messages that failed in the last two hours, and nothing else.

Filters select the set instead of ids, so they cannot be combined with explicit ids:

```
You cannot specify message ids when using the "--class-filter", "--failed-after" or "--failed-before" options.
```

On `messenger:failed:remove` they also cannot be combined with `--all`, which previously accepted `--all --class-filter=…` and then failed with a confusing message about ids after already prompting:

```
You cannot use the "--all" option together with the "--class-filter", "--failed-after" or "--failed-before" options.
```

When a filter matches nothing, `retry` and `remove` throw the message `remove` already used:

```
No failed messages were found with this filter.
```

`show` is a listing command, so it keeps printing `[OK] No failed messages were found.` instead.

## Confirmation on remove

`messenger:failed:remove` already asked `Can you confirm you want to remove %d message%s?` before removing a `--class-filter` selection. Every filter-selected set now goes through that same aggregate confirmation, so a time window cannot delete an unknown number of messages silently. `--force` keeps its current meaning: it skips the per-message `Do you want to permanently remove this message?` prompts, and in a non-interactive shell the aggregate question resolves to its `yes` default.

## Worked examples

The mail provider rate-limited us between 08:00 and 09:30, look at the damage:

```
$ php bin/console messenger:failed:show --failed-after='2024-05-01 08:00' --failed-before='2024-05-01 09:30' --stats

 ----------------------------- -------
  Class                         Count
 ----------------------------- -------
  App\Message\SendEmail         412
  App\Message\ScheduleMatch     3
 ----------------------------- -------
```

Only the emails should go out again, the three others need investigation:

```
$ php bin/console messenger:failed:retry \
    --class-filter='App\Message\SendEmail' \
    --failed-after='2024-05-01 08:00' --failed-before='2024-05-01 09:30' \
    --force
```

The streaming platform was down for an hour and the messages it produced were superseded by later ones, so they can go:

```
$ php bin/console messenger:failed:remove \
    --class-filter='App\Message\ScheduleMatch' --failed-after='-1 hour'

 Can you confirm you want to remove 27 messages? (yes/no) [yes]:
```

## Implementation

`FailedMessagesRemoveCommand::getMessageIdsByClassFilter()` moved up into `AbstractFailedMessagesCommand` and became `getMessageIdsByFilter()`, which walks `$receiver->all()` once and applies every active criterion through a shared `matchesFilter()` predicate. `AbstractFailedMessagesCommand` is `@internal`, so this adds no BC surface. `messenger:failed:show` uses the same predicate for its listing and for `--stats`, which as a side effect makes `--stats` honour `--class-filter`, something it silently ignored before.

## Replaces #65031

That pull request added `--from` and `--until` taking a numeric id range, and expanded it with `range($from, $to)` into one `ListableReceiverInterface::find()` call per integer. That only works where message ids are dense consecutive integers, which no transport guarantees: Redis ids are stream entry ids such as `1526984052530-0`, and the Doctrine ids come from an autoincrement shared with every other queue in the table, so the failure queue is sparse and a range of a few hundred ids can hold a handful of rows.

Filtering a single `all()` pass has none of that coupling. It only needs `ListableReceiverInterface`, which is already what `--class-filter`, `--all` and id-based removal require, and it treats the id as an opaque value. Failure time is also what the reporter was actually reaching for: ids were a proxy for "the messages from that incident".

## Documentation

A symfony-docs pull request should carry:

- `messenger.rst`, in the section on the failure transport: the three new options with their signatures, and the fact that `retry` now has `--class-filter`.
- That `--failed-after`/`--failed-before` accept anything `\DateTimeImmutable` accepts, that both bounds are inclusive, and a relative example such as `--failed-after='-1 hour'`.
- The rule that messages with no recorded failure time are never selected by a time filter, and why: the time comes from the redelivery history, so a message that never got redelivered has none.
- That the filters compose with AND, and that they are refused together with explicit ids and, on `remove`, with `--all`.
- That `remove` confirms the total count of the selection before deleting anything, and what `--force` does and does not skip.
- An incident-recovery example combining class and time window on `retry`.
- A note that these options need a listable failure transport (Doctrine, Redis, in-memory), like the existing id-based operations.
