### PR TITLE
[Form][Validator] Review Lithuanian (lt) translations

### DIFF
--- a/src/Symfony/Component/Form/Resources/translations/validators.lt.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.lt.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="129">
                 <source>Please enter a valid UUID.</source>
-                <target state="needs-review-translation">Prašome įvesti tinkamą UUID.</target>
+                <target>Prašome įvesti tinkamą UUID.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.lt.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.lt.xlf
@@ -556,19 +556,19 @@
             </trans-unit>
             <trans-unit id="143">
                 <source>This value is not valid XML.</source>
-                <target state="needs-review-translation">Ši reikšmė nėra tinkamas XML.</target>
+                <target>Ši reikšmė nėra tinkamas XML.</target>
             </trans-unit>
             <trans-unit id="144">
                 <source>This value does not conform to the expected XSD schema.</source>
-                <target state="needs-review-translation">Ši reikšmė neatitinka laukiamos XSD schemos.</target>
+                <target>Ši reikšmė neatitinka laukiamos XSD schemos.</target>
             </trans-unit>
             <trans-unit id="145">
                 <source>This XML payload is too large ({{ size }} bytes): it exceeds the limit of {{ limit }} bytes.</source>
-                <target state="needs-review-translation">Ši XML naudingoji apkrova yra per didelė ({{ size }} baitų): ji viršija {{ limit }} baitų ribą.</target>
+                <target>Ši XML apkrova per didelė ({{ size }} baitų): ji viršija {{ limit }} baitų ribą.</target>
             </trans-unit>
             <trans-unit id="146">
                 <source>This value is not a valid cron expression.</source>
-                <target state="needs-review-translation">Ši reikšmė nėra galiojanti cron išraiška.</target>
+                <target>Ši reikšmė nėra tinkama cron išraiška.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64504
| License       | MIT

Reviewed the five Lithuanian strings flagged as `needs-review-translation`:

| file | id | source | change |
| --- | --- | --- | --- |
| Form | 129 | Please enter a valid UUID. | text already correct, marker removed |
| Validator | 143 | This value is not valid XML. | text already correct, marker removed |
| Validator | 144 | This value does not conform to the expected XSD schema. | text already correct, marker removed |
| Validator | 145 | This XML payload is too large ... | reworded to more natural Lithuanian: `Ši XML apkrova per didelė...` (dropped the stiff "naudingoji" calque) |
| Validator | 146 | This value is not a valid cron expression. | `galiojanti` to `tinkama`, sounds more natural in Lithuanian |

`lint:xliff` passes for both catalogues.