### PR TITLE
[FrameworkBundle] Allow enabling advisory locks on a lock resource

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
  * Allow prefixing entries with `!` in `framework.workflows.<name>.events_to_dispatch` to permanently disable an event; e.g. `events_to_dispatch: ['!workflow.announce']` fires every event except `workflow.announce`. The GuardEvent can never be disabled; `!workflow.guard` is rejected at config compile time. Mixing allow-list and block-list entries in the same list is rejected at config compile time too.
  * Add support for the HttpClient `max_connect_duration` option to the `http_client` configuration
  * Report `.env` variables that the container never uses in `debug:container --env-vars`
+ * Add `service_id` and `advisory` options to lock stores to use advisory locks on an existing `\PDO` or Doctrine DBAL connection service
 
 8.1
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -1661,27 +1661,42 @@ class Configuration implements ConfigurationInterface
                                 ->ifArray()
                                 ->then(static function ($v) {
                                     if (!array_is_list($v)) {
-                                        return $v;
+                                        return isset($v['service_id']) ? ['default' => $v] : $v;
                                     }
 
                                     $resources = [];
                                     foreach ($v as $resource) {
-                                        $resources[] = \is_array($resource) && isset($resource['name'])
-                                            ? [$resource['name'] => $resource['value']]
-                                            : ['default' => $resource]
+                                        [$name, $store] = \is_array($resource) && isset($resource['name'])
+                                            ? [$resource['name'], $resource['value']]
+                                            : ['default', $resource]
                                         ;
+                                        $resources[] = [$name => \is_array($store) && !array_is_list($store) ? [$store] : $store];
                                     }
 
                                     return array_merge_recursive([], ...$resources);
                                 })
                             ->end()
                             ->prototype('array')
+                                ->info('Each store is a DSN, a store keyword, the id of a service holding a connection, or an array with a "service_id" key and an "advisory" key.')
                                 ->performNoDeepMerging()
                                 ->acceptAndWrap(['string'])
                                 // acceptAndWrap() doesn't list null as an accepted value on purpose,
                                 // yet the XML loader can yield some and we should convert them to 'null'
                                 ->beforeNormalization()->ifNull()->then(static fn () => ['null'])->end()
-                                ->prototype('scalar')->end()
+                                ->beforeNormalization()
+                                    ->ifTrue(static fn ($v) => \is_array($v) && (isset($v['service_id']) || isset($v['advisory'])))
+                                    ->then(static fn ($v) => [$v])
+                                ->end()
+                                ->variablePrototype()
+                                    ->beforeNormalization()
+                                        ->ifArray()
+                                        ->then(static fn ($v) => ['service_id' => $v['service_id'] ?? null, 'advisory' => $v['advisory'] ?? false] + $v)
+                                    ->end()
+                                    ->validate()
+                                        ->ifTrue(static fn ($v) => \is_array($v) && (2 !== \count($v) || !\is_string($v['service_id']) || !\is_bool($v['advisory'])))
+                                        ->thenInvalid('A lock store must be a string or an array with a "service_id" string and an optional "advisory" boolean, got %s.')
+                                    ->end()
+                                ->end()
                             ->end()
                         ->end()
                     ->end()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -2278,13 +2278,17 @@ class FrameworkExtension extends Extension
                 }
                 $usedEnvs = [];
                 $storeDsn = $container->resolveEnvPlaceholders($resourceStore, null, $usedEnvs);
-                if (!$usedEnvs && !str_contains($resourceStore, ':') && !\in_array($resourceStore, ['flock', 'semaphore', 'in-memory', 'null'], true)) {
+                $advisory = false;
+                if (\is_array($resourceStore)) {
+                    $advisory = $resourceStore['advisory'];
+                    $resourceStore = new Reference($resourceStore['service_id']);
+                } elseif (!$usedEnvs && !str_contains($resourceStore, ':') && !\in_array($resourceStore, ['flock', 'semaphore', 'in-memory', 'null'], true)) {
                     $resourceStore = new Reference($resourceStore);
                 }
                 $storeDefinition = new Definition(PersistingStoreInterface::class);
                 $storeDefinition
                     ->setFactory([StoreFactory::class, 'createStore'])
-                    ->setArguments([$resourceStore])
+                    ->setArguments($advisory ? [$resourceStore, true] : [$resourceStore])
                     ->addTag('lock.store');
 
                 $container->setDefinition($storeDefinitionId = '.lock.'.$resourceName.'.store.'.$container->hash($storeDsn), $storeDefinition);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -375,6 +375,54 @@ class ConfigurationTest extends TestCase
         yield [['enabled' => false, 'resource' => [['name' => 'foo', 'value' => 'flock'], ['name' => 'foo', 'value' => 'semaphore']]], ['enabled' => false, 'resources' => ['foo' => ['flock', 'semaphore']]]];
         yield [['enabled' => false, 'resource' => [['name' => 'foo', 'value' => 'flock'], ['name' => 'bar', 'value' => 'semaphore']]], ['enabled' => false, 'resources' => ['foo' => ['flock'], 'bar' => ['semaphore']]]];
         yield [['enabled' => false, 'resource' => [['name' => 'foo', 'value' => 'flock'], ['name' => 'foo', 'value' => 'semaphore'], ['name' => 'bar', 'value' => 'semaphore']]], ['enabled' => false, 'resources' => ['foo' => ['flock', 'semaphore'], 'bar' => ['semaphore']]]];
+
+        // service id and advisory locks
+
+        $advisory = ['service_id' => 'my_connection', 'advisory' => true];
+        $tableBased = ['service_id' => 'my_connection', 'advisory' => false];
+
+        yield [['service_id' => 'my_connection'], ['enabled' => true, 'resources' => ['default' => [$tableBased]]]];
+        yield [$advisory, ['enabled' => true, 'resources' => ['default' => [$advisory]]]];
+        yield [['advisory' => true, 'service_id' => 'my_connection'], ['enabled' => true, 'resources' => ['default' => [$advisory]]]];
+        yield [[$advisory], ['enabled' => true, 'resources' => ['default' => [$advisory]]]];
+        yield [['flock', $advisory], ['enabled' => true, 'resources' => ['default' => ['flock', $advisory]]]];
+        yield [['foo' => $advisory], ['enabled' => true, 'resources' => ['foo' => [$advisory]]]];
+        yield [['foo' => [$advisory]], ['enabled' => true, 'resources' => ['foo' => [$advisory]]]];
+        yield [['foo' => ['flock', $advisory], 'bar' => 'semaphore'], ['enabled' => true, 'resources' => ['foo' => ['flock', $advisory], 'bar' => ['semaphore']]]];
+        yield [['resources' => $advisory], ['enabled' => true, 'resources' => ['default' => [$advisory]]]];
+        yield [['resources' => ['foo' => $advisory]], ['enabled' => true, 'resources' => ['foo' => [$advisory]]]];
+        yield [['resources' => ['foo' => ['flock', $advisory]]], ['enabled' => true, 'resources' => ['foo' => ['flock', $advisory]]]];
+        yield [['enabled' => false, 'foo' => $advisory], ['enabled' => false, 'resources' => ['foo' => [$advisory]]]];
+    }
+
+    #[DataProvider('provideInvalidLockConfigurationTests')]
+    public function testInvalidLockConfiguration(array $lockConfig, string $expectedMessage)
+    {
+        $processor = new Processor();
+        $configuration = new Configuration(true);
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage($expectedMessage);
+
+        $processor->processConfiguration($configuration, [['lock' => $lockConfig]]);
+    }
+
+    public static function provideInvalidLockConfigurationTests(): iterable
+    {
+        yield [
+            ['foo' => ['advisory' => true]],
+            'Invalid configuration for path "framework.lock.resources.foo.0": A lock store must be a string or an array with a "service_id" string and an optional "advisory" boolean, got {"service_id":null,"advisory":true}.',
+        ];
+
+        yield [
+            ['foo' => ['service_id' => 'my_connection', 'advisory' => 'yes']],
+            'Invalid configuration for path "framework.lock.resources.foo.0": A lock store must be a string or an array with a "service_id" string and an optional "advisory" boolean, got {"service_id":"my_connection","advisory":"yes"}.',
+        ];
+
+        yield [
+            ['foo' => ['service_id' => 'my_connection', 'store' => 'postgresql_advisory']],
+            'Invalid configuration for path "framework.lock.resources.foo.0": A lock store must be a string or an array with a "service_id" string and an optional "advisory" boolean, got {"service_id":"my_connection","advisory":false,"store":"postgresql_advisory"}.',
+        ];
     }
 
     public function testLockMergeConfigs()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/lock_advisory.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/lock_advisory.php
@@ -1,0 +1,19 @@
+<?php
+
+$container->register('my_connection', \Doctrine\DBAL\Connection::class);
+
+$container->loadFromExtension('framework', [
+    'lock' => [
+        'foo' => [
+            'service_id' => 'my_connection',
+            'advisory' => true,
+        ],
+        'bar' => [
+            'service_id' => 'my_connection',
+        ],
+        'baz' => [
+            'flock',
+            ['service_id' => 'my_connection', 'advisory' => true],
+        ],
+    ],
+]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/lock_advisory.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/lock_advisory.yml
@@ -1,0 +1,15 @@
+services:
+    my_connection:
+        class: Doctrine\DBAL\Connection
+
+framework:
+    lock:
+        foo:
+            service_id: my_connection
+            advisory: true
+        bar:
+            service_id: my_connection
+        baz:
+            - flock
+            - service_id: my_connection
+              advisory: true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -3112,6 +3112,25 @@ abstract class FrameworkExtensionTestCase extends TestCase
         $this->assertEquals(new Reference('my_service'), $storeDef->getArgument(0));
     }
 
+    public function testLockWithAdvisoryService()
+    {
+        $container = $this->createContainerFromFile('lock_advisory', [], true, false);
+        $container->getCompilerPassConfig()->setOptimizationPasses([new ResolveChildDefinitionsPass()]);
+        $container->compile();
+
+        $storeDef = $container->getDefinition($container->getDefinition('lock.foo.factory')->getArgument(0));
+        $this->assertEquals([new Reference('my_connection'), true], $storeDef->getArguments());
+
+        $storeDef = $container->getDefinition($container->getDefinition('lock.bar.factory')->getArgument(0));
+        $this->assertEquals([new Reference('my_connection')], $storeDef->getArguments());
+
+        $combinedDef = $container->getDefinition($container->getDefinition('lock.baz.factory')->getArgument(0));
+        $this->assertIsArray($storeRefs = $combinedDef->getArgument(0));
+        $this->assertCount(2, $storeRefs);
+        $this->assertSame('.lock.flock.store', (string) $storeRefs[0]);
+        $this->assertEquals([new Reference('my_connection'), true], $container->getDefinition((string) $storeRefs[1])->getArguments());
+    }
+
     public function testLockWithServiceAndEnv()
     {
         $container = $this->createContainerFromFile('lock_service_and_env', [], true, false);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #64775
| License       | MIT

This completes at the bundle level the component work merged in #65021.

`StoreFactory::createStore()` gained an `$advisory` flag there, but FrameworkBundle had no way to pass it: `framework.lock` typed every store as a plain string, so a service id could only ever produce the table-based `PdoStore` or `DoctrineDbalStore`. Advisory locks were reachable through the `pgsql+advisory://` and `mysql+advisory://` DSNs, which open their own connection, but not when reusing a connection the application already has.

A store entry may now be an array instead of a string:

```yaml
framework:
    lock:
        invoice:
            service_id: doctrine.dbal.default_connection
            advisory: true
```

`service_id` is the id of a service holding a `\PDO` or a Doctrine DBAL `Connection`. `advisory` defaults to `false`, which is the behavior you get today. The same array works inside the list of stores of a resource, so it combines with the existing shapes:

```yaml
framework:
    lock:
        invoice:
            - flock
            - service_id: doctrine.dbal.default_connection
              advisory: true
```

and in PHP:

```php
$container->loadFromExtension('framework', [
    'lock' => [
        'invoice' => ['service_id' => 'doctrine.dbal.default_connection', 'advisory' => true],
    ],
]);
```

There is no XML syntax to add: support for the XML configuration format was removed from FrameworkBundle on this branch by af1f0305c6b.

With `advisory: true`, the component picks the store from the connection itself:

| connection | selector | store |
| --- | --- | --- |
| `\PDO` | driver `pgsql` | `PostgreSqlStore` |
| `\PDO` | driver `mysql` | `MysqlStore` |
| DBAL `Connection` | `PostgreSQLPlatform` | `DoctrineDbalPostgreSqlStore` |
| DBAL `Connection` | `AbstractMySQLPlatform` | `DoctrineDbalMysqlStore` |

Anything else throws `The "sqlite" PDO driver does not support advisory locks.` or `The "…Platform" platform does not support advisory locks.`

That check stays at runtime on purpose. At compile time the extension only holds a service id; the driver or platform is a property of the connection object, and a DBAL connection without a `serverVersion` parameter has to connect to the server to resolve its platform. Validating it during container compilation would mean opening a database connection while building the container.

The option is opt-in and off by default. When `advisory` is absent or `false` the generated definition keeps exactly one argument, so the compiled container is byte for byte what it was before for everyone not using it.

### Caveat worth repeating in the docs

Advisory locks are held by the **database session**, not by a row in a table. Reconnecting, closing the connection or hitting the server's idle timeout releases every lock the application holds, and nothing in the application notices. That matters most in the case this option exists for: reusing `doctrine.dbal.default_connection`, which the ORM also uses and which may be reset between requests or by a long-running worker. A connection dedicated to locking is the safer setup:

```yaml
doctrine:
    dbal:
        connections:
            default:
                url: '%env(DATABASE_URL)%'
            locking:
                url: '%env(DATABASE_URL)%'

framework:
    lock:
        invoice:
            service_id: doctrine.dbal.locking_connection
            advisory: true
```

### symfony-docs

A docs pull request should carry:

* the new `service_id` / `advisory` keys under `framework.lock`, in the reference and in the Lock article, with the YAML and PHP snippets above;
* the table of which driver and platform maps to which store;
* that `advisory` only applies to a `service_id` pointing at a `\PDO` or DBAL connection, and that DSNs already express the same thing through `pgsql+advisory://` and `mysql+advisory://`;
* the session-scope caveat, and the recommendation to dedicate a connection to locking rather than reusing the ORM one;
* that an unsupported driver or platform fails when the store is built, not when the container is compiled;
* the `versionadded` directive for 8.2.
