### PR TITLE
[Mailer][Sendgrid] Map the processed event to RECEIVED

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/RemoteEvent/SendgridPayloadConverter.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/RemoteEvent/SendgridPayloadConverter.php
@@ -26,7 +26,8 @@ final class SendgridPayloadConverter implements PayloadConverterInterface
     {
         if (\in_array($payload['event'], ['processed', 'delivered', 'bounce', 'dropped', 'deferred'], true)) {
             $name = match ($payload['event']) {
-                'processed', 'delivered' => MailerDeliveryEvent::DELIVERED,
+                'processed' => MailerDeliveryEvent::RECEIVED,
+                'delivered' => MailerDeliveryEvent::DELIVERED,
                 'dropped' => MailerDeliveryEvent::DROPPED,
                 'deferred' => MailerDeliveryEvent::DEFERRED,
                 'bounce' => MailerDeliveryEvent::BOUNCE,

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/RemoteEvent/SendgridPayloadConverterTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/RemoteEvent/SendgridPayloadConverterTest.php
@@ -43,7 +43,7 @@ class SendgridPayloadConverterTest extends TestCase
 
     public static function provideDeliveryEvents(): iterable
     {
-        yield ['processed', MailerDeliveryEvent::DELIVERED];
+        yield ['processed', MailerDeliveryEvent::RECEIVED];
         yield ['delivered', MailerDeliveryEvent::DELIVERED];
         yield ['bounce', MailerDeliveryEvent::BOUNCE];
         yield ['dropped', MailerDeliveryEvent::DROPPED];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`SendgridPayloadConverter` maps both `processed` and `delivered` to `MailerDeliveryEvent::DELIVERED`, so an application receives two delivery events for every message it sends. Anything that counts deliveries counts twice, and anything that treats `DELIVERED` as proof that the message reached the recipient acts on the first one, while the message is still queued inside SendGrid.

The two events describe different hops. SendGrid documents `processed` as the message having been received and being ready to be delivered, and `delivered` as the message having been delivered to the receiving server. `MailerDeliveryEvent` has a constant for each: `RECEIVED` for the provider accepting the message from the application, `DELIVERED` for the recipient's server accepting it.

Every other bridge keeps them apart: `accepted` and `delivered` in Mailgun, `request` and `delivered` in Brevo, `email.sent` and `email.delivered` in Resend, and the same pairing in AhaSend, MailerSend, Mailchimp, Sweego and Mailomat. Sendgrid is the only delivery converter in the tree that maps nothing to `RECEIVED`.

`processed` now maps to `RECEIVED`.

Applications that listen for `RECEIVED` start seeing an event they never got from this bridge before, and applications that listen for `DELIVERED` stop seeing the duplicate. That is the point of the change, and it makes the bridge behave like the other twelve.
