### PR TITLE
[CI] Authenticate remote git operations explicitly

### DIFF
--- a/.github/workflows/package-tests.yml
+++ b/.github/workflows/package-tests.yml
@@ -19,7 +19,13 @@ jobs:
           persist-credentials: false
 
       - name: Fetch branch from where the PR started
-        run: git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Credentials are not persisted by the checkout, so remote operations are given
+          # the job token explicitly. Public repositories would also accept anonymous reads,
+          # private forks do not.
+          git fetch --no-tags --prune --depth=1 "https://x-access-token:$GH_TOKEN@github.com/$GITHUB_REPOSITORY" +refs/heads/*:refs/remotes/origin/*
 
       - name: Find packages
         id: find-packages

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -47,10 +47,15 @@ jobs:
         run: ./vendor/bin/psalm.phar --set-baseline=.github/sa-tools/psalm.baseline.xml --no-progress
 
       - name: Switch to PR
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
+          # Credentials are not persisted by the checkout, so remote operations are given
+          # the job token explicitly. Public repositories would also accept anonymous reads,
+          # private forks do not.
           git checkout composer.json
           base_sha=$(git rev-parse HEAD)
-          git fetch --depth=1 origin '+${{ github.event.pull_request.head.sha }}'
+          git fetch --depth=1 "https://x-access-token:$GH_TOKEN@github.com/$GITHUB_REPOSITORY" '+${{ github.event.pull_request.head.sha }}'
           git checkout -m FETCH_HEAD
 
           # update dependencies when the PR changes composer.json so that packages it adds are resolvable
@@ -95,10 +100,15 @@ jobs:
         run: ./vendor/bin/phpstan analyse --error-format=json --no-progress --autoload-file='.github/sa-tools/rules/bootstrap.php' > .github/sa-tools/phpstan-base.json || true
 
       - name: Switch to PR
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
+          # Credentials are not persisted by the checkout, so remote operations are given
+          # the job token explicitly. Public repositories would also accept anonymous reads,
+          # private forks do not.
           git checkout composer.json
           base_sha=$(git rev-parse HEAD)
-          git fetch --depth=1 origin '+${{ github.event.pull_request.head.sha }}'
+          git fetch --depth=1 "https://x-access-token:$GH_TOKEN@github.com/$GITHUB_REPOSITORY" '+${{ github.event.pull_request.head.sha }}'
           git checkout -m FETCH_HEAD
 
           # update dependencies when the PR changes composer.json so that packages it adds are resolvable

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -56,7 +56,14 @@ jobs:
           tools: flex
 
       - name: Configure environment
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
+          # Credentials are not persisted by the checkout, so remote operations are given
+          # the job token explicitly. Public repositories would also accept anonymous reads,
+          # private forks do not.
+          GIT_REMOTE="https://x-access-token:$GH_TOKEN@github.com/$GITHUB_REPOSITORY"
+
           git config --global user.email ""
           git config --global user.name "Symfony"
           git config --global init.defaultBranch main
@@ -71,7 +78,6 @@ jobs:
           echo PHPUNIT="$(pwd)/phpunit --exclude-group tty,benchmark,intl-data,integration,transient" >> $GITHUB_ENV
           echo COMPOSER_UP='composer update --no-progress --ansi'$([[ "${{ matrix.mode }}" != low-deps ]] && echo ' --ignore-platform-req=php+') >> $GITHUB_ENV
 
-          SYMFONY_VERSIONS=$(git ls-remote -q --heads | cut -f2 | grep -o '/[1-9][0-9]*\.[0-9].*' | sort -V)
           SYMFONY_VERSION=$(grep ' VERSION = ' src/Symfony/Component/HttpKernel/Kernel.php | cut -d "'" -f2 | cut -d '.' -f 1-2)
           SYMFONY_FEATURE_BRANCH=$(curl -s https://raw.githubusercontent.com/symfony/recipes/flex/main/index.json | jq -r '.versions."dev-name"')
 
@@ -83,7 +89,7 @@ jobs:
           #SYMFONY_PHPUNIT_BRIDGE_PR=32886
 
           if [[ $SYMFONY_PHPUNIT_BRIDGE_PR ]]; then
-            git fetch --depth=2 origin refs/pull/$SYMFONY_PHPUNIT_BRIDGE_PR/head
+            git fetch --depth=2 "$GIT_REMOTE" refs/pull/$SYMFONY_PHPUNIT_BRIDGE_PR/head
             git rm -rq src/Symfony/Bridge/PhpUnit
             git checkout -q FETCH_HEAD -- src/Symfony/Bridge/PhpUnit
             SYMFONY_PHPUNIT_BRIDGE_REF=$(curl -s https://api.github.com/repos/symfony/symfony/pulls/$SYMFONY_PHPUNIT_BRIDGE_PR | jq -r .base.ref)
@@ -108,12 +114,16 @@ jobs:
           fi
 
           # For the highest branch, in high-deps mode, the version before it is checked out and tested with the locally patched components
-          if [[ "${{ matrix.mode }}" = high-deps && $SYMFONY_VERSION = $(echo "$SYMFONY_VERSIONS" | tail -n 1 | sed s/.//) ]]; then
-            echo FLIP='^' >> $GITHUB_ENV
-            SYMFONY_VERSION=$(echo "$SYMFONY_VERSIONS" | grep -FB1 /$SYMFONY_VERSION | head -n 1 | sed s/.//)
-            git fetch --depth=2 origin $SYMFONY_VERSION
-            git checkout -m FETCH_HEAD
-            echo COMPONENTS=$(find src/Symfony -mindepth 2 -type f -name phpunit.xml.dist -printf '%h ') >> $GITHUB_ENV
+          if [[ "${{ matrix.mode }}" = high-deps ]]; then
+            SYMFONY_VERSIONS=$(git ls-remote -q --heads "$GIT_REMOTE" | cut -f2 | grep -o '/[1-9][0-9]*\.[0-9].*' | sort -V)
+
+            if [[ $SYMFONY_VERSION = $(echo "$SYMFONY_VERSIONS" | tail -n 1 | sed s/.//) ]]; then
+              echo FLIP='^' >> $GITHUB_ENV
+              SYMFONY_VERSION=$(echo "$SYMFONY_VERSIONS" | grep -FB1 /$SYMFONY_VERSION | head -n 1 | sed s/.//)
+              git fetch --depth=2 "$GIT_REMOTE" $SYMFONY_VERSION
+              git checkout -m FETCH_HEAD
+              echo COMPONENTS=$(find src/Symfony -mindepth 2 -type f -name phpunit.xml.dist -printf '%h ') >> $GITHUB_ENV
+            fi
           fi
 
           # Skip the phpunit-bridge on bugfix-branches when not in *-deps mode
@@ -163,7 +173,11 @@ jobs:
           php .github/patch-types.php lint
 
       - name: Run tests
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
+          GIT_REMOTE="https://x-access-token:$GH_TOKEN@github.com/$GITHUB_REPOSITORY"
+
           _run_tests() {
             local ok=0
             local title="$1$FLIP"
@@ -211,7 +225,7 @@ jobs:
               echo -e "\\n\\e[33;1mChecking out Symfony $SYMFONY_VERSION and running tests with patched components as deps\\e[0m"
               export COMPOSER_ROOT_VERSION=$SYMFONY_VERSION.x-dev
               export SYMFONY_REQUIRE=">=$SYMFONY_VERSION"
-              git fetch --depth=2 origin $SYMFONY_VERSION
+              git fetch --depth=2 "$GIT_REMOTE" $SYMFONY_VERSION
               git checkout -m FETCH_HEAD
               PATCHED_COMPONENTS=$(echo "$PATCHED_COMPONENTS" | xargs dirname | xargs -I{} bash -c "[ -e '{}/phpunit.xml.dist' ] && echo '{}'" | sort || true)
               if [[ $PATCHED_COMPONENTS ]]; then


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Our workflows check out with `persist-credentials: false`, which is the right default: it keeps the job token out of `.git/config`, where every later step and every process in the job (composer plugins, test code, third-party actions) could read it.

The consequence is that no ambient credentials remain afterwards, and several steps still run remote git operations against `origin`:

- `unit-tests.yml`: `git ls-remote -q --heads`, and `git fetch origin` in three places
- `package-tests.yml`: `git fetch --no-tags --prune --depth=1 origin ...`
- `static-analysis.yml`: `git fetch origin '+<pr head sha>'` in both the Psalm and PHPStan jobs

On this repository those succeed because anonymous read access works. On a private fork they fail with:

```
fatal: could not read Username for 'https://github.com': No such device or address
```

which aborts the job before any test runs. That is the current state of Symfony's own private security fork, where every Unit Tests job dies in the `Configure environment` step and the static analysis jobs die in `Switch to PR` after several minutes of analysis.

This passes the job token explicitly to the operations that need it, rather than re-enabling `persist-credentials`. The token stays in the environment of the single step that uses it instead of being written to disk for the rest of the job, and `permissions: contents: read` already limits it to reads.

Second change, independent of the above: `SYMFONY_VERSIONS` was computed with `git ls-remote` on every job, but it is only consumed inside the `high-deps` branch that tests the previous version. It now runs only there, which removes a network round-trip from every other job.

`fabbot` is out of scope: it is an external service that cannot see a private repository at all.
