### PR TITLE
[Notifier] Add the Facebook Page bridge

### DIFF
--- a/splitsh.json
+++ b/splitsh.json
@@ -89,6 +89,7 @@
         "engagespot-notifier": "src/Symfony/Component/Notifier/Bridge/Engagespot",
         "esendex-notifier": "src/Symfony/Component/Notifier/Bridge/Esendex",
         "expo-notifier": "src/Symfony/Component/Notifier/Bridge/Expo",
+        "facebook-page-notifier": "src/Symfony/Component/Notifier/Bridge/FacebookPage",
         "fake-chat-notifier": "src/Symfony/Component/Notifier/Bridge/FakeChat",
         "fake-sms-notifier": "src/Symfony/Component/Notifier/Bridge/FakeSms",
         "firebase-notifier": "src/Symfony/Component/Notifier/Bridge/Firebase",

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -3251,6 +3251,7 @@ class FrameworkExtension extends Extension
             NotifierBridge\Engagespot\EngagespotTransportFactory::class => ['symfony/engagespot-notifier', 'notifier.transport_factory.engagespot'],
             NotifierBridge\Esendex\EsendexTransportFactory::class => ['symfony/esendex-notifier', 'notifier.transport_factory.esendex'],
             NotifierBridge\Expo\ExpoTransportFactory::class => ['symfony/expo-notifier', 'notifier.transport_factory.expo'],
+            NotifierBridge\FacebookPage\FacebookPageTransportFactory::class => ['symfony/facebook-page-notifier', 'notifier.transport_factory.facebook-page'],
             NotifierBridge\Firebase\FirebaseTransportFactory::class => ['symfony/firebase-notifier', 'notifier.transport_factory.firebase'],
             NotifierBridge\FortySixElks\FortySixElksTransportFactory::class => ['symfony/forty-six-elks-notifier', 'notifier.transport_factory.forty-six-elks'],
             NotifierBridge\FreeMobile\FreeMobileTransportFactory::class => ['symfony/free-mobile-notifier', 'notifier.transport_factory.free-mobile'],

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/notifier_transports.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/notifier_transports.php
@@ -29,6 +29,7 @@ return static function (ContainerConfigurator $container) {
         'bluesky' => Bridge\Bluesky\BlueskyTransportFactory::class,
         'chatwork' => Bridge\Chatwork\ChatworkTransportFactory::class,
         'discord' => Bridge\Discord\DiscordTransportFactory::class,
+        'facebook-page' => Bridge\FacebookPage\FacebookPageTransportFactory::class,
         'fake-chat' => Bridge\FakeChat\FakeChatTransportFactory::class,
         'firebase' => Bridge\Firebase\FirebaseTransportFactory::class,
         'google-chat' => Bridge\GoogleChat\GoogleChatTransportFactory::class,

--- a/src/Symfony/Component/Notifier/Bridge/FacebookPage/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/FacebookPage/.gitattributes
@@ -1,0 +1,3 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/FacebookPage/.gitignore
+++ b/src/Symfony/Component/Notifier/Bridge/FacebookPage/.gitignore
@@ -1,0 +1,3 @@
+vendor/
+composer.lock
+phpunit.xml

--- a/src/Symfony/Component/Notifier/Bridge/FacebookPage/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/FacebookPage/CHANGELOG.md
@@ -1,0 +1,7 @@
+CHANGELOG
+=========
+
+8.2
+---
+
+ * Add the bridge

--- a/src/Symfony/Component/Notifier/Bridge/FacebookPage/FacebookPageOptions.php
+++ b/src/Symfony/Component/Notifier/Bridge/FacebookPage/FacebookPageOptions.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\FacebookPage;
+
+use Symfony\Component\Notifier\Message\MessageOptionsInterface;
+
+/**
+ * Optional Facebook Page feed options.
+ *
+ * Personal-profile publishing is not supported by the Graph API.
+ *
+ * @author Mathieu Ledru <matyo91@gmail.com>
+ */
+final class FacebookPageOptions implements MessageOptionsInterface
+{
+    private ?string $link = null;
+
+    public function getRecipientId(): ?string
+    {
+        return null;
+    }
+
+    /**
+     * Attach a URL preview to the Page post (Graph `link` parameter).
+     */
+    public function link(string $url): static
+    {
+        $this->link = $url;
+
+        return $this;
+    }
+
+    public function getLink(): ?string
+    {
+        return $this->link;
+    }
+
+    public function toArray(): array
+    {
+        return array_filter([
+            'link' => $this->link,
+        ], static fn ($value) => null !== $value && '' !== $value);
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/FacebookPage/FacebookPageTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/FacebookPage/FacebookPageTransport.php
@@ -1,0 +1,109 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\FacebookPage;
+
+use Symfony\Component\Notifier\Exception\TransportException;
+use Symfony\Component\Notifier\Exception\UnsupportedMessageTypeException;
+use Symfony\Component\Notifier\Exception\UnsupportedOptionsException;
+use Symfony\Component\Notifier\Message\ChatMessage;
+use Symfony\Component\Notifier\Message\MessageInterface;
+use Symfony\Component\Notifier\Message\SentMessage;
+use Symfony\Component\Notifier\Transport\AbstractTransport;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * Posts to a Facebook Page feed via the Graph API.
+ *
+ * Personal-profile publishing is not supported (Meta removed publish_actions in 2018).
+ *
+ * @author Mathieu Ledru <matyo91@gmail.com>
+ */
+final class FacebookPageTransport extends AbstractTransport
+{
+    protected const HOST = 'graph.facebook.com';
+
+    public function __construct(
+        #[\SensitiveParameter] private string $pageAccessToken,
+        private string $pageId,
+        private string $apiVersion,
+        ?HttpClientInterface $client = null,
+        ?EventDispatcherInterface $dispatcher = null,
+    ) {
+        parent::__construct($client, $dispatcher);
+    }
+
+    public function __toString(): string
+    {
+        return \sprintf('facebook-page://%s?page_id=%s&api_version=%s', $this->getEndpoint(), $this->pageId, $this->apiVersion);
+    }
+
+    public function supports(MessageInterface $message): bool
+    {
+        return $message instanceof ChatMessage
+            && (null === $message->getOptions() || $message->getOptions() instanceof FacebookPageOptions);
+    }
+
+    protected function doSend(MessageInterface $message): SentMessage
+    {
+        if (!$message instanceof ChatMessage) {
+            throw new UnsupportedMessageTypeException(__CLASS__, ChatMessage::class, $message);
+        }
+
+        if (($options = $message->getOptions()) && !$options instanceof FacebookPageOptions) {
+            throw new UnsupportedOptionsException(__CLASS__, FacebookPageOptions::class, $options);
+        }
+
+        $endpoint = \sprintf('https://%s/%s/%s/feed', $this->getEndpoint(), $this->apiVersion, $this->pageId);
+
+        $body = ['message' => $message->getSubject()] + ($options?->toArray() ?? []);
+
+        $response = $this->client->request('POST', $endpoint, [
+            'auth_bearer' => $this->pageAccessToken,
+            'body' => $body,
+        ]);
+
+        try {
+            $statusCode = $response->getStatusCode();
+        } catch (TransportExceptionInterface $e) {
+            throw new TransportException('Could not reach the remote Facebook Graph API server.', $response, 0, $e);
+        }
+
+        if (200 !== $statusCode) {
+            try {
+                $errorMessage = $response->toArray(false)['error']['message'] ?? null;
+            } catch (DecodingExceptionInterface) {
+                $errorMessage = $response->getContent(false);
+            }
+
+            throw new TransportException(\sprintf('Unable to post the Facebook Page message: error %d ("%s").', $statusCode, $errorMessage ?: 'unknown error'), $response);
+        }
+
+        try {
+            $content = $response->toArray(false);
+        } catch (DecodingExceptionInterface $e) {
+            throw new TransportException('Unable to post the Facebook Page message: malformed response from the Facebook Graph API.', $response, 0, $e);
+        }
+
+        $postId = isset($content['id']) && \is_string($content['id']) ? $content['id'] : '';
+        if ('' === $postId) {
+            throw new TransportException('Unable to post the Facebook Page message: missing post id.', $response);
+        }
+
+        $sentMessage = new SentMessage($message, (string) $this);
+        $sentMessage->setMessageId($postId);
+
+        return $sentMessage;
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/FacebookPage/FacebookPageTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/FacebookPage/FacebookPageTransportFactory.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\FacebookPage;
+
+use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
+use Symfony\Component\Notifier\Transport\AbstractTransportFactory;
+use Symfony\Component\Notifier\Transport\Dsn;
+
+/**
+ * @author Mathieu Ledru <matyo91@gmail.com>
+ */
+final class FacebookPageTransportFactory extends AbstractTransportFactory
+{
+    private const DEFAULT_API_VERSION = 'v26.0';
+
+    public function create(Dsn $dsn): FacebookPageTransport
+    {
+        $scheme = $dsn->getScheme();
+
+        if ('facebook-page' !== $scheme) {
+            throw new UnsupportedSchemeException($dsn, 'facebook-page', $this->getSupportedSchemes());
+        }
+
+        $pageAccessToken = $this->getUser($dsn);
+        $pageId = $dsn->getRequiredOption('page_id');
+        $apiVersion = $dsn->getOption('api_version', self::DEFAULT_API_VERSION);
+        $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
+        $port = $dsn->getPort();
+
+        return (new FacebookPageTransport($pageAccessToken, $pageId, $apiVersion, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+    }
+
+    protected function getSupportedSchemes(): array
+    {
+        return ['facebook-page'];
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/FacebookPage/LICENSE
+++ b/src/Symfony/Component/Notifier/Bridge/FacebookPage/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2026-present Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Symfony/Component/Notifier/Bridge/FacebookPage/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/FacebookPage/README.md
@@ -1,0 +1,52 @@
+Facebook Page Notifier
+======================
+
+Provides [Facebook Pages API](https://developers.facebook.com/docs/pages-api/posts/)
+integration for Symfony Notifier, as a `Chatter` transport.
+
+> **Note**
+> This bridge posts to a **Facebook Page** via Graph API `POST /{page_id}/feed`
+> using a page access token. Personal-profile publishing is not available through
+> the Graph API (`publish_actions` was removed in 2018). Use Meta's Share Dialog
+> for user-timeline sharing.
+
+DSN example
+-----------
+
+```
+FACEBOOK_PAGE_DSN=facebook-page://PAGE_ACCESS_TOKEN@default?page_id=PAGE_ID&api_version=v26.0
+```
+
+where:
+
+- `PAGE_ACCESS_TOKEN` is a Page access token with `pages_manage_posts`
+- `PAGE_ID` is the numeric Facebook Page id
+- `api_version` is optional (defaults to `v26.0`)
+
+Sending a Page post
+-------------------
+
+```php
+use Symfony\Component\Notifier\Message\ChatMessage;
+
+$chatter->send(new ChatMessage('Hello from the Facebook Page!'));
+```
+
+Optional link attachment:
+
+```php
+use Symfony\Component\Notifier\Bridge\FacebookPage\FacebookPageOptions;
+use Symfony\Component\Notifier\Message\ChatMessage;
+
+$options = (new FacebookPageOptions())->link('https://example.com/article');
+
+$chatter->send((new ChatMessage('Read our latest article'))->options($options));
+```
+
+Resources
+---------
+
+- [Contributing](https://symfony.com/doc/current/contributing/index.html)
+- [Report issues](https://github.com/symfony/symfony/issues) and
+  [send Pull Requests](https://github.com/symfony/symfony/pulls)
+  in the [main Symfony repository](https://github.com/symfony/symfony)

--- a/src/Symfony/Component/Notifier/Bridge/FacebookPage/Tests/FacebookPageOptionsTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/FacebookPage/Tests/FacebookPageOptionsTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\FacebookPage\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Notifier\Bridge\FacebookPage\FacebookPageOptions;
+
+/**
+ * @author Mathieu Ledru <matyo91@gmail.com>
+ */
+final class FacebookPageOptionsTest extends TestCase
+{
+    public function testGetRecipientIdIsAlwaysNull()
+    {
+        self::assertNull((new FacebookPageOptions())->getRecipientId());
+        self::assertNull((new FacebookPageOptions())->link('https://example.com')->getRecipientId());
+    }
+
+    public function testLink()
+    {
+        $options = (new FacebookPageOptions())->link('https://example.com/article');
+
+        self::assertSame('https://example.com/article', $options->getLink());
+        self::assertSame(['link' => 'https://example.com/article'], $options->toArray());
+    }
+
+    public function testToArrayOmitsEmptyLink()
+    {
+        self::assertSame([], (new FacebookPageOptions())->toArray());
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/FacebookPage/Tests/FacebookPageTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/FacebookPage/Tests/FacebookPageTransportFactoryTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\FacebookPage\Tests;
+
+use Symfony\Component\Notifier\Bridge\FacebookPage\FacebookPageTransportFactory;
+use Symfony\Component\Notifier\Test\AbstractTransportFactoryTestCase;
+use Symfony\Component\Notifier\Test\IncompleteDsnTestTrait;
+use Symfony\Component\Notifier\Test\MissingRequiredOptionTestTrait;
+
+/**
+ * @author Mathieu Ledru <matyo91@gmail.com>
+ */
+final class FacebookPageTransportFactoryTest extends AbstractTransportFactoryTestCase
+{
+    use IncompleteDsnTestTrait;
+    use MissingRequiredOptionTestTrait;
+
+    public function createFactory(): FacebookPageTransportFactory
+    {
+        return new FacebookPageTransportFactory();
+    }
+
+    public static function createProvider(): iterable
+    {
+        yield [
+            'facebook-page://graph.facebook.com?page_id=1895547427139786&api_version=v26.0',
+            'facebook-page://token@default?page_id=1895547427139786',
+        ];
+    }
+
+    public static function supportsProvider(): iterable
+    {
+        yield [true, 'facebook-page://token@host.test?page_id=1895547427139786'];
+        yield [false, 'somethingElse://token@host.test?page_id=1895547427139786'];
+    }
+
+    public static function unsupportedSchemeProvider(): iterable
+    {
+        yield ['somethingElse://token@host.test?page_id=1895547427139786'];
+    }
+
+    public static function incompleteDsnProvider(): iterable
+    {
+        yield 'missing token' => ['facebook-page://host.test?page_id=1895547427139786'];
+    }
+
+    public static function missingRequiredOptionProvider(): iterable
+    {
+        yield 'missing option: page_id' => ['facebook-page://token@host.test'];
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/FacebookPage/Tests/FacebookPageTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/FacebookPage/Tests/FacebookPageTransportTest.php
@@ -1,0 +1,122 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\FacebookPage\Tests;
+
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\Notifier\Bridge\FacebookPage\FacebookPageOptions;
+use Symfony\Component\Notifier\Bridge\FacebookPage\FacebookPageTransport;
+use Symfony\Component\Notifier\Exception\TransportException;
+use Symfony\Component\Notifier\Message\ChatMessage;
+use Symfony\Component\Notifier\Message\SentMessage;
+use Symfony\Component\Notifier\Message\SmsMessage;
+use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Tests\Transport\DummyMessage;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * @author Mathieu Ledru <matyo91@gmail.com>
+ */
+final class FacebookPageTransportTest extends TransportTestCase
+{
+    public static function createTransport(?HttpClientInterface $client = null): FacebookPageTransport
+    {
+        return new FacebookPageTransport('page-access-token', '1895547427139786', 'v26.0', $client ?? new MockHttpClient());
+    }
+
+    public static function toStringProvider(): iterable
+    {
+        yield ['facebook-page://graph.facebook.com?page_id=1895547427139786&api_version=v26.0', self::createTransport()];
+    }
+
+    public static function supportedMessagesProvider(): iterable
+    {
+        yield [new ChatMessage('Hello!')];
+        yield [new ChatMessage('Hello!', (new FacebookPageOptions())->link('https://example.com'))];
+    }
+
+    public static function unsupportedMessagesProvider(): iterable
+    {
+        yield [new SmsMessage('0611223344', 'Hello!')];
+        yield [new DummyMessage()];
+    }
+
+    public function testSendPostsMessageAndAccessTokenToPageFeed()
+    {
+        $client = new MockHttpClient(static function (string $method, string $url, array $options): MockResponse {
+            self::assertSame('POST', $method);
+            self::assertSame('https://graph.facebook.com/v26.0/1895547427139786/feed', $url);
+
+            parse_str($options['body'], $body);
+            self::assertSame('Hello from Navi', $body['message'] ?? null);
+            self::assertContains('Authorization: Bearer page-access-token', $options['headers']);
+            self::assertArrayNotHasKey('access_token', $body);
+
+            return new MockResponse(json_encode(['id' => '1895547427139786_42'], \JSON_THROW_ON_ERROR));
+        });
+
+        $sentMessage = self::createTransport($client)->send(new ChatMessage('Hello from Navi'));
+
+        self::assertInstanceOf(SentMessage::class, $sentMessage);
+        self::assertSame('1895547427139786_42', $sentMessage->getMessageId());
+    }
+
+    public function testSendIncludesOptionalLink()
+    {
+        $client = new MockHttpClient(static function (string $method, string $url, array $options): MockResponse {
+            parse_str($options['body'], $body);
+            self::assertSame('https://example.com/article', $body['link'] ?? null);
+            self::assertContains('Authorization: Bearer page-access-token', $options['headers']);
+            self::assertArrayNotHasKey('access_token', $body);
+
+            return new MockResponse(json_encode(['id' => 'page_1'], \JSON_THROW_ON_ERROR));
+        });
+
+        $message = (new ChatMessage('Read this'))->options((new FacebookPageOptions())->link('https://example.com/article'));
+        $sentMessage = self::createTransport($client)->send($message);
+
+        self::assertSame('page_1', $sentMessage->getMessageId());
+    }
+
+    public function testSendThrowsOnNonSuccessfulResponse()
+    {
+        $client = new MockHttpClient(new MockResponse(
+            json_encode(['error' => ['message' => 'Invalid OAuth access token.']], \JSON_THROW_ON_ERROR),
+            ['http_code' => 400],
+        ));
+
+        $this->expectException(TransportException::class);
+        $this->expectExceptionMessage('Invalid OAuth access token.');
+
+        self::createTransport($client)->send(new ChatMessage('Hello'));
+    }
+
+    public function testSendThrowsTransportExceptionOnNonJsonErrorResponse()
+    {
+        $client = new MockHttpClient(new MockResponse('<html><body>502 Bad Gateway</body></html>', ['http_code' => 502]));
+
+        $this->expectException(TransportException::class);
+        $this->expectExceptionMessage('502 Bad Gateway');
+
+        self::createTransport($client)->send(new ChatMessage('Hello'));
+    }
+
+    public function testSendThrowsTransportExceptionOnNonJsonSuccessfulResponse()
+    {
+        $client = new MockHttpClient(new MockResponse(''));
+
+        $this->expectException(TransportException::class);
+        $this->expectExceptionMessage('malformed response from the Facebook Graph API');
+
+        self::createTransport($client)->send(new ChatMessage('Hello'));
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/FacebookPage/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/FacebookPage/composer.json
@@ -1,0 +1,39 @@
+{
+    "name": "symfony/facebook-page-notifier",
+    "type": "symfony-notifier-bridge",
+    "description": "Symfony Facebook Page Notifier Bridge, via Meta Graph API Page feed",
+    "keywords": [
+        "facebook",
+        "facebook page",
+        "meta",
+        "pages",
+        "notifier",
+        "chat"
+    ],
+    "homepage": "https://symfony.com",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Mathieu Ledru",
+            "email": "matyo91@gmail.com"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "https://symfony.com/contributors"
+        }
+    ],
+    "require": {
+        "php": ">=8.4.1",
+        "symfony/http-client": "^7.4|^8.0",
+        "symfony/notifier": "^7.4|^8.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Symfony\\Component\\Notifier\\Bridge\\FacebookPage\\": ""
+        },
+        "exclude-from-classmap": [
+            "/Tests/"
+        ]
+    },
+    "minimum-stability": "dev"
+}

--- a/src/Symfony/Component/Notifier/Bridge/FacebookPage/phpunit.xml.dist
+++ b/src/Symfony/Component/Notifier/Bridge/FacebookPage/phpunit.xml.dist
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/13.1/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+         failOnDeprecation="true"
+         failOnRisky="true"
+         failOnWarning="true"
+>
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Symfony Facebook Notifier Bridge Test Suite">
+            <directory>./Tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <source ignoreSuppressionOfDeprecations="true">
+        <include>
+            <directory>./</directory>
+        </include>
+        <exclude>
+            <directory>./Tests</directory>
+            <directory>./vendor</directory>
+        </exclude>
+    </source>
+
+    <extensions>
+        <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension" />
+    </extensions>
+</phpunit>

--- a/src/Symfony/Component/Notifier/Exception/UnsupportedSchemeException.php
+++ b/src/Symfony/Component/Notifier/Exception/UnsupportedSchemeException.php
@@ -68,6 +68,10 @@ class UnsupportedSchemeException extends LogicException
             'class' => Bridge\Expo\ExpoTransportFactory::class,
             'package' => 'symfony/expo-notifier',
         ],
+        'facebook-page' => [
+            'class' => Bridge\FacebookPage\FacebookPageTransportFactory::class,
+            'package' => 'symfony/facebook-page-notifier',
+        ],
         'fakechat' => [
             'class' => Bridge\FakeChat\FakeChatTransportFactory::class,
             'package' => 'symfony/fake-chat-notifier',

--- a/src/Symfony/Component/Notifier/Tests/Exception/UnsupportedSchemeExceptionTest.php
+++ b/src/Symfony/Component/Notifier/Tests/Exception/UnsupportedSchemeExceptionTest.php
@@ -39,6 +39,7 @@ final class UnsupportedSchemeExceptionTest extends TestCase
             Bridge\Engagespot\EngagespotTransportFactory::class => false,
             Bridge\Esendex\EsendexTransportFactory::class => false,
             Bridge\Expo\ExpoTransportFactory::class => false,
+            Bridge\FacebookPage\FacebookPageTransportFactory::class => false,
             Bridge\FakeChat\FakeChatTransportFactory::class => false,
             Bridge\FakeSms\FakeSmsTransportFactory::class => false,
             Bridge\Firebase\FirebaseTransportFactory::class => false,
@@ -138,6 +139,7 @@ final class UnsupportedSchemeExceptionTest extends TestCase
         yield ['engagespot', 'symfony/engagespot-notifier'];
         yield ['esendex', 'symfony/esendex-notifier'];
         yield ['expo', 'symfony/expo-notifier'];
+        yield ['facebook-page', 'symfony/facebook-page-notifier'];
         yield ['fakechat', 'symfony/fake-chat-notifier'];
         yield ['fakesms', 'symfony/fake-sms-notifier'];
         yield ['firebase', 'symfony/firebase-notifier'];

--- a/src/Symfony/Component/Notifier/Transport.php
+++ b/src/Symfony/Component/Notifier/Transport.php
@@ -41,6 +41,7 @@ final class Transport
         Bridge\Engagespot\EngagespotTransportFactory::class,
         Bridge\Esendex\EsendexTransportFactory::class,
         Bridge\Expo\ExpoTransportFactory::class,
+        Bridge\FacebookPage\FacebookPageTransportFactory::class,
         Bridge\FakeChat\FakeChatTransportFactory::class,
         Bridge\FakeSms\FakeSmsTransportFactory::class,
         Bridge\Firebase\FirebaseTransportFactory::class,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix Facebook content page post __invoke Tool from https://github.com/symfony/ai/pull/549
| License       | MIT

This adds a Notifier bridge for the [Facebook Pages API](https://developers.facebook.com/docs/pages-api/posts/),
Meta's Graph API for publishing as a Facebook Page. It registers a `Chatter` transport that posts to
`POST https://graph.facebook.com/{api_version}/{page_id}/feed`.

Personal-profile publishing is not supported: Meta removed `publish_actions` in 2018. This bridge only
posts as a **Page**, using a page access token with `pages_manage_posts`. For user-timeline sharing,
Meta's [Share Dialog](https://developers.facebook.com/docs/sharing/reference/share-dialog/) remains the supported path.

### DSN

```
FACEBOOK_DSN=facebook://PAGE_ACCESS_TOKEN@default?page_id=PAGE_ID&api_version=v26.0
```

`api_version` is optional and defaults to `v26.0`, the current Graph API version. Meta retires a
Graph API version roughly two years after the following one ships, so the option is there to let
applications move ahead of, or stay behind, the bridge's default.

### Getting the credentials

Both values come from an app in the [Meta developer console](https://developers.facebook.com/apps):

1. Create an app of type *Business* and add the **Pages** product to it.
2. Generate a user access token with `pages_show_list` and `pages_manage_posts` (and typically
   `pages_read_engagement`).
3. Call `GET /me/accounts` to list Pages you manage, then copy the target Page's **id** (`page_id`)
   and its **page access token** (`PAGE_ACCESS_TOKEN`). A short-lived token is fine for a first try;
   exchange it for a long-lived page token for production use.

### Sending messages

the DSN already identifies the Page, so a bare `ChatMessage` is supported. The subject is sent as the Page post `message`.

```php
use Symfony\Component\Notifier\Message\ChatMessage;

$chatter->send(new ChatMessage('Hello from the Facebook Page!'));
```

Optionally attach a link preview through `FacebookOptions::link()` (Graph `link` parameter):

```php
use Symfony\Component\Notifier\Bridge\Facebook\FacebookOptions;
use Symfony\Component\Notifier\Message\ChatMessage;

$options = (new FacebookOptions())->link('https://example.com/article');

$chatter->send((new ChatMessage('Read our latest article'))->options($options));
```

### Possible follow-up

Scheduled / unpublished Page posts (`published=false` + `scheduled_publish_time`) would be a natural
extension of `FacebookOptions`. It is deliberately out of scope here so the first version stays a
simple publish-now Page post.

### Documentation

A symfony-docs pull request should cover:

* the new `facebook` scheme and its row in the chatter transports table of `notifier.rst`, with the
  DSN format and the `symfony/facebook-notifier` package name;
* the two DSN options, `page_id` (required) and `api_version` (optional), and where the page id /
  page access token come from in the Meta developer console;
* the `pages_manage_posts` permission requirement, and the note that personal-profile publishing is
  not available via the Graph API;
* `FacebookOptions::link()` for optional link attachments;
* the fact that a bare `ChatMessage` is supported (no recipient), because the Page is selected by the DSN.