### PR TITLE
[DependencyInjection] Allow injecting a service as a lazy proxy on a per-argument basis

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Argument/LazyProxyArgument.php
+++ b/src/Symfony/Component/DependencyInjection/Argument/LazyProxyArgument.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Argument;
+
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Represents a reference to a service that should be injected as a lazy proxy.
+ *
+ * @author HypeMC <hypemc@gmail.com>
+ */
+class LazyProxyArgument implements ArgumentInterface
+{
+    use ArgumentTrait;
+
+    private Reference $service;
+    private array $interfaces;
+
+    /**
+     * @param string|string[] $interfaces The interface(s) the proxy should implement, or none to proxy the service's own class
+     */
+    public function __construct(Reference $service, string|array $interfaces = [])
+    {
+        $this->service = $service;
+        $this->setInterfaces($interfaces);
+    }
+
+    public function getValues(): array
+    {
+        return [$this->service, $this->interfaces];
+    }
+
+    public function setValues(array $values): void
+    {
+        $this->service = $values[0];
+
+        if (isset($values[1])) {
+            $this->setInterfaces($values[1]);
+        }
+    }
+
+    private function setInterfaces(string|array $interfaces): void
+    {
+        $isValid = \is_string($interfaces)
+            ? '' !== $interfaces
+            : $interfaces === array_filter($interfaces, static fn ($interface) => \is_string($interface) && '' !== $interface);
+
+        if (!$isValid) {
+            throw new InvalidArgumentException('A lazy proxy argument expects $interfaces to be a non-empty string or an array of non-empty strings.');
+        }
+
+        $this->interfaces = \is_string($interfaces) ? [$interfaces] : $interfaces;
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Allow computing tag attributes per tagged service when using `#[AutoconfigureTag]`, `#[Autoconfigure]` or `_instanceof`: pass a `\Closure` receiving the concrete class-string (requires PHP 8.5), or a `[class-string, method]` callable resolved against each concrete class (works on PHP 8.4)
  * Call `#[Required]` methods in the order defined by the attribute's `$priority` argument
+ * Add support for injecting a service as a lazy proxy on a per-argument basis, using the `!lazy_proxy` YAML tag, the `@~` reference prefix or the `lazy_proxy()` function in the PHP-DSL
 
 8.1
 ---

--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\DependencyInjection\Compiler;
 
 use Symfony\Component\Config\Resource\ClassExistenceResource;
 use Symfony\Component\DependencyInjection\Argument\EnvClosureArgument;
+use Symfony\Component\DependencyInjection\Argument\LazyProxyArgument;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\DependencyInjection\Attribute\AutowireDecorated;
 use Symfony\Component\DependencyInjection\Attribute\AutowireInline;
@@ -365,41 +366,12 @@ class AutowirePass extends AbstractRecursivePass
                         $value = $attribute->buildDefinition($value, $type, $parameter);
                         $value = $this->doProcessValue($value);
                     } elseif ($lazy = $attribute->lazy) {
+                        if (true === $lazy && str_contains($type, '|')) {
+                            throw new AutowiringFailedException($this->currentId, \sprintf('Cannot use #[Autowire] with option "lazy: true" on union types for service "%s"; set the option to the interface(s) that should be proxied instead.', $this->currentId));
+                        }
+
                         $value ??= $getValue();
-
-                        if (!\is_array($lazy)) {
-                            if (str_contains($type, '|')) {
-                                throw new AutowiringFailedException($this->currentId, \sprintf('Cannot use #[Autowire] with option "lazy: true" on union types for service "%s"; set the option to the interface(s) that should be proxied instead.', $this->currentId));
-                            }
-                            $lazy = str_contains($type, '&') ? explode('&', $type) : (\is_string($lazy) ? [$lazy] : []);
-                        }
-
-                        if (!$lazy && $value instanceof Reference && $this->container->has($value) && $this->container->findDefinition($value)->isLazy()) {
-                            $arguments[$index] = $value;
-
-                            continue 2;
-                        }
-
-                        $proxyType = $lazy ? $type : $this->resolveProxyType($type, $value);
-                        $definition = (new Definition($proxyType))
-                            ->setFactory('current')
-                            ->setArguments([[$value]])
-                            ->setLazy(true);
-
-                        if ($lazy) {
-                            if (!$this->container->getReflectionClass($proxyType, false)) {
-                                $definition->setClass('object');
-                            }
-                            foreach ($lazy as $v) {
-                                $definition->addTag('proxy', ['interface' => $v]);
-                            }
-                        }
-
-                        if ($definition->getClass() !== (string) $value || $definition->getTag('proxy')) {
-                            $value .= '.'.$this->container->hash([$definition->getClass(), $definition->getTag('proxy')]);
-                        }
-                        $this->container->setDefinition($value = '.lazy.'.$value, $definition);
-                        $value = new Reference($value);
+                        $value = new LazyProxyArgument(new TypedReference((string) $value, $type, $value->getInvalidBehavior()), true === $lazy ? [] : $lazy);
                     }
                     $arguments[$index] = $value;
 
@@ -778,27 +750,5 @@ class AutowirePass extends AbstractRecursivePass
         }
 
         return $alias;
-    }
-
-    /**
-     * Resolves the class name that should be proxied for a lazy service.
-     *
-     * @param string $originalType The original parameter type-hint (e.g., the interface)
-     * @param string $serviceId    The service ID the type-hint resolved to (e.g., the alias)
-     */
-    private function resolveProxyType(string $originalType, string $serviceId): string
-    {
-        if (!$this->container->has($serviceId)) {
-            return $originalType;
-        }
-
-        $resolvedType = $this->container->findDefinition($serviceId)->getClass();
-        $resolvedType = $this->container->getParameterBag()->resolveValue($resolvedType);
-
-        if (!$resolvedType || !$this->container->getReflectionClass($resolvedType, false)) {
-            return $originalType;
-        }
-
-        return $resolvedType;
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
@@ -71,6 +71,7 @@ class PassConfig
             new CheckDefinitionValidityPass(),
             new AutowirePass(false),
             new ServiceLocatorTagPass(),
+            new ResolveLazyProxyPass(),
             new ResolveTaggedIteratorArgumentPass(),
             new ResolveServiceSubscribersPass(),
             new ResolveReferencesToAliasesPass(),

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveLazyProxyPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveLazyProxyPass.php
@@ -1,0 +1,128 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Argument\LazyProxyArgument;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Exception\RuntimeException;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\TypedReference;
+
+/**
+ * Turns lazy proxy arguments into references to generated lazy-loading definitions.
+ *
+ * @author HypeMC <hypemc@gmail.com>
+ */
+class ResolveLazyProxyPass extends AbstractRecursivePass
+{
+    protected bool $skipScalars = true;
+
+    protected function processValue(mixed $value, bool $isRoot = false): mixed
+    {
+        if (!$value instanceof LazyProxyArgument) {
+            return parent::processValue($value, $isRoot);
+        }
+
+        [$reference, $interfaces] = $value->getValues();
+
+        if (!$definition = self::createProxyDefinition($this->container, $reference, $interfaces, $this->currentId)) {
+            return $reference;
+        }
+
+        $id = (string) $reference;
+
+        if ($definition->getClass() !== $id || $definition->getTag('proxy')) {
+            $id .= '.'.$this->container->hash([$definition->getClass(), $definition->getTag('proxy')]);
+        }
+        $this->container->setDefinition($id = '.lazy.'.$id, $definition);
+
+        return new Reference($id);
+    }
+
+    /**
+     * Creates the definition of the lazy-loading service that should replace the given reference,
+     * or null when the reference should be used as is.
+     *
+     * @internal
+     */
+    public static function createProxyDefinition(ContainerBuilder $container, Reference $reference, array $interfaces = [], ?string $currentId = null): ?Definition
+    {
+        $id = (string) $reference;
+        $hasService = $container->has($id);
+
+        if (!$hasService && ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE !== $reference->getInvalidBehavior()) {
+            return null;
+        }
+
+        if ($reference instanceof TypedReference) {
+            $type = $reference->getType();
+        } elseif (!$hasService) {
+            throw new ServiceNotFoundException($id, $currentId);
+        } elseif (!$type = $container->findDefinition($id)->getClass()) {
+            throw new InvalidArgumentException(\sprintf('Cannot create a lazy proxy for service "%s" because it has no class; configure the interface(s) that should be proxied instead.', $id));
+        }
+
+        if (!$interfaces) {
+            if (str_contains($type, '|')) {
+                throw new RuntimeException(\sprintf('Cannot lazily proxy union type "%s" for service "%s"; configure the interface(s) that should be proxied instead.', $type, $currentId));
+            }
+            $interfaces = str_contains($type, '&') ? explode('&', $type) : [];
+        }
+
+        if (!$interfaces && $hasService && $container->findDefinition($id)->isLazy()) {
+            return null;
+        }
+
+        $proxyType = $interfaces ? $type : self::resolveProxyType($container, $type, $id);
+        $definition = (new Definition($proxyType))
+            ->setFactory('current')
+            ->setArguments([[$reference]])
+            ->setLazy(true);
+
+        if ($interfaces) {
+            if (!$container->getReflectionClass($proxyType, false)) {
+                $definition->setClass('object');
+            }
+            foreach ($interfaces as $v) {
+                $definition->addTag('proxy', ['interface' => $v]);
+            }
+        }
+
+        return $definition;
+    }
+
+    /**
+     * Resolves the class name that should be proxied.
+     *
+     * @param string $originalType The original parameter type-hint (e.g., the interface)
+     * @param string $serviceId    The service ID the type-hint resolved to (e.g., the alias)
+     */
+    private static function resolveProxyType(ContainerBuilder $container, string $originalType, string $serviceId): string
+    {
+        if (!$container->has($serviceId)) {
+            return $originalType;
+        }
+
+        $resolvedType = $container->findDefinition($serviceId)->getClass();
+        $resolvedType = $container->getParameterBag()->resolveValue($resolvedType);
+
+        if (!$resolvedType || !$container->getReflectionClass($resolvedType, false)) {
+            return $originalType;
+        }
+
+        return $resolvedType;
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -26,6 +26,7 @@ use Symfony\Component\DependencyInjection\Argument\EnvClosure;
 use Symfony\Component\DependencyInjection\Argument\EnvClosureArgument;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\Argument\LazyClosure;
+use Symfony\Component\DependencyInjection\Argument\LazyProxyArgument;
 use Symfony\Component\DependencyInjection\Argument\RewindableGenerator;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocator;
@@ -35,6 +36,7 @@ use Symfony\Component\DependencyInjection\Compiler\Compiler;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\Compiler\ResolveEnvPlaceholdersPass;
+use Symfony\Component\DependencyInjection\Compiler\ResolveLazyProxyPass;
 use Symfony\Component\DependencyInjection\Exception\BadMethodCallException;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Exception\LogicException;
@@ -1322,6 +1324,12 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
                 $types[$k] = $v instanceof TypedReference ? $v->getType() : '?';
             }
             $value = new ServiceLocator($this->resolveServices(...), $refs, $types);
+        } elseif ($value instanceof LazyProxyArgument) {
+            [$reference, $interfaces] = $value->getValues();
+
+            $value = ($definition = ResolveLazyProxyPass::createProxyDefinition($this, $reference, $interfaces))
+                ? $this->createService($definition->setShared(false), $inlineServices, $isConstructorArgument, '.lazy.'.$reference)
+                : $this->doResolveServices($reference, $inlineServices, $isConstructorArgument);
         } elseif ($value instanceof Reference) {
             $value = $this->doGet((string) $value, $value->getInvalidBehavior(), $inlineServices, $isConstructorArgument);
         } elseif ($value instanceof Definition) {

--- a/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
@@ -16,6 +16,7 @@ use Symfony\Component\DependencyInjection\Argument\AbstractArgument;
 use Symfony\Component\DependencyInjection\Argument\ArgumentInterface;
 use Symfony\Component\DependencyInjection\Argument\EnvClosureArgument;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
+use Symfony\Component\DependencyInjection\Argument\LazyProxyArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
@@ -253,6 +254,15 @@ class YamlDumper extends Dumper
             $value = $value->getValues()[0];
 
             return new TaggedValue('service_closure', $this->dumpValue($value));
+        }
+        if ($value instanceof LazyProxyArgument) {
+            [$reference, $interfaces] = $value->getValues();
+
+            if (!$interfaces) {
+                return new TaggedValue('lazy_proxy', $this->dumpValue($reference));
+            }
+
+            return new TaggedValue('lazy_proxy', ['service' => $this->dumpValue($reference), 'interface' => $interfaces]);
         }
         if ($value instanceof EnvClosureArgument) {
             $envExpr = $this->container->resolveEnvPlaceholders($value->getValue());

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/AbstractConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/AbstractConfigurator.php
@@ -15,6 +15,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\Argument\AbstractArgument;
 use Symfony\Component\DependencyInjection\Argument\ArgumentInterface;
+use Symfony\Component\DependencyInjection\Argument\LazyProxyArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
@@ -93,7 +94,11 @@ abstract class AbstractConfigurator
         if ($value instanceof ReferenceConfigurator) {
             $reference = new Reference($value->id, $value->invalidBehavior);
 
-            return $value instanceof ClosureReferenceConfigurator ? new ServiceClosureArgument($reference) : $reference;
+            return match (true) {
+                $value instanceof ClosureReferenceConfigurator => new ServiceClosureArgument($reference),
+                $value instanceof LazyProxyReferenceConfigurator => new LazyProxyArgument($reference, $value->interfaces),
+                default => $reference,
+            };
         }
 
         if ($value instanceof InlineServiceConfigurator) {

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/ContainerConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/ContainerConfigurator.php
@@ -22,6 +22,7 @@ use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\DependencyInjection\Loader\UndefinedExtensionHandler;
+use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\ExpressionLanguage\Expression;
 
 /**
@@ -117,6 +118,16 @@ function service(string $serviceId): ReferenceConfigurator
 function inline_service(?string $class = null): InlineServiceConfigurator
 {
     return new InlineServiceConfigurator(new Definition($class));
+}
+
+/**
+ * Creates a reference to a service that is injected as a lazy proxy.
+ *
+ * @param string|string[] $interfaces The interface(s) the proxy should implement, or none to proxy the service's own class
+ */
+function lazy_proxy(string $serviceId, string|array $interfaces = []): LazyProxyReferenceConfigurator
+{
+    return new LazyProxyReferenceConfigurator($serviceId, $interfaces);
 }
 
 /**

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/LazyProxyReferenceConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/LazyProxyReferenceConfigurator.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+/**
+ * @author HypeMC <hypemc@gmail.com>
+ */
+class LazyProxyReferenceConfigurator extends ReferenceConfigurator
+{
+    /** @internal */
+    protected string|array $interfaces;
+
+    public function __construct(string $id, string|array $interfaces = [])
+    {
+        parent::__construct($id);
+
+        $this->interfaces = $interfaces;
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Loader/ContentLoaderTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/ContentLoaderTrait.php
@@ -16,6 +16,7 @@ use Symfony\Component\DependencyInjection\Argument\AbstractArgument;
 use Symfony\Component\DependencyInjection\Argument\BoundArgument;
 use Symfony\Component\DependencyInjection\Argument\EnvClosureArgument;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
+use Symfony\Component\DependencyInjection\Argument\LazyProxyArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
@@ -776,6 +777,26 @@ trait ContentLoaderTrait
 
                 return new ServiceClosureArgument($argument);
             }
+            if ('lazy_proxy' === $value->getTag()) {
+                $interfaces = [];
+
+                if (\is_array($argument) && isset($argument['service'])) {
+                    if ($diff = array_diff(array_keys($argument), $supportedKeys = ['service', 'interface'])) {
+                        throw new InvalidArgumentException(\sprintf('"!lazy_proxy" tag contains unsupported key "%s"; supported ones are "%s".', implode('", "', $diff), implode('", "', $supportedKeys)));
+                    }
+
+                    $interfaces = $argument['interface'] ?? [];
+                    $argument = $argument['service'];
+                }
+
+                $argument = $this->resolveServices($argument, $file, $isParameter);
+
+                if (!$argument instanceof Reference) {
+                    throw new InvalidArgumentException(\sprintf('"!lazy_proxy" tag only accepts a service reference or an array with a "service" key in "%s".', $file));
+                }
+
+                return new LazyProxyArgument($argument, $interfaces);
+            }
             if ('env_closure' === $value->getTag()) {
                 if (\is_array($argument)) {
                     $envExpr = $argument[0] ?? null;
@@ -886,6 +907,15 @@ trait ContentLoaderTrait
                 $argument = $this->resolveServices(substr_replace($value, '', 1, 1), $file, $isParameter);
 
                 return new ServiceClosureArgument($argument);
+            }
+            if (str_starts_with($value, '@~')) {
+                $argument = $this->resolveServices(substr_replace($value, '', 1, 1), $file, $isParameter);
+
+                if (!$argument instanceof Reference) {
+                    throw new InvalidArgumentException(\sprintf('The "@~" prefix only accepts a service reference in "%s".', $file));
+                }
+
+                return new LazyProxyArgument($argument);
             }
             if (str_starts_with($value, '@@')) {
                 $value = substr($value, 1);

--- a/src/Symfony/Component/DependencyInjection/Tests/Argument/LazyProxyArgumentTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Argument/LazyProxyArgumentTest.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Argument;
+
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Argument\LazyProxyArgument;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Reference;
+
+class LazyProxyArgumentTest extends TestCase
+{
+    #[TestWith([[], []], 'none')]
+    #[TestWith(['SomeInterface', ['SomeInterface']])]
+    #[TestWith([['SomeInterface'], ['SomeInterface']])]
+    #[TestWith([['SomeInterface', 'AnotherInterface'], ['SomeInterface', 'AnotherInterface']])]
+    public function testGetValues(string|array $interfaces, array $expectedInterfaces)
+    {
+        $argument = new LazyProxyArgument($reference = new Reference('a'), $interfaces);
+
+        self::assertSame([$reference, $expectedInterfaces], $argument->getValues());
+    }
+
+    public function testGetValuesDefaultsToNoInterface()
+    {
+        $argument = new LazyProxyArgument($reference = new Reference('a'));
+
+        self::assertSame([$reference, []], $argument->getValues());
+    }
+
+    public function testSetValues()
+    {
+        $argument = new LazyProxyArgument(new Reference('a'));
+        $argument->setValues([$reference = new Reference('b'), 'SomeInterface']);
+
+        self::assertSame([$reference, ['SomeInterface']], $argument->getValues());
+    }
+
+    public function testSetValuesKeepsInterfacesWhenNotProvided()
+    {
+        $argument = new LazyProxyArgument(new Reference('a'), ['SomeInterface']);
+        $argument->setValues([$reference = new Reference('b')]);
+
+        self::assertSame([$reference, ['SomeInterface']], $argument->getValues());
+    }
+
+    #[TestWith([''], 'empty string')]
+    #[TestWith([['']], 'array holding an empty string')]
+    #[TestWith([[null]], 'array holding null')]
+    #[TestWith([[123]], 'array holding an integer')]
+    #[TestWith([[true]], 'array holding a boolean')]
+    #[TestWith([['SomeInterface', '']], 'array holding one valid and one empty string')]
+    public function testInvalidInterfacesThrows(string|array $interfaces)
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('A lazy proxy argument expects $interfaces to be a non-empty string or an array of non-empty strings.');
+
+        new LazyProxyArgument(new Reference('a'), $interfaces);
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
@@ -18,6 +18,7 @@ use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Symfony\Bridge\PhpUnit\ClassExistsMock;
 use Symfony\Component\Config\Resource\ClassExistenceResource;
+use Symfony\Component\DependencyInjection\Argument\LazyProxyArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
@@ -26,6 +27,7 @@ use Symfony\Component\DependencyInjection\Compiler\AutowirePass;
 use Symfony\Component\DependencyInjection\Compiler\AutowireRequiredMethodsPass;
 use Symfony\Component\DependencyInjection\Compiler\DecoratorServicePass;
 use Symfony\Component\DependencyInjection\Compiler\ResolveClassPass;
+use Symfony\Component\DependencyInjection\Compiler\ResolveLazyProxyPass;
 use Symfony\Component\DependencyInjection\Compiler\TagDecoratorPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -1536,6 +1538,11 @@ class AutowirePassTest extends TestCase
 
         (new AutowirePass())->process($container);
 
+        $expected = new LazyProxyArgument(new TypedReference(A::class, A::class));
+        $this->assertEquals($expected, $container->getDefinition('foo')->getArgument(0));
+
+        (new ResolveLazyProxyPass())->process($container);
+
         $expected = new Reference('.lazy.'.A::class);
         $this->assertEquals($expected, $container->getDefinition('foo')->getArgument(0));
     }
@@ -1548,6 +1555,11 @@ class AutowirePassTest extends TestCase
 
         (new AutowirePass())->process($container);
 
+        $expected = new LazyProxyArgument(new TypedReference(A::class, A::class));
+        $this->assertEquals($expected, $container->getDefinition('foo')->getArgument(0));
+
+        (new ResolveLazyProxyPass())->process($container);
+
         $this->assertSame(A::class, (string) $container->getDefinition('foo')->getArgument(0));
         $this->assertFalse($container->hasDefinition('.lazy.'.A::class));
     }
@@ -1559,6 +1571,11 @@ class AutowirePassTest extends TestCase
         $container->register('foo', LazyServiceAttributeWithInterfaceAutowiring::class)->setAutowired(true);
 
         (new AutowirePass())->process($container);
+
+        $expected = new LazyProxyArgument(new TypedReference(FinalLazyProxyImplementation::class, FinalLazyProxyImplementation::class), LazyProxyTestInterface::class);
+        $this->assertEquals($expected, $container->getDefinition('foo')->getArgument(0));
+
+        (new ResolveLazyProxyPass())->process($container);
 
         $definition = $container->getDefinition((string) $container->getDefinition('foo')->getArgument(0));
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveLazyProxyPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveLazyProxyPassTest.php
@@ -1,0 +1,178 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Compiler;
+
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Argument\LazyProxyArgument;
+use Symfony\Component\DependencyInjection\Compiler\ResolveLazyProxyPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Exception\RuntimeException;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\TypedReference;
+
+require_once __DIR__.'/../Fixtures/includes/autowiring_classes.php';
+
+class ResolveLazyProxyPassTest extends TestCase
+{
+    public function testResolveLazyProxyArgument()
+    {
+        $container = new ContainerBuilder();
+        $container->register('a', A::class);
+        $container->register('foo', Foo::class)
+            ->addArgument(new LazyProxyArgument(new Reference('a')));
+
+        (new ResolveLazyProxyPass())->process($container);
+
+        $lazyId = (string) $container->getDefinition('foo')->getArgument(0);
+        self::assertStringStartsWith('.lazy.a.', $lazyId);
+        self::assertSame(A::class, $container->getDefinition($lazyId)->getClass());
+    }
+
+    public function testResolveLazyProxyArgumentWithExplicitInterfaces()
+    {
+        $container = new ContainerBuilder();
+        $container->register('final_impl', FinalLazyProxyImplementation::class);
+        $container->register('foo', Foo::class)
+            ->addArgument(new LazyProxyArgument(new Reference('final_impl'), LazyProxyTestInterface::class));
+
+        (new ResolveLazyProxyPass())->process($container);
+
+        $lazyId = (string) $container->getDefinition('foo')->getArgument(0);
+        self::assertStringStartsWith('.lazy.final_impl.', $lazyId);
+        self::assertSame(FinalLazyProxyImplementation::class, $container->getDefinition($lazyId)->getClass());
+        self::assertSame([['interface' => LazyProxyTestInterface::class]], $container->getDefinition($lazyId)->getTag('proxy'));
+    }
+
+    public function testResolveLazyProxyArgumentWithIntersectionType()
+    {
+        $container = new ContainerBuilder();
+        $container->register('a', A::class);
+        $container->register('foo', Foo::class)
+            ->addArgument(new LazyProxyArgument(new TypedReference('a', AInterface::class.'&'.LazyProxyTestInterface::class)));
+
+        (new ResolveLazyProxyPass())->process($container);
+
+        $lazyId = (string) $container->getDefinition('foo')->getArgument(0);
+        self::assertStringStartsWith('.lazy.a.', $lazyId);
+        self::assertSame('object', $container->getDefinition($lazyId)->getClass());
+        self::assertSame([
+            ['interface' => AInterface::class],
+            ['interface' => LazyProxyTestInterface::class],
+        ], $container->getDefinition($lazyId)->getTag('proxy'));
+    }
+
+    public function testAlreadyLazyTargetIsNotProxied()
+    {
+        $container = new ContainerBuilder();
+        $container->register('a', A::class)->setLazy(true);
+        $container->register('foo', Foo::class)
+            ->addArgument(new LazyProxyArgument($reference = new TypedReference('a', A::class)));
+
+        (new ResolveLazyProxyPass())->process($container);
+
+        self::assertSame($reference, $container->getDefinition('foo')->getArgument(0));
+
+        foreach ($container->getDefinitions() as $id => $definition) {
+            self::assertStringStartsNotWith('.lazy.', $id);
+        }
+    }
+
+    public function testUnionTypeThrows()
+    {
+        $container = new ContainerBuilder();
+        $container->register('a', A::class);
+        $container->register('foo', Foo::class)
+            ->addArgument(new LazyProxyArgument(new TypedReference('a', A::class.'|'.Foo::class)));
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage(\sprintf('Cannot lazily proxy union type "%s|%s" for service "foo"; configure the interface(s) that should be proxied instead.', A::class, Foo::class));
+
+        (new ResolveLazyProxyPass())->process($container);
+    }
+
+    public function testReferenceToMissingServiceThrows()
+    {
+        $container = new ContainerBuilder();
+        $container->register('foo', Foo::class)
+            ->addArgument(new LazyProxyArgument(new Reference('missing')));
+
+        $this->expectException(ServiceNotFoundException::class);
+        $this->expectExceptionMessage('The service "foo" has a dependency on a non-existent service "missing".');
+
+        (new ResolveLazyProxyPass())->process($container);
+    }
+
+    #[TestWith([ContainerInterface::IGNORE_ON_INVALID_REFERENCE], 'ignore on invalid')]
+    #[TestWith([ContainerInterface::NULL_ON_INVALID_REFERENCE], 'null on invalid')]
+    public function testOptionalReferenceToMissingServiceIsLeftUntouched(int $invalidBehavior)
+    {
+        $container = new ContainerBuilder();
+        $container->register('foo', Foo::class)
+            ->addArgument(new LazyProxyArgument($reference = new Reference('missing', $invalidBehavior)));
+
+        (new ResolveLazyProxyPass())->process($container);
+
+        self::assertSame($reference, $container->getDefinition('foo')->getArgument(0));
+
+        foreach ($container->getDefinitions() as $id => $definition) {
+            self::assertStringStartsNotWith('.lazy.', $id);
+        }
+    }
+
+    #[TestWith([ContainerInterface::IGNORE_ON_INVALID_REFERENCE], 'ignore on invalid')]
+    #[TestWith([ContainerInterface::NULL_ON_INVALID_REFERENCE], 'null on invalid')]
+    public function testOptionalReferenceToMissingServiceIsNullAfterCompilation(int $invalidBehavior)
+    {
+        $container = new ContainerBuilder();
+        $container->register('foo', Foo::class)
+            ->setPublic(true)
+            ->addArgument(new LazyProxyArgument(new Reference('missing', $invalidBehavior)));
+
+        $container->compile();
+
+        self::assertNull($container->getDefinition('foo')->getArgument(0));
+    }
+
+    public function testTargetWithoutClassThrows()
+    {
+        $container = new ContainerBuilder();
+        $container->register('a')->setSynthetic(true);
+        $container->register('foo', Foo::class)
+            ->addArgument(new LazyProxyArgument(new Reference('a')));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot create a lazy proxy for service "a" because it has no class; configure the interface(s) that should be proxied instead.');
+
+        (new ResolveLazyProxyPass())->process($container);
+    }
+
+    public function testLazyProxyArgumentIsResolvedDuringCompilation()
+    {
+        $container = new ContainerBuilder();
+        $container->register('a', A::class);
+        $container->register('foo', Foo::class)
+            ->setPublic(true)
+            ->addArgument(new LazyProxyArgument(new TypedReference('a', A::class)));
+
+        $container->compile();
+
+        $argument = $container->getDefinition('foo')->getArgument(0);
+        self::assertInstanceOf(Reference::class, $argument);
+        self::assertNotInstanceOf(LazyProxyArgument::class, $argument);
+        self::assertStringStartsWith('.lazy.a.', (string) $argument);
+        self::assertTrue($container->getDefinition((string) $argument)->isLazy());
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -26,6 +26,7 @@ use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\Argument\AbstractArgument;
 use Symfony\Component\DependencyInjection\Argument\EnvClosure;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
+use Symfony\Component\DependencyInjection\Argument\LazyProxyArgument;
 use Symfony\Component\DependencyInjection\Argument\RewindableGenerator;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Attribute\AsTaggedItem;
@@ -54,7 +55,9 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\ServiceLocator;
+use Symfony\Component\DependencyInjection\Tests\Compiler\FinalLazyProxyImplementation;
 use Symfony\Component\DependencyInjection\Tests\Compiler\Foo;
+use Symfony\Component\DependencyInjection\Tests\Compiler\LazyProxyTestInterface;
 use Symfony\Component\DependencyInjection\Tests\Compiler\MyCallable;
 use Symfony\Component\DependencyInjection\Tests\Compiler\SingleMethodInterface;
 use Symfony\Component\DependencyInjection\Tests\Compiler\Wither;
@@ -740,6 +743,44 @@ class ContainerBuilderTest extends TestCase
         $this->expectExceptionMessage('Argument "$baz" of service "foo" is abstract: should be defined by Pass.');
 
         $builder->get('foo');
+    }
+
+    public function testResolveServicesWithLazyProxyArgument()
+    {
+        $builder = new ContainerBuilder();
+        $builder->register('bar', 'BarClass');
+
+        $proxy = $builder->resolveServices(new LazyProxyArgument(new Reference('bar')));
+
+        $this->assertInstanceOf(\BarClass::class, $proxy);
+        $this->assertFalse($builder->initialized('bar'), 'The proxied service is not instantiated upfront');
+
+        $builder->get('bar')->foo = 'mutated';
+
+        $this->assertSame('mutated', $proxy->foo, 'The proxy resolves to the shared service');
+    }
+
+    public function testResolveServicesWithLazyProxyArgumentAndExplicitInterface()
+    {
+        $builder = new ContainerBuilder();
+        $builder->register('bar', FinalLazyProxyImplementation::class);
+
+        $proxy = $builder->resolveServices(new LazyProxyArgument(new Reference('bar'), LazyProxyTestInterface::class));
+
+        $this->assertInstanceOf(LazyProxyTestInterface::class, $proxy);
+        $this->assertNotInstanceOf(FinalLazyProxyImplementation::class, $proxy);
+        $this->assertFalse($builder->initialized('bar'), 'The proxied service is not instantiated upfront');
+
+        $proxy->getSelf();
+
+        $this->assertTrue($builder->initialized('bar'), 'Using the proxy resolves the service');
+    }
+
+    public function testResolveServicesWithLazyProxyArgumentAndIgnoredMissingService()
+    {
+        $builder = new ContainerBuilder();
+
+        $this->assertNull($builder->resolveServices(new LazyProxyArgument(new Reference('bar', ContainerInterface::IGNORE_ON_INVALID_REFERENCE))));
     }
 
     public function testResolveServices()

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -20,6 +20,7 @@ use Psr\Container\ContainerInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Argument\AbstractArgument;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
+use Symfony\Component\DependencyInjection\Argument\LazyProxyArgument;
 use Symfony\Component\DependencyInjection\Argument\RewindableGenerator;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocator as ArgumentServiceLocator;
@@ -55,9 +56,11 @@ use Symfony\Component\DependencyInjection\Tests\Compiler\AInterface;
 use Symfony\Component\DependencyInjection\Tests\Compiler\EInterface;
 use Symfony\Component\DependencyInjection\Tests\Compiler\EnvAutowireWithMissingArgument;
 use Symfony\Component\DependencyInjection\Tests\Compiler\F;
+use Symfony\Component\DependencyInjection\Tests\Compiler\FinalLazyProxyImplementation;
 use Symfony\Component\DependencyInjection\Tests\Compiler\Foo;
 use Symfony\Component\DependencyInjection\Tests\Compiler\FooVoid;
 use Symfony\Component\DependencyInjection\Tests\Compiler\IInterface;
+use Symfony\Component\DependencyInjection\Tests\Compiler\LazyProxyTestInterface;
 use Symfony\Component\DependencyInjection\Tests\Compiler\Listener1;
 use Symfony\Component\DependencyInjection\Tests\Compiler\Listener2;
 use Symfony\Component\DependencyInjection\Tests\Compiler\ListenerResolver;
@@ -81,6 +84,7 @@ use Symfony\Component\DependencyInjection\Tests\Fixtures\TestServiceSubscriber;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\WitherStaticReturnType;
 use Symfony\Component\DependencyInjection\TypedReference;
 use Symfony\Component\ExpressionLanguage\Expression;
+use Symfony\Component\VarExporter\LazyObjectInterface;
 
 require_once __DIR__.'/../Fixtures/includes/autowiring_classes.php';
 require_once __DIR__.'/../Fixtures/includes/classes.php';
@@ -2293,6 +2297,52 @@ class PhpDumperTest extends TestCase
         $this->assertStringEqualsGeneratedFile('lazy_autowire_attribute_with_intersection.php', $dumper->dump());
     }
 
+    public function testLazyProxyArgument()
+    {
+        $container = new ContainerBuilder();
+        $container->register('foo', Foo::class)
+            ->setPublic(true);
+        $container->register('bar', LazyProxyArgumentConsumer::class)
+            ->setPublic(true)
+            ->addArgument(new LazyProxyArgument(new Reference('foo')));
+        $container->compile();
+
+        $dumper = new PhpDumper($container);
+        eval('?>'.$dumper->dump(['class' => 'Symfony_DI_PhpDumper_Test_Lazy_Proxy_Argument']));
+
+        $container = new \Symfony_DI_PhpDumper_Test_Lazy_Proxy_Argument();
+
+        $bar = $container->get('bar');
+        $this->assertInstanceOf(Foo::class, $bar->foo);
+
+        $r = new \ReflectionClass(Foo::class);
+        $this->assertTrue($r->isUninitializedLazyObject($bar->foo));
+        $this->assertSame($container->get('foo'), $r->initializeLazyObject($bar->foo));
+    }
+
+    public function testLazyProxyArgumentWithInterface()
+    {
+        $container = new ContainerBuilder();
+        $container->register('foo', FinalLazyProxyImplementation::class)
+            ->setPublic(true);
+        $container->register('bar', LazyProxyInterfaceArgumentConsumer::class)
+            ->setPublic(true)
+            ->addArgument(new LazyProxyArgument(new Reference('foo'), LazyProxyTestInterface::class));
+        $container->compile();
+
+        $dumper = new PhpDumper($container);
+        eval('?>'.$dumper->dump(['class' => 'Symfony_DI_PhpDumper_Test_Lazy_Proxy_Argument_With_Interface']));
+
+        $container = new \Symfony_DI_PhpDumper_Test_Lazy_Proxy_Argument_With_Interface();
+
+        $bar = $container->get('bar');
+        $this->assertInstanceOf(LazyProxyTestInterface::class, $bar->foo);
+        $this->assertNotInstanceOf(FinalLazyProxyImplementation::class, $bar->foo);
+        $this->assertInstanceOf(LazyObjectInterface::class, $bar->foo);
+        $this->assertFalse($bar->foo->isLazyObjectInitialized());
+        $this->assertSame($container->get('foo'), $bar->foo->initializeLazyObject());
+    }
+
     public function testCallableAdapterConsumer()
     {
         $container = new ContainerBuilder();
@@ -2619,6 +2669,22 @@ class LazyServiceConsumer
     public function __construct(
         #[Autowire(lazy: true)]
         public Foo $foo,
+    ) {
+    }
+}
+
+class LazyProxyArgumentConsumer
+{
+    public function __construct(
+        public Foo $foo,
+    ) {
+    }
+}
+
+class LazyProxyInterfaceArgumentConsumer
+{
+    public function __construct(
+        public LazyProxyTestInterface $foo,
     ) {
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/YamlDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/YamlDumperTest.php
@@ -184,6 +184,25 @@ class YamlDumperTest extends TestCase
         $this->assertStringEqualsGeneratedFile('services_with_service_closure.yml', $dumper->dump());
     }
 
+    public function testDumpLoadLazyProxyArgument()
+    {
+        $container = new ContainerBuilder();
+        $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
+        $loader->load('services_with_lazy_proxy_argument.yml');
+
+        $dumper = new YamlDumper($container);
+        $this->assertStringEqualsGeneratedFile('services_dump_load_lazy_proxy.yml', $dumper->dump());
+
+        $reloadedContainer = new ContainerBuilder();
+        $loader = new YamlFileLoader($reloadedContainer, new FileLocator(self::$fixturesPath.'/yaml'));
+        $loader->load('services_dump_load_lazy_proxy.yml');
+
+        $this->assertEquals(
+            $container->getDefinition('bar_service')->getArguments(),
+            $reloadedContainer->getDefinition('bar_service')->getArguments(),
+        );
+    }
+
     public function testEnvClosure()
     {
         $container = new ContainerBuilder();

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/services_with_lazy_proxy_argument.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/services_with_lazy_proxy_argument.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+return function (ContainerConfigurator $configurator) {
+    $services = $configurator->services();
+
+    $services->set('foo_service', \stdClass::class);
+
+    $services->set('bar_service', \ArrayObject::class)
+        ->args([
+            lazy_proxy('foo_service'),
+            lazy_proxy('foo_service', 'SomeInterface'),
+            lazy_proxy('foo_service', ['SomeInterface', 'AnotherInterface']),
+        ]);
+};

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/services_with_lazy_proxy_invalid_behavior.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/services_with_lazy_proxy_invalid_behavior.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+return function (ContainerConfigurator $configurator) {
+    $services = $configurator->services();
+
+    $services->set('foo_service', \stdClass::class);
+
+    $services->set('bar_service', \ArrayObject::class)
+        ->args([
+            lazy_proxy('foo_service')->ignoreOnInvalid(),
+            lazy_proxy('foo_service')->nullOnInvalid(),
+            lazy_proxy('foo_service')->ignoreOnUninitialized(),
+            lazy_proxy('foo_service', 'SomeInterface')->ignoreOnInvalid(),
+            lazy_proxy('foo_service', ['SomeInterface', 'AnotherInterface'])->nullOnInvalid(),
+        ]);
+};

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/services_with_short_lazy_proxy.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/services_with_short_lazy_proxy.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+return function (ContainerConfigurator $configurator) {
+    $configurator->services()
+        ->set('foo', 'Foo')
+        ->args([
+            lazy_proxy('bar'),
+            lazy_proxy('bar')->ignoreOnInvalid(),
+            lazy_proxy('bar')->ignoreOnUninitialized(),
+        ]);
+};

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/lazy_proxy_invalid_key.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/lazy_proxy_invalid_key.yml
@@ -1,0 +1,3 @@
+services:
+    foo:
+        arguments: [!lazy_proxy { service: '@bar', foo: bar }]

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/lazy_proxy_invalid_value.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/lazy_proxy_invalid_value.yml
@@ -1,0 +1,3 @@
+services:
+    foo:
+        arguments: [!lazy_proxy bar]

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_dump_load_lazy_proxy.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_dump_load_lazy_proxy.yml
@@ -1,0 +1,11 @@
+
+services:
+    service_container:
+        class: Symfony\Component\DependencyInjection\ContainerInterface
+        public: true
+        synthetic: true
+    foo_service:
+        class: Foo
+    bar_service:
+        class: Bar
+        arguments: [!lazy_proxy '@foo_service', !lazy_proxy { service: '@foo_service', interface: [SomeInterface] }, !lazy_proxy { service: '@foo_service', interface: [SomeInterface, AnotherInterface] }, !lazy_proxy '@?foo_service']

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_with_lazy_proxy_argument.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_with_lazy_proxy_argument.yml
@@ -1,0 +1,15 @@
+
+services:
+    service_container:
+        class: Symfony\Component\DependencyInjection\ContainerInterface
+        public: true
+        synthetic: true
+    foo_service:
+        class: Foo
+    bar_service:
+        class: Bar
+        arguments:
+            - !lazy_proxy '@foo_service'
+            - !lazy_proxy { service: '@foo_service', interface: SomeInterface }
+            - !lazy_proxy { service: '@foo_service', interface: [SomeInterface, AnotherInterface] }
+            - !lazy_proxy '@?foo_service'

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_with_short_lazy_proxy.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_with_short_lazy_proxy.yml
@@ -1,0 +1,8 @@
+services:
+    service_container:
+        class: Symfony\Component\DependencyInjection\ContainerInterface
+        public: true
+        synthetic: true
+    foo:
+        class: Foo
+        arguments: ['@~bar', '@~?bar', '@~!bar']

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/short_lazy_proxy_invalid_value.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/short_lazy_proxy_invalid_value.yml
@@ -1,0 +1,3 @@
+services:
+    foo:
+        arguments: ['@~@bar']

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
@@ -17,8 +17,10 @@ require_once __DIR__.'/../Fixtures/includes/fixture_app_services.php';
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Argument\LazyProxyArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Dumper\PhpDumper;
 use Symfony\Component\DependencyInjection\Dumper\YamlDumper;
@@ -149,6 +151,34 @@ class PhpFileLoaderTest extends TestCase
         yield ['array_config_tagged_iterator'];
         yield ['object_array_config'];
         yield ['return_when_env'];
+    }
+
+    public function testConfigLazyProxyArgument()
+    {
+        $fixtures = realpath(__DIR__.'/../Fixtures');
+        $loader = new PhpFileLoader($container = new ContainerBuilder(), new FileLocator());
+        $loader->load($fixtures.'/config/services_with_lazy_proxy_argument.php');
+
+        $this->assertEquals([
+            new LazyProxyArgument(new Reference('foo_service')),
+            new LazyProxyArgument(new Reference('foo_service'), 'SomeInterface'),
+            new LazyProxyArgument(new Reference('foo_service'), ['SomeInterface', 'AnotherInterface']),
+        ], $container->getDefinition('bar_service')->getArguments());
+    }
+
+    public function testConfigLazyProxyArgumentWithInvalidBehavior()
+    {
+        $fixtures = realpath(__DIR__.'/../Fixtures');
+        $loader = new PhpFileLoader($container = new ContainerBuilder(), new FileLocator());
+        $loader->load($fixtures.'/config/services_with_lazy_proxy_invalid_behavior.php');
+
+        $this->assertEquals([
+            new LazyProxyArgument(new Reference('foo_service', ContainerInterface::IGNORE_ON_INVALID_REFERENCE)),
+            new LazyProxyArgument(new Reference('foo_service', ContainerInterface::NULL_ON_INVALID_REFERENCE)),
+            new LazyProxyArgument(new Reference('foo_service', ContainerInterface::IGNORE_ON_UNINITIALIZED_REFERENCE)),
+            new LazyProxyArgument(new Reference('foo_service', ContainerInterface::IGNORE_ON_INVALID_REFERENCE), 'SomeInterface'),
+            new LazyProxyArgument(new Reference('foo_service', ContainerInterface::NULL_ON_INVALID_REFERENCE), ['SomeInterface', 'AnotherInterface']),
+        ], $container->getDefinition('bar_service')->getArguments());
     }
 
     public function testResourceTags()

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -24,6 +24,7 @@ use Symfony\Component\Config\Resource\GlobResource;
 use Symfony\Component\DependencyInjection\Argument\BoundArgument;
 use Symfony\Component\DependencyInjection\Argument\EnvClosureArgument;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
+use Symfony\Component\DependencyInjection\Argument\LazyProxyArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
@@ -488,6 +489,74 @@ class YamlFileLoaderTest extends TestCase
         $loader->load('services_with_service_closure.yml');
 
         $this->assertEquals(new ServiceClosureArgument(new Reference('bar', ContainerInterface::IGNORE_ON_INVALID_REFERENCE)), $container->getDefinition('foo')->getArgument(0));
+    }
+
+    public function testParseLazyProxyArgument()
+    {
+        $container = new ContainerBuilder();
+        $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
+        $loader->load('services_with_lazy_proxy_argument.yml');
+
+        $this->assertEquals([
+            new LazyProxyArgument(new Reference('foo_service')),
+            new LazyProxyArgument(new Reference('foo_service'), 'SomeInterface'),
+            new LazyProxyArgument(new Reference('foo_service'), ['SomeInterface', 'AnotherInterface']),
+            new LazyProxyArgument(new Reference('foo_service', ContainerInterface::IGNORE_ON_INVALID_REFERENCE)),
+        ], $container->getDefinition('bar_service')->getArguments());
+    }
+
+    public function testParseLazyProxyArgumentWithUnsupportedKey()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('"!lazy_proxy" tag contains unsupported key "foo"; supported ones are "service", "interface".');
+
+        $loader = new YamlFileLoader(new ContainerBuilder(), new FileLocator(self::$fixturesPath.'/yaml'));
+        $loader->load('lazy_proxy_invalid_key.yml');
+    }
+
+    public function testParseLazyProxyArgumentWithUnsupportedValue()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('"!lazy_proxy" tag only accepts a service reference or an array with a "service" key in');
+
+        $loader = new YamlFileLoader(new ContainerBuilder(), new FileLocator(self::$fixturesPath.'/yaml'));
+        $loader->load('lazy_proxy_invalid_value.yml');
+    }
+
+    public function testParseShortLazyProxyWithUnsupportedValue()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "@~" prefix only accepts a service reference in');
+
+        $loader = new YamlFileLoader(new ContainerBuilder(), new FileLocator(self::$fixturesPath.'/yaml'));
+        $loader->load('short_lazy_proxy_invalid_value.yml');
+    }
+
+    public function testParseShortLazyProxy()
+    {
+        $container = new ContainerBuilder();
+        $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
+        $loader->load('services_with_short_lazy_proxy.yml');
+
+        $this->assertEquals([
+            new LazyProxyArgument(new Reference('bar')),
+            new LazyProxyArgument(new Reference('bar', ContainerInterface::IGNORE_ON_INVALID_REFERENCE)),
+            new LazyProxyArgument(new Reference('bar', ContainerInterface::IGNORE_ON_UNINITIALIZED_REFERENCE)),
+        ], $container->getDefinition('foo')->getArguments());
+    }
+
+    public function testShortLazyProxyMatchesThePhpDsl()
+    {
+        $yamlLoader = new YamlFileLoader($yamlContainer = new ContainerBuilder(), new FileLocator(self::$fixturesPath.'/yaml'));
+        $yamlLoader->load('services_with_short_lazy_proxy.yml');
+
+        $phpLoader = new PhpFileLoader($phpContainer = new ContainerBuilder(), new FileLocator(self::$fixturesPath.'/config'));
+        $phpLoader->load('services_with_short_lazy_proxy.php');
+
+        $this->assertEquals(
+            $yamlContainer->getDefinition('foo')->getArguments(),
+            $phpContainer->getDefinition('foo')->getArguments(),
+        );
     }
 
     public function testParseShortServiceClosure()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Marking a service `lazy` affects every consumer of it. When only one injection point needs the deferral, the attributes can already narrow it down:

```php
public function __construct(
    #[Lazy] private HeavyService $service,
) {
}
```

YAML and the PHP-DSL had no equivalent. The nearest thing was an inline wrapper that reads like a puzzle:

```yaml
arguments:
    - !service { class: 'App\HeavyService', factory: current, arguments: [['@App\HeavyService']], lazy: true }
```

This adds a first-class syntax for it.

## YAML

```yaml
services:
    App\Consumer:
        arguments:
            - '@~App\HeavyService'
```

`@~` wraps a reference in a lazy proxy. Like `@>` for service closures, it strips its own character and re-parses the rest, so it composes with the invalid-behavior prefixes for free:

```yaml
arguments: ['@~?App\Maybe', '@~!App\Maybe']
```

The tag form is equivalent, and is what you need in order to proxy specific interfaces rather than the whole class:

```yaml
arguments:
    - !lazy_proxy '@App\HeavyService'
    - !lazy_proxy { service: '@App\HeavyService', interface: 'App\HeavyInterface' }
    - !lazy_proxy { service: '@App\HeavyService', interface: ['App\HeavyInterface', 'App\OtherInterface'] }
```

Both forms take a reference, so `!lazy_proxy '@?App\Maybe'` works too.

## PHP-DSL

```php
$services->set(Consumer::class)
    ->args([
        lazy_proxy(HeavyService::class),
        lazy_proxy(HeavyService::class, HeavyInterface::class),
        lazy_proxy(HeavyService::class)->nullOnInvalid(),
    ]);
```

`lazy_proxy()` returns a reference configurator, so `ignoreOnInvalid()`, `nullOnInvalid()` and `ignoreOnUninitialized()` apply, exactly as they do for `service_closure()`.

## Behaviour

The target service is left alone: its other consumers still receive the real instance. Nothing is built until the proxy is touched, and it then resolves to the shared service. An optional reference to a missing service resolves to `null`, like any other optional reference.

Naming one or more interfaces produces a proxy implementing only those, which is what you want when the consumer type-hints the interface. Without them, the proxy stands in for the target's own class.

Lazy proxy arguments work on compiled and non-compiled containers alike, and round-trip through `YamlDumper`.

## For the documentation

- `@~`, and that it composes with `@?` and `@!`
- `!lazy_proxy`, both the string and the `{service, interface}` mapping form
- `lazy_proxy()` and the configurator methods it inherits
- the difference from `lazy: true` on a definition: one argument, not every consumer
