### PR TITLE
[Validator] Let the groups of Valid only trigger the cascade

### DIFF
--- a/UPGRADE-8.2.md
+++ b/UPGRADE-8.2.md
@@ -65,3 +65,8 @@ Translation
 -----------
 
  * `FilteringProvider::read()` now returns an empty `TranslatorBag` when none of the requested locales match the configured ones, and a bag of empty catalogues when no requested domain matches, instead of delegating to the wrapped provider
+
+Validator
+---------
+
+ * Add argument `$restrictGroups` to `Valid::__construct()`

--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.2
 ---
 
+ * Add the `restrictGroups` option to the `Valid` constraint
  * Add the `Cron` constraint to validate cron expressions
  * Allow passing `int`, `float`, `\Stringable` and `\DateTimeInterface` values to `ConstraintViolationBuilderInterface::setParameter()`
 

--- a/src/Symfony/Component/Validator/Constraints/Valid.php
+++ b/src/Symfony/Component/Validator/Constraints/Valid.php
@@ -23,12 +23,16 @@ use Symfony\Component\Validator\Exception\InvalidArgumentException;
 class Valid extends Constraint
 {
     public bool $traverse = true;
+    public bool $restrictGroups = true;
 
     /**
      * @param string[]|null $groups
-     * @param bool|null     $traverse Whether to validate {@see \Traversable} objects (defaults to true)
+     * @param bool|null     $traverse       Whether to validate {@see \Traversable} objects (defaults to true)
+     * @param bool|null     $restrictGroups Whether $groups also restrict the groups the nested object is validated
+     *                                      against; when false they only decide when to cascade, and the nested
+     *                                      object is validated against the groups being validated (defaults to true)
      */
-    public function __construct(?array $options = null, ?array $groups = null, $payload = null, ?bool $traverse = null)
+    public function __construct(?array $options = null, ?array $groups = null, $payload = null, ?bool $traverse = null, ?bool $restrictGroups = null)
     {
         if (null !== $options) {
             throw new InvalidArgumentException(\sprintf('Passing an array of options to configure the "%s" constraint is no longer supported.', static::class));
@@ -37,6 +41,7 @@ class Valid extends Constraint
         parent::__construct(null, $groups, $payload);
 
         $this->traverse = $traverse ?? $this->traverse;
+        $this->restrictGroups = $restrictGroups ?? $this->restrictGroups;
     }
 
     public function __get(string $option): mixed

--- a/src/Symfony/Component/Validator/Mapping/GenericMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/GenericMetadata.php
@@ -63,6 +63,13 @@ class GenericMetadata implements MetadataInterface
      */
     private int $autoMappingStrategy = AutoMappingStrategy::NONE;
 
+    /**
+     * The groups that trigger the cascade, when it is not triggered unconditionally.
+     *
+     * @var string[]|null
+     */
+    private ?array $cascadeGroups = null;
+
     public function __serialize(): array
     {
         return array_filter([
@@ -71,6 +78,7 @@ class GenericMetadata implements MetadataInterface
             'cascadingStrategy' => CascadingStrategy::NONE !== $this->cascadingStrategy ? $this->cascadingStrategy : null,
             'traversalStrategy' => TraversalStrategy::NONE !== $this->traversalStrategy ? $this->traversalStrategy : null,
             'autoMappingStrategy' => AutoMappingStrategy::NONE !== $this->autoMappingStrategy ? $this->autoMappingStrategy : null,
+            'cascadeGroups' => $this->cascadeGroups,
         ]);
     }
 
@@ -108,9 +116,10 @@ class GenericMetadata implements MetadataInterface
             throw new ConstraintDefinitionException(\sprintf('The constraint "%s" can only be put on classes. Please use "Symfony\Component\Validator\Constraints\Valid" instead.', get_debug_type($constraint)));
         }
 
-        if ($constraint instanceof Valid && null === $constraint->groups) {
+        if ($constraint instanceof Valid && (null === $constraint->groups || !$constraint->restrictGroups)) {
             $this->cascadingStrategy = CascadingStrategy::CASCADE;
             $this->traversalStrategy = $constraint->traverse ? TraversalStrategy::IMPLICIT : TraversalStrategy::NONE;
+            $this->cascadeGroups = $constraint->groups;
 
             // The constraint is not added
             return $this;
@@ -176,6 +185,16 @@ class GenericMetadata implements MetadataInterface
     public function findConstraints(string $group): array
     {
         return $this->constraintsByGroup[$group] ?? [];
+    }
+
+    /**
+     * Returns the groups that trigger the cascade, or null when it is triggered unconditionally.
+     *
+     * @return string[]|null
+     */
+    public function getCascadeGroups(): ?array
+    {
+        return $this->cascadeGroups;
     }
 
     public function getCascadingStrategy(): int

--- a/src/Symfony/Component/Validator/Tests/Mapping/ClassMetadataTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/ClassMetadataTest.php
@@ -240,6 +240,27 @@ class ClassMetadataTest extends TestCase
         $this->assertEquals($reflClass, $this->metadata->getReflectionClass());
     }
 
+    public function testCascadeGroupsSurviveSerialization()
+    {
+        $this->metadata->addPropertyConstraint('firstName', new Valid(groups: ['trigger'], restrictGroups: false));
+
+        $metadata = unserialize(serialize($this->metadata));
+
+        $this->assertSame(['trigger'], $metadata->getPropertyMetadata('firstName')[0]->getCascadeGroups());
+    }
+
+    public function testMetadataSerializedBeforeCascadeGroupsExistedStillCascades()
+    {
+        $this->metadata->addPropertyConstraint('firstName', new Valid());
+
+        // a validator.mapping.cache entry written by a version that did not know the key
+        $legacy = str_replace('cascadeGroups', 'zzzzzzzzzzzzz', serialize($this->metadata));
+        $propertyMetadata = unserialize($legacy)->getPropertyMetadata('firstName')[0];
+
+        $this->assertNull($propertyMetadata->getCascadeGroups());
+        $this->assertSame(CascadingStrategy::CASCADE, $propertyMetadata->getCascadingStrategy());
+    }
+
     public function testSerialize()
     {
         $this->metadata->addConstraint(new ConstraintA('A'));

--- a/src/Symfony/Component/Validator/Tests/Validator/RecursiveValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Validator/RecursiveValidatorTest.php
@@ -1118,7 +1118,7 @@ class RecursiveValidatorTest extends TestCase
             groups: ['Group 1'],
         ));
 
-        $stringableGroup = new class() implements \Stringable {
+        $stringableGroup = new class implements \Stringable {
             public function __toString(): string
             {
                 return 'Group 1';
@@ -1196,6 +1196,77 @@ class RecursiveValidatorTest extends TestCase
         /* @var ConstraintViolationInterface[] $violations */
         $this->assertCount(1, $violations);
         $this->assertSame('Violation in Group 2', $violations[0]->getMessage());
+    }
+
+    public function testValidGroupsOnlyTriggerTheCascadeWhenNotRestricting()
+    {
+        $entity = new Entity();
+        $entity->reference = new Reference();
+
+        $this->metadata->addPropertyConstraint('reference', new Valid(groups: ['trigger'], restrictGroups: false));
+        $this->referenceMetadata->addConstraint(new Callback(
+            callback: static fn ($value, ExecutionContextInterface $context) => $context->addViolation('Violation in Default group'),
+            groups: ['Default'],
+        ));
+        $this->referenceMetadata->addConstraint(new Callback(
+            callback: static fn ($value, ExecutionContextInterface $context) => $context->addViolation('Violation in other group'),
+            groups: ['other'],
+        ));
+
+        $violations = $this->validate($entity, null, ['Default', 'trigger', 'other']);
+
+        $this->assertCount(2, $violations);
+        $this->assertSame('Violation in Default group', $violations[0]->getMessage());
+        $this->assertSame('Violation in other group', $violations[1]->getMessage());
+    }
+
+    public function testValidGroupsNotRestrictingStillHonorTraverse()
+    {
+        $entity = new Entity();
+        $entity->reference = new \ArrayIterator(['key' => new Reference()]);
+
+        $this->metadataFactory->addMetadata(new ClassMetadata('ArrayIterator'));
+        $this->metadata->addPropertyConstraint('reference', new Valid(groups: ['trigger'], restrictGroups: false, traverse: false));
+        $this->referenceMetadata->addConstraint(new Callback(
+            callback: static fn ($value, ExecutionContextInterface $context) => $context->addViolation('Violation in Default group'),
+            groups: ['Default'],
+        ));
+
+        $violations = $this->validate($entity, null, ['Default', 'trigger']);
+
+        $this->assertCount(0, $violations);
+    }
+
+    public function testValidGroupsStillRestrictTheReferenceByDefault()
+    {
+        $entity = new Entity();
+        $entity->reference = new Reference();
+
+        $this->metadata->addPropertyConstraint('reference', new Valid(groups: ['trigger']));
+        $this->referenceMetadata->addConstraint(new Callback(
+            callback: static fn ($value, ExecutionContextInterface $context) => $context->addViolation('Violation in Default group'),
+            groups: ['Default'],
+        ));
+
+        $violations = $this->validate($entity, null, ['Default', 'trigger']);
+
+        $this->assertCount(0, $violations);
+    }
+
+    public function testValidGroupsNotBeingValidatedDoNotTriggerTheCascade()
+    {
+        $entity = new Entity();
+        $entity->reference = new Reference();
+
+        $this->metadata->addPropertyConstraint('reference', new Valid(groups: ['trigger'], restrictGroups: false));
+        $this->referenceMetadata->addConstraint(new Callback(
+            callback: static fn ($value, ExecutionContextInterface $context) => $context->addViolation('Violation in Default group'),
+            groups: ['Default'],
+        ));
+
+        $violations = $this->validate($entity, null, ['Default']);
+
+        $this->assertCount(0, $violations);
     }
 
     public function testPropagateDefaultGroupToReferenceWhenReplacingDefaultGroup()

--- a/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php
+++ b/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php
@@ -631,6 +631,13 @@ class RecursiveContextualValidator implements ContextualValidatorInterface
             return;
         }
 
+        // A Valid constraint carrying groups only cascades when one of them is being validated
+        if ($metadata instanceof GenericMetadata && null !== $cascadeGroups = $metadata->getCascadeGroups()) {
+            if (!array_intersect($groups, $cascadeGroups)) {
+                return;
+            }
+        }
+
         // If no specific traversal strategy was requested when this method
         // was called, use the traversal strategy of the node's metadata
         if ($traversalStrategy & TraversalStrategy::IMPLICIT) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #32900
| License       | MIT

Groups on the `Valid` constraint currently mean two things at once: when to cascade, and which groups the nested object is validated against. The second meaning is undocumented and rarely wanted, and it makes a reusable nested object hard to write, since the parent decides which of the child's constraints run.

`restrictGroups: false` keeps only the first meaning:

```php
class Order
{
    #[Assert\Valid(groups: ['alternateInvoiceAddress'], restrictGroups: false)]
    public Address $invoiceAddress;
}

$validator->validate($order, null, ['Default', 'alternateInvoiceAddress', 'cityAddress']);
```

The cascade happens because `alternateInvoiceAddress` is being validated, and `Address` is then validated against `Default`, `alternateInvoiceAddress` and `cityAddress`, which is what it would get from a plain `#[Assert\Valid]`. Validating without `alternateInvoiceAddress` skips the nested object entirely.

The default stays `true`, so nothing changes for existing code.

Implementation note: a non-restricting `Valid` goes through the cascading strategy instead of `ValidValidator`, the same path a plain `#[Assert\Valid]` takes, with the groups kept on the metadata to decide whether to cascade. That is why the nested object gets the groups being validated: the cascade path already forwards them. It also means `traverse` works together with groups, which it did not before.

Points for the documentation:

* `Valid` accepts `restrictGroups`, default `true`
* with the default, `groups` both trigger the cascade and restrict the nested object, which is today's behavior
* with `false`, `groups` only trigger the cascade and the nested object is validated against the groups being validated
* `traverse` applies in both cases
