### PR TITLE
[Uid] Fix the weak-secret guard in Uuid47Transformer for secrets longer than 16 bytes

### DIFF
--- a/src/Symfony/Component/Uid/Tests/Uuid47TransformerTest.php
+++ b/src/Symfony/Component/Uid/Tests/Uuid47TransformerTest.php
@@ -55,6 +55,9 @@ class Uuid47TransformerTest extends TestCase
         yield 'all NUL' => [str_repeat("\x00", 16)];
         yield 'all 0xFF' => [str_repeat("\xff", 16)];
         yield 'all "a"' => [str_repeat('a', 16)];
+        yield 'all NUL, longer than 16 bytes' => [str_repeat("\x00", 17)];
+        yield 'all 0xFF, longer than 16 bytes' => [str_repeat("\xff", 32)];
+        yield 'all "a", longer than 16 bytes' => [str_repeat('a', 64)];
     }
 
     #[DataProvider('provideWeakKeys')]

--- a/src/Symfony/Component/Uid/Uuid47Transformer.php
+++ b/src/Symfony/Component/Uid/Uuid47Transformer.php
@@ -59,7 +59,7 @@ class Uuid47Transformer
             throw new InvalidArgumentException('The secret must be at least 16 bytes.');
         }
 
-        if ($secret === str_repeat($secret[0], 16)) {
+        if ($secret === str_repeat($secret[0], \strlen($secret))) {
             throw new InvalidArgumentException('The secret is trivially weak; use random_bytes(16) or a key derived from a passphrase via hash_hkdf().');
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`Uuid47Transformer` rejects a secret made of identical bytes, but the check compares against `str_repeat($secret[0], 16)`, so it can only ever match a secret of exactly 16 bytes. One byte longer and the same secret passes:

```php
new Uuid47Transformer(str_repeat("\x00", 16)); // InvalidArgumentException, as intended
new Uuid47Transformer(str_repeat("\x00", 17)); // accepted
new Uuid47Transformer(str_repeat("\x00", 32)); // accepted
new Uuid47Transformer(str_repeat('A', 64));    // accepted
```

A secret longer than 16 bytes is then folded through `sha256`, so the derived key looks perfectly random while carrying no entropy at all. The caller gets no hint that the guard did not apply to them.

The existing `provideWeakKeys` data set states what the guard is meant to catch -- all NUL, all `0xFF`, all `'a'` -- but every case in it is exactly 16 bytes, which is why this went unnoticed. This PR adds the same three shapes at 17, 32 and 64 bytes: they fail on 8.1 and pass with the fix.

What this is not: the secret is still secret, and `Uuid47Transformer` documents itself as timestamp obfuscation rather than authenticated encryption, so nothing here is remotely exploitable by an attacker. It is the guard that is inconsistent -- the very same weak secret is refused at 16 bytes and accepted at 17 -- so I am sending it as an ordinary bug fix rather than through the security channel.
