### PR TITLE
[Uid] Avoid a CS fix that would fatally break Uuid47Transformer

### DIFF
--- a/src/Symfony/Component/Uid/Uuid47Transformer.php
+++ b/src/Symfony/Component/Uid/Uuid47Transformer.php
@@ -101,13 +101,8 @@ class Uuid47Transformer
         // so we XOR in reverse byte order.
         $hash = sodium_crypto_shorthash($sipInput, $secret);
 
-        $bytes[0] = $bytes[0] ^ $hash[5];
-        $bytes[1] = $bytes[1] ^ $hash[4];
-        $bytes[2] = $bytes[2] ^ $hash[3];
-        $bytes[3] = $bytes[3] ^ $hash[2];
-        $bytes[4] = $bytes[4] ^ $hash[1];
-        $bytes[5] = $bytes[5] ^ $hash[0];
-        $hex = bin2hex($bytes);
+        $mask = $hash[5].$hash[4].$hash[3].$hash[2].$hash[1].$hash[0];
+        $hex = bin2hex((substr($bytes, 0, 6) ^ $mask).substr($bytes, 6));
 
         return substr($hex, 0, 8).'-'.substr($hex, 8, 4).'-'.$targetVersion.substr($rfc4122, 15);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`Uuid47Transformer::transform()` masks the timestamp with six `$bytes[$i] = $bytes[$i] ^ $hash[$j]` assignments. Our CS config enables `@Symfony:risky`, which includes `long_to_shorthand_operator`, and that rule rewrites them to `$bytes[0] ^= $hash[5]`. PHP does not allow that on a string offset:

```
PHP Fatal error: Cannot use assign-op operators with string offsets in Uuid47Transformer.php:104
```

Minimal reproducer, independent of Symfony:

```php
$s = "abc";
$s[0] = $s[0] ^ "\x01";   // fine
$s[0] ^= "\x01";          // Fatal error: Cannot use assign-op operators with string offsets
```

The rule is upfront about this -- it is marked RISKY and its description names this very case ("Risky when applying for string offsets") -- so this is on our side rather than on php-cs-fixer.

The file is new in 8.1 and has not been modified since, and Fabbot only inspects changed files, which is why nobody has hit it yet. I did, on #65105: Fabbot fails, prints the patch and says "Then commit the changes and push to your PR branch". Following that instruction lands a fatal error in the component, and every future contributor touching this file meets the same trap.

Rather than silencing the rule for this path, this removes the pattern it trips on by XOR-ing the six bytes as a single string.

Verification: the rewritten expression was compared against the current one on 100k random `(bytes, hash)` pairs plus all-zero and all-0xFF edges, with no difference; the existing round-trip tests pass. With our own config, `php-cs-fixer --dry-run` reports "1 of 1 files can be fixed" before this change and "Found 0 of 1 files that can be fixed" after it.
