### PR TITLE
[Messenger] Messages which fail to decode should not be retried

### DIFF
--- a/src/Symfony/Component/Messenger/Exception/MessageDecodingFailedException.php
+++ b/src/Symfony/Component/Messenger/Exception/MessageDecodingFailedException.php
@@ -14,6 +14,6 @@ namespace Symfony\Component\Messenger\Exception;
 /**
  * Thrown when a message cannot be decoded in a serializer.
  */
-class MessageDecodingFailedException extends InvalidArgumentException
+class MessageDecodingFailedException extends InvalidArgumentException implements UnrecoverableExceptionInterface
 {
 }

--- a/src/Symfony/Component/Messenger/Tests/EventListener/SendFailedMessageToFailureTransportListenerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/EventListener/SendFailedMessageToFailureTransportListenerTest.php
@@ -12,10 +12,15 @@
 namespace Symfony\Component\Messenger\Tests\EventListener;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
+use Symfony\Component\Messenger\EventListener\SendFailedMessageForRetryListener;
 use Symfony\Component\Messenger\EventListener\SendFailedMessageToFailureTransportListener;
+use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
+use Symfony\Component\Messenger\Retry\RetryStrategyInterface;
+use Symfony\Component\Messenger\Stamp\SentForRetryStamp;
 use Symfony\Component\Messenger\Stamp\SentToFailureTransportStamp;
 use Symfony\Component\Messenger\Transport\Sender\SenderInterface;
 
@@ -183,5 +188,31 @@ class SendFailedMessageToFailureTransportListenerTest extends TestCase
         $event = new WorkerMessageFailedEvent($envelope, 'my_receiver', $exception);
 
         $listener->onMessageFailed($event);
+    }
+
+    public function testMessageDecodingFailedExceptionCausesNoRetry()
+    {
+        $sender = $this->createMock(SenderInterface::class);
+        $sender->expects($this->never())->method('send');
+        $senderLocator = new Container();
+        $senderLocator->set('my_receiver', $sender);
+
+        $retryStrategy = $this->createMock(RetryStrategyInterface::class);
+        $retryStrategy->expects($this->never())->method('isRetryable');
+        $retryStrategyLocator = new Container();
+        $retryStrategyLocator->set('my_receiver', $retryStrategy);
+
+        $listener = new SendFailedMessageForRetryListener($senderLocator, $retryStrategyLocator);
+
+        $event = new WorkerMessageFailedEvent(
+            new Envelope(new \stdClass()),
+            'my_receiver',
+            new MessageDecodingFailedException('Could not decode message'),
+        );
+        $listener->onMessageFailed($event);
+
+        $sentForRetryStamp = $event->getEnvelope()->last(SentForRetryStamp::class);
+        $this->assertInstanceOf(SentForRetryStamp::class, $sentForRetryStamp);
+        $this->assertFalse($sentForRetryStamp->isSent);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65107
| License       | MIT

`MessageDecodingFailedException` should probably implement `UnrecoverableExceptionInterface` since action must be taken before said message can be processed.
 
A message that fails to decode is deterministic: retrying it can never succeed. Without this the retry listener re-sends the envelope, which serializes the live `MessageDecodingFailedException`. That payload cannot be decoded either, so every retry creates a new, roughly 2x bigger undecodable message with a fresh retry counter.
 
