### PR TITLE
[DependencyInjection] Honor the interface passed to #[Lazy]

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
@@ -346,7 +346,7 @@ class AutowirePass extends AbstractRecursivePass
                             if (str_contains($type, '|')) {
                                 throw new AutowiringFailedException($this->currentId, \sprintf('Cannot use #[Autowire] with option "lazy: true" on union types for service "%s"; set the option to the interface(s) that should be proxied instead.', $this->currentId));
                             }
-                            $lazy = str_contains($type, '&') ? explode('&', $type) : [];
+                            $lazy = str_contains($type, '&') ? explode('&', $type) : (\is_string($lazy) ? [$lazy] : []);
                         }
 
                         if (!$lazy && $value instanceof Reference && $this->container->has($value) && $this->container->findDefinition($value)->isLazy()) {

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
@@ -1467,6 +1467,20 @@ class AutowirePassTest extends TestCase
         $this->assertFalse($container->hasDefinition('.lazy.'.A::class));
     }
 
+    public function testLazyServiceAttributeWithInterface()
+    {
+        $container = new ContainerBuilder();
+        $container->register(FinalLazyProxyImplementation::class, FinalLazyProxyImplementation::class)->setAutowired(true);
+        $container->register('foo', LazyServiceAttributeWithInterfaceAutowiring::class)->setAutowired(true);
+
+        (new AutowirePass())->process($container);
+
+        $definition = $container->getDefinition((string) $container->getDefinition('foo')->getArgument(0));
+
+        $this->assertTrue($definition->isLazy());
+        $this->assertSame([['interface' => LazyProxyTestInterface::class]], $definition->getTag('proxy'));
+    }
+
     public function testLazyNotCompatibleWithAutowire()
     {
         $container = new ContainerBuilder();

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes_80.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/autowiring_classes_80.php
@@ -171,6 +171,13 @@ class LazyServiceAttributeAutowiring
     }
 }
 
+class LazyServiceAttributeWithInterfaceAutowiring
+{
+    public function __construct(#[Lazy(LazyProxyTestInterface::class)] FinalLazyProxyImplementation $impl)
+    {
+    }
+}
+
 class LazyAutowireServiceAttributesAutowiring
 {
     public function __construct(#[Lazy, Autowire(lazy: true)] A $a)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`#[Lazy]` accepts an interface to proxy, like the `lazy` option of `#[Autowire]`:

```php
public function __construct(
    #[Lazy(HeavyInterface::class)]
    private Heavy $heavy,
) {
}
```

The interface was silently dropped. `Autowire` normalizes the option in its constructor, `\is_string($lazy) ? [$lazy] : $lazy`, so by the time `AutowirePass` sees it the value is already an array. `Lazy` keeps it as `bool|string|null`, and the pass then replaced any non-array value with an empty array, so the string never reached the `proxy` tag. The generated proxy extended the concrete class instead of implementing the requested interface, which also means it could not be generated at all for a `final` class, the case the option exists for.

The pass now keeps a string and wraps it, leaving `true` mapped to an empty array as before so the parameter type is proxied.

Spotted while reviewing #65103 
