### PR TITLE
[Validator] Add BcMath\Number support to comparison and Range constraints

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Add the `cascadeCurrentGroup` option to `GroupSequence` and `GroupSequenceProvider`
  * Remove the unused `GroupSequence::$cascadedGroup` property
  * Add the `restrictGroups` option to the `Valid` constraint
+ * Add support for `BcMath\Number` values in the `Range` and comparison constraints
  * Add the `Cron` constraint to validate cron expressions
  * Add the `message` option to the `Callback` constraint; the callback must then return a boolean, and a violation is raised when it returns `false`
  * Allow passing `int`, `float`, `\Stringable` and `\DateTimeInterface` values to `ConstraintViolationBuilderInterface::setParameter()`

--- a/src/Symfony/Component/Validator/Constraints/AbstractComparisonValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/AbstractComparisonValidator.php
@@ -30,6 +30,8 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
  */
 abstract class AbstractComparisonValidator extends ConstraintValidator
 {
+    use BcMathNumberTrait;
+
     public function __construct(
         private ?PropertyAccessorInterface $propertyAccessor = null,
         private ?ClockInterface $clock = null,
@@ -71,6 +73,12 @@ abstract class AbstractComparisonValidator extends ConstraintValidator
             } catch (\Exception) {
                 throw new ConstraintDefinitionException(\sprintf('The compared value "%s" could not be converted to a "%s" instance in the "%s" constraint.', $comparedValue, get_debug_type($value), get_debug_type($constraint)));
             }
+        }
+
+        // The compared value is converted so that the comparison keeps its arbitrary
+        // precision, and so that the violation message renders it without quotes
+        if ($value instanceof \BcMath\Number) {
+            $comparedValue = self::toBcMathNumber($comparedValue);
         }
 
         if (!$this->compareValues($value, $comparedValue)) {

--- a/src/Symfony/Component/Validator/Constraints/BcMathNumberTrait.php
+++ b/src/Symfony/Component/Validator/Constraints/BcMathNumberTrait.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+/**
+ * @internal
+ */
+trait BcMathNumberTrait
+{
+    /**
+     * Converts a numeric value to a BcMath\Number, so that comparing it with another
+     * BcMath\Number keeps the arbitrary precision. PHP truncates the other operand to
+     * an integer instead, which makes Number('10.2') greater than 10.5.
+     *
+     * Values that cannot be represented, such as INF and NAN, are returned unchanged.
+     */
+    private static function toBcMathNumber(mixed $value): mixed
+    {
+        if (!\is_int($value) && !(\is_float($value) && is_finite($value)) && !(\is_string($value) && is_numeric($value))) {
+            return $value;
+        }
+
+        try {
+            return new \BcMath\Number(self::toPlainDecimalNotation((string) $value));
+        } catch (\ValueError) {
+            return $value;
+        }
+    }
+
+    /**
+     * Rewrites the exponent notation BcMath\Number cannot parse, e.g. "1.0E-7" to "0.0000001".
+     */
+    private static function toPlainDecimalNotation(string $number): string
+    {
+        if (!preg_match('/^([+-]?)(\d*)(?:\.(\d*))?[eE]([+-]?\d+)$/', $number, $matches)) {
+            return $number;
+        }
+
+        [, $sign, $integerPart, $fractionPart, $exponent] = $matches;
+
+        $digits = $integerPart.$fractionPart;
+        $point = \strlen($integerPart) + (int) $exponent;
+
+        if ($point >= \strlen($digits)) {
+            return $sign.$digits.str_repeat('0', $point - \strlen($digits));
+        }
+
+        if ($point <= 0) {
+            $plain = '0.'.str_repeat('0', -$point).$digits;
+        } else {
+            $plain = substr($digits, 0, $point).'.'.substr($digits, $point);
+        }
+
+        // the trailing zeros of the mantissa would show up in violation messages
+        return $sign.rtrim(rtrim($plain, '0'), '.');
+    }
+}

--- a/src/Symfony/Component/Validator/Constraints/RangeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/RangeValidator.php
@@ -27,6 +27,8 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
  */
 class RangeValidator extends ConstraintValidator
 {
+    use BcMathNumberTrait;
+
     public function __construct(
         private ?PropertyAccessorInterface $propertyAccessor = null,
         private ?ClockInterface $clock = null,
@@ -46,7 +48,7 @@ class RangeValidator extends ConstraintValidator
         $min = $this->getLimit($constraint->minPropertyPath, $constraint->min, $constraint);
         $max = $this->getLimit($constraint->maxPropertyPath, $constraint->max, $constraint);
 
-        if (!is_numeric($value) && !$value instanceof \DateTimeInterface) {
+        if (!is_numeric($value) && !$value instanceof \DateTimeInterface && !$value instanceof \BcMath\Number) {
             if ($this->isParsableDatetimeString($min) && $this->isParsableDatetimeString($max)) {
                 $this->context->buildViolation($constraint->invalidDateTimeMessage)
                     ->setParameter('{{ value }}', $this->formatValue($value, self::PRETTY_DATE))
@@ -84,6 +86,12 @@ class RangeValidator extends ConstraintValidator
             }
         }
 
+        // Scalar limits are converted so that the comparison keeps its arbitrary precision
+        if ($value instanceof \BcMath\Number) {
+            $min = self::toBcMathNumber($min);
+            $max = self::toBcMathNumber($max);
+        }
+
         $hasLowerLimit = null !== $min;
         $hasUpperLimit = null !== $max;
 
@@ -92,9 +100,9 @@ class RangeValidator extends ConstraintValidator
             $code = Range::NOT_IN_RANGE_ERROR;
 
             $violationBuilder = $this->context->buildViolation($message)
-                ->setParameter('{{ value }}', $this->formatValue($value, self::PRETTY_DATE))
-                ->setParameter('{{ min }}', $this->formatValue($min, self::PRETTY_DATE))
-                ->setParameter('{{ max }}', $this->formatValue($max, self::PRETTY_DATE))
+                ->setParameter('{{ value }}', $this->formatValue($value, self::PRETTY_DATE | self::OBJECT_TO_STRING))
+                ->setParameter('{{ min }}', $this->formatValue($min, self::PRETTY_DATE | self::OBJECT_TO_STRING))
+                ->setParameter('{{ max }}', $this->formatValue($max, self::PRETTY_DATE | self::OBJECT_TO_STRING))
                 ->setCode($code);
 
             if (null !== $constraint->maxPropertyPath) {
@@ -112,8 +120,8 @@ class RangeValidator extends ConstraintValidator
 
         if ($hasUpperLimit && $value > $max) {
             $violationBuilder = $this->context->buildViolation($constraint->maxMessage)
-                ->setParameter('{{ value }}', $this->formatValue($value, self::PRETTY_DATE))
-                ->setParameter('{{ limit }}', $this->formatValue($max, self::PRETTY_DATE))
+                ->setParameter('{{ value }}', $this->formatValue($value, self::PRETTY_DATE | self::OBJECT_TO_STRING))
+                ->setParameter('{{ limit }}', $this->formatValue($max, self::PRETTY_DATE | self::OBJECT_TO_STRING))
                 ->setCode(Range::TOO_HIGH_ERROR);
 
             if (null !== $constraint->maxPropertyPath) {
@@ -131,8 +139,8 @@ class RangeValidator extends ConstraintValidator
 
         if ($hasLowerLimit && $value < $min) {
             $violationBuilder = $this->context->buildViolation($constraint->minMessage)
-                ->setParameter('{{ value }}', $this->formatValue($value, self::PRETTY_DATE))
-                ->setParameter('{{ limit }}', $this->formatValue($min, self::PRETTY_DATE))
+                ->setParameter('{{ value }}', $this->formatValue($value, self::PRETTY_DATE | self::OBJECT_TO_STRING))
+                ->setParameter('{{ limit }}', $this->formatValue($min, self::PRETTY_DATE | self::OBJECT_TO_STRING))
                 ->setCode(Range::TOO_LOW_ERROR);
 
             if (null !== $constraint->maxPropertyPath) {

--- a/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanOrEqualValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanOrEqualValidatorTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\GreaterThanOrEqual;
 use Symfony\Component\Validator\Constraints\GreaterThanOrEqualValidator;
@@ -80,5 +81,90 @@ class GreaterThanOrEqualValidatorTest extends AbstractComparisonValidatorTestCas
             [new \DateTime('2000/01/01 UTC'), self::normalizeIcuSpaces("Jan 1, 2000, 12:00\u{202F}AM"), '2005/01/01 UTC', self::normalizeIcuSpaces("Jan 1, 2005, 12:00\u{202F}AM"), 'DateTime'],
             ['b', '"b"', 'c', '"c"', 'string'],
         ];
+    }
+
+    #[RequiresPhpExtension('bcmath')]
+    public function testValidBcMathNumberWithStringValue()
+    {
+        $this->validator->validate(new \BcMath\Number('10.5'), new GreaterThanOrEqual('10'));
+
+        $this->assertNoViolation();
+    }
+
+    #[RequiresPhpExtension('bcmath')]
+    public function testValidBcMathNumberWithIntValue()
+    {
+        $this->validator->validate(new \BcMath\Number('10.5'), new GreaterThanOrEqual(10));
+
+        $this->assertNoViolation();
+    }
+
+    #[RequiresPhpExtension('bcmath')]
+    public function testInvalidBcMathNumberFormatsLimitWithoutQuotes()
+    {
+        $this->validator->validate(new \BcMath\Number('9.5'), new GreaterThanOrEqual(value: '10', message: 'myMessage'));
+
+        // The compared string limit must be rendered as "10", not the quoted
+        // string "\"10\"" that a plain string comparison would produce.
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', '9.5')
+            ->setParameter('{{ compared_value }}', '10')
+            ->setParameter('{{ compared_value_type }}', 'BcMath\Number')
+            ->setCode(GreaterThanOrEqual::TOO_LOW_ERROR)
+            ->assertRaised();
+    }
+
+    #[RequiresPhpExtension('bcmath')]
+    public function testBcMathNumberComparesWithFullPrecision()
+    {
+        $this->validator->validate(new \BcMath\Number('9.9999999999'), new GreaterThanOrEqual(value: 10, message: 'myMessage'));
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', '9.9999999999')
+            ->setParameter('{{ compared_value }}', '10')
+            ->setParameter('{{ compared_value_type }}', 'BcMath\Number')
+            ->setCode(GreaterThanOrEqual::TOO_LOW_ERROR)
+            ->assertRaised();
+    }
+
+    #[RequiresPhpExtension('bcmath')]
+    public function testBcMathNumberWithFloatValue()
+    {
+        // PHP truncates the float to an integer when comparing it with a BcMath\Number,
+        // which would make 10.2 greater than 10.5
+        $this->validator->validate(new \BcMath\Number('10.2'), new GreaterThanOrEqual(value: 10.5, message: 'myMessage'));
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', '10.2')
+            ->setParameter('{{ compared_value }}', '10.5')
+            ->setParameter('{{ compared_value_type }}', 'BcMath\Number')
+            ->setCode(GreaterThanOrEqual::TOO_LOW_ERROR)
+            ->assertRaised();
+    }
+
+    #[RequiresPhpExtension('bcmath')]
+    public function testBcMathNumberWithSmallFloatValue()
+    {
+        $this->validator->validate(new \BcMath\Number('0.00000005'), new GreaterThanOrEqual(value: 0.0000001, message: 'myMessage'));
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', '0.00000005')
+            ->setParameter('{{ compared_value }}', '0.0000001')
+            ->setParameter('{{ compared_value_type }}', 'BcMath\Number')
+            ->setCode(GreaterThanOrEqual::TOO_LOW_ERROR)
+            ->assertRaised();
+    }
+
+    #[RequiresPhpExtension('bcmath')]
+    public function testBcMathNumberWithExponentNotationStringValue()
+    {
+        $this->validator->validate(new \BcMath\Number('0.00000005'), new GreaterThanOrEqual(value: '1.0E-7', message: 'myMessage'));
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', '0.00000005')
+            ->setParameter('{{ compared_value }}', '0.0000001')
+            ->setParameter('{{ compared_value_type }}', 'BcMath\Number')
+            ->setCode(GreaterThanOrEqual::TOO_LOW_ERROR)
+            ->assertRaised();
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/RangeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/RangeValidatorTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Validator\Tests\Constraints;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use Symfony\Component\Clock\MockClock;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 use Symfony\Component\Validator\Constraints\Range;
@@ -154,6 +155,111 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
             ->setParameter('{{ max }}', 20)
             ->setCode(Range::NOT_IN_RANGE_ERROR)
             ->assertRaised();
+    }
+
+    #[RequiresPhpExtension('bcmath')]
+    public function testValidBcMathNumberWithScalarLimits()
+    {
+        $this->validator->validate(new \BcMath\Number('10.5'), new Range(min: 10, max: 20));
+
+        $this->assertNoViolation();
+    }
+
+    #[RequiresPhpExtension('bcmath')]
+    public function testValidBcMathNumberWithStringLimits()
+    {
+        $this->validator->validate(new \BcMath\Number('10.5'), new Range(min: '10', max: '20'));
+
+        $this->assertNoViolation();
+    }
+
+    #[RequiresPhpExtension('bcmath')]
+    public function testValidBcMathNumberWithBcMathLimits()
+    {
+        $this->validator->validate(new \BcMath\Number('10.5'), new Range(min: new \BcMath\Number('10'), max: new \BcMath\Number('20')));
+
+        $this->assertNoViolation();
+    }
+
+    #[RequiresPhpExtension('bcmath')]
+    public function testBcMathNumberTooLow()
+    {
+        $this->validator->validate(new \BcMath\Number('9.5'), new Range(min: 10, minMessage: 'myMessage'));
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', '9.5')
+            ->setParameter('{{ limit }}', '10')
+            ->setCode(Range::TOO_LOW_ERROR)
+            ->assertRaised();
+    }
+
+    #[RequiresPhpExtension('bcmath')]
+    public function testBcMathNumberTooHigh()
+    {
+        $this->validator->validate(new \BcMath\Number('20.5'), new Range(max: 20, maxMessage: 'myMessage'));
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', '20.5')
+            ->setParameter('{{ limit }}', '20')
+            ->setCode(Range::TOO_HIGH_ERROR)
+            ->assertRaised();
+    }
+
+    #[RequiresPhpExtension('bcmath')]
+    public function testBcMathNumberNotInRange()
+    {
+        $this->validator->validate(new \BcMath\Number('20.5'), new Range(min: 10, max: 20, notInRangeMessage: 'myMessage'));
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', '20.5')
+            ->setParameter('{{ min }}', '10')
+            ->setParameter('{{ max }}', '20')
+            ->setCode(Range::NOT_IN_RANGE_ERROR)
+            ->assertRaised();
+    }
+
+    #[RequiresPhpExtension('bcmath')]
+    public function testBcMathNumberComparesWithFullPrecision()
+    {
+        $this->validator->validate(new \BcMath\Number('10.0000000001'), new Range(max: 10, maxMessage: 'myMessage'));
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', '10.0000000001')
+            ->setParameter('{{ limit }}', '10')
+            ->setCode(Range::TOO_HIGH_ERROR)
+            ->assertRaised();
+    }
+
+    #[RequiresPhpExtension('bcmath')]
+    public function testBcMathNumberWithFloatLimitTooLow()
+    {
+        // PHP truncates the float to an integer when comparing it with a BcMath\Number,
+        // which would make 10.2 greater than 10.5
+        $this->validator->validate(new \BcMath\Number('10.2'), new Range(min: 10.5, minMessage: 'myMessage'));
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', '10.2')
+            ->setParameter('{{ limit }}', '10.5')
+            ->setCode(Range::TOO_LOW_ERROR)
+            ->assertRaised();
+    }
+
+    #[RequiresPhpExtension('bcmath')]
+    public function testValidBcMathNumberWithFloatLimits()
+    {
+        $this->validator->validate(new \BcMath\Number('10.2'), new Range(min: 9.5, max: 10.5));
+
+        $this->assertNoViolation();
+    }
+
+    #[RequiresPhpExtension('bcmath')]
+    public function testBcMathNumberWithInfiniteLimitDoesNotThrow()
+    {
+        // INF/NAN cannot be represented as a BcMath\Number; the limit is left
+        // untouched and the native comparison applies, without raising an error.
+        $this->validator->validate(new \BcMath\Number('10.2'), new Range(min: \NAN, max: \INF));
+
+        $this->assertNoViolation();
     }
 
     public static function getTenthToTwentiethMarch2014(): array
@@ -908,6 +1014,42 @@ class RangeValidatorTest extends ConstraintValidatorTestCase
         }
 
         return $value->format('Y-m-d H:i:s');
+    }
+
+    #[RequiresPhpExtension('bcmath')]
+    public function testBcMathNumberWithSmallFloatLimitTooLow()
+    {
+        $this->validator->validate(new \BcMath\Number('0.00000005'), new Range(min: 0.0000001, minMessage: 'myMessage'));
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', '0.00000005')
+            ->setParameter('{{ limit }}', '0.0000001')
+            ->setCode(Range::TOO_LOW_ERROR)
+            ->assertRaised();
+    }
+
+    #[RequiresPhpExtension('bcmath')]
+    public function testBcMathNumberWithLargeFloatLimitTooHigh()
+    {
+        $this->validator->validate(new \BcMath\Number('100000000000000000001'), new Range(max: 1.0E+20, maxMessage: 'myMessage'));
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', '100000000000000000001')
+            ->setParameter('{{ limit }}', '100000000000000000000')
+            ->setCode(Range::TOO_HIGH_ERROR)
+            ->assertRaised();
+    }
+
+    #[RequiresPhpExtension('bcmath')]
+    public function testBcMathNumberWithExponentNotationStringLimitTooLow()
+    {
+        $this->validator->validate(new \BcMath\Number('0.00000005'), new Range(min: '1.0E-7', minMessage: 'myMessage'));
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', '0.00000005')
+            ->setParameter('{{ limit }}', '0.0000001')
+            ->setCode(Range::TOO_LOW_ERROR)
+            ->assertRaised();
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #64562
| License       | MIT

`Range` and the comparison constraints now accept `BcMath\Number` values.

```php
use Symfony\Component\Validator\Constraints as Assert;

class Order
{
    #[Assert\Range(min: 0.01, max: 10000)]
    #[Assert\GreaterThanOrEqual(0.01)]
    public \BcMath\Number $amount;
}
```

Before, `Range` rejected such a value through `invalidMessage`, because a `BcMath\Number` is not `is_numeric()`. The comparison constraints accepted it, but only compared correctly when the configured value was itself a `BcMath\Number`.

## Why the limits are converted

PHP truncates the other operand to an integer when it is compared with a `BcMath\Number`:

```php
new \BcMath\Number('10.2') > 10.5;   // true
new \BcMath\Number('5') == 5.5;      // true
```

So a scalar limit is now converted to a `BcMath\Number` before the comparison, and the arbitrary precision is kept on both sides. Integers, floats and numeric strings are all converted, including the exponent notation `BcMath\Number` cannot parse itself:

```php
#[Assert\Range(min: 0.0000001)]      // (string) 0.0000001 is "1.0E-7"
#[Assert\GreaterThanOrEqual('1.0E-7')]
```

Values that have no `BcMath\Number` representation, `INF` and `NAN`, are left untouched and keep the native comparison, which does not raise an error.

Conversion only happens when the validated value is a `BcMath\Number`. Nothing changes for any other value.

## Violation messages

The limit is rendered as a number instead of a quoted string, so `Range(min: '10')` reports `should be 10 or more` rather than `should be "10" or more`.

## Not covered

`DivisibleBy` still rejects a `BcMath\Number` with `This value should be of type numeric.`, as it did before: an arbitrary precision modulo needs its own decision about scale. `IdenticalTo` and `NotIdenticalTo` compare object identity, so a `BcMath\Number` is never identical to a scalar.

The Form side is deliberately out of scope. A `bcmath` value for `NumberType`'s `input` option would still go through `NumberFormatter` and lose the precision it is meant to preserve.

## For the documentation

 * the constraints involved: `Range`, `EqualTo`, `NotEqualTo`, `GreaterThan`, `GreaterThanOrEqual`, `LessThan`, `LessThanOrEqual`
 * that a scalar limit keeps its precision, with the `10.2` against `10.5` example of what PHP does otherwise
 * that `INF` and `NAN` limits fall back to the native comparison
 * the three exclusions above
