### PR TITLE
[DependencyInjection] Fix generating one proxy class per set of "proxy" tags

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -578,10 +578,11 @@ class PhpDumper extends Dumper
             if (!$definition = $this->isProxyCandidate($definition, $asGhostObject, $id)) {
                 continue;
             }
-            if (isset($alreadyGenerated[$asGhostObject][$class = $definition->getClass()])) {
+            // the proxy class name derives from the "proxy" tags too, so one class can need several proxies
+            if (isset($alreadyGenerated[$asGhostObject][$class = $definition->getClass()][$tags = serialize($definition->getTag('proxy'))])) {
                 continue;
             }
-            $alreadyGenerated[$asGhostObject][$class] = true;
+            $alreadyGenerated[$asGhostObject][$class][$tags] = true;
 
             if ($this->container->isTrackingResources()) {
                 foreach (array_column($definition->getTag('proxy'), 'interface') ?: [$class] as $r) {

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -48,7 +48,9 @@ use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\DependencyInjection\Tests\Compiler\AAndIInterfaceConsumer;
 use Symfony\Component\DependencyInjection\Tests\Compiler\AInterface;
+use Symfony\Component\DependencyInjection\Tests\Compiler\EInterface;
 use Symfony\Component\DependencyInjection\Tests\Compiler\EnvAutowireWithMissingArgument;
+use Symfony\Component\DependencyInjection\Tests\Compiler\F;
 use Symfony\Component\DependencyInjection\Tests\Compiler\Foo;
 use Symfony\Component\DependencyInjection\Tests\Compiler\FooAnnotation;
 use Symfony\Component\DependencyInjection\Tests\Compiler\FooVoid;
@@ -1008,6 +1010,28 @@ class PhpDumperTest extends TestCase
 
         $legacy = \PHP_VERSION_ID < 80400 || !trait_exists(LazyDecoratorTrait::class) ? 'legacy_' : '';
         $this->assertStringEqualsFile(self::$fixturesPath.'/php/'.$legacy.'services_dedup_lazy.php', $dumper->dump());
+    }
+
+    public function testDedupLazyProxyWithDifferentInterfaces()
+    {
+        $container = new ContainerBuilder();
+        $container->register('foo', F::class)
+            ->setLazy(true)
+            ->setPublic(true)
+            ->addTag('proxy', ['interface' => EInterface::class]);
+        $container->register('bar', F::class)
+            ->setLazy(true)
+            ->setPublic(true)
+            ->addTag('proxy', ['interface' => IInterface::class]);
+        $container->compile();
+
+        $dumper = new PhpDumper($container);
+        eval('?>'.$dumper->dump(['class' => 'Symfony_DI_PhpDumper_Service_Dedup_Lazy_Proxy_Interfaces']));
+
+        $container = new \Symfony_DI_PhpDumper_Service_Dedup_Lazy_Proxy_Interfaces();
+
+        $this->assertInstanceOf(EInterface::class, $container->get('foo'));
+        $this->assertInstanceOf(IInterface::class, $container->get('bar'));
     }
 
     public function testLazyArgumentProvideGenerator()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`LazyServiceDumper::getProxyClass()` builds the proxy class name out of the service class **and** the `proxy` tags:

```php
return preg_replace('/^.*\\\\/', '', $definition->getClass()).'Proxy'
    .ucfirst(substr(hash(..., $this->salt.'+'.$class->name.'+'.serialize($definition->getTag('proxy'))), -7));
```

but `PhpDumper::generateProxyClasses()` de-duplicates on the class alone. Two definitions that share a class while proxying different interfaces therefore get a single proxy class dumped, although the container still references two:

```yaml
services:
    reader:
        class: App\Heavy
        lazy: 'App\ReaderInterface'

    writer:
        class: App\Heavy
        lazy: 'App\WriterInterface'
```

Whichever definition loses the race is then fatal at runtime:

```
Error: Class "HeavyProxyF252ae6" not found
```

On 8.x, where `getProxyClass()` can also return the concrete class name, the same collision can instead inject the *other* proxy, which fails later with a `TypeError` on the consuming service.

Keying the de-duplication on the class plus the serialized `proxy` tags mirrors exactly what the name is built from: same class and same tags still share one proxy (as `testDedupLazyProxy` already covers), different tags get one each.

Spotted while reviewing #65103.
