### PR TITLE
[DependencyInjection] Fix misleading error messages for invalid "proxy" tags

### DIFF
--- a/src/Symfony/Component/DependencyInjection/LazyProxy/PhpDumper/LazyServiceDumper.php
+++ b/src/Symfony/Component/DependencyInjection/LazyProxy/PhpDumper/LazyServiceDumper.php
@@ -113,12 +113,19 @@ final class LazyServiceDumper implements DumperInterface
         $interfaces = [];
 
         if ($definition->hasTag('proxy')) {
-            foreach ($definition->getTag('proxy') as $tag) {
+            $tags = $definition->getTag('proxy');
+
+            foreach ($tags as $tag) {
                 if (!isset($tag['interface'])) {
                     throw new InvalidArgumentException(\sprintf('Invalid definition for service "%s": the "interface" attribute is missing on a "proxy" tag.', $id ?? $definition->getClass()));
                 }
-                if (!interface_exists($tag['interface']) && !class_exists($tag['interface'], false)) {
-                    throw new InvalidArgumentException(\sprintf('Invalid definition for service "%s": several "proxy" tags found but "%s" is not an interface.', $id ?? $definition->getClass(), $tag['interface']));
+                if (!interface_exists($tag['interface'])) {
+                    if (!class_exists($tag['interface'], false)) {
+                        throw new InvalidArgumentException(\sprintf('Invalid "proxy" tag for service "%s": "%s" is neither a class nor an interface.', $id ?? $definition->getClass(), $tag['interface']));
+                    }
+                    if (1 < \count($tags)) {
+                        throw new InvalidArgumentException(\sprintf('Invalid "proxy" tag for service "%s": several "proxy" tags found but "%s" is not an interface.', $id ?? $definition->getClass(), $tag['interface']));
+                    }
                 }
                 if ('object' !== $definition->getClass() && !is_a($class->name, $tag['interface'], true)) {
                     throw new InvalidArgumentException(\sprintf('Invalid "proxy" tag for service "%s": class "%s" doesn\'t implement "%s".', $id ?? $definition->getClass(), $definition->getClass(), $tag['interface']));

--- a/src/Symfony/Component/DependencyInjection/Tests/LazyProxy/PhpDumper/LazyServiceDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/LazyProxy/PhpDumper/LazyServiceDumperTest.php
@@ -54,6 +54,43 @@ class LazyServiceDumperTest extends TestCase
         $dumper->getProxyCode($definition);
     }
 
+    public function testMissingInterfaceAttribute()
+    {
+        $dumper = new LazyServiceDumper();
+        $definition = (new Definition(TestContainer::class))
+            ->setLazy(true)
+            ->addTag('proxy', []);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid definition for service "Symfony\Component\DependencyInjection\Tests\LazyProxy\PhpDumper\TestContainer": the "interface" attribute is missing on a "proxy" tag.');
+        $dumper->getProxyCode($definition);
+    }
+
+    public function testUnknownInterface()
+    {
+        $dumper = new LazyServiceDumper();
+        $definition = (new Definition(TestContainer::class))
+            ->setLazy(true)
+            ->addTag('proxy', ['interface' => 'Not\A\Real\Interfase']);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid "proxy" tag for service "Symfony\Component\DependencyInjection\Tests\LazyProxy\PhpDumper\TestContainer": "Not\A\Real\Interfase" is neither a class nor an interface.');
+        $dumper->getProxyCode($definition);
+    }
+
+    public function testSeveralProxyTagsRequireInterfaces()
+    {
+        $dumper = new LazyServiceDumper();
+        $definition = (new Definition(TestContainer::class))
+            ->setLazy(true)
+            ->addTag('proxy', ['interface' => TestContainer::class])
+            ->addTag('proxy', ['interface' => ContainerInterface::class]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid "proxy" tag for service "Symfony\Component\DependencyInjection\Tests\LazyProxy\PhpDumper\TestContainer": several "proxy" tags found but "Symfony\Component\DependencyInjection\Tests\LazyProxy\PhpDumper\TestContainer" is not an interface.');
+        $dumper->getProxyCode($definition);
+    }
+
     /**
      * @requires PHP 8.3
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Two error messages raised while generating a lazy proxy point at the wrong thing.

**"several `proxy` tags found" is reported for a single tag.** The message is attached to the check that verifies the tagged name resolves to something loadable, so it fires whenever the name is unknown, no matter how many tags there are. The common case is a typo in an FQCN, and the message then sends you looking for tags you never wrote:

```yaml
services:
    App\PaymentGateway:
        lazy: true
        tags:
            - { name: proxy, interface: App\Contract\PaymentGatway }
```
```
Invalid definition for service "App\PaymentGateway":
several "proxy" tags found but "App\Contract\PaymentGatway" is not an interface.
```

It also says "is not an interface" when a class is in fact accepted: a single `proxy` tag may name a class, which the generated proxy then extends.

The message now states what was actually checked:

```
Invalid "proxy" tag for service "App\PaymentGateway":
"App\Contract\PaymentGatway" is neither a class nor an interface.
```

**The case the old wording described was not validated.** With several `proxy` tags, they must all be interfaces, since the proxy can only extend one class. Naming a class among them was not rejected here; it fell through to the generator and surfaced as a generic message, with the real reason reachable only through `getPrevious()`:

```
Invalid definition for service "App\PaymentGateway".
  previous: Cannot generate lazy proxy: "App\LegacyGateway" is not an interface.
```

That condition is now checked where the other `proxy` tag validation happens, which is also where the "several" wording belongs:

```
Invalid "proxy" tag for service "App\PaymentGateway":
several "proxy" tags found but "App\LegacyGateway" is not an interface.
```

Valid configurations are unaffected, and the exception class is unchanged in both cases. The `interface` attribute check was already correct and had no test; it gets one here.
