### PR TITLE
[DependencyInjection] Fix instantiating a lazy proxy for an inline definition

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -1088,7 +1088,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
                 (clone $definition)
                     ->setClass($class)
                     ->setTags(($definition->hasTag('proxy') ? ['proxy' => $parameterBag->resolveValue($definition->getTag('proxy'))] : []) + $definition->getTags()),
-                $id, function ($proxy = false) use ($definition, &$inlineServices, $id) {
+                $id ?? $class, function ($proxy = false) use ($definition, &$inlineServices, $id) {
                     return $this->createService($definition, $inlineServices, true, $id, $proxy);
                 }
             );

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -508,6 +508,19 @@ class ContainerBuilderTest extends TestCase
         $this->assertInstanceOf(\Bar\FooClass::class, $foo1);
     }
 
+    public function testCreateLazyProxyForInlineDefinition()
+    {
+        $builder = new ContainerBuilder();
+        $builder->register('foo', 'Bar\FooClass')
+            ->setPublic(true)
+            ->setArguments([(new Definition('Bar\FooClass'))->setLazy(true)]);
+
+        $inline = $builder->get('foo')->arguments;
+
+        $this->assertInstanceOf(\Bar\FooClass::class, $inline);
+        $this->assertNotSame(\Bar\FooClass::class, $inline::class, 'The inline service is injected as a proxy');
+    }
+
     public function testClosureProxy()
     {
         $container = new ContainerBuilder();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Using a lazy inline service as an argument fails with a raw `TypeError` on a container that has not been compiled:

```php
$container->register('foo', FooClass::class)
    ->setArguments([(new Definition(HeavyService::class))->setLazy(true)]);

$container->get('foo');
```
```
TypeError: LazyServiceInstantiator::instantiateProxy(): Argument #3 ($id)
must be of type string, null given, called in ContainerBuilder.php on line 1086
```

Inline definitions have no service id, so `createService()` passes `null` where `InstantiatorInterface::instantiateProxy()` declares `string $id`. The rest of the chain already handles this: `LazyServiceDumper::isProxyCandidate()` and `getProxyCode()` both accept `?string $id` and fall back to the definition's class when naming the service in their messages.

The call site now applies that same fallback, so the id passed down is the resolved class. Compiled containers are unaffected, since they never go through `createService()`.
