### PR TITLE
[DependencyInjection] Drop a lazy-proxy test assertion that does not hold on higher branches

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -518,7 +518,6 @@ class ContainerBuilderTest extends TestCase
         $inline = $builder->get('foo')->arguments;
 
         $this->assertInstanceOf(\Bar\FooClass::class, $inline);
-        $this->assertNotSame(\Bar\FooClass::class, $inline::class, 'The inline service is injected as a proxy');
     }
 
     public function testClosureProxy()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Follow-up to #65113, which added `testCreateLazyProxyForInlineDefinition`. One of its assertions is true on 6.4 but not on the branches it merges up into:

```php
$this->assertNotSame(\Bar\FooClass::class, $inline::class, 'The inline service is injected as a proxy');
```

On 6.4 the lazy ghost is a generated subclass, so the class names differ. From 7.4 on, `LazyServiceInstantiator` uses PHP's native lazy objects and `ReflectionClass::newLazyGhost()` returns an instance of the class itself, so the two names are equal and the assertion fails. Verified against 8.2, where the same scenario yields `Bar\FooClass` with `isUninitializedLazyObject()` returning `true`: still lazy, just not a distinct class.

There is no portable way to express "is lazy" across those branches, since 6.4 exposes it through `LazyObjectInterface` and 7.4+ through a PHP 8.4 reflection API. The assertion is dropped rather than guarded, leaving the test to cover what it was written for: the argument used to be rejected with a `TypeError` before #65113. Reverting that fix still makes this test error, so it remains an effective regression guard.
