### PR TITLE
[Lock] Fix a released read lock letting a new read lock through while a write lock is held

### DIFF
--- a/src/Symfony/Component/Lock/Store/InMemoryStore.php
+++ b/src/Symfony/Component/Lock/Store/InMemoryStore.php
@@ -101,6 +101,10 @@ class InMemoryStore implements SharedLockStoreInterface
         $token = $this->getUniqueToken($key);
 
         unset($this->readLocks[$hashKey][$token]);
+        if (!($this->readLocks[$hashKey] ?? null)) {
+            unset($this->readLocks[$hashKey]);
+        }
+
         if (($this->locks[$hashKey] ?? null) === $token) {
             unset($this->locks[$hashKey]);
         }

--- a/src/Symfony/Component/Lock/Tests/Store/SharedLockStoreTestTrait.php
+++ b/src/Symfony/Component/Lock/Tests/Store/SharedLockStoreTestTrait.php
@@ -112,6 +112,39 @@ trait SharedLockStoreTestTrait
         $this->assertFalse($store->exists($key2));
     }
 
+    public function testSharedLockReleaseReadLockFirstWriteSecondReadThird()
+    {
+        $store = $this->getStore();
+
+        $resource = uniqid(__METHOD__, true);
+        $key1 = new Key($resource);
+        $key2 = new Key($resource);
+
+        $store->saveRead($key1);
+        $this->assertTrue($store->exists($key1));
+        $this->assertFalse($store->exists($key2));
+
+        $store->delete($key1);
+        $this->assertFalse($store->exists($key1));
+        $this->assertFalse($store->exists($key2));
+
+        $store->save($key1);
+        $this->assertTrue($store->exists($key1));
+        $this->assertFalse($store->exists($key2));
+
+        try {
+            $store->saveRead($key2);
+            $this->fail('The store shouldn\'t save the second key');
+        } catch (LockConflictedException $e) {
+        }
+        $this->assertTrue($store->exists($key1));
+        $this->assertFalse($store->exists($key2));
+
+        $store->delete($key1);
+        $this->assertFalse($store->exists($key1));
+        $this->assertFalse($store->exists($key2));
+    }
+
     public function testSharedLockPromote()
     {
         $store = $this->getStore();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65115
| License       | MIT

`InMemoryStore` grants a read lock on a resource that is already write-locked, as soon as that resource has ever been read-locked and released.

```php
$store->saveRead($key1);   // read lock
$store->delete($key1);     // released
$store->save($key1);       // write lock
$store->saveRead($key2);   // granted, should throw LockConflictedException
```

`delete()` removed the caller's token from `readLocks[$resource]` but kept the now empty array. `saveRead()` tests that array with `isset()` to detect "this resource is already read-locked, just add me as a reader", so the shortcut stayed true forever and skipped the write lock check below it. The entry was also never reclaimed, so a long running process kept one empty array per resource it had ever read-locked.

The fix removes the entry once its last reader is gone, which is what the promotion path in `save()` already does.

The single key case is enough to show the corruption: after read, release, write, the same key's `saveRead()` adds itself as a reader without clearing the write lock, so one key ends up holding both on the same resource.

Only `InMemoryStore` is affected. `FlockStore` clears its state in `delete()`, and `RedisStore` checks `ZSCORE key "__write__"` in its `saveRead` Lua script. `PostgreSqlStore` and `DoctrineDbalPostgreSqlStore` use a per-connection `InMemoryStore` as their same-connection guard, so they are fixed by this too; their normal path was already safe, but the `finally` blocks that release a lock that was not acquired call the internal `delete()` directly.

The regression test lives in `SharedLockStoreTestTrait`, so it also pins the guarantee for the stores that already satisfied it.
