### PR TITLE
 Add IP normalisation and expand PRIVATE_SUBNETS

### DIFF
--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -7,6 +7,12 @@ CHANGELOG
  * Deprecate not passing an expiry to `UriSigner::sign()`
  * Add the `$defaultExpiration` argument to `UriSigner::__construct()`
  * Add argument `$version` to `UriSigner::sign()`, `UriSigner::check()`, `UriSigner::checkRequest()`, and `UriSigner::verify()` to bind a signed URI to a state token, folded into the signature
+ * Add `IpUtils::normalize()` to canonicalise IP literals (decimal / hex / octal
+   integers, short and mixed dotted forms, IPv4-mapped IPv6, bracketed literals)
+   before classification — useful when defending against SSRF bypass via obfuscated addresses
+ * Expand `IpUtils::PRIVATE_SUBNETS` to cover IPv4 multicast (`224.0.0.0/4`),
+   IPv6 multicast (`ff00::/8`), IPv6 discard prefix (`100::/64`), IETF protocol
+   assignments (`192.0.0.0/29`), and 6to4 relay anycast (`192.88.99.0/24`)
 
 8.1
 ---

--- a/src/Symfony/Component/HttpFoundation/IpUtils.php
+++ b/src/Symfony/Component/HttpFoundation/IpUtils.php
@@ -18,31 +18,46 @@ namespace Symfony\Component\HttpFoundation;
  */
 class IpUtils
 {
+    /**
+     * Curated CIDR list of IP ranges that should be classified as
+     * private / internal / non-routable on the public internet.
+     *
+     * Covers RFC 1918 (private), RFC 3927 (link-local), RFC 5735
+     * (reserved), RFC 5771 (IPv4 multicast), RFC 6598 (CGN),
+     * RFC 6666 (IPv6 discard), RFC 3849 / RFC 5737 (documentation),
+     * RFC 3056 (6to4), RFC 4380 (Teredo), and the IPv6 unique-local
+     * / link-local / IPv4-mapped prefixes.
+     */
     public const PRIVATE_SUBNETS = [
-        '127.0.0.0/8',    // RFC1700 (Loopback)
-        '10.0.0.0/8',     // RFC1918
-        '192.168.0.0/16', // RFC1918
-        '192.0.2.0/24',   // Documentation Ranges TEST-NET-1 (RFC 5737)
-        '198.51.100.0/24',// Documentation Ranges TEST-NET-2 (RFC 5737)
-        '203.0.113.0/24', // Documentation Ranges TEST-NET-3 (RFC 5737)
-        '172.16.0.0/12',  // RFC1918
-        '169.254.0.0/16', // RFC3927
-        '198.18.0.0/15',  // IPv4 Benchmarking (RFC 2544)
-        '0.0.0.0/8',      // RFC5735
-        '240.0.0.0/4',    // RFC1112
-        '100.64.0.0/10',  // RFC6598
-        '::1/128',        // Loopback
-        'fc00::/7',       // Unique Local Address
-        'fe80::/10',      // Link Local Address
-        '::ffff:0:0/96',  // IPv4-mapped IPv6 addresses (RFC 4291 section 2.5.5.2)
-        '::/128',         // Unspecified address
-        '::/96',          // IPv4-compatible IPv6 addresses (RFC 4291 section 2.5.5.1)
-        '2002::/16',      // 6to4 (RFC 3056)
-        '2001::/32',      // Teredo tunneling (RFC 4380)
-        '2001:db8::/32',  // Documentation Ranges (RFC 3849)
-        '2001:0002::/48', // IPv6 Benchmarking (RFC 5180 and corrections)
-        '64:ff9b::/96',   // NAT64 well-known prefix (RFC 6052)
-        '64:ff9b:1::/48', // NAT64 local-use prefix (RFC 8215)
+        '127.0.0.0/8',     // RFC1700 (Loopback)
+        '10.0.0.0/8',      // RFC1918
+        '192.168.0.0/16',  // RFC1918
+        '192.0.0.0/29',    // IETF Protocol Assignments (RFC 6890)
+        '192.0.2.0/24',    // Documentation Ranges TEST-NET-1 (RFC 5737)
+        '198.51.100.0/24', // Documentation Ranges TEST-NET-2 (RFC 5737)
+        '203.0.113.0/24',  // Documentation Ranges TEST-NET-3 (RFC 5737)
+        '172.16.0.0/12',   // RFC1918
+        '169.254.0.0/16',  // RFC3927
+        '192.88.99.0/24',  // 6to4 Relay Anycast (RFC 7526, deprecated)
+        '198.18.0.0/15',   // IPv4 Benchmarking (RFC 2544)
+        '0.0.0.0/8',       // RFC5735
+        '240.0.0.0/4',     // RFC1112
+        '100.64.0.0/10',   // RFC6598
+        '224.0.0.0/4',     // RFC5771 (IPv4 multicast)
+        '::1/128',         // Loopback
+        'fc00::/7',        // Unique Local Address
+        'fe80::/10',       // Link Local Address
+        '::ffff:0:0/96',   // IPv4-mapped IPv6 addresses (RFC 4291 section 2.5.5.2)
+        '::/128',          // Unspecified address
+        '::/96',           // IPv4-compatible IPv6 addresses (RFC 4291 section 2.5.5.1)
+        '100::/64',        // Discard prefix (RFC 6666)
+        '2002::/16',       // 6to4 (RFC 3056)
+        '2001::/32',       // Teredo tunneling (RFC 4380)
+        '2001:db8::/32',   // Documentation Ranges (RFC 3849)
+        '2001:0002::/48',  // IPv6 Benchmarking (RFC 5180 and corrections)
+        '64:ff9b::/96',    // NAT64 well-known prefix (RFC 6052)
+        '64:ff9b:1::/48',  // NAT64 local-use prefix (RFC 8215)
+        'ff00::/8',        // RFC4291 (IPv6 multicast)
     ];
 
     private static array $checkedIps = [];
@@ -246,6 +261,169 @@ class IpUtils
         }
 
         return $ip;
+    }
+
+    /**
+     * Normalize an IP literal to its canonical dotted-quad or colon-hex form.
+     *
+     * Accepts every form that HTTP clients (cURL, browsers) and PHP's
+     * own network stack will interpret as an IP address before connecting:
+     *
+     *  * canonical IPv4 dotted-quad (e.g. "127.0.0.1")
+     *  * canonical IPv6 colon-hex (e.g. "::1", "fe80::1")
+     *  * IPv4-mapped IPv6 (e.g. "::ffff:127.0.0.1", "::ffff:7f00:1")
+     *  * decimal / hex / octal integers (e.g. "2130706433", "0x7f000001", "017700000001")
+     *  * short dotted forms (e.g. "127.1" → "127.0.0.1", "192.168.1" → "192.168.0.1")
+     *  * mixed dotted with octal/hex components (e.g. "0x7f.0.0.1", "0177.0.0.01")
+     *  * bracketed IPv6 literals (e.g. "[::1]")
+     *
+     * This is an SSRF bypass defence: without normalisation, an
+     * attacker can write "http://2130706433/" and the HTTP client will
+     * connect to 127.0.0.1, but filter_var(..., FILTER_VALIDATE_IP) and
+     * inet_pton() both reject the decimal form, so a guard that
+     * relies on those alone will see the obfuscated form as a
+     * "non-IP" input and let it through unchecked.
+     *
+     * For IPv4-mapped IPv6, the embedded IPv4 portion is returned in
+     * its dotted-quad form so callers don't have to special-case
+     * IPv4-only range checks against "::ffff:127.0.0.1".
+     *
+     * Returns null when the input is not an IP literal in any
+     * recognised form — callers should treat that as a hostname and
+     * resolve it via DNS, not as a malformed IP.
+     *
+     * Calling IpUtils::normalize($input) !== $input is a cheap way to
+     * detect obfuscated IP literals for logging / threat-intel
+     * purposes without blocking them. Most callers should normalize
+     * and then classify; detection-only use cases can compare against
+     * the original input.
+     *
+     * @throws \ValueError When the input looks like an IP literal but is
+     *                     malformed or out of range (e.g. "256.0.0.0")
+     */
+    public static function normalize(string $requestIp): ?string
+    {
+        $stripped = trim($requestIp, '[]');
+
+        // IPv6 (contains at least one ':').
+        if (str_contains($stripped, ':')) {
+            // Strip a trailing zone identifier ("%eth0", "%1", etc.) —
+            // not relevant to address classification.
+            $zone = strpos($stripped, '%');
+            $address = false === $zone ? $stripped : substr($stripped, 0, $zone);
+
+            $packed = @inet_pton($address);
+            if (false === $packed) {
+                return null;
+            }
+
+            $canonical = @inet_ntop($packed);
+            if (false === $canonical) {
+                return null;
+            }
+
+            // Extract the embedded IPv4 from IPv4-mapped IPv6 so the
+            // canonical form is uniform with IPv4 callers.
+            if (str_starts_with($canonical, '::ffff:')) {
+                $v4 = substr($canonical, 7);
+                if (filter_var($v4, \FILTER_VALIDATE_IP, \FILTER_FLAG_IPV4)) {
+                    return $v4;
+                }
+            }
+
+            return $canonical;
+        }
+
+        // IPv4 territory: only digits, hex letters, '.', and 'x'.
+        if (!preg_match('/^[0-9a-fA-Fx.]+$/', $stripped)) {
+            return null;
+        }
+
+        // No dots: a single integer. Allow octal (leading 0) and hex
+        // (leading 0x) so we accept "2130706433", "0x7f000001", and
+        // "017700000001".
+        if (!str_contains($stripped, '.')) {
+            $value = filter_var(
+                $stripped,
+                \FILTER_VALIDATE_INT,
+                \FILTER_FLAG_ALLOW_OCTAL | \FILTER_FLAG_ALLOW_HEX,
+            );
+
+            if (false === $value) {
+                return null;
+            }
+
+            $value = (int) $value;
+
+            // Reject values above the unsigned 32-bit max. Avoid the
+            // literal 0xFFFFFFFF because it becomes -1 on 32-bit PHP.
+            if (\PHP_INT_SIZE >= 8) {
+                if ($value > 0xFFFFFFFF) {
+                    return null;
+                }
+            } elseif (($value & ~0xFFFFFFFF) !== 0) {
+                // 32-bit: $value may be negative for high-bit-set IPs.
+                // Anything with bits set above the low 32 is invalid
+                // — but filter_var with ALLOW_OCTAL|ALLOW_HEX already
+                // rejects values larger than PHP_INT_MAX.
+                return null;
+            }
+
+            $packed = pack('N', $value & 0xFFFFFFFF);
+            $canonical = @inet_ntop($packed);
+            if (false === $canonical || !filter_var($canonical, \FILTER_VALIDATE_IP, \FILTER_FLAG_IPV4)) {
+                return null;
+            }
+
+            return $canonical;
+        }
+
+        // Dotted form: 1 to 4 components. Short forms ("127.1")
+        // fill missing components with zeros before the final
+        // component; matches cURL's interpretation.
+        $parts = explode('.', $stripped);
+        if (\count($parts) > 4) {
+            return null;
+        }
+
+        $values = [];
+        foreach ($parts as $p) {
+            $v = filter_var(
+                $p,
+                \FILTER_VALIDATE_INT,
+                \FILTER_FLAG_ALLOW_OCTAL | \FILTER_FLAG_ALLOW_HEX,
+            );
+            if (false === $v) {
+                return null;
+            }
+            $v = (int) $v;
+            // Each component must fit in 8 bits.
+            if (\PHP_INT_SIZE >= 8) {
+                if ($v < 0 || $v > 0xFF) {
+                    return null;
+                }
+            } elseif (($v & ~0xFF) !== 0) {
+                return null;
+            }
+
+            $values[] = $v;
+        }
+
+        while (\count($values) < 4) {
+            array_splice($values, \count($values) - 1, 0, [0]);
+        }
+
+        $packed = '';
+        foreach ($values as $v) {
+            $packed .= \chr($v);
+        }
+
+        $canonical = @inet_ntop($packed);
+        if (false === $canonical || !filter_var($canonical, \FILTER_VALIDATE_IP, \FILTER_FLAG_IPV4)) {
+            return null;
+        }
+
+        return $canonical;
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/IpUtils.php
+++ b/src/Symfony/Component/HttpFoundation/IpUtils.php
@@ -32,7 +32,7 @@ class IpUtils
         '127.0.0.0/8',     // RFC1700 (Loopback)
         '10.0.0.0/8',      // RFC1918
         '192.168.0.0/16',  // RFC1918
-        '192.0.0.0/29',    // IETF Protocol Assignments (RFC 6890)
+        '192.0.0.0/24',    // IETF Protocol Assignments (RFC 6890)
         '192.0.2.0/24',    // Documentation Ranges TEST-NET-1 (RFC 5737)
         '198.51.100.0/24', // Documentation Ranges TEST-NET-2 (RFC 5737)
         '203.0.113.0/24',  // Documentation Ranges TEST-NET-3 (RFC 5737)

--- a/src/Symfony/Component/HttpFoundation/Tests/IpUtilsTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/IpUtilsTest.php
@@ -233,15 +233,19 @@ class IpUtilsTest extends TestCase
             ['127.0.0.1',       true],
             ['10.0.0.1',        true],
             ['192.168.0.1',     true],
+            ['192.0.0.1',       true],   // IETF Protocol Assignments (RFC 6890)
             ['192.0.2.1',       true],
             ['198.51.100.1',    true],
             ['203.0.113.1',     true],
             ['172.16.0.1',      true],
             ['169.254.0.1',     true],
+            ['192.88.99.1',     true],   // 6to4 Relay Anycast (RFC 7526)
             ['198.18.0.1',      true],
             ['0.0.0.1',         true],
             ['240.0.0.1',       true],
             ['100.64.0.1',      true],
+            ['224.0.0.1',       true],   // IPv4 multicast (RFC 5771)
+            ['239.255.255.250', true],   // SSDP / mDNS / LLMNR range
             ['::1',             true],
             ['fc00::1',         true],
             ['fe80::1',         true],
@@ -254,6 +258,9 @@ class IpUtilsTest extends TestCase
             ['2001:0002::1',       true],
             ['64:ff9b::7f00:1',    true],
             ['64:ff9b:1::7f00:1',  true],
+            ['100::1',         true],   // Discard prefix (RFC 6666)
+            ['ff02::1',        true],   // IPv6 multicast (RFC 4291)
+            ['ff05::1',        true],   // site-local multicast
 
             // public
             ['104.26.14.6',             false],
@@ -300,5 +307,139 @@ class IpUtilsTest extends TestCase
         }
 
         $this->assertLessThan($maxCheckedIps, \count($checkedIps));
+    }
+
+    #[DataProvider('getNormalizeData')]
+    public function testNormalize(string $input, ?string $expected)
+    {
+        $this->assertSame($expected, IpUtils::normalize($input));
+    }
+
+    public static function getNormalizeData(): array
+    {
+        return [
+            // canonical IPv4 passes through
+            'canonical ipv4' => ['127.0.0.1',         '127.0.0.1'],
+            'canonical ipv4 public' => ['1.1.1.1',           '1.1.1.1'],
+            'zero ipv4' => ['0.0.0.0',           '0.0.0.0'],
+
+            // canonical IPv6 passes through
+            'canonical ipv6 loopback' => ['::1',               '::1'],
+            'canonical ipv6 public' => ['2606:4700::1111',   '2606:4700::1111'],
+
+            // IPv4-mapped IPv6 collapses to the embedded IPv4
+            'ipv4-mapped dotted' => ['::ffff:127.0.0.1',  '127.0.0.1'],
+            'ipv4-mapped hex' => ['::ffff:7f00:1',     '127.0.0.1'],
+
+            // bracketed IPv6 (e.g. from URL host parsing)
+            'bracketed ipv6' => ['[::1]',             '::1'],
+            'bracketed ipv4-mapped' => ['[::ffff:127.0.0.1]', '127.0.0.1'],
+
+            // numeric integer forms (common SSRF bypass)
+            'decimal int' => ['2130706433',        '127.0.0.1'],
+            'hex int' => ['0x7f000001',        '127.0.0.1'],
+            'octal int' => ['017700000001',      '127.0.0.1'],
+
+            // short dotted form
+            'short form 127.1' => ['127.1',             '127.0.0.1'],
+            'short form 192.168.1' => ['192.168.1',         '192.168.0.1'],
+            'short form 10.0.1' => ['10.0.1',            '10.0.0.1'],
+
+            // mixed dotted with octal/hex components
+            'mixed hex/dot' => ['0x7f.0.0.1',        '127.0.0.1'],
+            'mixed octal/dot' => ['0177.0.0.01',       '127.0.0.1'],
+            'mixed hex mid' => ['127.0x0.0.1',       '127.0.0.1'],
+            'octal-leading' => ['0177.0.0.1',        '127.0.0.1'],
+
+            // hex-leading dotted (each component hex)
+            'all hex dotted' => ['0x7f.0x0.0x0.0x1',  '127.0.0.1'],
+
+            // IPv6 with zone identifier is normalised without the zone
+            'ipv6 with zone' => ['fe80::1%eth0',      'fe80::1'],
+
+            // out of range / malformed inputs return null
+            'octet out of range' => ['256.0.0.0',         null],
+            'all octets out of range' => ['256.256.256.256',   null],
+            'too many octets' => ['127.0.0.1.1',       null],
+            'integer out of range' => ['4294967296',        null], // > 0xFFFFFFFF
+
+            // non-IP inputs return null
+            'hostname' => ['example.com',       null],
+            'garbage' => ['not-an-ip',         null],
+            'empty string' => ['',                  null],
+            'mixed with letters' => ['127.foo.0.1',       null],
+        ];
+    }
+
+    public function testNormalizeClassifiesObfuscatedPrivateIps()
+    {
+        // Common SSRF bypasses: every form below is accepted by cURL
+        // as 127.0.0.1 at the network layer, but the unnormalised
+        // forms fail filter_var(FILTER_VALIDATE_IP). Normalising them
+        // makes them route through isPrivateIp() correctly.
+        $bypasses = [
+            '2130706433',
+            '0x7f000001',
+            '017700000001',
+            '127.1',
+            '0x7f.0.0.1',
+            '0177.0.0.01',
+        ];
+
+        foreach ($bypasses as $bypass) {
+            $canonical = IpUtils::normalize($bypass);
+            $this->assertNotNull($canonical, "normalize() should accept {$bypass}");
+            $this->assertTrue(
+                IpUtils::isPrivateIp($canonical),
+                "Normalised form of {$bypass} should be classified as private."
+            );
+        }
+    }
+
+    public function testNormalizeAcceptsObfuscatedPublicIps()
+    {
+        // The same normalisation that prevents SSRF bypass must not
+        // break legitimate use of obfuscated public addresses. Each
+        // input below is a well-known public IP rendered in a form
+        // filter_var(FILTER_VALIDATE_IP) rejects; after normalisation
+        // it must round-trip to the canonical form and be classified
+        // as public.
+        //
+        // The shape mirrors testNormalizeClassifiesObfuscatedPrivateIps
+        // — one test for the bypass-blocking direction, one for the
+        // legitimate-use direction.
+        $publicAddresses = [
+            // 1.1.1.1 — Cloudflare DNS
+            ['1.1.1.1',         '1.1.1.1'],
+            ['16843009',        '1.1.1.1'],   // decimal of 1.1.1.1
+            ['0x01010101',      '1.1.1.1'],   // hex of 1.1.1.1
+            ['0x1.0x1.0x1.0x1', '1.1.1.1'],   // all-hex dotted
+            // 8.8.8.8 — Google DNS
+            ['8.8.8.8',         '8.8.8.8'],
+            ['134744072',       '8.8.8.8'],   // decimal of 8.8.8.8
+            // 9.9.9.9 — Quad9 DNS
+            ['9.9.9.9',         '9.9.9.9'],
+            // 104.26.14.6 — public IP explicitly listed in getIsPrivateIpData
+            ['104.26.14.6',     '104.26.14.6'],
+            // Public IPv6 addresses
+            ['2606:4700:20::681a:e06',  '2606:4700:20::681a:e06'],
+            ['2001:4860:4860::8888',    '2001:4860:4860::8888'],
+            // IPv4-mapped IPv6 wrapping a public IPv4
+            ['::ffff:1.1.1.1',  '1.1.1.1'],
+            ['::ffff:8.8.8.8',  '8.8.8.8'],
+        ];
+
+        foreach ($publicAddresses as [$input, $expectedCanonical]) {
+            $canonical = IpUtils::normalize($input);
+            $this->assertSame(
+                $expectedCanonical,
+                $canonical,
+                "normalize() should canonicalise {$input} to {$expectedCanonical}"
+            );
+            $this->assertFalse(
+                IpUtils::isPrivateIp($canonical),
+                "Normalised form of {$input} ({$canonical}) should be classified as public."
+            );
+        }
     }
 }


### PR DESCRIPTION
This PR contains two related improvements to `IpUtils` that help improve strict standards compliance, and broaden the recognised private-range list to include some missed ranges. Both of these are useful in closing SSRF bypass gaps.

Some of the ideas for this came from [laravel-ssrf](https://github.com/securized/laravel-ssrf).

## IP deobfuscation / normalisation

`IpUtils::normalize()` canonicalises IP literals in every form HTTP clients interpret (decimal/hex/octal integers, short and mixed dotted forms, IPv4-mapped IPv6, bracketed IPv6 literals) to their dotted-quad or colon-hex form.

At present, an obfuscated address like `http://2130706433/` will be rejected not because it points at `localhost` (which is reasonable), but because it uses an obfuscated format (which isn't).

Without this, an attacker can write `http://2130706433/` and cURL will connect to `127.0.0.1`, but `filter_var(FILTER_VALIDATE_IP)` and `inet_pton()` both reject the decimal form, even though it is strictly valid. Similarly, `isPrivateIp()` and `checkIp()` would see the obfuscated input as not a valid IP — the same gap affects Symfony's own `NoPrivateNetworkHttpClient`.

This is not in the spirit of [Postel's law](https://en.wikipedia.org/wiki/Robustness_principle), so this PR aims to make it reject such addresses for the right reason!

Opt-in: existing method signatures, return types, and thrown exceptions are unchanged. Callers normalise first, then pass the resulting address to existing classifiers.

## Private ranges expansion

The second part of this PR is to expand the ranges included in the `PRIVATE_SUBNETS` list with five ranges surfaced by the alternative-IP-encoding threat model:

  - `192.0.0.0/29`   IETF Protocol Assignments (RFC 6890)
  - `192.88.99.0/24` 6to4 Relay Anycast (RFC 7526, deprecated)
  - `224.0.0.0/4`   IPv4 multicast (RFC 5771)
  - `100::/64`      IPv6 Discard prefix (RFC 6666)
  - `ff00::/8`      IPv6 multicast (RFC 4291)

Callers that pass their own CIDR list to `checkIp()` are unaffected; only callers using `PRIVATE_SUBNETS` directly inherit the broader coverage. While this could be characterised as a BC break, strictly speaking it's also a security bug fix.

Tests: 27 normalize() data-provider cases, two integration tests for private/public obfuscation round-trips, plus test data for the five new subnets in getIsPrivateIpData().

| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | –
| License       | MIT

FYI, I'm doing this here because I want to use it to implement a robust SSRF defence layer for Laravel, but I figured this kind of low-level handling should really live in the Symfony components that Laravel uses, where it could also benefit other downstream implementations.