### PR TITLE
[DependencyInjection] Fix `#[Autoconfigure]` being processed twice for PSR-4-discovered abstract types

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
@@ -203,7 +203,6 @@ abstract class FileLoader extends BaseFileLoader
                 if ($r->isInterface()) {
                     $this->interfaces[] = $class;
                 }
-                $autoconfigureAttributes?->processClass($this->container, $r);
                 $definition->setAbstract(true)
                     ->addTag('container.excluded', ['source' => 'because the class is abstract']);
                 continue;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/PrototypeAutoconfigure/AutoconfiguredInterface.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/PrototypeAutoconfigure/AutoconfiguredInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeAutoconfigure;
+
+use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
+
+#[Autoconfigure(
+    tags: ['prototype_autoconfigure'],
+    calls: [
+        ['addCall' => ['from_interface']],
+    ],
+)]
+interface AutoconfiguredInterface
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/PrototypeAutoconfigure/AutoconfiguredService.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/PrototypeAutoconfigure/AutoconfiguredService.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeAutoconfigure;
+
+class AutoconfiguredService implements AutoconfiguredInterface
+{
+    public array $calls = [];
+
+    public function addCall(string $value): void
+    {
+        $this->calls[] = $value;
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/FileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/FileLoaderTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Loader\LoaderResolver;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\Compiler\RegisterAutoconfigureAttributesPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
@@ -46,6 +47,7 @@ use Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeAsAlias\WithAs
 use Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeAsAlias\WithAsAliasMultiple;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeAsAlias\WithAsAliasProdEnv;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeAsAlias\WithCustomAsAlias;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeAutoconfigure\AutoconfiguredService;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\Utils\NotAService;
 
 class FileLoaderTest extends TestCase
@@ -185,6 +187,8 @@ class FileLoaderTest extends TestCase
         $this->assertFalse($alias->isPublic());
         $this->assertTrue($alias->isPrivate());
 
+        (new RegisterAutoconfigureAttributesPass())->process($container);
+
         $this->assertEquals([FooInterface::class => (new ChildDefinition(''))->addTag('foo')], $container->getAutoconfiguredInstanceof());
     }
 
@@ -204,6 +208,45 @@ class FileLoaderTest extends TestCase
         $this->assertTrue($definition->isAbstract());
         $this->assertTrue($definition->hasTag('container.excluded'));
         $this->assertTrue($definition->isAutoconfigured());
+    }
+
+    public function testRegisterClassesDoesNotDuplicateAutoconfigurationFromAbstractTypes()
+    {
+        $container = new ContainerBuilder();
+        $loader = new TestFileLoader($container, new FileLocator(self::$fixturesPath.'/Fixtures'));
+
+        $loader->registerClasses(
+            (new Definition())->setAutoconfigured(true)->setPublic(true),
+            'Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeAutoconfigure\\',
+            'PrototypeAutoconfigure/*'
+        );
+
+        $container->compile();
+
+        $definition = $container->getDefinition(AutoconfiguredService::class);
+        $this->assertCount(1, $definition->getMethodCalls());
+        $this->assertSame('addCall', $definition->getMethodCalls()[0][0]);
+        $this->assertSame([[]], $definition->getTag('prototype_autoconfigure'));
+        $this->assertSame(['from_interface'], $container->get(AutoconfiguredService::class)->calls);
+    }
+
+    public function testRegisterClassesTwiceDoesNotDuplicateAutoconfigurationFromAbstractTypes()
+    {
+        $container = new ContainerBuilder();
+        $loader = new TestFileLoader($container, new FileLocator(self::$fixturesPath.'/Fixtures'));
+
+        foreach ([1, 2] as $load) {
+            $loader->registerClasses(
+                (new Definition())->setAutoconfigured(true)->setPublic(true),
+                'Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeAutoconfigure\\',
+                'PrototypeAutoconfigure/*'
+            );
+        }
+
+        $container->compile();
+
+        $this->assertCount(1, $container->getDefinition(AutoconfiguredService::class)->getMethodCalls());
+        $this->assertSame(['from_interface'], $container->get(AutoconfiguredService::class)->calls);
     }
 
     public function testMissingParentClass()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Since #61578, `FileLoader::registerClasses()` keeps a `.abstract.*` definition for discovered abstract classes and interfaces, but it also kept the old eager call to `RegisterAutoconfigureAttributesPass::processClass()`. The retained definition is autoconfigured, so **the compiler pass processes the same class a second time**: tags happen to be deduplicated later, but configured method calls are appended and executed twice at runtime.

This PR removes the eager call, which was only needed when no definition was retained. Discovered abstract types now follow the same lifecycle as concrete and `#[Exclude]` classes: attributes are read once, by the compiler pass. This also fixes the duplication when overlapping `resource` prototypes scan the same abstract type, and the `merge()` "has already been autoconfigured" error when an app and a bundle discover the same interface.
