### PR TITLE
[Messenger] Re-send original payload when retrying undecodable messages

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/Transport/Serialization/SerializerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Serialization/SerializerTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
 use Symfony\Component\Messenger\Stamp\DeduplicateStamp;
 use Symfony\Component\Messenger\Stamp\NonSendableStampInterface;
+use Symfony\Component\Messenger\Stamp\RedeliveryStamp;
 use Symfony\Component\Messenger\Stamp\SerializedMessageStamp;
 use Symfony\Component\Messenger\Stamp\SerializerStamp;
 use Symfony\Component\Messenger\Stamp\ValidationStamp;
@@ -374,6 +375,75 @@ class SerializerTest extends TestCase
         $this->assertInstanceOf(DummyMessageWithSerializedTypeName::class, $decodedEnvelope->getMessage());
         $this->assertSame('Hello', $decodedEnvelope->getMessage()->getMessage());
     }
+
+    public function testDecodingFailureKeepsDecodedStampsOnTheWrappedEnvelope()
+    {
+        $serializer = new Serializer();
+
+        // a payload whose stamps decode fine but whose body cannot be deserialized
+        $encodedEnvelope = [
+            'body' => '{}',
+            'headers' => [
+                'type' => DummyMessageWithPrivateConstructorProperty::class,
+                'X-Message-Stamp-'.RedeliveryStamp::class => '[{"retryCount":2,"redeliveredAt":"2026-08-03T11:47:47+00:00"}]',
+                'Content-Type' => 'application/json',
+            ],
+        ];
+
+        $envelope = $serializer->decode($encodedEnvelope);
+
+        $this->assertInstanceOf(MessageDecodingFailedException::class, $envelope->getMessage());
+
+        $redeliveryStamp = $envelope->last(RedeliveryStamp::class);
+        $this->assertNotNull($redeliveryStamp, 'Stamps decoded from headers must be kept on the wrapper envelope, otherwise the retry counter resets on every redelivery.');
+        $this->assertSame(2, $redeliveryStamp->getRetryCount());
+    }
+
+    public function testEncodingDecodeFailureWrapperReemitsOriginalPayload()
+    {
+        $serializer = new Serializer();
+
+        $originalEncoded = [
+            'body' => '{"some":"payload"}',
+            'headers' => ['type' => 'App\NonExistentMessage', 'Content-Type' => 'application/json'],
+        ];
+
+        $wrapperEnvelope = $serializer->decode($originalEncoded);
+        $this->assertInstanceOf(MessageDecodingFailedException::class, $wrapperEnvelope->getMessage());
+
+        $reEncoded = $serializer->encode($wrapperEnvelope->with(new RedeliveryStamp(1)));
+
+        $this->assertSame($originalEncoded['body'], $reEncoded['body'], 'Re-sending a decode-failure wrapper must re-emit the original payload.');
+        $this->assertSame('App\NonExistentMessage', $reEncoded['headers']['type'], 'The original type header must be preserved so a later decode can succeed after a fix.');
+        $this->assertArrayHasKey('X-Message-Stamp-'.RedeliveryStamp::class, $reEncoded['headers'], 'Current stamps must be in the headers so the retry counter survives.');
+    }
+
+    public function testEncodingDecodeFailureWrapperWithoutOriginalHeaders()
+    {
+        $serializer = new Serializer();
+
+        // PhpSerializer::encode() returns a body without any headers
+        $envelope = new Envelope(new MessageDecodingFailedException('Could not decode message', 0, null, ['body' => 'a:0:{}']));
+
+        $reEncoded = $serializer->encode($envelope);
+
+        $this->assertSame('a:0:{}', $reEncoded['body']);
+        $this->assertSame(MessageDecodingFailedException::class, $reEncoded['headers']['type']);
+        $this->assertArrayNotHasKey('Content-Type', $reEncoded['headers'], 'The content type must not describe a body encoded by another serializer.');
+    }
+
+    public function testEncodingDecodeFailureWrapperWithoutOriginalBody()
+    {
+        $serializer = new Serializer();
+
+        $envelope = new Envelope(new MessageDecodingFailedException('Could not decode message', 0, null, ['headers' => ['type' => 'App\NonExistentMessage']]));
+
+        $reEncoded = $serializer->encode($envelope);
+
+        $this->assertStringContainsString('Could not decode message', $reEncoded['body']);
+        $this->assertSame(MessageDecodingFailedException::class, $reEncoded['headers']['type'], 'Without an original body, the headers must describe the body that was actually encoded.');
+        $this->assertSame('application/json', $reEncoded['headers']['Content-Type']);
+    }
 }
 class DummySymfonySerializerNonSendableStamp implements NonSendableStampInterface
 {
@@ -381,6 +451,12 @@ class DummySymfonySerializerNonSendableStamp implements NonSendableStampInterfac
 class DummySymfonySerializerInvalidConstructor
 {
     public function __construct(string $missingArgument)
+    {
+    }
+}
+class DummyMessageWithPrivateConstructorProperty
+{
+    public function __construct(private string $secret)
     {
     }
 }

--- a/src/Symfony/Component/Messenger/Transport/Serialization/Serializer.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/Serializer.php
@@ -109,7 +109,7 @@ class Serializer implements SerializerInterface, MessageTypeAwareSerializerInter
         try {
             $message = $this->serializer->deserialize($encodedEnvelope['body'], $type, $this->format, $context);
         } catch (\Throwable $e) {
-            return MessageDecodingFailedException::wrap($encodedEnvelope, 'Could not decode message: '.$e->getMessage(), (int) $e->getCode(), $e);
+            return MessageDecodingFailedException::wrap($encodedEnvelope, 'Could not decode message: '.$e->getMessage(), (int) $e->getCode(), $e)->with(...$stamps);
         }
 
         return new Envelope($message, $stamps);
@@ -131,19 +131,28 @@ class Serializer implements SerializerInterface, MessageTypeAwareSerializerInter
 
         $serializedMessageStamp = $envelope->last(SerializedMessageStamp::class);
 
+        // A decode failure keeps the original encoded envelope: re-emit its body as-is
+        // instead of serializing the exception, which cannot be decoded back
+        $decodingFailure = $envelope->getMessage() instanceof MessageDecodingFailedException
+            ? $envelope->getMessage()->encodedEnvelope
+            : [];
+        $decodingFailureBody = \is_string($decodingFailure['body'] ?? null) ? $decodingFailure['body'] : null;
+        // the original headers describe the original body, so they win for "type" and "Content-Type"
+        $decodingFailureHeaders = null !== $decodingFailureBody && \is_array($decodingFailure['headers'] ?? null) ? $decodingFailure['headers'] : [];
+
         $envelope = $envelope->withoutStampsOfType(NonSendableStampInterface::class);
 
         $headers = [
-            'type' => $this->getTypeFromEnvelope($envelope),
+            'type' => $decodingFailureHeaders['type'] ?? $this->getTypeFromEnvelope($envelope),
             ...$this->encodeStamps($envelope),
-            ...$this->getContentTypeHeader(),
+            ...(null !== $decodingFailureBody ? [] : $this->getContentTypeHeader()),
         ];
 
         return [
-            'body' => $serializedMessageStamp
-                ? $serializedMessageStamp->getSerializedMessage()
-                : $this->serializer->serialize($envelope->getMessage(), $this->format, $context),
-            'headers' => $headers,
+            'body' => $decodingFailureBody
+                ?? $serializedMessageStamp?->getSerializedMessage()
+                ?? $this->serializer->serialize($envelope->getMessage(), $this->format, $context),
+            'headers' => $headers + $decodingFailureHeaders,
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65107
| License       | MIT

A message that cannot be decoded is retried forever, with a payload that roughly doubles on every round and a retry counter that never advances.

Since 8.1, `Serializer::decode()` returns an `Envelope` wrapping a `MessageDecodingFailedException` instead of throwing, so the failure goes through the normal retry and failure transport path. Two things kept that path from ever ending.

`MessageDecodingFailedException::wrap()` builds a bare envelope, so the stamps that `decode()` had just read from the headers were dropped. The `RedeliveryStamp` went with them, so every redelivery started again from retry 0 and `max_retries` was never reached.

`encode()` then serialized the live exception object as the new body, including its `previous` chain and its `encodedEnvelope` property. The result cannot be decoded either, and it is bigger than what it wraps, so each cycle produced a larger undecodable message.

Measured on a poison message of 2 bytes with `max_retries: 3`, before:

```
body sizes:   2, 7176, 17764, 30777, 48640, 76203, 123166, 208929, 372292, 690855, ...
retry counts: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ...
failure transport: empty
```

after:

```
body sizes:   2, 2, 2, 2
retry counts: 0, 1, 2, 3
Removing from transport after 3 retries. Rejected message will be sent to the failure transport.
```

This fixes both halves in the transport `Serializer`:

* `decode()` keeps the stamps it decoded from the headers on the wrapper envelope, so the redelivery counter survives
* `encode()` re-emits the original body, plus the headers that describe it, instead of serializing the exception

The original headers win for `type` and `Content-Type`, because they describe the body being re-emitted. Stamp headers come from the current envelope, so the retry counter moves forward. Any other header present only on the original is carried over.

Both behaviors apply only when the original encoded envelope actually carries a body. A serializer that returns a body without headers, as `PhpSerializer` does, still works, and an exception constructed without an encoded envelope is serialized normally.

Once the cause is fixed, for example the missing class is deployed, the message is decoded and handled on the next attempt, which is the behavior `DecodeFailedMessageMiddleware` was added for. Replaying from the failure transport also works again, with both a `PhpSerializer` and a JSON failure transport.

Known gap, left for a follow-up: this covers the decode failure raised when `deserialize()` throws. The earlier returns in `decode()`, for an empty body, a missing `type` header, or stamp headers that cannot be decoded, still produce a wrapper without stamps. Those messages no longer grow, but they are still retried without the counter advancing.
