### PR TITLE
[HttpClient] Add the extra.cache_policy option to CachingHttpClient

### DIFF
--- a/src/Symfony/Component/HttpClient/CHANGELOG.md
+++ b/src/Symfony/Component/HttpClient/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `extra.cache_policy` option to `CachingHttpClient` to tag cached responses and force their lifetime
+
 8.1
 ---
 

--- a/src/Symfony/Component/HttpClient/CachePolicy.php
+++ b/src/Symfony/Component/HttpClient/CachePolicy.php
@@ -1,0 +1,114 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient;
+
+use Symfony\Component\HttpClient\Exception\InvalidArgumentException;
+use Symfony\Contracts\Cache\ItemInterface;
+
+/**
+ * Decides how a response is stored by CachingHttpClient.
+ *
+ * An instance is passed to the "extra.cache_policy" option, which is called once the
+ * response headers are known:
+ *
+ *     $client->request('GET', $url, ['extra' => ['cache' => function (CachePolicy $cache, int $statusCode, array $headers) {
+ *         $cache->tag('product-42')->expiresAfter(3600);
+ *     }]]);
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+final class CachePolicy
+{
+    private array $tags = [];
+    private ?int $ttl = null;
+    private ?\Closure $bodyTagResolver = null;
+
+    /**
+     * Tags the stored response, so that it can be invalidated with CacheInterface::invalidateTags().
+     *
+     * @param string|iterable<string> $tags
+     */
+    public function tag(string|iterable $tags): static
+    {
+        foreach (\is_string($tags) ? [$tags] : $tags as $tag) {
+            if (!\is_string($tag) || '' === $tag) {
+                throw new InvalidArgumentException(\sprintf('Cache tags must be non-empty strings, "%s" given.', get_debug_type($tag)));
+            }
+
+            if (strpbrk($tag, ItemInterface::RESERVED_CHARACTERS)) {
+                throw new InvalidArgumentException(\sprintf('The cache tag "%s" contains one of the reserved characters "%s".', $tag, ItemInterface::RESERVED_CHARACTERS));
+            }
+
+            $this->tags[] = $tag;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Stores the response for the given number of seconds, whatever its cache directives say.
+     *
+     * This makes a response cacheable that would not be, and replaces the freshness
+     * lifetime computed from its headers. Pass null to fall back to those headers.
+     */
+    public function expiresAfter(?int $ttl): static
+    {
+        if (null !== $ttl && $ttl < 0) {
+            throw new InvalidArgumentException(\sprintf('The cache TTL must be a positive number of seconds, "%d" given.', $ttl));
+        }
+
+        $this->ttl = $ttl;
+
+        return $this;
+    }
+
+    /**
+     * Tags the stored response with tags computed from its body.
+     *
+     * The resolver is called once the body has been received, which requires the
+     * "buffer" option to be true; the tags are dropped and a warning is logged otherwise.
+     *
+     * @param callable(string $body): iterable<string> $resolver
+     */
+    public function tagFromBody(callable $resolver): static
+    {
+        $this->bodyTagResolver = $resolver(...);
+
+        return $this;
+    }
+
+    /**
+     * @return list<string>
+     *
+     * @internal
+     */
+    public function getTags(): array
+    {
+        return array_values(array_unique($this->tags));
+    }
+
+    /**
+     * @internal
+     */
+    public function getTtl(): ?int
+    {
+        return $this->ttl;
+    }
+
+    /**
+     * @internal
+     */
+    public function getBodyTagResolver(): ?\Closure
+    {
+        return $this->bodyTagResolver;
+    }
+}

--- a/src/Symfony/Component/HttpClient/CachingHttpClient.php
+++ b/src/Symfony/Component/HttpClient/CachingHttpClient.php
@@ -16,6 +16,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpClient\Caching\Freshness;
 use Symfony\Component\HttpClient\Chunk\ErrorChunk;
 use Symfony\Component\HttpClient\Exception\ChunkCacheItemNotFoundException;
+use Symfony\Component\HttpClient\Exception\InvalidArgumentException;
 use Symfony\Component\HttpClient\Response\AsyncContext;
 use Symfony\Component\HttpClient\Response\AsyncResponse;
 use Symfony\Component\HttpClient\Response\MockResponse;
@@ -144,6 +145,12 @@ class CachingHttpClient implements HttpClientInterface, LoggerAwareInterface, Re
         $fullUrlTag = self::hash($fullUrl);
         $requestCacheControl = self::parseRequestCacheControlHeader($options['normalized_headers']['cache-control'] ?? []);
 
+        $cacheHook = $options['extra']['cache_policy'] ?? null;
+
+        if (null !== $cacheHook && !\is_callable($cacheHook)) {
+            throw new InvalidArgumentException(\sprintf('The "extra.cache_policy" option must be a callable, "%s" given.', get_debug_type($cacheHook)));
+        }
+
         if ('' !== $options['body'] || ($options['extra']['no_cache'] ?? false) || isset($options['normalized_headers']['range']) || !\in_array($method, self::CACHEABLE_METHODS, true)) {
             if (isset($requestCacheControl['only-if-cached'])) {
                 return self::createGatewayTimeoutResponse($method, $url, $options);
@@ -230,6 +237,7 @@ class CachingHttpClient implements HttpClientInterface, LoggerAwareInterface, Re
         $passthru = function (ChunkInterface $chunk, AsyncContext $context) use (
             $expiresAt,
             $fullUrlTag,
+            $cacheHook,
             $requestHash,
             $varyKey,
             $varyFields,
@@ -246,6 +254,11 @@ class CachingHttpClient implements HttpClientInterface, LoggerAwareInterface, Re
             static $attemptTag = null;
             static $firstChunkKey = null;
             static $chunkKey = null;
+            static $cachePolicy = null;
+            static $tagsFromResponseResolver = null;
+            static $extraTags = [];
+            static $pendingChunks = [];
+            static $accumulatedContent = '';
 
             if (null !== $chunk->getError() || $chunk->isTimeout()) {
                 null !== $attemptTag && $this->cache->invalidateTags([$attemptTag]);
@@ -303,14 +316,28 @@ class CachingHttpClient implements HttpClientInterface, LoggerAwareInterface, Re
                     }
                     $correctedInitialAge = self::getCorrectedInitialAge($headers, $requestTime, $responseTime);
                     $updatedHeaders = self::filterStorableHeaders(array_merge($cachedData['headers'], $headers), self::getExcludedHeaders($headers));
+                    // The entry is shared between requests, so the tags it already carries must
+                    // survive: a revalidating request can only add to them. Tags coming from the
+                    // response cannot be re-resolved here anyway, a 304 carries no body.
+                    $revalidationPolicy = null;
+
+                    if (null !== $cacheHook) {
+                        $cacheHook($revalidationPolicy = new CachePolicy(), $cachedData['status_code'], $updatedHeaders);
+                    }
+
+                    $tagsForRevalidation = self::mergeCacheTags(
+                        $cachedData['cache_tags'] ?? [],
+                        $revalidationPolicy?->getTags() ?? [],
+                    );
                     $updatedCachedData = array_replace($cachedData, [
                         'stored_at' => $responseTime,
                         'initial_age' => $correctedInitialAge,
                         'headers' => $updatedHeaders,
+                        'cache_tags' => $tagsForRevalidation,
                     ]);
 
                     $updatedCacheControl = self::parseCacheControlHeader($updatedCachedData['headers']['cache-control'] ?? []);
-                    $updatedCachedData['expires_at'] = self::calculateExpiresAt($this->determineMaxAge($updatedCachedData['headers'], $updatedCacheControl, $correctedInitialAge, $requestTime, $responseTime));
+                    $updatedCachedData['expires_at'] = self::calculateExpiresAt($revalidationPolicy?->getTtl() ?? $this->determineMaxAge($updatedCachedData['headers'], $updatedCacheControl, $correctedInitialAge, $requestTime, $responseTime));
 
                     $newVaryFields = $this->parseVaryFields($updatedCachedData['headers']['vary'] ?? []);
                     $updatedMetadataIsCacheable = !\in_array('*', $newVaryFields, true)
@@ -323,14 +350,14 @@ class CachingHttpClient implements HttpClientInterface, LoggerAwareInterface, Re
                         $context->passthru();
 
                         if (!$hasClientConditionalValidator) {
-                            $context->replaceResponse($this->createResponseFromCache($updatedCachedData, $method, $url, $options, $metadataKey, $expiresAt));
+                            $context->replaceResponse($this->createResponseFromCache($updatedCachedData, $method, $url, $options, $metadataKey, $expiresAt, [$fullUrlTag, $metadataKey, ...$tagsForRevalidation]));
                         }
 
                         return;
                     }
 
-                    $updatedCachedData = $this->cache->get($metadataKey, static function (ItemInterface $item) use ($updatedCachedData, $expiresAt, $fullUrlTag, $metadataKey): array {
-                        $item->expiresAt($expiresAt)->tag([$fullUrlTag, $metadataKey]);
+                    $updatedCachedData = $this->cache->get($metadataKey, static function (ItemInterface $item) use ($updatedCachedData, $expiresAt, $fullUrlTag, $metadataKey, $tagsForRevalidation): array {
+                        $item->expiresAt($expiresAt)->tag([$fullUrlTag, $metadataKey, ...$tagsForRevalidation]);
 
                         return $updatedCachedData;
                     }, \INF);
@@ -338,7 +365,7 @@ class CachingHttpClient implements HttpClientInterface, LoggerAwareInterface, Re
                     $context->passthru();
 
                     if (!$hasClientConditionalValidator) {
-                        $context->replaceResponse($this->createResponseFromCache($updatedCachedData, $method, $url, $options, $metadataKey, $expiresAt));
+                        $context->replaceResponse($this->createResponseFromCache($updatedCachedData, $method, $url, $options, $metadataKey, $expiresAt, [$fullUrlTag, $metadataKey, ...$tagsForRevalidation]));
                     }
 
                     return;
@@ -367,7 +394,12 @@ class CachingHttpClient implements HttpClientInterface, LoggerAwareInterface, Re
 
                 $cacheControl = self::parseCacheControlHeader($headers['cache-control'] ?? []);
 
-                if (!$this->isServerResponseCacheable($statusCode, $options['normalized_headers'], $headers, $cacheControl)) {
+                if (null !== $cacheHook) {
+                    $cacheHook($cachePolicy = new CachePolicy(), $statusCode, $headers);
+                }
+
+                // a forced TTL stores the response whatever its directives say
+                if (null === $cachePolicy?->getTtl() && !$this->isServerResponseCacheable($statusCode, $options['normalized_headers'], $headers, $cacheControl)) {
                     $context->passthru();
 
                     yield $chunk;
@@ -400,6 +432,23 @@ class CachingHttpClient implements HttpClientInterface, LoggerAwareInterface, Re
                     return $newVaryFields;
                 }, \INF);
 
+                // Tags depending on the response body are added at isLast(); see below.
+                $extraTags = $cachePolicy?->getTags() ?? [];
+                $tagsFromResponseResolver = $cachePolicy?->getBodyTagResolver();
+
+                // Tagging from the body means holding it in memory until the last chunk, which
+                // is the caller's decision to make through the "buffer" option. Asking for both
+                // is contradictory: the tags are dropped, and saying so out loud matters, the
+                // entry would otherwise be stored without the tags meant to invalidate it.
+                if (null !== $tagsFromResponseResolver && true !== ($options['buffer'] ?? true)) {
+                    $this->logger?->warning('Ignoring the tags of "tagFromBody()" for "{method} {url}": the "extra.cache_policy" option needs the "buffer" option to be true to read the response body.', [
+                        'method' => $method,
+                        'url' => $url,
+                    ]);
+
+                    $tagsFromResponseResolver = null;
+                }
+
                 $firstChunkKey = $chunkKey = self::generateChunkKey();
 
                 yield $chunk;
@@ -415,8 +464,30 @@ class CachingHttpClient implements HttpClientInterface, LoggerAwareInterface, Re
             }
 
             if ($chunk->isLast()) {
-                $this->cache->get($chunkKey, static function (ItemInterface $item) use ($expiresAt, $fullUrlTag, $metadataKey, $chunk, $attemptTag): array {
-                    $item->tag([$fullUrlTag, $metadataKey, $attemptTag])->expiresAt($expiresAt);
+                if (null !== $tagsFromResponseResolver) {
+                    $accumulatedContent .= $chunk->getContent();
+                    $extraTags = self::mergeCacheTags(
+                        $extraTags,
+
+                        self::resolveCacheTagsFromBody($tagsFromResponseResolver, $accumulatedContent),
+                    );
+
+                    foreach ($pendingChunks as $pending) {
+                        $content = substr($accumulatedContent, $pending['offset'], $pending['length']);
+                        $writeChunk = static function (ItemInterface $item) use ($content, $pending, $expiresAt, $fullUrlTag, $metadataKey, $attemptTag, $extraTags): array {
+                            $item->tag([$fullUrlTag, $metadataKey, $attemptTag, ...$extraTags])->expiresAt($expiresAt);
+
+                            return [
+                                'content' => $content,
+                                'next_chunk' => $pending['next_chunk'],
+                            ];
+                        };
+                        $this->cache->get($pending['key'], $writeChunk, \INF);
+                    }
+                }
+
+                $this->cache->get($chunkKey, static function (ItemInterface $item) use ($expiresAt, $fullUrlTag, $metadataKey, $chunk, $attemptTag, $extraTags): array {
+                    $item->tag([$fullUrlTag, $metadataKey, $attemptTag, ...$extraTags])->expiresAt($expiresAt);
 
                     return [
                         'content' => $chunk->getContent(),
@@ -427,9 +498,9 @@ class CachingHttpClient implements HttpClientInterface, LoggerAwareInterface, Re
                 $requestTime = (int) ($context->getInfo('start_time') ?? time());
                 $responseTime = time();
                 $correctedInitialAge = self::getCorrectedInitialAge($headers, $requestTime, $responseTime);
-                $maxAge = $this->determineMaxAge($headers, self::parseCacheControlHeader($headers['cache-control'] ?? []), $correctedInitialAge, $requestTime, $responseTime);
-                $this->cache->get($metadataKey, static function (ItemInterface $item) use ($context, $headers, $maxAge, $expiresAt, $fullUrlTag, $metadataKey, $attemptTag, $firstChunkKey, $responseTime, $correctedInitialAge): array {
-                    $item->tag([$fullUrlTag, $metadataKey, $attemptTag])->expiresAt($expiresAt);
+                $maxAge = $cachePolicy?->getTtl() ?? $this->determineMaxAge($headers, self::parseCacheControlHeader($headers['cache-control'] ?? []), $correctedInitialAge, $requestTime, $responseTime);
+                $this->cache->get($metadataKey, static function (ItemInterface $item) use ($context, $headers, $maxAge, $expiresAt, $fullUrlTag, $metadataKey, $attemptTag, $firstChunkKey, $responseTime, $correctedInitialAge, $extraTags): array {
+                    $item->tag([$fullUrlTag, $metadataKey, $attemptTag, ...$extraTags])->expiresAt($expiresAt);
 
                     return [
                         'status_code' => $context->getStatusCode(),
@@ -438,6 +509,7 @@ class CachingHttpClient implements HttpClientInterface, LoggerAwareInterface, Re
                         'stored_at' => $responseTime,
                         'expires_at' => self::calculateExpiresAt($maxAge),
                         'next_chunk' => $firstChunkKey,
+                        'cache_tags' => $extraTags,
                     ];
                 }, \INF);
 
@@ -447,14 +519,27 @@ class CachingHttpClient implements HttpClientInterface, LoggerAwareInterface, Re
             }
 
             $nextChunkKey = self::generateChunkKey();
-            $this->cache->get($chunkKey, static function (ItemInterface $item) use ($expiresAt, $fullUrlTag, $metadataKey, $attemptTag, $chunk, $nextChunkKey): array {
-                $item->tag([$fullUrlTag, $metadataKey, $attemptTag])->expiresAt($expiresAt);
-
-                return [
-                    'content' => $chunk->getContent(),
+            if (null !== $tagsFromResponseResolver) {
+                // chunk contents are sliced back out of $accumulatedContent at flush
+                // time, so the body is only held once in memory
+                $content = $chunk->getContent();
+                $pendingChunks[] = [
+                    'key' => $chunkKey,
+                    'offset' => \strlen($accumulatedContent),
+                    'length' => \strlen($content),
                     'next_chunk' => $nextChunkKey,
                 ];
-            }, \INF);
+                $accumulatedContent .= $content;
+            } else {
+                $this->cache->get($chunkKey, static function (ItemInterface $item) use ($expiresAt, $fullUrlTag, $metadataKey, $attemptTag, $chunk, $nextChunkKey, $extraTags): array {
+                    $item->tag([$fullUrlTag, $metadataKey, $attemptTag, ...$extraTags])->expiresAt($expiresAt);
+
+                    return [
+                        'content' => $chunk->getContent(),
+                        'next_chunk' => $nextChunkKey,
+                    ];
+                }, \INF);
+            }
             $chunkKey = $nextChunkKey;
 
             yield $chunk;
@@ -522,6 +607,29 @@ class CachingHttpClient implements HttpClientInterface, LoggerAwareInterface, Re
     private static function generateChunkKey(): string
     {
         return str_replace('/', '_', base64_encode(random_bytes(6)));
+    }
+
+    /**
+     * @return list<non-empty-string>
+     */
+    private static function resolveCacheTagsFromBody(\Closure $resolver, string $body): array
+    {
+        $policy = new CachePolicy();
+        $policy->tag($resolver($body));
+
+        return $policy->getTags();
+    }
+
+    /**
+     * Merges multiple sets of cache tags while preserving insertion order and removing duplicates.
+     *
+     * @param list<string> ...$tagSets
+     *
+     * @return list<non-empty-string>
+     */
+    private static function mergeCacheTags(array ...$tagSets): array
+    {
+        return array_values(array_unique(array_merge(...array_values($tagSets))));
     }
 
     /**
@@ -1149,8 +1257,10 @@ class CachingHttpClient implements HttpClientInterface, LoggerAwareInterface, Re
      * returned.
      *
      * @param array{next_chunk: string, status_code: int, initial_age: int, headers: array<string, string|string[]>, stored_at: int} $cachedData
+     * @param list<string>                                                                                                           $newTags    The tags to attach to the chunk items rewritten when extending their expiry,
+     *                                                                                                                                           as rewriting a tagged item without re-tagging it drops its tags
      */
-    private function createResponseFromCache(array $cachedData, string $method, string $url, array $options, string $metadataKey, \DateTimeImmutable|false|null $newExpiresAt = false): MockResponse
+    private function createResponseFromCache(array $cachedData, string $method, string $url, array $options, string $metadataKey, \DateTimeImmutable|false|null $newExpiresAt = false, array $newTags = []): MockResponse
     {
         $cache = $this->cache;
 
@@ -1163,12 +1273,12 @@ class CachingHttpClient implements HttpClientInterface, LoggerAwareInterface, Re
 
         if (false !== $newExpiresAt) {
             $beta = \INF;
-            $callback = static function (ItemInterface $item) use ($callback, $newExpiresAt): array {
+            $callback = static function (ItemInterface $item) use ($callback, $newExpiresAt, $newTags): array {
                 if (!$item->isHit()) {
                     $callback($item);
                 }
 
-                $item->expiresAt($newExpiresAt);
+                $item->tag($newTags)->expiresAt($newExpiresAt);
 
                 return $item->get();
             };

--- a/src/Symfony/Component/HttpClient/Tests/CachePolicyTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/CachePolicyTest.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\CachePolicy;
+use Symfony\Component\HttpClient\Exception\InvalidArgumentException;
+
+class CachePolicyTest extends TestCase
+{
+    public function testTagsMustNotHoldReservedCharacters()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('contains one of the reserved characters');
+
+        (new CachePolicy())->tag('foo{bar}');
+    }
+
+    public function testTagsMustBeNonEmptyStrings()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cache tags must be non-empty strings, "int" given.');
+
+        (new CachePolicy())->tag([42]);
+    }
+}

--- a/src/Symfony/Component/HttpClient/Tests/CachingHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/CachingHttpClientTest.php
@@ -15,11 +15,15 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\AbstractLogger;
+use Psr\Log\LogLevel;
 use Symfony\Bridge\PhpUnit\ClockMock;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\TagAwareAdapter;
 use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
+use Symfony\Component\HttpClient\CachePolicy;
 use Symfony\Component\HttpClient\CachingHttpClient;
+use Symfony\Component\HttpClient\Exception\InvalidArgumentException;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\NativeHttpClient;
 use Symfony\Component\HttpClient\Response\AsyncResponse;
@@ -2485,9 +2489,126 @@ class CachingHttpClientTest extends TestCase
         new CachingHttpClient(new MockHttpClient([]), $this->cacheAdapter, [], true, null);
     }
 
-    /**
-     * @param iterable<MockResponse> $responses
-     */
+    public function testTagsAllowTargetedInvalidation()
+    {
+        $client = $this->buildClient([
+            new MockResponse('body', ['response_headers' => ['Cache-Control' => 'max-age=300']]),
+            new MockResponse('miss'),
+        ]);
+        $options = ['extra' => ['cache_policy' => static fn (CachePolicy $cache) => $cache->tag(['product-1', 'catalog'])]];
+
+        $this->assertSame('body', $client->request('GET', 'http://example.com/p', $options)->getContent());
+        $this->assertSame('body', $client->request('GET', 'http://example.com/p', $options)->getContent());
+
+        $this->cacheAdapter->invalidateTags(['catalog']);
+
+        $this->assertSame('miss', $client->request('GET', 'http://example.com/p', $options)->getContent());
+    }
+
+    public function testTagsCanBeDerivedFromTheHeaders()
+    {
+        $client = $this->buildClient([
+            new MockResponse('body', ['response_headers' => ['Cache-Control' => 'max-age=300', 'X-Entity' => 'order-7']]),
+            new MockResponse('miss'),
+        ]);
+        $options = ['extra' => ['cache_policy' => static fn (CachePolicy $cache, int $status, array $headers) => $cache->tag($headers['x-entity'] ?? [])]];
+
+        $this->assertSame('body', $client->request('GET', 'http://example.com/p', $options)->getContent());
+
+        $this->cacheAdapter->invalidateTags(['order-7']);
+
+        $this->assertSame('miss', $client->request('GET', 'http://example.com/p', $options)->getContent());
+    }
+
+    public function testTagsCanBeDerivedFromTheBody()
+    {
+        $client = $this->buildClient([
+            new MockResponse('{"id":9}', ['response_headers' => ['Cache-Control' => 'max-age=300']]),
+            new MockResponse('miss'),
+        ]);
+        $options = ['extra' => ['cache_policy' => static fn (CachePolicy $cache) => $cache->tagFromBody(
+            static fn (string $body): array => \is_array($data = json_decode($body, true)) ? ['item-'.$data['id']] : [],
+        )]];
+
+        $this->assertSame('{"id":9}', $client->request('GET', 'http://example.com/p', $options)->getContent());
+
+        $this->cacheAdapter->invalidateTags(['item-9']);
+
+        $this->assertSame('miss', $client->request('GET', 'http://example.com/p', $options)->getContent());
+    }
+
+    public function testTagsFromTheBodyAreDroppedAndLoggedWhenBufferingIsOff()
+    {
+        $logger = new class extends AbstractLogger {
+            public array $records = [];
+
+            public function log($level, $message, array $context = []): void
+            {
+                $this->records[] = [$level, $message];
+            }
+        };
+
+        $client = $this->buildClient([
+            new MockResponse('{"id":9}', ['response_headers' => ['Cache-Control' => 'max-age=300']]),
+        ]);
+        $client->setLogger($logger);
+
+        $response = $client->request('GET', 'http://example.com/p', [
+            'buffer' => false,
+            'extra' => ['cache_policy' => static fn (CachePolicy $cache) => $cache->tagFromBody(static fn (string $body): array => ['item-9'])],
+        ]);
+        foreach ($client->stream($response) as $chunk) {
+        }
+
+        $this->assertContains(
+            [LogLevel::WARNING, 'Ignoring the tags of "tagFromBody()" for "{method} {url}": the "extra.cache_policy" option needs the "buffer" option to be true to read the response body.'],
+            $logger->records,
+        );
+    }
+
+    public function testExpiresAfterCachesAResponseThatSaysNotTo()
+    {
+        $client = $this->buildClient([
+            new MockResponse('body', ['response_headers' => ['Cache-Control' => 'no-store']]),
+            new MockResponse('miss'),
+        ]);
+        $options = ['extra' => ['cache_policy' => static fn (CachePolicy $cache) => $cache->expiresAfter(3600)]];
+
+        $this->assertSame('body', $client->request('GET', 'http://example.com/p', $options)->getContent());
+        $this->assertSame('body', $client->request('GET', 'http://example.com/p', $options)->getContent(), 'the forced TTL stores a response the server marked as no-store');
+    }
+
+    public function testWithoutTheHookANoStoreResponseIsNotCached()
+    {
+        $client = $this->buildClient([
+            new MockResponse('body', ['response_headers' => ['Cache-Control' => 'no-store']]),
+            new MockResponse('miss'),
+        ]);
+
+        $this->assertSame('body', $client->request('GET', 'http://example.com/p')->getContent());
+        $this->assertSame('miss', $client->request('GET', 'http://example.com/p')->getContent());
+    }
+
+    public function testExpiresAfterReplacesTheFreshnessOfTheHeaders()
+    {
+        $client = $this->buildClient([
+            new MockResponse('body', ['response_headers' => ['Cache-Control' => 'max-age=0']]),
+            new MockResponse('miss'),
+        ]);
+        $options = ['extra' => ['cache_policy' => static fn (CachePolicy $cache) => $cache->expiresAfter(3600)]];
+
+        $this->assertSame('body', $client->request('GET', 'http://example.com/p', $options)->getContent());
+        $this->assertSame('body', $client->request('GET', 'http://example.com/p', $options)->getContent(), 'max-age=0 would have revalidated, the forced TTL keeps it fresh');
+    }
+
+    public function testTheHookMustBeCallable()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "extra.cache_policy" option must be a callable, "string" given.');
+
+        $this->buildClient([new MockResponse('body')])->request('GET', 'http://example.com/p', ['extra' => ['cache_policy' => 'nope']]);
+    }
+
     private function buildClient(iterable $responses, array $defaultOptions = [], bool $sharedCache = true, int $maxTtl = 86400): CachingHttpClient
     {
         return new CachingHttpClient(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #63790
| License       | MIT

Alternative to #64177, built on top of it, so the credit for the machinery and for the tests goes to @Amoifr.

`CachingHttpClient` gains a single option, `extra.cache_policy`, called once the response headers are known, with an object deciding how the response is stored:

```php
$client->request('GET', $url, ['extra' => ['cache_policy' => function (CachePolicy $cache, int $statusCode, array $headers) {
    $cache->tag('product-42')->expiresAfter(3600);
}]]);
```

`tag()` attaches cache tags, so the response can be dropped later with `invalidateTags()`. `expiresAfter()` stores the response for that many seconds whatever its cache directives say, which is the greedy caching @Toflar asked for in #63790: it makes a response cacheable that would not be, and replaces the freshness computed from the headers.

Tags that depend on the body are declared from the same place:

```php
'cache_policy' => fn (CachePolicy $cache) => $cache->tagFromBody(fn (string $body) => ['item-'.json_decode($body, true)['id']]),
```

The resolver runs once the body has been received, which needs the `buffer` option to be `true`. Asking for both is contradictory, so the tags are dropped and a warning is logged: an entry stored without the tags meant to invalidate it is worth hearing about.

## Why one option

#64177 proposes `extra.cache_tags`, `extra.cache_tags_from_headers` and `extra.cache_tags_from_response`, and greedy caching would add a fourth. Each answers "what should the client do with this entry", which is what `CacheInterface::get()` already answers by handing the callback an item to configure. This mirrors that: one entry point, and the reasons to reach for it grow as methods rather than as options.

It is also smaller. The three options and their validation helpers are replaced by the policy object, so `CachingHttpClient` loses `parseStaticCacheTags()`, `parseCacheTagsResolver()`, `validateResolvedCacheTags()` and `resolveCacheTagsFromHeaders()`; header-derived tags need no dedicated mechanism because the headers are an argument of the hook.

## What it does not do

The policy is not the cache item. A stored response is a vary entry, a metadata entry and one entry per chunk, so there is nothing to hand out; the policy is applied by the client across the set, which also keeps the stored payload private.

The hook runs on revalidation too, with the merged headers, and can add tags there. Tags already carried by an entry are kept, since the entry is shared between requests.
