### PR TITLE
[Security] Serve the CSRF token id of a firewall through the manager it configures

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Deprecate the `remember_me` option of the `form_login`, `json_login`, `login_link`, and `access_token` authenticators, as it has no effect
  * Add the `ldap_users_only` option to the LDAP authenticators, to bind only `LdapUser` instances against the LDAP server
  * Show the deauthentication reason and the responsible user providers in the security profiler panel
+ * Serve the CSRF token id of a firewall through the `csrf_token_manager` it configures, so that `csrf_token()` no longer mints a token the firewall rejects
 
 8.1
 ---

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -164,6 +164,11 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
 
         $this->createFirewalls($config, $container);
 
+        if (!$container->getDefinition('security.csrf_token_manager_locator')->getArgument(0)) {
+            $container->removeDefinition('security.delegating_csrf_token_manager');
+            $container->removeDefinition('security.csrf_token_manager_locator');
+        }
+
         if ($container::willBeAvailable('symfony/routing', ContainerLoader::class, ['symfony/security-bundle'])) {
             $this->createLogoutUrisParameter($config['firewalls'] ?? [], $container);
         } else {
@@ -496,6 +501,10 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
                     false === $firewall['stateless'] && isset($firewall['context']) ? $firewall['context'] : null,
                 ])
             ;
+
+            if (isset($firewall['logout']['csrf_token_manager'])) {
+                $this->registerCsrfTokenManager($container, $id, $firewall['logout']['csrf_token_id'], $firewall['logout']['csrf_token_manager']);
+            }
 
             $config->replaceArgument(12, $firewall['logout']);
         }
@@ -1124,5 +1133,22 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
         }
 
         $container->setParameter('security.logout_uris', $logoutUris);
+    }
+
+    private function registerCsrfTokenManager(ContainerBuilder $container, string $firewallName, string $tokenId, string $tokenManagerId): void
+    {
+        if ('security.csrf.token_manager' === $tokenManagerId) {
+            // the decorated manager already handles the token ids that have no dedicated manager
+            return;
+        }
+
+        $locator = $container->getDefinition('security.csrf_token_manager_locator');
+        $tokenManagers = $locator->getArgument(0);
+
+        if (isset($tokenManagers[$tokenId]) && $tokenManagerId !== (string) $tokenManagers[$tokenId]->getValues()[0]) {
+            throw new InvalidConfigurationException(\sprintf('The "%s" firewall configures a "csrf_token_manager" for the "%s" token id, but another firewall already configured a different one. Give them distinct "csrf_token_id" values.', $firewallName, $tokenId));
+        }
+
+        $locator->replaceArgument(0, $tokenManagers + [$tokenId => new ServiceClosureArgument(new Reference($tokenManagerId))]);
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
@@ -19,6 +19,7 @@ use Symfony\Bundle\SecurityBundle\Security\FirewallConfig;
 use Symfony\Bundle\SecurityBundle\Security\FirewallContext;
 use Symfony\Bundle\SecurityBundle\Security\FirewallMap;
 use Symfony\Bundle\SecurityBundle\Security\LazyFirewallContext;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage as BaseExpressionLanguage;
 use Symfony\Component\Ldap\Security\LdapUserProvider;
@@ -44,6 +45,7 @@ use Symfony\Component\Security\Core\User\InMemoryUserChecker;
 use Symfony\Component\Security\Core\User\InMemoryUserProvider;
 use Symfony\Component\Security\Core\User\MissingUserProvider;
 use Symfony\Component\Security\Core\Validator\Constraints\UserPasswordValidator;
+use Symfony\Component\Security\Csrf\DelegatingCsrfTokenManager;
 use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
 use Symfony\Component\Security\Http\Controller\SecurityTokenValueResolver;
 use Symfony\Component\Security\Http\Controller\UserValueResolver;
@@ -128,6 +130,17 @@ return static function (ContainerConfigurator $container) {
 
         ->set('security.user_checker', InMemoryUserChecker::class)
         ->set('security.user_checker_locator', ServiceLocator::class)
+            ->args([[]])
+
+        ->set('security.delegating_csrf_token_manager', DelegatingCsrfTokenManager::class)
+            // outside SameOriginCsrfTokenManager (0), so that the manager a firewall configures for a token id wins
+            ->decorate('security.csrf.token_manager', null, -10, ContainerInterface::IGNORE_ON_INVALID_REFERENCE)
+            ->args([
+                service('.inner'),
+                service('security.csrf_token_manager_locator'),
+            ])
+
+        ->set('security.csrf_token_manager_locator', ServiceLocator::class)
             ->args([[]])
 
         ->set('security.expression_language', ExpressionLanguage::class)

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
@@ -22,6 +22,7 @@ use Symfony\Bundle\SecurityBundle\Tests\DependencyInjection\Fixtures\UserProvide
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
+use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Compiler\DecoratorServicePass;
 use Symfony\Component\DependencyInjection\Compiler\ResolveChildDefinitionsPass;
 use Symfony\Component\DependencyInjection\Compiler\ResolveReferencesToAliasesPass;
@@ -335,6 +336,89 @@ class SecurityExtensionTest extends TestCase
         $container->compile();
 
         $this->assertFalse($container->hasDefinition('security.access.role_hierarchy_voter'));
+    }
+
+    public function testCsrfTokenManagersAreRegisteredForTheirTokenId()
+    {
+        $container = $this->getRawContainer();
+
+        $container->loadFromExtension('security', [
+            'providers' => [
+                'default' => ['id' => 'foo'],
+            ],
+
+            'firewalls' => [
+                'custom_manager' => [
+                    'http_basic' => null,
+                    'logout' => ['csrf_token_manager' => 'app.csrf_token_manager'],
+                ],
+                'default_manager' => [
+                    'http_basic' => null,
+                    'logout' => ['enable_csrf' => true, 'csrf_token_id' => 'other_logout'],
+                ],
+                'no_csrf' => [
+                    'http_basic' => null,
+                    'logout' => true,
+                ],
+            ],
+        ]);
+
+        $container->compile();
+
+        $this->assertEquals(
+            ['logout' => new ServiceClosureArgument(new Reference('app.csrf_token_manager'))],
+            $container->getDefinition('security.csrf_token_manager_locator')->getArgument(0)
+        );
+    }
+
+    public function testTheDelegatingCsrfTokenManagerIsRemovedWhenNoFirewallNeedsIt()
+    {
+        $container = $this->getRawContainer();
+
+        $container->loadFromExtension('security', [
+            'providers' => [
+                'default' => ['id' => 'foo'],
+            ],
+
+            'firewalls' => [
+                'some_firewall' => [
+                    'http_basic' => null,
+                    'logout' => ['enable_csrf' => true],
+                ],
+            ],
+        ]);
+
+        $container->compile();
+
+        $this->assertFalse($container->hasDefinition('security.delegating_csrf_token_manager'));
+        $this->assertFalse($container->hasDefinition('security.csrf_token_manager_locator'));
+    }
+
+    public function testTwoFirewallsCannotMapTheSameTokenIdToDifferentCsrfTokenManagers()
+    {
+        $container = $this->getRawContainer();
+
+        $container->loadFromExtension('security', [
+            'providers' => [
+                'default' => ['id' => 'foo'],
+            ],
+
+            'firewalls' => [
+                'first' => [
+                    'http_basic' => null,
+                    'logout' => ['csrf_token_manager' => 'app.csrf_token_manager'],
+                ],
+                'second' => [
+                    'http_basic' => null,
+                    'logout' => ['csrf_token_manager' => 'app.other_csrf_token_manager'],
+                ],
+            ],
+        ]);
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('The "second" firewall configures a "csrf_token_manager" for the "logout" token id, but another firewall already configured a different one. Give them distinct "csrf_token_id" values.');
+
+        $container->compile();
     }
 
     public function testSwitchUserNotStatelessOnStatelessFirewall()

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/FixedCsrfTokenManager.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/FixedCsrfTokenManager.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
+
+use Symfony\Component\Security\Csrf\CsrfToken;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
+
+class FixedCsrfTokenManager implements CsrfTokenManagerInterface
+{
+    public const VALUE = 'a-token-no-other-manager-mints';
+
+    public function getToken(string $tokenId): CsrfToken
+    {
+        return new CsrfToken($tokenId, self::VALUE);
+    }
+
+    public function refreshToken(string $tokenId): CsrfToken
+    {
+        return $this->getToken($tokenId);
+    }
+
+    public function removeToken(string $tokenId): ?string
+    {
+        return null;
+    }
+
+    public function isTokenValid(CsrfToken $token): bool
+    {
+        return self::VALUE === $token->getValue();
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/LogoutTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/LogoutTest.php
@@ -78,6 +78,37 @@ class LogoutTest extends AbstractWebTestCase
         $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
     }
 
+    public function testTheCsrfTokenManagerOfTheFirewallMintsTheLogoutToken()
+    {
+        $client = $this->createClient(['test_case' => 'Logout', 'root_config' => 'config_csrf_custom_manager.yml']);
+
+        $client->request('POST', '/login', ['_username' => 'johannes', '_password' => 'test']);
+
+        // this is what csrf_token('logout') does in a template
+        $csrfToken = static::getContainer()->get('security.csrf.token_manager')->getToken('logout')->getValue();
+
+        $this->assertSame(FixedCsrfTokenManager::VALUE, $csrfToken);
+
+        $client->request('GET', '/logout?_csrf_token='.$csrfToken);
+
+        $this->assertRedirect($client->getResponse(), '/');
+    }
+
+    public function testTheCsrfTokenManagerOfTheFirewallWinsOverStatelessTokenIds()
+    {
+        $client = $this->createClient(['test_case' => 'Logout', 'root_config' => 'config_csrf_custom_manager_stateless.yml']);
+
+        $client->request('POST', '/login', ['_username' => 'johannes', '_password' => 'test']);
+
+        $csrfToken = static::getContainer()->get('security.csrf.token_manager')->getToken('logout')->getValue();
+
+        $this->assertSame(FixedCsrfTokenManager::VALUE, $csrfToken);
+
+        $client->request('GET', '/logout?_csrf_token='.$csrfToken);
+
+        $this->assertRedirect($client->getResponse(), '/');
+    }
+
     private function callInRequestContext(KernelBrowser $client, callable $callable): void
     {
         /** @var EventDispatcherInterface $eventDispatcher */

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Logout/config_csrf_custom_manager.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Logout/config_csrf_custom_manager.yml
@@ -1,0 +1,27 @@
+imports:
+- { resource: ./../config/framework.yml }
+
+services:
+    app.logout_csrf_token_manager:
+        class: Symfony\Bundle\SecurityBundle\Tests\Functional\FixedCsrfTokenManager
+
+security:
+    password_hashers:
+        Symfony\Component\Security\Core\User\InMemoryUser: plaintext
+
+    providers:
+        in_memory:
+            memory:
+                users:
+                    johannes: { password: test, roles: [ROLE_USER] }
+
+    firewalls:
+        default:
+            form_login:
+                check_path: login
+            logout:
+                csrf_token_manager: app.logout_csrf_token_manager
+
+    access_control:
+        - { path: ^/login$, roles: IS_AUTHENTICATED_ANONYMOUSLY }
+        - { path: .*, roles: IS_AUTHENTICATED_FULLY }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Logout/config_csrf_custom_manager_stateless.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Logout/config_csrf_custom_manager_stateless.yml
@@ -1,0 +1,6 @@
+imports:
+- { resource: ./config_csrf_custom_manager.yml }
+
+framework:
+    csrf_protection:
+        stateless_token_ids: [logout]

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -27,7 +27,7 @@
         "symfony/http-foundation": "^7.4|^8.0",
         "symfony/password-hasher": "^7.4|^8.0",
         "symfony/security-core": "^7.4|^8.0",
-        "symfony/security-csrf": "^7.4|^8.0",
+        "symfony/security-csrf": "^8.2",
         "symfony/security-http": "^8.2",
         "symfony/service-contracts": "^2.5|^3"
     },
@@ -39,7 +39,7 @@
         "symfony/dom-crawler": "^7.4|^8.0",
         "symfony/expression-language": "^7.4|^8.0",
         "symfony/form": "^7.4|^8.0",
-        "symfony/framework-bundle": "^7.4|^8.0",
+        "symfony/framework-bundle": "^8.1",
         "symfony/http-client": "^7.4|^8.0",
         "symfony/ldap": "^7.4|^8.0",
         "symfony/process": "^7.4|^8.0",
@@ -53,6 +53,9 @@
         "symfony/validator": "^7.4|^8.0",
         "symfony/yaml": "^7.4|^8.0",
         "web-token/jwt-library": "^3.3.2|^4.0"
+    },
+    "conflict": {
+        "symfony/framework-bundle": "<8.1"
     },
     "autoload": {
         "psr-4": { "Symfony\\Bundle\\SecurityBundle\\": "" },

--- a/src/Symfony/Component/Security/Csrf/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Csrf/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add `DelegatingCsrfTokenManager` to hand each token id over to the manager dedicated to it
+
 8.1
 ---
 

--- a/src/Symfony/Component/Security/Csrf/DelegatingCsrfTokenManager.php
+++ b/src/Symfony/Component/Security/Csrf/DelegatingCsrfTokenManager.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Csrf;
+
+use Psr\Container\ContainerInterface;
+
+/**
+ * This CSRF token manager hands each token id over to the manager dedicated to it, if any.
+ *
+ * Token ids with no dedicated manager are delegated to the decorated one, so that a token is
+ * always minted by the manager that validates it, wherever it is asked for.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+final class DelegatingCsrfTokenManager implements CsrfTokenManagerInterface
+{
+    /**
+     * @param ContainerInterface $csrfTokenManagers Locator of CsrfTokenManagerInterface instances, keyed by token id
+     */
+    public function __construct(
+        private CsrfTokenManagerInterface $fallbackCsrfTokenManager,
+        private ContainerInterface $csrfTokenManagers,
+    ) {
+    }
+
+    public function getToken(string $tokenId): CsrfToken
+    {
+        return $this->getCsrfTokenManager($tokenId)->getToken($tokenId);
+    }
+
+    public function refreshToken(string $tokenId): CsrfToken
+    {
+        return $this->getCsrfTokenManager($tokenId)->refreshToken($tokenId);
+    }
+
+    public function removeToken(string $tokenId): ?string
+    {
+        return $this->getCsrfTokenManager($tokenId)->removeToken($tokenId);
+    }
+
+    public function isTokenValid(CsrfToken $token): bool
+    {
+        return $this->getCsrfTokenManager($token->getId())->isTokenValid($token);
+    }
+
+    private function getCsrfTokenManager(string $tokenId): CsrfTokenManagerInterface
+    {
+        return $this->csrfTokenManagers->has($tokenId) ? $this->csrfTokenManagers->get($tokenId) : $this->fallbackCsrfTokenManager;
+    }
+}

--- a/src/Symfony/Component/Security/Csrf/Tests/DelegatingCsrfTokenManagerTest.php
+++ b/src/Symfony/Component/Security/Csrf/Tests/DelegatingCsrfTokenManagerTest.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Csrf\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\Security\Csrf\CsrfToken;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
+use Symfony\Component\Security\Csrf\DelegatingCsrfTokenManager;
+
+class DelegatingCsrfTokenManagerTest extends TestCase
+{
+    public function testTokensAreHandledByTheManagerRegisteredForTheirId()
+    {
+        $logoutManager = $this->createMock(CsrfTokenManagerInterface::class);
+        $logoutManager->expects($this->once())->method('getToken')->with('logout')->willReturn(new CsrfToken('logout', 'T0K3N'));
+        $logoutManager->expects($this->once())->method('refreshToken')->with('logout')->willReturn(new CsrfToken('logout', 'FR3SH'));
+        $logoutManager->expects($this->once())->method('removeToken')->with('logout')->willReturn('T0K3N');
+        $logoutManager->expects($this->once())->method('isTokenValid')->willReturn(true);
+
+        $fallbackManager = $this->createMock(CsrfTokenManagerInterface::class);
+        $fallbackManager->expects($this->never())->method($this->anything());
+
+        $manager = new DelegatingCsrfTokenManager($fallbackManager, $this->createLocator(['logout' => $logoutManager]));
+
+        $this->assertSame('T0K3N', $manager->getToken('logout')->getValue());
+        $this->assertSame('FR3SH', $manager->refreshToken('logout')->getValue());
+        $this->assertSame('T0K3N', $manager->removeToken('logout'));
+        $this->assertTrue($manager->isTokenValid(new CsrfToken('logout', 'T0K3N')));
+    }
+
+    public function testTokensWithNoDedicatedManagerAreHandledByTheDecoratedOne()
+    {
+        $logoutManager = $this->createMock(CsrfTokenManagerInterface::class);
+        $logoutManager->expects($this->never())->method($this->anything());
+
+        $fallbackManager = $this->createMock(CsrfTokenManagerInterface::class);
+        $fallbackManager->expects($this->once())->method('getToken')->with('submit')->willReturn(new CsrfToken('submit', 'T0K3N'));
+        $fallbackManager->expects($this->once())->method('refreshToken')->with('submit')->willReturn(new CsrfToken('submit', 'FR3SH'));
+        $fallbackManager->expects($this->once())->method('removeToken')->with('submit')->willReturn('T0K3N');
+        $fallbackManager->expects($this->once())->method('isTokenValid')->willReturn(false);
+
+        $manager = new DelegatingCsrfTokenManager($fallbackManager, $this->createLocator(['logout' => $logoutManager]));
+
+        $this->assertSame('T0K3N', $manager->getToken('submit')->getValue());
+        $this->assertSame('FR3SH', $manager->refreshToken('submit')->getValue());
+        $this->assertSame('T0K3N', $manager->removeToken('submit'));
+        $this->assertFalse($manager->isTokenValid(new CsrfToken('submit', 'T0K3N')));
+    }
+
+    /**
+     * @param array<string, CsrfTokenManagerInterface> $managers
+     */
+    private function createLocator(array $managers): ContainerInterface
+    {
+        return new class($managers) implements ContainerInterface {
+            public function __construct(private array $managers)
+            {
+            }
+
+            public function has(string $id): bool
+            {
+                return isset($this->managers[$id]);
+            }
+
+            public function get(string $id): mixed
+            {
+                return $this->managers[$id];
+            }
+        };
+    }
+}

--- a/src/Symfony/Component/Security/Csrf/composer.json
+++ b/src/Symfony/Component/Security/Csrf/composer.json
@@ -21,6 +21,7 @@
         "symfony/security-core": "^7.4|^8.0"
     },
     "require-dev": {
+        "psr/container": "^1.1|^2.0",
         "psr/log": "^1|^2|^3",
         "symfony/http-foundation": "^7.4|^8.0",
         "symfony/http-kernel": "^7.4|^8.0"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

A firewall can configure its own CSRF token manager:

```yaml
security:
    firewalls:
        main:
            logout:
                csrf_token_manager: app.logout_csrf_token_manager
```

Only the firewall's listener is given that manager. `csrf_token('logout')` in a template goes through `security.csrf.token_manager`, so it mints a token that the firewall's own manager then rejects, and nothing can reach the configured manager from a template at all. Rendering the logout form the documented way produces a 403.

`DelegatingCsrfTokenManager` decorates `security.csrf.token_manager` and hands each token id over to the manager registered for it, falling back to the decorated one for every other id. `SecurityExtension` registers what the firewalls configure, so the example above makes `csrf_token('logout')` mint a token `app.logout_csrf_token_manager` accepts, while every other token id keeps its current behavior. The decorator and its locator are dropped entirely when no firewall configures a manager, so containers that do not need it are unchanged.

This is `SameOriginCsrfTokenManager` generalized. That class already routes by token id, handling the ids listed in `stateless_token_ids` itself and delegating the rest to a fallback manager. The new one does the same with a locator instead of a single destination.

## Ordering

`DelegatingCsrfTokenManager` decorates from **outside** `SameOriginCsrfTokenManager`. Listing a token id in `stateless_token_ids` while a firewall configures a manager for it would otherwise answer the id statelessly, while the firewall's listener still validates it with the manager it was given. The explicit per-firewall option wins, and a functional test covers it.

## Ambiguous configurations

Two firewalls mapping the same token id to two different managers is refused at compile time:

> The "second" firewall configures a "csrf_token_manager" for the "logout" token id, but another firewall already configured a different one. Give them distinct "csrf_token_id" values.

A token id is all `csrf_token()` has to tell them apart, so picking a winner would just move the surprise somewhere else.

## Scope

Today `logout` is the only firewall option taking a `csrf_token_manager`, so it is the only registration site. #64879 adds the same option to `switch_user`; once both are in, the impersonation URL generator can drop the firewall-keyed locator it carries and resolve through the token id like everything else.
