### PR TITLE
[Serializer] Fix FILTER_BOOL breaking union type denormalization

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -464,6 +464,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
         $extraAttributesException = null;
         $missingConstructorArgumentsException = null;
         $isNullable = false;
+        $filterBoolFailed = false;
         foreach ($types as $type) {
             if (null === $data && $type->isNullable()) {
                 return null;
@@ -616,7 +617,11 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                 }
 
                 if (LegacyType::BUILTIN_TYPE_BOOL === $builtinType && (\is_string($data) || \is_int($data)) && ($context[self::FILTER_BOOL] ?? false)) {
-                    return filter_var($data, \FILTER_VALIDATE_BOOL, \FILTER_NULL_ON_FAILURE);
+                    if (null !== $filtered = filter_var($data, \FILTER_VALIDATE_BOOL, \FILTER_NULL_ON_FAILURE)) {
+                        return $filtered;
+                    }
+
+                    $filterBoolFailed = true;
                 }
 
                 if ((LegacyType::BUILTIN_TYPE_FALSE === $builtinType && false === $data) || (LegacyType::BUILTIN_TYPE_TRUE === $builtinType && true === $data)) {
@@ -681,6 +686,14 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
             return $data;
         }
 
+        if ($filterBoolFailed) {
+            foreach ($types as $t) {
+                if ($t->isNullable()) {
+                    return null;
+                }
+            }
+        }
+
         throw NotNormalizableValueException::createForUnexpectedDataType(\sprintf('The type of the "%s" attribute for class "%s" must be one of "%s" ("%s" given).', $attribute, $currentClass, implode('", "', array_keys($expectedTypes)), get_debug_type($data)), $data, array_keys($expectedTypes), $context['deserialization_path'] ?? $attribute);
     }
 
@@ -706,6 +719,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
         $e = null;
         $extraAttributesException = null;
         $missingConstructorArgumentsException = null;
+        $filterBoolFailed = false;
 
         $types = match (true) {
             $type instanceof IntersectionType => throw new LogicException('Unable to handle intersection type.'),
@@ -918,7 +932,11 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                 }
 
                 if (TypeIdentifier::BOOL === $typeIdentifier && (\is_string($data) || \is_int($data)) && ($context[self::FILTER_BOOL] ?? false)) {
-                    return filter_var($data, \FILTER_VALIDATE_BOOL, \FILTER_NULL_ON_FAILURE);
+                    if (null !== $filtered = filter_var($data, \FILTER_VALIDATE_BOOL, \FILTER_NULL_ON_FAILURE)) {
+                        return $filtered;
+                    }
+
+                    $filterBoolFailed = true;
                 }
 
                 $dataMatchesExpectedType = match ($typeIdentifier) {
@@ -987,6 +1005,10 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
 
         if ($context[self::DISABLE_TYPE_ENFORCEMENT] ?? $this->defaultContext[self::DISABLE_TYPE_ENFORCEMENT] ?? false) {
             return $data;
+        }
+
+        if ($filterBoolFailed && $type->isNullable()) {
+            return null;
         }
 
         throw NotNormalizableValueException::createForUnexpectedDataType(\sprintf('The type of the "%s" attribute for class "%s" must be one of "%s" ("%s" given).', $attribute, $currentClass, implode('", "', array_keys($expectedTypes)), get_debug_type($data)), $data, array_keys($expectedTypes), $context['deserialization_path'] ?? $attribute);

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
@@ -1643,6 +1643,34 @@ class AbstractObjectNormalizerTest extends TestCase
         }
     }
 
+    public function testDenormalizeUnionTypeWithFilterBool()
+    {
+        $normalizer = new AbstractObjectNormalizerWithMetadataAndPropertyTypeExtractors();
+
+        foreach ([null, XmlEncoder::FORMAT, CsvEncoder::FORMAT] as $format) {
+            $dummy = $normalizer->denormalize(['foo' => 'publish'], UnionBoolPropertyDummy::class, $format, [AbstractNormalizer::FILTER_BOOL => true]);
+            $this->assertSame('publish', $dummy->foo);
+
+            $dummy = $normalizer->denormalize(['foo' => 'on'], UnionBoolPropertyDummy::class, $format, [AbstractNormalizer::FILTER_BOOL => true]);
+            $this->assertTrue($dummy->foo);
+        }
+    }
+
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
+    public function testDenormalizeUnionTypeWithFilterBoolLegacy()
+    {
+        $normalizer = new AbstractObjectNormalizerWithMetadataAndLegacyUnionPropertyTypeExtractor();
+
+        foreach ([null, XmlEncoder::FORMAT, CsvEncoder::FORMAT] as $format) {
+            $dummy = $normalizer->denormalize(['foo' => 'publish'], UnionBoolPropertyDummy::class, $format, [AbstractNormalizer::FILTER_BOOL => true]);
+            $this->assertSame('publish', $dummy->foo);
+
+            $dummy = $normalizer->denormalize(['foo' => 'on'], UnionBoolPropertyDummy::class, $format, [AbstractNormalizer::FILTER_BOOL => true]);
+            $this->assertTrue($dummy->foo);
+        }
+    }
+
     public static function provideDenormalizeWithFilterBoolData(): array
     {
         return [
@@ -2050,6 +2078,11 @@ class BoolPropertyDummy
     public $foo;
 }
 
+class UnionBoolPropertyDummy
+{
+    public bool|string $foo;
+}
+
 class DummyWithArrayObject
 {
     /** @var \ArrayObject<string, mixed> */
@@ -2291,6 +2324,43 @@ class AbstractObjectNormalizerWithMetadataAndLegacyPropertyTypeExtractor extends
             public function getTypes(string $class, string $property, array $context = []): ?array
             {
                 return [new LegacyType(LegacyType::BUILTIN_TYPE_BOOL, true)];
+            }
+        });
+    }
+
+    protected function extractAttributes(object $object, ?string $format = null, array $context = []): array
+    {
+        return [];
+    }
+
+    protected function getAttributeValue(object $object, string $attribute, ?string $format = null, array $context = []): mixed
+    {
+        return null;
+    }
+
+    protected function setAttributeValue(object $object, string $attribute, mixed $value, ?string $format = null, array $context = []): void
+    {
+        if (property_exists($object, $attribute)) {
+            $object->$attribute = $value;
+        }
+    }
+
+    public function getSupportedTypes(?string $format): array
+    {
+        return [
+            '*' => false,
+        ];
+    }
+}
+
+class AbstractObjectNormalizerWithMetadataAndLegacyUnionPropertyTypeExtractor extends AbstractObjectNormalizer
+{
+    public function __construct()
+    {
+        parent::__construct(new ClassMetadataFactory(new AttributeLoader()), null, new class implements PropertyTypeExtractorInterface {
+            public function getTypes(string $class, string $property, array $context = []): ?array
+            {
+                return [new LegacyType(LegacyType::BUILTIN_TYPE_BOOL), new LegacyType(LegacyType::BUILTIN_TYPE_STRING)];
             }
         });
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65121
| License       | MIT

Denormalizing a union type that contains `bool` fails when the `filter_bool` context option is enabled and the value is not a recognisable boolean.

```php
final readonly class Dto
{
    public function __construct(public string|bool $value)
    {
    }
}

$serializer->denormalize(['value' => 'publish'], Dto::class, 'csv', ['filter_bool' => true]);
// Expected argument of type "string|bool", "null" given at property path "value".
```

`filter_var()` is called with `FILTER_NULL_ON_FAILURE`, so it returns `null` for a value it does not recognise as a boolean, and that `null` was returned as the denormalized value. Inside the loop that walks the members of a union type, a `return` is final: the remaining members are never tried. So `bool` swallowed `string` and the property received `null`.

This affects every `#[MapRequestPayload]` on a union containing `bool`, because `RequestPayloadValueResolver` denormalizes form payloads with the `csv` format and `filter_bool: true`.

The fix returns the filtered value only when the filter succeeded. When it fails, the loop carries on and the other members of the union get their turn. If no member matches and the declared type accepts `null`, `null` is still returned, so `filter_bool` keeps its existing behavior for a nullable bool.

Behavior after this change, with `filter_bool: true`:

| declared type | value | result |
| --- | --- | --- |
| `string\|bool` | `'publish'` | `'publish'` |
| `string\|bool` | `'on'` | `true` |
| `?bool` | `'publish'` | `null` |
| `?bool` | `'on'` | `true` |
| `bool` | `'publish'` | `NotNormalizableValueException` |

Both denormalization paths are patched, the TypeInfo one and the legacy one.

The regression was introduced in 7.4.15 by #64724, which let unparsable values reach `filter_var()` for the `xml` and `csv` formats instead of throwing before it. The `null` return itself dates back to 7.1.2, so the bug was only reachable for those two formats until 7.4.15.
