### PR TITLE
 Add treatPhpDocTypesAsCertain parameter to PHPStan

### DIFF
--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -5,6 +5,7 @@ includes:
 parameters:
     level: 5
     reportUnmatchedIgnoredErrors: false
+    treatPhpDocTypesAsCertain: false
     tmpDir: .github/sa-tools/phpstan-cache
     paths:
         - src


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | n/a
| License       | MIT

This avoids getting phpstan errors when adding runtime type checks validating phpdoc types.
We do have such type guards in some places. Existing ones are ignored already by our differential analysis setup for PRs. This avoids getting errors reported for new guards, like in https://github.com/symfony/symfony/pull/65123