### PR TITLE
[HttpClient] Allow passing a stream or a closure to HttpOptions::buffer()

### DIFF
--- a/UPGRADE-8.2.md
+++ b/UPGRADE-8.2.md
@@ -25,6 +25,11 @@ FrameworkBundle
 
  * Deprecate the `framework.ide` config option, use the `SYMFONY_IDE` env var instead
 
+HttpClient
+----------
+
+ * [BC BREAK] Widen the type of the `$buffer` argument of `HttpOptions::buffer()` from `bool` to `mixed`, so that the stream and closure forms the option accepts can be passed; a class extending `HttpOptions` and overriding that method must widen it too
+
 HttpFoundation
 --------------
 

--- a/src/Symfony/Component/HttpClient/CHANGELOG.md
+++ b/src/Symfony/Component/HttpClient/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add the `extra.cache_policy` option to `CachingHttpClient` to tag cached responses and force their lifetime
+ * Allow passing a stream or a closure to `HttpOptions::buffer()`
 
 8.1
 ---

--- a/src/Symfony/Component/HttpClient/HttpOptions.php
+++ b/src/Symfony/Component/HttpClient/HttpOptions.php
@@ -156,9 +156,12 @@ class HttpOptions
     }
 
     /**
+     * @param bool|resource|\Closure $buffer Whether to buffer the response, or a stream to write it to,
+     *                                       or a closure deciding it from the response headers
+     *
      * @return $this
      */
-    public function buffer(bool $buffer): static
+    public function buffer(mixed $buffer): static
     {
         $this->options['buffer'] = $buffer;
 

--- a/src/Symfony/Component/HttpClient/Tests/HttpOptionsTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/HttpOptionsTest.php
@@ -20,6 +20,20 @@ use Symfony\Component\HttpClient\HttpOptions;
  */
 class HttpOptionsTest extends TestCase
 {
+    public function testBufferAcceptsEveryFormOfTheOption()
+    {
+        $stream = fopen('php://temp', 'w+');
+        $closure = static fn (array $headers): bool => true;
+
+        try {
+            $this->assertSame(['buffer' => false], (new HttpOptions())->buffer(false)->toArray());
+            $this->assertSame(['buffer' => $stream], (new HttpOptions())->buffer($stream)->toArray());
+            $this->assertSame(['buffer' => $closure], (new HttpOptions())->buffer($closure)->toArray());
+        } finally {
+            fclose($stream);
+        }
+    }
+
     public static function provideSetAuthBasic(): iterable
     {
         yield ['user:password', 'user', 'password'];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Spotted by @Toflar in #65123.

`HttpClientInterface` documents the `buffer` option as accepting three forms:

```php
// bool|resource|\Closure - whether the content of the response should be buffered or not,
//   or a stream resource where the response body should be written,
//   or a closure telling if/where the response should be buffered based on its headers
'buffer' => true,
```

`HttpOptions::buffer()` only accepted the first one, so the fluent builder could not express the other two:

```php
(new HttpOptions())->buffer(fopen('php://temp', 'w+'));
// TypeError: HttpOptions::buffer(): Argument #1 ($buffer) must be of type bool, resource given
```

The argument is now `mixed`, with the accepted forms in the phpdoc. That matches `HttpOptions::setBody()`, which already documents `array|string|resource|\Traversable|\Closure` the same way, since a resource cannot appear in a union type.

Note this is a minor BC break, recorded in `UPGRADE-8.2.md`: a class extending `HttpOptions` and overriding `buffer()` with the `bool` type keeps the narrower signature and PHP rejects it.

```
Declaration of C::buffer(bool $b): static must be compatible with P::buffer(mixed $b): static
```

Nothing in the repository extends `HttpOptions`, and overriding a setter of a fluent options builder is unusual, so the practical exposure looks small.
