### PR TITLE
[Mime] Escape backslashes in Address::getEncodedName()

### DIFF
--- a/src/Symfony/Component/Mime/Address.php
+++ b/src/Symfony/Component/Mime/Address.php
@@ -87,7 +87,7 @@ final class Address
             return '';
         }
 
-        return \sprintf('"%s"', preg_replace('/"/u', '\"', $this->getName()));
+        return \sprintf('"%s"', preg_replace('/["\\\\]/', '\\\\$0', $this->getName()));
     }
 
     public static function create(self|string $address): self

--- a/src/Symfony/Component/Mime/Tests/AddressTest.php
+++ b/src/Symfony/Component/Mime/Tests/AddressTest.php
@@ -182,4 +182,19 @@ class AddressTest extends TestCase
         $address = new Address('fabien@symfony.com', 'Fabien, "Potencier');
         $this->assertSame('"Fabien, \"Potencier" <fabien@symfony.com>', $address->toString());
     }
+
+    public function testEncodeNameIfNameContainsBackslashes()
+    {
+        $address = new Address('fabien@symfony.com', 'Fabien \ "Potencier');
+        $this->assertSame('"Fabien \\\\ \"Potencier" <fabien@symfony.com>', $address->toString());
+
+        $address = new Address('fabien@symfony.com', 'Fabien\\');
+        $this->assertSame('"Fabien\\\\" <fabien@symfony.com>', $address->toString());
+    }
+
+    public function testEncodeNameIfNameIsNotValidUtf8()
+    {
+        $address = new Address('fabien@symfony.com', "Fabien \xB1 \\ Potencier");
+        $this->assertSame("\"Fabien \xB1 \\\\ Potencier\" <fabien@symfony.com>", $address->toString());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | none
| License       | MIT

`getEncodedName()` escapes quotes in the display name but not backslashes. Inside a quoted-string a backslash starts a quoted-pair ([RFC 5322 3.2.4](https://datatracker.ietf.org/doc/html/rfc5322#section-3.2.4)). A name ending in a backslash escapes its own closing quote and the header is malformed:

```php
$a = new Address('fabien@symfony.com', 'Fabien\\');
$a->toString(); // "Fabien\" <fabien@symfony.com>
```

`AbstractHeader::createPhrase()` already escapes both characters. Same address, two serializations:

```
toString():   "Fabien \ \"Potencier" <fabien@symfony.com>
header path:  "Fabien \\ \"Potencier" <fabien@symfony.com>
```

Most Mailer API transports build their payloads from `toString()`, so the malformed form reaches the provider. The fix adds the backslash to the existing preg_replace and both paths now match. New test covers the trailing and mixed cases.
