### PR TITLE
[Security] Add a form helper for the logout

### DIFF
--- a/src/Symfony/Bridge/Twig/CHANGELOG.md
+++ b/src/Symfony/Bridge/Twig/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `logout_form()` function to build a form that logs the user out with a POST
+
 8.1
 ---
 

--- a/src/Symfony/Bridge/Twig/Extension/LogoutUrlExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/LogoutUrlExtension.php
@@ -32,6 +32,7 @@ final class LogoutUrlExtension extends AbstractExtension
         return [
             new TwigFunction('logout_url', $this->getLogoutUrl(...)),
             new TwigFunction('logout_path', $this->getLogoutPath(...)),
+            new TwigFunction('logout_form', $this->getLogoutForm(...)),
         ];
     }
 
@@ -53,5 +54,17 @@ final class LogoutUrlExtension extends AbstractExtension
     public function getLogoutUrl(?string $key = null): string
     {
         return $this->generator->getLogoutUrl($key);
+    }
+
+    /**
+     * Returns the action and the hidden fields of a form triggering the logout.
+     *
+     * @param string|null $key The firewall key or null to use the current firewall key
+     *
+     * @return array{action: string, fields: array<string, string>}
+     */
+    public function getLogoutForm(?string $key = null): array
+    {
+        return $this->generator->getLogoutForm($key);
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/FormLoginBundle/Controller/LoginController.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/FormLoginBundle/Controller/LoginController.php
@@ -55,6 +55,11 @@ class LoginController implements ServiceSubscriberInterface
         return new Response('', 400);
     }
 
+    public function logoutFormAction()
+    {
+        return new Response($this->container->get('twig')->render('@FormLogin/Login/logout_form.html.twig'));
+    }
+
     public function secureAction()
     {
         throw new \Exception('Wrapper', 0, new \Exception('Another Wrapper', 0, new AccessDeniedException()));

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/FormLoginBundle/Resources/views/Login/logout_form.html.twig
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/FormLoginBundle/Resources/views/Login/logout_form.html.twig
@@ -1,0 +1,12 @@
+{% extends 'base.html.twig' %}
+
+{% block body %}
+    {% set logout = logout_form() %}
+    <form method="post" action="{{ logout.action }}">
+        {% for name, value in logout.fields %}
+            <input type="hidden" name="{{ name }}" value="{{ value }}" />
+        {% endfor %}
+
+        <input type="submit" name="logout" />
+    </form>
+{% endblock %}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/LogoutTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/LogoutTest.php
@@ -109,6 +109,48 @@ class LogoutTest extends AbstractWebTestCase
         $this->assertRedirect($client->getResponse(), '/');
     }
 
+    public function testTheLogoutFormHelperBuildsAFormTheListenerAccepts()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $crawler = $client->request('GET', '/logout-form');
+        $client->submit($crawler->selectButton('logout')->form());
+
+        $this->assertRedirect($client->getResponse(), '/');
+    }
+
+    public function testLoggingOutWithoutTheTokenTheFormCarriesIsDenied()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $client->request('POST', '/logout');
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
+    }
+
+    public function testTheLogoutPathCannotBeFollowedAsALinkWhenTheRouteIsPostOnly()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $client->request('GET', '/logout');
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_METHOD_NOT_ALLOWED);
+    }
+
+    private function createAuthenticatedClient(): KernelBrowser
+    {
+        $client = $this->createClient(['test_case' => 'StandardFormLogin', 'root_config' => 'logout_csrf.yml']);
+        $client->followRedirects(true);
+
+        $form = $client->request('GET', '/login')->selectButton('login')->form();
+        $form['_username'] = 'johannes';
+        $form['_password'] = 'test';
+        $client->submit($form);
+        $client->followRedirects(false);
+
+        return $client;
+    }
+
     private function callInRequestContext(KernelBrowser $client, callable $callable): void
     {
         /** @var EventDispatcherInterface $eventDispatcher */

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/logout_csrf.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/logout_csrf.yml
@@ -1,0 +1,8 @@
+imports:
+    - { resource: ./base_config.yml }
+
+security:
+    firewalls:
+        default:
+            logout:
+                enable_csrf: true

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/routing.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/routing.yml
@@ -3,3 +3,11 @@ _form_login_bundle:
 
 _form_login_localized:
     resource: '@FormLoginBundle/Resources/config/localized_routing.yml'
+
+logout_form:
+    path:     /logout-form
+    defaults: { _controller: Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\FormLoginBundle\Controller\LoginController::logoutFormAction }
+
+app_logout:
+    path:     /logout
+    methods:  [POST]

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -49,7 +49,7 @@
         "symfony/serializer": "^7.4|^8.0",
         "symfony/translation": "^7.4|^8.0",
         "symfony/twig-bundle": "^7.4|^8.0",
-        "symfony/twig-bridge": "^7.4|^8.0",
+        "symfony/twig-bridge": "^8.2",
         "symfony/validator": "^7.4|^8.0",
         "symfony/yaml": "^7.4|^8.0",
         "web-token/jwt-library": "^3.3.2|^4.0"

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Add `allowed_time_drift` option to `OidcTokenHandler` to configure time tolerance for token validation (`iat`, `nbf`, `exp` claims)
  * Throw a 403 `Symfony\Component\Security\Http\Exception\InvalidCsrfTokenException` instead of the `Security\Core` one when the `#[IsCsrfTokenValid]` attribute fails, so the failure is no longer handled as an authentication failure
  * Add the deauthentication reason and the responsible user providers to `TokenDeauthenticatedEvent`
+ * Add `LogoutUrlGenerator::getLogoutForm()` to build a form that logs the user out with a POST
 
 8.1
 ---

--- a/src/Symfony/Component/Security/Http/Logout/LogoutUrlGenerator.php
+++ b/src/Symfony/Component/Security/Http/Logout/LogoutUrlGenerator.php
@@ -66,6 +66,21 @@ class LogoutUrlGenerator implements ResetInterface
         return $this->generateLogoutUrl($key, UrlGeneratorInterface::ABSOLUTE_URL);
     }
 
+    /**
+     * Returns the action and the hidden fields of a form triggering the logout.
+     *
+     * Unlike the URLs, this keeps the CSRF token out of the address bar and suits a
+     * logout endpoint restricted to POST requests.
+     *
+     * @return array{action: string, fields: array<string, string>}
+     */
+    public function getLogoutForm(?string $key = null): array
+    {
+        [$action, $fields] = $this->buildParts($key, UrlGeneratorInterface::ABSOLUTE_PATH);
+
+        return ['action' => $action, 'fields' => $fields];
+    }
+
     public function setCurrentFirewall(?string $key, ?string $context = null): void
     {
         $this->currentFirewallName = $key;
@@ -77,6 +92,20 @@ class LogoutUrlGenerator implements ResetInterface
      */
     private function generateLogoutUrl(?string $key, int $referenceType): string
     {
+        [$url, $parameters] = $this->buildParts($key, $referenceType);
+
+        if (!$parameters) {
+            return $url;
+        }
+
+        return $url.(str_contains($url, '?') ? '&' : '?').http_build_query($parameters, '', '&');
+    }
+
+    /**
+     * @return array{0: string, 1: array<string, string>}
+     */
+    private function buildParts(?string $key, int $referenceType): array
+    {
         [$logoutPath, $csrfTokenId, $csrfParameter, $csrfTokenManager] = $this->getListener($key);
 
         if (null === $logoutPath) {
@@ -85,31 +114,45 @@ class LogoutUrlGenerator implements ResetInterface
 
         $parameters = null !== $csrfTokenManager ? [$csrfParameter => (string) $csrfTokenManager->getToken($csrfTokenId)] : [];
 
-        if ('/' === $logoutPath[0]) {
-            if (!$this->requestStack) {
-                throw new \LogicException('Unable to generate the logout URL without a RequestStack.');
-            }
-
-            $request = $this->requestStack->getCurrentRequest();
-
-            if (!$request) {
-                throw new \LogicException('Unable to generate the logout URL without a Request.');
-            }
-
-            $url = UrlGeneratorInterface::ABSOLUTE_URL === $referenceType ? $request->getUriForPath($logoutPath) : $request->getBaseUrl().$logoutPath;
-
-            if ($parameters) {
-                $url .= '?'.http_build_query($parameters, '', '&');
-            }
-        } else {
+        if ('/' !== $logoutPath[0]) {
             if (!$this->router) {
                 throw new \LogicException('Unable to generate the logout URL without a Router.');
             }
 
-            $url = $this->router->generate($logoutPath, $parameters, $referenceType);
+            // the route may take the parameters as placeholders, only the others are left over
+            return self::splitQuery($this->router->generate($logoutPath, $parameters, $referenceType));
         }
 
-        return $url;
+        if (!$this->requestStack) {
+            throw new \LogicException('Unable to generate the logout URL without a RequestStack.');
+        }
+
+        $request = $this->requestStack->getCurrentRequest();
+
+        if (!$request) {
+            throw new \LogicException('Unable to generate the logout URL without a Request.');
+        }
+
+        $url = UrlGeneratorInterface::ABSOLUTE_URL === $referenceType ? $request->getUriForPath($logoutPath) : $request->getBaseUrl().$logoutPath;
+
+        return [$url, $parameters];
+    }
+
+    /**
+     * @return array{0: string, 1: array<string, string>}
+     */
+    private static function splitQuery(string $url): array
+    {
+        [$url, $query] = explode('?', $url, 2) + ['', ''];
+        $parameters = [];
+
+        // parse_str() cannot be used here as it turns dots and spaces in parameter names into underscores
+        foreach ('' === $query ? [] : explode('&', $query) as $pair) {
+            [$name, $value] = explode('=', $pair, 2) + ['', ''];
+            $parameters[urldecode($name)] = urldecode($value);
+        }
+
+        return [$url, $parameters];
     }
 
     /**

--- a/src/Symfony/Component/Security/Http/Tests/Logout/LogoutUrlGeneratorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Logout/LogoutUrlGeneratorTest.php
@@ -14,9 +14,12 @@ namespace Symfony\Component\Security\Http\Tests\Logout;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\User\InMemoryUser;
+use Symfony\Component\Security\Csrf\CsrfToken;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Symfony\Component\Security\Http\Logout\LogoutUrlGenerator;
 
 /**
@@ -119,5 +122,60 @@ class LogoutUrlGeneratorTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('This request is not behind a firewall, pass the firewall name manually to generate a logout URL.');
         $this->generator->getLogoutPath();
+    }
+
+    public function testGetLogoutFormWithoutCsrfProtection()
+    {
+        $this->generator->registerListener('secured_area', '/logout', null, null);
+
+        $this->assertSame(['action' => '/logout', 'fields' => []], $this->generator->getLogoutForm('secured_area'));
+    }
+
+    public function testGetLogoutFormCarriesTheCsrfTokenUnderTheConfiguredParameter()
+    {
+        $csrfTokenManager = $this->createMock(CsrfTokenManagerInterface::class);
+        $csrfTokenManager->expects($this->once())
+            ->method('getToken')->with('logout_id')
+            ->willReturn(new CsrfToken('logout_id', 'T0K3N'));
+
+        $this->generator->registerListener('secured_area', '/logout', 'logout_id', '_token', $csrfTokenManager);
+
+        $this->assertSame([
+            'action' => '/logout',
+            'fields' => ['_token' => 'T0K3N'],
+        ], $this->generator->getLogoutForm('secured_area'));
+    }
+
+    public function testGetLogoutFormFromARouteName()
+    {
+        $router = $this->createStub(UrlGeneratorInterface::class);
+        $router->method('generate')->willReturnCallback(
+            static fn (string $name, array $parameters) => '/logout'.($parameters ? '?'.http_build_query($parameters, '', '&') : '')
+        );
+
+        $csrfTokenManager = $this->createStub(CsrfTokenManagerInterface::class);
+        $csrfTokenManager->method('getToken')->willReturn(new CsrfToken('logout', 'T0K3N'));
+
+        $requestStack = new RequestStack();
+        $requestStack->push(new Request());
+        $generator = new LogoutUrlGenerator($requestStack, $router, $this->tokenStorage);
+        $generator->registerListener('secured_area', 'app_logout', 'logout', '_csrf_token', $csrfTokenManager);
+
+        $this->assertSame([
+            'action' => '/logout',
+            'fields' => ['_csrf_token' => 'T0K3N'],
+        ], $generator->getLogoutForm('secured_area'));
+    }
+
+    public function testTheLogoutFormAndTheLogoutPathCarryTheSameParameters()
+    {
+        $csrfTokenManager = $this->createStub(CsrfTokenManagerInterface::class);
+        $csrfTokenManager->method('getToken')->willReturn(new CsrfToken('logout', 'T0K3N'));
+
+        $this->generator->registerListener('secured_area', '/logout', 'logout', '_csrf_token', $csrfTokenManager);
+
+        ['action' => $action, 'fields' => $fields] = $this->generator->getLogoutForm('secured_area');
+
+        $this->assertSame($this->generator->getLogoutPath('secured_area'), $action.'?'.http_build_query($fields, '', '&'));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Logging out with a GET is a link away, and browsers, scanners, corporate proxies and link-preview bots all follow links on their own. Restricting the logout route to POST fixes that:

```yaml
# config/routes.yaml
app_logout:
    path: /logout
    methods: [POST]
```

Except `logout_path()` cannot drive that route: a link issues a GET, and routing rejects it at priority 32, long before the logout listener runs at 8. Building the form by hand instead means hardcoding the configured `csrf_parameter`, and minting the token with `csrf_token()`, which reaches for the application's default manager rather than the one the firewall configured.

`getLogoutForm()` returns the action and the hidden fields to render, exposed to templates as `logout_form()`:

```twig
{% set logout = logout_form() %}

<form method="post" action="{{ logout.action }}">
    {% for name, value in logout.fields %}
        <input type="hidden" name="{{ name }}" value="{{ value }}">
    {% endfor %}

    <button>Log out</button>
</form>
```

The parameter name comes from the configuration and the token from the firewall's `csrf_token_manager`, so the form carries what the listener expects. It takes the same optional firewall key as `logout_path()`, and returns `fields: []` when the firewall does not enable CSRF, which still leaves you the configured path and a POST.

`logout_path()` and `logout_url()` are unchanged and still suit a link on a route that accepts GET.

## Implementation

`generateLogoutUrl()` already computed a URL and a parameter map before glueing them together. That split is now a `buildParts()` both APIs consume, so the two cannot drift. Parameters a route takes as placeholders land in the action rather than in the fields, and the query is parsed by hand rather than with `parse_str()`, which would rewrite dots and spaces in a configurable parameter name into underscores.

## Tests

Four unit tests on the parts, covering a path, a route name, no CSRF, and an invariant that `action` plus `fields` reconstructs what `getLogoutPath()` returns.

Three functional ones against a firewall with `logout.enable_csrf` and a **POST-only** logout route: the rendered form logs the user out, a POST without the token it carries is refused with a 403, and `GET /logout` is refused with a 405. That last one is the motivation, pinned as a test.

## Not in scope

Nothing makes the logout route POST-only for you. `LogoutRouteLoader` registers `new Route($logoutPath)` with no method restriction, so the auto-registered route accepts GET and the hardening above needs the route declared by hand. Giving the loader a way to express that seems worth doing, but it is a configuration change rather than a helper, so I kept it out of here.

This is the same shape as the impersonation form helpers in #64879. Whichever lands second, the query splitting is worth factoring out rather than kept in both generators.
