### PR TITLE
[Tui] Add Transitions and TransitionWidget

### DIFF
--- a/src/Symfony/Component/Tui/CHANGELOG.md
+++ b/src/Symfony/Component/Tui/CHANGELOG.md
@@ -12,6 +12,7 @@ CHANGELOG
  * Add `AbstractWidget::attachChild()` and `AbstractWidget::detachChild()` to wire child widgets
  * Add multi-select support to `SelectListWidget`
  * [BC BREAK] Add `$multiselect` as the third argument of `SelectListWidget::__construct()`, moving `$keybindings` to fourth position
+ * Add `TransitionWidget` and the `Slide`, `Wipe`, `Slice`, `Diamond`, `Shutters` and `Spiral` transitions
 
 8.1
 ---

--- a/src/Symfony/Component/Tui/Tests/Transition/AbstractTransitionTestCase.php
+++ b/src/Symfony/Component/Tui/Tests/Transition/AbstractTransitionTestCase.php
@@ -1,0 +1,124 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Tests\Transition;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Tui\Ansi\AnsiUtils;
+use Symfony\Component\Tui\Transition\TransitionInterface;
+
+abstract class AbstractTransitionTestCase extends TestCase
+{
+    protected array $fromLines;
+    protected array $toLines;
+
+    /**
+     * @var list<string>
+     */
+    protected array $fromCells;
+
+    /**
+     * @var list<string>
+     */
+    protected array $toCells;
+    protected int $width = 10;
+    protected int $height = 5;
+
+    protected function setUp(): void
+    {
+        $this->fromLines = array_fill(0, $this->height, 'AAAAAAAAAA');
+        $this->toLines = array_fill(0, $this->height, 'BBBBBBBBBB');
+
+        // Uniform screens only tell which screen a cell came from. These carry coordinates
+        // instead: the letter advances with both column and row, lowercase for "from" and
+        // uppercase for "to", so a cell that moves by one column or one row changes character.
+        $this->fromCells = [];
+        $this->toCells = [];
+        for ($y = 0; $y < $this->height; ++$y) {
+            $row = '';
+            for ($x = 0; $x < $this->width; ++$x) {
+                $row .= \chr(\ord('a') + $y + $x);
+            }
+            $this->fromCells[] = $row;
+            $this->toCells[] = strtoupper($row);
+        }
+    }
+
+    /**
+     * Asserts every cell was taken from its own coordinates in one screen or the other.
+     *
+     * Transitions that reveal in place must never move a cell: each (x, y) holds either the
+     * "from" or the "to" character for that exact position. This fails both on a blend that
+     * invents content and on one that is off by a column or a row.
+     *
+     * @param list<string> $lines
+     */
+    protected function assertCellsKeepTheirCoordinates(array $lines, string $message = ''): void
+    {
+        $this->assertCount($this->height, $lines, $message ?: 'The blend must return one line per row.');
+
+        for ($y = 0; $y < $this->height; ++$y) {
+            for ($x = 0; $x < $this->width; ++$x) {
+                $actual = AnsiUtils::sliceByColumn($lines[$y], $x, 1);
+                $expected = [$this->fromCells[$y][$x], $this->toCells[$y][$x]];
+
+                $this->assertContains($actual, $expected, $message ?: \sprintf('Cell (%d, %d) holds "%s", which belongs to neither screen at that position (expected "%s" or "%s").', $x, $y, $actual, $expected[0], $expected[1]));
+            }
+        }
+    }
+
+    /**
+     * Asserts the blend keeps every line at the requested width when both screens hold
+     * double-width graphemes.
+     *
+     * The graphemes sit at different columns on every row, so sweeping the progress makes
+     * the slicing boundaries land inside them: a slice that drops or duplicates a column
+     * there shifts the whole region and wraps the terminal.
+     */
+    protected function assertWideGraphemesKeepTheLineWidth(TransitionInterface $transition): void
+    {
+        $width = 12;
+        $height = 4;
+        $from = [];
+        $to = [];
+        for ($y = 0; $y < $height; ++$y) {
+            $from[] = str_repeat('a', $y)."\u{1F600}".str_repeat('b', 8 - $y)."\u{1F600}";
+            $to[] = str_repeat('X', 2 + $y)."\u{1F600}".str_repeat('Y', 6 - $y)."\u{1F600}";
+        }
+
+        foreach ([...$from, ...$to] as $line) {
+            $this->assertSame($width, AnsiUtils::visibleWidth($line));
+        }
+
+        for ($i = 1; $i < 20; ++$i) {
+            $progress = $i / 20;
+            foreach ($transition->blend($from, $to, $width, $height, $progress) as $lineNo => $line) {
+                $this->assertSame($width, AnsiUtils::visibleWidth($line), \sprintf('Line %d does not measure %d columns at progress %.2f.', $lineNo, $width, $progress));
+            }
+        }
+    }
+
+    protected function assertLinesMatch(array $expected, array $actual, string $message = ''): void
+    {
+        $this->assertSame($expected, $actual, $message);
+    }
+
+    /**
+     * Asserts that a specific character is at a given position in the resulting lines.
+     */
+    protected function assertCharAt(int $x, int $y, string $expected, array $lines, string $message = ''): void
+    {
+        $line = $lines[$y] ?? '';
+        $char = AnsiUtils::sliceByColumn($line, $x, 1);
+
+        $this->assertSame($expected, $char, $message ?: \sprintf("Character at (%d, %d) should be '%s', got '%s'.", $x, $y, $expected, $char));
+    }
+}

--- a/src/Symfony/Component/Tui/Tests/Transition/DiamondTransitionTest.php
+++ b/src/Symfony/Component/Tui/Tests/Transition/DiamondTransitionTest.php
@@ -1,0 +1,140 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Tests\Transition;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Component\Tui\Transition\DiamondTransition;
+use Symfony\Component\Tui\Transition\Direction\RadialDirection;
+
+class DiamondTransitionTest extends AbstractTransitionTestCase
+{
+    /**
+     * @return iterable<string, array{RadialDirection, list<array{int, int, string}>}>
+     */
+    public static function directionProvider(): iterable
+    {
+        // @0.5 the reveal region is complementary between directions, not identical: Outward's
+        // diamond (center) holds "to" with "from" corners; Inward's diamond holds "from" with "to"
+        // corners: the mirror image, since Inward is meant to shrink the "from" screen away.
+        yield 'outward' => [RadialDirection::Outward, [[5, 2, 'B'], [0, 0, 'A']]];
+        yield 'inward' => [RadialDirection::Inward, [[5, 2, 'A'], [0, 0, 'B']]];
+    }
+
+    #[DataProvider('directionProvider')]
+    public function testBoundariesReturnExactScreens(RadialDirection $direction, array $cells)
+    {
+        $transition = new DiamondTransition($direction);
+
+        $this->assertSame($this->fromLines, $transition->blend($this->fromLines, $this->toLines, $this->width, $this->height, 0.0));
+        $this->assertSame($this->toLines, $transition->blend($this->fromLines, $this->toLines, $this->width, $this->height, 1.0));
+    }
+
+    /**
+     * @param list<array{int, int, string}> $cells
+     */
+    #[DataProvider('directionProvider')]
+    public function testControlPointsAtHalf(RadialDirection $direction, array $cells)
+    {
+        $transition = new DiamondTransition($direction);
+        $res = $transition->blend($this->fromLines, $this->toLines, $this->width, $this->height, 0.5);
+
+        foreach ($cells as [$x, $y, $char]) {
+            $this->assertCharAt($x, $y, $char, $res);
+        }
+    }
+
+    /**
+     * @return iterable<string, array{RadialDirection, float, string, string}>
+     */
+    public static function cornerFallbackProvider(): iterable
+    {
+        // On the 10x5 screen these progress points make rows 0 and 4 satisfy d<0, reaching the
+        // corner-fallback branch, while the center row stays inside the diamond's active height
+        // range. Outward and Inward use symmetric progress values (0.2 / 1 - 0.2) so both land on the
+        // same diamond size: Outward's small growing diamond still holds "to" at the center; Inward's
+        // small remaining diamond (same size, mirrored) still holds "from" at the center.
+        yield 'outward at 0.2 keeps from-corner' => [RadialDirection::Outward, 0.2, 'A', 'B'];
+        yield 'inward at 0.8 shows to-corner' => [RadialDirection::Inward, 0.8, 'B', 'A'];
+    }
+
+    #[DataProvider('cornerFallbackProvider')]
+    public function testCornerFallbackDiscriminatesDirection(RadialDirection $direction, float $progress, string $corner, string $center)
+    {
+        $transition = new DiamondTransition($direction);
+        $res = $transition->blend($this->fromLines, $this->toLines, $this->width, $this->height, $progress);
+
+        // The d<0 corner fallback: 'A' for Outward@0.2 vs 'B' for Inward@0.8 is the discrimination.
+        $this->assertCharAt(0, 0, $corner, $res);
+        // The diamond itself still holds the direction-appropriate screen at this progress.
+        $this->assertCharAt(5, 2, $center, $res);
+    }
+
+    /**
+     * @return iterable<string, array{RadialDirection}>
+     */
+    public static function monotonicDirectionProvider(): iterable
+    {
+        yield 'outward' => [RadialDirection::Outward];
+        yield 'inward' => [RadialDirection::Inward];
+    }
+
+    /**
+     * A true mirror of a monotonically growing reveal (Outward) must itself be monotonic: the
+     * amount of "to" on screen never regresses as progress advances. This is what broke before
+     * the Inward fix (only the fallback and effectiveProgress were swapped, not the diamond's own
+     * interior), so the "to" coverage rose, fell, then rose again instead of climbing steadily.
+     */
+    #[DataProvider('monotonicDirectionProvider')]
+    public function testToCoverageNeverRegresses(RadialDirection $direction)
+    {
+        $transition = new DiamondTransition($direction);
+        $previousCount = -1;
+        $counts = [];
+
+        foreach ([0.02, 0.1, 0.25, 0.4, 0.5, 0.6, 0.75, 0.9, 0.98] as $progress) {
+            $res = $transition->blend($this->fromLines, $this->toLines, $this->width, $this->height, $progress);
+            $count = array_sum(array_map(static fn (string $line) => substr_count($line, 'B'), $res));
+
+            $this->assertGreaterThanOrEqual($previousCount, $count, \sprintf('"to" coverage regressed at progress %.2f.', $progress));
+            $previousCount = $count;
+            $counts[] = $count;
+        }
+
+        // Monotonicity alone is satisfied by a blend that never changes at all, so pin the
+        // climb itself: nearly nothing of the "to" screen at the start, nearly all of it at
+        // the end.
+        $total = $this->width * $this->height;
+        $this->assertLessThan($total / 4, $counts[0], 'The reveal should barely have started at progress 0.02.');
+        $this->assertGreaterThan(3 * $total / 4, end($counts), 'The reveal should be nearly complete at progress 0.98.');
+    }
+
+    /**
+     * @param list<array{int, int, string}> $cells
+     */
+    #[DataProvider('directionProvider')]
+    public function testCellsAreRevealedInPlace(RadialDirection $direction, array $cells)
+    {
+        $transition = new DiamondTransition($direction);
+
+        foreach ([0.1, 0.25, 0.4, 0.5, 0.6, 0.75, 0.9] as $progress) {
+            $lines = $transition->blend($this->fromCells, $this->toCells, $this->width, $this->height, $progress);
+
+            $this->assertCellsKeepTheirCoordinates($lines, \sprintf('Progress %.2f moved a cell away from its own coordinates.', $progress));
+        }
+    }
+
+    #[DataProvider('directionProvider')]
+    public function testWideGraphemesKeepTheLineWidth(RadialDirection $direction, array $cells)
+    {
+        $this->assertWideGraphemesKeepTheLineWidth(new DiamondTransition($direction));
+    }
+}

--- a/src/Symfony/Component/Tui/Tests/Transition/ShuttersTransitionTest.php
+++ b/src/Symfony/Component/Tui/Tests/Transition/ShuttersTransitionTest.php
@@ -1,0 +1,109 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Tests\Transition;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Component\Tui\Exception\InvalidArgumentException;
+use Symfony\Component\Tui\Transition\Direction\HorizontalDirection;
+use Symfony\Component\Tui\Transition\Direction\VerticalDirection;
+use Symfony\Component\Tui\Transition\ShuttersTransition;
+
+class ShuttersTransitionTest extends AbstractTransitionTestCase
+{
+    /**
+     * @return iterable<string, array{HorizontalDirection|VerticalDirection, list<array{int, int, string}>}>
+     */
+    public static function directionProvider(): iterable
+    {
+        // Default size 4, @0.5 reveals half of each shutter from its entrance edge.
+        yield 'from left' => [HorizontalDirection::Left, [[0, 0, 'B'], [2, 0, 'A'], [4, 0, 'B']]];
+        yield 'from right' => [HorizontalDirection::Right, [[0, 0, 'A'], [2, 0, 'B'], [4, 0, 'A']]];
+        yield 'from top' => [VerticalDirection::Top, [[0, 0, 'B'], [0, 2, 'A'], [0, 4, 'B'], [9, 4, 'A']]];
+        yield 'from bottom' => [VerticalDirection::Bottom, [[0, 0, 'A'], [0, 2, 'B'], [0, 4, 'B'], [9, 4, 'A']]];
+    }
+
+    #[DataProvider('directionProvider')]
+    public function testBoundariesReturnExactScreens(HorizontalDirection|VerticalDirection $direction, array $cells)
+    {
+        $transition = new ShuttersTransition($direction);
+
+        $this->assertSame($this->fromLines, $transition->blend($this->fromLines, $this->toLines, $this->width, $this->height, 0.0));
+        $this->assertSame($this->toLines, $transition->blend($this->fromLines, $this->toLines, $this->width, $this->height, 1.0));
+    }
+
+    /**
+     * @param list<array{int, int, string}> $cells
+     */
+    #[DataProvider('directionProvider')]
+    public function testControlPointsAtHalf(HorizontalDirection|VerticalDirection $direction, array $cells)
+    {
+        $transition = new ShuttersTransition($direction);
+        $res = $transition->blend($this->fromLines, $this->toLines, $this->width, $this->height, 0.5);
+
+        foreach ($cells as [$x, $y, $char]) {
+            $this->assertCharAt($x, $y, $char, $res);
+        }
+    }
+
+    public function testVerticalEntranceWipesTheBoundaryRowInsteadOfJumping()
+    {
+        // Default size 4, @0.375 reveal = 1.5: row 0 fully "to", row 1 mid-wipe, rows 2-3 "from".
+        // A hard row-count reveal (the old behavior) could only ever land on revealSize 0-3 here;
+        // this progress falls *between* two of those steps, which is exactly the point.
+        $transition = new ShuttersTransition(VerticalDirection::Top);
+        $res = $transition->blend($this->fromLines, $this->toLines, $this->width, $this->height, 0.375);
+
+        $this->assertCharAt(0, 0, 'B', $res);
+        $this->assertCharAt(0, 1, 'B', $res);
+        $this->assertCharAt(4, 1, 'B', $res);
+        $this->assertCharAt(5, 1, 'A', $res);
+        $this->assertCharAt(9, 1, 'A', $res);
+        $this->assertCharAt(0, 2, 'A', $res);
+    }
+
+    /**
+     * @param list<array{int, int, string}> $cells
+     */
+    #[DataProvider('directionProvider')]
+    public function testCellsAreRevealedInPlace(HorizontalDirection|VerticalDirection $direction, array $cells)
+    {
+        $transition = new ShuttersTransition($direction);
+
+        foreach ([0.1, 0.25, 0.4, 0.5, 0.6, 0.75, 0.9] as $progress) {
+            $lines = $transition->blend($this->fromCells, $this->toCells, $this->width, $this->height, $progress);
+
+            $this->assertCellsKeepTheirCoordinates($lines, \sprintf('Progress %.2f moved a cell away from its own coordinates.', $progress));
+        }
+    }
+
+    #[DataProvider('directionProvider')]
+    public function testWideGraphemesKeepTheLineWidth(HorizontalDirection|VerticalDirection $direction, array $cells)
+    {
+        $this->assertWideGraphemesKeepTheLineWidth(new ShuttersTransition($direction, 3));
+    }
+
+    public function testZeroSizeThrows()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Size must be greater than 0, got 0.');
+
+        new ShuttersTransition(size: 0);
+    }
+
+    public function testNegativeSizeThrows()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Size must be greater than 0, got -1.');
+
+        new ShuttersTransition(size: -1);
+    }
+}

--- a/src/Symfony/Component/Tui/Tests/Transition/SliceTransitionTest.php
+++ b/src/Symfony/Component/Tui/Tests/Transition/SliceTransitionTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Tests\Transition;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Component\Tui\Exception\InvalidArgumentException;
+use Symfony\Component\Tui\Transition\Direction\HorizontalDirection;
+use Symfony\Component\Tui\Transition\Direction\VerticalDirection;
+use Symfony\Component\Tui\Transition\SliceTransition;
+
+class SliceTransitionTest extends AbstractTransitionTestCase
+{
+    /**
+     * @return iterable<string, array{HorizontalDirection|VerticalDirection, list<array{int, int, string}>}>
+     */
+    public static function directionProvider(): iterable
+    {
+        // Horizontal slices alternate their entrance edge from one row to the next.
+        yield 'from left' => [HorizontalDirection::Left, [[0, 0, 'B'], [9, 0, 'A'], [0, 1, 'A'], [9, 1, 'B']]];
+        yield 'from right' => [HorizontalDirection::Right, [[0, 0, 'A'], [9, 0, 'B'], [0, 1, 'B'], [9, 1, 'A']]];
+        // Vertical slices are four columns wide and alternate their entrance edge by band.
+        yield 'from top' => [VerticalDirection::Top, [[0, 0, 'B'], [4, 0, 'A'], [0, 4, 'A'], [4, 4, 'B']]];
+        yield 'from bottom' => [VerticalDirection::Bottom, [[0, 0, 'A'], [4, 0, 'B'], [0, 4, 'B'], [4, 4, 'A']]];
+    }
+
+    #[DataProvider('directionProvider')]
+    public function testBoundariesReturnExactScreens(HorizontalDirection|VerticalDirection $direction, array $cells)
+    {
+        $transition = new SliceTransition($direction);
+
+        $this->assertSame($this->fromLines, $transition->blend($this->fromLines, $this->toLines, $this->width, $this->height, 0.0));
+        $this->assertSame($this->toLines, $transition->blend($this->fromLines, $this->toLines, $this->width, $this->height, 1.0));
+    }
+
+    /**
+     * @param list<array{int, int, string}> $cells
+     */
+    #[DataProvider('directionProvider')]
+    public function testControlPointsAtHalf(HorizontalDirection|VerticalDirection $direction, array $cells)
+    {
+        $transition = new SliceTransition($direction);
+        $res = $transition->blend($this->fromLines, $this->toLines, $this->width, $this->height, 0.5);
+
+        foreach ($cells as [$x, $y, $char]) {
+            $this->assertCharAt($x, $y, $char, $res);
+        }
+    }
+
+    /**
+     * @param list<array{int, int, string}> $cells
+     */
+    #[DataProvider('directionProvider')]
+    public function testCellsAreRevealedInPlace(HorizontalDirection|VerticalDirection $direction, array $cells)
+    {
+        $transition = new SliceTransition($direction);
+
+        foreach ([0.1, 0.25, 0.4, 0.5, 0.6, 0.75, 0.9] as $progress) {
+            $lines = $transition->blend($this->fromCells, $this->toCells, $this->width, $this->height, $progress);
+
+            $this->assertCellsKeepTheirCoordinates($lines, \sprintf('Progress %.2f moved a cell away from its own coordinates.', $progress));
+        }
+    }
+
+    #[DataProvider('directionProvider')]
+    public function testWideGraphemesKeepTheLineWidth(HorizontalDirection|VerticalDirection $direction, array $cells)
+    {
+        $this->assertWideGraphemesKeepTheLineWidth(new SliceTransition($direction, 3));
+    }
+
+    public function testZeroSizeThrows()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Size must be greater than 0, got 0.');
+
+        new SliceTransition(size: 0);
+    }
+
+    public function testNegativeSizeThrows()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Size must be greater than 0, got -1.');
+
+        new SliceTransition(size: -1);
+    }
+}

--- a/src/Symfony/Component/Tui/Tests/Transition/SlideTransitionTest.php
+++ b/src/Symfony/Component/Tui/Tests/Transition/SlideTransitionTest.php
@@ -1,0 +1,137 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Tests\Transition;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Component\Tui\Transition\Direction\HorizontalDirection;
+use Symfony\Component\Tui\Transition\Direction\VerticalDirection;
+use Symfony\Component\Tui\Transition\SlideTransition;
+
+class SlideTransitionTest extends AbstractTransitionTestCase
+{
+    /**
+     * @return iterable<string, array{HorizontalDirection|VerticalDirection, list<array{int, int, string}>}>
+     */
+    public static function directionProvider(): iterable
+    {
+        // At 0.5, offset = (int) (10 * 0.5) = 5 horizontally, (int) (5 * 0.5) = 2 vertically.
+        yield 'from left' => [HorizontalDirection::Left, [[0, 0, 'B'], [9, 0, 'A']]];
+        yield 'from right' => [HorizontalDirection::Right, [[0, 0, 'A'], [9, 0, 'B']]];
+        yield 'from top' => [VerticalDirection::Top, [[0, 0, 'B'], [0, 4, 'A']]];
+        yield 'from bottom' => [VerticalDirection::Bottom, [[0, 0, 'A'], [0, 4, 'B']]];
+    }
+
+    #[DataProvider('directionProvider')]
+    public function testBoundariesReturnExactScreens(HorizontalDirection|VerticalDirection $direction, array $cells)
+    {
+        $transition = new SlideTransition($direction);
+
+        $this->assertSame($this->fromLines, $transition->blend($this->fromLines, $this->toLines, $this->width, $this->height, 0.0));
+        $this->assertSame($this->toLines, $transition->blend($this->fromLines, $this->toLines, $this->width, $this->height, 1.0));
+    }
+
+    /**
+     * @param list<array{int, int, string}> $cells
+     */
+    #[DataProvider('directionProvider')]
+    public function testControlPointsAtHalf(HorizontalDirection|VerticalDirection $direction, array $cells)
+    {
+        $transition = new SlideTransition($direction);
+        $res = $transition->blend($this->fromLines, $this->toLines, $this->width, $this->height, 0.5);
+
+        foreach ($cells as [$x, $y, $char]) {
+            $this->assertCharAt($x, $y, $char, $res);
+        }
+    }
+
+    /**
+     * @return iterable<string, array{HorizontalDirection|VerticalDirection, list<string>}>
+     */
+    public static function slidAtHalfProvider(): iterable
+    {
+        // A slide translates content instead of revealing it in place, so the whole line has to
+        // be pinned: sampling two columns cannot tell a correct offset from one off by a column.
+        yield 'from left' => [HorizontalDirection::Left, [
+            'FGHIJabcde',
+            'GHIJKbcdef',
+            'HIJKLcdefg',
+            'IJKLMdefgh',
+            'JKLMNefghi',
+        ]];
+        yield 'from right' => [HorizontalDirection::Right, [
+            'fghijABCDE',
+            'ghijkBCDEF',
+            'hijklCDEFG',
+            'ijklmDEFGH',
+            'jklmnEFGHI',
+        ]];
+        yield 'from top' => [VerticalDirection::Top, [
+            'DEFGHIJKLM',
+            'EFGHIJKLMN',
+            'abcdefghij',
+            'bcdefghijk',
+            'cdefghijkl',
+        ]];
+        yield 'from bottom' => [VerticalDirection::Bottom, [
+            'cdefghijkl',
+            'defghijklm',
+            'efghijklmn',
+            'ABCDEFGHIJ',
+            'BCDEFGHIJK',
+        ]];
+    }
+
+    /**
+     * @param list<string> $expected
+     */
+    #[DataProvider('slidAtHalfProvider')]
+    public function testEveryColumnIsSlidByTheExactOffset(HorizontalDirection|VerticalDirection $direction, array $expected)
+    {
+        $transition = new SlideTransition($direction);
+
+        $this->assertSame($expected, $transition->blend($this->fromCells, $this->toCells, $this->width, $this->height, 0.5));
+    }
+
+    #[DataProvider('directionProvider')]
+    public function testWideGraphemesKeepTheLineWidth(HorizontalDirection|VerticalDirection $direction, array $cells)
+    {
+        $this->assertWideGraphemesKeepTheLineWidth(new SlideTransition($direction));
+    }
+
+    public function testEasingAboveOneClampsToDestination()
+    {
+        $transition = (new SlideTransition(HorizontalDirection::Right))->setEasing(static fn (float $p) => 1.5);
+
+        $this->assertSame($this->toLines, $transition->blend($this->fromLines, $this->toLines, $this->width, $this->height, 0.5));
+    }
+
+    public function testEasingBelowZeroClampsToSource()
+    {
+        $transition = (new SlideTransition(HorizontalDirection::Right))->setEasing(static fn (float $p) => -0.5);
+
+        $this->assertSame($this->fromLines, $transition->blend($this->fromLines, $this->toLines, $this->width, $this->height, 0.5));
+    }
+
+    public function testNormalEasingStillBlends()
+    {
+        $transition = (new SlideTransition(HorizontalDirection::Right))->setEasing(static fn (float $p) => $p * $p);
+
+        $res = $transition->blend($this->fromLines, $this->toLines, $this->width, $this->height, 0.5);
+
+        $this->assertNotSame($this->fromLines, $res);
+        $this->assertNotSame($this->toLines, $res);
+        $this->assertCharAt(0, 0, 'A', $res);
+        $this->assertCharAt(7, 0, 'A', $res);
+        $this->assertCharAt(8, 0, 'B', $res);
+        $this->assertCharAt(9, 0, 'B', $res);
+    }
+}

--- a/src/Symfony/Component/Tui/Tests/Transition/SpiralTransitionTest.php
+++ b/src/Symfony/Component/Tui/Tests/Transition/SpiralTransitionTest.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Tests\Transition;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Component\Tui\Exception\InvalidArgumentException;
+use Symfony\Component\Tui\Transition\Direction\RadialDirection;
+use Symfony\Component\Tui\Transition\SpiralTransition;
+
+class SpiralTransitionTest extends AbstractTransitionTestCase
+{
+    /**
+     * @return iterable<string, array{RadialDirection, list<array{int, int, string}>}>
+     */
+    public static function directionProvider(): iterable
+    {
+        // size 1, @0.5 half the blocks are revealed following the spiral path.
+        // Inward starts from the outer edge: top row is "to", the center stays "from".
+        yield 'inward' => [RadialDirection::Inward, [[0, 0, 'B'], [5, 2, 'A']]];
+        // Outward starts from the center: center is "to", the corners stay "from".
+        yield 'outward' => [RadialDirection::Outward, [[5, 2, 'B'], [0, 0, 'A']]];
+    }
+
+    #[DataProvider('directionProvider')]
+    public function testBoundariesReturnExactScreens(RadialDirection $direction, array $cells)
+    {
+        $transition = new SpiralTransition($direction, 1);
+
+        $this->assertSame($this->fromLines, $transition->blend($this->fromLines, $this->toLines, $this->width, $this->height, 0.0));
+        $this->assertSame($this->toLines, $transition->blend($this->fromLines, $this->toLines, $this->width, $this->height, 1.0));
+    }
+
+    /**
+     * @param list<array{int, int, string}> $cells
+     */
+    #[DataProvider('directionProvider')]
+    public function testControlPointsAtHalf(RadialDirection $direction, array $cells)
+    {
+        $transition = new SpiralTransition($direction, 1);
+        $res = $transition->blend($this->fromLines, $this->toLines, $this->width, $this->height, 0.5);
+
+        foreach ($cells as [$x, $y, $char]) {
+            $this->assertCharAt($x, $y, $char, $res);
+        }
+    }
+
+    /**
+     * @param list<array{int, int, string}> $cells
+     */
+    #[DataProvider('directionProvider')]
+    public function testCellsAreRevealedInPlace(RadialDirection $direction, array $cells)
+    {
+        $transition = new SpiralTransition($direction);
+
+        foreach ([0.1, 0.25, 0.4, 0.5, 0.6, 0.75, 0.9] as $progress) {
+            $lines = $transition->blend($this->fromCells, $this->toCells, $this->width, $this->height, $progress);
+
+            $this->assertCellsKeepTheirCoordinates($lines, \sprintf('Progress %.2f moved a cell away from its own coordinates.', $progress));
+        }
+    }
+
+    #[DataProvider('directionProvider')]
+    public function testWideGraphemesKeepTheLineWidth(RadialDirection $direction, array $cells)
+    {
+        $this->assertWideGraphemesKeepTheLineWidth(new SpiralTransition($direction, 3));
+    }
+
+    public function testZeroSizeThrows()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Size must be greater than 0, got 0.');
+
+        new SpiralTransition(size: 0);
+    }
+
+    public function testNegativeSizeThrows()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Size must be greater than 0, got -1.');
+
+        new SpiralTransition(size: -1);
+    }
+}

--- a/src/Symfony/Component/Tui/Tests/Transition/WipeTransitionTest.php
+++ b/src/Symfony/Component/Tui/Tests/Transition/WipeTransitionTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Tests\Transition;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Component\Tui\Ansi\AnsiUtils;
+use Symfony\Component\Tui\Transition\Direction\HorizontalDirection;
+use Symfony\Component\Tui\Transition\Direction\VerticalDirection;
+use Symfony\Component\Tui\Transition\WipeTransition;
+
+class WipeTransitionTest extends AbstractTransitionTestCase
+{
+    /**
+     * @return iterable<string, array{HorizontalDirection|VerticalDirection, list<array{int, int, string}>}>
+     */
+    public static function directionProvider(): iterable
+    {
+        // At 0.5, split = (int) (10 * 0.5) = 5 horizontally, (int) (5 * 0.5) = 2 vertically.
+        yield 'from left' => [HorizontalDirection::Left, [[0, 0, 'B'], [9, 0, 'A']]];
+        yield 'from right' => [HorizontalDirection::Right, [[0, 0, 'A'], [9, 0, 'B']]];
+        yield 'from top' => [VerticalDirection::Top, [[0, 0, 'B'], [0, 4, 'A']]];
+        yield 'from bottom' => [VerticalDirection::Bottom, [[0, 0, 'A'], [0, 4, 'B']]];
+    }
+
+    #[DataProvider('directionProvider')]
+    public function testBoundariesReturnExactScreens(HorizontalDirection|VerticalDirection $direction, array $cells)
+    {
+        $transition = new WipeTransition($direction);
+
+        $this->assertSame($this->fromLines, $transition->blend($this->fromLines, $this->toLines, $this->width, $this->height, 0.0));
+        $this->assertSame($this->toLines, $transition->blend($this->fromLines, $this->toLines, $this->width, $this->height, 1.0));
+    }
+
+    /**
+     * @param list<array{int, int, string}> $cells
+     */
+    #[DataProvider('directionProvider')]
+    public function testControlPointsAtHalf(HorizontalDirection|VerticalDirection $direction, array $cells)
+    {
+        $transition = new WipeTransition($direction);
+        $res = $transition->blend($this->fromLines, $this->toLines, $this->width, $this->height, 0.5);
+
+        foreach ($cells as [$x, $y, $char]) {
+            $this->assertCharAt($x, $y, $char, $res);
+        }
+    }
+
+    /**
+     * @param list<array{int, int, string}> $cells
+     */
+    #[DataProvider('directionProvider')]
+    public function testCellsAreRevealedInPlace(HorizontalDirection|VerticalDirection $direction, array $cells)
+    {
+        $transition = new WipeTransition($direction);
+
+        foreach ([0.1, 0.25, 0.4, 0.5, 0.6, 0.75, 0.9] as $progress) {
+            $lines = $transition->blend($this->fromCells, $this->toCells, $this->width, $this->height, $progress);
+
+            $this->assertCellsKeepTheirCoordinates($lines, \sprintf('Progress %.2f moved a cell away from its own coordinates.', $progress));
+        }
+    }
+
+    #[DataProvider('directionProvider')]
+    public function testWideGraphemesKeepTheLineWidth(HorizontalDirection|VerticalDirection $direction, array $cells)
+    {
+        $this->assertWideGraphemesKeepTheLineWidth(new WipeTransition($direction));
+    }
+
+    public function testWideGraphemesAreNotCutInHalf()
+    {
+        $emoji = "\u{1F600}";
+        $from = ['AAAAAA'.$emoji.'AA'];
+        $to = ['BB'.$emoji.'BBBBBB'];
+
+        $res = (new WipeTransition(HorizontalDirection::Left))->blend($from, $to, 10, 1, 0.5);
+
+        $this->assertSame(2, substr_count($res[0], $emoji), 'Both wide graphemes must survive intact, none half-cut.');
+    }
+}

--- a/src/Symfony/Component/Tui/Tests/Widget/TransitionWidgetTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/TransitionWidgetTest.php
@@ -1,0 +1,315 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Tests\Widget;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Tui\Ansi\AnsiUtils;
+use Symfony\Component\Tui\Exception\InvalidArgumentException;
+use Symfony\Component\Tui\Focus\FocusManager;
+use Symfony\Component\Tui\Input\Keybindings;
+use Symfony\Component\Tui\Render\RenderContext;
+use Symfony\Component\Tui\Render\Renderer;
+use Symfony\Component\Tui\Render\RenderRequestorInterface;
+use Symfony\Component\Tui\Style\Style;
+use Symfony\Component\Tui\Style\StyleSheet;
+use Symfony\Component\Tui\Terminal\VirtualTerminal;
+use Symfony\Component\Tui\Transition\SlideTransition;
+use Symfony\Component\Tui\Tui;
+use Symfony\Component\Tui\Widget\ContainerWidget;
+use Symfony\Component\Tui\Widget\TextWidget;
+use Symfony\Component\Tui\Widget\TransitionWidget;
+use Symfony\Component\Tui\Widget\WidgetTree;
+
+class TransitionWidgetTest extends TestCase
+{
+    public function testGetTo()
+    {
+        $widget = new TransitionWidget();
+        $to = new TextWidget('To');
+
+        $widget->start(new TextWidget('From'), $to, new SlideTransition());
+
+        $this->assertSame($to, $widget->getTo());
+    }
+
+    public function testAllReturnsBothWidgets()
+    {
+        $widget = new TransitionWidget();
+        $from = new TextWidget('From');
+        $to = new TextWidget('To');
+
+        $widget->start($from, $to, new SlideTransition());
+
+        $this->assertCount(2, $widget->all());
+        $this->assertContains($from, $widget->all());
+        $this->assertContains($to, $widget->all());
+    }
+
+    public function testStartActivatesTheTransitionAtProgressZero()
+    {
+        $widget = new TransitionWidget();
+        $widget->start(new TextWidget('From'), new TextWidget('To'), new SlideTransition(), 1.0);
+
+        $this->assertTrue($widget->isActive());
+        $this->assertSame(0.0, $widget->getProgress());
+    }
+
+    #[DataProvider('nonPositiveDurationProvider')]
+    public function testStartRejectsNonPositiveDurations(float $duration)
+    {
+        $widget = new TransitionWidget();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Duration must be greater than 0');
+
+        $widget->start(new TextWidget('From'), new TextWidget('To'), new SlideTransition(), $duration);
+    }
+
+    public static function nonPositiveDurationProvider(): iterable
+    {
+        yield 'zero' => [0.0];
+        yield 'negative' => [-1.0];
+        yield 'negative fraction' => [-0.001];
+    }
+
+    public function testTickAdvancesProgressByTheGivenDelta()
+    {
+        $widget = new TransitionWidget();
+        $widget->start(new TextWidget('From'), new TextWidget('To'), new SlideTransition(), 2.0);
+
+        $widget->tick(0.5);
+
+        $this->assertEqualsWithDelta(0.25, $widget->getProgress(), 1e-9);
+
+        $widget->tick(0.5);
+
+        $this->assertEqualsWithDelta(0.5, $widget->getProgress(), 1e-9);
+    }
+
+    public function testTickWithoutDeltaFollowsWallClock()
+    {
+        $widget = new TransitionWidget();
+        $widget->start(new TextWidget('From'), new TextWidget('To'), new SlideTransition(), 10.0);
+
+        usleep(20_000);
+        $widget->tick();
+
+        // 20ms out of a 10s transition: a frame-counting tick would report a fixed 0.0016
+        // whatever the elapsed time, so only a clock-reading tick lands in this window.
+        $this->assertGreaterThan(0.0, $widget->getProgress());
+        $this->assertLessThan(0.05, $widget->getProgress());
+    }
+
+    public function testProgressClampsAtOneAndDeactivates()
+    {
+        $widget = new TransitionWidget();
+        $widget->start(new TextWidget('From'), new TextWidget('To'), new SlideTransition(), 1.0);
+
+        $widget->tick(0.6);
+        $this->assertTrue($widget->isActive());
+
+        $widget->tick(0.6);
+        $this->assertSame(1.0, $widget->getProgress());
+        $this->assertFalse($widget->isActive());
+
+        // Further ticks are no-ops and never overshoot.
+        $this->assertFalse($widget->tick(0.6));
+        $this->assertSame(1.0, $widget->getProgress());
+    }
+
+    public function testTickReturnsFalseWhenNotActive()
+    {
+        $widget = new TransitionWidget();
+
+        $this->assertFalse($widget->tick());
+    }
+
+    public function testTickReturnsTrueWhenActive()
+    {
+        $widget = new TransitionWidget();
+        $widget->start(new TextWidget('From'), new TextWidget('To'), new SlideTransition(), 1.0);
+
+        $this->assertTrue($widget->tick(0.1));
+    }
+
+    public function testRestartResetsProgress()
+    {
+        $widget = new TransitionWidget();
+        $widget->start(new TextWidget('From'), new TextWidget('To'), new SlideTransition(), 1.0);
+        $widget->tick(0.5);
+
+        $widget->start(new TextWidget('From2'), new TextWidget('To2'), new SlideTransition(), 1.0);
+
+        $this->assertSame(0.0, $widget->getProgress());
+        $this->assertTrue($widget->isActive());
+    }
+
+    public function testRenderReturnsEmptyWithoutContext()
+    {
+        $widget = new TransitionWidget();
+
+        $this->assertSame([], $widget->render(new RenderContext(80, 24)));
+    }
+
+    public function testStartBeforeAttachIsResumedOnceAttached()
+    {
+        $tui = new Tui(terminal: new VirtualTerminal(20, 5));
+
+        // start() runs while getContext() is still null: the interval is recorded, and
+        // onAttach() is what actually hands it to the scheduler.
+        $widget = new TransitionWidget();
+        $widget->start(new TextWidget('From'), new TextWidget('To'), new SlideTransition(), 10.0);
+
+        $tui->add($widget);
+        $tui->start();
+        usleep(20_000);
+        $tui->tick();
+        $tui->stop();
+
+        $this->assertGreaterThan(0.0, $widget->getProgress());
+    }
+
+    public function testScheduledTickStopsOnDetach()
+    {
+        $tui = new Tui(terminal: new VirtualTerminal(20, 5));
+
+        $widget = new TransitionWidget();
+        $tui->add($widget);
+        $widget->start(new TextWidget('From'), new TextWidget('To'), new SlideTransition(), 10.0);
+
+        $tui->start();
+        usleep(20_000);
+        $tui->tick();
+
+        $progressWhileAttached = $widget->getProgress();
+        $this->assertGreaterThan(0.0, $progressWhileAttached);
+
+        $tui->remove($widget);
+        usleep(20_000);
+        $tui->tick();
+        $tui->stop();
+
+        $this->assertSame($progressWhileAttached, $widget->getProgress());
+    }
+
+    public function testRenderBlendsBothScreensMidTransition()
+    {
+        [$root, $widget] = $this->buildTree(new TextWidget('AAAAAAAA'), new TextWidget('BBBBBBBB'));
+        $widget->tick(0.016);
+
+        $lines = (new Renderer())->renderFrame($root, 12, 4)->toArray();
+        $content = AnsiUtils::stripAnsiCodes(implode("\n", $lines));
+
+        $this->assertStringContainsString('A', $content);
+        $this->assertStringContainsString('B', $content);
+        foreach ($lines as $line) {
+            $this->assertSame(12, AnsiUtils::visibleWidth($line));
+        }
+    }
+
+    public function testFullWidthScreensArePassedThroughUnpadded()
+    {
+        [$root, $widget] = $this->buildTree(new TextWidget('AAAAAAAA'), new TextWidget('BBBBBBBB'));
+        $widget->tick(0.016);
+
+        $lines = (new Renderer())->renderFrame($root, 8, 4)->toArray();
+        $content = AnsiUtils::stripAnsiCodes(implode("\n", $lines));
+
+        $this->assertStringContainsString('A', $content);
+        $this->assertStringContainsString('B', $content);
+        foreach ($lines as $line) {
+            $this->assertSame(8, AnsiUtils::visibleWidth($line));
+        }
+    }
+
+    public function testRenderShowsDestinationWhenFinished()
+    {
+        [$root, $widget] = $this->buildTree(new TextWidget('AAAAAAAA'), new TextWidget('BBBBBBBB'));
+        $widget->tick(0.016);
+        $widget->tick(0.016);
+
+        $content = AnsiUtils::stripAnsiCodes(implode("\n", (new Renderer())->renderFrame($root, 12, 4)->toArray()));
+
+        $this->assertStringContainsString('B', $content);
+        $this->assertStringNotContainsString('A', $content);
+    }
+
+    public function testRestartWhileAttachedSwapsChildren()
+    {
+        [$root, $widget] = $this->buildTree(new TextWidget('AAAAAAAA'), new TextWidget('BBBBBBBB'));
+        $newTo = new TextWidget('DDDDDDDD');
+        $widget->start(new TextWidget('CCCCCCCC'), $newTo, new SlideTransition(), 0.032);
+
+        $this->assertSame($newTo, $widget->getTo());
+
+        $widget->tick(0.016);
+        $content = AnsiUtils::stripAnsiCodes(implode("\n", (new Renderer())->renderFrame($root, 12, 4)->toArray()));
+
+        $this->assertStringContainsString('C', $content);
+        $this->assertStringContainsString('D', $content);
+        $this->assertStringNotContainsString('A', $content);
+    }
+
+    public function testRenderedLinesNeverEndOnAnOpenStyle()
+    {
+        [, $widget] = $this->buildTree(
+            new TextWidget('AAAAAAAA')->addStyleClass('from-screen'),
+            new TextWidget('BBBBBBBB')->addStyleClass('to-screen'),
+            new StyleSheet([
+                '.from-screen' => new Style(background: 'red'),
+                '.to-screen' => new Style(background: 'blue'),
+            ]),
+        );
+        $widget->tick(0.016);
+
+        $styled = 0;
+        foreach ($widget->render(new RenderContext(12, 4)) as $line) {
+            if (!str_contains($line, "\x1b")) {
+                continue;
+            }
+
+            ++$styled;
+            $this->assertStringEndsWith("\x1b[0m", $line);
+        }
+
+        $this->assertGreaterThan(0, $styled, 'The blend is expected to emit styled lines.');
+    }
+
+    /**
+     * @return array{ContainerWidget, TransitionWidget}
+     */
+    private function buildTree(TextWidget $from, TextWidget $to, ?StyleSheet $styleSheet = null): array
+    {
+        $terminal = new VirtualTerminal(80, 24);
+        $tui = new Tui(terminal: $terminal);
+        $tree = new WidgetTree(
+            $tui,
+            new Keybindings(),
+            new FocusManager($this->createStub(RenderRequestorInterface::class)),
+            new Renderer($styleSheet),
+            $terminal,
+            $tui->getEventDispatcher(),
+        );
+
+        $widget = new TransitionWidget();
+        $widget->expandVertically(true);
+        $widget->start($from, $to, new SlideTransition(), 0.032);
+
+        $root = new ContainerWidget();
+        $root->expandVertically(true);
+        $root->add($widget);
+        $tree->setRoot($root);
+
+        return [$root, $widget];
+    }
+}

--- a/src/Symfony/Component/Tui/Transition/AbstractTransition.php
+++ b/src/Symfony/Component/Tui/Transition/AbstractTransition.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Transition;
+
+/**
+ * Base class for string-based cinematic transitions with easing support.
+ *
+ * @experimental
+ *
+ * @author Simon André <smn.andre@gmail.com>
+ */
+abstract class AbstractTransition implements TransitionInterface
+{
+    /**
+     * @var \Closure(float): float|null
+     */
+    private ?\Closure $easing = null;
+
+    public function setEasing(?callable $easing): static
+    {
+        $this->easing = null === $easing ? null : $easing(...);
+
+        return $this;
+    }
+
+    public function blend(array $fromLines, array $toLines, int $width, int $height, float $progress): array
+    {
+        // Checked on the raw progress, before easing: a bouncy or elastic easing is expected to
+        // overshoot past 0.0/1.0 mid-transition (that's what makes it look bouncy), and a widget
+        // only ever reports those exact values at its true start and end. Checking post-easing
+        // would latch the render onto a flat "from"/"to" screen for the rest of the transition
+        // the moment the eased curve first touches a bound, hiding any settle/bounce that follows.
+        if (0.0 === $progress) {
+            return $fromLines;
+        }
+
+        if (1.0 === $progress) {
+            return $toLines;
+        }
+
+        if (null !== $this->easing) {
+            $progress = ($this->easing)($progress);
+        }
+
+        $progress = max(0.0, min(1.0, $progress));
+
+        return $this->doBlend($fromLines, $toLines, $width, $height, $progress);
+    }
+
+    /**
+     * Blends the rendered lines of the old and new screens at the current transition progress.
+     *
+     * @param list<string> $fromLines Lines rendered by the outgoing screen
+     * @param list<string> $toLines   Lines rendered by the incoming screen
+     * @param int          $width     Available width, in terminal columns
+     * @param int          $height    Available height, in terminal rows
+     * @param float        $progress  Eased and clamped progress from 0.0 (outgoing) to 1.0 (incoming)
+     *
+     * @return list<string> The blended screen lines
+     */
+    abstract protected function doBlend(array $fromLines, array $toLines, int $width, int $height, float $progress): array;
+}

--- a/src/Symfony/Component/Tui/Transition/DiamondTransition.php
+++ b/src/Symfony/Component/Tui/Transition/DiamondTransition.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Transition;
+
+use Symfony\Component\Tui\Ansi\AnsiUtils;
+use Symfony\Component\Tui\Transition\Direction\RadialDirection;
+
+/**
+ * Expanding diamond-shape reveal transition.
+ *
+ * @experimental
+ *
+ * @author Simon André <smn.andre@gmail.com>
+ */
+final class DiamondTransition extends AbstractTransition
+{
+    /**
+     * @param RadialDirection $direction Inward (old screen shrinks to center) or Outward (new screen grows from center)
+     */
+    public function __construct(
+        private readonly RadialDirection $direction = RadialDirection::Outward,
+    ) {
+    }
+
+    protected function doBlend(array $fromLines, array $toLines, int $width, int $height, float $progress): array
+    {
+        $outward = RadialDirection::Outward === $this->direction;
+        $effectiveProgress = $outward ? $progress : (1.0 - $progress);
+
+        // Outward: the growing diamond holds "to", everywhere else holds "from". Inward is the
+        // mirror of that, not a variant of it: the shrinking diamond holds "from" and everywhere
+        // else holds "to". Both the row-range fallback below and the in-row segment need this
+        // swap, not just the fallback: swapping only the fallback still paints the diamond's own
+        // interior with "to" for Inward, which is the same shape Outward draws, not its mirror.
+        $insideLines = $outward ? $toLines : $fromLines;
+        $outsideLines = $outward ? $fromLines : $toLines;
+
+        $centerX = (int) ($width / 2);
+        $centerY = (int) ($height / 2);
+        $maxDist = $centerX + $centerY;
+        $threshold = $maxDist * $effectiveProgress;
+
+        $result = [];
+        for ($y = 0; $y < $height; ++$y) {
+            $dy = abs($y - $centerY);
+            $d = $threshold - $dy;
+
+            if ($d < 0) {
+                $result[] = $outsideLines[$y] ?? '';
+                continue;
+            }
+
+            $start = max(0, (int) ($centerX - $d));
+            $end = min($width, (int) ($centerX + $d + 1));
+            $len = $end - $start;
+
+            $line = AnsiUtils::sliceToWidth($outsideLines[$y] ?? '', 0, $start);
+            $line .= AnsiUtils::sliceToWidth($insideLines[$y] ?? '', $start, $len);
+            $line .= AnsiUtils::sliceToWidth($outsideLines[$y] ?? '', $end, $width - $end);
+
+            $result[] = $line;
+        }
+
+        return $result;
+    }
+}

--- a/src/Symfony/Component/Tui/Transition/Direction/HorizontalDirection.php
+++ b/src/Symfony/Component/Tui/Transition/Direction/HorizontalDirection.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Transition\Direction;
+
+/**
+ * Horizontal entrance direction for transitions.
+ *
+ * @experimental
+ *
+ * @author Simon André <smn.andre@gmail.com>
+ */
+enum HorizontalDirection
+{
+    /** The incoming screen enters from the left edge. */
+    case Left;
+
+    /** The incoming screen enters from the right edge. */
+    case Right;
+}

--- a/src/Symfony/Component/Tui/Transition/Direction/RadialDirection.php
+++ b/src/Symfony/Component/Tui/Transition/Direction/RadialDirection.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Transition\Direction;
+
+/**
+ * Radial reveal direction for transitions.
+ *
+ * @experimental
+ *
+ * @author Simon André <smn.andre@gmail.com>
+ */
+enum RadialDirection
+{
+    /** The reveal travels from the outer edge towards the center. */
+    case Inward;
+
+    /** The reveal travels from the center towards the outer edge. */
+    case Outward;
+}

--- a/src/Symfony/Component/Tui/Transition/Direction/VerticalDirection.php
+++ b/src/Symfony/Component/Tui/Transition/Direction/VerticalDirection.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Transition\Direction;
+
+/**
+ * Vertical entrance direction for transitions.
+ *
+ * @experimental
+ *
+ * @author Simon André <smn.andre@gmail.com>
+ */
+enum VerticalDirection
+{
+    /** The incoming screen enters from the top edge. */
+    case Top;
+
+    /** The incoming screen enters from the bottom edge. */
+    case Bottom;
+}

--- a/src/Symfony/Component/Tui/Transition/ShuttersTransition.php
+++ b/src/Symfony/Component/Tui/Transition/ShuttersTransition.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Transition;
+
+use Symfony\Component\Tui\Ansi\AnsiUtils;
+use Symfony\Component\Tui\Exception\InvalidArgumentException;
+use Symfony\Component\Tui\Transition\Direction\HorizontalDirection;
+use Symfony\Component\Tui\Transition\Direction\VerticalDirection;
+
+/**
+ * Rhythmic shutter reveal transition.
+ *
+ * @experimental
+ *
+ * @author Simon André <smn.andre@gmail.com>
+ */
+final class ShuttersTransition extends AbstractTransition
+{
+    /**
+     * @param HorizontalDirection|VerticalDirection $direction Entrance edge within each shutter
+     * @param int                                   $size      Shutter thickness in cells
+     */
+    public function __construct(
+        private readonly HorizontalDirection|VerticalDirection $direction = VerticalDirection::Top,
+        private readonly int $size = 4,
+    ) {
+        if ($size <= 0) {
+            throw new InvalidArgumentException(\sprintf('Size must be greater than 0, got %d.', $size));
+        }
+    }
+
+    protected function doBlend(array $fromLines, array $toLines, int $width, int $height, float $progress): array
+    {
+        $result = [];
+
+        if ($this->direction instanceof VerticalDirection) {
+            // The row-level reveal is necessarily as coarse as $size (an integer count of rows),
+            // but the one row currently mid-reveal doesn't have to jump in a single frame: wiping
+            // it left-to-right by the fractional part of $exactReveal spreads that jump across as
+            // many frames as the transition's own duration allows, instead of capping the whole
+            // shutter at $size distinct visual steps.
+            $fromTop = VerticalDirection::Top === $this->direction;
+
+            for ($y = 0; $y < $height; ++$y) {
+                $shutterStart = intdiv($y, $this->size) * $this->size;
+                $shutterHeight = min($this->size, $height - $shutterStart);
+                $exactReveal = $shutterHeight * $progress;
+                $revealed = (int) $exactReveal;
+                $boundary = $exactReveal - $revealed;
+                $offset = $y - $shutterStart;
+                $toLine = $toLines[$y] ?? '';
+                $fromLine = $fromLines[$y] ?? '';
+                $fullyRevealed = $fromTop ? $offset < $revealed : $offset >= $shutterHeight - $revealed;
+                $boundaryOffset = $fromTop ? $revealed : $shutterHeight - $revealed - 1;
+
+                if ($fullyRevealed) {
+                    $result[] = $toLine;
+                } elseif ($offset === $boundaryOffset && $boundary > 0.0) {
+                    $wipe = (int) ($width * $boundary);
+                    $result[] = AnsiUtils::sliceToWidth($toLine, 0, $wipe).AnsiUtils::sliceToWidth($fromLine, $wipe, $width - $wipe);
+                } else {
+                    $result[] = $fromLine;
+                }
+            }
+
+            return $result;
+        }
+
+        $fromLeft = HorizontalDirection::Left === $this->direction;
+
+        for ($y = 0; $y < $height; ++$y) {
+            $toLine = $toLines[$y] ?? '';
+            $fromLine = $fromLines[$y] ?? '';
+
+            $line = '';
+            for ($x = 0; $x < $width; $x += $this->size) {
+                $shutterWidth = min($this->size, $width - $x);
+                $revealWidth = (int) ($shutterWidth * $progress);
+
+                if ($fromLeft) {
+                    $line .= AnsiUtils::sliceToWidth($toLine, $x, $revealWidth);
+                    $line .= AnsiUtils::sliceToWidth($fromLine, $x + $revealWidth, $shutterWidth - $revealWidth);
+                } else {
+                    $line .= AnsiUtils::sliceToWidth($fromLine, $x, $shutterWidth - $revealWidth);
+                    $line .= AnsiUtils::sliceToWidth($toLine, $x + $shutterWidth - $revealWidth, $revealWidth);
+                }
+            }
+
+            $result[] = $line;
+        }
+
+        return $result;
+    }
+}

--- a/src/Symfony/Component/Tui/Transition/SliceTransition.php
+++ b/src/Symfony/Component/Tui/Transition/SliceTransition.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Transition;
+
+use Symfony\Component\Tui\Ansi\AnsiUtils;
+use Symfony\Component\Tui\Exception\InvalidArgumentException;
+use Symfony\Component\Tui\Transition\Direction\HorizontalDirection;
+use Symfony\Component\Tui\Transition\Direction\VerticalDirection;
+
+/**
+ * Alternating slice reveal transition.
+ *
+ * @experimental
+ *
+ * @author Simon André <smn.andre@gmail.com>
+ */
+final class SliceTransition extends AbstractTransition
+{
+    /**
+     * @param HorizontalDirection|VerticalDirection $direction Entrance edge of the first slice; subsequent slices alternate
+     * @param int                                   $size      Column band width in cells for vertical entrances
+     */
+    public function __construct(
+        private readonly HorizontalDirection|VerticalDirection $direction = HorizontalDirection::Left,
+        private readonly int $size = 4,
+    ) {
+        if ($size <= 0) {
+            throw new InvalidArgumentException(\sprintf('Size must be greater than 0, got %d.', $size));
+        }
+    }
+
+    protected function doBlend(array $fromLines, array $toLines, int $width, int $height, float $progress): array
+    {
+        if ($this->direction instanceof HorizontalDirection) {
+            $revealWidth = (int) ($width * $progress);
+            $result = [];
+
+            for ($y = 0; $y < $height; ++$y) {
+                $toLine = $toLines[$y] ?? '';
+                $fromLine = $fromLines[$y] ?? '';
+
+                $fromLeft = HorizontalDirection::Left === $this->direction;
+                if (1 === $y % 2) {
+                    $fromLeft = !$fromLeft;
+                }
+
+                if ($fromLeft) {
+                    $result[] = AnsiUtils::sliceToWidth($toLine, 0, $revealWidth).AnsiUtils::sliceToWidth($fromLine, $revealWidth, $width - $revealWidth);
+                } else {
+                    $result[] = AnsiUtils::sliceToWidth($fromLine, 0, $width - $revealWidth).AnsiUtils::sliceToWidth($toLine, $width - $revealWidth, $revealWidth);
+                }
+            }
+
+            return $result;
+        }
+
+        $revealHeight = (int) ($height * $progress);
+        $result = [];
+
+        for ($y = 0; $y < $height; ++$y) {
+            $toLine = $toLines[$y] ?? '';
+            $fromLine = $fromLines[$y] ?? '';
+
+            $line = '';
+            for ($x = 0; $x < $width; $x += $this->size) {
+                $sliceWidth = min($this->size, $width - $x);
+                $fromTop = VerticalDirection::Top === $this->direction;
+                if (1 === intdiv($x, $this->size) % 2) {
+                    $fromTop = !$fromTop;
+                }
+
+                $revealed = $fromTop ? $y < $revealHeight : $y >= $height - $revealHeight;
+                $line .= AnsiUtils::sliceToWidth($revealed ? $toLine : $fromLine, $x, $sliceWidth);
+            }
+
+            $result[] = $line;
+        }
+
+        return $result;
+    }
+}

--- a/src/Symfony/Component/Tui/Transition/SlideTransition.php
+++ b/src/Symfony/Component/Tui/Transition/SlideTransition.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Transition;
+
+use Symfony\Component\Tui\Ansi\AnsiUtils;
+use Symfony\Component\Tui\Transition\Direction\HorizontalDirection;
+use Symfony\Component\Tui\Transition\Direction\VerticalDirection;
+
+/**
+ * Sliding transition.
+ *
+ * @experimental
+ *
+ * @author Simon André <smn.andre@gmail.com>
+ */
+final class SlideTransition extends AbstractTransition
+{
+    /**
+     * @param HorizontalDirection|VerticalDirection $direction Edge the incoming screen slides from
+     */
+    public function __construct(
+        private readonly HorizontalDirection|VerticalDirection $direction = HorizontalDirection::Right,
+    ) {
+    }
+
+    protected function doBlend(array $fromLines, array $toLines, int $width, int $height, float $progress): array
+    {
+        if ($this->direction instanceof HorizontalDirection) {
+            $result = [];
+            $offset = (int) ($width * $progress);
+
+            if (HorizontalDirection::Right === $this->direction) {
+                for ($i = 0; $i < $height; ++$i) {
+                    $fromPart = AnsiUtils::sliceToWidth($fromLines[$i] ?? '', $offset, $width - $offset);
+                    $toPart = AnsiUtils::sliceToWidth($toLines[$i] ?? '', 0, $offset);
+                    $result[] = $fromPart.$toPart;
+                }
+
+                return $result;
+            }
+
+            // HorizontalDirection::Left
+            for ($i = 0; $i < $height; ++$i) {
+                $toPart = AnsiUtils::sliceToWidth($toLines[$i] ?? '', $width - $offset, $offset);
+                $fromPart = AnsiUtils::sliceToWidth($fromLines[$i] ?? '', 0, $width - $offset);
+                $result[] = $toPart.$fromPart;
+            }
+
+            return $result;
+        }
+
+        $offset = (int) ($height * $progress);
+
+        if (VerticalDirection::Bottom === $this->direction) {
+            return array_merge(
+                \array_slice($fromLines, $offset),
+                \array_slice($toLines, 0, $offset)
+            );
+        }
+
+        // VerticalDirection::Top
+        return array_merge(
+            \array_slice($toLines, $height - $offset),
+            \array_slice($fromLines, 0, $height - $offset)
+        );
+    }
+}

--- a/src/Symfony/Component/Tui/Transition/SpiralTransition.php
+++ b/src/Symfony/Component/Tui/Transition/SpiralTransition.php
@@ -1,0 +1,130 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Transition;
+
+use Symfony\Component\Tui\Ansi\AnsiUtils;
+use Symfony\Component\Tui\Exception\InvalidArgumentException;
+use Symfony\Component\Tui\Transition\Direction\RadialDirection;
+
+/**
+ * Reveal cells along a spiral path.
+ *
+ * @experimental
+ *
+ * @author Simon André <smn.andre@gmail.com>
+ */
+final class SpiralTransition extends AbstractTransition
+{
+    /**
+     * Caches each spiral path by its block-grid dimensions (`{columns}x{rows}`).
+     *
+     * @var array<string, list<array{int, int}>> Block coordinates, in reveal order
+     */
+    private array $pathCache = [];
+
+    /**
+     * @param RadialDirection $direction Inward (towards center) or Outward (from center)
+     * @param int             $size      Block thickness in cells
+     */
+    public function __construct(
+        private readonly RadialDirection $direction = RadialDirection::Inward,
+        private readonly int $size = 1,
+    ) {
+        if ($size <= 0) {
+            throw new InvalidArgumentException(\sprintf('Size must be greater than 0, got %d.', $size));
+        }
+    }
+
+    protected function doBlend(array $fromLines, array $toLines, int $width, int $height, float $progress): array
+    {
+        $cols = (int) ceil($width / $this->size);
+        $rows = (int) ceil($height / $this->size);
+        $totalBlocks = $cols * $rows;
+
+        $cacheKey = "{$cols}x{$rows}";
+        if (!isset($this->pathCache[$cacheKey])) {
+            $this->pathCache[$cacheKey] = $this->generateSpiralPath($cols, $rows);
+        }
+
+        $path = $this->pathCache[$cacheKey];
+        if (RadialDirection::Outward === $this->direction) {
+            $path = array_reverse($path);
+        }
+
+        $threshold = (int) ($totalBlocks * $progress);
+        $visibleBlocks = array_fill(0, $totalBlocks, false);
+        for ($i = 0; $i < $threshold; ++$i) {
+            $visibleBlocks[$path[$i][1] * $cols + $path[$i][0]] = true;
+        }
+
+        $result = [];
+        for ($y = 0; $y < $height; ++$y) {
+            $blockY = (int) ($y / $this->size);
+            $line = '';
+            for ($bx = 0; $bx < $cols; ++$bx) {
+                $blockIdx = $blockY * $cols + $bx;
+                $startX = $bx * $this->size;
+                $w = min($this->size, $width - $startX);
+
+                if ($visibleBlocks[$blockIdx] ?? false) {
+                    $line .= AnsiUtils::sliceToWidth($toLines[$y] ?? '', $startX, $w);
+                } else {
+                    $line .= AnsiUtils::sliceToWidth($fromLines[$y] ?? '', $startX, $w);
+                }
+            }
+            $result[] = $line;
+        }
+
+        return $result;
+    }
+
+    /**
+     * @return list<array{int, int}>
+     */
+    private function generateSpiralPath(int $w, int $h): array
+    {
+        $path = [];
+        $top = 0;
+        $bottom = $h - 1;
+        $left = 0;
+        $right = $w - 1;
+
+        while ($top <= $bottom && $left <= $right) {
+            // Right
+            for ($i = $left; $i <= $right; ++$i) {
+                $path[] = [$i, $top];
+            }
+            ++$top;
+            // Down
+            for ($i = $top; $i <= $bottom; ++$i) {
+                $path[] = [$right, $i];
+            }
+            --$right;
+            if ($top <= $bottom) {
+                // Left
+                for ($i = $right; $i >= $left; --$i) {
+                    $path[] = [$i, $bottom];
+                }
+                --$bottom;
+            }
+            if ($left <= $right) {
+                // Up
+                for ($i = $bottom; $i >= $top; --$i) {
+                    $path[] = [$left, $i];
+                }
+                ++$left;
+            }
+        }
+
+        return $path;
+    }
+}

--- a/src/Symfony/Component/Tui/Transition/TransitionInterface.php
+++ b/src/Symfony/Component/Tui/Transition/TransitionInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Transition;
+
+/**
+ * Interface for cinematic screen transitions using raw ANSI strings.
+ *
+ * @experimental
+ *
+ * @author Simon André <smn.andre@gmail.com>
+ */
+interface TransitionInterface
+{
+    /**
+     * Blend two screens represented as arrays of ANSI-formatted strings.
+     *
+     * @param list<string> $fromLines ANSI strings of the starting screen
+     * @param list<string> $toLines   ANSI strings of the destination screen
+     * @param int          $width     The width of the screen
+     * @param int          $height    The height of the screen
+     * @param float        $progress  Normalized progress from 0.0 to 1.0
+     *
+     * @return list<string> The blended ANSI strings
+     */
+    public function blend(array $fromLines, array $toLines, int $width, int $height, float $progress): array;
+}

--- a/src/Symfony/Component/Tui/Transition/WipeTransition.php
+++ b/src/Symfony/Component/Tui/Transition/WipeTransition.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Transition;
+
+use Symfony\Component\Tui\Ansi\AnsiUtils;
+use Symfony\Component\Tui\Transition\Direction\HorizontalDirection;
+use Symfony\Component\Tui\Transition\Direction\VerticalDirection;
+
+/**
+ * Wiping transition.
+ *
+ * @experimental
+ *
+ * @author Simon André <smn.andre@gmail.com>
+ */
+final class WipeTransition extends AbstractTransition
+{
+    /**
+     * @param HorizontalDirection|VerticalDirection $direction Edge the incoming screen is revealed from
+     */
+    public function __construct(
+        private readonly HorizontalDirection|VerticalDirection $direction = HorizontalDirection::Left,
+    ) {
+    }
+
+    protected function doBlend(array $fromLines, array $toLines, int $width, int $height, float $progress): array
+    {
+        if ($this->direction instanceof HorizontalDirection) {
+            $result = [];
+            $split = (int) ($width * $progress);
+
+            if (HorizontalDirection::Right === $this->direction) {
+                for ($i = 0; $i < $height; ++$i) {
+                    $fromPart = AnsiUtils::sliceToWidth($fromLines[$i] ?? '', 0, $width - $split);
+                    $toPart = AnsiUtils::sliceToWidth($toLines[$i] ?? '', $width - $split, $split);
+                    $result[] = $fromPart.$toPart;
+                }
+
+                return $result;
+            }
+
+            // HorizontalDirection::Left
+            for ($i = 0; $i < $height; ++$i) {
+                $toPart = AnsiUtils::sliceToWidth($toLines[$i] ?? '', 0, $split);
+                $fromPart = AnsiUtils::sliceToWidth($fromLines[$i] ?? '', $split, $width - $split);
+                $result[] = $toPart.$fromPart;
+            }
+
+            return $result;
+        }
+
+        $split = (int) ($height * $progress);
+
+        if (VerticalDirection::Bottom === $this->direction) {
+            return array_merge(
+                \array_slice($fromLines, 0, $height - $split),
+                \array_slice($toLines, $height - $split)
+            );
+        }
+
+        // VerticalDirection::Top
+        return array_merge(
+            \array_slice($toLines, 0, $split),
+            \array_slice($fromLines, $split)
+        );
+    }
+}

--- a/src/Symfony/Component/Tui/Widget/TransitionWidget.php
+++ b/src/Symfony/Component/Tui/Widget/TransitionWidget.php
@@ -1,0 +1,252 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Widget;
+
+use Symfony\Component\Tui\Ansi\AnsiUtils;
+use Symfony\Component\Tui\Exception\InvalidArgumentException;
+use Symfony\Component\Tui\Loop\LoopClock;
+use Symfony\Component\Tui\Render\RenderContext;
+use Symfony\Component\Tui\Transition\TransitionInterface;
+
+/**
+ * A widget that orchestrates cinematic transitions natively via AnsiUtils (No CellBuffer hacks).
+ *
+ * @experimental
+ *
+ * @author Simon André <smn.andre@gmail.com>
+ */
+final class TransitionWidget extends AbstractWidget implements ParentInterface, VerticallyExpandableInterface
+{
+    use ScheduledTickTrait;
+
+    private const TICK_INTERVAL = 0.016;
+
+    private ?AbstractWidget $from = null;
+    private ?AbstractWidget $to = null;
+    private ?TransitionInterface $transition = null;
+    private float $progress = 0.0;
+    private float $duration = 1.0;
+    private bool $active = false;
+    private bool $verticallyExpanded = false;
+    private ?string $fromBackground = null;
+    private ?string $toBackground = null;
+    private LoopClock $clock;
+
+    public function __construct()
+    {
+        $this->clock = new LoopClock();
+    }
+
+    public function expandVertically(bool $expand): static
+    {
+        $this->verticallyExpanded = $expand;
+        $this->invalidate();
+
+        return $this;
+    }
+
+    public function isVerticallyExpanded(): bool
+    {
+        return $this->verticallyExpanded;
+    }
+
+    public function start(AbstractWidget $from, AbstractWidget $to, TransitionInterface $transition, float $duration = 1.0): void
+    {
+        if ($duration <= 0.0) {
+            throw new InvalidArgumentException(\sprintf('Duration must be greater than 0, got "%s".', $duration));
+        }
+
+        $this->stopScheduledTick();
+
+        foreach ($this->all() as $child) {
+            $this->detachChild($child);
+        }
+
+        $this->from = $from;
+        $this->to = $to;
+
+        $this->attachChild($from);
+        $this->attachChild($to);
+
+        $this->transition = $transition;
+        $this->duration = $duration;
+        $this->progress = 0.0;
+        $this->active = true;
+        $this->fromBackground = null;
+        $this->toBackground = null;
+        $this->clock->reset();
+
+        $this->invalidate();
+
+        $this->startScheduledTick(self::TICK_INTERVAL);
+    }
+
+    protected function resolveScheduledTickContext(): ?WidgetContext
+    {
+        return $this->getContext();
+    }
+
+    /**
+     * Advances the transition by the elapsed wall-clock time, or by $deltaTime when given.
+     */
+    public function tick(?float $deltaTime = null): bool
+    {
+        if (!$this->active) {
+            $this->stopScheduledTick();
+
+            return false;
+        }
+
+        $this->progress += $this->clock->advance($deltaTime) / $this->duration;
+
+        if ($this->progress >= 1.0) {
+            $this->progress = 1.0;
+            $this->active = false;
+            $this->stopScheduledTick();
+        }
+
+        $this->invalidate();
+
+        return true;
+    }
+
+    protected function onAttach(WidgetContext $context): void
+    {
+        if ($this->active) {
+            $this->clock->reset();
+            $this->resumeScheduledTick();
+        }
+    }
+
+    protected function onDetach(): void
+    {
+        $this->stopScheduledTick();
+    }
+
+    protected function onScheduledTick(): void
+    {
+        $this->tick();
+    }
+
+    public function getTo(): ?AbstractWidget
+    {
+        return $this->to;
+    }
+
+    /**
+     * Whether a transition is running, i.e. started and not yet at its end.
+     */
+    public function isActive(): bool
+    {
+        return $this->active;
+    }
+
+    /**
+     * How far the running transition has gone, from 0.0 to 1.0.
+     */
+    public function getProgress(): float
+    {
+        return $this->progress;
+    }
+
+    public function render(RenderContext $context): array
+    {
+        if (null === $this->getContext()) {
+            return [];
+        }
+
+        if (!$this->active || !$this->from || !$this->to || !$this->transition) {
+            return $this->to ? $this->getContext()->renderWidget($this->to, $context) : [];
+        }
+
+        $width = $context->getColumns();
+        $height = $context->getRows();
+
+        $fromLines = $this->getContext()->renderWidget($this->from, $context);
+        $toLines = $this->getContext()->renderWidget($this->to, $context);
+
+        // The background can't change for the lifetime of a start() call, but resolving it
+        // walks the full style cascade (class hierarchy + style classes + state selectors);
+        // resolve it once lazily and reuse it on every later render() until the next start().
+        $this->fromBackground ??= $this->getBackgroundColor($this->from);
+        $this->toBackground ??= $this->getBackgroundColor($this->to);
+
+        $fromLines = $this->padLines($fromLines, $width, $height, $this->fromBackground);
+        $toLines = $this->padLines($toLines, $width, $height, $this->toBackground);
+
+        $resultLines = $this->transition->blend($fromLines, $toLines, $width, $height, $this->progress);
+
+        return array_map($this->closeStyles(...), $resultLines);
+    }
+
+    /**
+     * Closes any style a blended line ends on.
+     *
+     * blend() concatenates slices of both screens, so a line routinely ends while one of their
+     * colors is still active. Left open, that color runs past the widget: the parent container
+     * paints its own padding with it instead of its background.
+     */
+    private function closeStyles(string $line): string
+    {
+        if (!str_contains($line, "\x1b") || str_ends_with($line, "\x1b[0m")) {
+            return $line;
+        }
+
+        return $line."\x1b[0m";
+    }
+
+    /**
+     * @param array<string> $lines
+     *
+     * @return list<string>
+     */
+    private function padLines(array $lines, int $width, int $height, string $bgCode): array
+    {
+        $padded = [];
+        $fullPadding = null;
+
+        for ($i = 0; $i < $height; ++$i) {
+            $line = $lines[$i] ?? '';
+            $lineWidth = AnsiUtils::visibleWidth($line);
+
+            // renderWidget() already guarantees non-image lines never exceed $width, and image
+            // lines have no meaningful column width, so a full-or-wider line is passed through
+            // untouched; only shorter lines are padded to keep every buffer $width wide.
+            if ($lineWidth >= $width) {
+                $padded[] = $line;
+
+                continue;
+            }
+
+            if (null === $fullPadding) {
+                $fullPadding = $bgCode.str_repeat(' ', $width)."\x1b[0m";
+            }
+
+            $padded[] = $line.AnsiUtils::sliceByColumn($fullPadding, 0, $width - $lineWidth);
+        }
+
+        return $padded;
+    }
+
+    private function getBackgroundColor(AbstractWidget $widget): string
+    {
+        $style = $this->getContext()->resolveElement($widget, '');
+        $bgColor = $style->getBackground();
+
+        return $bgColor ? $bgColor->toBackgroundCode() : '';
+    }
+
+    public function all(): array
+    {
+        return array_filter([$this->from, $this->to]);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | -
| License       | MIT


Adds transitions for the TUI component
* orchestrated by a `TransitionWidget`
* 6 transitions: Slide, Wipe, Slice, Diamond, Shutters, Spiral 
* 3 types of options: direction, duration, easing

A transition blends between any two widgets, so it can work
* as a full-screen swap...
* ...or scoped to a single widget inside a layout.

<img width="500" height="303" alt="All six transitions running in a 3x2 grid" src="https://github.com/user-attachments/assets/d48593a7-6502-420a-a0e2-b2592213eda4" />

(each cell is its own `TransitionWidget`)

--

## Transitions

| | | |
|:---:|:---:|:---:|
| <img width="200" height="121" alt="slide" src="https://github.com/user-attachments/assets/d3d7ec0b-c5a3-4c0a-ac72-1d9356d02645" /> | <img width="200" height="121" alt="wipe" src="https://github.com/user-attachments/assets/a2c8299b-7787-46d0-b464-c9d9f2eee006" /> | <img width="200" height="121" alt="slice" src="https://github.com/user-attachments/assets/55373d9e-580d-48a6-aa00-e8d8f3e585f1" /> |
| <img width="200" height="121" alt="diamond" src="https://github.com/user-attachments/assets/e24aee42-320c-4e23-af4b-743c22bfee15" /> | <img width="200" height="121" alt="shutters" src="https://github.com/user-attachments/assets/0c4bde9b-6f2c-43db-b3b8-d8f892c77475" /> | <img width="200" height="121" alt="spiral" src="https://github.com/user-attachments/assets/addacdf0-82d4-4edb-9dfa-02948fdc78f6" /> |

## Usage

```php
use Symfony\Component\Tui\Transition\Direction\HorizontalDirection;
use Symfony\Component\Tui\Transition\SlideTransition;
use Symfony\Component\Tui\Widget\TransitionWidget;

$transition = new TransitionWidget();
$tui->add($transition);

// $from, $to, transition, duration in seconds
$transition->start($screenA, $screenB, new SlideTransition(HorizontalDirection::Left), 0.5);
```

`TransitionWidget` schedules its own ticks once attached (no manual tick call needed).

## Settings

- **Direction**: each transition only accepts the direction enums that fit its geometry, so invalid combinations cannot be constructed. Slide, Wipe, Slice and Shutters take `HorizontalDirection` (`Left`/`Right`) or `VerticalDirection` (`Top`/`Bottom`); Diamond and Spiral take `RadialDirection` (`Inward`/`Outward`).
- **Easing**: any `callable(float): float`, linear by default: `(new SlideTransition())->setEasing(fn (float $p) => $p * $p);`.
- **Size**: positive integer, band/block thickness in cells (`Slice`, `Shutters`, `Spiral` only).

## Custom transitions

Extend `AbstractTransition` and implement `doBlend()`:

```php
final class MyTransition extends AbstractTransition
{
    protected function doBlend(array $fromLines, array $toLines, int $width, int $height, float $progress): array
    {
        // return the blended string[] of ANSI lines
    }
}
```

## Documentation

Branch based on fabpot TUI documentation (unmerged) PR: https://github.com/symfony/symfony-docs/commit/3d84613af9535e4fcef39afefe0eda8aa6ca6fcf 


