### PR TITLE
[FrameworkBundle] Fix "cache:clear" failing when the cache dir is rebuilt concurrently

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
@@ -170,6 +170,11 @@ class CacheClearCommand extends Command
                 $fs->rename($realBuildDir, $oldBuildDir);
             }
 
+            // Under load, a concurrent request can boot the kernel and rebuild the cache
+            // in $realBuildDir while it is moved aside above. Drop that partial rebuild,
+            // the warmed-up directory supersedes it.
+            $fs->remove($realBuildDir);
+
             $fs->rename($warmupDir, $realBuildDir);
 
             if ($output->isVerbose()) {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CacheClearCommand/CacheClearCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CacheClearCommand/CacheClearCommandTest.php
@@ -11,11 +11,13 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\Command\CacheClearCommand;
 
+use Symfony\Bundle\FrameworkBundle\Command\CacheClearCommand;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\Tests\Command\CacheClearCommand\Fixture\TestAppKernel;
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
 use Symfony\Component\Config\ConfigCacheFactory;
 use Symfony\Component\Config\Resource\ResourceInterface;
+use Symfony\Component\Console\Command\LazyCommand;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\DependencyInjection\Container;
@@ -111,6 +113,57 @@ class CacheClearCommandTest extends TestCase
         $application->doRun($input, new NullOutput());
 
         $this->assertTrue(is_file($this->kernel->getCacheDir().'/dummy.txt'));
+    }
+
+    public function testCacheIsClearedWhenBuildDirIsRecreatedConcurrently()
+    {
+        // Boot once to learn the exact build dir path the command will use.
+        $this->kernel->boot();
+        $realBuildDir = $this->kernel->getContainer()->getParameter('kernel.build_dir');
+
+        // Simulate a concurrent HTTP request that reboots the kernel and recreates
+        // the build directory in the small window after cache:clear has moved it
+        // aside (rename to the "old" dir) but before it renames the freshly warmed-up
+        // dir into place. Without handling, that final rename fails with
+        // "Cannot rename because the target ... already exists.".
+        $fs = new class($realBuildDir) extends Filesystem {
+            public function __construct(private string $realBuildDir)
+            {
+            }
+
+            public function rename(string $origin, string $target, bool $overwrite = false): void
+            {
+                parent::rename($origin, $target, $overwrite);
+
+                if ($origin === $this->realBuildDir && !is_dir($this->realBuildDir)) {
+                    $this->mkdir($this->realBuildDir);
+                    file_put_contents($this->realBuildDir.'/concurrent.php', '<?php // rebuilt by a concurrent request');
+                }
+            }
+        };
+
+        $application = new Application($this->kernel);
+        $application->setCatchExceptions(false);
+        $command = $application->find('cache:clear');
+        if ($command instanceof LazyCommand) {
+            $command = $command->getCommand();
+        }
+        (new \ReflectionProperty(CacheClearCommand::class, 'filesystem'))->setValue($command, $fs);
+
+        // Force the rebuild+publish path (the container looks stale) instead of the
+        // "cache is fresh" shortcut, so the final rename is actually exercised.
+        $requestTime = $_SERVER['REQUEST_TIME'];
+        $_SERVER['REQUEST_TIME'] = time() + 1;
+        try {
+            $application->doRun(new ArrayInput(['cache:clear']), new NullOutput());
+        } finally {
+            $_SERVER['REQUEST_TIME'] = $requestTime;
+        }
+
+        // The freshly warmed-up cache wins: the command completes, the warmer output is
+        // in place and the concurrent rebuild is gone instead of being merged into it.
+        $this->assertTrue(is_file($this->kernel->getCacheDir().'/dummy.txt'));
+        $this->assertFileDoesNotExist($realBuildDir.'/concurrent.php');
     }
 
     public function testCacheIsWarmedWithOldContainer()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #59692
| License       | MIT

Under production traffic, `cache:clear` intermittently fails with:

```
In Filesystem.php line 294:
  Cannot rename because the target "…/var/cache/prod" already exists.
```

and the environment is left half-built until the command is run again.

`CacheClearCommand` warms the cache up in a temporary directory, moves the current build directory aside to an `~`/`+` "old" directory, then renames the warmed-up directory into place:

```php
$fs->rename($realBuildDir, $oldBuildDir);   // the build dir disappears here
$fs->rename($warmupDir, $realBuildDir);     // and reappears here
```

Between those two calls the build directory does not exist. A concurrent HTTP request that boots the kernel in that window finds no cache, rebuilds it, and recreates the directory. The second rename then throws because its target exists again, leaving the old cache in the "old" directory, the good cache in the warmup directory, and a partial rebuild in place.

This drops the concurrently-created rebuild before publishing:

```php
$fs->remove($realBuildDir);

$fs->rename($warmupDir, $realBuildDir);
```

That directory can only exist at this point if another process recreated it, since both branches above guarantee it is gone, so removing it unconditionally is safe. The warmed-up cache supersedes it.

This is a best-effort improvement, not a guarantee. The window cannot be closed by a rename-based publish, because the build directory is by design absent between the two renames. A request that recreates the directory during the `remove()` call itself will still hit the original error, and clearing the cache in place on a live server remains something to avoid.
