### PR TITLE
[DependencyInjection] Fix ParameterBag::clear() leaving stale deprecations and resolution state

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
@@ -37,6 +37,8 @@ class ParameterBag implements ParameterBagInterface
     public function clear()
     {
         $this->parameters = [];
+        $this->deprecatedParameters = [];
+        $this->resolved = false;
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/ParameterBagTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/ParameterBagTest.php
@@ -33,12 +33,24 @@ class ParameterBagTest extends TestCase
 
     public function testClear()
     {
-        $bag = new ParameterBag($parameters = [
+        $bag = new ParameterBag([
             'foo' => 'foo',
             'bar' => 'bar',
         ]);
+        $bag->deprecate('foo', 'symfony/test', '6.3');
+        $bag->resolve();
         $bag->clear();
         $this->assertEquals([], $bag->all(), '->clear() removes all parameters');
+        $this->assertEquals([], $bag->allDeprecated(), '->clear() removes all deprecated parameters');
+        $this->assertFalse($bag->isResolved(), '->clear() resets the resolved state');
+
+        $bag->set('base', 'value');
+        $bag->set('ref', '%base%');
+        $bag->set('escaped', 'foo %%bar%% baz');
+        $bag->resolve();
+        $this->assertSame('value', $bag->get('ref'), '->resolve() resolves parameters added after clear()');
+        $this->assertSame('foo %bar% baz', $bag->get('escaped'), '->resolve() unescapes parameters added after clear() only once');
+        $this->assertTrue($bag->isResolved());
     }
 
     public function testRemove()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`ParameterBag::clear()` currently only empties the parameter values, leaving the rest of the bag state behind:

* `$deprecatedParameters` is kept, so `allDeprecated()` still returns stale entries and re-adding a parameter with the same name inherits the old deprecation;
* `$resolved` stays `true`, so repopulating a previously resolved bag and calling `resolve()` is a no-op, leaving `%placeholder%` values unresolved.

This PR makes `clear()` reset all state (parameters, deprecation metadata and the resolved flag), consistent with what `remove()` already does per parameter.

Note: resetting `$resolved` here is safe regarding the double-resolution issue that led to reverting #62541 in #62665. A new test asserts that.

-----

When merging this up, we need to add the following in 7.4:

In `ParameterBag.php`:

```php
public function clear(): void
{
    // ...
    $this->nonEmptyParameters = [];
}
```

And in `ParameterBagTest::testClear()`:

```php
$bag->deprecate('foo', 'symfony/test', '6.3');
$bag->cannotBeEmpty('bar', 'Parameter "bar" cannot be empty.');   // add this line

// ...

$this->assertEquals([], $bag->allDeprecated(), '->clear() removes all deprecated parameters');
$this->assertEquals([], $bag->allNonEmpty(), '->clear() removes all non-empty parameters');   // add this line

// ...
```