### PR TITLE
[HttpClient] Document the signature of the closure accepted by the "buffer" option

### DIFF
--- a/src/Symfony/Component/HttpClient/HttpOptions.php
+++ b/src/Symfony/Component/HttpClient/HttpOptions.php
@@ -156,8 +156,9 @@ class HttpOptions
     }
 
     /**
-     * @param bool|resource|\Closure $buffer Whether to buffer the response, or a stream to write it to,
-     *                                       or a closure deciding it from the response headers
+     * Whether to buffer the response, or a stream to write it to, or a closure deciding it from the response headers.
+     *
+     * @param bool|resource|\Closure(array<string, list<string>> $headers): (bool|resource) $buffer
      *
      * @return $this
      */

--- a/src/Symfony/Component/HttpClient/Tests/MockHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/MockHttpClientTest.php
@@ -255,6 +255,25 @@ class MockHttpClientTest extends HttpClientTestCase
         $this->assertSame('bar ccc', $chunks[2]->getError());
     }
 
+    public function testBufferClosureReceivesLowercasedHeadersAndCanReturnAStream()
+    {
+        $sink = fopen('php://temp', 'w+');
+        $headers = null;
+        $client = new MockHttpClient(new MockResponse('Hello', ['response_headers' => ['Content-Type: text/plain', 'X-Foo: BaR']]));
+
+        $response = $client->request('GET', 'http://example.com', ['buffer' => static function (array $h) use ($sink, &$headers) {
+            $headers = $h;
+
+            return $sink;
+        }]);
+
+        $this->assertSame('Hello', $response->getContent());
+        $this->assertSame(['content-type' => ['text/plain'], 'x-foo' => ['BaR']], $headers);
+
+        rewind($sink);
+        $this->assertSame('Hello', stream_get_contents($sink));
+    }
+
     public function testMergeDefaultOptions()
     {
         $mockHttpClient = new MockHttpClient(null, 'https://example.com');

--- a/src/Symfony/Contracts/HttpClient/HttpClientInterface.php
+++ b/src/Symfony/Contracts/HttpClient/HttpClientInterface.php
@@ -53,9 +53,10 @@ interface HttpClientInterface
         'http_version' => null,
         // string - the URI to resolve relative URLs, following rules in RFC 3986, section 2
         'base_uri' => null,
-        // bool|resource|\Closure - whether the content of the response should be buffered or not,
-        //   or a stream resource where the response body should be written,
-        //   or a closure telling if/where the response should be buffered based on its headers
+        // bool|resource|\Closure(array<string, list<string>> $headers): (bool|resource) - whether
+        //   the content of the response should be buffered or not, or a stream resource where the
+        //   response body should be written, or a closure telling if/where the response should be
+        //   buffered based on its headers, which are keyed by lowercased header names
         'buffer' => true,
         // callable(int $dlNow, int $dlSize, array $info) - throwing any exceptions MUST abort the
         //   request; it MUST be called on connection, on headers and on completion; it SHOULD be


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Follow-up of #65127, where @stof suggested spelling out the signature of the closure accepted by the `buffer` option.

The suggestion is right about the argument: the closure is called with the response headers, keyed by lowercased header names, values being lists of strings (`TransportResponseTrait` passes `$response->headers`, filled through `strtolower()`; `AsyncResponse` passes `getHeaders(false)`).

It is incomplete about the return type though: the closure may return a bool *or* a writable stream resource, which is what "if/**where**" in the existing comment refers to. `HttpClientTrait` validates exactly that:

```php
if (!\is_bool($buffer = $buffer($headers))) {
    if (!\is_array($bufferInfo = @stream_get_meta_data($buffer))) {
        throw new \LogicException(\sprintf('The closure passed as option "buffer" must return bool or stream resource, got "%s".', get_debug_type($buffer)));
    }
    ...
```

So the documented type is `\Closure(array<string, list<string>> $headers): (bool|resource)`, applied to both `HttpClientInterface::OPTIONS_DEFAULTS` and `HttpOptions::buffer()`. `array<string, list<string>>` matches what `ResponseInterface::getHeaders()` already documents, rather than `lowercase-string` which is used nowhere else in the repository.

A test pins the two documented facts that had no coverage: the headers the closure receives, and a closure returning a stream.
