### PR TITLE
[FrameworkBundle] Default Messenger AMQP retry jitter to 0

### DIFF
--- a/UPGRADE-8.2.md
+++ b/UPGRADE-8.2.md
@@ -23,6 +23,9 @@ DoctrineBridge
 FrameworkBundle
 ---------------
 
+ * The `messenger.transports.*.retry_strategy.jitter` option now defaults to `0` instead of `0.1` for `amqp` and `amqps`
+   DSNs, as jittered delays make the AMQP transport create a large number of ephemeral delay queues, which RabbitMQ is
+   not designed to handle; configure the option explicitly to restore the previous behavior
  * Deprecate the `framework.ide` config option, use the `SYMFONY_IDE` env var instead
 
 HttpClient

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add `framework.cache.default_provider` to configure `cache.app` with a DSN
+ * Default the `messenger.transports.*.retry_strategy.jitter` option to `0` for `amqp` and `amqps` DSNs, as jittered delays make the AMQP transport create a large number of ephemeral delay queues
  * Add `uri_signer.expiration` option that allows configuring the default URI signer expiration
  * Add `--dispatchers` option to `debug:event-dispatcher` command
  * Deprecate the `framework.ide` config option, use the `SYMFONY_IDE` env var instead

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -1833,6 +1833,23 @@ class Configuration implements ConfigurationInterface
                             ->useAttributeAsKey('name')
                             ->arrayPrototype()
                                 ->acceptAndWrap(['string'], 'dsn')
+                                ->beforeNormalization()
+                                    ->ifArray()
+                                    ->then(static function (array $v): array {
+                                        // jittered delays make the AMQP transport create a large number of ephemeral
+                                        // delay queues, which RabbitMQ is not designed to handle; disable jitter by
+                                        // default for this transport, unless the user explicitly configured it.
+                                        if (\is_string($v['dsn'] ?? null)
+                                            && (str_starts_with($v['dsn'], 'amqp://') || str_starts_with($v['dsn'], 'amqps://'))
+                                            && (!isset($v['retry_strategy']) || \is_array($v['retry_strategy']))
+                                            && !isset($v['retry_strategy']['jitter'])
+                                        ) {
+                                            $v['retry_strategy']['jitter'] = 0.0;
+                                        }
+
+                                        return $v;
+                                    })
+                                ->end()
                                 ->children()
                                     ->scalarNode('dsn')->end()
                                     ->scalarNode('serializer')->defaultNull()->info('Service id of a custom serializer to use.')->end()
@@ -1866,7 +1883,7 @@ class Configuration implements ConfigurationInterface
                                             ->integerNode('delay')->defaultValue(1000)->min(0)->info('Time in ms to delay (or the initial value when multiplier is used).')->end()
                                             ->floatNode('multiplier')->defaultValue(2)->min(1)->info('If greater than 1, delay will grow exponentially for each retry: this delay = (delay * (multiple ^ retries)).')->end()
                                             ->integerNode('max_delay')->defaultValue(0)->min(0)->info('Max time in ms that a retry should ever be delayed (0 = infinite).')->end()
-                                            ->floatNode('jitter')->defaultValue(0.1)->min(0)->max(1)->info('Randomness to apply to the delay (between 0 and 1).')->end()
+                                            ->floatNode('jitter')->defaultValue(0.1)->min(0)->max(1)->info('Randomness to apply to the delay (between 0 and 1). Defaults to 0 for "amqp" and "amqps" DSNs, as jittered delays make the AMQP transport create a large number of ephemeral delay queues.')->end()
                                         ->end()
                                     ->end()
                                     ->scalarNode('rate_limiter')

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_transports.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_transports.php
@@ -18,6 +18,7 @@ $container->loadFromExtension('framework', [
                     'delay' => 7,
                     'multiplier' => 3,
                     'max_delay' => 100,
+                    'jitter' => 0.25,
                 ],
                 'rate_limiter' => 'customised_worker',
             ],

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_transports.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_transports.yml
@@ -17,6 +17,7 @@ framework:
                     delay: 7
                     multiplier: 3
                     max_delay: 100
+                    jitter: 0.25
                 rate_limiter: customised_worker
             failed: 'in-memory:///'
             redis: 'redis://127.0.0.1:6379/messages'

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -1268,6 +1268,13 @@ abstract class FrameworkExtensionTestCase extends TestCase
         $this->assertSame(7, $container->getDefinition('messenger.retry.multiplier_retry_strategy.customised')->getArgument(1));
         $this->assertSame(3, $container->getDefinition('messenger.retry.multiplier_retry_strategy.customised')->getArgument(2));
         $this->assertSame(100, $container->getDefinition('messenger.retry.multiplier_retry_strategy.customised')->getArgument(3));
+        $this->assertSame(0.25, $container->getDefinition('messenger.retry.multiplier_retry_strategy.customised')->getArgument(4));
+
+        // AMQP transports default to a jitter of 0 when not explicitly configured, as jittered
+        // delays make the transport create a large number of ephemeral delay queues.
+        $this->assertSame(0.0, $container->getDefinition('messenger.retry.multiplier_retry_strategy.default')->getArgument(4));
+        // non-AMQP transports keep the regular default jitter
+        $this->assertSame(0.1, $container->getDefinition('messenger.retry.multiplier_retry_strategy.redis')->getArgument(4));
 
         $failureTransportsByTransportNameServiceLocator = $container->getDefinition('messenger.failure.send_failed_message_to_failure_transport_listener')->getArgument(0);
         $failureTransports = $container->getDefinition((string) $failureTransportsByTransportNameServiceLocator)->getArgument(0);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | not really, but a bit
| New feature?  | yes
| Deprecations? | no
| Issues        |
| License       | MIT

Jittered retry delays make the AMQP transport create a distinct
ephemeral delay queue per unique delay value, since the queue name
embeds the exact delay in ms (see Connection::getRoutingKeyForDelay()).
With the default 10% jitter, almost every retried message gets its
own delay value, and therefore its own queue.

RabbitMQ is not designed to hold a large, high-churn set of queues:

 * Each queue is an Erlang process with its own memory and CPU
   overhead (index, state machine, etc.), so the total queue count
   directly drives broker resource usage.
 * Queue metadata (declare/bind/delete) is cluster-wide state: it is
   replicated to every node via Mnesia for classic queues or via Raft
   consensus for quorum queues. Each declare/delete is therefore a
   comparatively expensive, synchronous, cluster-replicated operation
   rather than a cheap local one.
 * Rapid create/delete churn -- exactly what a unique delay queue per
   jittered retry produces -- is the worst case for this replication
   overhead, and is called out in RabbitMQ's own operational guidance
   as something to avoid.
 * A very large queue count also degrades the management UI, CLI
   tools like `rabbitmqctl list_queues`, and Prometheus/metrics
   scraping, which enumerate all queues.
 * RabbitMQ's own guidance is to keep queue counts in the low
   thousands per node; an AMQP-backed Messenger transport under
   moderate retry volume can otherwise create that many ephemeral
   delay queues in a short window.

Default the jitter to 0 for amqp:// and amqps:// DSNs unless the user
configures it explicitly, so retries fall back to the small, bounded
set of delay queues produced by the multiplier/max_delay progression
instead of one queue per message.
