### PR TITLE
[Security] Throw the status-code-specific HttpException for #[IsGranted]

### DIFF
--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Throw a 403 `Symfony\Component\Security\Http\Exception\InvalidCsrfTokenException` instead of the `Security\Core` one when the `#[IsCsrfTokenValid]` attribute fails, so the failure is no longer handled as an authentication failure
  * Add the deauthentication reason and the responsible user providers to `TokenDeauthenticatedEvent`
  * Add `LogoutUrlGenerator::getLogoutForm()` to build a form that logs the user out with a POST
+ * Throw the status-code-specific `HttpException` (e.g. `NotFoundHttpException`, `AccessDeniedHttpException`) instead of a generic one when `#[IsGranted]`'s `statusCode` option is set
 
 8.1
 ---

--- a/src/Symfony/Component/Security/Http/EventListener/IsGrantedAttributeListener.php
+++ b/src/Symfony/Component/Security/Http/EventListener/IsGrantedAttributeListener.php
@@ -95,7 +95,7 @@ class IsGrantedAttributeListener implements EventSubscriberInterface
             $message = $attribute->message ?: $accessDecision->getMessage();
 
             if ($statusCode = $attribute->statusCode) {
-                throw new HttpException($statusCode, $message, code: $attribute->exceptionCode ?? 0);
+                throw HttpException::fromStatusCode($statusCode, $message, code: $attribute->exceptionCode ?? 0);
             }
 
             $e = new AccessDeniedException($message, code: $attribute->exceptionCode ?? 403);

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/IsGrantedAttributeListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/IsGrantedAttributeListenerTest.php
@@ -21,6 +21,7 @@ use Symfony\Component\HttpKernel\Event\ControllerArgumentsEvent;
 use Symfony\Component\HttpKernel\Event\ControllerAttributeEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
@@ -292,7 +293,7 @@ class IsGrantedAttributeListenerTest extends TestCase
             ->method('isGranted')
             ->willReturn(false);
 
-        $this->expectException(HttpException::class);
+        $this->expectException(NotFoundHttpException::class);
         $this->expectExceptionMessage('Not found');
 
         $event = new ControllerArgumentsEvent(
@@ -305,7 +306,7 @@ class IsGrantedAttributeListenerTest extends TestCase
 
         $listener = new IsGrantedAttributeListener($authChecker);
 
-        $this->expectException(HttpException::class);
+        $this->expectException(NotFoundHttpException::class);
         $this->expectExceptionMessage('Not found');
 
         $listener->onKernelControllerArguments($event);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65134
| License       | MIT

`#[IsGranted('ROLE_ADMIN', statusCode: 404)]` currently throws a plain `HttpException`, so the class that matches the status code never reaches the application. Going through `HttpException::fromStatusCode()` instead gives you a `NotFoundHttpException` here, and an `AccessDeniedHttpException` with `statusCode: 403`, which is what people catch or check for.

Nothing breaks along the way. The exception only gets more specific, so an existing `catch (HttpException $e)` or `instanceof HttpException` still matches, as xabbuh pointed out on the issue. Status codes and exception codes stay the same.
