### PR TITLE
[ObjectMapper] Skip nested mapping when no target fits the destination property type

### DIFF
--- a/src/Symfony/Component/ObjectMapper/ObjectMapper.php
+++ b/src/Symfony/Component/ObjectMapper/ObjectMapper.php
@@ -400,6 +400,9 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
      *
      * A nested class declaring several #[Map] targets yields one Mapping per target. When the
      * destination property is typed, only one of them can be assigned to it, so the mapping is not ambiguous.
+     * When none of them can be assigned to it, no mapping applies and the value is written as it is.
+     * Mappings carrying a transform are kept: what lands in the property is the transform's return value,
+     * not the declared target.
      *
      * @param Mapping[] $metadata
      *
@@ -407,7 +410,7 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
      */
     private function filterMetadataByPropertyType(array $metadata, object $target, ?string $targetPropertyName): array
     {
-        if (null === $targetPropertyName || 2 > \count($metadata)) {
+        if (null === $targetPropertyName || !$metadata) {
             return $metadata;
         }
 
@@ -421,12 +424,12 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
         }
 
         $propertyClass = $type->getName();
-        $filtered = array_values(array_filter($metadata, static fn (Mapping $m): bool => \is_string($m->target)
+        $filtered = array_values(array_filter($metadata, static fn (Mapping $m): bool => $m->transform || (\is_string($m->target)
             && class_exists($m->target)
-            && is_a($m->target, $propertyClass, true)
+            && is_a($m->target, $propertyClass, true))
         ));
 
-        return 1 === \count($filtered) ? $filtered : $metadata;
+        return 1 < \count($filtered) ? $metadata : $filtered;
     }
 
     private function applyTransforms(Mapping $map, mixed $value, object $source, ?object $target): mixed

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedClassTransform/Animal.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedClassTransform/Animal.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\NestedClassTransform;
+
+class Animal
+{
+    public string $name;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedClassTransform/Dog.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedClassTransform/Dog.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\NestedClassTransform;
+
+class Dog extends Animal
+{
+    public static function transform(Pet $value): self
+    {
+        $target = new self();
+        $target->name = $value->name;
+
+        return $target;
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedClassTransform/KennelSource.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedClassTransform/KennelSource.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\NestedClassTransform;
+
+class KennelSource
+{
+    public Pet $pet;
+
+    public function __construct()
+    {
+        $this->pet = new Pet();
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedClassTransform/KennelTarget.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedClassTransform/KennelTarget.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\NestedClassTransform;
+
+class KennelTarget
+{
+    public Dog $pet;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedClassTransform/Pet.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedClassTransform/Pet.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\NestedClassTransform;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(target: Animal::class, transform: [Dog::class, 'transform'])]
+class Pet
+{
+    public string $name = 'rex';
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedMultiTarget/OuterTargetWithInnerSourceProperty.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedMultiTarget/OuterTargetWithInnerSourceProperty.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMultiTarget;
+
+class OuterTargetWithInnerSourceProperty
+{
+    public InnerSource $inner;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedValueOfPropertyType/InnerSource.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedValueOfPropertyType/InnerSource.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\NestedValueOfPropertyType;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(target: InnerTarget::class)]
+class InnerSource
+{
+    public string $value = 'inner-value';
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedValueOfPropertyType/InnerTarget.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedValueOfPropertyType/InnerTarget.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\NestedValueOfPropertyType;
+
+class InnerTarget
+{
+    public string $value;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedValueOfPropertyType/OuterSource.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedValueOfPropertyType/OuterSource.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\NestedValueOfPropertyType;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(target: OuterTarget::class)]
+class OuterSource
+{
+    public InnerSource $inner;
+
+    public function __construct()
+    {
+        $this->inner = new InnerSource();
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedValueOfPropertyType/OuterTarget.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/NestedValueOfPropertyType/OuterTarget.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\NestedValueOfPropertyType;
+
+class OuterTarget
+{
+    public InnerSource $inner;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
@@ -88,6 +88,9 @@ use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargets\C as MultipleT
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargetsWithTransform\PlainTarget as MultipleTargetsWithTransformPlainTarget;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargetsWithTransform\Source as MultipleTargetsWithTransformSource;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MyProxy;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\NestedClassTransform\Dog;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\NestedClassTransform\KennelSource;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\NestedClassTransform\KennelTarget;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\NestedConstructedTarget\Inner;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\NestedConstructedTarget\InnerMapped;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\NestedConstructedTarget\Outer;
@@ -99,9 +102,12 @@ use Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMultiTarget\InnerTargetA
 use Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMultiTarget\OuterSource as MultiTargetOuterSource;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMultiTarget\OuterSourceWithRenamedProperty;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMultiTarget\OuterTarget as MultiTargetOuterTarget;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMultiTarget\OuterTargetWithInnerSourceProperty;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMultiTarget\OuterTargetWithInterfaceProperty;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMultiTarget\OuterTargetWithRenamedProperty;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\NestedMultiTarget\OuterTargetWithUntypedProperty;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\NestedValueOfPropertyType\OuterSource as PropertyTypeOuterSource;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\NestedValueOfPropertyType\OuterTarget as PropertyTypeOuterTarget;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\PartialInput\FinalInput;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\PartialInput\PartialInput;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\PrivateParentProperty\ChildEntity;
@@ -917,6 +923,36 @@ final class ObjectMapperTest extends TestCase
         $this->expectExceptionMessage('Ambiguous mapping');
 
         $mapper->map(new MultiTargetOuterSource(), OuterTargetWithInterfaceProperty::class);
+    }
+
+    public function testNestedPropertyWithSeveralMapTargetsIsLeftAloneWhenNoneMatchesItsDeclaredType()
+    {
+        $mapper = new ObjectMapper();
+
+        $source = new MultiTargetOuterSource();
+        $target = $mapper->map($source, OuterTargetWithInnerSourceProperty::class);
+
+        $this->assertSame($source->inner, $target->inner);
+    }
+
+    public function testNestedPropertyWithASingleMapTargetIsLeftAloneWhenItDoesNotMatchItsDeclaredType()
+    {
+        $mapper = new ObjectMapper();
+
+        $source = new PropertyTypeOuterSource();
+        $target = $mapper->map($source, PropertyTypeOuterTarget::class);
+
+        $this->assertSame($source->inner, $target->inner);
+    }
+
+    public function testNestedPropertyWithAClassTransformIsMappedWhenOnlyTheTransformMatchesItsDeclaredType()
+    {
+        $mapper = new ObjectMapper();
+
+        $target = $mapper->map(new KennelSource(), KennelTarget::class);
+
+        $this->assertInstanceOf(Dog::class, $target->pet);
+        $this->assertSame('rex', $target->pet->name);
     }
 
     public function testExplicitMappingTakesPriorityOverImplicitSameNameProperty()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65138
| License       | MIT

`filterMetadataByPropertyType()` narrows the mappings of a nested value by the declared type of the property it is written into. It had two gaps.

With a single candidate it returned early and never checked the type at all, so the value was replaced by an object of a class the property cannot hold:

```php
#[Map(target: InnerTarget::class)]
class InnerSource
{
    public string $value = 'inner-value';
}

class OuterTarget
{
    public InnerSource $inner;   // not an InnerTarget
}

// before: TypeError, "Cannot assign InnerTarget to property
//         OuterTarget::$inner of type InnerSource"
// after:  the InnerSource is written as it is
$mapper->map(new OuterSource(), OuterTarget::class);
```

With several candidates and none of them assignable, it returned all of them, which surfaced as `Ambiguous mapping for "InnerSource". Multiple #[Map] attributes match.` rather than as "no mapping applies here".

Both cases now leave the value alone. When no declared target fits the property, there is no mapping to apply, so the value is written unchanged.

Mappings that carry a `transform` stay eligible regardless of their declared target, because what lands in the property is the transform's return value:

```php
#[Map(target: Animal::class, transform: [Dog::class, 'transform'])]
class Pet
{
    public string $name = 'rex';
}

class KennelTarget
{
    public Dog $pet;   // Dog, not Animal
}

// the transform returns a Dog, so the mapping applies even though the
// declared target Animal cannot be assigned to the property
$mapper->map(new KennelSource(), KennelTarget::class);
```

Note that the check is on the declared targets, not on the value: when nothing fits, the mapping is skipped and the value is written as it is, whatever its type.
