### PR TITLE
[ObjectMapper] Fix the class-level mapping of another target being applied

### DIFF
--- a/src/Symfony/Component/ObjectMapper/ObjectMapper.php
+++ b/src/Symfony/Component/ObjectMapper/ObjectMapper.php
@@ -63,7 +63,7 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
     private function doMap(object $source, object|string|null $target, \WeakMap $objectMap, bool $constructTarget = false): object
     {
         $metadata = $this->metadataFactory->create($source);
-        $map = $this->getMapTarget($metadata, null, $source, null, null === $target);
+        $map = $this->getMapTarget($this->filterMetadataByTarget($metadata, $target), null, $source, null, null === $target);
         $target ??= $map?->target;
         $mappingToObject = \is_object($target);
 
@@ -372,6 +372,27 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
         }
 
         return $mapTo;
+    }
+
+    /**
+     * Narrows the class-level mappings of a source to the ones related to the target the caller asked for.
+     *
+     * A mapping declaring a subclass of that target is kept: its transform can still produce an
+     * instance the caller accepts.
+     *
+     * @param Mapping[] $metadata
+     *
+     * @return Mapping[]
+     */
+    private function filterMetadataByTarget(array $metadata, object|string|null $target): array
+    {
+        if (null === $target) {
+            return $metadata;
+        }
+
+        $targetClass = \is_object($target) ? $target::class : $target;
+
+        return array_filter($metadata, static fn (Mapping $m): bool => null === $m->target || is_a($targetClass, $m->target, true) || is_a($m->target, $targetClass, true));
     }
 
     /**

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MultipleTargetsWithTransform/PlainTarget.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MultipleTargetsWithTransform/PlainTarget.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargetsWithTransform;
+
+class PlainTarget
+{
+    public string $name;
+    public string $label;
+
+    public function __construct()
+    {
+        $this->label = 'constructed';
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MultipleTargetsWithTransform/Source.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MultipleTargetsWithTransform/Source.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargetsWithTransform;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(target: PlainTarget::class)]
+#[Map(target: TransformedTarget::class, transform: [TransformedTarget::class, 'transform'])]
+class Source
+{
+    public string $name = 'test';
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MultipleTargetsWithTransform/TransformedTarget.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/MultipleTargetsWithTransform/TransformedTarget.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargetsWithTransform;
+
+class TransformedTarget
+{
+    public string $name;
+
+    public static function transform(mixed $value, object $source, ?object $target): self
+    {
+        return new self();
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/SubclassTargetWithTransform/ChildTarget.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/SubclassTargetWithTransform/ChildTarget.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\SubclassTargetWithTransform;
+
+class ChildTarget extends ParentTarget
+{
+    public static function transform(mixed $value, object $source, ?object $target): self
+    {
+        return new self();
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/SubclassTargetWithTransform/ParentTarget.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/SubclassTargetWithTransform/ParentTarget.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\SubclassTargetWithTransform;
+
+class ParentTarget
+{
+    public string $name;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/SubclassTargetWithTransform/Source.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/SubclassTargetWithTransform/Source.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\SubclassTargetWithTransform;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(target: ChildTarget::class, transform: [ChildTarget::class, 'transform'])]
+class Source
+{
+    public string $name = 'test';
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
@@ -85,6 +85,8 @@ use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargetProperty\B as Mu
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargetProperty\C as MultipleTargetPropertyC;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargets\A as MultipleTargetsA;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargets\C as MultipleTargetsC;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargetsWithTransform\PlainTarget as MultipleTargetsWithTransformPlainTarget;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\MultipleTargetsWithTransform\Source as MultipleTargetsWithTransformSource;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\MyProxy;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\NestedConstructedTarget\Inner;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\NestedConstructedTarget\InnerMapped;
@@ -127,6 +129,9 @@ use Symfony\Component\ObjectMapper\Tests\Fixtures\ServiceLocator\A as ServiceLoc
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ServiceLocator\B as ServiceLocatorB;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ServiceLocator\ConditionCallable;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ServiceLocator\TransformCallable;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\SubclassTargetWithTransform\ChildTarget as SubclassTargetWithTransformChildTarget;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\SubclassTargetWithTransform\ParentTarget as SubclassTargetWithTransformParentTarget;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\SubclassTargetWithTransform\Source as SubclassTargetWithTransformSource;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\TargetTransform\SourceEntity;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\TargetTransform\TargetDto as TargetTransformTargetDto;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\TransformCollection\TransformCollectionA;
@@ -850,6 +855,27 @@ final class ObjectMapperTest extends TestCase
         $source = new MultipleTargetPropertyA();
         $mapper = new ObjectMapper();
         $mapper->map($source);
+    }
+
+    public function testExplicitTargetIsNotMappedWithTheTransformOfAnotherTarget()
+    {
+        $mapper = new ObjectMapper();
+
+        $target = $mapper->map(new MultipleTargetsWithTransformSource(), MultipleTargetsWithTransformPlainTarget::class);
+
+        $this->assertInstanceOf(MultipleTargetsWithTransformPlainTarget::class, $target);
+        $this->assertSame('test', $target->name);
+        $this->assertSame('constructed', $target->label);
+    }
+
+    public function testExplicitTargetIsMappedWithTheTransformOfOneOfItsSubclasses()
+    {
+        $mapper = new ObjectMapper();
+
+        $target = $mapper->map(new SubclassTargetWithTransformSource(), SubclassTargetWithTransformParentTarget::class);
+
+        $this->assertInstanceOf(SubclassTargetWithTransformChildTarget::class, $target);
+        $this->assertSame('test', $target->name);
     }
 
     public function testNestedPropertyWithSeveralMapTargetsIsResolvedByItsDeclaredType()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65140
| License       | MIT

`doMap()` picks the class-level mapping from everything the metadata factory reports for the source, without comparing it to the target the caller asked for. So when a source has more than one class-level mapping, `map($source, SomeDto::class)` runs the `transform` declared for some other target, and that transform's presence also stops `SomeDto::__construct()` from running.

```php
#[Map(target: PlainTarget::class)]
#[Map(target: TransformedTarget::class, transform: [TransformedTarget::class, 'transform'])]
class Source
{
    public string $name = 'test';
}

// before: MappingException, "Expected the mapped object to be an instance of
//         PlainTarget but got TransformedTarget"
// after:  a PlainTarget, built by its own constructor
$mapper->map(new Source(), PlainTarget::class);
```

The fix narrows the class-level mappings to the ones related to the requested target before choosing one. A mapping is kept when it declares no target, when the requested target is an instance of its target, or when its target is a subclass of the requested one. That last case keeps working:

```php
#[Map(target: ChildTarget::class, transform: [ChildTarget::class, 'transform'])]
class Source
{
    public string $name = 'test';
}

// still returns a ChildTarget built by the transform, since a ChildTarget
// is an acceptable ParentTarget
$mapper->map(new Source(), ParentTarget::class);
```

Passing no target is unaffected: the ambiguity exception and the resolution of the target from the attribute both behave as before.

On 8.1 and later this also covers the reported case, where `ReverseClassObjectMapperMetadataFactory` synthesizes a class-level mapping on the source for every DTO that reads from it, so an unrelated DTO could supply the transform.
