### PR TITLE
[Messenger] Use configured senders when RedispatchMessage has no transport name

### DIFF
--- a/UPGRADE-8.2.md
+++ b/UPGRADE-8.2.md
@@ -51,6 +51,22 @@ Loco Translation Provider
  * Deprecate passing `LocoProvider` and `LocoProviderFactory` constructor a `$defaultLocale` argument. It has no effect and can be removed.
  * Deprecate passing no domains or `*` to `LocoProvider::read()`, configure your loco provider domains as an associative array with an empty string key and `*` as value
 
+Messenger
+---------
+
+ * `RedispatchMessage` now dispatches to the senders configured for the message (via
+   `framework.messenger.routing` or `#[AsMessage]`) when `$transportNames` is empty, instead of sending to no
+   sender at all. Code that relied on `new RedispatchMessage($message)`, or on an empty array or string, to
+   force in-process handling of a message that also has a configured route must now carry an empty
+   `TransportNamesStamp` on the inner envelope:
+
+   ```php
+   new RedispatchMessage(new Envelope($message, [new TransportNamesStamp([])]))
+   ```
+
+   Note that a message sent to a transport is no longer handled in process, so `RedispatchMessageHandler`
+   returns `null` for it instead of the result of the handler
+
 Security
 --------
 

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add `$serializedTypeNameAliases` parameter to `#[AsMessage]` to accept alternate serialized type names when decoding
  * Add `--failed-after` and `--failed-before` options to the `messenger:failed:retry`, `messenger:failed:remove` and `messenger:failed:show` commands, and a `--class-filter` option to `messenger:failed:retry`
+ * `RedispatchMessage` now dispatches to the senders configured for the message (routing config or `#[AsMessage]`) when `$transportNames` is empty, instead of sending to no sender at all
 
 8.1
 ---

--- a/src/Symfony/Component/Messenger/Handler/RedispatchMessageHandler.php
+++ b/src/Symfony/Component/Messenger/Handler/RedispatchMessageHandler.php
@@ -25,7 +25,10 @@ final class RedispatchMessageHandler
 
     public function __invoke(RedispatchMessage $message): mixed
     {
-        $envelope = $this->bus->dispatch($message->envelope, [new TransportNamesStamp($message->transportNames)]);
+        // no transport name means "use the senders configured for the message" instead of "use no sender"
+        $transportNames = array_values(array_filter((array) $message->transportNames, static fn ($name): bool => '' !== $name));
+
+        $envelope = $this->bus->dispatch($message->envelope, $transportNames ? [new TransportNamesStamp($transportNames)] : []);
 
         return $envelope->last(HandledStamp::class)?->getResult();
     }

--- a/src/Symfony/Component/Messenger/Message/RedispatchMessage.php
+++ b/src/Symfony/Component/Messenger/Message/RedispatchMessage.php
@@ -17,7 +17,8 @@ final class RedispatchMessage implements \Stringable
 {
     /**
      * @param object|Envelope $envelope       The message or the message pre-wrapped in an envelope
-     * @param string[]|string $transportNames Transport names to be used for the message
+     * @param string[]|string $transportNames Transport names to be used for the message, or an empty
+     *                                        array/string to use the senders configured for the message
      */
     public function __construct(
         public readonly object $envelope,

--- a/src/Symfony/Component/Messenger/Tests/Handler/RedispatchMessageHandlerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Handler/RedispatchMessageHandlerTest.php
@@ -1,0 +1,179 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Handler;
+
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Handler\HandlersLocator;
+use Symfony\Component\Messenger\Handler\RedispatchMessageHandler;
+use Symfony\Component\Messenger\Message\RedispatchMessage;
+use Symfony\Component\Messenger\MessageBus;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Middleware\HandleMessageMiddleware;
+use Symfony\Component\Messenger\Middleware\SendMessageMiddleware;
+use Symfony\Component\Messenger\Stamp\HandledStamp;
+use Symfony\Component\Messenger\Stamp\TransportNamesStamp;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Messenger\Transport\Sender\SenderInterface;
+use Symfony\Component\Messenger\Transport\Sender\SendersLocator;
+
+class RedispatchMessageHandlerTest extends TestCase
+{
+    public function testRedispatchWithTransportNamesAddsTransportNamesStamp()
+    {
+        $message = new DummyMessage('hello');
+        $resultEnvelope = new Envelope($message, [new HandledStamp('result', 'handler')]);
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects($this->once())
+            ->method('dispatch')
+            ->with($message, $this->callback(function (array $stamps) {
+                $this->assertCount(1, $stamps);
+                $this->assertInstanceOf(TransportNamesStamp::class, $stamps[0]);
+                $this->assertSame(['async'], $stamps[0]->getTransportNames());
+
+                return true;
+            }))
+            ->willReturn($resultEnvelope);
+
+        $handler = new RedispatchMessageHandler($bus);
+
+        $this->assertSame('result', $handler(new RedispatchMessage($message, ['async'])));
+    }
+
+    public function testRedispatchWithoutTransportNamesAddsNoTransportNamesStamp()
+    {
+        $message = new DummyMessage('hello');
+        $resultEnvelope = new Envelope($message);
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects($this->once())
+            ->method('dispatch')
+            ->with($message, [])
+            ->willReturn($resultEnvelope);
+
+        $handler = new RedispatchMessageHandler($bus);
+
+        $handler(new RedispatchMessage($message));
+    }
+
+    #[TestWith([[]])]
+    #[TestWith([''])]
+    #[TestWith([['']])]
+    public function testRedispatchWithoutTransportNamesSendsToTheConfiguredSender(array|string $transportNames)
+    {
+        $sender = $this->createSender();
+        $handled = [];
+        $bus = $this->createBus([DummyMessage::class => ['async']], ['async' => $sender], $handled);
+
+        $envelope = $bus->dispatch(new RedispatchMessage(new DummyMessage('hello'), $transportNames));
+
+        $this->assertCount(1, $sender->sent);
+        $this->assertSame([], $handled);
+        $this->assertNull($envelope->last(HandledStamp::class)->getResult());
+    }
+
+    public function testRedispatchWithoutTransportNamesIsHandledInProcessWhenNoSenderIsConfigured()
+    {
+        $sender = $this->createSender();
+        $handled = [];
+        $bus = $this->createBus([], ['async' => $sender], $handled);
+
+        $envelope = $bus->dispatch(new RedispatchMessage(new DummyMessage('hello')));
+
+        $this->assertCount(0, $sender->sent);
+        $this->assertCount(1, $handled);
+        $this->assertSame('handled in process', $envelope->last(HandledStamp::class)->getResult());
+    }
+
+    #[TestWith(['0'])]
+    #[TestWith([['0']])]
+    public function testRedispatchUsesATransportNamedZero(array|string $transportNames)
+    {
+        $zero = $this->createSender();
+        $async = $this->createSender();
+        $handled = [];
+        $bus = $this->createBus([DummyMessage::class => ['async']], ['0' => $zero, 'async' => $async], $handled);
+
+        $bus->dispatch(new RedispatchMessage(new DummyMessage('hello'), $transportNames));
+
+        $this->assertCount(1, $zero->sent);
+        $this->assertCount(0, $async->sent);
+    }
+
+    public function testRedispatchKeepsTheTransportNamesStampOfTheInnerEnvelope()
+    {
+        $inner = $this->createSender();
+        $async = $this->createSender();
+        $handled = [];
+        $bus = $this->createBus([DummyMessage::class => ['async']], ['inner' => $inner, 'async' => $async], $handled);
+
+        $message = new DummyMessage('hello');
+        $bus->dispatch(new RedispatchMessage(new Envelope($message, [new TransportNamesStamp(['inner'])])));
+
+        $this->assertCount(1, $inner->sent);
+        $this->assertCount(0, $async->sent);
+    }
+
+    public function testRedispatchWithAnEmptyTransportNamesStampIsHandledInProcess()
+    {
+        $async = $this->createSender();
+        $handled = [];
+        $bus = $this->createBus([DummyMessage::class => ['async']], ['async' => $async], $handled);
+
+        $message = new DummyMessage('hello');
+        $bus->dispatch(new RedispatchMessage(new Envelope($message, [new TransportNamesStamp([])])));
+
+        $this->assertCount(0, $async->sent);
+        $this->assertCount(1, $handled);
+    }
+
+    private function createSender()
+    {
+        return new class implements SenderInterface {
+            public array $sent = [];
+
+            public function send(Envelope $envelope): Envelope
+            {
+                return $this->sent[] = $envelope;
+            }
+        };
+    }
+
+    private function createBus(array $sendersMap, array $senders, array &$handled): MessageBus
+    {
+        $bus = null;
+
+        $sendersLocator = new Container();
+        foreach ($senders as $alias => $sender) {
+            $sendersLocator->set($alias, $sender);
+        }
+
+        $handlers = new HandlersLocator([
+            RedispatchMessage::class => [static function (RedispatchMessage $message) use (&$bus) {
+                return (new RedispatchMessageHandler($bus))($message);
+            }],
+            DummyMessage::class => [static function (DummyMessage $message) use (&$handled) {
+                $handled[] = $message;
+
+                return 'handled in process';
+            }],
+        ]);
+
+        return $bus = new MessageBus([
+            new SendMessageMiddleware(new SendersLocator($sendersMap, $sendersLocator)),
+            new HandleMessageMiddleware($handlers),
+        ]);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        |
| License       | MIT

---

`RedispatchMessage` re-dispatches a message on a fresh envelope so that it goes through Messenger routing again. That is what the Scheduler needs: a message coming out of the scheduler transport carries a `ReceivedStamp`, and `SendMessageMiddleware` never re-sends a message that already has one.

Until now the handler always attached a `TransportNamesStamp`, including when `$transportNames` was empty. `SendersLocator::getSenders()` treats the presence of that stamp as "use exactly this list of senders", so an empty list resolved to no sender at all and the message was handled in process. The transport name had to be repeated on every `RedispatchMessage`, even though the message class already had senders configured.

The handler now attaches the stamp only when at least one transport name is given. With none, the senders configured for the message class apply, whether they come from `framework.messenger.routing` or from `#[AsMessage]`.

## Before

```php
new SymfonySchedule()->add(
    RecurringMessage::cron(
        '0 9 * * *',
        new RedispatchMessage(new SendConcertReminders(), 'async'),
    ),
);
```

## After

```php
new SymfonySchedule()->add(
    RecurringMessage::cron(
        '0 9 * * *',
        new RedispatchMessage(new SendConcertReminders()),
    ),
);
```

An explicit transport name still takes precedence over the configured senders, so `new RedispatchMessage($message, 'async')` behaves as before. When the message class has no configured sender either, it is still handled in process.

## Backward compatibility

This is a marked BC break, see the new `Messenger` entry in `UPGRADE-8.2.md`. Code that relied on an empty transport list to force in-process handling of a message that also has a configured sender is now routed to that sender. To keep the previous behaviour, carry an empty `TransportNamesStamp` on the inner envelope:

```php
new RedispatchMessage(new Envelope($message, [new TransportNamesStamp([])]))
```

A message that is sent to a transport is not handled in process, so `RedispatchMessageHandler` returns `null` for it instead of the result of the handler.

## Documentation

The `RedispatchMessage` documentation should carry these points:

* the transport names are optional, and omitting them uses the senders configured for the message class, through `framework.messenger.routing` or `#[AsMessage]`;
* an explicit transport name still overrides those senders;
* with no configured sender and no transport name, the message is handled in process;
* an empty `TransportNamesStamp` on the inner envelope is the way to ask for in-process handling of a message that does have a configured sender;
* the handler returns the result of the message handler only when the message is handled in process.
