### PR TITLE
[FrameworkBundle][Messenger][Scheduler] Add framework.scheduler.use_messenger_routing

### DIFF
--- a/UPGRADE-8.2.md
+++ b/UPGRADE-8.2.md
@@ -62,6 +62,7 @@ FrameworkBundle
  * Deprecate the `framework.ide` config option, use the `SYMFONY_IDE` env var instead
  * BrowserKit assertions are no longer verbose by default. Failed response assertions no longer include the response body unless `setBrowserKitAssertionsAsVerbose(true)` is called or `verbose: true` is passed to the assertion.
  * Deprecate the `framework.fragments.hinclude_default_template` config option and the `fragment.renderer.hinclude.global_template` parameter; use the `esi` or `inline` fragment renderer, or [Symfony UX Turbo](https://ux.symfony.com/turbo), instead
+ * Deprecate not setting the `framework.scheduler.use_messenger_routing` config option; it will default to `true` in 9.0
 
 HttpClient
 ----------

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -20,6 +20,8 @@ CHANGELOG
  * Deprecate the `framework.ide` config option, use the `SYMFONY_IDE` env var instead
  * Allow prefixing entries with `!` in `framework.workflows.<name>.events_to_dispatch` to permanently disable an event; e.g. `events_to_dispatch: ['!workflow.announce']` fires every event except `workflow.announce`. The GuardEvent can never be disabled; `!workflow.guard` is rejected at config compile time. Mixing allow-list and block-list entries in the same list is rejected at config compile time too.
  * Add support for the HttpClient `max_connect_duration` option to the `http_client` configuration
+ * Add `framework.scheduler.use_messenger_routing` to automatically wrap scheduled messages in a `RedispatchMessage` so they go through the Messenger senders configured for their class instead of being handled synchronously by the scheduler worker
+ * Deprecate not setting the `framework.scheduler.use_messenger_routing` config option; it will default to `true` in 9.0
  * Report `.env` variables that the container never uses in `debug:container --env-vars`
  * Add `service_id` and `advisory` options to lock stores to use advisory locks on an existing `\PDO` or Doctrine DBAL connection service
  * Add `framework.webhook.signature_format`, `framework.webhook.timestamp_header_name` and `framework.webhook.timestamp_tolerance` options

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -2070,6 +2070,12 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('scheduler')
                     ->info('Scheduler configuration')
                     ->{$enableIfStandalone('symfony/scheduler', Schedule::class)}()
+                    ->children()
+                        ->booleanNode('use_messenger_routing')
+                            ->defaultNull()
+                            ->info('Whether scheduled messages are automatically wrapped in a "RedispatchMessage" so they go through the Messenger senders configured for their class instead of being handled synchronously by the scheduler worker. A "transports" option set explicitly on a task always takes precedence.')
+                        ->end()
+                    ->end()
                 ->end()
             ->end()
         ;

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -2447,7 +2447,20 @@ class FrameworkExtension extends Extension
             trigger_deprecation('symfony/framework-bundle', '8.2', 'Not setting the "framework.scheduler.use_messenger_routing" configuration option is deprecated, it will default to "true" in version 9.0.');
         }
 
-        $container->setParameter('scheduler.use_messenger_routing', $config['use_messenger_routing'] ?? false);
+        $useMessengerRouting = $config['use_messenger_routing'] ?? false;
+
+        if (\is_string($useMessengerRouting)) {
+            $usedEnvs = [];
+            $container->resolveEnvPlaceholders($useMessengerRouting, null, $usedEnvs);
+
+            if ($usedEnvs) {
+                throw new InvalidArgumentException(\sprintf('The "framework.scheduler.use_messenger_routing" option is consumed at compile time and cannot use env vars (got "%%env(%s)%%"). Set a static boolean instead.', implode('", "', array_keys($usedEnvs))));
+            }
+        }
+
+        // the leading dot marks it as internal: it is consumed at build time only
+        // and dropped from the compiled container by RemoveBuildParametersPass
+        $container->setParameter('.scheduler.use_messenger_routing', $useMessengerRouting);
     }
 
     private function registerMessengerConfiguration(array $config, ContainerBuilder $container, PhpFileLoader $loader, bool $validationEnabled, bool $lockEnabled): void

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -577,7 +577,7 @@ class FrameworkExtension extends Extension
             if (!$messengerEnabled) {
                 throw new LogicException('Scheduler support cannot be enabled as the Messenger component is not '.(interface_exists(MessageBusInterface::class) ? 'enabled.' : 'installed. Try running "composer require symfony/messenger".'));
             }
-            $this->registerSchedulerConfiguration($container, $loader);
+            $this->registerSchedulerConfiguration($config['scheduler'], $container, $loader);
         } else {
             $container->removeDefinition('cache.scheduler');
             $container->removeDefinition('console.command.scheduler_debug');
@@ -2431,7 +2431,7 @@ class FrameworkExtension extends Extension
         }
     }
 
-    private function registerSchedulerConfiguration(ContainerBuilder $container, PhpFileLoader $loader): void
+    private function registerSchedulerConfiguration(array $config, ContainerBuilder $container, PhpFileLoader $loader): void
     {
         if (!class_exists(SchedulerTransportFactory::class)) {
             throw new LogicException('Scheduler support cannot be enabled as the Scheduler component is not installed. Try running "composer require symfony/scheduler".');
@@ -2442,6 +2442,12 @@ class FrameworkExtension extends Extension
         if (!$this->hasConsole()) {
             $container->removeDefinition('console.command.scheduler_debug');
         }
+
+        if (null === $config['use_messenger_routing']) {
+            trigger_deprecation('symfony/framework-bundle', '8.2', 'Not setting the "framework.scheduler.use_messenger_routing" configuration option is deprecated, it will default to "true" in version 9.0.');
+        }
+
+        $container->setParameter('scheduler.use_messenger_routing', $config['use_messenger_routing'] ?? false);
     }
 
     private function registerMessengerConfiguration(array $config, ContainerBuilder $container, PhpFileLoader $loader, bool $validationEnabled, bool $lockEnabled): void

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/scheduler.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/scheduler.php
@@ -27,6 +27,7 @@ return static function (ContainerConfigurator $container) {
             ->args([
                 tagged_locator('scheduler.schedule_provider', 'name'),
                 service('clock'),
+                param('.scheduler.use_messenger_routing'),
             ])
             ->tag('messenger.transport_factory')
         ->set('scheduler.event_listener', DispatchSchedulerEventListener::class)

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -1385,6 +1385,7 @@ class ConfigurationTest extends TestCase
             ],
             'scheduler' => [
                 'enabled' => !class_exists(FullStack::class) && class_exists(SchedulerTransportFactory::class),
+                'use_messenger_routing' => null,
             ],
             'exceptions' => [],
             'webhook' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger.php
@@ -4,7 +4,10 @@ use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\BarMessage;
 use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\FooMessage;
 
 $container->loadFromExtension('framework', [
-    'scheduler' => true,
+    'scheduler' => [
+        'enabled' => true,
+        'use_messenger_routing' => false,
+    ],
     'messenger' => [
         'routing' => [
             FooMessage::class => ['sender.bar', 'sender.biz'],

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/scheduler_use_messenger_routing_legacy.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/scheduler_use_messenger_routing_legacy.php
@@ -1,0 +1,6 @@
+<?php
+
+$container->loadFromExtension('framework', [
+    'scheduler' => true,
+    'messenger' => true,
+]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger.yml
@@ -1,5 +1,7 @@
 framework:
-    scheduler: true
+    scheduler:
+        enabled: true
+        use_messenger_routing: false
     messenger:
         routing:
             'Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\FooMessage': ['sender.bar', 'sender.biz']

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/scheduler_use_messenger_routing_legacy.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/scheduler_use_messenger_routing_legacy.yml
@@ -1,0 +1,3 @@
+framework:
+    scheduler: true
+    messenger: true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -1260,6 +1260,17 @@ abstract class FrameworkExtensionTestCase extends TestCase
         $this->assertFalse($container->hasDefinition('messenger.listener.reset_services'));
     }
 
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
+    public function testLegacySchedulerUseMessengerRoutingNotSet()
+    {
+        $this->expectUserDeprecationMessage('Since symfony/framework-bundle 8.2: Not setting the "framework.scheduler.use_messenger_routing" configuration option is deprecated, it will default to "true" in version 9.0.');
+
+        $container = $this->createContainerFromFile('scheduler_use_messenger_routing_legacy');
+
+        $this->assertFalse($container->getParameter('scheduler.use_messenger_routing'));
+    }
+
     public function testMessengerMultipleFailureTransports()
     {
         $container = $this->createContainerFromFile('messenger_multiple_failure_transports');

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -1268,7 +1268,22 @@ abstract class FrameworkExtensionTestCase extends TestCase
 
         $container = $this->createContainerFromFile('scheduler_use_messenger_routing_legacy');
 
-        $this->assertFalse($container->getParameter('scheduler.use_messenger_routing'));
+        $this->assertFalse($container->getParameter('.scheduler.use_messenger_routing'));
+    }
+
+    public function testSchedulerUseMessengerRoutingRejectsEnvVar()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "framework.scheduler.use_messenger_routing" option is consumed at compile time and cannot use env vars (got "%env(bool:SCHEDULER_USE_MESSENGER_ROUTING)%"). Set a static boolean instead.');
+
+        $this->createContainerFromClosure(static function (ContainerBuilder $container) {
+            $container->loadFromExtension('framework', [
+                'messenger' => true,
+                'scheduler' => [
+                    'use_messenger_routing' => '%env(bool:SCHEDULER_USE_MESSENGER_ROUTING)%',
+                ],
+            ]);
+        });
     }
 
     public function testMessengerMultipleFailureTransports()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Scheduler/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Scheduler/config.yml
@@ -3,7 +3,8 @@ imports:
 
 framework:
     lock: ~
-    scheduler: ~
+    scheduler:
+        use_messenger_routing: false
     messenger: ~
 
 services:

--- a/src/Symfony/Component/Messenger/Message/RedispatchMessage.php
+++ b/src/Symfony/Component/Messenger/Message/RedispatchMessage.php
@@ -29,7 +29,12 @@ final class RedispatchMessage implements \Stringable
     public function __toString(): string
     {
         $message = $this->envelope instanceof Envelope ? $this->envelope->getMessage() : $this->envelope;
+        $description = $message instanceof \Stringable ? (string) $message : $message::class;
 
-        return \sprintf('%s via %s', $message instanceof \Stringable ? (string) $message : $message::class, implode(', ', (array) $this->transportNames));
+        if (!$transportNames = array_filter((array) $this->transportNames)) {
+            return $description;
+        }
+
+        return \sprintf('%s via %s', $description, implode(', ', $transportNames));
     }
 }

--- a/src/Symfony/Component/Scheduler/CHANGELOG.md
+++ b/src/Symfony/Component/Scheduler/CHANGELOG.md
@@ -7,6 +7,10 @@ CHANGELOG
  * Add a "Next Run In" column to `debug:scheduler` showing the time until the next run
  * Add `env` option to `#[AsCronTask]` and `#[AsPeriodicTask]` to restrict a task to one or more environments
  * Deprecate `Schedule::with()`, use `add()` on a new `Schedule` instead
+ * `AddScheduleMessengerPass` now wraps scheduled messages in a `RedispatchMessage` when the container parameter
+   `scheduler.use_messenger_routing` is `true`, even without an explicit `transports` option, so they go through
+   the Messenger senders configured for their class instead of being handled synchronously by the scheduler worker
+   (see `framework.scheduler.use_messenger_routing` in FrameworkBundle)
 
 8.1
 ---

--- a/src/Symfony/Component/Scheduler/DependencyInjection/AddScheduleMessengerPass.php
+++ b/src/Symfony/Component/Scheduler/DependencyInjection/AddScheduleMessengerPass.php
@@ -36,7 +36,7 @@ class AddScheduleMessengerPass implements CompilerPassInterface
             $container->removeDefinition('scheduler.event_listener');
         }
 
-        $useMessengerRouting = $container->hasParameter('scheduler.use_messenger_routing') && $container->getParameter('scheduler.use_messenger_routing');
+        $useMessengerRouting = $container->hasParameter('.scheduler.use_messenger_routing') && $container->getParameter('.scheduler.use_messenger_routing');
 
         $receivers = [];
         foreach ($container->findTaggedServiceIds('messenger.receiver') as $serviceId => $tags) {

--- a/src/Symfony/Component/Scheduler/DependencyInjection/AddScheduleMessengerPass.php
+++ b/src/Symfony/Component/Scheduler/DependencyInjection/AddScheduleMessengerPass.php
@@ -36,6 +36,8 @@ class AddScheduleMessengerPass implements CompilerPassInterface
             $container->removeDefinition('scheduler.event_listener');
         }
 
+        $useMessengerRouting = $container->hasParameter('scheduler.use_messenger_routing') && $container->getParameter('scheduler.use_messenger_routing');
+
         $receivers = [];
         foreach ($container->findTaggedServiceIds('messenger.receiver') as $serviceId => $tags) {
             $receivers[$serviceId] = true;
@@ -98,6 +100,8 @@ class AddScheduleMessengerPass implements CompilerPassInterface
 
                 if ($tagAttributes['transports'] ?? null) {
                     $message = new Definition(RedispatchMessage::class, [$message, $tagAttributes['transports']]);
+                } elseif ($useMessengerRouting) {
+                    $message = new Definition(RedispatchMessage::class, [$message]);
                 }
 
                 $taskArguments = [

--- a/src/Symfony/Component/Scheduler/Messenger/SchedulerTransport.php
+++ b/src/Symfony/Component/Scheduler/Messenger/SchedulerTransport.php
@@ -21,6 +21,7 @@ class SchedulerTransport implements TransportInterface
 {
     public function __construct(
         private readonly MessageGeneratorInterface $messageGenerator,
+        private readonly bool $useMessengerRouting = false,
     ) {
     }
 
@@ -32,7 +33,9 @@ class SchedulerTransport implements TransportInterface
         foreach ($this->messageGenerator->getMessages() as $context => $message) {
             $stamp = new ScheduledStamp($context);
 
-            if ($message instanceof RedispatchMessage) {
+            if ($this->useMessengerRouting && !$message instanceof RedispatchMessage) {
+                $message = new RedispatchMessage(Envelope::wrap($message, [$stamp]));
+            } elseif ($message instanceof RedispatchMessage) {
                 $message = new RedispatchMessage(
                     Envelope::wrap($message->envelope, [$stamp]),
                     $message->transportNames,

--- a/src/Symfony/Component/Scheduler/Messenger/SchedulerTransportFactory.php
+++ b/src/Symfony/Component/Scheduler/Messenger/SchedulerTransportFactory.php
@@ -28,6 +28,7 @@ class SchedulerTransportFactory implements TransportFactoryInterface
     public function __construct(
         private readonly ContainerInterface $scheduleProviders,
         private readonly ClockInterface $clock = new Clock(),
+        private readonly bool $useMessengerRouting = false,
     ) {
     }
 
@@ -46,7 +47,7 @@ class SchedulerTransportFactory implements TransportFactoryInterface
         /** @var ScheduleProviderInterface $scheduleProvider */
         $scheduleProvider = $this->scheduleProviders->get($scheduleName);
 
-        return new SchedulerTransport(new MessageGenerator($scheduleProvider, $scheduleName, $this->clock));
+        return new SchedulerTransport(new MessageGenerator($scheduleProvider, $scheduleName, $this->clock), $this->useMessengerRouting);
     }
 
     public function supports(string $dsn, array $options): bool

--- a/src/Symfony/Component/Scheduler/Tests/DependencyInjection/AddScheduleMessengerPassTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/DependencyInjection/AddScheduleMessengerPassTest.php
@@ -16,10 +16,62 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\Messenger\Message\RedispatchMessage;
 use Symfony\Component\Scheduler\DependencyInjection\AddScheduleMessengerPass;
+use Symfony\Component\Scheduler\Messenger\ServiceCallMessage;
 
 class AddScheduleMessengerPassTest extends TestCase
 {
+    public function testMessageIsNotWrappedByDefault()
+    {
+        $messageDefinition = $this->processTask([]);
+
+        $this->assertSame(ServiceCallMessage::class, $messageDefinition->getClass());
+    }
+
+    public function testMessageIsNotWrappedWhenUseMessengerRoutingIsDisabled()
+    {
+        $messageDefinition = $this->processTask([], false);
+
+        $this->assertSame(ServiceCallMessage::class, $messageDefinition->getClass());
+    }
+
+    public function testMessageIsWrappedInRedispatchMessageWhenUseMessengerRoutingIsEnabled()
+    {
+        $messageDefinition = $this->processTask([], true);
+
+        $this->assertSame(RedispatchMessage::class, $messageDefinition->getClass());
+        $this->assertCount(1, $messageDefinition->getArguments());
+        $this->assertSame(ServiceCallMessage::class, $messageDefinition->getArgument(0)->getClass());
+    }
+
+    public function testExplicitTransportsTakePrecedenceOverUseMessengerRouting()
+    {
+        $messageDefinition = $this->processTask(['transports' => ['async']], true);
+
+        $this->assertSame(RedispatchMessage::class, $messageDefinition->getClass());
+        $this->assertSame(['async'], $messageDefinition->getArgument(1));
+    }
+
+    private function processTask(array $extraTagAttributes, ?bool $useMessengerRouting = null): Definition
+    {
+        $container = new ContainerBuilder();
+        if (null !== $useMessengerRouting) {
+            $container->setParameter('scheduler.use_messenger_routing', $useMessengerRouting);
+        }
+
+        $definition = new Definition(\stdClass::class);
+        $definition->addTag('scheduler.task', ['trigger' => 'every', 'frequency' => '1 hour'] + $extraTagAttributes);
+        $container->setDefinition('task', $definition);
+
+        (new AddScheduleMessengerPass())->process($container);
+
+        $schedulerProvider = $container->getDefinition('scheduler.provider.default');
+        $calls = $schedulerProvider->getMethodCalls();
+
+        return $calls[0][1][0]->getArgument('$message');
+    }
+
     #[DataProvider('processSchedulerTaskCommandProvider')]
     public function testProcessSchedulerTaskCommand(array $arguments, string $expectedCommand, string $commandClass = SchedulableCommand::class)
     {

--- a/src/Symfony/Component/Scheduler/Tests/DependencyInjection/AddScheduleMessengerPassTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/DependencyInjection/AddScheduleMessengerPassTest.php
@@ -57,7 +57,7 @@ class AddScheduleMessengerPassTest extends TestCase
     {
         $container = new ContainerBuilder();
         if (null !== $useMessengerRouting) {
-            $container->setParameter('scheduler.use_messenger_routing', $useMessengerRouting);
+            $container->setParameter('.scheduler.use_messenger_routing', $useMessengerRouting);
         }
 
         $definition = new Definition(\stdClass::class);

--- a/src/Symfony/Component/Scheduler/Tests/Messenger/SchedulerTransportTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/Messenger/SchedulerTransportTest.php
@@ -64,6 +64,34 @@ class SchedulerTransportTest extends TestCase
         $this->assertSame('id', $stamp->messageContext->id);
     }
 
+    public function testMessageIsNotWrappedWhenUseMessengerRoutingIsDisabled()
+    {
+        $generator = $this->createStub(MessageGeneratorInterface::class);
+        $generator->method('getMessages')->willReturnCallback(function (): \Generator {
+            yield new MessageContext('default', 'id', $this->createStub(TriggerInterface::class), new \DateTimeImmutable()) => new \stdClass();
+        });
+        $envelopes = iterator_to_array((new SchedulerTransport($generator, useMessengerRouting: false))->get());
+
+        $this->assertInstanceOf(\stdClass::class, $envelopes[0]->getMessage());
+    }
+
+    public function testMessageIsWrappedInRedispatchMessageWhenUseMessengerRoutingIsEnabled()
+    {
+        $generator = $this->createStub(MessageGeneratorInterface::class);
+        $generator->method('getMessages')->willReturnCallback(function (): \Generator {
+            yield new MessageContext('default', 'id', $this->createStub(TriggerInterface::class), new \DateTimeImmutable()) => new \stdClass();
+        });
+        $envelopes = iterator_to_array((new SchedulerTransport($generator, useMessengerRouting: true))->get());
+
+        $this->assertInstanceOf(RedispatchMessage::class, $envelopes[0]->getMessage());
+        $this->assertSame([], $envelopes[0]->getMessage()->transportNames);
+        // the ScheduledStamp must live on the inner envelope so it survives the redispatch
+        $this->assertSame(
+            $envelopes[0]->getMessage()->envelope->last(ScheduledStamp::class),
+            $envelopes[0]->last(ScheduledStamp::class)
+        );
+    }
+
     public function testAckIgnored()
     {
         $transport = new SchedulerTransport($this->createStub(MessageGeneratorInterface::class));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Issues        |
| License       | MIT

By default a scheduled message does not go through Messenger routing: `SchedulerTransport` hands it to the worker, which runs it inline. Wrapping a message in a `RedispatchMessage` sends it through routing, but nothing points you at that class, and until #65143 you also had to repeat the transport name that `framework.messenger.routing` (or `#[AsMessage]`) already knows.

This PR adds `framework.scheduler.use_messenger_routing`, so that routing applies to scheduled messages the way it applies everywhere else:

- `framework.scheduler.use_messenger_routing`: `bool|null`, defaults to `null`. `null` keeps the current behavior, tasks run inline, and is deprecated: the option will default to `true` in 9.0.
- When `true`, `SchedulerTransport` wraps every scheduled message, attribute-declared tasks and `#[AsSchedule]` provider messages alike, in a `RedispatchMessage`, unless it already is one. A `transports` option set on a task still takes precedence.
- The deprecation is triggered from `SchedulerTransport::get()`, only when an unwrapped message is actually yielded, so an install with the component present and nothing due stays quiet instead of warning on every container build.
- `symfony/scheduler` now requires and conflicts on `symfony/messenger` `^8.2`: below that version, `RedispatchMessageHandler` attaches an empty `TransportNamesStamp`, which makes the option a silent no-op.

Worth knowing before turning it on in an existing app: if a scheduled message's class has a route, and a `'*'` catch-all counts, the task is sent to that transport instead of running inline. A consumer must be running for it, or the task is queued and never executes, with nothing logged beyond "Sending message". From there on, retries, the failure transport and serialization of the message arguments apply like for any other async message. To keep a task inline, route its class, or set `transports: 'sync'` on the attribute, to a `sync://` transport.

Two things that wrapping used to break are fixed here, because the option turns them from an exception into the common case:

- The scheduler events carried the `RedispatchMessage` rather than the scheduled message, so a listener matching on the task class silently stopped matching, `shouldCancel()` included. `PreRunEvent`, `PostRunEvent` and `FailureEvent` now always carry the scheduled message. On a routed task the pair fires twice: in the scheduler worker when the task is dispatched, with a `null` result, and in the consumer when it actually runs.
- `ScheduledStamp` carries the trigger, so a task whose trigger holds a closure, `CallbackTrigger` or anything decorating one, died at send time with `Serialization of 'Closure' is not allowed` and never ran. `ScheduledStamp` now serializes the trigger as a description, restored as a `SerializedTrigger`, which is what the `TriggerInterface` normalizer already did for the Symfony serializer. The payload keeps its shape, so messages queued before the upgrade still decode.

A follow-up on symfony/recipes, symfony/recipes#1573, sets `use_messenger_routing: true` in the recipe for 8.2, since new apps should start with the option on.

The documentation should cover: the option, its default and the 9.0 flip; that routing then applies to every scheduled message; how to keep a task inline; that a routed task needs a running consumer and gains retries and a failure transport; that the message arguments must be serializable; and that the scheduler events fire in the scheduler worker and again in the consumer, where the trigger arrives as a description only.
