### PR TITLE
[AssetMapper] Preserve the order of entries in importmap during update

### DIFF
--- a/src/Symfony/Component/AssetMapper/CHANGELOG.md
+++ b/src/Symfony/Component/AssetMapper/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.2
 ---
 
+ * Defined stable alphabetical order of importmap entries
  * Add support for adding integrity metadata to importmaps
  * Add a `--no-esm` option to `importmap:require` and an `esm` option to importmap entries
 

--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapConfigReader.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapConfigReader.php
@@ -110,6 +110,7 @@ class ImportMapConfigReader
             $importMapConfig[$entry->importName] = $config;
         }
 
+        uksort($importMapConfig, strcmp(...));
         $map = class_exists(VarExporter::class) ? VarExporter::export($importMapConfig) : var_export($importMapConfig, true);
         $this->filesystem->dumpFile($this->importMapConfigPath, <<<EOF
             <?php

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapConfigReaderTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapConfigReaderTest.php
@@ -43,19 +43,12 @@ class ImportMapConfigReaderTest extends TestCase
         $importMap = <<<EOF
             <?php
             return [
-                'remote_package' => [
-                    'version' => '3.2.1',
-                ],
-                'local_package' => [
-                    'path' => 'app.js',
-                ],
-                'type_css' => [
-                    'path' => 'styles/app.css',
-                    'type' => 'css',
-                ],
                 'entry_point' => [
                     'path' => 'entry.js',
                     'entrypoint' => true,
+                ],
+                'local_package' => [
+                    'path' => 'app.js',
                 ],
                 'package/with_file.js' => [
                     'version' => '1.0.0',
@@ -63,6 +56,13 @@ class ImportMapConfigReaderTest extends TestCase
                 'raw_esm_package' => [
                     'version' => '2.0.0',
                     'esm' => false,
+                ],
+                'remote_package' => [
+                    'version' => '3.2.1',
+                ],
+                'type_css' => [
+                    'path' => 'styles/app.css',
+                    'type' => 'css',
                 ],
             ];
             EOF;
@@ -82,7 +82,17 @@ class ImportMapConfigReaderTest extends TestCase
         $allEntries = iterator_to_array($entries);
         $this->assertCount(6, $allEntries);
 
-        $remotePackageEntry = $allEntries[0];
+        $localPackageEntry = $allEntries[1];
+        $this->assertFalse($localPackageEntry->isRemotePackage());
+        $this->assertSame('app.js', $localPackageEntry->path);
+
+        $packageWithFileEntry = $allEntries[2];
+        $this->assertSame('package/with_file.js', $packageWithFileEntry->packageModuleSpecifier);
+
+        $rawEsmEntry = $allEntries[3];
+        $this->assertFalse($rawEsmEntry->useEsm);
+
+        $remotePackageEntry = $allEntries[4];
         $this->assertSame('remote_package', $remotePackageEntry->importName);
         $this->assertSame('/path/to/vendor/remote_package.js', $remotePackageEntry->path);
         $this->assertSame('3.2.1', $remotePackageEntry->version);
@@ -90,18 +100,8 @@ class ImportMapConfigReaderTest extends TestCase
         $this->assertFalse($remotePackageEntry->isEntrypoint);
         $this->assertSame('remote_package', $remotePackageEntry->packageModuleSpecifier);
 
-        $localPackageEntry = $allEntries[1];
-        $this->assertFalse($localPackageEntry->isRemotePackage());
-        $this->assertSame('app.js', $localPackageEntry->path);
-
-        $typeCssEntry = $allEntries[2];
+        $typeCssEntry = $allEntries[5];
         $this->assertSame('css', $typeCssEntry->type->value);
-
-        $packageWithFileEntry = $allEntries[4];
-        $this->assertSame('package/with_file.js', $packageWithFileEntry->packageModuleSpecifier);
-
-        $rawEsmEntry = $allEntries[5];
-        $this->assertFalse($rawEsmEntry->useEsm);
 
         // now save the original raw data from importmap.php and delete the file
         $originalImportMapData = (static fn () => eval('?>'.file_get_contents(__DIR__.'/../Fixtures/importmap_config_reader/importmap.php')))();
@@ -111,6 +111,44 @@ class ImportMapConfigReaderTest extends TestCase
         $newImportMapData = (static fn () => eval('?>'.file_get_contents(__DIR__.'/../Fixtures/importmap_config_reader/importmap.php')))();
 
         $this->assertSame($originalImportMapData, $newImportMapData);
+    }
+
+    #[DataProvider('getAlphabeticalEntriesTests')]
+    public function testWriteEntriesEstablishesAlphabeticalEntryOrder(ImportMapEntries $entries, array $expectedKeys)
+    {
+        $configReader = new ImportMapConfigReader(
+            __DIR__.'/../Fixtures/importmap_config_reader/importmap.php',
+            new RemotePackageStorage(sys_get_temp_dir()),
+        );
+
+        $configReader->writeEntries($entries);
+        $importMapData = (static fn () => eval('?>'.file_get_contents(__DIR__.'/../Fixtures/importmap_config_reader/importmap.php')))();
+
+        $this->assertSame($expectedKeys, array_keys($importMapData));
+    }
+
+    public static function getAlphabeticalEntriesTests()
+    {
+        $alpha = ImportMapEntry::createLocal('alpha', ImportMapType::JS, 'alpha.js', false);
+        $beta = ImportMapEntry::createLocal('beta', ImportMapType::JS, 'beta.js', false);
+        $gamma = ImportMapEntry::createLocal('gamma', ImportMapType::JS, 'gamma.js', false);
+        $delta = ImportMapEntry::createLocal('delta', ImportMapType::JS, 'delta.js', false);
+        $expectedKeys = [$alpha->importName, $beta->importName, $delta->importName, $gamma->importName];
+
+        yield 'ascending' => [
+            'entries' => new ImportMapEntries([$alpha, $beta, $delta, $gamma]),
+            'expectedKeys' => $expectedKeys,
+        ];
+
+        yield 'descending' => [
+            'entries' => new ImportMapEntries([$gamma, $delta, $beta, $alpha]),
+            'expectedKeys' => $expectedKeys,
+        ];
+
+        yield 'random' => [
+            'entries' => new ImportMapEntries([$delta, $beta, $alpha, $gamma]),
+            'expectedKeys' => $expectedKeys,
+        ];
     }
 
     #[DataProvider('getPathToFilesystemPathTests')]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65117 
| License       | MIT

As reported in #65117, the `importmap:update` command would change the order of entries in the `importmap.php` file. This behavior is caused by the way the update process is implemented in `ImportMapManager`. Currently, it first removes the entry and then adds it back as freshly installed. This removal and subsequent re-addition cause the mentioned change in order.

This PR defines a stable alphabetical order of entries in the importmap file by sorting its them (in `ImportMapConfigReader`) just before they are written to the file. This leads to a small quality of life improvement by making the diffs clearer.

Please note that existing users of the AssetMapper component may experience a one-time larger diff in the importmap file due to the mentioned sorting of entries.

This is my first contribution to Symfony. Any feedback is appreciated!