### PR TITLE
[DependencyInjection] Resolve factories on "service_container" against the concrete container class

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/AbstractRecursivePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AbstractRecursivePass.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Argument\ArgumentInterface;
 use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Exception\LogicException;
@@ -143,6 +144,10 @@ abstract class AbstractRecursivePass implements CompilerPassInterface
             }
 
             if ($class instanceof Reference) {
+                if ('service_container' === (string) $class && method_exists(Container::class, $method)) {
+                    return new \ReflectionMethod(Container::class, $method);
+                }
+
                 $factoryDefinition = $this->container->findDefinition((string) $class);
                 while ((null === $class = $factoryDefinition->getClass()) && $factoryDefinition instanceof ChildDefinition) {
                     $factoryDefinition = $this->container->findDefinition($factoryDefinition->getParent());

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckTypeDeclarationsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckTypeDeclarationsPassTest.php
@@ -575,6 +575,21 @@ class CheckTypeDeclarationsPassTest extends TestCase
         $this->addToAssertionCount(1);
     }
 
+    public function testProcessFactoryOnServiceContainer()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('bar', WeakMapConsumer::class)
+            ->addArgument((new Definition(\WeakMap::class))->setFactory([
+                new Reference('service_container'),
+                'getResetMap',
+            ]));
+
+        (new CheckTypeDeclarationsPass(true))->process($container);
+
+        $this->addToAssertionCount(1);
+    }
+
     public function testProcessPassingBuiltinTypeDoesNotLoadCodeByDefault()
     {
         $container = new ContainerBuilder();
@@ -1078,6 +1093,13 @@ class StringableClass implements \Stringable
 class StringConsumer
 {
     public function __construct(string $value)
+    {
+    }
+}
+
+class WeakMapConsumer
+{
+    public function __construct(\WeakMap $map)
     {
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65146
| License       | MIT

Any app that declares a non-shared resettable service now fails `lint:container` with `Invalid service "services_resetter": method "Symfony\Component\DependencyInjection\ContainerInterface::getResetMap()" does not exist.`

`ResettableServicePass` builds the reset map through a factory on the `service_container` service, and that service is defined with `ContainerInterface` as its class. `getResetMap()` is declared on `Container` instead, so the reflection lookup in `AbstractRecursivePass` finds nothing, even though the dumped container does call the method on itself just fine.

Factories on `service_container` are now reflected against `Container`, which is what `CheckTypeDeclarationsPass` already assumes for that service.
