### PR TITLE
[Tui] Render raw HTML in MarkdownWidget instead of dropping it

### DIFF
--- a/src/Symfony/Component/Tui/Tests/Widget/MarkdownTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/MarkdownTest.php
@@ -143,15 +143,27 @@ class MarkdownTest extends TestCase
         $this->assertStringContainsString('World', $lines2[0]);
     }
 
-    public function testStripHtmlTags()
+    public function testRenderRawHtmlTags()
     {
-        $md = $this->createMarkdown('Hello <b>world</b> test');
+        $md = $this->createMarkdown('Hello <b>world</b> and <system-reminder> test');
         $lines = $md->render(new RenderContext(60, 24));
 
         $content = implode('', $lines);
-        $this->assertStringNotContainsString('<b>', $content);
-        $this->assertStringNotContainsString('</b>', $content);
+        $this->assertStringContainsString('<b>', $content);
+        $this->assertStringContainsString('</b>', $content);
+        $this->assertStringContainsString('<system-reminder>', $content);
         $this->assertStringContainsString('world', $content);
+    }
+
+    public function testRenderRawHtmlBlocksWithoutDroppingSurroundingText()
+    {
+        $md = $this->createMarkdown("before\n<div>inside</div>\nafter");
+        $lines = $md->render(new RenderContext(60, 24));
+
+        $content = implode("\n", $lines);
+        $this->assertStringContainsString('before', $content);
+        $this->assertStringContainsString('<div>inside</div>', $content);
+        $this->assertStringContainsString('after', $content);
     }
 
     public function testLongLinesAreWrapped()

--- a/src/Symfony/Component/Tui/Widget/MarkdownWidget.php
+++ b/src/Symfony/Component/Tui/Widget/MarkdownWidget.php
@@ -16,12 +16,14 @@ use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
 use League\CommonMark\Extension\CommonMark\Node\Block\BlockQuote;
 use League\CommonMark\Extension\CommonMark\Node\Block\FencedCode;
 use League\CommonMark\Extension\CommonMark\Node\Block\Heading;
+use League\CommonMark\Extension\CommonMark\Node\Block\HtmlBlock;
 use League\CommonMark\Extension\CommonMark\Node\Block\IndentedCode;
 use League\CommonMark\Extension\CommonMark\Node\Block\ListBlock;
 use League\CommonMark\Extension\CommonMark\Node\Block\ListItem;
 use League\CommonMark\Extension\CommonMark\Node\Block\ThematicBreak;
 use League\CommonMark\Extension\CommonMark\Node\Inline\Code;
 use League\CommonMark\Extension\CommonMark\Node\Inline\Emphasis;
+use League\CommonMark\Extension\CommonMark\Node\Inline\HtmlInline;
 use League\CommonMark\Extension\CommonMark\Node\Inline\Link;
 use League\CommonMark\Extension\CommonMark\Node\Inline\Strong;
 use League\CommonMark\Extension\GithubFlavoredMarkdownExtension;
@@ -188,6 +190,7 @@ class MarkdownWidget extends AbstractWidget
             $node instanceof ListBlock => $this->renderList($node, $columns),
             $node instanceof ThematicBreak => [$this->resolveElement('hr')->apply(str_repeat('─', $columns))],
             $node instanceof Table => $this->renderTable($node, $columns),
+            $node instanceof HtmlBlock => TextWrapper::wrapTextWithAnsi($this->resolveElement('code')->apply($node->getLiteral()).$this->restoreContext, $columns),
             default => $this->renderGenericBlock($node, $columns),
         };
     }
@@ -554,6 +557,7 @@ class MarkdownWidget extends AbstractWidget
             $node instanceof Emphasis => $this->resolveElement('italic')->apply($this->renderInlineNodes($node)).$this->restoreContext,
             $node instanceof Strikethrough => $this->resolveElement('strikethrough')->apply($this->renderInlineNodes($node)).$this->restoreContext,
             $node instanceof Code => $this->resolveElement('code')->apply($node->getLiteral()).$this->restoreContext,
+            $node instanceof HtmlInline => $this->resolveElement('code')->apply($node->getLiteral()).$this->restoreContext,
             $node instanceof Link => $this->resolveElement('link')->apply($this->renderInlineNodes($node)).$this->restoreContext.' '.$this->resolveElement('link-url')->apply('('.$node->getUrl().')').$this->restoreContext,
             $node instanceof Newline => "\n",
             default => $this->renderInlineNodes($node), // For nested structures


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65148
| License       | MIT

`MarkdownWidget` silently dropped raw HTML. Both `renderInlineNode()` and `renderNode()` are `match(true)` chains whose `default` arm recurses into child nodes, and neither had an arm for the two HTML node types. `HtmlInline` and `HtmlBlock` keep their source in `getLiteral()` and have no children, so the recursion returned an empty string.

Inline HTML lost the tag:

```
in:  Hello <b>world</b> and <system-reminder> test
out: Hello world and  test
```

Block-level HTML was worse. CommonMark groups the lines that follow an opening tag into the same `HtmlBlock`, so the user's own prose disappeared with it:

```
in:  <system-reminder>\nimportant user text\nmore text
out:

in:  Text\n<div>x</div>\nText2
out: Text
```

Both node types are now printed verbatim, using the same style as inline code:

```
in:  Hello <b>world</b> and <system-reminder> test
out: Hello <b>world</b> and <system-reminder> test

in:  Text\n<div>x</div>\nText2
out: Text\n\n<div>x</div>\nText2
```

Notes for whoever reads this later:

- This reverses the assertion in `testStripHtmlTags`, which came with the component in a81867921ed. There is no stripping code anywhere, only the missing arms, so that test recorded what fell out of the implementation rather than an intent. Tui is `@experimental`, so the output change is allowed on 8.1, but it is a visible change for 8.1.x users.
- HTML comments, CDATA sections and DOCTYPE declarations are now shown too, since they parse into the same node types.
- Raw HTML reuses the `code` element, so it cannot be styled separately from inline code. A dedicated style key would be a new feature and does not belong on this branch.
- No escape-sequence risk is introduced. `MarkdownWidget::__construct()` and `::setText()` are the only writers of the text and both run `StringUtils::stripControlBytes(StringUtils::sanitizeUtf8())`, so an ESC byte inside a tag never reaches the terminal. Verified on both the inline and the block path.
