### PR TITLE
[Mailer] Preserve the Message-ID header on emails sent through API transports

### DIFF
--- a/src/Symfony/Component/Mailer/Tests/Transport/AbstractApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/AbstractApiTransportTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Mailer\Tests\Transport;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Exception\RuntimeException;
 use Symfony\Component\Mailer\SentMessage;
@@ -43,5 +44,40 @@ class AbstractApiTransportTest extends TestCase
         $this->expectExceptionMessage(\sprintf('Unable to send message with the "%s" transport: the message must be an instance of "%s" (got "%s"). An API transport builds its payload from the message fields; use an SMTP transport to send a raw message.', $transport::class, Message::class, RawMessage::class));
 
         $transport->send(new RawMessage('Raw email content'), new Envelope(new Address('fabien@symfony.com'), [new Address('helene@symfony.com')]));
+    }
+
+    public function testSendPreservesTheGeneratedMessageIdOnTheApiEmail()
+    {
+        $transport = new class(new MockHttpClient()) extends AbstractApiTransport {
+            public ?Email $capturedEmail = null;
+
+            protected function doSendApi(SentMessage $sentMessage, Email $email, Envelope $envelope): ResponseInterface
+            {
+                $this->capturedEmail = $email;
+
+                return new MockResponse();
+            }
+
+            public function __toString(): string
+            {
+                return 'api://test';
+            }
+        };
+
+        $email = (new Email())
+            ->from('fabien@symfony.com')
+            ->to('helene@symfony.com')
+            ->text('Hello there!');
+
+        $sentMessage = $transport->send($email);
+
+        // The email handed to the API must carry the Message-ID header generated for
+        // this message, the way the SMTP transport sends it via SentMessage::getMessage().
+        $this->assertNotSame('', $sentMessage->getMessageId());
+        $this->assertInstanceOf(Email::class, $transport->capturedEmail);
+        $this->assertSame('<'.$sentMessage->getMessageId().'>', $transport->capturedEmail->getHeaders()->get('Message-ID')->getBodyAsString());
+
+        // The caller's original message must not be mutated in the process.
+        $this->assertFalse($email->getHeaders()->has('Message-ID'));
     }
 }

--- a/src/Symfony/Component/Mailer/Transport/AbstractApiTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/AbstractApiTransport.php
@@ -40,6 +40,16 @@ abstract class AbstractApiTransport extends AbstractHttpTransport
             throw new RuntimeException(\sprintf('Unable to send message with the "%s" transport: ', static::class).$e->getMessage(), 0, $e);
         }
 
+        // SentMessage generates the Message-ID on its own copy of the message, so the
+        // original message used here to build the API payload does not carry it. Stamp
+        // it on the email (without mutating the caller's message) so the API-sent
+        // message includes a Message-ID header, the way the SMTP transport already does
+        // by sending SentMessage::getMessage().
+        if (!$email->getHeaders()->has('Message-ID')) {
+            $email = clone $email;
+            $email->getHeaders()->addIdHeader('Message-ID', $message->getMessageId());
+        }
+
         return $this->doSendApi($message, $email, $message->getEnvelope());
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64964
| License       | MIT

Follow-up to #64985, which fixed point 1 of #64964 (the `TypeError` when a `RawMessage` reaches an API transport). This PR addresses the remaining point 2: the Message-ID header is lost on emails sent through API transports.

### The problem

`SentMessage::__construct()` generates a `Message-ID` on its own **clone** of the message (kept in `$raw`, and sent as-is by `SmtpTransport` via `SentMessage::getMessage()`). The `$original` message returned by `getOriginalMessage()` never receives it.

`AbstractApiTransport::doSendHttp()` builds the API payload from `getOriginalMessage()`:

```php
$email = MessageConverter::toEmail($message->getOriginalMessage());
```

so that email carries **no** `Message-ID` header. Concrete API transports (Mailgun, Brevo, Postmark, …) forward `$email->getHeaders()` verbatim, so the message actually put on the wire ends up without a `Message-ID`, while the SMTP path always sends one. That inconsistency breaks correlation/logging that relies on the sent message having a stable `Message-ID`.

### The fix

Stamp the generated `Message-ID` header onto the email before handing it to `doSendApi()`, mirroring what the SMTP transport already sends — only when the message doesn't already carry one, so an explicitly set `Message-ID` is preserved:

```php
if (!$email->getHeaders()->has('Message-ID')) {
    $email = clone $email;
    $email->getHeaders()->addIdHeader('Message-ID', $message->getMessageId());
}
```

`MessageConverter::toEmail()` returns the same instance when given an `Email`, and that instance is what `getOriginalMessage()` exposes; the `clone` ensures the caller's message is not mutated as a side effect (`Message::__clone()` deep-copies headers and body). The fix lives in the single `doSendHttp()` choke point, so every `AbstractApiTransport` subclass benefits without per-transport changes.

### Test verification (RED → GREEN)

Added `AbstractApiTransportTest::testSendPreservesTheGeneratedMessageIdOnTheApiEmail`, which captures the `Email` passed to `doSendApi()` and asserts it carries the generated `Message-ID` header (and that the caller's message stays untouched).

RED — on the unmodified 6.4 branch (no `Message-ID` header on the API email):

```
1) Symfony\Component\Mailer\Tests\Transport\AbstractApiTransportTest::testSendPreservesTheGeneratedMessageIdOnTheApiEmail
Error: Call to a member function getBodyAsString() on null
.../Tests/Transport/AbstractApiTransportTest.php:78
ERRORS! Tests: 1, Assertions: 2, Errors: 1.
```

GREEN — with the fix:

```
OK (1 test, 4 assertions)
```

Full `Mailer` component suite is iso-baseline (the same two pre-existing failures unrelated to this change — a missing `symfony/phpunit-bridge` mock class and an SMTP socket test requiring outbound network — appear identically with and without the patch; the new test passes and no new failures are introduced).
