### PR TITLE
[Cache] Remove superflous implements of AdapterInterface as described in #65151

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/AbstractTagAwareAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/AbstractTagAwareAdapter.php
@@ -31,7 +31,7 @@ use Symfony\Contracts\Cache\TagAwareCacheInterface;
  *
  * @internal
  */
-abstract class AbstractTagAwareAdapter implements TagAwareAdapterInterface, TagAwareCacheInterface, AdapterInterface, NamespacedPoolInterface, LoggerAwareInterface, ResettableInterface
+abstract class AbstractTagAwareAdapter implements TagAwareAdapterInterface, TagAwareCacheInterface, NamespacedPoolInterface, LoggerAwareInterface, ResettableInterface
 {
     use AbstractAdapterTrait;
     use ContractsTrait;


### PR DESCRIPTION
Fixes the problem as mentioned in ticket #65151 

| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65151 
| License       | MIT

Removes the second implements of the AdapterInterface as this is already done in TagAwareAdapterInterface via extends AdapterInterface.
According to my understanding should be compatible with the bc promise as the interface isn't removed from the public api of the class.
Edit: changed branch as suggested by bot