### PR TITLE
[ObjectMapper] Fix target property mappings dropped when the source carries metadata

### DIFF
--- a/src/Symfony/Component/ObjectMapper/ObjectMapper.php
+++ b/src/Symfony/Component/ObjectMapper/ObjectMapper.php
@@ -190,7 +190,11 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
                     continue;
                 }
 
-                $implicitValues[$propertyName] = $this->getSourceValue($source, $mappedTarget, $this->getRawValue($source, $propertyName), $objectMap, null, $propertyName);
+                // when metadata is read from the source, the #[Map] declared on the target property
+                // itself is never surfaced above, so honor its transform for the same-name copy
+                $sameNameMapping = $readMetadataFromTarget ? null : $this->getSameNameTargetMapping($mappedTarget, $propertyName);
+
+                $implicitValues[$propertyName] = $this->getSourceValue($source, $mappedTarget, $this->getRawValue($source, $propertyName), $objectMap, $sameNameMapping, $propertyName);
             }
         }
 
@@ -277,6 +281,26 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
         }
 
         return $source->{$propertyName};
+    }
+
+    /**
+     * Returns the unconditional #[Map] declared on the target's own property when it describes a
+     * same-name copy (same source and target property name), so its transform still applies even
+     * when the iteration reads metadata from the source side. Conditional mappings are left to the
+     * regular same-name copy, which does not evaluate conditions.
+     */
+    private function getSameNameTargetMapping(object $target, string $propertyName): ?Mapping
+    {
+        foreach ($this->metadataFactory->create($target, $propertyName) as $mapping) {
+            if (null === $mapping->if
+                && ($mapping->target ?? $propertyName) === $propertyName
+                && ($mapping->source ?? $propertyName) === $propertyName
+            ) {
+                return $mapping;
+            }
+        }
+
+        return null;
     }
 
     private function getSourceValue(object $source, object $target, mixed $value, \WeakMap $objectMap, ?Mapping $mapping = null, ?string $targetPropertyName = null): mixed

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/SourceCarriesMetadata/Lead.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/SourceCarriesMetadata/Lead.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\SourceCarriesMetadata;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(target: UnrelatedLeadView::class)]
+class Lead
+{
+    public int $id = 1;
+    public Type $type;
+
+    public function __construct()
+    {
+        $this->type = new Type();
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/SourceCarriesMetadata/LeadDto.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/SourceCarriesMetadata/LeadDto.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\SourceCarriesMetadata;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+/**
+ * Reached only through a transform or an explicit map($lead, LeadDto::class), so it is never itself
+ * referenced by a class-level #[Map]. Its $type property declares its own transform, which must be
+ * honored even when the source carries metadata.
+ */
+final class LeadDto
+{
+    public function __construct(
+        public int $id,
+        #[Map(source: 'type', transform: [ToTypeDto::class, 'transform'])]
+        public TypeDto $type,
+    ) {
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/SourceCarriesMetadata/ToTypeDto.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/SourceCarriesMetadata/ToTypeDto.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\SourceCarriesMetadata;
+
+final class ToTypeDto
+{
+    public static function transform(mixed $value, object $source, ?object $target): TypeDto
+    {
+        return new TypeDto($value->id, $value->name);
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/SourceCarriesMetadata/Type.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/SourceCarriesMetadata/Type.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\SourceCarriesMetadata;
+
+class Type
+{
+    public int $id = 7;
+    public string $name = 'moving';
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/SourceCarriesMetadata/TypeDto.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/SourceCarriesMetadata/TypeDto.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\SourceCarriesMetadata;
+
+final readonly class TypeDto
+{
+    public function __construct(
+        public int $id,
+        public string $name,
+    ) {
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/SourceCarriesMetadata/UnrelatedLeadView.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/SourceCarriesMetadata/UnrelatedLeadView.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\SourceCarriesMetadata;
+
+/**
+ * An unrelated view that Lead declares a class-level #[Map] to. Its only purpose is to make Lead
+ * "carry metadata", so ObjectMapper reads metadata from the source side when mapping to LeadDto.
+ */
+class UnrelatedLeadView
+{
+    public int $id = 0;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
@@ -23,6 +23,9 @@ use Symfony\Component\ObjectMapper\Metadata\ObjectMapperMetadataFactoryInterface
 use Symfony\Component\ObjectMapper\Metadata\ReflectionObjectMapperMetadataFactory;
 use Symfony\Component\ObjectMapper\ObjectMapper;
 use Symfony\Component\ObjectMapper\ObjectMapperInterface;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\SourceCarriesMetadata\Lead as SourceCarriesMetadataLead;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\SourceCarriesMetadata\LeadDto as SourceCarriesMetadataLeadDto;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\SourceCarriesMetadata\TypeDto as SourceCarriesMetadataTypeDto;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\A;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\B;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\C;
@@ -1115,5 +1118,17 @@ final class ObjectMapperTest extends TestCase
         $this->assertSame('bar', $mapped->inner->name);
         // computed by the constructor, so it can only be set if the constructor ran
         $this->assertSame('slug-of-bar', $mapped->inner->slug);
+    }
+
+    public function testSameNameTargetPropertyMappingIsHonoredWhenSourceCarriesMetadata()
+    {
+        // Lead carries a class-level #[Map] to an unrelated view, so ObjectMapper reads metadata from
+        // the source side. The #[Map(transform)] declared on LeadDto::$type must still be applied to the
+        // same-name copy; otherwise the raw Type reaches the typed constructor argument and throws.
+        $dto = (new ObjectMapper())->map(new SourceCarriesMetadataLead(), SourceCarriesMetadataLeadDto::class);
+
+        $this->assertInstanceOf(SourceCarriesMetadataTypeDto::class, $dto->type);
+        $this->assertSame(7, $dto->type->id);
+        $this->assertSame('moving', $dto->type->name);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65139
| License       | MIT

When the source class carries mapping metadata, `ObjectMapper::doMap()` reads metadata from the **source** side and walks the source's properties. A source "carries metadata" as soon as it declares a single class-level `#[Map]` (or, on 8.1+, as soon as `ReverseClassObjectMapperMetadataFactory` puts it in its class map). In that source-driven pass, the same-name copy passed a `null` mapping, so the `#[Map]` declared on the **target** property itself — in particular its `transform` — was silently dropped.

This bites a target DTO that is *not itself* referenced by a class-level `#[Map]` — the normal case for a nested DTO reached through a `transform` or an explicit `map($entity, SomeDto::class)`. Because the constructor arguments are pre-filled with the raw source values, the dropped transform does not merely leave the property unset: the raw related object reaches a typed constructor parameter and throws a `TypeError`.

The flaw predates 8.1 — it reproduces on 7.4 with a plain `new ObjectMapper()` and the default reflection factory — so the fix targets **7.4**.

### What the fix does

In the source-driven pass, read the target property's own **unconditional same-name** `#[Map]` and honor its `transform` for the same-name copy. Conditional mappings are left to the regular same-name copy, which does not evaluate conditions. Target-driven mapping is untouched.

### Out of scope (deliberately)

The issue also mentions the same-name copy being dropped when a source property additionally feeds a *renamed* target. On plain 7.4 that shape is a plain `#[Map(target: …)]` rename, which has always been a **move** (the same-name target is intentionally left at its default). The genuine copy-vs-move divergence only exists once `ReverseClassObjectMapperMetadataFactory` synthesizes a fan-out mapping (`Mapping::$targetClass` set), i.e. 8.1+, and is best handled in a dedicated PR with a `targetClass`-narrowed gate. This PR keeps the 7.4 behavior of D/F/`target:'other'` unchanged.

## Test verification (RED → GREEN)

New test `ObjectMapperTest::testSameNameTargetPropertyMappingIsHonoredWhenSourceCarriesMetadata`, on the current 7.4 tip.

**RED** — fix reverted, new test only:

```
There was 1 error:
TypeError: ...\SourceCarriesMetadata\LeadDto::__construct(): Argument #2 ($type)
must be of type ...\TypeDto, ...\Type given, called in .../ObjectMapper.php on line 207
Tests: 1, Errors: 1.
```

**GREEN** — with the fix:

```
OK — Tests: 1, Assertions: 3.
```

Full component suite: **80 → 81 tests, 194 → 197 assertions, no regressions**.
