### PR TITLE
[AhaSend] Add support for the v2 API

### DIFF
--- a/UPGRADE-8.2.md
+++ b/UPGRADE-8.2.md
@@ -96,6 +96,7 @@ Loco Translation Provider
 Mailer
 ------
 
+ * [AhaSend] Deprecate sending through the legacy v1 API, use a v2 API key and add your account id to the DSN
  * Deprecate sending an S/MIME message unencrypted when a recipient has no certificate (the default
    `SmimeEncryptedMessageListener::ON_MISSING_CERTIFICATE_SEND_UNENCRYPTED` behavior); it will throw in 9.0.
    Set the `on_missing_certificate` option (or the `X-SMime-Encrypt` header) to `fail`, `encrypt` or `skip`:

--- a/src/Symfony/Component/Mailer/Bridge/AhaSend/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/Bridge/AhaSend/CHANGELOG.md
@@ -1,6 +1,13 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add support for the v2 API, used when an account id is set in the DSN
+ * Deprecate sending through the legacy v1 API
+ * Use the `Message-ID` returned by the v2 API as the remote event id, instead of AhaSend's internal event id
+
 7.3
 ---
 

--- a/src/Symfony/Component/Mailer/Bridge/AhaSend/README.md
+++ b/src/Symfony/Component/Mailer/Bridge/AhaSend/README.md
@@ -10,13 +10,17 @@ Configuration example:
 MAILER_DSN=ahasend+smtp://USERNAME:PASSWORD@default
 
 # API
+MAILER_DSN=ahasend+api://API_KEY:ACCOUNT_ID@default
+
+# API (legacy v1, deprecated)
 MAILER_DSN=ahasend+api://API_KEY@default
 ```
 
 where:
  - `USERNAME` is your AhaSend SMTP Credentials username
  - `PASSWORD` is your AhaSend SMTP Credentials password
- - `API_KEY` is your AhaSend API Key credential
+ - `API_KEY` is your AhaSend API key
+ - `ACCOUNT_ID` is your AhaSend account ID; without it, the key is used with the legacy v1 API
 
 Sponsor
 -------

--- a/src/Symfony/Component/Mailer/Bridge/AhaSend/RemoteEvent/AhaSendPayloadConverter.php
+++ b/src/Symfony/Component/Mailer/Bridge/AhaSend/RemoteEvent/AhaSendPayloadConverter.php
@@ -21,13 +21,20 @@ final class AhaSendPayloadConverter implements PayloadConverterInterface
 {
     public function convert(array $payload): AbstractMailerEvent
     {
+        if (!isset($payload['data']['message_id_header'], $payload['data']['recipient'])) {
+            throw new ParseException('The payload is malformed.');
+        }
+
+        // "data.id" is AhaSend's internal event id; "data.message_id_header" carries the
+        // Message-ID that the v2 send API returned, so it is what matches sent emails
+
         if (\in_array($payload['type'], ['message.clicked', 'message.opened'], true)) {
             $name = match ($payload['type']) {
                 'message.clicked' => MailerEngagementEvent::CLICK,
                 'message.opened' => MailerEngagementEvent::OPEN,
                 default => throw new ParseException(\sprintf('Unsupported event "%s".', $payload['type'])),
             };
-            $event = new MailerEngagementEvent($name, $payload['data']['id'], $payload);
+            $event = new MailerEngagementEvent($name, $payload['data']['message_id_header'], $payload);
         } elseif (str_starts_with($payload['type'], 'message.')) {
             $name = match ($payload['type']) {
                 'message.reception' => MailerDeliveryEvent::RECEIVED,
@@ -37,7 +44,7 @@ final class AhaSendPayloadConverter implements PayloadConverterInterface
                 'message.suppressed' => MailerDeliveryEvent::DROPPED,
                 default => throw new ParseException(\sprintf('Unsupported event "%s".', $payload['type'])),
             };
-            $event = new MailerDeliveryEvent($name, $payload['data']['id'], $payload);
+            $event = new MailerDeliveryEvent($name, $payload['data']['message_id_header'], $payload);
         } else {
             // suppressions and domain DNS problem webhooks. Ignore them for now.
             throw new ParseException(\sprintf('Unsupported event "%s".', $payload['type']));

--- a/src/Symfony/Component/Mailer/Bridge/AhaSend/Tests/RemoteEvent/AhaSendPayloadConverterTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/AhaSend/Tests/RemoteEvent/AhaSendPayloadConverterTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\AhaSend\Tests\RemoteEvent;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Mailer\Bridge\AhaSend\RemoteEvent\AhaSendPayloadConverter;
+use Symfony\Component\RemoteEvent\Event\Mailer\MailerDeliveryEvent;
+use Symfony\Component\RemoteEvent\Exception\ParseException;
+
+class AhaSendPayloadConverterTest extends TestCase
+{
+    public function testConvertUsesTheMessageIdHeaderAsId()
+    {
+        $event = (new AhaSendPayloadConverter())->convert([
+            'type' => 'message.delivered',
+            'timestamp' => '2024-10-27T19:37:30.928534039Z',
+            'data' => [
+                'recipient' => 'someone@example.com',
+                'message_id_header' => 'message-id-header',
+                'id' => 'ahasend-internal-id',
+            ],
+        ]);
+
+        $this->assertInstanceOf(MailerDeliveryEvent::class, $event);
+        $this->assertSame('message-id-header', $event->getId());
+        $this->assertSame('someone@example.com', $event->getRecipientEmail());
+    }
+
+    #[DataProvider('provideMalformedPayloads')]
+    public function testConvertThrowsOnMalformedPayload(array $data)
+    {
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage('The payload is malformed.');
+
+        (new AhaSendPayloadConverter())->convert([
+            'type' => 'message.delivered',
+            'timestamp' => '2024-10-27T19:37:30.928534039Z',
+            'data' => $data,
+        ]);
+    }
+
+    public static function provideMalformedPayloads(): iterable
+    {
+        yield 'missing message_id_header' => [['recipient' => 'someone@example.com']];
+        yield 'missing recipient' => [['message_id_header' => 'message-id-header']];
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/AhaSend/Tests/Transport/AhaSendApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/AhaSend/Tests/Transport/AhaSendApiTransportTest.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\Mailer\Bridge\AhaSend\Tests\Transport;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpClient\MockHttpClient;
@@ -19,6 +21,7 @@ use Symfony\Component\HttpClient\Response\JsonMockResponse;
 use Symfony\Component\Mailer\Bridge\AhaSend\Event\AhaSendDeliveryEvent;
 use Symfony\Component\Mailer\Bridge\AhaSend\Transport\AhaSendApiTransport;
 use Symfony\Component\Mailer\Envelope;
+use Symfony\Component\Mailer\Exception\IncompleteDsnException;
 use Symfony\Component\Mailer\Header\TagHeader;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
@@ -36,9 +39,15 @@ class AhaSendApiTransportTest extends TestCase
     public static function getTransportData()
     {
         return [
+            // v1
             [
                 new AhaSendApiTransport('KEY'),
                 'ahasend+api://send.ahasend.com',
+            ],
+            // v2
+            [
+                new AhaSendApiTransport('aha-sk-KEY', accountId: 'ACCOUNT-ID'),
+                'ahasend+api://api.ahasend.com',
             ],
             [
                 (new AhaSendApiTransport('KEY'))->setHost('example.com'),
@@ -51,8 +60,20 @@ class AhaSendApiTransportTest extends TestCase
         ];
     }
 
-    public function testSend()
+    public function testV2ApiKeyWithoutAccountId()
     {
+        $this->expectException(IncompleteDsnException::class);
+        $this->expectExceptionMessage('A v2 AhaSend API key requires an account id: use the "ahasend+api://API_KEY:ACCOUNT_ID@default" DSN.');
+
+        new AhaSendApiTransport('aha-sk-KEY');
+    }
+
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
+    public function testSendV1()
+    {
+        $this->expectUserDeprecationMessage('Since symfony/aha-send-mailer 8.2: Sending through the legacy AhaSend v1 API is deprecated, use a v2 API key and add your account id to the DSN.');
+
         $email = new Email();
         $email->from(new Address('foo@example.com', 'Ms. Foo Bar'))
             ->to(new Address('bar@example.com', 'Mr. Recipient'))
@@ -95,7 +116,73 @@ class AhaSendApiTransportTest extends TestCase
         $mailer->send($email);
     }
 
-    public function testSendDeliveryEventIsDispatched()
+    public function testSendV2()
+    {
+        $email = new Email();
+        $email->from(new Address('foo@example.com', 'Ms. Foo Bar'))
+            ->to(new Address('bar@example.com', 'Mr. Recipient'))
+            ->bcc('baz@example.com')
+            ->subject('An email')
+            ->text('Test email body')
+            ->html('<html lang="en"><body><p>Test email body</p></body></html>')
+            ->replyTo(new Address('bar2@example.com', 'Mr. Recipient'));
+
+        $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
+            $this->assertSame('POST', $method);
+            $this->assertSame('https://api.ahasend.com/v2/accounts/SAMPLE-ACCOUNT-ID/messages', $url);
+            $this->assertStringContainsString('Authorization: Bearer aha-sk-foo', $options['headers'][0] ?? $options['request_headers'][0]);
+
+            $body = json_decode($options['body'], true);
+            $this->assertSame('foo@example.com', $body['from']['email']);
+            $this->assertSame('Ms. Foo Bar', $body['from']['name']);
+            $this->assertSame('bar@example.com', $body['recipients'][0]['email']);
+            $this->assertSame('Mr. Recipient', $body['recipients'][0]['name']);
+            $this->assertSame('baz@example.com', $body['recipients'][1]['email']);
+            $this->assertArrayNotHasKey('name', $body['recipients'][1]);
+            $this->assertSame('An email', $body['subject']);
+            $this->assertSame('Test email body', $body['text_content']);
+            $this->assertSame('<html lang="en"><body><p>Test email body</p></body></html>', $body['html_content']);
+            $this->assertSame('bar2@example.com', $body['reply_to']['email']);
+            $this->assertSame('Mr. Recipient', $body['reply_to']['name']);
+            $this->assertSame('baz@example.com', $body['headers']['Bcc']);
+
+            return new JsonMockResponse([
+                'object' => 'list',
+                'data' => [
+                    [
+                        'object' => 'message',
+                        'id' => '3f8e2b1a-7c4d-4e2a-9b1e-2f3a4b5c6d7e',
+                        'recipient' => [
+                            'email' => 'bar@example.com',
+                            'name' => 'Mr. Recipient',
+                        ],
+                        'status' => 'queued',
+                        'error' => null,
+                    ],
+                    [
+                        'object' => 'message',
+                        'id' => '8a1b2c3d-4e5f-4a6b-8c7d-9e0f1a2b3c4d',
+                        'recipient' => [
+                            'email' => 'baz@example.com',
+                        ],
+                        'status' => 'queued',
+                        'error' => null,
+                    ],
+                ],
+            ], [
+                'http_code' => 202,
+            ]);
+        });
+
+        $mailer = new AhaSendApiTransport('aha-sk-foo', $client, accountId: 'SAMPLE-ACCOUNT-ID');
+        $sentMessage = $mailer->send($email);
+
+        $this->assertSame('3f8e2b1a-7c4d-4e2a-9b1e-2f3a4b5c6d7e', $sentMessage->getMessageId());
+    }
+
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
+    public function testSendDeliveryEventIsDispatchedV1()
     {
         $responseFactory = new JsonMockResponse([
             'success_count' => 0,
@@ -135,6 +222,72 @@ class AhaSendApiTransportTest extends TestCase
         $transport->send($email);
     }
 
+    public function testSendDeliveryEventIsDispatchedV2PerFailedRecipient()
+    {
+        $responseFactory = new JsonMockResponse([
+            'object' => 'list',
+            'data' => [
+                [
+                    'object' => 'message',
+                    'id' => null,
+                    'recipient' => [
+                        'email' => 'someone@gmil.com',
+                        'name' => 'Mr. Someone',
+                    ],
+                    'status' => 'error',
+                    'error' => 'someone@gmil.com: Invalid recipient',
+                ],
+                [
+                    'object' => 'message',
+                    'id' => '3f8e2b1a-7c4d-4e2a-9b1e-2f3a4b5c6d7e',
+                    'recipient' => [
+                        'email' => 'someoneelse@example.com',
+                    ],
+                    'status' => 'queued',
+                    'error' => null,
+                ],
+                [
+                    'object' => 'message',
+                    'id' => null,
+                    'recipient' => [
+                        'email' => 'other@gmil.com',
+                    ],
+                    'status' => 'error',
+                    'error' => 'other@gmil.com: Invalid recipient',
+                ],
+            ],
+        ], [
+            'http_code' => 202,
+        ]);
+        $client = new MockHttpClient($responseFactory);
+
+        $email = new Email();
+        $email->from(new Address('foo@example.com', 'Ms. Foo Bar'))
+            ->to(new Address('someone@gmil.com', 'Mr. Someone'), new Address('someoneelse@example.com'), new Address('other@gmil.com'))
+            ->subject('An email')
+            ->text('Test email body');
+
+        $dispatchedErrors = [];
+
+        $dispatcher = $this->createStub(EventDispatcherInterface::class);
+        $dispatcher
+            ->method('dispatch')
+            ->willReturnCallback(static function ($event) use (&$dispatchedErrors) {
+                if ($event instanceof AhaSendDeliveryEvent) {
+                    $dispatchedErrors[] = $event->getMessage();
+                }
+
+                return $event;
+            });
+
+        $transport = new AhaSendApiTransport('aha-sk-foo', $client, $dispatcher, accountId: 'SAMPLE-ACCOUNT-ID');
+
+        $sentMessage = $transport->send($email);
+
+        $this->assertSame(['someone@gmil.com: Invalid recipient', 'other@gmil.com: Invalid recipient'], $dispatchedErrors);
+        $this->assertSame('3f8e2b1a-7c4d-4e2a-9b1e-2f3a4b5c6d7e', $sentMessage->getMessageId());
+    }
+
     public function testCustomHeader()
     {
         $email = new Email();
@@ -142,7 +295,7 @@ class AhaSendApiTransportTest extends TestCase
         $envelope = new Envelope(new Address('alice@system.com'), [new Address('bob@system.com')]);
 
         $transport = new AhaSendApiTransport('ACCESS_KEY');
-        $method = new \ReflectionMethod(AhaSendApiTransport::class, 'getPayload');
+        $method = new \ReflectionMethod(AhaSendApiTransport::class, 'getLegacyPayload');
         $payload = $method->invoke($transport, $email, $envelope);
 
         $this->assertArrayHasKey('headers', $payload['content']);
@@ -163,7 +316,7 @@ class AhaSendApiTransportTest extends TestCase
         $envelope = new Envelope(new Address($from), [new Address($to)]);
 
         $transport = new AhaSendApiTransport('ACCESS_KEY');
-        $method = new \ReflectionMethod(AhaSendApiTransport::class, 'getPayload');
+        $method = new \ReflectionMethod(AhaSendApiTransport::class, 'getLegacyPayload');
         $payload = $method->invoke($transport, $email, $envelope);
 
         $this->assertArrayHasKey('from', $payload);
@@ -190,7 +343,7 @@ class AhaSendApiTransportTest extends TestCase
         $envelope = new Envelope(new Address($envelopeFrom), [new Address($envelopeTo), new Address('cc@example.com'), new Address('bcc@example.com')]);
 
         $transport = new AhaSendApiTransport('ACCESS_KEY');
-        $method = new \ReflectionMethod(AhaSendApiTransport::class, 'getPayload');
+        $method = new \ReflectionMethod(AhaSendApiTransport::class, 'getLegacyPayload');
         $payload = $method->invoke($transport, $email, $envelope);
 
         $this->assertArrayHasKey('from', $payload);
@@ -211,7 +364,7 @@ class AhaSendApiTransportTest extends TestCase
         $envelope = new Envelope(new Address('alice@system.com'), [new Address('bob@system.com')]);
 
         $transport = new AhaSendApiTransport('ACCESS_KEY');
-        $method = new \ReflectionMethod(AhaSendApiTransport::class, 'getPayload');
+        $method = new \ReflectionMethod(AhaSendApiTransport::class, 'getLegacyPayload');
         $payload = $method->invoke($transport, $email, $envelope);
 
         $this->assertArrayHasKey('headers', $payload['content']);
@@ -234,7 +387,7 @@ class AhaSendApiTransportTest extends TestCase
         $envelope = new Envelope(new Address('alice@system.com'), [new Address('bob@system.com')]);
 
         $transport = new AhaSendApiTransport('ACCESS_KEY');
-        $method = new \ReflectionMethod(AhaSendApiTransport::class, 'getPayload');
+        $method = new \ReflectionMethod(AhaSendApiTransport::class, 'getLegacyPayload');
         $payload = $method->invoke($transport, $email, $envelope);
 
         $this->assertArrayHasKey('attachments', $payload['content']);
@@ -254,7 +407,7 @@ class AhaSendApiTransportTest extends TestCase
         $envelope = new Envelope(new Address('alice@system.com'), [new Address('bob@system.com')]);
 
         $transport = new AhaSendApiTransport('ACCESS_KEY');
-        $method = new \ReflectionMethod(AhaSendApiTransport::class, 'getPayload');
+        $method = new \ReflectionMethod(AhaSendApiTransport::class, 'getLegacyPayload');
         $payload = $method->invoke($transport, $email, $envelope);
 
         $this->assertArrayHasKey('attachments', $payload['content']);
@@ -273,7 +426,7 @@ class AhaSendApiTransportTest extends TestCase
         $envelope = new Envelope(new Address('alice@system.com'), [new Address('bob@system.com')]);
 
         $transport = new AhaSendApiTransport('ACCESS_KEY');
-        $method = new \ReflectionMethod(AhaSendApiTransport::class, 'getPayload');
+        $method = new \ReflectionMethod(AhaSendApiTransport::class, 'getLegacyPayload');
         $payload = $method->invoke($transport, $email, $envelope);
 
         $this->assertArrayHasKey('attachments', $payload['content']);
@@ -293,7 +446,7 @@ class AhaSendApiTransportTest extends TestCase
         $envelope = new Envelope(new Address('alice@system.com'), [new Address('bob@system.com')]);
 
         $transport = new AhaSendApiTransport('ACCESS_KEY');
-        $method = new \ReflectionMethod(AhaSendApiTransport::class, 'getPayload');
+        $method = new \ReflectionMethod(AhaSendApiTransport::class, 'getLegacyPayload');
         $payload = $method->invoke($transport, $email, $envelope);
 
         $this->assertArrayHasKey('attachments', $payload['content']);
@@ -301,5 +454,57 @@ class AhaSendApiTransportTest extends TestCase
         $this->assertArrayHasKey('base64', $payload['content']['attachments'][0]);
 
         $this->assertFalse($payload['content']['attachments'][0]['base64']);
+    }
+
+    public function testTagHeadersV2()
+    {
+        $email = new Email();
+        $email->getHeaders()->add(new TagHeader('category-one'));
+        $email->getHeaders()->add(new TagHeader('category-two'));
+        $envelope = new Envelope(new Address('alice@system.com'), [new Address('bob@system.com')]);
+
+        $transport = new AhaSendApiTransport('aha-sk-ACCESS_KEY', accountId: 'ACCOUNT_ID');
+        $method = new \ReflectionMethod(AhaSendApiTransport::class, 'getPayload');
+        $payload = $method->invoke($transport, $email, $envelope);
+
+        $this->assertSame(['category-one', 'category-two'], $payload['tags']);
+        $this->assertArrayNotHasKey('headers', $payload);
+        $this->assertFalse($email->getHeaders()->has('AhaSend-Tags'));
+    }
+
+    public function testCustomHeaderV2()
+    {
+        $email = new Email();
+        $email->getHeaders()->addTextHeader('foo', 'bar');
+        $envelope = new Envelope(new Address('alice@system.com'), [new Address('bob@system.com')]);
+
+        $transport = new AhaSendApiTransport('aha-sk-ACCESS_KEY', accountId: 'ACCOUNT_ID');
+        $method = new \ReflectionMethod(AhaSendApiTransport::class, 'getPayload');
+        $payload = $method->invoke($transport, $email, $envelope);
+
+        $this->assertArrayHasKey('headers', $payload);
+        $this->assertSame(['foo' => 'bar'], $payload['headers']);
+        $this->assertArrayNotHasKey('tags', $payload);
+    }
+
+    public function testAttachmentsV2()
+    {
+        $inlinePart = (new DataPart('text-contents', 'text.txt'));
+        $inlinePart->asInline();
+        $inlinePart->setContentId('content-identifier@symfony');
+
+        $email = new Email();
+        $email->addPart($inlinePart);
+        $email->addPart(new DataPart('image-contents', 'image.png'));
+        $envelope = new Envelope(new Address('alice@system.com'), [new Address('bob@system.com')]);
+
+        $transport = new AhaSendApiTransport('aha-sk-ACCESS_KEY', accountId: 'ACCOUNT_ID');
+        $method = new \ReflectionMethod(AhaSendApiTransport::class, 'getPayload');
+        $payload = $method->invoke($transport, $email, $envelope);
+
+        $this->assertCount(2, $payload['attachments']);
+        $this->assertSame('content-identifier@symfony', $payload['attachments'][0]['content_id']);
+        $this->assertTrue($payload['attachments'][1]['base64']);
+        $this->assertSame(base64_encode('image-contents'), $payload['attachments'][1]['data']);
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/AhaSend/Tests/Transport/AhaSendTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/AhaSend/Tests/Transport/AhaSendTransportFactoryTest.php
@@ -63,6 +63,11 @@ class AhaSendTransportFactoryTest extends AbstractTransportFactoryTestCase
         ];
 
         yield [
+            new Dsn('ahasend+api', 'default', self::USER, 'ACCOUNT_ID'),
+            new AhaSendApiTransport(self::USER, new MockHttpClient(), null, $logger, 'ACCOUNT_ID'),
+        ];
+
+        yield [
             new Dsn('ahasend+api', 'example.com', self::USER, '', 8080),
             (new AhaSendApiTransport(self::USER, new MockHttpClient(), null, $logger))->setHost('example.com')->setPort(8080),
         ];

--- a/src/Symfony/Component/Mailer/Bridge/AhaSend/Tests/Webhook/Fixtures/bounced.php
+++ b/src/Symfony/Component/Mailer/Bridge/AhaSend/Tests/Webhook/Fixtures/bounced.php
@@ -1,9 +1,18 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 use Symfony\Component\RemoteEvent\Event\Mailer\MailerDeliveryEvent;
 
-$wh = new MailerDeliveryEvent(MailerDeliveryEvent::BOUNCE, 'ahasend-message-id', json_decode(file_get_contents(str_replace('.php', '.json', __FILE__)), true));
+$wh = new MailerDeliveryEvent(MailerDeliveryEvent::BOUNCE, 'message-id-header', json_decode(file_get_contents(str_replace('.php', '.json', __FILE__)), true));
 $wh->setRecipientEmail('someone@example.com');
-$wh->setDate(\DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.uT', '2024-10-27T19:35:58.267106Z'));
+$wh->setDate(DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.uT', '2024-10-27T19:35:58.267106Z'));
 
 return $wh;

--- a/src/Symfony/Component/Mailer/Bridge/AhaSend/Tests/Webhook/Fixtures/clicked.php
+++ b/src/Symfony/Component/Mailer/Bridge/AhaSend/Tests/Webhook/Fixtures/clicked.php
@@ -1,9 +1,18 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 use Symfony\Component\RemoteEvent\Event\Mailer\MailerEngagementEvent;
 
-$wh = new MailerEngagementEvent(MailerEngagementEvent::CLICK, 'ahasend-message-id', json_decode(file_get_contents(str_replace('.php', '.json', __FILE__)), true));
+$wh = new MailerEngagementEvent(MailerEngagementEvent::CLICK, 'message-id-header', json_decode(file_get_contents(str_replace('.php', '.json', __FILE__)), true));
 $wh->setRecipientEmail('someone@example.com');
-$wh->setDate(\DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.uT', '2024-10-28T18:30:01.799449Z'));
+$wh->setDate(DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.uT', '2024-10-28T18:30:01.799449Z'));
 
 return $wh;

--- a/src/Symfony/Component/Mailer/Bridge/AhaSend/Tests/Webhook/Fixtures/delivered.php
+++ b/src/Symfony/Component/Mailer/Bridge/AhaSend/Tests/Webhook/Fixtures/delivered.php
@@ -1,9 +1,18 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 use Symfony\Component\RemoteEvent\Event\Mailer\MailerDeliveryEvent;
 
-$wh = new MailerDeliveryEvent(MailerDeliveryEvent::DELIVERED, 'ahasend-message-id', json_decode(file_get_contents(str_replace('.php', '.json', __FILE__)), true));
+$wh = new MailerDeliveryEvent(MailerDeliveryEvent::DELIVERED, 'message-id-header', json_decode(file_get_contents(str_replace('.php', '.json', __FILE__)), true));
 $wh->setRecipientEmail('someone@example.com');
-$wh->setDate(\DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.uT', '2024-10-27T19:37:30.928534Z'));
+$wh->setDate(DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.uT', '2024-10-27T19:37:30.928534Z'));
 
 return $wh;

--- a/src/Symfony/Component/Mailer/Bridge/AhaSend/Tests/Webhook/Fixtures/opened.php
+++ b/src/Symfony/Component/Mailer/Bridge/AhaSend/Tests/Webhook/Fixtures/opened.php
@@ -1,9 +1,18 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 use Symfony\Component\RemoteEvent\Event\Mailer\MailerEngagementEvent;
 
-$wh = new MailerEngagementEvent(MailerEngagementEvent::OPEN, 'ahasend-message-id', json_decode(file_get_contents(str_replace('.php', '.json', __FILE__)), true));
+$wh = new MailerEngagementEvent(MailerEngagementEvent::OPEN, 'message-id-header', json_decode(file_get_contents(str_replace('.php', '.json', __FILE__)), true));
 $wh->setRecipientEmail('someone@example.com');
-$wh->setDate(\DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.uT', '2024-10-28T18:30:01.797985Z'));
+$wh->setDate(DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.uT', '2024-10-28T18:30:01.797985Z'));
 
 return $wh;

--- a/src/Symfony/Component/Mailer/Bridge/AhaSend/Tests/Webhook/Fixtures/reception.php
+++ b/src/Symfony/Component/Mailer/Bridge/AhaSend/Tests/Webhook/Fixtures/reception.php
@@ -1,9 +1,18 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 use Symfony\Component\RemoteEvent\Event\Mailer\MailerDeliveryEvent;
 
-$wh = new MailerDeliveryEvent(MailerDeliveryEvent::RECEIVED, 'ahasend-message-id', json_decode(file_get_contents(str_replace('.php', '.json', __FILE__)), true));
+$wh = new MailerDeliveryEvent(MailerDeliveryEvent::RECEIVED, 'message-id-header', json_decode(file_get_contents(str_replace('.php', '.json', __FILE__)), true));
 $wh->setRecipientEmail('someone@example.com');
-$wh->setDate(\DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.uT', '2024-10-27T19:37:30.926210Z'));
+$wh->setDate(DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.uT', '2024-10-27T19:37:30.926210Z'));
 
 return $wh;

--- a/src/Symfony/Component/Mailer/Bridge/AhaSend/Tests/Webhook/Fixtures/suppressed.php
+++ b/src/Symfony/Component/Mailer/Bridge/AhaSend/Tests/Webhook/Fixtures/suppressed.php
@@ -1,9 +1,18 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 use Symfony\Component\RemoteEvent\Event\Mailer\MailerDeliveryEvent;
 
-$wh = new MailerDeliveryEvent(MailerDeliveryEvent::DROPPED, 'ahasend-message-id', json_decode(file_get_contents(str_replace('.php', '.json', __FILE__)), true));
+$wh = new MailerDeliveryEvent(MailerDeliveryEvent::DROPPED, 'message-id-header', json_decode(file_get_contents(str_replace('.php', '.json', __FILE__)), true));
 $wh->setRecipientEmail('someone@example.com');
-$wh->setDate(\DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.uT', '2024-10-27T19:37:30.935569Z'));
+$wh->setDate(DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.uT', '2024-10-27T19:37:30.935569Z'));
 
 return $wh;

--- a/src/Symfony/Component/Mailer/Bridge/AhaSend/Tests/Webhook/Fixtures/transient_error.php
+++ b/src/Symfony/Component/Mailer/Bridge/AhaSend/Tests/Webhook/Fixtures/transient_error.php
@@ -1,9 +1,18 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 use Symfony\Component\RemoteEvent\Event\Mailer\MailerDeliveryEvent;
 
-$wh = new MailerDeliveryEvent(MailerDeliveryEvent::DEFERRED, 'ahasend-message-id', json_decode(file_get_contents(str_replace('.php', '.json', __FILE__)), true));
+$wh = new MailerDeliveryEvent(MailerDeliveryEvent::DEFERRED, 'message-id-header', json_decode(file_get_contents(str_replace('.php', '.json', __FILE__)), true));
 $wh->setRecipientEmail('someone@example.com');
-$wh->setDate(\DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.uT', '2024-10-27T19:37:30.929792Z'));
+$wh->setDate(DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s.uT', '2024-10-27T19:37:30.929792Z'));
 
 return $wh;

--- a/src/Symfony/Component/Mailer/Bridge/AhaSend/Transport/AhaSendApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/AhaSend/Transport/AhaSendApiTransport.php
@@ -16,6 +16,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\Mailer\Bridge\AhaSend\Event\AhaSendDeliveryEvent;
 use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Exception\HttpTransportException;
+use Symfony\Component\Mailer\Exception\IncompleteDsnException;
 use Symfony\Component\Mailer\Header\TagHeader;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\AbstractApiTransport;
@@ -32,15 +33,25 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  */
 final class AhaSendApiTransport extends AbstractApiTransport
 {
-    private const HOST = 'send.ahasend.com';
+    private const HOST = 'api.ahasend.com';
+    private const LEGACY_HOST = 'send.ahasend.com';
+
+    private bool $legacy;
 
     public function __construct(
         #[\SensitiveParameter] private readonly string $apiKey,
         ?HttpClientInterface $client = null,
         private ?EventDispatcherInterface $dispatcher = null,
         ?LoggerInterface $logger = null,
+        private readonly ?string $accountId = null,
     ) {
         parent::__construct($client, $dispatcher, $logger);
+
+        $this->legacy = !$accountId;
+
+        if ($this->legacy && str_starts_with($apiKey, 'aha-sk-')) {
+            throw new IncompleteDsnException('A v2 AhaSend API key requires an account id: use the "ahasend+api://API_KEY:ACCOUNT_ID@default" DSN.');
+        }
     }
 
     public function __toString(): string
@@ -50,8 +61,53 @@ final class AhaSendApiTransport extends AbstractApiTransport
 
     protected function doSendApi(SentMessage $sentMessage, Email $email, Envelope $envelope): ResponseInterface
     {
-        $response = $this->client->request('POST', 'https://'.$this->getEndpoint().'/v1/email/send', [
+        if ($this->legacy) {
+            return $this->doSendLegacyApi($sentMessage, $email, $envelope);
+        }
+
+        $response = $this->client->request('POST', 'https://'.$this->getEndpoint().'/v2/accounts/'.$this->accountId.'/messages', [
             'json' => $this->getPayload($email, $envelope),
+            'headers' => [
+                'Authorization' => 'Bearer '.$this->apiKey,
+            ],
+        ]);
+
+        try {
+            $statusCode = $response->getStatusCode();
+            $result = $response->toArray(false);
+        } catch (DecodingExceptionInterface) {
+            throw new HttpTransportException('Unable to send an email: '.$response->getContent(false).\sprintf(' (code %d).', $statusCode), $response);
+        } catch (TransportExceptionInterface $e) {
+            throw new HttpTransportException('Could not reach the remote AhaSend server.', $response, 0, $e);
+        }
+
+        if (202 !== $statusCode) {
+            throw new HttpTransportException('Unable to send an email: '.$response->getContent(false).\sprintf(' (code %d).', $statusCode), $response);
+        }
+
+        // one entry per recipient, each with its own generated Message-ID
+        $messageId = null;
+        foreach ($result['data'] ?? [] as $message) {
+            if (null === $messageId && !empty($message['id'])) {
+                $messageId = $message['id'];
+            }
+            if (null !== $this->dispatcher && !empty($message['error'])) {
+                $this->dispatcher->dispatch(new AhaSendDeliveryEvent($message['error']));
+            }
+        }
+        if (null !== $messageId) {
+            $sentMessage->setMessageId($messageId);
+        }
+
+        return $response;
+    }
+
+    private function doSendLegacyApi(SentMessage $sentMessage, Email $email, Envelope $envelope): ResponseInterface
+    {
+        trigger_deprecation('symfony/aha-send-mailer', '8.2', 'Sending through the legacy AhaSend v1 API is deprecated, use a v2 API key and add your account id to the DSN.');
+
+        $response = $this->client->request('POST', 'https://'.$this->getEndpoint().'/v1/email/send', [
+            'json' => $this->getLegacyPayload($email, $envelope),
             'headers' => [
                 'X-Api-Key' => $this->apiKey,
             ],
@@ -70,11 +126,9 @@ final class AhaSendApiTransport extends AbstractApiTransport
             throw new HttpTransportException('Unable to send an email: '.$response->getContent(false).\sprintf(' (code %d).', $statusCode), $response);
         }
 
-        if ($result['fail_count'] > 0) {
-            if (null !== $this->dispatcher) {
-                foreach ($result['errors'] as $error) {
-                    $this->dispatcher->dispatch(new AhaSendDeliveryEvent($error));
-                }
+        if (null !== $this->dispatcher && \array_key_exists('fail_count', $result) && $result['fail_count'] > 0) {
+            foreach ($result['errors'] as $error) {
+                $this->dispatcher->dispatch(new AhaSendDeliveryEvent($error));
             }
         }
 
@@ -84,7 +138,7 @@ final class AhaSendApiTransport extends AbstractApiTransport
     /**
      * @param Address[] $addresses
      *
-     * @return list<string>
+     * @return list<array{email: string, name?: string}>
      */
     private function formatAddresses(array $addresses): array
     {
@@ -97,28 +151,62 @@ final class AhaSendApiTransport extends AbstractApiTransport
         $payload = [
             'recipients' => $this->formatAddresses($envelope->getRecipients()),
             'from' => $this->formatAddress($envelope->getSender()),
+            'subject' => $email->getSubject(),
+        ];
+
+        if ($text = $email->getTextBody()) {
+            $payload['text_content'] = $text;
+        }
+        if ($html = $email->getHtmlBody()) {
+            $payload['html_content'] = $html;
+        }
+        if ($replyTo = $email->getReplyTo()) {
+            $payload['reply_to'] = $this->formatAddress(array_pop($replyTo));
+        }
+
+        [$headers, $tags] = $this->prepareHeaders($email->getHeaders());
+        if ($headers) {
+            $payload['headers'] = $headers;
+        }
+        if ($tags) {
+            $payload['tags'] = $tags;
+        }
+
+        if ($email->getAttachments()) {
+            $payload['attachments'] = $this->getAttachments($email);
+        }
+
+        return $payload;
+    }
+
+    private function getLegacyPayload(Email $email, Envelope $envelope): array
+    {
+        // "From" and "Subject" headers are handled by the message itself
+        $payload = [
+            'recipients' => $this->formatAddresses($envelope->getRecipients()),
+            'from' => $this->formatAddress($envelope->getSender()),
             'content' => [
                 'subject' => $email->getSubject(),
             ],
         ];
 
-        $text = $email->getTextBody();
-        if (!empty($text)) {
+        if ($text = $email->getTextBody()) {
             $payload['content']['text_body'] = $text;
         }
-        $html = $email->getHtmlBody();
-        if (!empty($html)) {
+        if ($html = $email->getHtmlBody()) {
             $payload['content']['html_body'] = $html;
         }
-
-        $replyTo = $email->getReplyTo();
-        if ($replyTo) {
-            $replyTo = array_pop($replyTo);
-            $payload['content']['reply_to'] = $this->formatAddress($replyTo);
+        if ($replyTo = $email->getReplyTo()) {
+            $payload['content']['reply_to'] = $this->formatAddress(array_pop($replyTo));
         }
 
-        $headers = $this->prepareHeaders($email->getHeaders());
-        if (!empty($headers)) {
+        [$headers, $tags] = $this->prepareHeaders($email->getHeaders());
+        if ($tags) {
+            $tagsStr = implode(',', $tags);
+            $email->getHeaders()->addTextHeader('AhaSend-Tags', $tagsStr);
+            $headers['AhaSend-Tags'] = $tagsStr;
+        }
+        if ($headers) {
             $payload['content']['headers'] = $headers;
         }
 
@@ -129,6 +217,9 @@ final class AhaSendApiTransport extends AbstractApiTransport
         return $payload;
     }
 
+    /**
+     * @return array{0: array<string, string>, 1: list<string>}
+     */
     private function prepareHeaders(Headers $headers): array
     {
         $headersPrepared = [];
@@ -147,13 +238,8 @@ final class AhaSendApiTransport extends AbstractApiTransport
 
             $headersPrepared[$header->getName()] = $header->getBodyAsString();
         }
-        if (!empty($tags)) {
-            $tagsStr = implode(',', $tags);
-            $headers->addTextHeader('AhaSend-Tags', $tagsStr);
-            $headersPrepared['AhaSend-Tags'] = $tagsStr;
-        }
 
-        return $headersPrepared;
+        return [$headersPrepared, $tags];
     }
 
     private function getAttachments(Email $email): array
@@ -173,7 +259,7 @@ final class AhaSendApiTransport extends AbstractApiTransport
             }
 
             $att = [
-                'content_type' => $headers->get('Content-Type')->getBody(),
+                'content_type' => $contentType,
                 'file_name' => $attachment->getFilename(),
                 'data' => $body,
                 'base64' => $base64,
@@ -202,8 +288,8 @@ final class AhaSendApiTransport extends AbstractApiTransport
         return $formattedAddress;
     }
 
-    private function getEndpoint(): ?string
+    private function getEndpoint(): string
     {
-        return ($this->host ?: self::HOST).($this->port ? ':'.$this->port : '');
+        return ($this->host ?: ($this->legacy ? self::LEGACY_HOST : self::HOST)).($this->port ? ':'.$this->port : '');
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/AhaSend/Transport/AhaSendTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Bridge/AhaSend/Transport/AhaSendTransportFactory.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Mailer\Bridge\AhaSend\Transport;
 
+use Symfony\Component\Mailer\Exception\IncompleteDsnException;
 use Symfony\Component\Mailer\Exception\UnsupportedSchemeException;
 use Symfony\Component\Mailer\Transport\AbstractTransportFactory;
 use Symfony\Component\Mailer\Transport\Dsn;
@@ -28,10 +29,16 @@ final class AhaSendTransportFactory extends AbstractTransportFactory
         $user = $this->getUser($dsn);
 
         if ('ahasend+api' === $scheme) {
+            try {
+                $password = $this->getPassword($dsn);
+            } catch (IncompleteDsnException) {
+                $password = null;
+            }
+
             $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
             $port = $dsn->getPort();
 
-            $transport = (new AhaSendApiTransport($user, $this->client, $this->dispatcher, $this->logger))->setHost($host)->setPort($port);
+            $transport = (new AhaSendApiTransport($user, $this->client, $this->dispatcher, $this->logger, $password))->setHost($host)->setPort($port);
         }
 
         if ('ahasend+smtp' === $scheme || 'ahasend' === $scheme) {

--- a/src/Symfony/Component/Mailer/Bridge/AhaSend/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/AhaSend/composer.json
@@ -18,6 +18,7 @@
     "require": {
         "php": ">=8.4.1",
         "psr/event-dispatcher": "^1",
+        "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/mailer": "^7.4|^8.0"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Issues        | /
| License       | MIT

This adds support for AhaSend's v2 API to the mailer bridge. AhaSend has moved v1 to maintenance mode and recommends v2 for all integrations; v2 is also the only API whose send response can be matched to webhook events.

The API version is selected by the DSN: providing an account id switches to v2, and v1 keeps working unchanged for existing DSNs.

```env
# API
MAILER_DSN=ahasend+api://API_KEY:ACCOUNT_ID@default

# API (legacy v1, deprecated)
MAILER_DSN=ahasend+api://API_KEY@default
```

What v2 brings:

- The v2 send response returns one entry per recipient, each carrying the `Message-ID` that AhaSend generated. The first one is recorded on the `SentMessage`, and an `AhaSendDeliveryEvent` is dispatched for every recipient the API rejected.
- The webhook payload's `message_id_header` field carries that same generated `Message-ID`, so remote events now use it as their event id and can be joined to sent messages. Before this PR the event id was AhaSend's internal id, which appears nowhere in any send response, so the join was impossible on both API versions. This changes the reported id for existing webhook consumers; the internal id remains available in the event payload under `data.id`.
- Tags are sent through the native v2 `tags` field instead of the `AhaSend-Tags` header.

Sending through the v1 API is deprecated; a v2 API key (`aha-sk-` prefix) without an account id in the DSN fails at container build time with a message pointing to the v2 DSN form, instead of failing at send time with a 401.

The payload converter now rejects webhook payloads missing `message_id_header` or `recipient` with a `ParseException` (406) instead of an uncaught `TypeError` (500).

For the documentation: the two DSN forms above, the v1 deprecation, and the fact that the remote event id equals the `Message-ID` returned by the v2 send API.
