### PR TITLE
[FrameworkBundle] Require object-mapper ^8.1.2 for reverse class mapping

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -59,7 +59,7 @@
         "symfony/messenger": "^7.4.10|^8.0.10",
         "symfony/mime": "^7.4.9|^8.0.9",
         "symfony/notifier": "^7.4|^8.0",
-        "symfony/object-mapper": "^7.4.9|^8.0.9",
+        "symfony/object-mapper": "^8.1.2",
         "symfony/polyfill-intl-icu": "^1.0",
         "symfony/process": "^7.4|^8.0",
         "symfony/property-info": "^7.4|^8.0",


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Branch?         | 8.2
| Bug fix?        | yes
| New feature?    | no
| Deprecations?   | no
| Issues          | Fix #65156
| License         | MIT

The **Unit Tests (8.4, low-deps)** job fails on `8.2` in `src/Symfony/Bundle/FrameworkBundle` with:

```
TypeError: …\ParentEntityResource::__construct(): Argument #2 ($nested) must be of type
?…\NestedEntityResource, …\NestedEntity given, called in
…/FrameworkBundle/vendor/symfony/object-mapper/ObjectMapper.php on line 190
```

FrameworkBundle's ObjectMapper integration wires `ReverseClassObjectMapperMetadataFactory`
(introduced in object-mapper **8.1.0**) and relies on nested-value resolution by the destination
property type (added in object-mapper **8.1.2**). Neither exists in `7.4.x` / `8.0.x`. The constraint
`^7.4.9|^8.0.9` lets `--prefer-lowest` install **7.4.9**, so `FrameworkExtension` removes the
reverse-class metadata factory and the nested `NestedEntity` is passed unmapped into the constructor.

Minimal fix — raise the minimum to the lowest release that has both features:

```diff
-        "symfony/object-mapper": "^7.4.9|^8.0.9",
+        "symfony/object-mapper": "^8.1.2",
```

Per the low-deps interaction: only `symfony/object-mapper` is changed; every other dependency
(including `symfony/mime`, `symfony/property-info`, `symfony/type-info`, …) stays at its lowest
resolved version in both runs below, so the flip is attributable to object-mapper alone.

## Test verification (RED → GREEN)

Reproduced by mirroring the low-deps job (`flex`, `SYMFONY_REQUIRE=">=6.4"`,
`.github/build-packages.php`, then `composer update --prefer-lowest --prefer-stable` in the component)
in a clean container.

**RED** — `8.2` unchanged, `--prefer-lowest` installs object-mapper 7.4.9:

```
symfony/object-mapper = v7.4.9
1) …\ObjectMapperTest::testMapNestedObjectWhoseClassDeclaresNoMapping
TypeError: …\ParentEntityResource::__construct(): Argument #2 ($nested) must be of type
?…\NestedEntityResource, …\NestedEntity given, called in
…/vendor/symfony/object-mapper/ObjectMapper.php on line 190
ERRORS! Tests: 1, Assertions: 0, Errors: 1.
```

**GREEN** — only the constraint bumped to `^8.1.2` (every other dep still lowest):

```
symfony/object-mapper = v8.1.2
OK, but there were issues!
Tests: 1, Assertions: 3, Deprecations: 5.
```

**High-deps (no regression)** — object-mapper resolves to `8.2.x-dev`:

```
symfony/object-mapper = 8.2.x-dev
OK (1 test, 3 assertions)
```
