### PR TITLE
[Workflow] Add missing context argument to WorkflowInterface::getMarking

### DIFF
--- a/src/Symfony/Component/Workflow/WorkflowInterface.php
+++ b/src/Symfony/Component/Workflow/WorkflowInterface.php
@@ -28,7 +28,7 @@ interface WorkflowInterface
      *
      * @throws LogicException
      */
-    public function getMarking(object $subject): Marking;
+    public function getMarking(object $subject, array $context = []): Marking;
 
     /**
      * Returns true if the transition is enabled.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #... <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

Fixes php-stan issues while passing `$context` to `getMarking` method 

https://github.com/symfony/symfony/blob/8.2/src/Symfony/Component/Workflow/Workflow.php#L117
