### PR TITLE
[RateLimiter] Dispatch a RateLimitExceededEvent when the #[RateLimit] attribute rejects a request

### DIFF
--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Add `#[AsControllerAttributeListener]` attribute to declare event listeners for controller attributes
  * Add the `$expiration` argument to `FragmentUriGenerator::__construct()` and sign fragment URIs with a 5-year expiration by default
  * Add `hasDump()` method to `Profile` to track profiles with dump
+ * Dispatch `RateLimitExceededEvent` from `RateLimitAttributeListener` when the `#[RateLimit]` attribute rejects a request
 
 8.1
 ---

--- a/src/Symfony/Component/HttpKernel/EventListener/RateLimitAttributeListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/RateLimitAttributeListener.php
@@ -17,7 +17,9 @@ use Symfony\Component\HttpKernel\Event\ControllerArgumentsEvent;
 use Symfony\Component\HttpKernel\Event\ControllerAttributeEvent;
 use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
 use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\RateLimiter\Event\RateLimitExceededEvent;
 use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\Service\ServiceProviderInterface;
 
 /**
@@ -38,7 +40,7 @@ final class RateLimitAttributeListener implements EventSubscriberInterface
     /**
      * @param ControllerAttributeEvent<RateLimit, ControllerArgumentsEvent> $event
      */
-    public function onKernelControllerAttribute(ControllerAttributeEvent $event): void
+    public function onKernelControllerAttribute(ControllerAttributeEvent $event, ?string $eventName = null, ?EventDispatcherInterface $dispatcher = null): void
     {
         $request = $event->kernelEvent->getRequest();
         $attribute = $event->attribute;
@@ -60,6 +62,10 @@ final class RateLimitAttributeListener implements EventSubscriberInterface
         $rateLimit = $this->limiters->get($attribute->limiter)->create($key)->consume($attribute->tokens);
 
         if (!$rateLimit->isAccepted()) {
+            if ($dispatcher && class_exists(RateLimitExceededEvent::class)) {
+                $dispatcher->dispatch(new RateLimitExceededEvent($rateLimit, $attribute->limiter, $key));
+            }
+
             throw new TooManyRequestsHttpException(max(0, $rateLimit->getRetryAfter()->getTimestamp() - time()));
         }
     }

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/RateLimitAttributeListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/RateLimitAttributeListenerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpKernel\Tests\EventListener;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\HttpFoundation\Request;
@@ -21,6 +22,7 @@ use Symfony\Component\HttpKernel\Event\ControllerAttributeEvent;
 use Symfony\Component\HttpKernel\EventListener\RateLimitAttributeListener;
 use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\RateLimiter\Event\RateLimitExceededEvent;
 use Symfony\Component\RateLimiter\LimiterInterface;
 use Symfony\Component\RateLimiter\RateLimit as RateLimitResult;
 use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
@@ -130,6 +132,73 @@ class RateLimitAttributeListenerTest extends TestCase
             new RateLimit('api', key: static fn () => 42),
             Request::create('/'),
         ));
+    }
+
+    public function testRejectedDispatchesRateLimitExceededEvent()
+    {
+        if (!class_exists(RateLimitExceededEvent::class)) {
+            $this->markTestSkipped('The installed "symfony/rate-limiter" does not provide RateLimitExceededEvent.');
+        }
+
+        $result = new RateLimitResult(0, new \DateTimeImmutable('+1 minute'), false, 5);
+
+        $limiter = $this->createStub(LimiterInterface::class);
+        $limiter->method('consume')->willReturn($result);
+
+        $factory = $this->createStub(RateLimiterFactoryInterface::class);
+        $factory->method('create')->willReturn($limiter);
+
+        $locator = $this->createStub(ServiceProviderInterface::class);
+        $locator->method('has')->willReturn(true);
+        $locator->method('get')->willReturn($factory);
+        $locator->method('getProvidedServices')->willReturn(['api' => RateLimiterFactoryInterface::class]);
+
+        $dispatcher = new EventDispatcher();
+        $dispatchedEvent = null;
+        $dispatcher->addListener(RateLimitExceededEvent::class, static function (RateLimitExceededEvent $event) use (&$dispatchedEvent) {
+            $dispatchedEvent = $event;
+        });
+
+        $listener = new RateLimitAttributeListener($locator);
+        $request = Request::create('/', server: ['REMOTE_ADDR' => '9.9.9.9']);
+
+        try {
+            $listener->onKernelControllerAttribute($this->makeEvent(new RateLimit('api'), $request), null, $dispatcher);
+            $this->fail('Expected TooManyRequestsHttpException');
+        } catch (TooManyRequestsHttpException) {
+        }
+
+        $this->assertInstanceOf(RateLimitExceededEvent::class, $dispatchedEvent);
+        $this->assertSame($result, $dispatchedEvent->getRateLimit());
+        $this->assertSame('api', $dispatchedEvent->getLimiterName());
+        $this->assertSame('9.9.9.9~GET~/', $dispatchedEvent->getKey());
+    }
+
+    public function testAcceptedDoesNotDispatchEvent()
+    {
+        $dispatched = [];
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener(RateLimitExceededEvent::class, static function ($event) use (&$dispatched) {
+            $dispatched[] = $event;
+        });
+
+        $result = new RateLimitResult(4, new \DateTimeImmutable('+1 minute'), true, 5);
+
+        $limiter = $this->createStub(LimiterInterface::class);
+        $limiter->method('consume')->willReturn($result);
+
+        $factory = $this->createStub(RateLimiterFactoryInterface::class);
+        $factory->method('create')->willReturn($limiter);
+
+        $locator = $this->createStub(ServiceProviderInterface::class);
+        $locator->method('has')->willReturn(true);
+        $locator->method('get')->willReturn($factory);
+        $locator->method('getProvidedServices')->willReturn(['api' => RateLimiterFactoryInterface::class]);
+
+        $listener = new RateLimitAttributeListener($locator);
+        $listener->onKernelControllerAttribute($this->makeEvent(new RateLimit('api'), Request::create('/')), null, $dispatcher);
+
+        $this->assertSame([], $dispatched);
     }
 
     public function testMethodFilterSkipsNonMatchingMethod()

--- a/src/Symfony/Component/RateLimiter/CHANGELOG.md
+++ b/src/Symfony/Component/RateLimiter/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add `RateLimitExceededEvent`
+
 8.1
 ---
 

--- a/src/Symfony/Component/RateLimiter/Event/RateLimitExceededEvent.php
+++ b/src/Symfony/Component/RateLimiter/Event/RateLimitExceededEvent.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\RateLimiter\Event;
+
+use Symfony\Component\RateLimiter\RateLimit;
+
+/**
+ * Dispatched when a caller rejects a hit that a rate limiter denied.
+ *
+ * A denied hit is not a rejection by itself. Callers decide what to do with it,
+ * so this event is dispatched by them, not by the limiters.
+ *
+ * @author Marie Charles <marie.charles@hetic.net>
+ */
+final class RateLimitExceededEvent
+{
+    public function __construct(
+        private readonly RateLimit $rateLimit,
+        private readonly ?string $limiterName = null,
+        private readonly ?string $key = null,
+    ) {
+    }
+
+    public function getRateLimit(): RateLimit
+    {
+        return $this->rateLimit;
+    }
+
+    public function getLimiterName(): ?string
+    {
+        return $this->limiterName;
+    }
+
+    /**
+     * The key that was consumed, when known. Its format is defined by the caller.
+     */
+    public function getKey(): ?string
+    {
+        return $this->key;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        |
| License       | MIT

When a request exceeds a limit enforced by the `#[RateLimit]` attribute, `RateLimitAttributeListener` throws `TooManyRequestsHttpException` and nothing else is exposed. There is no way to see which limiter rejected the request, or for which key.

This adds `Symfony\Component\RateLimiter\Event\RateLimitExceededEvent`, dispatched right before the exception is thrown:

```php
use Symfony\Component\RateLimiter\Event\RateLimitExceededEvent;

#[AsEventListener]
public function onRateLimitExceeded(RateLimitExceededEvent $event): void
{
    $this->logger->warning('Rate limit "{limiter}" exceeded for key "{key}", retry after {retry_after}.', [
        'limiter' => $event->getLimiterName(),
        'key' => $event->getKey(),
        'retry_after' => $event->getRateLimit()->getRetryAfter()->format(\DATE_ATOM),
    ]);
}
```

The event carries:

- `getRateLimit()`: the `RateLimiter\RateLimit` result, with `getRetryAfter()`, `getRemainingTokens()` and `getLimit()`.
- `getLimiterName()`: the limiter named by the attribute.
- `getKey()`: the consumed key, which defaults to `{clientIp}~{method}~{path}`.

Listening is observation only. The event is dispatched before the exception, and a listener cannot prevent the rejection or alter the response.

### No new service wiring

The listener does not receive an event dispatcher. `ControllerAttributesListener` dispatches `ControllerAttributeEvent` through the regular dispatcher, and `EventDispatcher::callListeners()` calls every listener as `$listener($event, $eventName, $this)`, so `onKernelControllerAttribute()` takes the dispatcher as its third argument. The `rate_limiter.attribute_listener` service definition is unchanged.

The `new RateLimitExceededEvent(...)` call is guarded by `class_exists()`. HttpKernel allows `symfony/rate-limiter` from `^7.4`, and the event class only exists from 8.2, so an application mixing http-kernel 8.2 with rate-limiter 8.1 would otherwise hit a fatal error the first time a limit is exceeded. With the guard it keeps throwing `TooManyRequestsHttpException` and simply dispatches nothing.

### Scope

Only the `#[RateLimit]` attribute path dispatches the event. `RateLimit::ensureAccepted()`, `LoginThrottlingListener`, `Messenger\Worker` and `AbstractRequestRateLimiter` reject without it.

### Documentation

Points a symfony-docs pull request should carry:

- `RateLimitExceededEvent` and its three getters, dispatched when `#[RateLimit]` rejects a request.
- It is informational: the `TooManyRequestsHttpException` follows whatever a listener does, and throwing from a listener replaces the 429 instead of suppressing it.
- It covers the `#[RateLimit]` attribute only, not every rate limiter rejection.
