### PR TITLE
[HttpFoundation] Reject a Cookie with an invalid __Secure-/__Host- prefix

### DIFF
--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Add the `$defaultExpiration` argument to `UriSigner::__construct()`
  * Add argument `$version` to `UriSigner::sign()`, `UriSigner::check()`, `UriSigner::checkRequest()`, and `UriSigner::verify()` to bind a signed URI to a state token, folded into the signature
  * Add `ParameterBag::filterCallback()` to filter a parameter value through a callback
+ * Reject a `Cookie` whose name uses the `__Secure-`/`__Host-` prefix when its attributes break the prefix contract
 
 8.1
 ---

--- a/src/Symfony/Component/HttpFoundation/Cookie.php
+++ b/src/Symfony/Component/HttpFoundation/Cookie.php
@@ -44,7 +44,7 @@ class Cookie
             'expires' => 0,
             'path' => '/',
             'domain' => null,
-            'secure' => false,
+            'secure' => null,
             'httponly' => false,
             'raw' => !$decode,
             'samesite' => null,
@@ -113,6 +113,7 @@ class Cookie
 
         self::validateAttribute('path', $path);
         self::validateAttribute('domain', $domain);
+        self::validateNamePrefix($name, $secure, $domain, $path ?: '/');
 
         $this->expire = self::expiresTimestamp($expire);
         $this->path = $path ?: '/';
@@ -136,6 +137,7 @@ class Cookie
     public function withDomain(?string $domain): static
     {
         self::validateAttribute('domain', $domain);
+        self::validateNamePrefix($this->name, $this->secure, $domain, $this->path);
 
         $cookie = clone $this;
         $cookie->domain = $domain;
@@ -189,6 +191,7 @@ class Cookie
     public function withPath(string $path): static
     {
         self::validateAttribute('path', $path);
+        self::validateNamePrefix($this->name, $this->secure, $this->domain, '' === $path ? '/' : $path);
 
         $cookie = clone $this;
         $cookie->path = '' === $path ? '/' : $path;
@@ -201,6 +204,8 @@ class Cookie
      */
     public function withSecure(bool $secure = true): static
     {
+        self::validateNamePrefix($this->name, $secure, $this->domain, $this->path);
+
         $cookie = clone $this;
         $cookie->secure = $secure;
 
@@ -421,5 +426,29 @@ class Cookie
     public function setSecureDefault(bool $default): void
     {
         $this->secureDefault = $default;
+    }
+
+    /**
+     * Rejects a "__Host-" prefixed name combined with attributes that make browsers discard the cookie.
+     *
+     * @see https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis#section-4.1.3
+     */
+    private static function validateNamePrefix(string $name, ?bool $secure, ?string $domain, string $path): void
+    {
+        if (false === $secure && (str_starts_with($name, '__Secure-') || str_starts_with($name, '__Host-'))) {
+            throw new \InvalidArgumentException(\sprintf('The cookie name "%s" uses a reserved prefix, which requires the "secure" flag to be enabled.', $name));
+        }
+
+        if (!str_starts_with($name, '__Host-')) {
+            return;
+        }
+
+        if ('' !== (string) $domain) {
+            throw new \InvalidArgumentException(\sprintf('The cookie name "%s" uses the "__Host-" prefix, which requires the cookie to have no "domain" attribute.', $name));
+        }
+
+        if ('/' !== $path) {
+            throw new \InvalidArgumentException(\sprintf('The cookie name "%s" uses the "__Host-" prefix, which requires the cookie path to be "/".', $name));
+        }
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/CookieTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/CookieTest.php
@@ -155,6 +155,117 @@ class CookieTest extends TestCase
         $this->assertNull($cookie->getDomain());
     }
 
+    public function testInstantiationThrowsExceptionIfHostPrefixedNameHasDomain()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The cookie name "__Host-foo" uses the "__Host-" prefix, which requires the cookie to have no "domain" attribute.');
+        Cookie::create('__Host-foo', 'bar', 0, '/', 'example.com');
+    }
+
+    public function testInstantiationThrowsExceptionIfHostPrefixedNameHasNonRootPath()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The cookie name "__Host-foo" uses the "__Host-" prefix, which requires the cookie path to be "/".');
+        Cookie::create('__Host-foo', 'bar', 0, '/admin');
+    }
+
+    public function testWithDomainThrowsExceptionIfHostPrefixedNameGetsADomain()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The cookie name "__Host-foo" uses the "__Host-" prefix, which requires the cookie to have no "domain" attribute.');
+        Cookie::create('__Host-foo', 'bar')->withDomain('example.com');
+    }
+
+    public function testWithPathThrowsExceptionIfHostPrefixedNameGetsANonRootPath()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The cookie name "__Host-foo" uses the "__Host-" prefix, which requires the cookie path to be "/".');
+        Cookie::create('__Host-foo', 'bar')->withPath('/admin');
+    }
+
+    public function testHostPrefixedNameIsAcceptedWithoutDomainAndOnRootPath()
+    {
+        $cookie = Cookie::create('__Host-foo', 'bar');
+
+        $this->assertNull($cookie->getDomain());
+        $this->assertSame('/', $cookie->getPath());
+
+        $cookie = Cookie::create('__Host-foo', 'bar', 0, '', '');
+
+        $this->assertSame('', $cookie->getDomain());
+        $this->assertSame('/', $cookie->getPath());
+
+        $cookie = Cookie::create('__Host-foo', 'bar')->withDomain('')->withPath('');
+
+        $this->assertSame('', $cookie->getDomain());
+        $this->assertSame('/', $cookie->getPath());
+    }
+
+    public function testSecurePrefixedNameIsNotConstrainedToADomainOrAPath()
+    {
+        $cookie = Cookie::create('__Secure-foo', 'bar', 0, '/admin', 'example.com');
+
+        $this->assertSame('example.com', $cookie->getDomain());
+        $this->assertSame('/admin', $cookie->getPath());
+    }
+
+    public function testInstantiationThrowsExceptionIfPrefixedNameIsExplicitlyInsecure()
+    {
+        foreach (['__Secure-foo', '__Host-foo'] as $name) {
+            try {
+                Cookie::create($name, 'bar', 0, '/', null, false);
+                $this->fail(\sprintf('Expected an exception for "%s".', $name));
+            } catch (\InvalidArgumentException $e) {
+                $this->assertSame(\sprintf('The cookie name "%s" uses a reserved prefix, which requires the "secure" flag to be enabled.', $name), $e->getMessage());
+            }
+        }
+    }
+
+    public function testWithSecureThrowsExceptionIfPrefixedNameIsMadeInsecure()
+    {
+        foreach (['__Secure-foo', '__Host-foo'] as $name) {
+            try {
+                Cookie::create($name, 'bar', 0, '/', null, true)->withSecure(false);
+                $this->fail(\sprintf('Expected an exception for "%s".', $name));
+            } catch (\InvalidArgumentException $e) {
+                $this->assertSame(\sprintf('The cookie name "%s" uses a reserved prefix, which requires the "secure" flag to be enabled.', $name), $e->getMessage());
+            }
+        }
+    }
+
+    public function testPrefixedNameWithNullSecureIsAccepted()
+    {
+        foreach (['__Secure-foo', '__Host-foo'] as $name) {
+            $cookie = Cookie::create($name, 'bar', 0, '/', null, null);
+
+            $this->assertFalse($cookie->isSecure());
+
+            $cookie->setSecureDefault(true);
+
+            $this->assertTrue($cookie->isSecure());
+        }
+    }
+
+    public function testHostPrefixedNameIsParsedFromAValidHeader()
+    {
+        $cookie = Cookie::fromString('__Host-foo=bar; path=/; secure');
+
+        $this->assertSame('__Host-foo', $cookie->getName());
+        $this->assertNull($cookie->getDomain());
+        $this->assertSame('/', $cookie->getPath());
+    }
+
+    public function testParsingAHeaderWithoutSecureDefersInsteadOfFailing()
+    {
+        $cookie = Cookie::fromString('__Host-foo=bar');
+
+        $this->assertFalse($cookie->isSecure());
+
+        $cookie->setSecureDefault(true);
+
+        $this->assertTrue($cookie->isSecure());
+    }
+
     public function testInvalidExpiration()
     {
         $this->expectException(\InvalidArgumentException::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Browsers apply a naming contract to cookies whose name carries a reserved prefix, and store the cookie only if it holds:

- `__Secure-`: the `Secure` attribute.
- `__Host-`: the `Secure` attribute, no `Domain` attribute, and a `/` path.

A cookie breaking the contract is discarded on arrival, whatever the rest of the header says. `Cookie` did not check this, so the mistake surfaced client side, days later, as a cookie that is simply never sent back.

```php
// accepted before, now throws
new Cookie('__Host-session', 'value', 0, '/', null, false);
new Cookie('__Secure-session', 'value', 0, '/', null, false);
new Cookie('__Host-session', 'value', 0, '/', 'example.com', true);
new Cookie('__Host-session', 'value', 0, '/admin', null, true);
Cookie::create('__Host-session', 'value')->withDomain('example.com');
Cookie::create('__Host-session', 'value')->withPath('/admin');
Cookie::create('__Host-session', 'value')->withSecure(false);
```

Each throws `InvalidArgumentException`, naming which part of the contract was broken. The check runs where the other cookie attributes are already validated: `__construct()`, `withDomain()`, `withPath()` and `withSecure()`. An empty string domain counts as no domain, matching `__toString()`, which omits the attribute entirely in that case.

### Only an explicit `secure` is judged

`secure` is three-valued. `null` means "defer", and `Response::prepare()` resolves it once the request is known:

```php
if ($request->isSecure()) {
    foreach ($headers->getCookies() as $cookie) {
        $cookie->setSecureDefault(true);
    }
}
```

So a `null` is left alone: at construction time it cannot be told apart from one that will resolve to `true`. Only an explicitly provided `false` is rejected, which is never valid under either prefix.

`Cookie::fromString()` used to default `secure` to `false`, which made a header that omits the attribute indistinguishable from one explicitly marked insecure. It now defaults to `null`, so such a header parses as deferred instead of failing.

### Consequences to expect

A prefixed cookie name only works over HTTPS. Where the `secure` flag is computed rather than deferred, an invalid combination is now an exception instead of a silently dropped cookie:

- `framework.session.name: __Host-session` with `cookie_secure: 'auto'` resolves to `true` over HTTPS and works. Over plain HTTP it resolves to `false` and now throws, where before the application ran with a session the browser kept discarding.
- `ResponseHeaderBag::clearCookie('__Host-foo')` throws with its default `$secure = false`. A deletion header must satisfy the prefix contract too, otherwise the browser ignores it and the cookie is not cleared, so it has to be called with `$secure = true`.

### Documentation

Points a symfony-docs pull request should carry:

- The prefix rules and where Symfony enforces them: `__construct()`, `withDomain()`, `withPath()`, `withSecure()`.
- They come from the cookie specification, not from Symfony: https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis#section-4.1.3
- A prefixed cookie name requires HTTPS. Configuring one while serving over plain HTTP is now an error rather than a silent no-op, so a development setup must use HTTPS for it.
- Deleting a prefixed cookie requires passing `$secure = true` to `clearCookie()`.
- `secure: null` still defers to `setSecureDefault()`, so it is not validated at construction.
