### PR TITLE
[TwigBridge] Fix low-deps tests

### DIFF
--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -31,7 +31,7 @@
         "symfony/emoji": "^7.4|^8.0",
         "symfony/expression-language": "^7.4|^8.0",
         "symfony/finder": "^7.4|^8.0",
-        "symfony/form": "^7.4.4|^8.0.4",
+        "symfony/form": "^8.2",
         "symfony/html-sanitizer": "^7.4|^8.0",
         "symfony/http-foundation": "^7.4|^8.0",
         "symfony/http-kernel": "^7.4|^8.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

#63819 added a `choice_help` option to `ChoiceType` on 8.2, but the `FormExtensionDivLayoutTest` uses it against `^7.4.4|^8.0.4` [which makes low-deps tests fail](https://github.com/symfony/symfony/actions/runs/31002234375/job/92293601295#step:8:1413).

Remaining low-deps failures fixed by #65166.