### PR TITLE
[FrameworkBundle] Fix low-deps tests

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -59,7 +59,7 @@
         "symfony/messenger": "^7.4.10|^8.0.10",
         "symfony/mime": "^7.4.9|^8.0.9",
         "symfony/notifier": "^7.4|^8.0",
-        "symfony/object-mapper": "^7.4.9|^8.0.9",
+        "symfony/object-mapper": "^8.1",
         "symfony/polyfill-intl-icu": "^1.0",
         "symfony/process": "^7.4|^8.0",
         "symfony/property-info": "^7.4|^8.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

#63705 added `ObjectMapperTest::testMapNestedObjectWhoseClassDeclaresNoMapping()` which depends on #62522, so FrameworkBundle’s tests need `symfony/object-mapper@^8.1` [not to fail](https://github.com/symfony/symfony/actions/runs/30835554150/job/91759733753#step:8:6993).

Remaining low-deps failures fixed by #65164.