### PR TITLE
[Serializer] Align union member order between the legacy and TypeInfo paths

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -465,6 +465,14 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
         $missingConstructorArgumentsException = null;
         $isNullable = false;
         $filterBoolFailed = false;
+
+        // property-info reports union members in the order PHP declares them, which always puts
+        // "bool" last, while TypeInfo sorts them by name. Sorting here the same way makes both
+        // paths try the members in the same order and return the same value.
+        if ($isUnionType) {
+            usort($types, static fn (LegacyType $a, LegacyType $b): int => ($a->getClassName() ?? $a->getBuiltinType()) <=> ($b->getClassName() ?? $b->getBuiltinType()));
+        }
+
         foreach ($types as $type) {
             if (null === $data && $type->isNullable()) {
                 return null;

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
@@ -1660,7 +1660,10 @@ class AbstractObjectNormalizerTest extends TestCase
     #[IgnoreDeprecations]
     public function testDenormalizeUnionTypeWithFilterBoolLegacy()
     {
-        $normalizer = new AbstractObjectNormalizerWithMetadataAndLegacyUnionPropertyTypeExtractor();
+        $normalizer = new AbstractObjectNormalizerWithMetadataAndLegacyUnionPropertyTypeExtractor([
+            new LegacyType(LegacyType::BUILTIN_TYPE_BOOL),
+            new LegacyType(LegacyType::BUILTIN_TYPE_STRING),
+        ]);
 
         foreach ([null, XmlEncoder::FORMAT, CsvEncoder::FORMAT] as $format) {
             $dummy = $normalizer->denormalize(['foo' => 'publish'], UnionBoolPropertyDummy::class, $format, [AbstractNormalizer::FILTER_BOOL => true]);
@@ -1669,6 +1672,72 @@ class AbstractObjectNormalizerTest extends TestCase
             $dummy = $normalizer->denormalize(['foo' => 'on'], UnionBoolPropertyDummy::class, $format, [AbstractNormalizer::FILTER_BOOL => true]);
             $this->assertTrue($dummy->foo);
         }
+    }
+
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
+    public function testDenormalizeUnionTypeWithFilterBoolStringFirstLegacy()
+    {
+        $normalizer = new AbstractObjectNormalizerWithMetadataAndLegacyUnionPropertyTypeExtractor([
+            new LegacyType(LegacyType::BUILTIN_TYPE_STRING),
+            new LegacyType(LegacyType::BUILTIN_TYPE_BOOL),
+        ]);
+
+        foreach ([null, XmlEncoder::FORMAT, CsvEncoder::FORMAT] as $format) {
+            $dummy = $normalizer->denormalize(['foo' => 'publish'], UnionBoolPropertyDummy::class, $format, [AbstractNormalizer::FILTER_BOOL => true]);
+            $this->assertSame('publish', $dummy->foo);
+
+            $dummy = $normalizer->denormalize(['foo' => 'on'], UnionBoolPropertyDummy::class, $format, [AbstractNormalizer::FILTER_BOOL => true]);
+            $this->assertTrue($dummy->foo);
+        }
+    }
+
+    public function testDenormalizeUnionTypeWithFilterBoolKeepsEmptyArray()
+    {
+        $normalizer = new AbstractObjectNormalizerWithMetadataAndPropertyTypeExtractors();
+
+        foreach ([XmlEncoder::FORMAT, CsvEncoder::FORMAT] as $format) {
+            $dummy = $normalizer->denormalize(['foo' => ''], UnionArrayBoolPropertyDummy::class, $format, [AbstractNormalizer::FILTER_BOOL => true]);
+            $this->assertSame([], $dummy->foo);
+        }
+    }
+
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
+    public function testDenormalizeUnionTypeWithFilterBoolKeepsEmptyArrayLegacy()
+    {
+        $normalizer = new AbstractObjectNormalizerWithMetadataAndLegacyUnionPropertyTypeExtractor([
+            new LegacyType(LegacyType::BUILTIN_TYPE_ARRAY, false, null, true),
+            new LegacyType(LegacyType::BUILTIN_TYPE_BOOL),
+        ]);
+
+        foreach ([XmlEncoder::FORMAT, CsvEncoder::FORMAT] as $format) {
+            $dummy = $normalizer->denormalize(['foo' => ''], UnionArrayBoolPropertyDummy::class, $format, [AbstractNormalizer::FILTER_BOOL => true]);
+            $this->assertSame([], $dummy->foo);
+        }
+    }
+
+    public function testDenormalizeUnionTypeWithFilterBoolKeepsBackedEnum()
+    {
+        $normalizer = new AbstractObjectNormalizerWithMetadataAndPropertyTypeExtractors();
+        new Serializer([new BackedEnumNormalizer(), $normalizer]);
+
+        $dummy = $normalizer->denormalize(['foo' => 'on'], UnionEnumBoolPropertyDummy::class, null, [AbstractNormalizer::FILTER_BOOL => true]);
+        $this->assertSame(SwitchEnum::On, $dummy->foo);
+    }
+
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
+    public function testDenormalizeUnionTypeWithFilterBoolKeepsBackedEnumLegacy()
+    {
+        $normalizer = new AbstractObjectNormalizerWithMetadataAndLegacyUnionPropertyTypeExtractor([
+            new LegacyType(LegacyType::BUILTIN_TYPE_OBJECT, false, SwitchEnum::class),
+            new LegacyType(LegacyType::BUILTIN_TYPE_BOOL),
+        ]);
+        new Serializer([new BackedEnumNormalizer(), $normalizer]);
+
+        $dummy = $normalizer->denormalize(['foo' => 'on'], UnionEnumBoolPropertyDummy::class, null, [AbstractNormalizer::FILTER_BOOL => true]);
+        $this->assertSame(SwitchEnum::On, $dummy->foo);
     }
 
     public static function provideDenormalizeWithFilterBoolData(): array
@@ -2083,6 +2152,16 @@ class UnionBoolPropertyDummy
     public bool|string $foo;
 }
 
+class UnionArrayBoolPropertyDummy
+{
+    public array|bool $foo;
+}
+
+class UnionEnumBoolPropertyDummy
+{
+    public bool|SwitchEnum $foo;
+}
+
 class DummyWithArrayObject
 {
     /** @var \ArrayObject<string, mixed> */
@@ -2225,6 +2304,12 @@ enum EnumB: string
     case B = 'b';
 }
 
+enum SwitchEnum: string
+{
+    case On = 'on';
+    case Off = 'off';
+}
+
 class DummyWithEnumUnion
 {
     public function __construct(
@@ -2355,12 +2440,17 @@ class AbstractObjectNormalizerWithMetadataAndLegacyPropertyTypeExtractor extends
 
 class AbstractObjectNormalizerWithMetadataAndLegacyUnionPropertyTypeExtractor extends AbstractObjectNormalizer
 {
-    public function __construct()
+    public function __construct(array $types)
     {
-        parent::__construct(new ClassMetadataFactory(new AttributeLoader()), null, new class implements PropertyTypeExtractorInterface {
+        parent::__construct(new ClassMetadataFactory(new AttributeLoader()), null, new class($types) implements PropertyTypeExtractorInterface {
+            public function __construct(
+                private readonly array $types,
+            ) {
+            }
+
             public function getTypes(string $class, string $property, array $context = []): ?array
             {
-                return [new LegacyType(LegacyType::BUILTIN_TYPE_BOOL), new LegacyType(LegacyType::BUILTIN_TYPE_STRING)];
+                return $this->types;
             }
         });
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65163
| License       | MIT

`AbstractObjectNormalizer` denormalizes a union type by trying each member in turn and keeping the first one that accepts the value. The `FILTER_BOOL` coercion that turns `'on'` into `true` lives inside that loop, so it only runs when the `bool` member is tried before a member that would otherwise accept the value, such as `string`.

The order the members arrive in is not the same on both code paths:

* `property-info` reports them in the order PHP declares them, and PHP always puts `bool` last: `bool|string` is reported as `string, bool`.
* `type-info` holds them in a `UnionType`, whose constructor sorts them by name, and `bool` sorts before `string`.

So the coercion wins on the `type-info` path and never runs on the legacy `PropertyInfo\Type[]` path, for any union taken from a native property type. The low-deps CI job installs `property-info` 6.4, which has no `getType()`, so it takes the legacy path and fails:

```
AbstractObjectNormalizerTest::testDenormalizeUnionTypeWithFilterBool
Failed asserting that 'on' is true.
```

This is not a regression from #65125. The legacy path returned the string before that pull request and after it. What #65125 added was a test asserting the `type-info` behaviour, which the legacy path never had. This pull request aligns the two.

## The fix

The legacy member list is sorted with the same key `UnionType` uses, so both paths try the members in the same order and return the same value.

Sorting rather than making `bool` win outright matters: `FILTER_BOOL` must not beat a member that sorts before `bool` and that the `type-info` path would have picked. Two cases where it would:

* `array|bool` receiving an empty string in the `xml` and `csv` formats has to stay `[]`, which is what `#[MapRequestPayload]` relies on for an empty form field.
* `bool|SomeBackedEnum` receiving `'on'` has to stay the enum case when the enum backs that value.

## Behaviour change

On the legacy path only, with `FILTER_BOOL` enabled and a union containing `bool`:

| declared type | value | before | after |
| --- | --- | --- | --- |
| `string\|bool` | `'1'` `'0'` `'yes'` `'no'` `'on'` `'off'` `'true'` `'false'` `''` | the string | the boolean |
| `int\|bool` | `1` `0` | `1` `0` | `true` `false` |
| `float\|bool` | `1` `'1'` | `1.0` | `true` |

Every one of these already behaved this way on the `type-info` path.

## Tests

`testDenormalizeUnionTypeWithFilterBoolStringFirstLegacy` pins the member order to string-then-bool through a custom extractor, so it reproduces the bug on any dependency set rather than only on low-deps. It fails on `7.4` with `Failed asserting that 'on' is true.`

`testDenormalizeUnionTypeWithFilterBoolKeepsEmptyArrayLegacy` and `testDenormalizeUnionTypeWithFilterBoolKeepsBackedEnumLegacy` cover the two cases above, each with a `type-info` counterpart that passes on `7.4` and guards the alignment from the other side.
