### PR TITLE
[Messenger][Amqp] Round delays up to bound the number of delay queues

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Amqp/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.2
 ---
 
+ * Round delays up to two significant digits and add the `delay[granularity]` option to control that rounding
  * Implement the `KeepaliveReceiverInterface` to enable asynchronously notifying AMQP that the job is still being processed, in order to avoid timeouts
 
 8.1

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/ConnectionTest.php
@@ -591,6 +591,80 @@ class ConnectionTest extends TestCase
         $connection->publish('{}', ['x-some-headers' => 'foo'], 5000);
     }
 
+    public function testItRoundsTheDelayUpToTheConfiguredGranularity()
+    {
+        $delayExchange = $this->createMock(\AMQPExchange::class);
+        $delayExchange->expects($this->once())
+            ->method('publish')
+            ->with('{}', 'delay_messages__6000_delay', \AMQP_NOPARAM);
+        $connection = $this->createDelayOrRetryConnection($delayExchange, self::DEFAULT_EXCHANGE_NAME, 'delay_messages__6000_delay', false, 6000, ['granularity' => 1000]);
+
+        $connection->publish('{}', [], 5200);
+    }
+
+    public function testTheDelayGranularityIsNormalizedToAnInteger()
+    {
+        $delayExchange = $this->createMock(\AMQPExchange::class);
+        $delayExchange->expects($this->once())
+            ->method('publish')
+            ->with('{}', 'delay_messages__6000_delay', \AMQP_NOPARAM);
+        $connection = $this->createDelayOrRetryConnection($delayExchange, self::DEFAULT_EXCHANGE_NAME, 'delay_messages__6000_delay', false, 6000, ['granularity' => '1000']);
+
+        $connection->publish('{}', [], 5200);
+    }
+
+    public function testADelayOnTheGranularityGridIsLeftUnchanged()
+    {
+        $delayExchange = $this->createMock(\AMQPExchange::class);
+        $delayExchange->expects($this->once())
+            ->method('publish')
+            ->with('{}', 'delay_messages__5000_delay', \AMQP_NOPARAM);
+        $connection = $this->createDelayOrRetryConnection($delayExchange, self::DEFAULT_EXCHANGE_NAME, 'delay_messages__5000_delay', false, 5000, ['granularity' => 1000]);
+
+        $connection->publish('{}', [], 5000);
+    }
+
+    public function testItRoundsTheDelayUpToTwoSignificantDigitsByDefault()
+    {
+        $delayExchange = $this->createMock(\AMQPExchange::class);
+        $delayExchange->expects($this->once())
+            ->method('publish')
+            ->with('{}', 'delay_messages__5300_delay', \AMQP_NOPARAM);
+        $connection = $this->createDelayOrRetryConnection($delayExchange, self::DEFAULT_EXCHANGE_NAME, 'delay_messages__5300_delay', false, 5300);
+
+        $connection->publish('{}', [], 5234);
+    }
+
+    public function testTheDefaultDelayGranularityScalesWithTheDelay()
+    {
+        $delayExchange = $this->createMock(\AMQPExchange::class);
+        $delayExchange->expects($this->once())
+            ->method('publish')
+            ->with('{}', 'delay_messages__53000_delay', \AMQP_NOPARAM);
+        $connection = $this->createDelayOrRetryConnection($delayExchange, self::DEFAULT_EXCHANGE_NAME, 'delay_messages__53000_delay', false, 53000);
+
+        $connection->publish('{}', [], 52345);
+    }
+
+    public function testTheDelayRoundingIsDisabledByAGranularityOfOne()
+    {
+        $delayExchange = $this->createMock(\AMQPExchange::class);
+        $delayExchange->expects($this->once())
+            ->method('publish')
+            ->with('{}', 'delay_messages__5234_delay', \AMQP_NOPARAM);
+        $connection = $this->createDelayOrRetryConnection($delayExchange, self::DEFAULT_EXCHANGE_NAME, 'delay_messages__5234_delay', false, 5234, ['granularity' => 1]);
+
+        $connection->publish('{}', [], 5234);
+    }
+
+    public function testItThrowsWhenTheDelayGranularityIsNotPositive()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "delay.granularity" option of the AMQP Messenger transport must be a positive integer, "0" given.');
+
+        Connection::fromDsn('amqp://localhost?delay[granularity]=0');
+    }
+
     public function testItPublishesImmediatelyWithNegativeDelay()
     {
         $factory = new TestAmqpFactory(
@@ -1069,7 +1143,7 @@ class ConnectionTest extends TestCase
         $connection->publish('body');
     }
 
-    private function createDelayOrRetryConnection(\AMQPExchange $delayExchange, string $deadLetterExchangeName, string $delayQueueName, bool|string $dailyDelayQueues = false): Connection
+    private function createDelayOrRetryConnection(\AMQPExchange $delayExchange, string $deadLetterExchangeName, string $delayQueueName, bool|string $dailyDelayQueues = false, int $expectedDelay = 5000, array $delayOptions = []): Connection
     {
         $amqpConnection = $this->createStub(\AMQPConnection::class);
         $amqpChannel = $this->createStub(\AMQPChannel::class);
@@ -1084,17 +1158,19 @@ class ConnectionTest extends TestCase
         $baseExpire = filter_var($dailyDelayQueues, \FILTER_VALIDATE_BOOL) ? 86400 * 1000 : 0;
         $delayQueue->expects($this->once())->method('setName')->with($delayQueueName);
         $delayQueue->expects($this->once())->method('setArguments')->with([
-            'x-message-ttl' => 5000,
-            'x-expires' => 5000 + 10000 + $baseExpire,
+            'x-message-ttl' => $expectedDelay,
+            'x-expires' => $expectedDelay + 10000 + $baseExpire,
             'x-dead-letter-exchange' => $deadLetterExchangeName,
             'x-dead-letter-routing-key' => '',
         ]);
 
         $delayQueue->expects($this->once())->method('declareQueue');
         $delayQueue->expects($this->once())->method('bind')->with('delays', $delayQueueName);
-        $options = false === $dailyDelayQueues ? [] : ['delay' => ['daily_delay_queues' => $dailyDelayQueues]];
+        if (false !== $dailyDelayQueues) {
+            $delayOptions['daily_delay_queues'] = $dailyDelayQueues;
+        }
 
-        return Connection::fromDsn('amqp://localhost', $options, $factory);
+        return Connection::fromDsn('amqp://localhost', $delayOptions ? ['delay' => $delayOptions] : [], $factory);
     }
 
     public function testGettingDefaultExchange()

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
@@ -155,6 +155,13 @@ class Connection
      *     * queue_name_pattern: Pattern to use to create the queues (Default: "delay_%exchange_name%_%routing_key%_%delay%")
      *     * exchange_name: Name of the exchange to be used for the delayed/retried messages (Default: "delays")
      *     * arguments: array of extra delay queue arguments (for example:  ['x-queue-type' => 'classic', 'x-message-deduplication' => true,])
+     *     * granularity: Delays are rounded up to a multiple of this many milliseconds before being used as the
+     *       queue name and the "x-message-ttl" of the delay queue. Since one distinct delay means one delay queue,
+     *       this bounds how many queues randomized delays can create, at the cost of releasing a message slightly
+     *       later than asked. Use a value that is small compared to your delays. By default, delays are rounded up
+     *       to two significant digits (e.g. 5234 becomes 5300 and 52345 becomes 53000), which bounds the number of
+     *       queues whatever the magnitude of the delay is and never delays a message by more than 10%.
+     *       Set it to 1 to publish delays as they are. (Default: 10 ** (floor(log10(delay)) - 1))
      *     * daily_delay_queues: When true, the current date is appended to the delay queue names
      *       (e.g. "delay_messages__5000_delay_2025-04-28") and their "x-expires" argument is increased by 24 hours
      *       (24 * 60 * 60 * 1000 ms), so RabbitMQ deletes them automatically once the day is over. This is useful for
@@ -227,6 +234,14 @@ class Connection
 
         if (isset($amqpOptions['delay']['daily_delay_queues'])) {
             $amqpOptions['delay']['daily_delay_queues'] = filter_var($amqpOptions['delay']['daily_delay_queues'], \FILTER_VALIDATE_BOOL);
+        }
+
+        if (isset($amqpOptions['delay']['granularity'])) {
+            if (false === $granularity = filter_var($amqpOptions['delay']['granularity'], \FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]])) {
+                throw new InvalidArgumentException(\sprintf('The "delay.granularity" option of the AMQP Messenger transport must be a positive integer, "%s" given.', $amqpOptions['delay']['granularity']));
+            }
+
+            $amqpOptions['delay']['granularity'] = $granularity;
         }
 
         $queuesOptions = array_map(static function ($queueOptions) {
@@ -340,6 +355,15 @@ class Connection
     {
         $routingKey = $this->getRoutingKeyForMessage($amqpStamp);
         $isRetryAttempt = $amqpStamp && $amqpStamp->isRetryAttempt();
+
+        // the delay is part of the queue name and of its "x-message-ttl", so each distinct value needs its
+        // own queue; rounding up keeps randomized delays spread over a bounded number of queues. The default
+        // keeps two significant digits, which bounds that number whatever the magnitude of the delay is.
+        $granularity = $this->connectionOptions['delay']['granularity'] ?? 10 ** max(0, (int) log10($delay) - 1);
+
+        if (1 < $granularity) {
+            $delay = (int) (ceil($delay / $granularity) * $granularity);
+        }
 
         $this->setupDelay($delay, $routingKey, $isRetryAttempt);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        |
| License       | MIT

Alternative to #65136.

The AMQP transport has no native per-message delay, so it emulates one with a queue whose `x-message-ttl` is the delay and whose dead letter exchange is the original exchange. The delay is therefore part of the queue name, and `setupDelay()` declares and binds that queue on every publish. One distinct delay means one delay queue.

That makes randomized retry delays expensive. With the default `retry_strategy` of `max_retries: 3`, `delay: 1000`, `multiplier: 2` and `jitter: 0.1`, the delays are spread over roughly 1400 distinct values instead of 3, so each publish declares and binds a queue that is almost certainly new. With `delay[daily_delay_queues]` enabled those queues also stay for 24 hours instead of expiring 10 seconds after the message.

This rounds delays up to two significant digits before using them as the queue name and as `x-message-ttl`: 5234 ms becomes 5300 ms, 52345 ms becomes 53000 ms. Rounding up rather than to the nearest value means a message is never released earlier than asked, and two significant digits keep it from being released more than 10% later, which is inside the spread jitter already introduces.

The rounding is relative to the delay, so the bound holds at every scale. Measured over 60000 delays per retry strategy:

| retry strategy | delay queues before | after | max lateness |
| --- | --- | --- | --- |
| `delay: 1000`, jitter 0.1 | 1403 | 26 | 9.9% |
| `delay: 60000`, jitter 0.1 | 39496 | 23 | 9.1% |
| `delay: 100`, jitter 0.1 | 143 | 26 | 8.9% |

A `delay[granularity]` option, in milliseconds, overrides the rounding with a fixed grid:

```
amqp://localhost?delay[granularity]=1000
```

A value of `1` disables the rounding and publishes delays exactly as asked. Note that a fixed granularity only fits delays of a comparable magnitude: `1000` bounds a 60-second retry strategy to 85 queues, but pushes a 100 ms delay up to 1000 ms.

Because this belongs to the transport, it applies whatever the DSN is built from, including `%env(MESSENGER_TRANSPORT_DSN)%`, and it also covers code that wires the AMQP transport without FrameworkBundle.

## Documentation

The AMQP transport reference should carry these points:

* one distinct delay means one delay queue, which is why randomized delays multiply queues;
* delays are rounded up to two significant digits, so a message can be released up to 10% later than asked, and never earlier;
* `delay[granularity]` replaces that with a fixed number of milliseconds, and `1` turns the rounding off;
* a fixed granularity should be small compared to the configured delays;
* it pairs with `delay[daily_delay_queues]`, which extends how long each delay queue lives.
