### PR TITLE
[TwigBridge] skip `choice_help` option tests with symfony/form < 8.2

### DIFF
--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionDivLayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionDivLayoutTest.php
@@ -178,6 +178,10 @@ class FormExtensionDivLayoutTest extends AbstractDivLayoutTestCase
 
     public function testExpandedChoiceHelpIsRenderedAndDescribesTheChoice()
     {
+        if (new \ReflectionClass(ChoiceView::class)->getConstructor()->getNumberOfParameters() < 6) {
+            $this->markTestSkipped('The "choice_help" option requires symfony/form 8.2+');
+        }
+
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, [
             'choices' => ['Apple' => 'a', 'Banana' => 'b'],
             'choice_help' => ['Apple' => 'A fruit', 'Banana' => 'Yellow'],
@@ -200,6 +204,10 @@ class FormExtensionDivLayoutTest extends AbstractDivLayoutTestCase
 
     public function testExpandedChoiceWithoutHelpRendersNoHelpElement()
     {
+        if (new \ReflectionClass(ChoiceView::class)->getConstructor()->getNumberOfParameters() < 6) {
+            $this->markTestSkipped('The "choice_help" option requires symfony/form 8.2+');
+        }
+
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, [
             'choices' => ['Apple' => 'a'],
             'choice_help' => ['Banana' => 'Yellow'],
@@ -214,6 +222,10 @@ class FormExtensionDivLayoutTest extends AbstractDivLayoutTestCase
 
     public function testCollapsedChoiceHelpIsNotRenderedButStaysOnTheView()
     {
+        if (new \ReflectionClass(ChoiceView::class)->getConstructor()->getNumberOfParameters() < 6) {
+            $this->markTestSkipped('The "choice_help" option requires symfony/form 8.2+');
+        }
+
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', null, [
             'choices' => ['Apple' => 'a'],
             'choice_help' => ['Apple' => 'A fruit'],

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -31,7 +31,7 @@
         "symfony/emoji": "^7.4|^8.0",
         "symfony/expression-language": "^7.4|^8.0",
         "symfony/finder": "^7.4|^8.0",
-        "symfony/form": "^8.2",
+        "symfony/form": "^7.4.4|^8.0.4",
         "symfony/html-sanitizer": "^7.4|^8.0",
         "symfony/http-foundation": "^7.4|^8.0",
         "symfony/http-kernel": "^7.4|^8.0",

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -59,7 +59,7 @@
         "symfony/messenger": "^7.4.10|^8.0.10",
         "symfony/mime": "^7.4.9|^8.0.9",
         "symfony/notifier": "^7.4|^8.0",
-        "symfony/object-mapper": "^8.1",
+        "symfony/object-mapper": "^7.4.9|^8.0.9",
         "symfony/polyfill-intl-icu": "^1.0",
         "symfony/process": "^7.4|^8.0",
         "symfony/property-info": "^7.4|^8.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT
