### PR TITLE
[DependencyInjection] Don't keep partially-configured shared services when their setup fails

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -230,8 +230,8 @@ class Container implements ContainerInterface, ResetInterface
             } elseif (isset($container->methodMap[$id])) {
                 return /* self::IGNORE_ON_UNINITIALIZED_REFERENCE */ 4 === $invalidBehavior ? null : $container->{$container->methodMap[$id]}($container);
             }
-        } catch (\Exception $e) {
-            unset($container->services[$id]);
+        } catch (\Throwable $e) {
+            unset($container->services[$id], $container->privates[$id]);
 
             throw $e;
         } finally {

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -1159,41 +1159,55 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
             }
         }
 
-        if (null === $lastWitherIndex && (true === $tryProxy || !$definition->isLazy())) {
-            // share only if proxying failed, or if not a proxy, and if no withers are found
-            $this->shareService($definition, $service, $id, $inlineServices);
-        }
-
-        $properties = $this->doResolveServices($parameterBag->unescapeValue($parameterBag->resolveValue($definition->getProperties())), $inlineServices);
-        foreach ($properties as $name => $value) {
-            $service->$name = $value;
-        }
-
-        foreach ($definition->getMethodCalls() as $k => $call) {
-            $service = $this->callMethod($service, $call, $inlineServices);
-
-            if ($lastWitherIndex === $k && (true === $tryProxy || !$definition->isLazy())) {
-                // share only if proxying failed, or if not a proxy, and this is the last wither
+        try {
+            if (null === $lastWitherIndex && (true === $tryProxy || !$definition->isLazy())) {
+                // share only if proxying failed, or if not a proxy, and if no withers are found
                 $this->shareService($definition, $service, $id, $inlineServices);
             }
-        }
 
-        if ($callable = $definition->getConfigurator()) {
-            if (\is_array($callable)) {
-                $callable[0] = $parameterBag->resolveValue($callable[0]);
+            $properties = $this->doResolveServices($parameterBag->unescapeValue($parameterBag->resolveValue($definition->getProperties())), $inlineServices);
+            foreach ($properties as $name => $value) {
+                $service->$name = $value;
+            }
 
-                if ($callable[0] instanceof Reference) {
-                    $callable[0] = $this->doGet((string) $callable[0], $callable[0]->getInvalidBehavior(), $inlineServices);
-                } elseif ($callable[0] instanceof Definition) {
-                    $callable[0] = $this->createService($callable[0], $inlineServices);
+            foreach ($definition->getMethodCalls() as $k => $call) {
+                $service = $this->callMethod($service, $call, $inlineServices);
+
+                if ($lastWitherIndex === $k && (true === $tryProxy || !$definition->isLazy())) {
+                    // share only if proxying failed, or if not a proxy, and this is the last wither
+                    $this->shareService($definition, $service, $id, $inlineServices);
                 }
             }
 
-            if (!\is_callable($callable)) {
-                throw new InvalidArgumentException(\sprintf('The configure callable for class "%s" is not a callable.', get_debug_type($service)));
+            if ($callable = $definition->getConfigurator()) {
+                if (\is_array($callable)) {
+                    $callable[0] = $parameterBag->resolveValue($callable[0]);
+
+                    if ($callable[0] instanceof Reference) {
+                        $callable[0] = $this->doGet((string) $callable[0], $callable[0]->getInvalidBehavior(), $inlineServices);
+                    } elseif ($callable[0] instanceof Definition) {
+                        $callable[0] = $this->createService($callable[0], $inlineServices);
+                    }
+                }
+
+                if (!\is_callable($callable)) {
+                    throw new InvalidArgumentException(\sprintf('The configure callable for class "%s" is not a callable.', get_debug_type($service)));
+                }
+
+                $callable($service);
+            }
+        } catch (\Throwable $e) {
+            // evict the partially-configured instance, but only if this frame shared it; in the
+            // proxy-initializer frame, the cached proxy must stay so a retry re-runs the initializer
+            if (true === $tryProxy || !$definition->isLazy()) {
+                unset($inlineServices[$id ?? spl_object_hash($definition)]);
+
+                if (null !== $id) {
+                    unset($this->services[$id], $this->privates[$id]);
+                }
             }
 
-            $callable($service);
+            throw $e;
         }
 
         return $service;

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -84,6 +84,7 @@ class PhpDumper extends Dumper
     private array $inlinedRequires = [];
     private array $circularReferences = [];
     private array $singleUsePrivateIds = [];
+    private bool $sharesBeforeSetup = false;
     private array $preload = [];
     private bool $addGetService = false;
     private array $locatedIds = [];
@@ -710,10 +711,9 @@ class PhpDumper extends Dumper
         }
 
         $shouldShareInline = !$isProxyCandidate && $definition->isShared() && !isset($this->singleUsePrivateIds[$id]) && null === $lastWitherIndex;
-        $serviceAccessor = \sprintf('$container->%s[%s]', $this->container->getDefinition($id)->isPublic() ? 'services' : 'privates', $this->doExport($id));
+        $serviceAccessor = $this->getServiceAccessor($id);
         $return = match (true) {
             $shouldShareInline && !isset($this->circularReferences[$id]) && $isSimpleInstance => 'return '.$serviceAccessor.' = ',
-            $shouldShareInline && !isset($this->circularReferences[$id]) => $serviceAccessor.' = $instance = ',
             $shouldShareInline || !$isSimpleInstance => '$instance = ',
             default => 'return ',
         };
@@ -721,6 +721,10 @@ class PhpDumper extends Dumper
         $code = $this->addNewInstance($definition, '        '.$return, $id, $asGhostObject);
 
         if ($shouldShareInline && isset($this->circularReferences[$id])) {
+            // sharing before the service is fully configured is required to break the
+            // circular reference, but then a failing setter/configurator must evict it
+            $this->sharesBeforeSetup = !$isSimpleInstance;
+
             $code .= \sprintf(
                 "\n        if (isset(%s)) {\n            return %1\$s;\n        }\n\n        %s%1\$s = \$instance;\n",
                 $serviceAccessor,
@@ -729,6 +733,11 @@ class PhpDumper extends Dumper
         }
 
         return $code;
+    }
+
+    private function getServiceAccessor(string $id): string
+    {
+        return \sprintf('$container->%s[%s]', $this->container->getDefinition($id)->isPublic() ? 'services' : 'privates', $this->doExport($id));
     }
 
     private function isTrivialInstance(Definition $definition): bool
@@ -793,6 +802,7 @@ class PhpDumper extends Dumper
             if ($call[2] ?? false) {
                 if (null !== $sharedNonLazyId && $lastWitherIndex === $k && 'instance' === $variableName) {
                     $witherAssignation = \sprintf('$container->%s[\'%s\'] = ', $definition->isPublic() ? 'services' : 'privates', $sharedNonLazyId);
+                    $this->sharesBeforeSetup = true;
                 }
                 $witherAssignation .= \sprintf('$%s = ', $variableName);
             }
@@ -965,6 +975,13 @@ class PhpDumper extends Dumper
 
             $c = $this->addInlineService($id, $definition);
 
+            if ($this->sharesBeforeSetup) {
+                $this->sharesBeforeSetup = false;
+                $c = implode("\n", array_map(static fn ($line) => $line ? '    '.$line : $line, explode("\n", $c)));
+
+                $c = \sprintf("        try {\n%s        } catch (\\Throwable \$e) {\n            unset(%s);\n\n            throw \$e;\n        }\n", $c, $this->getServiceAccessor($id));
+            }
+
             if (!$isProxyCandidate && !$definition->isShared()) {
                 $c = implode("\n", array_map(static fn ($line) => $line ? '    '.$line : $line, explode("\n", $c)));
                 $lazyloadInitialization = $definition->isLazy() ? ', $lazyLoad = true' : '';
@@ -1105,7 +1122,7 @@ class PhpDumper extends Dumper
             }
 
             $code .= $this->addServiceProperties($inlineDef, $name);
-            $code .= $this->addServiceMethodCalls($inlineDef, $name, !$isProxyCandidate && $inlineDef->isShared() && !isset($this->singleUsePrivateIds[$id]) ? $id : null);
+            $code .= $this->addServiceMethodCalls($inlineDef, $name, !$isProxyCandidate && $inlineDef->isShared() && !isset($this->singleUsePrivateIds[$id]) && isset($this->circularReferences[$id]) ? $id : null);
             $code .= $this->addServiceConfigurator($inlineDef, $name);
         }
 
@@ -1113,7 +1130,10 @@ class PhpDumper extends Dumper
             return $code;
         }
 
-        return $code."\n        return \$instance;\n";
+        // sharing only once the service is fully configured makes a construction failure atomic
+        $share = !$isProxyCandidate && $definition->isShared() && !isset($this->singleUsePrivateIds[$id]) && !isset($this->circularReferences[$id]);
+
+        return $code."\n        return ".($share ? $this->getServiceAccessor($id).' = ' : '')."\$instance;\n";
     }
 
     private function addServices(?array &$services = null): string

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -350,6 +350,160 @@ class ContainerBuilderTest extends TestCase
         $builder->get('foo');
     }
 
+    public function testGetEvictsSharedServiceWhenMethodCallFails()
+    {
+        FailingSetupService::$attempts = 0;
+        $builder = new ContainerBuilder();
+        $builder->register('foo', FailingSetupService::class)->addMethodCall('fail');
+
+        $first = null;
+        try {
+            $builder->get('foo');
+        } catch (\RuntimeException $first) {
+        }
+        $this->assertSame('Setup failed.', $first?->getMessage(), '->get() should throw when a method call fails');
+
+        $second = null;
+        try {
+            $builder->get('foo');
+        } catch (\RuntimeException $second) {
+        }
+        $this->assertSame('Setup failed.', $second?->getMessage(), '->get() should throw again instead of returning a partially-configured service');
+
+        $this->assertSame(2, FailingSetupService::$attempts);
+    }
+
+    public function testGetEvictsSharedServiceWhenPropertyInjectionFails()
+    {
+        $builder = new ContainerBuilder();
+        $builder->register('foo', FailingSetupService::class)->setProperty('count', 'not-a-number');
+
+        $first = null;
+        try {
+            $builder->get('foo');
+        } catch (\TypeError $first) {
+        }
+        $this->assertNotNull($first, '->get() should throw when injecting a property fails');
+
+        $second = null;
+        try {
+            $builder->get('foo');
+        } catch (\TypeError $second) {
+        }
+        $this->assertNotNull($second, '->get() should throw again instead of returning a partially-configured service');
+    }
+
+    public function testGetEvictsSharedServiceWhenConfiguratorFails()
+    {
+        FailingSetupService::$attempts = 0;
+        $builder = new ContainerBuilder();
+        $builder->register('foo', 'stdClass')->setConfigurator([FailingSetupService::class, 'failToConfigure']);
+
+        $first = null;
+        try {
+            $builder->get('foo');
+        } catch (\RuntimeException $first) {
+        }
+        $this->assertSame('Configuration failed.', $first?->getMessage(), '->get() should throw when the configurator fails');
+
+        $second = null;
+        try {
+            $builder->get('foo');
+        } catch (\RuntimeException $second) {
+        }
+        $this->assertSame('Configuration failed.', $second?->getMessage(), '->get() should throw again instead of returning a partially-configured service');
+
+        $this->assertSame(2, FailingSetupService::$attempts);
+    }
+
+    public function testGetEvictsSharedServiceWhenConfiguratorIsNotACallable()
+    {
+        $builder = new ContainerBuilder();
+        $builder->register('foo', 'stdClass')->setConfigurator('there_is_no_such_configurator_function');
+
+        $first = null;
+        try {
+            $builder->get('foo');
+        } catch (InvalidArgumentException $first) {
+        }
+        $this->assertNotNull($first, '->get() should throw when the configurator is not a callable');
+
+        $second = null;
+        try {
+            $builder->get('foo');
+        } catch (InvalidArgumentException $second) {
+        }
+        $this->assertNotNull($second, '->get() should throw again instead of returning a partially-configured service');
+    }
+
+    public function testGetEvictsWitherServiceWhenSetupFails()
+    {
+        $builder = new ContainerBuilder();
+        $builder->register('wither', WitherFailingSetup::class)
+            ->addMethodCall('withNothing', [], true)
+            ->addMethodCall('fail');
+
+        $first = null;
+        try {
+            $builder->get('wither');
+        } catch (\RuntimeException $first) {
+        }
+        $this->assertSame('Setup failed.', $first?->getMessage(), '->get() should throw when a method call fails after the last wither');
+
+        $second = null;
+        try {
+            $builder->get('wither');
+        } catch (\RuntimeException $second) {
+        }
+        $this->assertSame('Setup failed.', $second?->getMessage(), '->get() should throw again instead of returning a partially-configured service');
+    }
+
+    public function testGetEvictsPrivateSharedServiceWhenSetupFails()
+    {
+        FailingSetupService::$attempts = 0;
+        $builder = new ContainerBuilder();
+        $builder->register('failer', FailingSetupService::class)->addMethodCall('fail');
+        $builder->register('consumer1', 'stdClass')->setPublic(true)->setProperty('failer', new Reference('failer'));
+        $builder->register('consumer2', 'stdClass')->setPublic(true)->setProperty('failer', new Reference('failer'));
+        $builder->compile();
+
+        $first = null;
+        try {
+            $builder->get('consumer1');
+        } catch (\RuntimeException $first) {
+        }
+        $this->assertSame('Setup failed.', $first?->getMessage(), '->get() should throw when building a private dependency fails');
+
+        $second = null;
+        try {
+            $builder->get('consumer1');
+        } catch (\RuntimeException $second) {
+        }
+        $this->assertSame('Setup failed.', $second?->getMessage(), '->get() should throw again instead of returning a partially-configured service');
+
+        $this->assertSame(2, FailingSetupService::$attempts);
+    }
+
+    public function testCircularSetterInjectionRetriesAfterFailure()
+    {
+        FailsOnceConfigurator::$calls = 0;
+        $builder = new ContainerBuilder();
+        $builder->register('a', CircularSetterA::class)->setPublic(true)->addMethodCall('setB', [new Reference('b')]);
+        $builder->register('b', CircularSetterB::class)->addMethodCall('setA', [new Reference('a')])->setConfigurator([FailsOnceConfigurator::class, 'configure']);
+
+        $first = null;
+        try {
+            $builder->get('a');
+        } catch (\RuntimeException $first) {
+        }
+        $this->assertSame('First attempt fails.', $first?->getMessage(), '->get() should throw when configuring a service of the circular graph fails');
+
+        $a = $builder->get('a');
+
+        $this->assertInstanceOf(CircularSetterB::class, $a->b);
+        $this->assertSame($a, $a->b->a);
+    }
+
     public function testGetServiceIds()
     {
         $builder = new ContainerBuilder();
@@ -2114,5 +2268,70 @@ class E
     {
         $this->first = $first;
         $this->second = $second;
+    }
+}
+
+class FailingSetupService
+{
+    public static int $attempts = 0;
+    public int $count = 0;
+
+    public function fail(): void
+    {
+        ++self::$attempts;
+
+        throw new \RuntimeException('Setup failed.');
+    }
+
+    public static function failToConfigure(object $service): void
+    {
+        ++self::$attempts;
+
+        throw new \RuntimeException('Configuration failed.');
+    }
+}
+
+class WitherFailingSetup
+{
+    public function withNothing(): static
+    {
+        return clone $this;
+    }
+
+    public function fail(): void
+    {
+        throw new \RuntimeException('Setup failed.');
+    }
+}
+
+class CircularSetterA
+{
+    public ?object $b = null;
+
+    public function setB(object $b): void
+    {
+        $this->b = $b;
+    }
+}
+
+class CircularSetterB
+{
+    public ?object $a = null;
+
+    public function setA(object $a): void
+    {
+        $this->a = $a;
+    }
+}
+
+class FailsOnceConfigurator
+{
+    public static int $calls = 0;
+
+    public static function configure(object $service): void
+    {
+        if (1 === ++self::$calls) {
+            throw new \RuntimeException('First attempt fails.');
+        }
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
@@ -144,7 +144,7 @@ class ContainerTest extends TestCase
 
         $sc = new ProjectServiceContainer();
         $sc->set('foo', $obj = new \stdClass());
-        $this->assertEquals(['service_container', 'bar', 'foo_bar', 'foo.baz', 'circular', 'throw_exception', 'throws_exception_on_service_configuration', 'internal_dependency', 'alias', 'foo'], $sc->getServiceIds(), '->getServiceIds() returns defined service ids by factory methods in the method map, followed by service ids defined by set()');
+        $this->assertEquals(['service_container', 'bar', 'foo_bar', 'foo.baz', 'circular', 'throw_exception', 'throws_exception_on_service_configuration', 'throws_error_on_service_configuration', 'throws_exception_on_private_service_configuration', 'internal_dependency', 'alias', 'foo'], $sc->getServiceIds(), '->getServiceIds() returns defined service ids by factory methods in the method map, followed by service ids defined by set()');
     }
 
     public function testSet()
@@ -372,6 +372,50 @@ class ContainerTest extends TestCase
         $this->assertFalse($c->initialized('throws_exception_on_service_configuration'));
     }
 
+    public function testGetThrowsErrorOnServiceConfiguration()
+    {
+        $c = new ProjectServiceContainer();
+
+        try {
+            $c->get('throws_error_on_service_configuration');
+            $this->fail('->get() should throw the error raised while configuring the service');
+        } catch (\Error $e) {
+            // Do nothing.
+        }
+
+        $this->assertFalse($c->initialized('throws_error_on_service_configuration'));
+
+        // Retry, to make sure that get*Service() will be called.
+        try {
+            $c->get('throws_error_on_service_configuration');
+            $this->fail('->get() should throw the error again instead of returning a partially-configured service');
+        } catch (\Error $e) {
+            // Do nothing.
+        }
+        $this->assertFalse($c->initialized('throws_error_on_service_configuration'));
+    }
+
+    public function testGetThrowsExceptionOnPrivateServiceConfiguration()
+    {
+        $c = new ProjectServiceContainer();
+
+        try {
+            $c->get('throws_exception_on_private_service_configuration');
+        } catch (\Exception $e) {
+            // Do nothing.
+        }
+
+        $this->assertArrayNotHasKey('throws_exception_on_private_service_configuration', $this->getField($c, 'privates'));
+
+        // Retry, to make sure that get*Service() will be called.
+        try {
+            $c->get('throws_exception_on_private_service_configuration');
+        } catch (\Exception $e) {
+            // Do nothing.
+        }
+        $this->assertArrayNotHasKey('throws_exception_on_private_service_configuration', $this->getField($c, 'privates'));
+    }
+
     protected function getField($obj, $field)
     {
         $reflection = new \ReflectionProperty($obj, $field);
@@ -461,6 +505,8 @@ class ProjectServiceContainer extends Container
             'circular' => 'getCircularService',
             'throw_exception' => 'getThrowExceptionService',
             'throws_exception_on_service_configuration' => 'getThrowsExceptionOnServiceConfigurationService',
+            'throws_error_on_service_configuration' => 'getThrowsErrorOnServiceConfigurationService',
+            'throws_exception_on_private_service_configuration' => 'getThrowsExceptionOnPrivateServiceConfigurationService',
             'internal_dependency' => 'getInternalDependencyService',
         ];
     }
@@ -500,6 +546,20 @@ class ProjectServiceContainer extends Container
         $this->services['throws_exception_on_service_configuration'] = $instance = new \stdClass();
 
         throw new \Exception('Something was terribly wrong while trying to configure the service!');
+    }
+
+    protected function getThrowsErrorOnServiceConfigurationService()
+    {
+        $this->services['throws_error_on_service_configuration'] = $instance = new \stdClass();
+
+        throw new \Error('Something was terribly wrong while trying to configure the service!');
+    }
+
+    protected function getThrowsExceptionOnPrivateServiceConfigurationService()
+    {
+        $this->privates['throws_exception_on_private_service_configuration'] = $instance = new \stdClass();
+
+        throw new \Exception('Something was terribly wrong while trying to configure the private service!');
     }
 
     protected function getInternalDependencyService()

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -93,6 +93,15 @@ class PhpDumperTest extends TestCase
         self::$fixturesPath = realpath(__DIR__.'/../Fixtures/');
     }
 
+    public static function assertStringEqualsFile(string $expectedFile, string $actualString, string $message = ''): void
+    {
+        if (getenv('UPDATE_FIXTURES')) {
+            file_put_contents($expectedFile, $actualString);
+        }
+
+        parent::assertStringEqualsFile($expectedFile, $actualString, $message);
+    }
+
     public function testDump()
     {
         $container = new ContainerBuilder();
@@ -2353,6 +2362,184 @@ class PhpDumperTest extends TestCase
         $this->assertStringNotContainsString(': \?stdClass', $code);
         $this->assertStringContainsString(': ?\stdClass', $code);
     }
+
+    public function testDumpedContainerEvictsSharedServiceOnMethodCallFailure()
+    {
+        PhpDumperTest_FailingSetup::$attempts = 0;
+        $container = new ContainerBuilder();
+        $container->register('foo', PhpDumperTest_FailingSetup::class)->setPublic(true)->addMethodCall('fail');
+        $container->compile();
+
+        $dumper = new PhpDumper($container);
+        eval('?>'.$dumper->dump(['class' => $class = 'Symfony_DI_PhpDumper_Test_Evict_Method_Call']));
+
+        $dumpedContainer = new $class();
+
+        $first = null;
+        try {
+            $dumpedContainer->get('foo');
+        } catch (\RuntimeException $first) {
+        }
+        $this->assertSame('Setup failed.', $first?->getMessage(), '->get() should throw when a method call fails');
+
+        $this->assertFalse($dumpedContainer->initialized('foo'));
+
+        $second = null;
+        try {
+            $dumpedContainer->get('foo');
+        } catch (\RuntimeException $second) {
+        }
+        $this->assertSame('Setup failed.', $second?->getMessage(), '->get() should throw again instead of returning a partially-configured service');
+
+        $this->assertSame(2, PhpDumperTest_FailingSetup::$attempts);
+    }
+
+    public function testDumpedContainerEvictsSharedServiceOnPropertyTypeError()
+    {
+        $container = new ContainerBuilder();
+        $container->register('foo', PhpDumperTest_FailingSetup::class)->setPublic(true)->setProperty('count', 'not-a-number');
+        $container->compile();
+
+        $dumper = new PhpDumper($container);
+        eval('?>'.$dumper->dump(['class' => $class = 'Symfony_DI_PhpDumper_Test_Evict_Property_Type_Error']));
+
+        $dumpedContainer = new $class();
+
+        $first = null;
+        try {
+            $dumpedContainer->get('foo');
+        } catch (\TypeError $first) {
+        }
+        $this->assertNotNull($first, '->get() should throw when injecting a property fails');
+
+        $second = null;
+        try {
+            $dumpedContainer->get('foo');
+        } catch (\TypeError $second) {
+        }
+        $this->assertNotNull($second, '->get() should throw again instead of returning a partially-configured service');
+    }
+
+    public function testDumpedContainerEvictsSharedServiceOnConfiguratorFailure()
+    {
+        PhpDumperTest_FailingSetup::$attempts = 0;
+        $container = new ContainerBuilder();
+        $container->register('foo', 'stdClass')->setPublic(true)->setConfigurator([PhpDumperTest_FailingSetup::class, 'failToConfigure']);
+        $container->compile();
+
+        $dumper = new PhpDumper($container);
+        eval('?>'.$dumper->dump(['class' => $class = 'Symfony_DI_PhpDumper_Test_Evict_Configurator']));
+
+        $dumpedContainer = new $class();
+
+        $first = null;
+        try {
+            $dumpedContainer->get('foo');
+        } catch (\RuntimeException $first) {
+        }
+        $this->assertSame('Configuration failed.', $first?->getMessage(), '->get() should throw when the configurator fails');
+
+        $second = null;
+        try {
+            $dumpedContainer->get('foo');
+        } catch (\RuntimeException $second) {
+        }
+        $this->assertSame('Configuration failed.', $second?->getMessage(), '->get() should throw again instead of returning a partially-configured service');
+
+        $this->assertSame(2, PhpDumperTest_FailingSetup::$attempts);
+    }
+
+    public function testDumpedContainerEvictsPrivateSharedServiceOnFailure()
+    {
+        PhpDumperTest_FailingSetup::$attempts = 0;
+        $container = new ContainerBuilder();
+        $container->register('failer', PhpDumperTest_FailingSetup::class)->addMethodCall('fail');
+        $container->register('consumer1', 'stdClass')->setPublic(true)->setProperty('failer', new Reference('failer'));
+        $container->register('consumer2', 'stdClass')->setPublic(true)->setProperty('failer', new Reference('failer'));
+        $container->compile();
+
+        $dumper = new PhpDumper($container);
+        eval('?>'.$dumper->dump(['class' => $class = 'Symfony_DI_PhpDumper_Test_Evict_Private']));
+
+        $dumpedContainer = new $class();
+
+        $first = null;
+        try {
+            $dumpedContainer->get('consumer1');
+        } catch (\RuntimeException $first) {
+        }
+        $this->assertSame('Setup failed.', $first?->getMessage(), '->get() should throw when building a private dependency fails');
+
+        $second = null;
+        try {
+            $dumpedContainer->get('consumer1');
+        } catch (\RuntimeException $second) {
+        }
+        $this->assertSame('Setup failed.', $second?->getMessage(), '->get() should throw again instead of returning a partially-configured service');
+
+        $this->assertSame(2, PhpDumperTest_FailingSetup::$attempts);
+    }
+
+    public function testDumpedContainerEvictsCircularServicesOnFailure()
+    {
+        PhpDumperTest_FailsOnceConfigurator::$calls = 0;
+        $container = new ContainerBuilder();
+        $container->register('a', PhpDumperTest_CircularSetterA::class)->setPublic(true)->addMethodCall('setB', [new Reference('b')]);
+        $container->register('b', PhpDumperTest_CircularSetterB::class)->setPublic(true)->addMethodCall('setA', [new Reference('a')])->setConfigurator([PhpDumperTest_FailsOnceConfigurator::class, 'configure']);
+        $container->compile();
+
+        $dumper = new PhpDumper($container);
+        $dumper->setProxyDumper(new NullDumper());
+        eval('?>'.$dumper->dump(['class' => $class = 'Symfony_DI_PhpDumper_Test_Evict_Circular']));
+
+        $dumpedContainer = new $class();
+
+        $first = null;
+        try {
+            $dumpedContainer->get('a');
+        } catch (\RuntimeException $first) {
+        }
+        $this->assertSame('First attempt fails.', $first?->getMessage(), '->get() should throw when configuring a service of the circular graph fails');
+
+        $this->assertFalse($dumpedContainer->initialized('a'));
+        $this->assertFalse($dumpedContainer->initialized('b'));
+
+        $a = $dumpedContainer->get('a');
+
+        $this->assertInstanceOf(PhpDumperTest_CircularSetterB::class, $a->b);
+        $this->assertSame($a, $a->b->a);
+    }
+
+    public function testDumpedContainerEvictsWitherServiceOnSetupFailure()
+    {
+        $container = new ContainerBuilder();
+        $container->register('wither', PhpDumperTest_WitherFailingSetup::class)
+            ->setPublic(true)
+            ->addMethodCall('withNothing', [], true)
+            ->addMethodCall('fail');
+        $container->compile();
+
+        $dumper = new PhpDumper($container);
+        eval('?>'.$dumper->dump(['class' => $class = 'Symfony_DI_PhpDumper_Test_Evict_Wither']));
+
+        $dumpedContainer = new $class();
+
+        $first = null;
+        try {
+            $dumpedContainer->get('wither');
+        } catch (\RuntimeException $first) {
+        }
+        $this->assertSame('Setup failed.', $first?->getMessage(), '->get() should throw when a method call fails after the last wither');
+
+        $this->assertFalse($dumpedContainer->initialized('wither'));
+
+        $second = null;
+        try {
+            $dumpedContainer->get('wither');
+        } catch (\RuntimeException $second) {
+        }
+        $this->assertSame('Setup failed.', $second?->getMessage(), '->get() should throw again instead of returning a partially-configured service');
+    }
 }
 
 class Rot13EnvVarProcessor implements EnvVarProcessorInterface
@@ -2473,5 +2660,70 @@ class PhpDumperTest_TaggedIteratorWrapperFactory
     public function create(): PhpDumperTest_TaggedIteratorWrapper
     {
         return new PhpDumperTest_TaggedIteratorWrapper($this->taggedServices);
+    }
+}
+
+class PhpDumperTest_FailingSetup
+{
+    public static int $attempts = 0;
+    public int $count = 0;
+
+    public function fail(): void
+    {
+        ++self::$attempts;
+
+        throw new \RuntimeException('Setup failed.');
+    }
+
+    public static function failToConfigure(object $service): void
+    {
+        ++self::$attempts;
+
+        throw new \RuntimeException('Configuration failed.');
+    }
+}
+
+class PhpDumperTest_WitherFailingSetup
+{
+    public function withNothing(): static
+    {
+        return clone $this;
+    }
+
+    public function fail(): void
+    {
+        throw new \RuntimeException('Setup failed.');
+    }
+}
+
+class PhpDumperTest_CircularSetterA
+{
+    public ?object $b = null;
+
+    public function setB(object $b): void
+    {
+        $this->b = $b;
+    }
+}
+
+class PhpDumperTest_CircularSetterB
+{
+    public ?object $a = null;
+
+    public function setA(object $a): void
+    {
+        $this->a = $a;
+    }
+}
+
+class PhpDumperTest_FailsOnceConfigurator
+{
+    public static int $calls = 0;
+
+    public static function configure(object $service): void
+    {
+        if (1 === ++self::$calls) {
+            throw new \RuntimeException('First attempt fails.');
+        }
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services10_as_files.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services10_as_files.txt
@@ -28,11 +28,11 @@ class getClosureService extends ProjectServiceContainer
      */
     public static function do($container, $lazyLoad = true)
     {
-        $container->services['closure'] = $instance = new \stdClass();
+        $instance = new \stdClass();
 
         $instance->closures = [#[\Closure(name: 'foo', class: 'FooClass')] fn (): ?\stdClass => ($container->services['foo'] ?? null)];
 
-        return $instance;
+        return $container->services['closure'] = $instance;
     }
 }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services19.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services19.php
@@ -56,11 +56,11 @@ class ProjectServiceContainer extends Container
      */
     protected static function getServiceWithMethodCallAndFactoryService($container)
     {
-        $container->services['service_with_method_call_and_factory'] = $instance = new \Bar\FooClass();
+        $instance = new \Bar\FooClass();
 
         $instance->setBar(\Bar\FooClass::getInstance());
 
-        return $instance;
+        return $container->services['service_with_method_call_and_factory'] = $instance;
     }
 
     public function getParameter(string $name): array|bool|string|int|float|\UnitEnum|null

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_as_files.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_as_files.txt
@@ -38,11 +38,11 @@ class getBAR2Service extends ProjectServiceContainer
      */
     public static function do($container, $lazyLoad = true)
     {
-        $container->services['BAR'] = $instance = new \stdClass();
+        $instance = new \stdClass();
 
         $instance->bar = ($container->services['bar'] ?? self::getBarService($container));
 
-        return $instance;
+        return $container->services['BAR'] = $instance;
     }
 }
 
@@ -117,17 +117,23 @@ class getBazService extends ProjectServiceContainer
      */
     public static function do($container, $lazyLoad = true)
     {
-        $instance = new \Baz();
+        try {
+            $instance = new \Baz();
 
-        if (isset($container->services['baz'])) {
-            return $container->services['baz'];
+            if (isset($container->services['baz'])) {
+                return $container->services['baz'];
+            }
+
+            $container->services['baz'] = $instance;
+
+            $instance->setFoo(($container->services['foo_with_inline'] ?? $container->load('getFooWithInlineService')));
+
+            return $instance;
+        } catch (\Throwable $e) {
+            unset($container->services['baz']);
+
+            throw $e;
         }
-
-        $container->services['baz'] = $instance;
-
-        $instance->setFoo(($container->services['foo_with_inline'] ?? $container->load('getFooWithInlineService')));
-
-        return $instance;
     }
 }
 
@@ -142,14 +148,14 @@ class getConfiguredServiceService extends ProjectServiceContainer
      */
     public static function do($container, $lazyLoad = true)
     {
-        $container->services['configured_service'] = $instance = new \stdClass();
+        $instance = new \stdClass();
 
         $a = new \ConfClass();
         $a->setFoo(($container->services['baz'] ?? $container->load('getBazService')));
 
         $a->configureStdClass($instance);
 
-        return $instance;
+        return $container->services['configured_service'] = $instance;
     }
 }
 
@@ -164,11 +170,11 @@ class getConfiguredServiceSimpleService extends ProjectServiceContainer
      */
     public static function do($container, $lazyLoad = true)
     {
-        $container->services['configured_service_simple'] = $instance = new \stdClass();
+        $instance = new \stdClass();
 
         (new \ConfClass('bar'))->configureStdClass($instance);
 
-        return $instance;
+        return $container->services['configured_service_simple'] = $instance;
     }
 }
 
@@ -283,7 +289,7 @@ class getFooService extends ProjectServiceContainer
     {
         $a = ($container->services['foo.baz'] ?? $container->load('getFoo_BazService'));
 
-        $container->services['foo'] = $instance = \Bar\FooClass::getInstance('foo', $a, ['bar' => 'foo is bar', 'foobar' => 'bar'], true, $container);
+        $instance = \Bar\FooClass::getInstance('foo', $a, ['bar' => 'foo is bar', 'foobar' => 'bar'], true, $container);
 
         $instance->foo = 'bar';
         $instance->moo = $a;
@@ -292,7 +298,7 @@ class getFooService extends ProjectServiceContainer
         $instance->initialize();
         sc_configure($instance);
 
-        return $instance;
+        return $container->services['foo'] = $instance;
     }
 }
 
@@ -307,11 +313,11 @@ class getFoo_BazService extends ProjectServiceContainer
      */
     public static function do($container, $lazyLoad = true)
     {
-        $container->services['foo.baz'] = $instance = \BazClass::getInstance();
+        $instance = \BazClass::getInstance();
 
         \BazClass::configureStatic1($instance);
 
-        return $instance;
+        return $container->services['foo.baz'] = $instance;
     }
 }
 
@@ -345,21 +351,27 @@ class getFooWithInlineService extends ProjectServiceContainer
      */
     public static function do($container, $lazyLoad = true)
     {
-        $instance = new \Foo();
+        try {
+            $instance = new \Foo();
 
-        if (isset($container->services['foo_with_inline'])) {
-            return $container->services['foo_with_inline'];
+            if (isset($container->services['foo_with_inline'])) {
+                return $container->services['foo_with_inline'];
+            }
+
+            $container->services['foo_with_inline'] = $instance;
+
+            $a = new \Bar();
+            $a->pub = 'pub';
+            $a->setBaz(($container->services['baz'] ?? $container->load('getBazService')));
+
+            $instance->setBar($a);
+
+            return $instance;
+        } catch (\Throwable $e) {
+            unset($container->services['foo_with_inline']);
+
+            throw $e;
         }
-
-        $container->services['foo_with_inline'] = $instance;
-
-        $a = new \Bar();
-        $a->pub = 'pub';
-        $a->setBaz(($container->services['baz'] ?? $container->load('getBazService')));
-
-        $instance->setBar($a);
-
-        return $instance;
     }
 }
 
@@ -411,13 +423,13 @@ class getMethodCall1Service extends ProjectServiceContainer
     {
         include_once $container->targetDir.''.'/Fixtures/includes/foo.php';
 
-        $container->services['method_call1'] = $instance = new \Bar\FooClass();
+        $instance = new \Bar\FooClass();
 
         $instance->setBar(($container->services['foo'] ?? $container->load('getFooService')));
         $instance->setBar(NULL);
         $instance->setBar((($container->services['foo'] ?? $container->load('getFooService'))->foo() . (($container->hasParameter("foo")) ? ($container->getParameter("foo")) : ("default"))));
 
-        return $instance;
+        return $container->services['method_call1'] = $instance;
     }
 }
 
@@ -435,11 +447,11 @@ class getNewFactoryServiceService extends ProjectServiceContainer
         $a = new \FactoryClass();
         $a->foo = 'bar';
 
-        $container->services['new_factory_service'] = $instance = $a->getInstance();
+        $instance = $a->getInstance();
 
         $instance->foo = 'bar';
 
-        return $instance;
+        return $container->services['new_factory_service'] = $instance;
     }
 }
 
@@ -652,11 +664,11 @@ class ProjectServiceContainer extends Container
     {
         $a = ($container->services['foo.baz'] ?? $container->load('getFoo_BazService'));
 
-        $container->services['bar'] = $instance = new \Bar\FooClass('foo', $a, $container->getParameter('foo_bar'));
+        $instance = new \Bar\FooClass('foo', $a, $container->getParameter('foo_bar'));
 
         $a->configure($instance);
 
-        return $instance;
+        return $container->services['bar'] = $instance;
     }
 
     public function getParameter(string $name): array|bool|string|int|float|\UnitEnum|null

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
@@ -92,11 +92,11 @@ class ProjectServiceContainer extends Container
      */
     protected static function getBARService($container)
     {
-        $container->services['BAR'] = $instance = new \stdClass();
+        $instance = new \stdClass();
 
         $instance->bar = ($container->services['bar'] ?? self::getBar3Service($container));
 
-        return $instance;
+        return $container->services['BAR'] = $instance;
     }
 
     /**
@@ -138,11 +138,11 @@ class ProjectServiceContainer extends Container
     {
         $a = ($container->services['foo.baz'] ?? self::getFoo_BazService($container));
 
-        $container->services['bar'] = $instance = new \Bar\FooClass('foo', $a, $container->getParameter('foo_bar'));
+        $instance = new \Bar\FooClass('foo', $a, $container->getParameter('foo_bar'));
 
         $a->configure($instance);
 
-        return $instance;
+        return $container->services['bar'] = $instance;
     }
 
     /**
@@ -162,17 +162,23 @@ class ProjectServiceContainer extends Container
      */
     protected static function getBazService($container)
     {
-        $instance = new \Baz();
+        try {
+            $instance = new \Baz();
 
-        if (isset($container->services['baz'])) {
-            return $container->services['baz'];
+            if (isset($container->services['baz'])) {
+                return $container->services['baz'];
+            }
+
+            $container->services['baz'] = $instance;
+
+            $instance->setFoo(($container->services['foo_with_inline'] ?? self::getFooWithInlineService($container)));
+
+            return $instance;
+        } catch (\Throwable $e) {
+            unset($container->services['baz']);
+
+            throw $e;
         }
-
-        $container->services['baz'] = $instance;
-
-        $instance->setFoo(($container->services['foo_with_inline'] ?? self::getFooWithInlineService($container)));
-
-        return $instance;
     }
 
     /**
@@ -182,14 +188,14 @@ class ProjectServiceContainer extends Container
      */
     protected static function getConfiguredServiceService($container)
     {
-        $container->services['configured_service'] = $instance = new \stdClass();
+        $instance = new \stdClass();
 
         $a = new \ConfClass();
         $a->setFoo(($container->services['baz'] ?? self::getBazService($container)));
 
         $a->configureStdClass($instance);
 
-        return $instance;
+        return $container->services['configured_service'] = $instance;
     }
 
     /**
@@ -199,11 +205,11 @@ class ProjectServiceContainer extends Container
      */
     protected static function getConfiguredServiceSimpleService($container)
     {
-        $container->services['configured_service_simple'] = $instance = new \stdClass();
+        $instance = new \stdClass();
 
         (new \ConfClass('bar'))->configureStdClass($instance);
 
-        return $instance;
+        return $container->services['configured_service_simple'] = $instance;
     }
 
     /**
@@ -269,7 +275,7 @@ class ProjectServiceContainer extends Container
     {
         $a = ($container->services['foo.baz'] ?? self::getFoo_BazService($container));
 
-        $container->services['foo'] = $instance = \Bar\FooClass::getInstance('foo', $a, ['bar' => 'foo is bar', 'foobar' => 'bar'], true, $container);
+        $instance = \Bar\FooClass::getInstance('foo', $a, ['bar' => 'foo is bar', 'foobar' => 'bar'], true, $container);
 
         $instance->foo = 'bar';
         $instance->moo = $a;
@@ -278,7 +284,7 @@ class ProjectServiceContainer extends Container
         $instance->initialize();
         sc_configure($instance);
 
-        return $instance;
+        return $container->services['foo'] = $instance;
     }
 
     /**
@@ -288,11 +294,11 @@ class ProjectServiceContainer extends Container
      */
     protected static function getFoo_BazService($container)
     {
-        $container->services['foo.baz'] = $instance = \BazClass::getInstance();
+        $instance = \BazClass::getInstance();
 
         \BazClass::configureStatic1($instance);
 
-        return $instance;
+        return $container->services['foo.baz'] = $instance;
     }
 
     /**
@@ -316,21 +322,27 @@ class ProjectServiceContainer extends Container
      */
     protected static function getFooWithInlineService($container)
     {
-        $instance = new \Foo();
+        try {
+            $instance = new \Foo();
 
-        if (isset($container->services['foo_with_inline'])) {
-            return $container->services['foo_with_inline'];
+            if (isset($container->services['foo_with_inline'])) {
+                return $container->services['foo_with_inline'];
+            }
+
+            $container->services['foo_with_inline'] = $instance;
+
+            $a = new \Bar();
+            $a->pub = 'pub';
+            $a->setBaz(($container->services['baz'] ?? self::getBazService($container)));
+
+            $instance->setBar($a);
+
+            return $instance;
+        } catch (\Throwable $e) {
+            unset($container->services['foo_with_inline']);
+
+            throw $e;
         }
-
-        $container->services['foo_with_inline'] = $instance;
-
-        $a = new \Bar();
-        $a->pub = 'pub';
-        $a->setBaz(($container->services['baz'] ?? self::getBazService($container)));
-
-        $instance->setBar($a);
-
-        return $instance;
     }
 
     /**
@@ -367,13 +379,13 @@ class ProjectServiceContainer extends Container
     {
         include_once '%path%foo.php';
 
-        $container->services['method_call1'] = $instance = new \Bar\FooClass();
+        $instance = new \Bar\FooClass();
 
         $instance->setBar(($container->services['foo'] ?? self::getFooService($container)));
         $instance->setBar(NULL);
         $instance->setBar((($container->services['foo'] ?? self::getFooService($container))->foo() . (($container->hasParameter("foo")) ? ($container->getParameter("foo")) : ("default"))));
 
-        return $instance;
+        return $container->services['method_call1'] = $instance;
     }
 
     /**
@@ -386,11 +398,11 @@ class ProjectServiceContainer extends Container
         $a = new \FactoryClass();
         $a->foo = 'bar';
 
-        $container->services['new_factory_service'] = $instance = $a->getInstance();
+        $instance = $a->getInstance();
 
         $instance->foo = 'bar';
 
-        return $instance;
+        return $container->services['new_factory_service'] = $instance;
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_inlined_factories.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_inlined_factories.txt
@@ -111,11 +111,11 @@ class ProjectServiceContainer extends Container
      */
     protected static function getBARService($container)
     {
-        $container->services['BAR'] = $instance = new \stdClass();
+        $instance = new \stdClass();
 
         $instance->bar = ($container->services['bar'] ?? self::getBar3Service($container));
 
-        return $instance;
+        return $container->services['BAR'] = $instance;
     }
 
     /**
@@ -157,11 +157,11 @@ class ProjectServiceContainer extends Container
     {
         $a = ($container->services['foo.baz'] ?? self::getFoo_BazService($container));
 
-        $container->services['bar'] = $instance = new \Bar\FooClass('foo', $a, $container->getParameter('foo_bar'));
+        $instance = new \Bar\FooClass('foo', $a, $container->getParameter('foo_bar'));
 
         $a->configure($instance);
 
-        return $instance;
+        return $container->services['bar'] = $instance;
     }
 
     /**
@@ -181,17 +181,23 @@ class ProjectServiceContainer extends Container
      */
     protected static function getBazService($container)
     {
-        $instance = new \Baz();
+        try {
+            $instance = new \Baz();
 
-        if (isset($container->services['baz'])) {
-            return $container->services['baz'];
+            if (isset($container->services['baz'])) {
+                return $container->services['baz'];
+            }
+
+            $container->services['baz'] = $instance;
+
+            $instance->setFoo(($container->services['foo_with_inline'] ?? self::getFooWithInlineService($container)));
+
+            return $instance;
+        } catch (\Throwable $e) {
+            unset($container->services['baz']);
+
+            throw $e;
         }
-
-        $container->services['baz'] = $instance;
-
-        $instance->setFoo(($container->services['foo_with_inline'] ?? self::getFooWithInlineService($container)));
-
-        return $instance;
     }
 
     /**
@@ -201,14 +207,14 @@ class ProjectServiceContainer extends Container
      */
     protected static function getConfiguredServiceService($container)
     {
-        $container->services['configured_service'] = $instance = new \stdClass();
+        $instance = new \stdClass();
 
         $a = new \ConfClass();
         $a->setFoo(($container->services['baz'] ?? self::getBazService($container)));
 
         $a->configureStdClass($instance);
 
-        return $instance;
+        return $container->services['configured_service'] = $instance;
     }
 
     /**
@@ -218,11 +224,11 @@ class ProjectServiceContainer extends Container
      */
     protected static function getConfiguredServiceSimpleService($container)
     {
-        $container->services['configured_service_simple'] = $instance = new \stdClass();
+        $instance = new \stdClass();
 
         (new \ConfClass('bar'))->configureStdClass($instance);
 
-        return $instance;
+        return $container->services['configured_service_simple'] = $instance;
     }
 
     /**
@@ -288,7 +294,7 @@ class ProjectServiceContainer extends Container
     {
         $a = ($container->services['foo.baz'] ?? self::getFoo_BazService($container));
 
-        $container->services['foo'] = $instance = \Bar\FooClass::getInstance('foo', $a, ['bar' => 'foo is bar', 'foobar' => 'bar'], true, $container);
+        $instance = \Bar\FooClass::getInstance('foo', $a, ['bar' => 'foo is bar', 'foobar' => 'bar'], true, $container);
 
         $instance->foo = 'bar';
         $instance->moo = $a;
@@ -297,7 +303,7 @@ class ProjectServiceContainer extends Container
         $instance->initialize();
         sc_configure($instance);
 
-        return $instance;
+        return $container->services['foo'] = $instance;
     }
 
     /**
@@ -309,11 +315,11 @@ class ProjectServiceContainer extends Container
     {
         include_once $container->targetDir.''.'/Fixtures/includes/classes.php';
 
-        $container->services['foo.baz'] = $instance = \BazClass::getInstance();
+        $instance = \BazClass::getInstance();
 
         \BazClass::configureStatic1($instance);
 
-        return $instance;
+        return $container->services['foo.baz'] = $instance;
     }
 
     /**
@@ -337,21 +343,27 @@ class ProjectServiceContainer extends Container
      */
     protected static function getFooWithInlineService($container)
     {
-        $instance = new \Foo();
+        try {
+            $instance = new \Foo();
 
-        if (isset($container->services['foo_with_inline'])) {
-            return $container->services['foo_with_inline'];
+            if (isset($container->services['foo_with_inline'])) {
+                return $container->services['foo_with_inline'];
+            }
+
+            $container->services['foo_with_inline'] = $instance;
+
+            $a = new \Bar();
+            $a->pub = 'pub';
+            $a->setBaz(($container->services['baz'] ?? self::getBazService($container)));
+
+            $instance->setBar($a);
+
+            return $instance;
+        } catch (\Throwable $e) {
+            unset($container->services['foo_with_inline']);
+
+            throw $e;
         }
-
-        $container->services['foo_with_inline'] = $instance;
-
-        $a = new \Bar();
-        $a->pub = 'pub';
-        $a->setBaz(($container->services['baz'] ?? self::getBazService($container)));
-
-        $instance->setBar($a);
-
-        return $instance;
     }
 
     /**
@@ -392,13 +404,13 @@ class ProjectServiceContainer extends Container
     {
         include_once $container->targetDir.''.'/Fixtures/includes/foo.php';
 
-        $container->services['method_call1'] = $instance = new \Bar\FooClass();
+        $instance = new \Bar\FooClass();
 
         $instance->setBar(($container->services['foo'] ?? self::getFooService($container)));
         $instance->setBar(NULL);
         $instance->setBar((($container->services['foo'] ?? self::getFooService($container))->foo() . (($container->hasParameter("foo")) ? ($container->getParameter("foo")) : ("default"))));
 
-        return $instance;
+        return $container->services['method_call1'] = $instance;
     }
 
     /**
@@ -411,11 +423,11 @@ class ProjectServiceContainer extends Container
         $a = new \FactoryClass();
         $a->foo = 'bar';
 
-        $container->services['new_factory_service'] = $instance = $a->getInstance();
+        $instance = $a->getInstance();
 
         $instance->foo = 'bar';
 
-        return $instance;
+        return $container->services['new_factory_service'] = $instance;
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_adawson.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_adawson.php
@@ -57,7 +57,7 @@ class ProjectServiceContainer extends Container
     {
         $a = ($container->services['App\\Db'] ?? self::getDbService($container));
 
-        $container->services['App\\Bus'] = $instance = new \App\Bus($a);
+        $instance = new \App\Bus($a);
 
         $b = ($container->privates['App\\Schema'] ?? self::getSchemaService($container));
         $c = new \App\Registry();
@@ -68,7 +68,7 @@ class ProjectServiceContainer extends Container
         $instance->handler1 = new \App\Handler1($a, $b, $d);
         $instance->handler2 = new \App\Handler2($a, $b, $d);
 
-        return $instance;
+        return $container->services['App\\Bus'] = $instance;
     }
 
     /**
@@ -78,17 +78,23 @@ class ProjectServiceContainer extends Container
      */
     protected static function getDbService($container)
     {
-        $instance = new \App\Db();
+        try {
+            $instance = new \App\Db();
 
-        if (isset($container->services['App\\Db'])) {
-            return $container->services['App\\Db'];
+            if (isset($container->services['App\\Db'])) {
+                return $container->services['App\\Db'];
+            }
+
+            $container->services['App\\Db'] = $instance;
+
+            $instance->schema = ($container->privates['App\\Schema'] ?? self::getSchemaService($container));
+
+            return $instance;
+        } catch (\Throwable $e) {
+            unset($container->services['App\\Db']);
+
+            throw $e;
         }
-
-        $container->services['App\\Db'] = $instance;
-
-        $instance->schema = ($container->privates['App\\Schema'] ?? self::getSchemaService($container));
-
-        return $instance;
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_almost_circular_private.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_almost_circular_private.php
@@ -106,17 +106,23 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
      */
     protected static function getBar2Service($container)
     {
-        $instance = new \BarCircular();
+        try {
+            $instance = new \BarCircular();
 
-        if (isset($container->services['bar2'])) {
-            return $container->services['bar2'];
+            if (isset($container->services['bar2'])) {
+                return $container->services['bar2'];
+            }
+
+            $container->services['bar2'] = $instance;
+
+            $instance->addFoobar(new \FoobarCircular(($container->services['foo2'] ?? self::getFoo2Service($container))));
+
+            return $instance;
+        } catch (\Throwable $e) {
+            unset($container->services['bar2']);
+
+            throw $e;
         }
-
-        $container->services['bar2'] = $instance;
-
-        $instance->addFoobar(new \FoobarCircular(($container->services['foo2'] ?? self::getFoo2Service($container))));
-
-        return $instance;
     }
 
     /**
@@ -126,13 +132,13 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
      */
     protected static function getBar3Service($container)
     {
-        $container->services['bar3'] = $instance = new \BarCircular();
+        $instance = new \BarCircular();
 
         $a = new \FoobarCircular();
 
         $instance->addFoobar($a, $a);
 
-        return $instance;
+        return $container->services['bar3'] = $instance;
     }
 
     /**
@@ -142,11 +148,11 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
      */
     protected static function getBaz6Service($container)
     {
-        $container->services['baz6'] = $instance = new \stdClass();
+        $instance = new \stdClass();
 
         $instance->bar6 = ($container->privates['bar6'] ?? self::getBar6Service($container));
 
-        return $instance;
+        return $container->services['baz6'] = $instance;
     }
 
     /**
@@ -156,23 +162,29 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
      */
     protected static function getConnectionService($container)
     {
-        $a = new \stdClass();
+        try {
+            $a = new \stdClass();
 
-        $b = new \stdClass();
+            $b = new \stdClass();
 
-        $instance = new \stdClass($a, $b);
+            $instance = new \stdClass($a, $b);
 
-        if (isset($container->services['connection'])) {
-            return $container->services['connection'];
+            if (isset($container->services['connection'])) {
+                return $container->services['connection'];
+            }
+
+            $container->services['connection'] = $instance;
+
+            $b->logger = ($container->services['logger'] ?? self::getLoggerService($container));
+
+            $a->subscriber = ($container->services['subscriber'] ?? self::getSubscriberService($container));
+
+            return $instance;
+        } catch (\Throwable $e) {
+            unset($container->services['connection']);
+
+            throw $e;
         }
-
-        $container->services['connection'] = $instance;
-
-        $b->logger = ($container->services['logger'] ?? self::getLoggerService($container));
-
-        $a->subscriber = ($container->services['subscriber'] ?? self::getSubscriberService($container));
-
-        return $instance;
     }
 
     /**
@@ -182,29 +194,35 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
      */
     protected static function getConnection2Service($container)
     {
-        $a = new \stdClass();
+        try {
+            $a = new \stdClass();
 
-        $b = new \stdClass();
+            $b = new \stdClass();
 
-        $instance = new \stdClass($a, $b);
+            $instance = new \stdClass($a, $b);
 
-        if (isset($container->services['connection2'])) {
-            return $container->services['connection2'];
+            if (isset($container->services['connection2'])) {
+                return $container->services['connection2'];
+            }
+
+            $container->services['connection2'] = $instance;
+
+            $c = new \stdClass($instance);
+
+            $d = ($container->services['manager2'] ?? self::getManager2Service($container));
+
+            $c->handler2 = new \stdClass($d);
+
+            $b->logger2 = $c;
+
+            $a->subscriber2 = new \stdClass($d);
+
+            return $instance;
+        } catch (\Throwable $e) {
+            unset($container->services['connection2']);
+
+            throw $e;
         }
-
-        $container->services['connection2'] = $instance;
-
-        $c = new \stdClass($instance);
-
-        $d = ($container->services['manager2'] ?? self::getManager2Service($container));
-
-        $c->handler2 = new \stdClass($d);
-
-        $b->logger2 = $c;
-
-        $a->subscriber2 = new \stdClass($d);
-
-        return $instance;
     }
 
     /**
@@ -238,11 +256,11 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
     {
         $a = new \BarCircular();
 
-        $container->services['foo'] = $instance = new \FooCircular($a);
+        $instance = new \FooCircular($a);
 
         $a->addFoobar(new \FoobarCircular($instance));
 
-        return $instance;
+        return $container->services['foo'] = $instance;
     }
 
     /**
@@ -274,14 +292,14 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
      */
     protected static function getFoo5Service($container)
     {
-        $container->services['foo5'] = $instance = new \stdClass();
+        $instance = new \stdClass();
 
         $a = new \stdClass($instance);
         $a->foo = $instance;
 
         $instance->bar = $a;
 
-        return $instance;
+        return $container->services['foo5'] = $instance;
     }
 
     /**
@@ -291,17 +309,23 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
      */
     protected static function getFoo6Service($container)
     {
-        $instance = new \stdClass();
+        try {
+            $instance = new \stdClass();
 
-        if (isset($container->services['foo6'])) {
-            return $container->services['foo6'];
+            if (isset($container->services['foo6'])) {
+                return $container->services['foo6'];
+            }
+
+            $container->services['foo6'] = $instance;
+
+            $instance->bar6 = ($container->privates['bar6'] ?? self::getBar6Service($container));
+
+            return $instance;
+        } catch (\Throwable $e) {
+            unset($container->services['foo6']);
+
+            throw $e;
         }
-
-        $container->services['foo6'] = $instance;
-
-        $instance->bar6 = ($container->privates['bar6'] ?? self::getBar6Service($container));
-
-        return $instance;
     }
 
     /**
@@ -313,11 +337,11 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
     {
         $a = new \stdClass();
 
-        $container->services['foobar4'] = $instance = new \stdClass($a);
+        $instance = new \stdClass($a);
 
         $a->foobar = $instance;
 
-        return $instance;
+        return $container->services['foobar4'] = $instance;
     }
 
     /**
@@ -327,17 +351,23 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
      */
     protected static function getListener3Service($container)
     {
-        $instance = new \stdClass();
+        try {
+            $instance = new \stdClass();
 
-        if (isset($container->services['listener3'])) {
-            return $container->services['listener3'];
+            if (isset($container->services['listener3'])) {
+                return $container->services['listener3'];
+            }
+
+            $container->services['listener3'] = $instance;
+
+            $instance->manager = ($container->services['manager3'] ?? self::getManager3Service($container));
+
+            return $instance;
+        } catch (\Throwable $e) {
+            unset($container->services['listener3']);
+
+            throw $e;
         }
-
-        $container->services['listener3'] = $instance;
-
-        $instance->manager = ($container->services['manager3'] ?? self::getManager3Service($container));
-
-        return $instance;
     }
 
     /**
@@ -369,23 +399,29 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
      */
     protected static function getLoggerService($container)
     {
-        $a = ($container->services['connection'] ?? self::getConnectionService($container));
+        try {
+            $a = ($container->services['connection'] ?? self::getConnectionService($container));
 
-        if (isset($container->services['logger'])) {
-            return $container->services['logger'];
+            if (isset($container->services['logger'])) {
+                return $container->services['logger'];
+            }
+
+            $instance = new \stdClass($a);
+
+            if (isset($container->services['logger'])) {
+                return $container->services['logger'];
+            }
+
+            $container->services['logger'] = $instance;
+
+            $instance->handler = new \stdClass(($container->services['manager'] ?? self::getManagerService($container)));
+
+            return $instance;
+        } catch (\Throwable $e) {
+            unset($container->services['logger']);
+
+            throw $e;
         }
-
-        $instance = new \stdClass($a);
-
-        if (isset($container->services['logger'])) {
-            return $container->services['logger'];
-        }
-
-        $container->services['logger'] = $instance;
-
-        $instance->handler = new \stdClass(($container->services['manager'] ?? self::getManagerService($container)));
-
-        return $instance;
     }
 
     /**
@@ -461,11 +497,11 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
      */
     protected static function getMonolog_LoggerService($container)
     {
-        $container->services['monolog.logger'] = $instance = new \stdClass();
+        $instance = new \stdClass();
 
         $instance->handler = ($container->privates['mailer.transport'] ?? self::getMailer_TransportService($container));
 
-        return $instance;
+        return $container->services['monolog.logger'] = $instance;
     }
 
     /**
@@ -475,11 +511,11 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
      */
     protected static function getMonologInline_LoggerService($container)
     {
-        $container->services['monolog_inline.logger'] = $instance = new \stdClass();
+        $instance = new \stdClass();
 
         $instance->handler = ($container->privates['mailer_inline.mailer'] ?? self::getMailerInline_MailerService($container));
 
-        return $instance;
+        return $container->services['monolog_inline.logger'] = $instance;
     }
 
     /**
@@ -489,24 +525,30 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
      */
     protected static function getPAService($container)
     {
-        $a = ($container->privates['pC'] ?? self::getPCService($container));
+        try {
+            $a = ($container->privates['pC'] ?? self::getPCService($container));
 
-        if (isset($container->services['pA'])) {
-            return $container->services['pA'];
+            if (isset($container->services['pA'])) {
+                return $container->services['pA'];
+            }
+            $b = new \stdClass();
+
+            $instance = new \stdClass($b, $a);
+
+            if (isset($container->services['pA'])) {
+                return $container->services['pA'];
+            }
+
+            $container->services['pA'] = $instance;
+
+            $b->d = ($container->privates['pD'] ?? self::getPDService($container));
+
+            return $instance;
+        } catch (\Throwable $e) {
+            unset($container->services['pA']);
+
+            throw $e;
         }
-        $b = new \stdClass();
-
-        $instance = new \stdClass($b, $a);
-
-        if (isset($container->services['pA'])) {
-            return $container->services['pA'];
-        }
-
-        $container->services['pA'] = $instance;
-
-        $b->d = ($container->privates['pD'] ?? self::getPDService($container));
-
-        return $instance;
     }
 
     /**
@@ -576,17 +618,23 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
      */
     protected static function getConnection3Service($container)
     {
-        $instance = new \stdClass();
+        try {
+            $instance = new \stdClass();
 
-        if (isset($container->privates['connection3'])) {
-            return $container->privates['connection3'];
+            if (isset($container->privates['connection3'])) {
+                return $container->privates['connection3'];
+            }
+
+            $container->privates['connection3'] = $instance;
+
+            $instance->listener = [($container->services['listener3'] ?? self::getListener3Service($container))];
+
+            return $instance;
+        } catch (\Throwable $e) {
+            unset($container->privates['connection3']);
+
+            throw $e;
         }
-
-        $container->privates['connection3'] = $instance;
-
-        $instance->listener = [($container->services['listener3'] ?? self::getListener3Service($container))];
-
-        return $instance;
     }
 
     /**
@@ -596,17 +644,23 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
      */
     protected static function getConnection4Service($container)
     {
-        $instance = new \stdClass();
+        try {
+            $instance = new \stdClass();
 
-        if (isset($container->privates['connection4'])) {
-            return $container->privates['connection4'];
+            if (isset($container->privates['connection4'])) {
+                return $container->privates['connection4'];
+            }
+
+            $container->privates['connection4'] = $instance;
+
+            $instance->listener = [($container->services['listener4'] ?? self::getListener4Service($container))];
+
+            return $instance;
+        } catch (\Throwable $e) {
+            unset($container->privates['connection4']);
+
+            throw $e;
         }
-
-        $container->privates['connection4'] = $instance;
-
-        $instance->listener = [($container->services['listener4'] ?? self::getListener4Service($container))];
-
-        return $instance;
     }
 
     /**
@@ -640,11 +694,11 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
     {
         $a = new \Symfony\Component\DependencyInjection\Tests\Fixtures\FooForCircularWithAddCalls();
 
-        $container->privates['level5'] = $instance = new \stdClass($a);
+        $instance = new \stdClass($a);
 
         $a->call($instance);
 
-        return $instance;
+        return $container->privates['level5'] = $instance;
     }
 
     /**
@@ -673,19 +727,25 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
      */
     protected static function getMailer_TransportFactory_AmazonService($container)
     {
-        $a = new \stdClass();
+        try {
+            $a = new \stdClass();
 
-        $instance = new \stdClass($a);
+            $instance = new \stdClass($a);
 
-        if (isset($container->privates['mailer.transport_factory.amazon'])) {
-            return $container->privates['mailer.transport_factory.amazon'];
+            if (isset($container->privates['mailer.transport_factory.amazon'])) {
+                return $container->privates['mailer.transport_factory.amazon'];
+            }
+
+            $container->privates['mailer.transport_factory.amazon'] = $instance;
+
+            $a->handler = ($container->privates['mailer.transport'] ?? self::getMailer_TransportService($container));
+
+            return $instance;
+        } catch (\Throwable $e) {
+            unset($container->privates['mailer.transport_factory.amazon']);
+
+            throw $e;
         }
-
-        $container->privates['mailer.transport_factory.amazon'] = $instance;
-
-        $a->handler = ($container->privates['mailer.transport'] ?? self::getMailer_TransportService($container));
-
-        return $instance;
     }
 
     /**
@@ -740,17 +800,23 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
      */
     protected static function getPCService($container, $lazyLoad = true)
     {
-        $instance = new \stdClass();
+        try {
+            $instance = new \stdClass();
 
-        if (isset($container->privates['pC'])) {
-            return $container->privates['pC'];
+            if (isset($container->privates['pC'])) {
+                return $container->privates['pC'];
+            }
+
+            $container->privates['pC'] = $instance;
+
+            $instance->d = ($container->privates['pD'] ?? self::getPDService($container));
+
+            return $instance;
+        } catch (\Throwable $e) {
+            unset($container->privates['pC']);
+
+            throw $e;
         }
-
-        $container->privates['pC'] = $instance;
-
-        $instance->d = ($container->privates['pD'] ?? self::getPDService($container));
-
-        return $instance;
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_almost_circular_public.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_almost_circular_public.php
@@ -106,17 +106,23 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      */
     protected static function getBarService($container)
     {
-        $instance = new \BarCircular();
+        try {
+            $instance = new \BarCircular();
 
-        if (isset($container->services['bar'])) {
-            return $container->services['bar'];
+            if (isset($container->services['bar'])) {
+                return $container->services['bar'];
+            }
+
+            $container->services['bar'] = $instance;
+
+            $instance->addFoobar(($container->services['foobar'] ?? self::getFoobarService($container)));
+
+            return $instance;
+        } catch (\Throwable $e) {
+            unset($container->services['bar']);
+
+            throw $e;
         }
-
-        $container->services['bar'] = $instance;
-
-        $instance->addFoobar(($container->services['foobar'] ?? self::getFoobarService($container)));
-
-        return $instance;
     }
 
     /**
@@ -126,13 +132,13 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      */
     protected static function getBar3Service($container)
     {
-        $container->services['bar3'] = $instance = new \BarCircular();
+        $instance = new \BarCircular();
 
         $a = ($container->services['foobar3'] ??= new \FoobarCircular());
 
         $instance->addFoobar($a, $a);
 
-        return $instance;
+        return $container->services['bar3'] = $instance;
     }
 
     /**
@@ -142,23 +148,29 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      */
     protected static function getBar5Service($container)
     {
-        $a = ($container->services['foo5'] ?? self::getFoo5Service($container));
+        try {
+            $a = ($container->services['foo5'] ?? self::getFoo5Service($container));
 
-        if (isset($container->services['bar5'])) {
-            return $container->services['bar5'];
+            if (isset($container->services['bar5'])) {
+                return $container->services['bar5'];
+            }
+
+            $instance = new \stdClass($a);
+
+            if (isset($container->services['bar5'])) {
+                return $container->services['bar5'];
+            }
+
+            $container->services['bar5'] = $instance;
+
+            $instance->foo = $a;
+
+            return $instance;
+        } catch (\Throwable $e) {
+            unset($container->services['bar5']);
+
+            throw $e;
         }
-
-        $instance = new \stdClass($a);
-
-        if (isset($container->services['bar5'])) {
-            return $container->services['bar5'];
-        }
-
-        $container->services['bar5'] = $instance;
-
-        $instance->foo = $a;
-
-        return $instance;
     }
 
     /**
@@ -168,11 +180,11 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      */
     protected static function getBaz6Service($container)
     {
-        $container->services['baz6'] = $instance = new \stdClass();
+        $instance = new \stdClass();
 
         $instance->bar6 = ($container->privates['bar6'] ?? self::getBar6Service($container));
 
-        return $instance;
+        return $container->services['baz6'] = $instance;
     }
 
     /**
@@ -182,24 +194,30 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      */
     protected static function getConnectionService($container)
     {
-        $a = ($container->services['dispatcher'] ?? self::getDispatcherService($container));
+        try {
+            $a = ($container->services['dispatcher'] ?? self::getDispatcherService($container));
 
-        if (isset($container->services['connection'])) {
-            return $container->services['connection'];
+            if (isset($container->services['connection'])) {
+                return $container->services['connection'];
+            }
+            $b = new \stdClass();
+
+            $instance = new \stdClass($a, $b);
+
+            if (isset($container->services['connection'])) {
+                return $container->services['connection'];
+            }
+
+            $container->services['connection'] = $instance;
+
+            $b->logger = ($container->services['logger'] ?? self::getLoggerService($container));
+
+            return $instance;
+        } catch (\Throwable $e) {
+            unset($container->services['connection']);
+
+            throw $e;
         }
-        $b = new \stdClass();
-
-        $instance = new \stdClass($a, $b);
-
-        if (isset($container->services['connection'])) {
-            return $container->services['connection'];
-        }
-
-        $container->services['connection'] = $instance;
-
-        $b->logger = ($container->services['logger'] ?? self::getLoggerService($container));
-
-        return $instance;
     }
 
     /**
@@ -209,27 +227,33 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      */
     protected static function getConnection2Service($container)
     {
-        $a = ($container->services['dispatcher2'] ?? self::getDispatcher2Service($container));
+        try {
+            $a = ($container->services['dispatcher2'] ?? self::getDispatcher2Service($container));
 
-        if (isset($container->services['connection2'])) {
-            return $container->services['connection2'];
+            if (isset($container->services['connection2'])) {
+                return $container->services['connection2'];
+            }
+            $b = new \stdClass();
+
+            $instance = new \stdClass($a, $b);
+
+            if (isset($container->services['connection2'])) {
+                return $container->services['connection2'];
+            }
+
+            $container->services['connection2'] = $instance;
+
+            $c = new \stdClass($instance);
+            $c->handler2 = new \stdClass(($container->services['manager2'] ?? self::getManager2Service($container)));
+
+            $b->logger2 = $c;
+
+            return $instance;
+        } catch (\Throwable $e) {
+            unset($container->services['connection2']);
+
+            throw $e;
         }
-        $b = new \stdClass();
-
-        $instance = new \stdClass($a, $b);
-
-        if (isset($container->services['connection2'])) {
-            return $container->services['connection2'];
-        }
-
-        $container->services['connection2'] = $instance;
-
-        $c = new \stdClass($instance);
-        $c->handler2 = new \stdClass(($container->services['manager2'] ?? self::getManager2Service($container)));
-
-        $b->logger2 = $c;
-
-        return $instance;
     }
 
     /**
@@ -239,17 +263,23 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      */
     protected static function getConnection3Service($container)
     {
-        $instance = new \stdClass();
+        try {
+            $instance = new \stdClass();
 
-        if (isset($container->services['connection3'])) {
-            return $container->services['connection3'];
+            if (isset($container->services['connection3'])) {
+                return $container->services['connection3'];
+            }
+
+            $container->services['connection3'] = $instance;
+
+            $instance->listener = [($container->services['listener3'] ?? self::getListener3Service($container))];
+
+            return $instance;
+        } catch (\Throwable $e) {
+            unset($container->services['connection3']);
+
+            throw $e;
         }
-
-        $container->services['connection3'] = $instance;
-
-        $instance->listener = [($container->services['listener3'] ?? self::getListener3Service($container))];
-
-        return $instance;
     }
 
     /**
@@ -259,17 +289,23 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      */
     protected static function getConnection4Service($container)
     {
-        $instance = new \stdClass();
+        try {
+            $instance = new \stdClass();
 
-        if (isset($container->services['connection4'])) {
-            return $container->services['connection4'];
+            if (isset($container->services['connection4'])) {
+                return $container->services['connection4'];
+            }
+
+            $container->services['connection4'] = $instance;
+
+            $instance->listener = [($container->services['listener4'] ?? self::getListener4Service($container))];
+
+            return $instance;
+        } catch (\Throwable $e) {
+            unset($container->services['connection4']);
+
+            throw $e;
         }
-
-        $container->services['connection4'] = $instance;
-
-        $instance->listener = [($container->services['listener4'] ?? self::getListener4Service($container))];
-
-        return $instance;
     }
 
     /**
@@ -279,17 +315,23 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      */
     protected static function getDispatcherService($container, $lazyLoad = true)
     {
-        $instance = new \stdClass();
+        try {
+            $instance = new \stdClass();
 
-        if (isset($container->services['dispatcher'])) {
-            return $container->services['dispatcher'];
+            if (isset($container->services['dispatcher'])) {
+                return $container->services['dispatcher'];
+            }
+
+            $container->services['dispatcher'] = $instance;
+
+            $instance->subscriber = ($container->services['subscriber'] ?? self::getSubscriberService($container));
+
+            return $instance;
+        } catch (\Throwable $e) {
+            unset($container->services['dispatcher']);
+
+            throw $e;
         }
-
-        $container->services['dispatcher'] = $instance;
-
-        $instance->subscriber = ($container->services['subscriber'] ?? self::getSubscriberService($container));
-
-        return $instance;
     }
 
     /**
@@ -299,17 +341,23 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      */
     protected static function getDispatcher2Service($container, $lazyLoad = true)
     {
-        $instance = new \stdClass();
+        try {
+            $instance = new \stdClass();
 
-        if (isset($container->services['dispatcher2'])) {
-            return $container->services['dispatcher2'];
+            if (isset($container->services['dispatcher2'])) {
+                return $container->services['dispatcher2'];
+            }
+
+            $container->services['dispatcher2'] = $instance;
+
+            $instance->subscriber2 = ($container->privates['subscriber2'] ?? self::getSubscriber2Service($container));
+
+            return $instance;
+        } catch (\Throwable $e) {
+            unset($container->services['dispatcher2']);
+
+            throw $e;
         }
-
-        $container->services['dispatcher2'] = $instance;
-
-        $instance->subscriber2 = ($container->privates['subscriber2'] ?? self::getSubscriber2Service($container));
-
-        return $instance;
     }
 
     /**
@@ -406,19 +454,25 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      */
     protected static function getFoo2Service($container)
     {
-        $a = new \BarCircular();
+        try {
+            $a = new \BarCircular();
 
-        $instance = new \FooCircular($a);
+            $instance = new \FooCircular($a);
 
-        if (isset($container->services['foo2'])) {
-            return $container->services['foo2'];
+            if (isset($container->services['foo2'])) {
+                return $container->services['foo2'];
+            }
+
+            $container->services['foo2'] = $instance;
+
+            $a->addFoobar(($container->services['foobar2'] ?? self::getFoobar2Service($container)));
+
+            return $instance;
+        } catch (\Throwable $e) {
+            unset($container->services['foo2']);
+
+            throw $e;
         }
-
-        $container->services['foo2'] = $instance;
-
-        $a->addFoobar(($container->services['foobar2'] ?? self::getFoobar2Service($container)));
-
-        return $instance;
     }
 
     /**
@@ -446,17 +500,23 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      */
     protected static function getFoo5Service($container)
     {
-        $instance = new \stdClass();
+        try {
+            $instance = new \stdClass();
 
-        if (isset($container->services['foo5'])) {
-            return $container->services['foo5'];
+            if (isset($container->services['foo5'])) {
+                return $container->services['foo5'];
+            }
+
+            $container->services['foo5'] = $instance;
+
+            $instance->bar = ($container->services['bar5'] ?? self::getBar5Service($container));
+
+            return $instance;
+        } catch (\Throwable $e) {
+            unset($container->services['foo5']);
+
+            throw $e;
         }
-
-        $container->services['foo5'] = $instance;
-
-        $instance->bar = ($container->services['bar5'] ?? self::getBar5Service($container));
-
-        return $instance;
     }
 
     /**
@@ -466,17 +526,23 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      */
     protected static function getFoo6Service($container)
     {
-        $instance = new \stdClass();
+        try {
+            $instance = new \stdClass();
 
-        if (isset($container->services['foo6'])) {
-            return $container->services['foo6'];
+            if (isset($container->services['foo6'])) {
+                return $container->services['foo6'];
+            }
+
+            $container->services['foo6'] = $instance;
+
+            $instance->bar6 = ($container->privates['bar6'] ?? self::getBar6Service($container));
+
+            return $instance;
+        } catch (\Throwable $e) {
+            unset($container->services['foo6']);
+
+            throw $e;
         }
-
-        $container->services['foo6'] = $instance;
-
-        $instance->bar6 = ($container->privates['bar6'] ?? self::getBar6Service($container));
-
-        return $instance;
     }
 
     /**
@@ -542,11 +608,11 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
     {
         $a = new \stdClass();
 
-        $container->services['foobar4'] = $instance = new \stdClass($a);
+        $instance = new \stdClass($a);
 
         $a->foobar = $instance;
 
-        return $instance;
+        return $container->services['foobar4'] = $instance;
     }
 
     /**
@@ -556,17 +622,23 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      */
     protected static function getListener3Service($container)
     {
-        $instance = new \stdClass();
+        try {
+            $instance = new \stdClass();
 
-        if (isset($container->services['listener3'])) {
-            return $container->services['listener3'];
+            if (isset($container->services['listener3'])) {
+                return $container->services['listener3'];
+            }
+
+            $container->services['listener3'] = $instance;
+
+            $instance->manager = ($container->services['manager3'] ?? self::getManager3Service($container));
+
+            return $instance;
+        } catch (\Throwable $e) {
+            unset($container->services['listener3']);
+
+            throw $e;
         }
-
-        $container->services['listener3'] = $instance;
-
-        $instance->manager = ($container->services['manager3'] ?? self::getManager3Service($container));
-
-        return $instance;
     }
 
     /**
@@ -598,23 +670,29 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      */
     protected static function getLoggerService($container)
     {
-        $a = ($container->services['connection'] ?? self::getConnectionService($container));
+        try {
+            $a = ($container->services['connection'] ?? self::getConnectionService($container));
 
-        if (isset($container->services['logger'])) {
-            return $container->services['logger'];
+            if (isset($container->services['logger'])) {
+                return $container->services['logger'];
+            }
+
+            $instance = new \stdClass($a);
+
+            if (isset($container->services['logger'])) {
+                return $container->services['logger'];
+            }
+
+            $container->services['logger'] = $instance;
+
+            $instance->handler = new \stdClass(($container->services['manager'] ?? self::getManagerService($container)));
+
+            return $instance;
+        } catch (\Throwable $e) {
+            unset($container->services['logger']);
+
+            throw $e;
         }
-
-        $instance = new \stdClass($a);
-
-        if (isset($container->services['logger'])) {
-            return $container->services['logger'];
-        }
-
-        $container->services['logger'] = $instance;
-
-        $instance->handler = new \stdClass(($container->services['manager'] ?? self::getManagerService($container)));
-
-        return $instance;
     }
 
     /**
@@ -773,11 +851,11 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      */
     protected static function getMonolog_LoggerService($container)
     {
-        $container->services['monolog.logger'] = $instance = new \stdClass();
+        $instance = new \stdClass();
 
         $instance->handler = ($container->services['mailer.transport'] ?? self::getMailer_TransportService($container));
 
-        return $instance;
+        return $container->services['monolog.logger'] = $instance;
     }
 
     /**
@@ -787,17 +865,23 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      */
     protected static function getMonolog_Logger2Service($container)
     {
-        $instance = new \stdClass();
+        try {
+            $instance = new \stdClass();
 
-        if (isset($container->services['monolog.logger_2'])) {
-            return $container->services['monolog.logger_2'];
+            if (isset($container->services['monolog.logger_2'])) {
+                return $container->services['monolog.logger_2'];
+            }
+
+            $container->services['monolog.logger_2'] = $instance;
+
+            $instance->handler = ($container->services['mailer.transport'] ?? self::getMailer_TransportService($container));
+
+            return $instance;
+        } catch (\Throwable $e) {
+            unset($container->services['monolog.logger_2']);
+
+            throw $e;
         }
-
-        $container->services['monolog.logger_2'] = $instance;
-
-        $instance->handler = ($container->services['mailer.transport'] ?? self::getMailer_TransportService($container));
-
-        return $instance;
     }
 
     /**
@@ -807,11 +891,11 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      */
     protected static function getMonologInline_LoggerService($container)
     {
-        $container->services['monolog_inline.logger'] = $instance = new \stdClass();
+        $instance = new \stdClass();
 
         $instance->handler = ($container->privates['mailer_inline.mailer'] ?? self::getMailerInline_MailerService($container));
 
-        return $instance;
+        return $container->services['monolog_inline.logger'] = $instance;
     }
 
     /**
@@ -821,11 +905,11 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      */
     protected static function getMonologInline_Logger2Service($container)
     {
-        $container->services['monolog_inline.logger_2'] = $instance = new \stdClass();
+        $instance = new \stdClass();
 
         $instance->handler = ($container->privates['mailer_inline.mailer'] ?? self::getMailerInline_MailerService($container));
 
-        return $instance;
+        return $container->services['monolog_inline.logger_2'] = $instance;
     }
 
     /**
@@ -862,17 +946,23 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      */
     protected static function getPBService($container)
     {
-        $instance = new \stdClass();
+        try {
+            $instance = new \stdClass();
 
-        if (isset($container->services['pB'])) {
-            return $container->services['pB'];
+            if (isset($container->services['pB'])) {
+                return $container->services['pB'];
+            }
+
+            $container->services['pB'] = $instance;
+
+            $instance->d = ($container->services['pD'] ?? self::getPDService($container));
+
+            return $instance;
+        } catch (\Throwable $e) {
+            unset($container->services['pB']);
+
+            throw $e;
         }
-
-        $container->services['pB'] = $instance;
-
-        $instance->d = ($container->services['pD'] ?? self::getPDService($container));
-
-        return $instance;
     }
 
     /**
@@ -882,17 +972,23 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
      */
     protected static function getPCService($container, $lazyLoad = true)
     {
-        $instance = new \stdClass();
+        try {
+            $instance = new \stdClass();
 
-        if (isset($container->services['pC'])) {
-            return $container->services['pC'];
+            if (isset($container->services['pC'])) {
+                return $container->services['pC'];
+            }
+
+            $container->services['pC'] = $instance;
+
+            $instance->d = ($container->services['pD'] ?? self::getPDService($container));
+
+            return $instance;
+        } catch (\Throwable $e) {
+            unset($container->services['pC']);
+
+            throw $e;
         }
-
-        $container->services['pC'] = $instance;
-
-        $instance->d = ($container->services['pD'] ?? self::getPDService($container));
-
-        return $instance;
     }
 
     /**
@@ -986,11 +1082,11 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Public extends Container
     {
         $a = new \Symfony\Component\DependencyInjection\Tests\Fixtures\FooForCircularWithAddCalls();
 
-        $container->privates['level5'] = $instance = new \stdClass($a);
+        $instance = new \stdClass($a);
 
         $a->call($instance);
 
-        return $instance;
+        return $container->privates['level5'] = $instance;
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_array_params.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_array_params.php
@@ -45,11 +45,11 @@ class ProjectServiceContainer extends Container
      */
     protected static function getBarService($container)
     {
-        $container->services['bar'] = $instance = new \BarClass();
+        $instance = new \BarClass();
 
         $instance->setBaz($container->parameters['array_1'], $container->parameters['array_2'], '%array_1%', $container->parameters['array_1']);
 
-        return $instance;
+        return $container->services['bar'] = $instance;
     }
 
     public function getParameter(string $name): array|bool|string|int|float|\UnitEnum|null

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_deep_graph.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_deep_graph.php
@@ -50,17 +50,23 @@ class Symfony_DI_PhpDumper_Test_Deep_Graph extends Container
      */
     protected static function getBarService($container)
     {
-        $instance = new \stdClass();
+        try {
+            $instance = new \stdClass();
 
-        if (isset($container->services['bar'])) {
-            return $container->services['bar'];
+            if (isset($container->services['bar'])) {
+                return $container->services['bar'];
+            }
+
+            $container->services['bar'] = $instance;
+
+            $instance->p5 = new \stdClass(($container->services['foo'] ?? self::getFooService($container)));
+
+            return $instance;
+        } catch (\Throwable $e) {
+            unset($container->services['bar']);
+
+            throw $e;
         }
-
-        $container->services['bar'] = $instance;
-
-        $instance->p5 = new \stdClass(($container->services['foo'] ?? self::getFooService($container)));
-
-        return $instance;
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_errored_definition.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_errored_definition.php
@@ -92,11 +92,11 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
      */
     protected static function getBARService($container)
     {
-        $container->services['BAR'] = $instance = new \stdClass();
+        $instance = new \stdClass();
 
         $instance->bar = ($container->services['bar'] ?? self::getBar3Service($container));
 
-        return $instance;
+        return $container->services['BAR'] = $instance;
     }
 
     /**
@@ -138,11 +138,11 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
     {
         $a = ($container->services['foo.baz'] ?? self::getFoo_BazService($container));
 
-        $container->services['bar'] = $instance = new \Bar\FooClass('foo', $a, 'foo_bar');
+        $instance = new \Bar\FooClass('foo', $a, 'foo_bar');
 
         $a->configure($instance);
 
-        return $instance;
+        return $container->services['bar'] = $instance;
     }
 
     /**
@@ -162,17 +162,23 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
      */
     protected static function getBazService($container)
     {
-        $instance = new \Baz();
+        try {
+            $instance = new \Baz();
 
-        if (isset($container->services['baz'])) {
-            return $container->services['baz'];
+            if (isset($container->services['baz'])) {
+                return $container->services['baz'];
+            }
+
+            $container->services['baz'] = $instance;
+
+            $instance->setFoo(($container->services['foo_with_inline'] ?? self::getFooWithInlineService($container)));
+
+            return $instance;
+        } catch (\Throwable $e) {
+            unset($container->services['baz']);
+
+            throw $e;
         }
-
-        $container->services['baz'] = $instance;
-
-        $instance->setFoo(($container->services['foo_with_inline'] ?? self::getFooWithInlineService($container)));
-
-        return $instance;
     }
 
     /**
@@ -182,14 +188,14 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
      */
     protected static function getConfiguredServiceService($container)
     {
-        $container->services['configured_service'] = $instance = new \stdClass();
+        $instance = new \stdClass();
 
         $a = new \ConfClass();
         $a->setFoo(($container->services['baz'] ?? self::getBazService($container)));
 
         $a->configureStdClass($instance);
 
-        return $instance;
+        return $container->services['configured_service'] = $instance;
     }
 
     /**
@@ -199,11 +205,11 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
      */
     protected static function getConfiguredServiceSimpleService($container)
     {
-        $container->services['configured_service_simple'] = $instance = new \stdClass();
+        $instance = new \stdClass();
 
         (new \ConfClass('bar'))->configureStdClass($instance);
 
-        return $instance;
+        return $container->services['configured_service_simple'] = $instance;
     }
 
     /**
@@ -269,7 +275,7 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
     {
         $a = ($container->services['foo.baz'] ?? self::getFoo_BazService($container));
 
-        $container->services['foo'] = $instance = \Bar\FooClass::getInstance('foo', $a, ['bar' => 'foo is bar', 'foobar' => 'bar'], true, $container);
+        $instance = \Bar\FooClass::getInstance('foo', $a, ['bar' => 'foo is bar', 'foobar' => 'bar'], true, $container);
 
         $instance->foo = 'bar';
         $instance->moo = $a;
@@ -278,7 +284,7 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
         $instance->initialize();
         sc_configure($instance);
 
-        return $instance;
+        return $container->services['foo'] = $instance;
     }
 
     /**
@@ -288,11 +294,11 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
      */
     protected static function getFoo_BazService($container)
     {
-        $container->services['foo.baz'] = $instance = \BazClass::getInstance();
+        $instance = \BazClass::getInstance();
 
         \BazClass::configureStatic1($instance);
 
-        return $instance;
+        return $container->services['foo.baz'] = $instance;
     }
 
     /**
@@ -316,21 +322,27 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
      */
     protected static function getFooWithInlineService($container)
     {
-        $instance = new \Foo();
+        try {
+            $instance = new \Foo();
 
-        if (isset($container->services['foo_with_inline'])) {
-            return $container->services['foo_with_inline'];
+            if (isset($container->services['foo_with_inline'])) {
+                return $container->services['foo_with_inline'];
+            }
+
+            $container->services['foo_with_inline'] = $instance;
+
+            $a = new \Bar();
+            $a->pub = 'pub';
+            $a->setBaz(($container->services['baz'] ?? self::getBazService($container)));
+
+            $instance->setBar($a);
+
+            return $instance;
+        } catch (\Throwable $e) {
+            unset($container->services['foo_with_inline']);
+
+            throw $e;
         }
-
-        $container->services['foo_with_inline'] = $instance;
-
-        $a = new \Bar();
-        $a->pub = 'pub';
-        $a->setBaz(($container->services['baz'] ?? self::getBazService($container)));
-
-        $instance->setBar($a);
-
-        return $instance;
     }
 
     /**
@@ -367,13 +379,13 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
     {
         include_once '%path%foo.php';
 
-        $container->services['method_call1'] = $instance = new \Bar\FooClass();
+        $instance = new \Bar\FooClass();
 
         $instance->setBar(($container->services['foo'] ?? self::getFooService($container)));
         $instance->setBar(NULL);
         $instance->setBar((($container->services['foo'] ?? self::getFooService($container))->foo() . (($container->hasParameter("foo")) ? ($container->getParameter("foo")) : ("default"))));
 
-        return $instance;
+        return $container->services['method_call1'] = $instance;
     }
 
     /**
@@ -386,11 +398,11 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
         $a = new \FactoryClass();
         $a->foo = 'bar';
 
-        $container->services['new_factory_service'] = $instance = $a->getInstance();
+        $instance = $a->getInstance();
 
         $instance->foo = 'bar';
 
-        return $instance;
+        return $container->services['new_factory_service'] = $instance;
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_inline_self_ref.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_inline_self_ref.php
@@ -48,10 +48,10 @@ class Symfony_DI_PhpDumper_Test_Inline_Self_Ref extends Container
         $b = new \App\Baz($a);
         $b->bar = $a;
 
-        $container->services['App\\Foo'] = $instance = new \App\Foo($b);
+        $instance = new \App\Foo($b);
 
         $a->foo = $instance;
 
-        return $instance;
+        return $container->services['App\\Foo'] = $instance;
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_locator.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_locator.php
@@ -120,11 +120,11 @@ class ProjectServiceContainer extends Container
      */
     protected static function getTranslator2Service($container)
     {
-        $container->services['translator_2'] = $instance = new \Symfony\Component\DependencyInjection\Tests\Fixtures\StubbedTranslator(new \Symfony\Component\DependencyInjection\ServiceLocator(['translator.loader_2' => #[\Closure(name: 'translator.loader_2', class: 'stdClass')] fn () => ($container->services['translator.loader_2'] ??= new \stdClass())]));
+        $instance = new \Symfony\Component\DependencyInjection\Tests\Fixtures\StubbedTranslator(new \Symfony\Component\DependencyInjection\ServiceLocator(['translator.loader_2' => #[\Closure(name: 'translator.loader_2', class: 'stdClass')] fn () => ($container->services['translator.loader_2'] ??= new \stdClass())]));
 
         $instance->addResource('db', ($container->services['translator.loader_2'] ??= new \stdClass()), 'nl');
 
-        return $instance;
+        return $container->services['translator_2'] = $instance;
     }
 
     /**
@@ -134,13 +134,13 @@ class ProjectServiceContainer extends Container
      */
     protected static function getTranslator3Service($container)
     {
-        $container->services['translator_3'] = $instance = new \Symfony\Component\DependencyInjection\Tests\Fixtures\StubbedTranslator(new \Symfony\Component\DependencyInjection\ServiceLocator(['translator.loader_3' => #[\Closure(name: 'translator.loader_3', class: 'stdClass')] fn () => ($container->services['translator.loader_3'] ??= new \stdClass())]));
+        $instance = new \Symfony\Component\DependencyInjection\Tests\Fixtures\StubbedTranslator(new \Symfony\Component\DependencyInjection\ServiceLocator(['translator.loader_3' => #[\Closure(name: 'translator.loader_3', class: 'stdClass')] fn () => ($container->services['translator.loader_3'] ??= new \stdClass())]));
 
         $a = ($container->services['translator.loader_3'] ??= new \stdClass());
 
         $instance->addResource('db', $a, 'nl');
         $instance->addResource('db', $a, 'en');
 
-        return $instance;
+        return $container->services['translator_3'] = $instance;
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_service_locator_argument.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_service_locator_argument.php
@@ -58,7 +58,7 @@ class Symfony_DI_PhpDumper_Service_Locator_Argument extends Container
      */
     protected static function getBarService($container)
     {
-        $container->services['bar'] = $instance = new \stdClass();
+        $instance = new \stdClass();
 
         $instance->locator = new \Symfony\Component\DependencyInjection\Argument\ServiceLocator($container->getService ??= $container->getService(...), [
             'foo1' => ['services', 'foo1', 'getFoo1Service', false],
@@ -74,7 +74,7 @@ class Symfony_DI_PhpDumper_Service_Locator_Argument extends Container
             'foo5' => '?',
         ]);
 
-        return $instance;
+        return $container->services['bar'] = $instance;
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_tsantos.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_tsantos.php
@@ -57,7 +57,7 @@ class ProjectServiceContainer extends Container
         $c = new \TSantos\Serializer\EventDispatcher\EventDispatcher();
         $c->addSubscriber(new \TSantos\SerializerBundle\EventListener\StopwatchListener(new \Symfony\Component\Stopwatch\Stopwatch(true)));
 
-        $container->services['tsantos_serializer'] = $instance = new \TSantos\Serializer\EventEmitterSerializer(new \TSantos\Serializer\Encoder\JsonEncoder(), $a, $c);
+        $instance = new \TSantos\Serializer\EventEmitterSerializer(new \TSantos\Serializer\Encoder\JsonEncoder(), $a, $c);
 
         $b->setSerializer($instance);
         $d = new \TSantos\Serializer\Normalizer\JsonNormalizer();
@@ -67,6 +67,6 @@ class ProjectServiceContainer extends Container
         $a->add($b);
         $a->add($d);
 
-        return $instance;
+        return $container->services['tsantos_serializer'] = $instance;
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_uninitialized_ref.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_uninitialized_ref.php
@@ -53,7 +53,7 @@ class Symfony_DI_PhpDumper_Test_Uninitialized_Reference extends Container
      */
     protected static function getBarService($container)
     {
-        $container->services['bar'] = $instance = new \stdClass();
+        $instance = new \stdClass();
 
         $instance->foo1 = ($container->services['foo1'] ?? null);
         $instance->foo2 = null;
@@ -71,7 +71,7 @@ class Symfony_DI_PhpDumper_Test_Uninitialized_Reference extends Container
             }
         }, fn () => 0 + (int) (isset($container->services['foo1'])) + (int) (false) + (int) (isset($container->privates['foo3'])));
 
-        return $instance;
+        return $container->services['bar'] = $instance;
     }
 
     /**
@@ -81,11 +81,11 @@ class Symfony_DI_PhpDumper_Test_Uninitialized_Reference extends Container
      */
     protected static function getBazService($container)
     {
-        $container->services['baz'] = $instance = new \stdClass();
+        $instance = new \stdClass();
 
         $instance->foo3 = ($container->privates['foo3'] ??= new \stdClass());
 
-        return $instance;
+        return $container->services['baz'] = $instance;
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_wither.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_wither.php
@@ -56,9 +56,9 @@ class Symfony_DI_PhpDumper_Service_Wither extends Container
         $a = $a->cloneFoo();
 
         $instance = $instance->withFoo1($a);
-        $container->services['wither'] = $instance = $instance->withFoo2($a);
+        $instance = $instance->withFoo2($a);
         $instance->setFoo($a);
 
-        return $instance;
+        return $container->services['wither'] = $instance;
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_wither_annotation.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_wither_annotation.php
@@ -56,9 +56,9 @@ class Symfony_DI_PhpDumper_Service_Wither_Annotation extends Container
         $a = $a->cloneFoo();
 
         $instance = $instance->withFoo1($a);
-        $container->services['wither'] = $instance = $instance->withFoo2($a);
+        $instance = $instance->withFoo2($a);
         $instance->setFoo($a);
 
-        return $instance;
+        return $container->services['wither'] = $instance;
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_wither_staticreturntype.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_wither_staticreturntype.php
@@ -54,9 +54,9 @@ class Symfony_DI_PhpDumper_Service_WitherStaticReturnType extends Container
 
         $a = new \Symfony\Component\DependencyInjection\Tests\Compiler\Foo();
 
-        $container->services['wither'] = $instance = $instance->withFoo($a);
+        $instance = $instance->withFoo($a);
         $instance->setFoo($a);
 
-        return $instance;
+        return $container->services['wither'] = $instance;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Shared services are cached before their properties, method calls and configurator run _(this early sharing is what makes circular setter injection work)_. But when that setup throws, the half-configured instance stayed in the cache: the first `get()` reported the exception, while a second `get()` silently returned the broken service.

```php
$container->register('foo', Foo::class)->addMethodCall('setUp'); // setUp() throws

try { $container->get('foo'); } catch (\Exception $e) {} // reports the failure
$container->get('foo'); // returned the partially-configured Foo instead of failing again
```

This affected `ContainerBuilder` for every failure type, and dumped containers for `\Error`/`TypeError` failures and for private services (whose generated getters are called directly, bypassing the existing `Container::make()` cleanup).

This PR makes those services construction atomic.
