### PR TITLE
[Tui] Keep ANSI codes ordered when slicing across a color change

### DIFF
--- a/src/Symfony/Component/Tui/Ansi/AnsiUtils.php
+++ b/src/Symfony/Component/Tui/Ansi/AnsiUtils.php
@@ -362,6 +362,13 @@ final class AnsiUtils
                     if ($j < $lineLen && \ord($line[$j]) >= 0x40 && \ord($line[$j]) <= 0x7E) {
                         $code = substr($line, $i, $j + 1 - $i);
                         if ($currentCol >= $startCol && $currentCol < $endCol) {
+                            // Flush first: pendingAnsi holds codes seen before startCol and must
+                            // stay ahead of any code encountered once we're inside the range, or
+                            // the active state at this column ends up reversed.
+                            if ('' !== $pendingAnsi) {
+                                $result .= $pendingAnsi;
+                                $pendingAnsi = '';
+                            }
                             $result .= $code;
                         } elseif ($currentCol < $startCol) {
                             $pendingAnsi .= $code;
@@ -373,6 +380,10 @@ final class AnsiUtils
                 $ansi = self::extractAnsiCode($line, $i);
                 if (null !== $ansi) {
                     if ($currentCol >= $startCol && $currentCol < $endCol) {
+                        if ('' !== $pendingAnsi) {
+                            $result .= $pendingAnsi;
+                            $pendingAnsi = '';
+                        }
                         $result .= $ansi['code'];
                     } elseif ($currentCol < $startCol) {
                         $pendingAnsi .= $ansi['code'];

--- a/src/Symfony/Component/Tui/Tests/Ansi/AnsiUtilsTest.php
+++ b/src/Symfony/Component/Tui/Tests/Ansi/AnsiUtilsTest.php
@@ -212,6 +212,24 @@ class AnsiUtilsTest extends TestCase
         $this->assertSame(3, AnsiUtils::visibleWidth($result));
     }
 
+    public function testSliceByColumnPreservesCodeOrderWhenAColorChangeLandsOnStartColumn()
+    {
+        // "AA" red, "BB" blue: slicing from column 1 crosses into the pending-before-start red
+        // code (column 0) and the in-range blue code (starts exactly at column 1). The pending
+        // code must stay ordered before the in-range one, or the wrong color ends up active.
+        $line = "\x1b[31mA\x1b[34mABB\x1b[0m";
+
+        $result = AnsiUtils::sliceByColumn($line, 1, 1);
+
+        $redPos = strpos($result, "\x1b[31m");
+        $bluePos = strpos($result, "\x1b[34m");
+
+        $this->assertNotFalse($redPos);
+        $this->assertNotFalse($bluePos);
+        $this->assertLessThan($bluePos, $redPos, 'The pending (earlier) color code must appear before the in-range (later) one, so blue is the last -- and therefore active -- code.');
+        $this->assertSame('A', AnsiUtils::stripAnsiCodes($result));
+    }
+
     /**
      * @return iterable<string, array{string, bool}>
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`AnsiUtils::sliceByColumn()` collects the ANSI codes it sees before the start column and emits them once it reaches the range, but it emitted them *after* any code found inside the range. When a color change lands exactly on the start column, the two come out in the wrong order, so the last code standing is the one that should have been left behind and the slice renders in the wrong color.

```php
// "A" red, then blue from column 1 on
$line = "\x1b[31mA\x1b[34mABB\x1b[0m";

AnsiUtils::sliceByColumn($line, 1, 1);
// the red code was emitted after the blue one, so red stayed active
```

Extracted from #65130, where every transition slices lines this way and hits it. It stands on its own, so it is here as a separate bug fix.

Found by @smnandre, patch is his.
