### PR TITLE
[Tui] Add attachChild() and detachChild() to AbstractWidget

### DIFF
--- a/src/Symfony/Component/Tui/CHANGELOG.md
+++ b/src/Symfony/Component/Tui/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add `AbstractWidget::attachChild()` and `AbstractWidget::detachChild()` to wire child widgets
+
 8.1
 ---
 

--- a/src/Symfony/Component/Tui/Tests/Widget/ChildWidgetTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/ChildWidgetTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Tests\Widget;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Tui\Render\RenderContext;
+use Symfony\Component\Tui\Widget\AbstractWidget;
+use Symfony\Component\Tui\Widget\TextWidget;
+
+class ChildWidgetTest extends TestCase
+{
+    public function testAttachChildSetsTheParent()
+    {
+        $parent = new ChildWidgetTest_Owner();
+        $child = new TextWidget('child');
+
+        $this->assertNull($child->getParent());
+
+        $parent->own($child);
+
+        $this->assertSame($parent, $child->getParent());
+    }
+
+    public function testDetachChildClearsTheParent()
+    {
+        $parent = new ChildWidgetTest_Owner();
+        $child = new TextWidget('child');
+
+        $parent->own($child);
+        $parent->release($child);
+
+        $this->assertNull($child->getParent());
+    }
+
+    public function testChildrenCanBeWiredBeforeTheOwnerIsAttached()
+    {
+        $parent = new ChildWidgetTest_Owner();
+        $child = new TextWidget('child');
+
+        $this->assertNull($parent->getContext());
+
+        $parent->own($child);
+        $parent->release($child);
+
+        $this->addToAssertionCount(1);
+    }
+}
+
+class ChildWidgetTest_Owner extends AbstractWidget
+{
+    public function own(AbstractWidget $child): void
+    {
+        $this->attachChild($child);
+    }
+
+    public function release(AbstractWidget $child): void
+    {
+        $this->detachChild($child);
+    }
+
+    public function render(RenderContext $context): array
+    {
+        return [];
+    }
+}

--- a/src/Symfony/Component/Tui/Widget/AbstractWidget.php
+++ b/src/Symfony/Component/Tui/Widget/AbstractWidget.php
@@ -388,6 +388,28 @@ abstract class AbstractWidget
     abstract public function render(RenderContext $context): array;
 
     /**
+     * Makes a widget a child of this one, so it takes part in the render tree.
+     *
+     * Call it from a widget that owns other widgets, once the child is stored.
+     * It is safe to call before this widget is attached itself: the child joins
+     * the context along with its parent.
+     */
+    final protected function attachChild(self $child): void
+    {
+        $child->setParent($this);
+        $this->getContext()?->attachChild($this, $child);
+    }
+
+    /**
+     * Releases a widget previously passed to attachChild().
+     */
+    final protected function detachChild(self $child): void
+    {
+        $child->setParent(null);
+        $this->getContext()?->detachChild($child);
+    }
+
+    /**
      * @internal
      */
     final protected function setParent(?self $parent): void

--- a/src/Symfony/Component/Tui/Widget/ContainerWidget.php
+++ b/src/Symfony/Component/Tui/Widget/ContainerWidget.php
@@ -51,13 +51,9 @@ class ContainerWidget extends AbstractWidget implements WidgetContainerInterface
      */
     public function add(AbstractWidget $widget): static
     {
-        $widget->setParent($this);
         $this->children[] = $widget;
+        $this->attachChild($widget);
         $this->invalidate();
-
-        if (null !== $this->getContext()) {
-            $this->getContext()->attachChild($this, $widget);
-        }
 
         return $this;
     }
@@ -68,11 +64,7 @@ class ContainerWidget extends AbstractWidget implements WidgetContainerInterface
     public function remove(AbstractWidget $widget): static
     {
         if (false !== $index = array_search($widget, $this->children, true)) {
-            $child = $this->children[$index];
-            $child->setParent(null);
-            if (null !== $this->getContext()) {
-                $this->getContext()->detachChild($child);
-            }
+            $this->detachChild($this->children[$index]);
             array_splice($this->children, $index, 1);
             $this->invalidate();
         }
@@ -88,10 +80,7 @@ class ContainerWidget extends AbstractWidget implements WidgetContainerInterface
     public function clear(): static
     {
         foreach ($this->children as $child) {
-            $child->setParent(null);
-            if (null !== $this->getContext()) {
-                $this->getContext()->detachChild($child);
-            }
+            $this->detachChild($child);
         }
         if ($this->children) {
             $this->children = [];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Writing a widget that owns other widgets means putting each child in the render tree. That took two calls, both marked `@internal`:

```php
$child->setParent($this);                       // @internal
$this->getContext()?->attachChild($this, $child); // @internal
```

`ContainerWidget` and `SettingsListWidget` each spell it out by hand, and anything outside the component had to reach for the same internals. This adds the pair that does it:

```php
final protected function attachChild(AbstractWidget $child): void;
final protected function detachChild(AbstractWidget $child): void;
```

They are safe to call before the owner is attached: the children join the context along with their parent. `ContainerWidget` now uses them, which is where the 14 removed lines come from.

This is the piece missing for writing a container widget outside Tui, which came up while reviewing #65130.

### Documentation

Points a symfony-docs pull request should carry:

- A widget owning other widgets calls `attachChild()` once the child is stored, and `detachChild()` when it is dropped.
- Ordering does not matter: children can be wired before the owner is attached.
- `setParent()` and `WidgetContext::attachChild()` stay internal.

### Note

`SettingsListWidget` attaches its submenu to the tree without setting the parent, unlike `ContainerWidget`. It is left alone here since converting it would change behavior rather than just the spelling, but it looks unintended.
