### PR TITLE
[HttpClient] Fix `GuzzleHttpHandler` crashing with `guzzlehttp/guzzle` ^8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -140,7 +140,7 @@
         "doctrine/orm": "^3.4",
         "dragonmantank/cron-expression": "^3.1",
         "egulias/email-validator": "^2.1.10|^3.1|^4",
-        "guzzlehttp/guzzle": "^7.10",
+        "guzzlehttp/guzzle": "^7.10|^8.0",
         "jolicode/jolinotif": "^2.7.2|^3.0",
         "jsonpath-standard/jsonpath-compliance-test-suite": "*",
         "league/commonmark": "^2.9",

--- a/src/Symfony/Component/HttpClient/GuzzleHttpHandler.php
+++ b/src/Symfony/Component/HttpClient/GuzzleHttpHandler.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\HttpClient;
 
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\ResponseException;
 use GuzzleHttp\Promise\Promise;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Promise\Utils as PromiseUtils;
@@ -196,7 +197,7 @@ final class GuzzleHttpHandler
                             [$guzzleRequest, , $promise] = $this->pending[$response];
                             unset($this->pending[$response], $this->psr7Responses[$response]);
                             $this->fireOnStats($guzzleOpts, $guzzleRequest, $psrResponse, $e, $response);
-                            $promise->reject(new RequestException($e->getMessage(), $guzzleRequest, $psrResponse, $e));
+                            $promise->reject($this->createRequestException($e->getMessage(), $guzzleRequest, $psrResponse, $e));
 
                             $response->cancel();
                         }
@@ -275,12 +276,24 @@ final class GuzzleHttpHandler
             }
 
             $this->fireOnStats($options, $guzzleRequest, $psrResponse, $e, $response);
-            $promise->reject(new RequestException($e->getMessage(), $guzzleRequest, $psrResponse, $e));
+            $promise->reject($this->createRequestException($e->getMessage(), $guzzleRequest, $psrResponse, $e));
         } else {
             // No headers received: connection-level failure.
             $this->fireOnStats($options, $guzzleRequest, null, $e, $response);
-            $promise->reject(new ConnectException($e->getMessage(), $guzzleRequest, null, [], $e));
+            $promise->reject(new ConnectException($e->getMessage(), $guzzleRequest, $e));
         }
+    }
+
+    /**
+     * Builds a Guzzle exception carrying a response, bridging the constructor
+     * signature change between Guzzle 7 (response on RequestException) and
+     * Guzzle 8 (response moved to the new ResponseException subclass).
+     */
+    private function createRequestException(string $message, RequestInterface $guzzleRequest, ResponseInterface $psrResponse, \Throwable $previous): RequestException
+    {
+        return class_exists(ResponseException::class)
+            ? new ResponseException($message, $guzzleRequest, $psrResponse, $previous)
+            : new RequestException($message, $guzzleRequest, $psrResponse, $previous);
     }
 
     private function fireOnStats(array $options, RequestInterface $request, ?ResponseInterface $psrResponse, ?\Throwable $error, SymfonyResponseInterface $symfonyResponse): void

--- a/src/Symfony/Component/HttpClient/Tests/GuzzleHttpHandlerTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/GuzzleHttpHandlerTest.php
@@ -510,6 +510,26 @@ class GuzzleHttpHandlerTest extends TestCase
         }
     }
 
+    public function testMidStreamTransportErrorRejectsWithRequestException()
+    {
+        $client = new MockHttpClient(static fn () => new MockResponse((static function (): \Generator {
+            yield 'partial body';
+            yield new \RuntimeException('Connection reset by peer');
+        })(), ['http_code' => 200]));
+        $handler = new GuzzleHttpHandler($client);
+
+        $promise = $handler(new Request('GET', 'https://example.com/'), []);
+
+        try {
+            $promise->wait();
+            $this->fail('Expected RequestException');
+        } catch (RequestException $e) {
+            $this->assertSame('Connection reset by peer', $e->getMessage());
+            $this->assertNotNull($e->getResponse());
+            $this->assertSame(200, $e->getResponse()->getStatusCode());
+        }
+    }
+
     // -- Async / concurrency --------------------------------------------------
 
     public function testInvokeReturnsPendingPromise()

--- a/src/Symfony/Component/HttpClient/composer.json
+++ b/src/Symfony/Component/HttpClient/composer.json
@@ -31,7 +31,7 @@
     "require-dev": {
         "amphp/http-client": "^5.3.2",
         "amphp/http-tunnel": "^2.0",
-        "guzzlehttp/guzzle": "^7.10",
+        "guzzlehttp/guzzle": "^7.10|^8.0",
         "nyholm/psr7": "^1.0",
         "php-http/httplug": "^1.0|^2.0",
         "psr/http-client": "^1.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1 <!-- GuzzleHttpHandler was introduced in 8.1; fix targets the lowest maintained branch that has the bug -->
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #-
| License       | MIT

## Problem

Since `guzzlehttp/guzzle` 8.0, `GuzzleHttpHandler` throws a fatal `TypeError` as soon
as a request fails after its response headers have already been received (e.g. a
connection reset mid-stream, or an exception thrown from an `on_headers` callback):

```
TypeError: GuzzleHttp\Exception\RequestException::__construct(): Argument #3 ($code) must be of type int, GuzzleHttp\Psr7\Response given, called in /var/www/html/vendor/symfony/http-client/GuzzleHttpHandler.php on line 278
#0 /vendor/guzzlehttp/guzzle/src/Exception/RequestException.php(22): GuzzleHttp\Exception\RequestException::__construct
#1 /vendor/symfony/http-client/GuzzleHttpHandler.php(278): Symfony\Component\HttpClient\GuzzleHttpHandler::rejectResponse
#2 /vendor/symfony/http-client/GuzzleHttpHandler.php(227): Symfony\Component\HttpClient\GuzzleHttpHandler::streamPending
#3 /vendor/symfony/http-client/GuzzleHttpHandler.php(103): Symfony\Component\HttpClient\GuzzleHttpHandler::{closure:Symfony\Component\HttpClient\GuzzleHttpHandler::__invoke():102}
#4 /vendor/guzzlehttp/promises/src/Promise.php(293): GuzzleHttp\Promise\Promise::invokeWaitFn
#5 /vendor/guzzlehttp/promises/src/Promise.php(269): GuzzleHttp\Promise\Promise::waitIfPending
#6 /vendor/guzzlehttp/promises/src/Promise.php(314): GuzzleHttp\Promise\Promise::invokeWaitList
#7 /vendor/guzzlehttp/promises/src/Promise.php(271): GuzzleHttp\Promise\Promise::waitIfPending
#8 /vendor/guzzlehttp/promises/src/Promise.php(109): GuzzleHttp\Promise\Promise::wait
#9 /vendor/guzzlehttp/guzzle/src/Client.php(656): GuzzleHttp\Client::request
#10 /vendor/guzzlehttp/guzzle/src/ClientTrait.php(202): GuzzleHttp\Client::get
```

## Cause

Guzzle 8 changed the constructor signatures of `RequestException` and
`ConnectException`:

* `RequestException::__construct(string $message, RequestInterface $request, ?ResponseInterface $response, ?\Throwable $previous, array $handlerContext)` (Guzzle 7)
  became
  `RequestException::__construct(string $message, RequestInterface $request, int $code = 0, ?\Throwable $previous = null)` (Guzzle 8) — the response is no longer
  accepted by the base class at all; it moved to the new `ResponseException`
  subclass (`ResponseException::__construct(string $message, RequestInterface $request, ResponseInterface $response, ?\Throwable $previous = null)`).
* `ConnectException` similarly dropped its `$response`/`$handlerContext` constructor
  parameters in Guzzle 8.

`GuzzleHttpHandler` still called the old Guzzle 7 signatures, so a `Response`
instance ended up in the new `int $code` slot, producing the `TypeError` above.
The `ConnectException` call site had a related, pre-existing bug: it passed 5
arguments to a 4-parameter (Guzzle 7) / 3-parameter (Guzzle 8) constructor, so the
`$previous` exception was silently dropped and never chained (not fatal, but it
broke exception chaining for connection-level failures).

## Fix

* Added a small `createRequestException()` helper that builds a
  `GuzzleHttp\Exception\ResponseException` when it exists (Guzzle ≥8), or falls
  back to the old `RequestException` constructor otherwise (Guzzle 7), and used it
  at both call sites that reject a promise with a response present.
* Fixed the `ConnectException` call to pass `$previous` correctly
  (`new ConnectException($e->getMessage(), $guzzleRequest, $e)`), which is valid on
  both Guzzle 7 and 8 and restores proper exception chaining.
* Widened the `guzzlehttp/guzzle` require-dev constraint to `^7.10|^8.0`.
* Added a regression test (`testMidStreamTransportErrorRejectsWithRequestException`)
  that simulates a transport error occurring after the response headers/first chunk
  were already received — the exact scenario that crashed.

## Testing

Verified against the real published packages (not just reasoning from source):

* Reproduced the exact reported `TypeError` using the unmodified
  `symfony/http-client:8.1.3` + `guzzlehttp/guzzle:8.0.2` from Packagist.
* Applied the fix and re-ran the full `GuzzleHttpHandlerTest` suite (65 tests / 116
  assertions) against:
  * `guzzlehttp/guzzle:^8.0` (`8.0.2`) — all green, including the new regression
    test.
  * `guzzlehttp/guzzle:^7.10` (`7.15.3`) — all green, no regression.
