### PR TITLE
[Notifier] Add the Threads bridge

### DIFF
--- a/splitsh.json
+++ b/splitsh.json
@@ -151,6 +151,7 @@
         "telegram-notifier": "src/Symfony/Component/Notifier/Bridge/Telegram",
         "telnyx-notifier": "src/Symfony/Component/Notifier/Bridge/Telnyx",
         "termii-notifier": "src/Symfony/Component/Notifier/Bridge/Termii",
+        "threads-notifier": "src/Symfony/Component/Notifier/Bridge/Threads",
         "turbo-sms-notifier": "src/Symfony/Component/Notifier/Bridge/TurboSms",
         "twilio-notifier": "src/Symfony/Component/Notifier/Bridge/Twilio",
         "twitter-notifier": "src/Symfony/Component/Notifier/Bridge/Twitter",

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -3320,6 +3320,7 @@ class FrameworkExtension extends Extension
             NotifierBridge\Telegram\TelegramTransportFactory::class => ['symfony/telegram-notifier', 'notifier.transport_factory.telegram'],
             NotifierBridge\Telnyx\TelnyxTransportFactory::class => ['symfony/telnyx-notifier', 'notifier.transport_factory.telnyx'],
             NotifierBridge\Termii\TermiiTransportFactory::class => ['symfony/termii-notifier', 'notifier.transport_factory.termii'],
+            NotifierBridge\Threads\ThreadsTransportFactory::class => ['symfony/threads-notifier', 'notifier.transport_factory.threads'],
             NotifierBridge\TurboSms\TurboSmsTransportFactory::class => ['symfony/turbo-sms-notifier', 'notifier.transport_factory.turbo-sms'],
             NotifierBridge\Twilio\TwilioTransportFactory::class => ['symfony/twilio-notifier', 'notifier.transport_factory.twilio'],
             NotifierBridge\Twitter\TwitterTransportFactory::class => ['symfony/twitter-notifier', 'notifier.transport_factory.twitter'],

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/notifier_transports.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/notifier_transports.php
@@ -45,6 +45,7 @@ return static function (ContainerConfigurator $container) {
         'rocket-chat' => Bridge\RocketChat\RocketChatTransportFactory::class,
         'slack' => Bridge\Slack\SlackTransportFactory::class,
         'telegram' => Bridge\Telegram\TelegramTransportFactory::class,
+        'threads' => Bridge\Threads\ThreadsTransportFactory::class,
         'twitter' => Bridge\Twitter\TwitterTransportFactory::class,
         'whats-app' => Bridge\WhatsApp\WhatsAppTransportFactory::class,
         'zendesk' => Bridge\Zendesk\ZendeskTransportFactory::class,

--- a/src/Symfony/Component/Notifier/Bridge/Threads/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/Threads/.gitattributes
@@ -1,0 +1,3 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/Threads/.gitignore
+++ b/src/Symfony/Component/Notifier/Bridge/Threads/.gitignore
@@ -1,0 +1,3 @@
+vendor/
+composer.lock
+phpunit.xml

--- a/src/Symfony/Component/Notifier/Bridge/Threads/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Threads/CHANGELOG.md
@@ -1,0 +1,7 @@
+CHANGELOG
+=========
+
+8.2
+---
+
+ * Add the bridge

--- a/src/Symfony/Component/Notifier/Bridge/Threads/LICENSE
+++ b/src/Symfony/Component/Notifier/Bridge/Threads/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2026-present Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Symfony/Component/Notifier/Bridge/Threads/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/Threads/README.md
@@ -1,0 +1,49 @@
+Threads Notifier
+================
+
+Provides [Threads API](https://developers.facebook.com/docs/threads/posts/)
+integration for Symfony Notifier, as a `Chatter` transport.
+
+DSN example
+-----------
+
+```
+THREADS_DSN=threads://ACCESS_TOKEN@default?user_id=THREADS_USER_ID&api_version=v1.0
+```
+
+where:
+
+- `ACCESS_TOKEN` is a Threads user access token
+- `THREADS_USER_ID` is the Threads user id
+- `api_version` is optional (defaults to `v1.0`)
+- `poll_attempts` is optional (defaults to `30`): how many times an image or video
+  container is checked before giving up
+- `poll_delay` is optional (defaults to `2`): seconds between two checks
+
+Sending a text post
+-------------------
+
+```php
+use Symfony\Component\Notifier\Message\ChatMessage;
+
+$chatter->send(new ChatMessage('Hello from Threads'));
+```
+
+Image / video (public HTTPS URL required):
+
+```php
+use Symfony\Component\Notifier\Bridge\Threads\ThreadsOptions;
+use Symfony\Component\Notifier\Message\ChatMessage;
+
+$options = (new ThreadsOptions())->imageUrl('https://example.com/photo.jpg');
+
+$chatter->send((new ChatMessage('Caption'))->options($options));
+```
+
+Resources
+---------
+
+- [Contributing](https://symfony.com/doc/current/contributing/index.html)
+- [Report issues](https://github.com/symfony/symfony/issues) and
+  [send Pull Requests](https://github.com/symfony/symfony/pulls)
+  in the [main Symfony repository](https://github.com/symfony/symfony)

--- a/src/Symfony/Component/Notifier/Bridge/Threads/Tests/ThreadsOptionsTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Threads/Tests/ThreadsOptionsTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Threads\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Notifier\Bridge\Threads\ThreadsOptions;
+
+/**
+ * @author Mathieu Ledru <matyo91@gmail.com>
+ */
+final class ThreadsOptionsTest extends TestCase
+{
+    public function testGetRecipientIdIsAlwaysNull()
+    {
+        self::assertNull((new ThreadsOptions())->getRecipientId());
+        self::assertNull((new ThreadsOptions())->imageUrl('https://example.com/a.jpg')->getRecipientId());
+    }
+
+    public function testImageUrlSetsMediaType()
+    {
+        $options = (new ThreadsOptions())->imageUrl('https://example.com/a.jpg');
+
+        self::assertSame(ThreadsOptions::MEDIA_TYPE_IMAGE, $options->getMediaType());
+        self::assertSame('https://example.com/a.jpg', $options->getImageUrl());
+        self::assertSame([
+            'media_type' => 'IMAGE',
+            'image_url' => 'https://example.com/a.jpg',
+        ], $options->toArray());
+    }
+
+    public function testVideoUrlSetsMediaType()
+    {
+        $options = (new ThreadsOptions())->videoUrl('https://example.com/a.mp4');
+
+        self::assertSame(ThreadsOptions::MEDIA_TYPE_VIDEO, $options->getMediaType());
+        self::assertSame('https://example.com/a.mp4', $options->getVideoUrl());
+        self::assertSame([
+            'media_type' => 'VIDEO',
+            'video_url' => 'https://example.com/a.mp4',
+        ], $options->toArray());
+    }
+
+    public function testDefaultToArray()
+    {
+        self::assertSame(['media_type' => 'TEXT'], (new ThreadsOptions())->toArray());
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Threads/Tests/ThreadsTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Threads/Tests/ThreadsTransportFactoryTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Threads\Tests;
+
+use Symfony\Component\Notifier\Bridge\Threads\ThreadsTransportFactory;
+use Symfony\Component\Notifier\Test\AbstractTransportFactoryTestCase;
+use Symfony\Component\Notifier\Test\IncompleteDsnTestTrait;
+use Symfony\Component\Notifier\Test\MissingRequiredOptionTestTrait;
+
+/**
+ * @author Mathieu Ledru <matyo91@gmail.com>
+ */
+final class ThreadsTransportFactoryTest extends AbstractTransportFactoryTestCase
+{
+    use IncompleteDsnTestTrait;
+    use MissingRequiredOptionTestTrait;
+
+    public function createFactory(): ThreadsTransportFactory
+    {
+        return new ThreadsTransportFactory();
+    }
+
+    public static function createProvider(): iterable
+    {
+        yield [
+            'threads://graph.threads.net?user_id=1234567890&api_version=v1.0',
+            'threads://token@default?user_id=1234567890',
+        ];
+    }
+
+    public static function supportsProvider(): iterable
+    {
+        yield [true, 'threads://token@host.test?user_id=1234567890'];
+        yield [false, 'somethingElse://token@host.test?user_id=1234567890'];
+    }
+
+    public static function unsupportedSchemeProvider(): iterable
+    {
+        yield ['somethingElse://token@host.test?user_id=1234567890'];
+    }
+
+    public static function incompleteDsnProvider(): iterable
+    {
+        yield 'missing token' => ['threads://host.test?user_id=1234567890'];
+    }
+
+    public static function missingRequiredOptionProvider(): iterable
+    {
+        yield 'missing option: user_id' => ['threads://token@host.test'];
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Threads/Tests/ThreadsTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Threads/Tests/ThreadsTransportTest.php
@@ -1,0 +1,195 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Threads\Tests;
+
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\Notifier\Bridge\Threads\ThreadsOptions;
+use Symfony\Component\Notifier\Bridge\Threads\ThreadsTransport;
+use Symfony\Component\Notifier\Exception\TransportException;
+use Symfony\Component\Notifier\Message\ChatMessage;
+use Symfony\Component\Notifier\Message\SentMessage;
+use Symfony\Component\Notifier\Message\SmsMessage;
+use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * @author Mathieu Ledru <matyo91@gmail.com>
+ */
+final class ThreadsTransportTest extends TransportTestCase
+{
+    public static function createTransport(?HttpClientInterface $client = null, int $pollAttempts = ThreadsTransport::POLL_ATTEMPTS): ThreadsTransport
+    {
+        return new ThreadsTransport('threads-access-token', '1234567890', 'v1.0', $client ?? new MockHttpClient(), null, $pollAttempts, 0.0);
+    }
+
+    public static function toStringProvider(): iterable
+    {
+        yield ['threads://graph.threads.net?user_id=1234567890&api_version=v1.0', self::createTransport()];
+    }
+
+    public static function supportedMessagesProvider(): iterable
+    {
+        yield [new ChatMessage('Hello!')];
+        yield [new ChatMessage('Hello!', (new ThreadsOptions())->imageUrl('https://example.com/a.jpg'))];
+    }
+
+    public static function unsupportedMessagesProvider(): iterable
+    {
+        yield [new SmsMessage('0611223344', 'Hello!')];
+    }
+
+    public function testSendTextCreatesContainerAndPublishes()
+    {
+        $request = 0;
+        $client = new MockHttpClient(static function (string $method, string $url, array $options) use (&$request): MockResponse {
+            ++$request;
+            self::assertSame('POST', $method);
+            self::assertContains('Authorization: Bearer threads-access-token', $options['headers']);
+            parse_str($options['body'], $body);
+            self::assertArrayNotHasKey('access_token', $body);
+
+            if (1 === $request) {
+                self::assertSame('https://graph.threads.net/v1.0/1234567890/threads', $url);
+                self::assertSame('TEXT', $body['media_type'] ?? null);
+                self::assertSame('Hello Threads', $body['text'] ?? null);
+
+                return new MockResponse(json_encode(['id' => 'container-1'], \JSON_THROW_ON_ERROR));
+            }
+
+            self::assertSame('https://graph.threads.net/v1.0/1234567890/threads_publish', $url);
+            self::assertSame('container-1', $body['creation_id'] ?? null);
+
+            return new MockResponse(json_encode(['id' => 'post-99'], \JSON_THROW_ON_ERROR));
+        });
+
+        $sentMessage = self::createTransport($client)->send(new ChatMessage('Hello Threads'));
+
+        self::assertInstanceOf(SentMessage::class, $sentMessage);
+        self::assertSame('post-99', $sentMessage->getMessageId());
+        self::assertSame(2, $request);
+    }
+
+    public function testSendImagePollsThenPublishes()
+    {
+        $request = 0;
+        $client = new MockHttpClient(static function (string $method, string $url, array $options) use (&$request): MockResponse {
+            ++$request;
+            self::assertContains('Authorization: Bearer threads-access-token', $options['headers']);
+
+            if (1 === $request) {
+                parse_str($options['body'], $body);
+                self::assertSame('IMAGE', $body['media_type'] ?? null);
+                self::assertSame('https://cdn.example.com/a.jpg', $body['image_url'] ?? null);
+                self::assertArrayNotHasKey('access_token', $body);
+
+                return new MockResponse(json_encode(['id' => 'container-img'], \JSON_THROW_ON_ERROR));
+            }
+
+            if (2 === $request) {
+                self::assertSame('GET', $method);
+                self::assertStringContainsString('/container-img?', $url);
+
+                return new MockResponse(json_encode(['id' => 'container-img', 'status' => 'FINISHED'], \JSON_THROW_ON_ERROR));
+            }
+
+            parse_str($options['body'], $body);
+            self::assertSame('container-img', $body['creation_id'] ?? null);
+
+            return new MockResponse(json_encode(['id' => 'post-img'], \JSON_THROW_ON_ERROR));
+        });
+
+        $message = (new ChatMessage('With image'))->options((new ThreadsOptions())->imageUrl('https://cdn.example.com/a.jpg'));
+        $sentMessage = self::createTransport($client)->send($message);
+
+        self::assertSame('post-img', $sentMessage->getMessageId());
+        self::assertSame(3, $request);
+    }
+
+    public function testSendRetriesUntilTheContainerIsReady()
+    {
+        $statusCalls = 0;
+        $client = new MockHttpClient(static function (string $method, string $url) use (&$statusCalls): MockResponse {
+            if (str_contains($url, '/threads_publish')) {
+                return new MockResponse(json_encode(['id' => 'post-img'], \JSON_THROW_ON_ERROR));
+            }
+
+            if ('GET' === $method) {
+                return new MockResponse(json_encode([
+                    'id' => 'container-img',
+                    'status' => ++$statusCalls < 3 ? 'IN_PROGRESS' : 'FINISHED',
+                ], \JSON_THROW_ON_ERROR));
+            }
+
+            return new MockResponse(json_encode(['id' => 'container-img'], \JSON_THROW_ON_ERROR));
+        });
+
+        $message = (new ChatMessage('With image'))->options((new ThreadsOptions())->imageUrl('https://cdn.example.com/a.jpg'));
+        $sentMessage = self::createTransport($client)->send($message);
+
+        self::assertSame('post-img', $sentMessage->getMessageId());
+        self::assertSame(3, $statusCalls);
+    }
+
+    public function testSendThrowsWhenTheContainerFailsToProcess()
+    {
+        $client = new MockHttpClient(static function (string $method, string $url): MockResponse {
+            if ('GET' === $method) {
+                return new MockResponse(json_encode([
+                    'id' => 'container-img',
+                    'status' => 'ERROR',
+                    'error_message' => 'Media download failed',
+                ], \JSON_THROW_ON_ERROR));
+            }
+
+            return new MockResponse(json_encode(['id' => 'container-img'], \JSON_THROW_ON_ERROR));
+        });
+
+        $message = (new ChatMessage('With image'))->options((new ThreadsOptions())->imageUrl('https://cdn.example.com/a.jpg'));
+
+        $this->expectException(TransportException::class);
+        $this->expectExceptionMessage('Threads container processing failed (status "ERROR"): "Media download failed"');
+
+        self::createTransport($client)->send($message);
+    }
+
+    public function testSendThrowsWhenTheContainerNeverBecomesReady()
+    {
+        $client = new MockHttpClient(static function (string $method, string $url): MockResponse {
+            if ('GET' === $method) {
+                return new MockResponse(json_encode(['id' => 'container-img', 'status' => 'IN_PROGRESS'], \JSON_THROW_ON_ERROR));
+            }
+
+            return new MockResponse(json_encode(['id' => 'container-img'], \JSON_THROW_ON_ERROR));
+        });
+
+        $message = (new ChatMessage('With image'))->options((new ThreadsOptions())->imageUrl('https://cdn.example.com/a.jpg'));
+
+        $this->expectException(TransportException::class);
+        $this->expectExceptionMessage('Threads container "container-img" did not finish processing in time.');
+
+        self::createTransport($client, 2)->send($message);
+    }
+
+    public function testSendThrowsTransportExceptionOnApiError()
+    {
+        $client = new MockHttpClient(new MockResponse(
+            json_encode(['error' => ['message' => 'bad token', 'code' => 190, 'fbtrace_id' => 'abc']], \JSON_THROW_ON_ERROR),
+            ['http_code' => 400],
+        ));
+
+        $this->expectException(TransportException::class);
+        $this->expectExceptionMessage('Unable to create the Threads media container: HTTP 400, code 190, subcode n/a, fbtrace_id abc ("bad token")');
+
+        self::createTransport($client)->send(new ChatMessage('Hello'));
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Threads/ThreadsOptions.php
+++ b/src/Symfony/Component/Notifier/Bridge/Threads/ThreadsOptions.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Threads;
+
+use Symfony\Component\Notifier\Message\MessageOptionsInterface;
+
+/**
+ * Optional Threads post options (text / image / video).
+ *
+ * @author Mathieu Ledru <matyo91@gmail.com>
+ */
+final class ThreadsOptions implements MessageOptionsInterface
+{
+    public const MEDIA_TYPE_TEXT = 'TEXT';
+
+    public const MEDIA_TYPE_IMAGE = 'IMAGE';
+
+    public const MEDIA_TYPE_VIDEO = 'VIDEO';
+
+    private string $mediaType = self::MEDIA_TYPE_TEXT;
+
+    private ?string $imageUrl = null;
+
+    private ?string $videoUrl = null;
+
+    public function getRecipientId(): ?string
+    {
+        return null;
+    }
+
+    public function mediaType(string $mediaType): static
+    {
+        $this->mediaType = strtoupper($mediaType);
+
+        return $this;
+    }
+
+    public function getMediaType(): string
+    {
+        return $this->mediaType;
+    }
+
+    public function imageUrl(string $url): static
+    {
+        $this->imageUrl = $url;
+        $this->mediaType = self::MEDIA_TYPE_IMAGE;
+
+        return $this;
+    }
+
+    public function getImageUrl(): ?string
+    {
+        return $this->imageUrl;
+    }
+
+    public function videoUrl(string $url): static
+    {
+        $this->videoUrl = $url;
+        $this->mediaType = self::MEDIA_TYPE_VIDEO;
+
+        return $this;
+    }
+
+    public function getVideoUrl(): ?string
+    {
+        return $this->videoUrl;
+    }
+
+    public function toArray(): array
+    {
+        $options = ['media_type' => $this->mediaType];
+
+        if (self::MEDIA_TYPE_IMAGE === $this->mediaType) {
+            $options['image_url'] = $this->imageUrl;
+        }
+
+        if (self::MEDIA_TYPE_VIDEO === $this->mediaType) {
+            $options['video_url'] = $this->videoUrl;
+        }
+
+        return array_filter($options, static fn ($value) => null !== $value && '' !== $value);
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Threads/ThreadsTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Threads/ThreadsTransport.php
@@ -1,0 +1,259 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Threads;
+
+use Symfony\Component\Notifier\Exception\InvalidArgumentException;
+use Symfony\Component\Notifier\Exception\TransportException;
+use Symfony\Component\Notifier\Exception\UnsupportedMessageTypeException;
+use Symfony\Component\Notifier\Exception\UnsupportedOptionsException;
+use Symfony\Component\Notifier\Message\ChatMessage;
+use Symfony\Component\Notifier\Message\MessageInterface;
+use Symfony\Component\Notifier\Message\SentMessage;
+use Symfony\Component\Notifier\Transport\AbstractTransport;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * Publishes to Threads via the Threads Graph API (container → publish).
+ *
+ * @author Mathieu Ledru <matyo91@gmail.com>
+ *
+ * @see https://developers.facebook.com/docs/threads/posts
+ */
+final class ThreadsTransport extends AbstractTransport
+{
+    protected const HOST = 'graph.threads.net';
+
+    public const MAX_TEXT_LENGTH = 500;
+
+    public const POLL_ATTEMPTS = 30;
+
+    public const POLL_DELAY_SECONDS = 2;
+
+    public function __construct(
+        #[\SensitiveParameter] private string $accessToken,
+        private string $userId,
+        private string $apiVersion,
+        ?HttpClientInterface $client = null,
+        ?EventDispatcherInterface $dispatcher = null,
+        private int $pollAttempts = self::POLL_ATTEMPTS,
+        private float $pollDelay = self::POLL_DELAY_SECONDS,
+    ) {
+        parent::__construct($client, $dispatcher);
+    }
+
+    public function __toString(): string
+    {
+        return \sprintf('threads://%s?user_id=%s&api_version=%s', $this->getEndpoint(), $this->userId, $this->apiVersion);
+    }
+
+    public function supports(MessageInterface $message): bool
+    {
+        return $message instanceof ChatMessage
+            && (null === $message->getOptions() || $message->getOptions() instanceof ThreadsOptions);
+    }
+
+    /**
+     * @return array{id: string, status: string, error_message: ?string, raw: array<string, mixed>, response: ResponseInterface}
+     */
+    private function getContainerStatus(string $containerId): array
+    {
+        $containerId = trim($containerId);
+        if ('' === $containerId) {
+            throw new InvalidArgumentException('Threads container id is empty.');
+        }
+
+        $response = $this->client->request('GET', $this->graphUrl($containerId), [
+            'auth_bearer' => $this->accessToken,
+            'query' => [
+                'fields' => 'id,status,error_message',
+            ],
+        ]);
+
+        $data = $this->decodeSuccessfulResponse($response, 'Unable to fetch the Threads container status');
+
+        $status = isset($data['status']) && \is_string($data['status']) ? strtoupper($data['status']) : 'UNKNOWN';
+        $errorMessage = isset($data['error_message']) && \is_string($data['error_message']) ? $data['error_message'] : null;
+        $id = isset($data['id']) && \is_string($data['id']) ? $data['id'] : $containerId;
+
+        return [
+            'id' => $id,
+            'status' => $status,
+            'error_message' => $errorMessage,
+            'raw' => $data,
+            'response' => $response,
+        ];
+    }
+
+    protected function doSend(MessageInterface $message): SentMessage
+    {
+        if (!$message instanceof ChatMessage) {
+            throw new UnsupportedMessageTypeException(__CLASS__, ChatMessage::class, $message);
+        }
+
+        if (($options = $message->getOptions()) && !$options instanceof ThreadsOptions) {
+            throw new UnsupportedOptionsException(__CLASS__, ThreadsOptions::class, $options);
+        }
+
+        $options ??= new ThreadsOptions();
+        $text = trim($message->getSubject());
+        $mediaType = $options->getMediaType();
+
+        if (ThreadsOptions::MEDIA_TYPE_TEXT === $mediaType && '' === $text) {
+            throw new InvalidArgumentException('Threads text posts require a non-empty message subject.');
+        }
+
+        if (mb_strlen($text) > self::MAX_TEXT_LENGTH) {
+            throw new InvalidArgumentException(\sprintf('Threads text exceeds the %d character limit.', self::MAX_TEXT_LENGTH));
+        }
+
+        $createBody = $options->toArray();
+        if ('' !== $text) {
+            $createBody['text'] = $text;
+        }
+
+        if (ThreadsOptions::MEDIA_TYPE_IMAGE === $mediaType) {
+            $this->assertHttpsUrl($createBody['image_url'] ?? '', 'image_url');
+        }
+
+        if (ThreadsOptions::MEDIA_TYPE_VIDEO === $mediaType) {
+            $this->assertHttpsUrl($createBody['video_url'] ?? '', 'video_url');
+        }
+
+        $createResponse = $this->client->request('POST', $this->graphUrl($this->userId.'/threads'), [
+            'auth_bearer' => $this->accessToken,
+            'body' => $createBody,
+        ]);
+        $created = $this->decodeSuccessfulResponse($createResponse, 'Unable to create the Threads media container');
+        $containerId = isset($created['id']) && \is_string($created['id']) ? $created['id'] : '';
+        if ('' === $containerId) {
+            throw new TransportException('Unable to create the Threads media container: missing container id.', $createResponse);
+        }
+
+        if (ThreadsOptions::MEDIA_TYPE_TEXT !== $mediaType) {
+            $this->waitUntilContainerReady($containerId);
+        }
+
+        $publishResponse = $this->client->request('POST', $this->graphUrl($this->userId.'/threads_publish'), [
+            'auth_bearer' => $this->accessToken,
+            'body' => [
+                'creation_id' => $containerId,
+            ],
+        ]);
+        $published = $this->decodeSuccessfulResponse($publishResponse, 'Unable to publish the Threads container');
+        $postId = isset($published['id']) && \is_string($published['id']) ? $published['id'] : '';
+        if ('' === $postId) {
+            throw new TransportException('Unable to publish the Threads container: missing post id.', $publishResponse);
+        }
+
+        $sentMessage = new SentMessage($message, (string) $this);
+        $sentMessage->setMessageId($postId);
+
+        return $sentMessage;
+    }
+
+    private function waitUntilContainerReady(string $containerId): void
+    {
+        $status = null;
+        for ($attempt = 0; $attempt < $this->pollAttempts; ++$attempt) {
+            $status = $this->getContainerStatus($containerId);
+            $code = $status['status'];
+
+            if (\in_array($code, ['FINISHED', 'PUBLISHED'], true)) {
+                return;
+            }
+
+            if (\in_array($code, ['ERROR', 'EXPIRED'], true)) {
+                throw new TransportException(\sprintf('Threads container processing failed (status "%s"): "%s"', $code, $status['error_message'] ?? 'unknown error'), $status['response']);
+            }
+
+            // let the client drive the wait when it can, so the loop does not block the process
+            ($status['response']->getInfo('pause_handler') ?? sleep(...))($this->pollDelay);
+        }
+
+        $status ??= $this->getContainerStatus($containerId);
+
+        throw new TransportException(\sprintf('Threads container "%s" did not finish processing in time.', $containerId), $status['response']);
+    }
+
+    private function assertHttpsUrl(string $url, string $field): void
+    {
+        if ('' === trim($url) || !str_starts_with(strtolower($url), 'https://')) {
+            throw new InvalidArgumentException(\sprintf('Threads "%s" must be a public HTTPS URL.', $field));
+        }
+    }
+
+    private function graphUrl(string $path): string
+    {
+        return \sprintf('https://%s/%s/%s', $this->getEndpoint(), $this->apiVersion, ltrim($path, '/'));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeSuccessfulResponse(ResponseInterface $response, string $failurePrefix): array
+    {
+        try {
+            $statusCode = $response->getStatusCode();
+        } catch (TransportExceptionInterface $e) {
+            throw new TransportException('Could not reach the remote Threads Graph API server.', $response, 0, $e);
+        }
+
+        if ($statusCode < 200 || $statusCode >= 300) {
+            throw new TransportException(\sprintf('%s: %s', $failurePrefix, $this->formatGraphError($response, $statusCode)), $response);
+        }
+
+        try {
+            $content = $response->toArray(false);
+        } catch (DecodingExceptionInterface $e) {
+            throw new TransportException(\sprintf('%s: malformed response from the Threads Graph API.', $failurePrefix), $response, 0, $e);
+        }
+
+        return $content;
+    }
+
+    private function formatGraphError(ResponseInterface $response, int $statusCode): string
+    {
+        try {
+            $data = $response->toArray(false);
+            $error = $data['error'] ?? null;
+            if (\is_array($error)) {
+                $message = isset($error['message']) && \is_string($error['message']) ? $error['message'] : 'unknown error';
+                $code = $error['code'] ?? null;
+                $subcode = $error['error_subcode'] ?? null;
+                $trace = isset($error['fbtrace_id']) && \is_string($error['fbtrace_id']) ? $error['fbtrace_id'] : null;
+
+                return \sprintf(
+                    'HTTP %d, code %s, subcode %s, fbtrace_id %s ("%s")',
+                    $statusCode,
+                    null !== $code ? (string) $code : 'n/a',
+                    null !== $subcode ? (string) $subcode : 'n/a',
+                    $trace ?? 'n/a',
+                    $message,
+                );
+            }
+        } catch (DecodingExceptionInterface) {
+            // Fall through.
+        }
+
+        try {
+            $raw = $response->getContent(false);
+        } catch (TransportExceptionInterface) {
+            $raw = '';
+        }
+
+        return \sprintf('HTTP %d ("%s")', $statusCode, '' !== $raw ? $raw : 'unknown error');
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Threads/ThreadsTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Threads/ThreadsTransportFactory.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Threads;
+
+use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
+use Symfony\Component\Notifier\Transport\AbstractTransportFactory;
+use Symfony\Component\Notifier\Transport\Dsn;
+
+/**
+ * @author Mathieu Ledru <matyo91@gmail.com>
+ */
+final class ThreadsTransportFactory extends AbstractTransportFactory
+{
+    private const DEFAULT_API_VERSION = 'v1.0';
+
+    public function create(Dsn $dsn): ThreadsTransport
+    {
+        $scheme = $dsn->getScheme();
+
+        if ('threads' !== $scheme) {
+            throw new UnsupportedSchemeException($dsn, 'threads', $this->getSupportedSchemes());
+        }
+
+        $accessToken = $this->getUser($dsn);
+        $userId = $dsn->getRequiredOption('user_id');
+        $apiVersion = $dsn->getOption('api_version', self::DEFAULT_API_VERSION);
+        $pollAttempts = (int) $dsn->getOption('poll_attempts', ThreadsTransport::POLL_ATTEMPTS);
+        $pollDelay = (float) $dsn->getOption('poll_delay', ThreadsTransport::POLL_DELAY_SECONDS);
+        $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
+        $port = $dsn->getPort();
+
+        return (new ThreadsTransport($accessToken, $userId, $apiVersion, $this->client, $this->dispatcher, $pollAttempts, $pollDelay))->setHost($host)->setPort($port);
+    }
+
+    protected function getSupportedSchemes(): array
+    {
+        return ['threads'];
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Threads/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Threads/composer.json
@@ -1,0 +1,37 @@
+{
+    "name": "symfony/threads-notifier",
+    "type": "symfony-notifier-bridge",
+    "description": "Symfony Threads Notifier Bridge",
+    "keywords": [
+        "threads",
+        "meta",
+        "notifier",
+        "chat"
+    ],
+    "homepage": "https://symfony.com",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Mathieu Ledru",
+            "email": "matyo91@gmail.com"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "https://symfony.com/contributors"
+        }
+    ],
+    "require": {
+        "php": ">=8.4.1",
+        "symfony/http-client": "^7.4|^8.0",
+        "symfony/notifier": "^7.4|^8.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Symfony\\Component\\Notifier\\Bridge\\Threads\\": ""
+        },
+        "exclude-from-classmap": [
+            "/Tests/"
+        ]
+    },
+    "minimum-stability": "dev"
+}

--- a/src/Symfony/Component/Notifier/Bridge/Threads/phpunit.xml.dist
+++ b/src/Symfony/Component/Notifier/Bridge/Threads/phpunit.xml.dist
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/13.1/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+         failOnDeprecation="true"
+         failOnRisky="true"
+         failOnWarning="true"
+>
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Symfony Threads Notifier Bridge Test Suite">
+            <directory>./Tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <source ignoreSuppressionOfDeprecations="true">
+        <include>
+            <directory>./</directory>
+        </include>
+        <exclude>
+            <directory>./Tests</directory>
+            <directory>./vendor</directory>
+        </exclude>
+    </source>
+
+    <extensions>
+        <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension" />
+    </extensions>
+</phpunit>

--- a/src/Symfony/Component/Notifier/Exception/UnsupportedSchemeException.php
+++ b/src/Symfony/Component/Notifier/Exception/UnsupportedSchemeException.php
@@ -320,6 +320,10 @@ class UnsupportedSchemeException extends LogicException
             'class' => Bridge\Termii\TermiiTransportFactory::class,
             'package' => 'symfony/termii-notifier',
         ],
+        'threads' => [
+            'class' => Bridge\Threads\ThreadsTransportFactory::class,
+            'package' => 'symfony/threads-notifier',
+        ],
         'turbosms' => [
             'class' => Bridge\TurboSms\TurboSmsTransportFactory::class,
             'package' => 'symfony/turbo-sms-notifier',

--- a/src/Symfony/Component/Notifier/Tests/Exception/UnsupportedSchemeExceptionTest.php
+++ b/src/Symfony/Component/Notifier/Tests/Exception/UnsupportedSchemeExceptionTest.php
@@ -101,6 +101,7 @@ final class UnsupportedSchemeExceptionTest extends TestCase
             Bridge\Telegram\TelegramTransportFactory::class => false,
             Bridge\Telnyx\TelnyxTransportFactory::class => false,
             Bridge\Termii\TermiiTransportFactory::class => false,
+            Bridge\Threads\ThreadsTransportFactory::class => false,
             Bridge\TurboSms\TurboSmsTransportFactory::class => false,
             Bridge\Twilio\TwilioTransportFactory::class => false,
             Bridge\Twitter\TwitterTransportFactory::class => false,
@@ -194,6 +195,7 @@ final class UnsupportedSchemeExceptionTest extends TestCase
         yield ['telegram', 'symfony/telegram-notifier'];
         yield ['telnyx', 'symfony/telnyx-notifier'];
         yield ['termii', 'symfony/termii-notifier'];
+        yield ['threads', 'symfony/threads-notifier'];
         yield ['turbosms', 'symfony/turbo-sms-notifier'];
         yield ['twilio', 'symfony/twilio-notifier'];
         yield ['twitter', 'symfony/twitter-notifier'];

--- a/src/Symfony/Component/Notifier/Transport.php
+++ b/src/Symfony/Component/Notifier/Transport.php
@@ -102,6 +102,7 @@ final class Transport
         Bridge\Telegram\TelegramTransportFactory::class,
         Bridge\Telnyx\TelnyxTransportFactory::class,
         Bridge\Termii\TermiiTransportFactory::class,
+        Bridge\Threads\ThreadsTransportFactory::class,
         Bridge\TurboSms\TurboSmsTransportFactory::class,
         Bridge\Twilio\TwilioTransportFactory::class,
         Bridge\Twitter\TwitterTransportFactory::class,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix Threads content page post __invoke Tool from https://github.com/symfony/ai/pull/549
| License       | MIT

This adds a Notifier bridge for the [Threads API](https://developers.facebook.com/docs/threads/posts/),
Meta's Graph API for publishing Threads posts. It registers a `Chatter` transport that creates a media
container and then publishes it:

1. `POST https://graph.threads.net/{api_version}/{user_id}/threads`
2. `POST https://graph.threads.net/{api_version}/{user_id}/threads_publish`

For image and video posts, the transport waits until the container status is `FINISHED` /
`PUBLISHED` before calling publish (same container → publish flow as Meta documents).

### DSN

```
THREADS_DSN=threads://ACCESS_TOKEN@default?user_id=THREADS_USER_ID&api_version=v1.0
```

`api_version` is optional and defaults to `v1.0`, the current Threads Graph API version on
`graph.threads.net`. The option is there so applications can pin or move versions independently of
the bridge default.

### Getting the credentials

Both values come from an app in the [Meta developer console](https://developers.facebook.com/apps):

1. Create or open an app and add the **Threads** use case / product.
2. Complete Threads API setup and request permissions (typically `threads_basic` and
   `threads_content_publish`; verify current names in Meta's docs).
3. Complete the OAuth authorization for the Threads account that should publish.
4. Use the resulting **user access token** (`ACCESS_TOKEN`) and the Threads **user id**
   (`user_id`). A short-lived token is fine for a first try; exchange it for a long-lived token for
   production use.

### Sending messages

The DSN already identifies the Threads user, so a bare `ChatMessage` is supported. The subject is
sent as the post `text` (max 500 characters).

```php
use Symfony\Component\Notifier\Message\ChatMessage;

$chatter->send(new ChatMessage('Hello from Threads'));
```

Optionally publish an image or video through `ThreadsOptions`. Media URLs must be **public HTTPS**
URLs (`image_url` / `video_url`); local paths are not supported.

```php
use Symfony\Component\Notifier\Bridge\Threads\ThreadsOptions;
use Symfony\Component\Notifier\Message\ChatMessage;

$options = (new ThreadsOptions())->imageUrl('https://example.com/photo.jpg');

$chatter->send((new ChatMessage('Caption'))->options($options));
```

```php
$options = (new ThreadsOptions())->videoUrl('https://example.com/video.mp4');

$chatter->send((new ChatMessage('Caption'))->options($options));
```

### Possible follow-up

Carousels, quote posts, and replies would be natural extensions of `ThreadsOptions`. They are
deliberately out of scope here so the first version stays a simple text / single-image / single-video
publish flow.

### Documentation

A symfony-docs pull request should cover:

* the new `threads` scheme and its row in the chatter transports table of `notifier.rst`, with the
  DSN format and the `symfony/threads-notifier` package name;
* the two DSN options, `user_id` (required) and `api_version` (optional), and where the Threads user
  id / access token come from in the Meta developer console;
* the `threads_basic` / `threads_content_publish` permission requirements;
* `ThreadsOptions::imageUrl()` / `ThreadsOptions::videoUrl()` for optional media, including that URLs
  must be public HTTPS;
* the 500-character text limit;
* the fact that a bare `ChatMessage` is supported (no recipient), because the Threads user is
  selected by the DSN.