### PR TITLE
[Notifier] Add the Instagram bridge

### DIFF
--- a/splitsh.json
+++ b/splitsh.json
@@ -99,6 +99,7 @@
         "go-ip-notifier": "src/Symfony/Component/Notifier/Bridge/GoIp",
         "google-chat-notifier": "src/Symfony/Component/Notifier/Bridge/GoogleChat",
         "infobip-notifier": "src/Symfony/Component/Notifier/Bridge/Infobip",
+        "instagram-notifier": "src/Symfony/Component/Notifier/Bridge/Instagram",
         "iqsms-notifier": "src/Symfony/Component/Notifier/Bridge/Iqsms",
         "isendpro-notifier": "src/Symfony/Component/Notifier/Bridge/Isendpro",
         "joli-notif-notifier": "src/Symfony/Component/Notifier/Bridge/JoliNotif",

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -3268,6 +3268,7 @@ class FrameworkExtension extends Extension
             NotifierBridge\GoIp\GoIpTransportFactory::class => ['symfony/go-ip-notifier', 'notifier.transport_factory.go-ip'],
             NotifierBridge\GoogleChat\GoogleChatTransportFactory::class => ['symfony/google-chat-notifier', 'notifier.transport_factory.google-chat'],
             NotifierBridge\Infobip\InfobipTransportFactory::class => ['symfony/infobip-notifier', 'notifier.transport_factory.infobip'],
+            NotifierBridge\Instagram\InstagramTransportFactory::class => ['symfony/instagram-notifier', 'notifier.transport_factory.instagram'],
             NotifierBridge\Iqsms\IqsmsTransportFactory::class => ['symfony/iqsms-notifier', 'notifier.transport_factory.iqsms'],
             NotifierBridge\Isendpro\IsendproTransportFactory::class => ['symfony/isendpro-notifier', 'notifier.transport_factory.isendpro'],
             NotifierBridge\JoliNotif\JoliNotifTransportFactory::class => ['symfony/joli-notif-notifier', 'notifier.transport_factory.joli-notif'],

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/notifier_transports.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/notifier_transports.php
@@ -33,6 +33,7 @@ return static function (ContainerConfigurator $container) {
         'fake-chat' => Bridge\FakeChat\FakeChatTransportFactory::class,
         'firebase' => Bridge\Firebase\FirebaseTransportFactory::class,
         'google-chat' => Bridge\GoogleChat\GoogleChatTransportFactory::class,
+        'instagram' => Bridge\Instagram\InstagramTransportFactory::class,
         'line-bot' => Bridge\LineBot\LineBotTransportFactory::class,
         'line-notify' => Bridge\LineNotify\LineNotifyTransportFactory::class,
         'linked-in' => Bridge\LinkedIn\LinkedInTransportFactory::class,

--- a/src/Symfony/Component/Notifier/Bridge/Instagram/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/Instagram/.gitattributes
@@ -1,0 +1,3 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/Instagram/.gitignore
+++ b/src/Symfony/Component/Notifier/Bridge/Instagram/.gitignore
@@ -1,0 +1,3 @@
+vendor/
+composer.lock
+phpunit.xml

--- a/src/Symfony/Component/Notifier/Bridge/Instagram/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Instagram/CHANGELOG.md
@@ -1,0 +1,7 @@
+CHANGELOG
+=========
+
+8.2
+---
+
+ * Add the bridge

--- a/src/Symfony/Component/Notifier/Bridge/Instagram/InstagramOptions.php
+++ b/src/Symfony/Component/Notifier/Bridge/Instagram/InstagramOptions.php
@@ -1,0 +1,116 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Instagram;
+
+use Symfony\Component\Notifier\Exception\InvalidArgumentException;
+use Symfony\Component\Notifier\Message\MessageOptionsInterface;
+
+/**
+ * Instagram content-publishing options (image feed post or Reel).
+ *
+ * @author Mathieu Ledru <matyo91@gmail.com>
+ */
+final class InstagramOptions implements MessageOptionsInterface
+{
+    public const MEDIA_TYPE_IMAGE = 'IMAGE';
+
+    public const MEDIA_TYPE_REELS = 'REELS';
+
+    private string $mediaType = self::MEDIA_TYPE_IMAGE;
+
+    private ?string $imageUrl = null;
+
+    private ?string $videoUrl = null;
+
+    private ?bool $shareToFeed = null;
+
+    public function getRecipientId(): ?string
+    {
+        return null;
+    }
+
+    public function mediaType(string $mediaType): static
+    {
+        $normalized = strtoupper($mediaType);
+        $normalized = 'REEL' === $normalized ? self::MEDIA_TYPE_REELS : $normalized;
+
+        if (!\in_array($normalized, [self::MEDIA_TYPE_IMAGE, self::MEDIA_TYPE_REELS], true)) {
+            throw new InvalidArgumentException(\sprintf('Unsupported Instagram media type "%s". Supported ones are "%s".', $mediaType, implode('", "', [self::MEDIA_TYPE_IMAGE, self::MEDIA_TYPE_REELS])));
+        }
+
+        $this->mediaType = $normalized;
+
+        return $this;
+    }
+
+    public function getMediaType(): string
+    {
+        return $this->mediaType;
+    }
+
+    public function imageUrl(string $url): static
+    {
+        $this->imageUrl = $url;
+        $this->mediaType = self::MEDIA_TYPE_IMAGE;
+
+        return $this;
+    }
+
+    public function getImageUrl(): ?string
+    {
+        return $this->imageUrl;
+    }
+
+    public function videoUrl(string $url): static
+    {
+        $this->videoUrl = $url;
+        $this->mediaType = self::MEDIA_TYPE_REELS;
+
+        return $this;
+    }
+
+    public function getVideoUrl(): ?string
+    {
+        return $this->videoUrl;
+    }
+
+    public function shareToFeed(bool $shareToFeed): static
+    {
+        $this->shareToFeed = $shareToFeed;
+
+        return $this;
+    }
+
+    public function getShareToFeed(): ?bool
+    {
+        return $this->shareToFeed;
+    }
+
+    public function toArray(): array
+    {
+        if (self::MEDIA_TYPE_REELS === $this->mediaType) {
+            $options = [
+                'media_type' => self::MEDIA_TYPE_REELS,
+                'video_url' => $this->videoUrl,
+            ];
+        } else {
+            // Meta infers an image container from image_url alone, media_type is not sent
+            $options = ['image_url' => $this->imageUrl];
+        }
+
+        if (null !== $this->shareToFeed) {
+            $options['share_to_feed'] = $this->shareToFeed ? 'true' : 'false';
+        }
+
+        return array_filter($options, static fn ($value) => null !== $value && '' !== $value);
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Instagram/InstagramTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Instagram/InstagramTransport.php
@@ -1,0 +1,247 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Instagram;
+
+use Symfony\Component\Notifier\Exception\InvalidArgumentException;
+use Symfony\Component\Notifier\Exception\TransportException;
+use Symfony\Component\Notifier\Exception\UnsupportedMessageTypeException;
+use Symfony\Component\Notifier\Exception\UnsupportedOptionsException;
+use Symfony\Component\Notifier\Message\ChatMessage;
+use Symfony\Component\Notifier\Message\MessageInterface;
+use Symfony\Component\Notifier\Message\SentMessage;
+use Symfony\Component\Notifier\Transport\AbstractTransport;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * Publishes Instagram media via Instagram API with Instagram Login (container → publish).
+ *
+ * @author Mathieu Ledru <matyo91@gmail.com>
+ *
+ * @see https://developers.facebook.com/docs/instagram-platform/instagram-api-with-instagram-login/content-publishing
+ */
+final class InstagramTransport extends AbstractTransport
+{
+    protected const HOST = 'graph.instagram.com';
+
+    public const POLL_ATTEMPTS = 45;
+
+    public const POLL_DELAY_SECONDS = 2;
+
+    public function __construct(
+        #[\SensitiveParameter] private string $accessToken,
+        private string $userId,
+        private string $apiVersion,
+        ?HttpClientInterface $client = null,
+        ?EventDispatcherInterface $dispatcher = null,
+        private int $pollAttempts = self::POLL_ATTEMPTS,
+        private float $pollDelay = self::POLL_DELAY_SECONDS,
+    ) {
+        parent::__construct($client, $dispatcher);
+    }
+
+    public function __toString(): string
+    {
+        return \sprintf('instagram://%s?user_id=%s&api_version=%s', $this->getEndpoint(), $this->userId, $this->apiVersion);
+    }
+
+    public function supports(MessageInterface $message): bool
+    {
+        return $message instanceof ChatMessage
+            && (null === $message->getOptions() || $message->getOptions() instanceof InstagramOptions);
+    }
+
+    /**
+     * @return array{id: string, status_code: string, error_message: ?string, raw: array<string, mixed>, response: ResponseInterface}
+     */
+    private function getContainerStatus(string $containerId): array
+    {
+        $containerId = trim($containerId);
+        if ('' === $containerId) {
+            throw new InvalidArgumentException('Instagram container id is empty.');
+        }
+
+        $response = $this->client->request('GET', $this->graphUrl($containerId), [
+            'auth_bearer' => $this->accessToken,
+            'query' => [
+                'fields' => 'id,status_code,status,error_message',
+            ],
+        ]);
+
+        $data = $this->decodeSuccessfulResponse($response, 'Unable to fetch the Instagram container status');
+
+        $statusCode = isset($data['status_code']) && \is_string($data['status_code'])
+            ? strtoupper($data['status_code'])
+            : (isset($data['status']) && \is_string($data['status']) ? strtoupper($data['status']) : 'UNKNOWN');
+        $errorMessage = isset($data['error_message']) && \is_string($data['error_message']) ? $data['error_message'] : null;
+        $id = isset($data['id']) && \is_string($data['id']) ? $data['id'] : $containerId;
+
+        return [
+            'id' => $id,
+            'status_code' => $statusCode,
+            'error_message' => $errorMessage,
+            'raw' => $data,
+            'response' => $response,
+        ];
+    }
+
+    protected function doSend(MessageInterface $message): SentMessage
+    {
+        if (!$message instanceof ChatMessage) {
+            throw new UnsupportedMessageTypeException(__CLASS__, ChatMessage::class, $message);
+        }
+
+        if (($options = $message->getOptions()) && !$options instanceof InstagramOptions) {
+            throw new UnsupportedOptionsException(__CLASS__, InstagramOptions::class, $options);
+        }
+
+        $options ??= new InstagramOptions();
+        $caption = trim($message->getSubject());
+        $mediaType = $options->getMediaType();
+
+        $createBody = $options->toArray();
+        if ('' !== $caption) {
+            $createBody['caption'] = $caption;
+        }
+
+        if (InstagramOptions::MEDIA_TYPE_REELS === $mediaType) {
+            $this->assertHttpsUrl($createBody['video_url'] ?? '', 'video_url');
+        } else {
+            $this->assertHttpsUrl($createBody['image_url'] ?? '', 'image_url');
+        }
+
+        $createResponse = $this->client->request('POST', $this->graphUrl($this->userId.'/media'), [
+            'auth_bearer' => $this->accessToken,
+            'body' => $createBody,
+        ]);
+        $created = $this->decodeSuccessfulResponse($createResponse, 'Unable to create the Instagram media container');
+        $containerId = isset($created['id']) && \is_string($created['id']) ? $created['id'] : '';
+        if ('' === $containerId) {
+            throw new TransportException('Unable to create the Instagram media container: missing container id.', $createResponse);
+        }
+
+        $this->waitUntilContainerReady($containerId);
+
+        $publishResponse = $this->client->request('POST', $this->graphUrl($this->userId.'/media_publish'), [
+            'auth_bearer' => $this->accessToken,
+            'body' => [
+                'creation_id' => $containerId,
+            ],
+        ]);
+        $published = $this->decodeSuccessfulResponse($publishResponse, 'Unable to publish the Instagram container');
+        $mediaId = isset($published['id']) && \is_string($published['id']) ? $published['id'] : '';
+        if ('' === $mediaId) {
+            throw new TransportException('Unable to publish the Instagram container: missing media id.', $publishResponse);
+        }
+
+        $sentMessage = new SentMessage($message, (string) $this);
+        $sentMessage->setMessageId($mediaId);
+
+        return $sentMessage;
+    }
+
+    private function waitUntilContainerReady(string $containerId): void
+    {
+        $status = null;
+        for ($attempt = 0; $attempt < $this->pollAttempts; ++$attempt) {
+            $status = $this->getContainerStatus($containerId);
+            $code = $status['status_code'];
+
+            if (\in_array($code, ['FINISHED', 'PUBLISHED'], true)) {
+                return;
+            }
+
+            if (\in_array($code, ['ERROR', 'EXPIRED'], true)) {
+                throw new TransportException(\sprintf('Instagram container processing failed (status "%s"): "%s"', $code, $status['error_message'] ?? 'unknown error'), $status['response']);
+            }
+
+            // let the client drive the wait when it can, so the loop does not block the process
+            ($status['response']->getInfo('pause_handler') ?? sleep(...))($this->pollDelay);
+        }
+
+        $status ??= $this->getContainerStatus($containerId);
+
+        throw new TransportException(\sprintf('Instagram container "%s" did not finish processing in time.', $containerId), $status['response']);
+    }
+
+    private function assertHttpsUrl(string $url, string $field): void
+    {
+        if ('' === trim($url) || !str_starts_with(strtolower($url), 'https://')) {
+            throw new InvalidArgumentException(\sprintf('Instagram "%s" must be a public HTTPS URL.', $field));
+        }
+    }
+
+    private function graphUrl(string $path): string
+    {
+        return \sprintf('https://%s/%s/%s', $this->getEndpoint(), $this->apiVersion, ltrim($path, '/'));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeSuccessfulResponse(ResponseInterface $response, string $failurePrefix): array
+    {
+        try {
+            $statusCode = $response->getStatusCode();
+        } catch (TransportExceptionInterface $e) {
+            throw new TransportException('Could not reach the remote Instagram Graph API server.', $response, 0, $e);
+        }
+
+        if ($statusCode < 200 || $statusCode >= 300) {
+            throw new TransportException(\sprintf('%s: %s', $failurePrefix, $this->formatGraphError($response, $statusCode)), $response);
+        }
+
+        try {
+            $content = $response->toArray(false);
+        } catch (DecodingExceptionInterface $e) {
+            throw new TransportException(\sprintf('%s: malformed response from the Instagram Graph API.', $failurePrefix), $response, 0, $e);
+        }
+
+        return $content;
+    }
+
+    private function formatGraphError(ResponseInterface $response, int $statusCode): string
+    {
+        try {
+            $data = $response->toArray(false);
+            $error = $data['error'] ?? null;
+            if (\is_array($error)) {
+                $message = isset($error['message']) && \is_string($error['message']) ? $error['message'] : 'unknown error';
+                $code = $error['code'] ?? null;
+                $subcode = $error['error_subcode'] ?? null;
+                $trace = isset($error['fbtrace_id']) && \is_string($error['fbtrace_id']) ? $error['fbtrace_id'] : null;
+
+                return \sprintf(
+                    'HTTP %d, code %s, subcode %s, fbtrace_id %s ("%s")',
+                    $statusCode,
+                    null !== $code ? (string) $code : 'n/a',
+                    null !== $subcode ? (string) $subcode : 'n/a',
+                    $trace ?? 'n/a',
+                    $message,
+                );
+            }
+        } catch (DecodingExceptionInterface) {
+            // Fall through.
+        }
+
+        try {
+            $raw = $response->getContent(false);
+        } catch (TransportExceptionInterface) {
+            $raw = '';
+        }
+
+        return \sprintf('HTTP %d ("%s")', $statusCode, '' !== $raw ? $raw : 'unknown error');
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Instagram/InstagramTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Instagram/InstagramTransportFactory.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Instagram;
+
+use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
+use Symfony\Component\Notifier\Transport\AbstractTransportFactory;
+use Symfony\Component\Notifier\Transport\Dsn;
+
+/**
+ * @author Mathieu Ledru <matyo91@gmail.com>
+ */
+final class InstagramTransportFactory extends AbstractTransportFactory
+{
+    private const DEFAULT_API_VERSION = 'v22.0';
+
+    public function create(Dsn $dsn): InstagramTransport
+    {
+        $scheme = $dsn->getScheme();
+
+        if ('instagram' !== $scheme) {
+            throw new UnsupportedSchemeException($dsn, 'instagram', $this->getSupportedSchemes());
+        }
+
+        $accessToken = $this->getUser($dsn);
+        $userId = $dsn->getRequiredOption('user_id');
+        $apiVersion = $dsn->getOption('api_version', self::DEFAULT_API_VERSION);
+        $pollAttempts = (int) $dsn->getOption('poll_attempts', InstagramTransport::POLL_ATTEMPTS);
+        $pollDelay = (float) $dsn->getOption('poll_delay', InstagramTransport::POLL_DELAY_SECONDS);
+        $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
+        $port = $dsn->getPort();
+
+        return (new InstagramTransport($accessToken, $userId, $apiVersion, $this->client, $this->dispatcher, $pollAttempts, $pollDelay))->setHost($host)->setPort($port);
+    }
+
+    protected function getSupportedSchemes(): array
+    {
+        return ['instagram'];
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Instagram/LICENSE
+++ b/src/Symfony/Component/Notifier/Bridge/Instagram/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2026-present Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Symfony/Component/Notifier/Bridge/Instagram/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/Instagram/README.md
@@ -1,0 +1,54 @@
+Instagram Notifier
+==================
+
+Provides [Instagram content publishing](https://developers.facebook.com/docs/instagram-platform/instagram-api-with-instagram-login/content-publishing)
+via Instagram API with Instagram Login, as a Symfony Notifier `Chatter` transport.
+
+DSN example
+-----------
+
+```
+INSTAGRAM_DSN=instagram://ACCESS_TOKEN@default?user_id=IG_USER_ID&api_version=v22.0
+```
+
+where:
+
+- `ACCESS_TOKEN` is an Instagram user access token (Instagram Login)
+- `IG_USER_ID` is the Instagram user id
+- `api_version` is optional (defaults to `v22.0`)
+- `poll_attempts` is optional (defaults to `45`): how many times the media
+  container is checked before giving up
+- `poll_delay` is optional (defaults to `2`): seconds between two checks
+
+Sending an image feed post
+--------------------------
+
+```php
+use Symfony\Component\Notifier\Bridge\Instagram\InstagramOptions;
+use Symfony\Component\Notifier\Message\ChatMessage;
+
+$options = (new InstagramOptions())->imageUrl('https://example.com/photo.jpg');
+
+$chatter->send((new ChatMessage('Caption'))->options($options));
+```
+
+Reel (public HTTPS `video_url` required):
+
+```php
+use Symfony\Component\Notifier\Bridge\Instagram\InstagramOptions;
+use Symfony\Component\Notifier\Message\ChatMessage;
+
+$options = (new InstagramOptions())
+    ->videoUrl('https://example.com/reel.mp4')
+    ->shareToFeed(true);
+
+$chatter->send((new ChatMessage('Reel caption'))->options($options));
+```
+
+Resources
+---------
+
+- [Contributing](https://symfony.com/doc/current/contributing/index.html)
+- [Report issues](https://github.com/symfony/symfony/issues) and
+  [send Pull Requests](https://github.com/symfony/symfony/pulls)
+  in the [main Symfony repository](https://github.com/symfony/symfony)

--- a/src/Symfony/Component/Notifier/Bridge/Instagram/Tests/InstagramOptionsTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Instagram/Tests/InstagramOptionsTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Instagram\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Notifier\Bridge\Instagram\InstagramOptions;
+use Symfony\Component\Notifier\Exception\InvalidArgumentException;
+
+/**
+ * @author Mathieu Ledru <matyo91@gmail.com>
+ */
+final class InstagramOptionsTest extends TestCase
+{
+    public function testGetRecipientIdIsAlwaysNull()
+    {
+        self::assertNull((new InstagramOptions())->getRecipientId());
+        self::assertNull((new InstagramOptions())->imageUrl('https://example.com/a.jpg')->getRecipientId());
+    }
+
+    public function testImageUrlSetsMediaType()
+    {
+        $options = (new InstagramOptions())->imageUrl('https://example.com/a.jpg');
+
+        self::assertSame(InstagramOptions::MEDIA_TYPE_IMAGE, $options->getMediaType());
+        self::assertSame('https://example.com/a.jpg', $options->getImageUrl());
+        // Meta infers an image container from image_url, so media_type is not sent
+        self::assertSame(['image_url' => 'https://example.com/a.jpg'], $options->toArray());
+    }
+
+    public function testVideoUrlSetsReelsMediaType()
+    {
+        $options = (new InstagramOptions())->videoUrl('https://example.com/a.mp4')->shareToFeed(true);
+
+        self::assertSame(InstagramOptions::MEDIA_TYPE_REELS, $options->getMediaType());
+        self::assertSame('https://example.com/a.mp4', $options->getVideoUrl());
+        self::assertTrue($options->getShareToFeed());
+        self::assertSame([
+            'media_type' => 'REELS',
+            'video_url' => 'https://example.com/a.mp4',
+            'share_to_feed' => 'true',
+        ], $options->toArray());
+    }
+
+    public function testMediaTypeNormalizesReelAlias()
+    {
+        $options = (new InstagramOptions())->mediaType('REEL');
+
+        self::assertSame(InstagramOptions::MEDIA_TYPE_REELS, $options->getMediaType());
+    }
+
+    public function testDefaultToArray()
+    {
+        self::assertSame([], (new InstagramOptions())->toArray());
+    }
+
+    public function testShareToFeedIsSentForAnImagePost()
+    {
+        $options = (new InstagramOptions())->imageUrl('https://example.com/a.jpg')->shareToFeed(true);
+
+        self::assertSame([
+            'image_url' => 'https://example.com/a.jpg',
+            'share_to_feed' => 'true',
+        ], $options->toArray());
+    }
+
+    public function testUnsupportedMediaTypeIsRejected()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unsupported Instagram media type "STORIES". Supported ones are "IMAGE", "REELS".');
+
+        (new InstagramOptions())->mediaType('STORIES');
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Instagram/Tests/InstagramTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Instagram/Tests/InstagramTransportFactoryTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Instagram\Tests;
+
+use Symfony\Component\Notifier\Bridge\Instagram\InstagramTransportFactory;
+use Symfony\Component\Notifier\Test\AbstractTransportFactoryTestCase;
+use Symfony\Component\Notifier\Test\IncompleteDsnTestTrait;
+use Symfony\Component\Notifier\Test\MissingRequiredOptionTestTrait;
+
+/**
+ * @author Mathieu Ledru <matyo91@gmail.com>
+ */
+final class InstagramTransportFactoryTest extends AbstractTransportFactoryTestCase
+{
+    use IncompleteDsnTestTrait;
+    use MissingRequiredOptionTestTrait;
+
+    public function createFactory(): InstagramTransportFactory
+    {
+        return new InstagramTransportFactory();
+    }
+
+    public static function createProvider(): iterable
+    {
+        yield [
+            'instagram://graph.instagram.com?user_id=17841400000000000&api_version=v22.0',
+            'instagram://token@default?user_id=17841400000000000&api_version=v22.0',
+        ];
+    }
+
+    public static function supportsProvider(): iterable
+    {
+        yield [true, 'instagram://token@host.test?user_id=17841400000000000'];
+        yield [false, 'somethingElse://token@host.test?user_id=17841400000000000'];
+    }
+
+    public static function unsupportedSchemeProvider(): iterable
+    {
+        yield ['somethingElse://token@host.test?user_id=17841400000000000'];
+    }
+
+    public static function incompleteDsnProvider(): iterable
+    {
+        yield 'missing token' => ['instagram://host.test?user_id=17841400000000000'];
+    }
+
+    public static function missingRequiredOptionProvider(): iterable
+    {
+        yield 'missing option: user_id' => ['instagram://token@host.test'];
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Instagram/Tests/InstagramTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Instagram/Tests/InstagramTransportTest.php
@@ -1,0 +1,208 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Instagram\Tests;
+
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\Notifier\Bridge\Instagram\InstagramOptions;
+use Symfony\Component\Notifier\Bridge\Instagram\InstagramTransport;
+use Symfony\Component\Notifier\Exception\InvalidArgumentException;
+use Symfony\Component\Notifier\Exception\TransportException;
+use Symfony\Component\Notifier\Message\ChatMessage;
+use Symfony\Component\Notifier\Message\SentMessage;
+use Symfony\Component\Notifier\Message\SmsMessage;
+use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * @author Mathieu Ledru <matyo91@gmail.com>
+ */
+final class InstagramTransportTest extends TransportTestCase
+{
+    public static function createTransport(?HttpClientInterface $client = null, int $pollAttempts = InstagramTransport::POLL_ATTEMPTS): InstagramTransport
+    {
+        return new InstagramTransport('ig-access-token', '17841400000000000', 'v22.0', $client ?? new MockHttpClient(), null, $pollAttempts, 0.0);
+    }
+
+    public static function toStringProvider(): iterable
+    {
+        yield ['instagram://graph.instagram.com?user_id=17841400000000000&api_version=v22.0', self::createTransport()];
+    }
+
+    public static function supportedMessagesProvider(): iterable
+    {
+        yield [new ChatMessage('Caption', (new InstagramOptions())->imageUrl('https://example.com/a.jpg'))];
+    }
+
+    public static function unsupportedMessagesProvider(): iterable
+    {
+        yield [new SmsMessage('0611223344', 'Hello!')];
+    }
+
+    public function testSendImageCreatesContainerPollsAndPublishes()
+    {
+        $request = 0;
+        $client = new MockHttpClient(static function (string $method, string $url, array $options) use (&$request): MockResponse {
+            ++$request;
+            self::assertContains('Authorization: Bearer ig-access-token', $options['headers']);
+
+            if (1 === $request) {
+                self::assertSame('POST', $method);
+                self::assertSame('https://graph.instagram.com/v22.0/17841400000000000/media', $url);
+                parse_str($options['body'], $body);
+                self::assertSame('https://cdn.example.com/photo.jpg', $body['image_url'] ?? null);
+                self::assertSame('A Darkwood publication', $body['caption'] ?? null);
+                self::assertArrayNotHasKey('access_token', $body);
+
+                return new MockResponse(json_encode(['id' => 'container-1'], \JSON_THROW_ON_ERROR));
+            }
+
+            if (2 === $request) {
+                self::assertSame('GET', $method);
+
+                return new MockResponse(json_encode(['id' => 'container-1', 'status_code' => 'FINISHED'], \JSON_THROW_ON_ERROR));
+            }
+
+            self::assertSame('POST', $method);
+            self::assertSame('https://graph.instagram.com/v22.0/17841400000000000/media_publish', $url);
+            parse_str($options['body'], $body);
+            self::assertSame('container-1', $body['creation_id'] ?? null);
+            self::assertArrayNotHasKey('access_token', $body);
+
+            return new MockResponse(json_encode(['id' => 'media-42'], \JSON_THROW_ON_ERROR));
+        });
+
+        $message = (new ChatMessage('A Darkwood publication'))
+            ->options((new InstagramOptions())->imageUrl('https://cdn.example.com/photo.jpg'));
+        $sentMessage = self::createTransport($client)->send($message);
+
+        self::assertInstanceOf(SentMessage::class, $sentMessage);
+        self::assertSame('media-42', $sentMessage->getMessageId());
+        self::assertSame(3, $request);
+    }
+
+    public function testSendReelUsesVideoUrlAndShareToFeed()
+    {
+        $request = 0;
+        $client = new MockHttpClient(static function (string $method, string $url, array $options) use (&$request): MockResponse {
+            ++$request;
+            if (1 === $request) {
+                parse_str($options['body'], $body);
+                self::assertSame('REELS', $body['media_type'] ?? null);
+                self::assertSame('https://cdn.example.com/reel.mp4', $body['video_url'] ?? null);
+                self::assertSame('true', $body['share_to_feed'] ?? null);
+                self::assertArrayNotHasKey('access_token', $body);
+
+                return new MockResponse(json_encode(['id' => 'reel-container'], \JSON_THROW_ON_ERROR));
+            }
+
+            if (2 === $request) {
+                return new MockResponse(json_encode(['id' => 'reel-container', 'status_code' => 'FINISHED'], \JSON_THROW_ON_ERROR));
+            }
+
+            return new MockResponse(json_encode(['id' => 'reel-media'], \JSON_THROW_ON_ERROR));
+        });
+
+        $message = (new ChatMessage('Reel caption'))
+            ->options((new InstagramOptions())->videoUrl('https://cdn.example.com/reel.mp4')->shareToFeed(true));
+        $sentMessage = self::createTransport($client)->send($message);
+
+        self::assertSame('reel-media', $sentMessage->getMessageId());
+    }
+
+    public function testSendRetriesUntilTheContainerIsReady()
+    {
+        $statusCalls = 0;
+        $client = new MockHttpClient(static function (string $method, string $url) use (&$statusCalls): MockResponse {
+            if (str_contains($url, '/media_publish')) {
+                return new MockResponse(json_encode(['id' => 'media-1'], \JSON_THROW_ON_ERROR));
+            }
+
+            if ('GET' === $method) {
+                return new MockResponse(json_encode([
+                    'id' => 'container-1',
+                    'status_code' => ++$statusCalls < 3 ? 'IN_PROGRESS' : 'FINISHED',
+                ], \JSON_THROW_ON_ERROR));
+            }
+
+            return new MockResponse(json_encode(['id' => 'container-1'], \JSON_THROW_ON_ERROR));
+        });
+
+        $message = (new ChatMessage('Caption'))->options((new InstagramOptions())->imageUrl('https://cdn.example.com/a.jpg'));
+
+        self::assertSame('media-1', self::createTransport($client)->send($message)->getMessageId());
+        self::assertSame(3, $statusCalls);
+    }
+
+    public function testSendThrowsWhenTheContainerFailsToProcess()
+    {
+        $client = new MockHttpClient(static function (string $method): MockResponse {
+            if ('GET' === $method) {
+                return new MockResponse(json_encode([
+                    'id' => 'container-1',
+                    'status_code' => 'ERROR',
+                    'error_message' => 'Media download failed',
+                ], \JSON_THROW_ON_ERROR));
+            }
+
+            return new MockResponse(json_encode(['id' => 'container-1'], \JSON_THROW_ON_ERROR));
+        });
+
+        $message = (new ChatMessage('Caption'))->options((new InstagramOptions())->imageUrl('https://cdn.example.com/a.jpg'));
+
+        $this->expectException(TransportException::class);
+        $this->expectExceptionMessage('Instagram container processing failed (status "ERROR"): "Media download failed"');
+
+        self::createTransport($client)->send($message);
+    }
+
+    public function testSendThrowsWhenTheContainerNeverBecomesReady()
+    {
+        $client = new MockHttpClient(static function (string $method): MockResponse {
+            if ('GET' === $method) {
+                return new MockResponse(json_encode(['id' => 'container-1', 'status_code' => 'IN_PROGRESS'], \JSON_THROW_ON_ERROR));
+            }
+
+            return new MockResponse(json_encode(['id' => 'container-1'], \JSON_THROW_ON_ERROR));
+        });
+
+        $message = (new ChatMessage('Caption'))->options((new InstagramOptions())->imageUrl('https://cdn.example.com/a.jpg'));
+
+        $this->expectException(TransportException::class);
+        $this->expectExceptionMessage('Instagram container "container-1" did not finish processing in time.');
+
+        self::createTransport($client, 2)->send($message);
+    }
+
+    public function testSendRejectsANonHttpsMediaUrl()
+    {
+        $message = (new ChatMessage('Caption'))->options((new InstagramOptions())->imageUrl('http://cdn.example.com/a.jpg'));
+
+        $this->expectException(InvalidArgumentException::class);
+
+        self::createTransport()->send($message);
+    }
+
+    public function testSendThrowsTransportExceptionOnApiError()
+    {
+        $client = new MockHttpClient(new MockResponse(
+            json_encode(['error' => ['message' => 'unsupported format', 'code' => 100, 'error_subcode' => 2207051, 'fbtrace_id' => 'xyz']], \JSON_THROW_ON_ERROR),
+            ['http_code' => 400],
+        ));
+
+        $this->expectException(TransportException::class);
+        $this->expectExceptionMessage('Unable to create the Instagram media container: HTTP 400, code 100, subcode 2207051, fbtrace_id xyz ("unsupported format")');
+
+        $message = (new ChatMessage('Caption'))->options((new InstagramOptions())->imageUrl('https://cdn.example.com/a.jpg'));
+        self::createTransport($client)->send($message);
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Instagram/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Instagram/composer.json
@@ -1,0 +1,37 @@
+{
+    "name": "symfony/instagram-notifier",
+    "type": "symfony-notifier-bridge",
+    "description": "Symfony Instagram Notifier Bridge",
+    "keywords": [
+        "instagram",
+        "meta",
+        "notifier",
+        "chat"
+    ],
+    "homepage": "https://symfony.com",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Mathieu Ledru",
+            "email": "matyo91@gmail.com"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "https://symfony.com/contributors"
+        }
+    ],
+    "require": {
+        "php": ">=8.4.1",
+        "symfony/http-client": "^7.4|^8.0",
+        "symfony/notifier": "^7.4|^8.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Symfony\\Component\\Notifier\\Bridge\\Instagram\\": ""
+        },
+        "exclude-from-classmap": [
+            "/Tests/"
+        ]
+    },
+    "minimum-stability": "dev"
+}

--- a/src/Symfony/Component/Notifier/Bridge/Instagram/phpunit.xml.dist
+++ b/src/Symfony/Component/Notifier/Bridge/Instagram/phpunit.xml.dist
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/13.1/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+         failOnDeprecation="true"
+         failOnRisky="true"
+         failOnWarning="true"
+>
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Symfony Instagram Notifier Bridge Test Suite">
+            <directory>./Tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <source ignoreSuppressionOfDeprecations="true">
+        <include>
+            <directory>./</directory>
+        </include>
+        <exclude>
+            <directory>./Tests</directory>
+            <directory>./vendor</directory>
+        </exclude>
+    </source>
+
+    <extensions>
+        <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension" />
+    </extensions>
+</phpunit>

--- a/src/Symfony/Component/Notifier/Exception/UnsupportedSchemeException.php
+++ b/src/Symfony/Component/Notifier/Exception/UnsupportedSchemeException.php
@@ -108,6 +108,10 @@ class UnsupportedSchemeException extends LogicException
             'class' => Bridge\Infobip\InfobipTransportFactory::class,
             'package' => 'symfony/infobip-notifier',
         ],
+        'instagram' => [
+            'class' => Bridge\Instagram\InstagramTransportFactory::class,
+            'package' => 'symfony/instagram-notifier',
+        ],
         'iqsms' => [
             'class' => Bridge\Iqsms\IqsmsTransportFactory::class,
             'package' => 'symfony/iqsms-notifier',

--- a/src/Symfony/Component/Notifier/Tests/Exception/UnsupportedSchemeExceptionTest.php
+++ b/src/Symfony/Component/Notifier/Tests/Exception/UnsupportedSchemeExceptionTest.php
@@ -51,6 +51,7 @@ final class UnsupportedSchemeExceptionTest extends TestCase
             Bridge\Infobip\InfobipTransportFactory::class => false,
             Bridge\Iqsms\IqsmsTransportFactory::class => false,
             Bridge\Isendpro\IsendproTransportFactory::class => false,
+            Bridge\Instagram\InstagramTransportFactory::class => false,
             Bridge\KazInfoTeh\KazInfoTehTransportFactory::class => false,
             Bridge\LightSms\LightSmsTransportFactory::class => false,
             Bridge\LineBot\LineBotTransportFactory::class => false,
@@ -148,6 +149,7 @@ final class UnsupportedSchemeExceptionTest extends TestCase
         yield ['gatewayapi', 'symfony/gateway-api-notifier'];
         yield ['googlechat', 'symfony/google-chat-notifier'];
         yield ['infobip', 'symfony/infobip-notifier'];
+        yield ['instagram', 'symfony/instagram-notifier'];
         yield ['iqsms', 'symfony/iqsms-notifier'];
         yield ['isendpro', 'symfony/isendpro-notifier'];
         yield ['kaz-info-teh', 'symfony/kaz-info-teh-notifier'];

--- a/src/Symfony/Component/Notifier/Transport.php
+++ b/src/Symfony/Component/Notifier/Transport.php
@@ -51,6 +51,7 @@ final class Transport
         Bridge\GoIp\GoIpTransportFactory::class,
         Bridge\GoogleChat\GoogleChatTransportFactory::class,
         Bridge\Infobip\InfobipTransportFactory::class,
+        Bridge\Instagram\InstagramTransportFactory::class,
         Bridge\Iqsms\IqsmsTransportFactory::class,
         Bridge\Isendpro\IsendproTransportFactory::class,
         Bridge\JoliNotif\JoliNotifTransportFactory::class,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix Instagram content page post __invoke Tool from https://github.com/symfony/ai/pull/549
| License       | MIT

This adds a Notifier bridge for [Instagram content publishing](https://developers.facebook.com/docs/instagram-platform/instagram-api-with-instagram-login/content-publishing)
via **Instagram API with Instagram Login**. It registers a `Chatter` transport that creates a media
container and then publishes it on `graph.instagram.com`:

1. `POST https://graph.instagram.com/{api_version}/{user_id}/media`
2. poll container status until ready
3. `POST https://graph.instagram.com/{api_version}/{user_id}/media_publish`

Facebook Login / `graph.facebook.com` publishing is intentionally out of scope; this bridge targets
Instagram Login only.

Unlike text-first bridges (e.g. Facebook Page or Threads), Instagram always needs media: an image
feed post or a Reel. The `ChatMessage` subject is used as the caption.

### DSN

```
INSTAGRAM_DSN=instagram://ACCESS_TOKEN@default?user_id=IG_USER_ID&api_version=v22.0
```

`api_version` is optional and defaults to `v22.0`. Meta retires Graph API versions over time, so the
option lets applications move ahead of, or stay behind, the bridge's default.

### Getting the credentials

Both values come from an app in the [Meta developer console](https://developers.facebook.com/apps):

1. Create or open an app and configure **Instagram API with Instagram Login**.
2. Complete OAuth setup and request permissions (typically `instagram_business_basic` and
   `instagram_business_content_publish`; verify current names in Meta's docs).
3. Authorize an Instagram professional account that has a role on the app (Development mode only
   allows publishing to those accounts; App Review / Advanced Access is required for broader use).
4. Use the resulting **Instagram user access token** (`ACCESS_TOKEN`) and Instagram **user id**
   (`user_id`). A short-lived token is fine for a first try; exchange it for a long-lived token for
   production use.

### Sending messages

The DSN already identifies the Instagram user. Media is selected through `InstagramOptions`. Image
and Reel URLs must be **public HTTPS** URLs (`image_url` / `video_url`); local paths are not
supported. Meta fetches the media itself.

Image feed post:

```php
use Symfony\Component\Notifier\Bridge\Instagram\InstagramOptions;
use Symfony\Component\Notifier\Message\ChatMessage;

$options = (new InstagramOptions())->imageUrl('https://example.com/photo.jpg');

$chatter->send((new ChatMessage('Caption'))->options($options));
```

Reel (sets `media_type=REELS`; optional `share_to_feed`):

```php
use Symfony\Component\Notifier\Bridge\Instagram\InstagramOptions;
use Symfony\Component\Notifier\Message\ChatMessage;

$options = (new InstagramOptions())
    ->videoUrl('https://example.com/reel.mp4')
    ->shareToFeed(true);

$chatter->send((new ChatMessage('Reel caption'))->options($options));
```

### Possible follow-up

Stories, carousels, and Facebook Login / resumable upload would be natural extensions. They are
deliberately out of scope here so the first version stays a simple image / Reel publish-now flow
over Instagram Login.

### Documentation

A symfony-docs pull request should cover:

* the new `instagram` scheme and its row in the chatter transports table of `notifier.rst`, with the
  DSN format and the `symfony/instagram-notifier` package name;
* the two DSN options, `user_id` (required) and `api_version` (optional), and where the Instagram
  user id / access token come from in the Meta developer console;
* that this bridge uses **Instagram Login** (`graph.instagram.com`), not Facebook Login;
* the `instagram_business_basic` / `instagram_business_content_publish` permission requirements, and
  the Development-mode vs App Review note;
* `InstagramOptions::imageUrl()`, `InstagramOptions::videoUrl()`, and `InstagramOptions::shareToFeed()`;
* that media URLs must be public HTTPS, and that a bare text-only `ChatMessage` is not enough
  (media is required);
* the fact that no recipient is needed, because the Instagram user is selected by the DSN.