### PR TITLE
[HttpKernel] Fix failing reset methods preventing later services from resetting

### DIFF
--- a/src/Symfony/Component/HttpKernel/DependencyInjection/ServicesResetter.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/ServicesResetter.php
@@ -40,6 +40,8 @@ class ServicesResetter implements ResetInterface
 
     public function reset(): void
     {
+        $throwable = null;
+
         foreach ($this->resettableServices as $id => $service) {
             if ($service instanceof LazyObjectInterface && !$service->isLazyObjectInitialized(true)) {
                 continue;
@@ -54,8 +56,17 @@ class ServicesResetter implements ResetInterface
                     continue;
                 }
 
-                $service->$resetMethod();
+                try {
+                    $service->$resetMethod();
+                } catch (\Throwable $e) {
+                    // failing to reset one service should not prevent resetting the remaining ones
+                    $throwable ??= $e;
+                }
             }
+        }
+
+        if (null !== $throwable) {
+            throw $throwable;
         }
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/ServicesResetterTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/ServicesResetterTest.php
@@ -73,4 +73,71 @@ class ServicesResetterTest extends TestCase
         $resetter->reset();
         $this->assertSame(1, LazyResettableService::$counter);
     }
+
+    public function testResetThrowingServiceDoesNotPreventLaterServicesReset()
+    {
+        $throwingService = new class {
+            public function reset(): void
+            {
+                throw new \RuntimeException('boom');
+            }
+        };
+
+        $resetter = new ServicesResetter(new \ArrayIterator([
+            'id1' => $throwingService,
+            'id2' => new ResettableService(),
+        ]), [
+            'id1' => ['reset'],
+            'id2' => ['reset'],
+        ]);
+
+        $thrown = null;
+
+        try {
+            $resetter->reset();
+        } catch (\Throwable $e) {
+            $thrown = $e;
+        }
+
+        $this->assertInstanceOf(\RuntimeException::class, $thrown);
+        $this->assertSame('boom', $thrown->getMessage());
+        $this->assertSame(1, ResettableService::$counter);
+    }
+
+    public function testFirstThrowableIsRethrownAfterAllMethodsRun()
+    {
+        $service = new class {
+            public int $secondCounter = 0;
+
+            public function resetFirst(): void
+            {
+                throw new \RuntimeException('first');
+            }
+
+            public function resetSecond(): void
+            {
+                ++$this->secondCounter;
+
+                throw new \RuntimeException('second');
+            }
+        };
+
+        $resetter = new ServicesResetter(new \ArrayIterator([
+            'id1' => $service,
+        ]), [
+            'id1' => ['resetFirst', 'resetSecond'],
+        ]);
+
+        $thrown = null;
+
+        try {
+            $resetter->reset();
+        } catch (\Throwable $e) {
+            $thrown = $e;
+        }
+
+        $this->assertInstanceOf(\RuntimeException::class, $thrown);
+        $this->assertSame('first', $thrown->getMessage());
+        $this->assertSame(1, $service->secondCounter);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`ServicesResetter::reset()` calls the reset methods without any error handling, so the first method that throws aborts the whole traversal and all remaining `kernel.reset` services keep their request state.

When the resetter is invoked through `Container::reset()`, which catches and discards any `\Throwable`, the failure is silent: later services are never reset, and externally retained instances can carry request state into subsequent work (long-running workers, Messenger, etc.).

This PR calls all reset methods and the first exception (if any) is rethrown at the end. Direct callers (`Kernel`, `KernelTestCase`, Messenger's `ResetServicesListener`) keep seeing the same exception as before, while `Container::reset()` now always completes the full reset pass.

-----

**Note when upmerging**: On 8.1 branch, this code changed a lot. The class moved to `src/Symfony/Component/DependencyInjection/ServicesResetter.php`, gained a third constructor arg `?\WeakMap $resetMap` (non-shared instances), and the loop body was extracted into `resetInstance()`.

The changes needed:

```diff
  public function reset(): void
  {
+     $throwable = null;
  
      foreach ($this->resettableServices as $id => $service) {
-         $this->resetInstance($service, (array) $this->resetMethods[$id]);
+         $throwable ??= $this->resetInstance($service, (array) $this->resetMethods[$id]);
      }
  
      if (null !== $this->resetMap) {
          foreach ($this->resetMap as $service => $methods) {
-             $this->resetInstance($service, $methods);
+             $throwable ??= $this->resetInstance($service, $methods);
          }
      }
  
+     if (null !== $throwable) {
+         throw $throwable;
+     }
  }
  
  private function resetInstance(object $service, array $methods): ?\Throwable
  {
      if ($this->isUninitializedLazyObject($service)) {
          return null;
      }
  
+     $throwable = null;
  
      foreach ($methods as $resetMethod) {
          if ('?' === $resetMethod[0] && !method_exists($service, $resetMethod = substr($resetMethod, 1))) {
              continue;
          }
  
+         try {
              $service->$resetMethod();
+         } catch (\Throwable $e) {
+             // failing to reset one service should not prevent resetting the remaining ones
+             $throwable ??= $e;
+         }
      }
  
+     return $throwable;
  }
```

The rethrow must happen after the `WeakMap` loop, so a throwing shared service can no longer prevent non-shared tracked instances from being reset.