### PR TITLE
 Fix: form currency type choice list cache key

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/CurrencyType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CurrencyType.php
@@ -47,6 +47,14 @@ class CurrencyType extends AbstractType
                     false => '0',
                 };
 
+                // The date alone is ambiguous: "active_at" and "not_active_at" select opposite
+                // sets of currencies, so the key must record which one the date came from.
+                $dateCacheKey = match (true) {
+                    null !== $activeAt => 'A'.$activeAt->format('Y-m-d\TH:i:s'),
+                    null !== $notActiveAt => 'N'.$notActiveAt->format('Y-m-d\TH:i:s'),
+                    default => 'X',
+                };
+
                 return ChoiceList::loader(
                     $this,
                     new IntlCallbackChoiceLoader(
@@ -74,7 +82,7 @@ class CurrencyType extends AbstractType
                             return array_flip($filteredCurrencyNames);
                         },
                     ),
-                    $choiceTranslationLocale.($activeAt ?? $notActiveAt)?->format('Y-m-d\TH:i:s').$legalTenderCacheKey.(int) $includeUndated,
+                    $choiceTranslationLocale.$dateCacheKey.$legalTenderCacheKey.(int) $includeUndated,
                 );
             },
             'choice_translation_domain' => false,

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CurrencyTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CurrencyTypeTest.php
@@ -106,6 +106,39 @@ class CurrencyTypeTest extends BaseTypeTestCase
         $this->assertContainsEquals(new ChoiceView('SIT', 'SIT', 'tolar slovène'), $choices);
     }
 
+    /**
+     * The choice loader is cached per process on a key built from the options. "active_at" and
+     * "not_active_at" select opposite sets of currencies, so building both in the same process
+     * must not make the second form reuse the choice list of the first one.
+     */
+    #[RequiresPhpExtension('intl')]
+    public function testActiveAtAndNotActiveAtDoNotShareTheirChoiceListForTheSameDate()
+    {
+        // The SIT currency expired on 2007-01-14.
+        $date = new \DateTimeImmutable('2007-01-15', new \DateTimeZone('Etc/UTC'));
+        $sit = new ChoiceView('SIT', 'SIT', 'tolar slovène');
+
+        $activeChoices = $this->factory
+            ->create(static::TESTED_TYPE, null, [
+                'choice_translation_locale' => 'fr',
+                'legal_tender' => true,
+                'active_at' => $date,
+            ])
+            ->createView()->vars['choices'];
+
+        $notActiveChoices = $this->factory
+            ->create(static::TESTED_TYPE, null, [
+                'choice_translation_locale' => 'fr',
+                'legal_tender' => true,
+                'active_at' => null,
+                'not_active_at' => $date,
+            ])
+            ->createView()->vars['choices'];
+
+        $this->assertNotContainsEquals($sit, $activeChoices);
+        $this->assertContainsEquals($sit, $notActiveChoices);
+    }
+
     public function testAnExceptionShouldBeThrownWhenTheActiveAtAndNotActiveAtOptionsAreBothSet()
     {
         $this->expectException(InvalidOptionsException::class);

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -579,12 +579,7 @@ class ObjectNormalizerTest extends TestCase
         $normalizer = new ObjectNormalizer(new ClassMetadataFactory(new AttributeLoader()), null, null, new PropertyInfoExtractor([], [new ReflectionExtractor()]));
 
         $this->expectException(NotNormalizableValueException::class);
-
-        if (class_exists(Type::class) && method_exists(PropertyInfoExtractor::class, 'getType')) {
-            $this->expectExceptionMessage('The type of the "value" attribute for class "Symfony\Component\Serializer\Tests\Fixtures\DummyWithUnion" must be one of "float", "int" ("string" given).');
-        } else {
-            $this->expectExceptionMessage('The type of the "value" attribute for class "Symfony\Component\Serializer\Tests\Fixtures\DummyWithUnion" must be one of "int", "float" ("string" given).');
-        }
+        $this->expectExceptionMessage('The type of the "value" attribute for class "Symfony\Component\Serializer\Tests\Fixtures\DummyWithUnion" must be one of "float", "int" ("string" given).');
 
         $normalizer->denormalize($data, DummyWithUnion::class, 'xml', [
             AbstractNormalizer::ALLOW_EXTRA_ATTRIBUTES => false,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2 for features / 6.4, 7.4, 8.1 for bug fixes
| Bug fix?      | yes/no
| New feature?  | yes/no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | yes/no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

<!--
🛠️ Replace this text with a concise explanation of your change:
- What it does and why it's needed
- A simple example of how it works (include PHP, YAML, etc.)
- If it modifies existing behavior, include a before/after comparison

Contributor guidelines:
- ✅ Add tests and ensure they pass
- 🐞 Bug fixes must target the **lowest maintained** branch where they apply
  https://symfony.com/releases#maintained-symfony-branches
- ✨ New features and deprecations must target the **feature** branch
  and must add an entry to the changelog file of the patched component:
  https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
- 🔒 Do not break backward compatibility:
  https://symfony.com/bc
-->
