### PR TITLE
 Fix: intl currency expiry without start date

### DIFF
--- a/src/Symfony/Component/Intl/Currencies.php
+++ b/src/Symfony/Component/Intl/Currencies.php
@@ -219,20 +219,19 @@ final class Currencies extends ResourceBundle
      */
     private static function isDateActive(array $currencyMetadata, \DateTimeInterface $date, bool $includeUndated): bool
     {
-        if (!\array_key_exists('from', $currencyMetadata)) {
+        $hasFrom = \array_key_exists('from', $currencyMetadata);
+        $hasTo = \array_key_exists('to', $currencyMetadata);
+
+        if (!$hasFrom && !$hasTo) {
             // Note: currencies that are not legal tender don't have often validity dates.
             return $includeUndated;
         }
 
-        $from = \DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s', $currencyMetadata['from'], new \DateTimeZone('Etc/UTC'));
+        $utc = new \DateTimeZone('Etc/UTC');
+        $from = $hasFrom ? \DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s', $currencyMetadata['from'], $utc) : null;
+        $to = $hasTo ? \DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s', $currencyMetadata['to'], $utc) : null;
 
-        if (\array_key_exists('to', $currencyMetadata)) {
-            $to = \DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s', $currencyMetadata['to'], new \DateTimeZone('Etc/UTC'));
-        } else {
-            $to = null;
-        }
-
-        return $from <= $date && (null === $to || $to >= $date);
+        return (null === $from || $from <= $date) && (null === $to || $to >= $date);
     }
 
     /**

--- a/src/Symfony/Component/Intl/Tests/CurrenciesTest.php
+++ b/src/Symfony/Component/Intl/Tests/CurrenciesTest.php
@@ -827,6 +827,30 @@ class CurrenciesTest extends ResourceBundleTestCase
         $this->assertFalse(Currencies::isValidInAnyCountry('ESB', true, null));
     }
 
+    /**
+     * USS is only described by an expiry date: it has a "to" but no "from".
+     * Such a currency is not undated, so its expiry must still be honored.
+     */
+    public function testUssCurrencyIsExpiredAfterItsEndDate()
+    {
+        $this->assertFalse(Currencies::isValidInAnyCountry('USS', null, true, new \DateTimeImmutable('2025-01-01', new \DateTimeZone('Etc/UTC'))));
+    }
+
+    public function testUssCurrencyIsActiveBeforeItsEndDate()
+    {
+        $this->assertTrue(Currencies::isValidInAnyCountry('USS', null, true, new \DateTimeImmutable('2010-01-01', new \DateTimeZone('Etc/UTC'))));
+    }
+
+    public function testUssCurrencyIsReportedAsInactiveAfterItsEndDate()
+    {
+        $this->assertTrue(Currencies::isValidInAnyCountry('USS', null, false, new \DateTimeImmutable('2025-01-01', new \DateTimeZone('Etc/UTC'))));
+    }
+
+    public function testExpiredUndatedStartCurrenciesAreExcludedFromTheirCountry()
+    {
+        $this->assertNotContains('USS', Currencies::forCountry('US', null, true, new \DateTimeImmutable('2025-01-01', new \DateTimeZone('Etc/UTC'))));
+    }
+
     public function testCurrenciesOfSwitzerlandIn2025()
     {
         $this->assertSame(['CHF'], Currencies::forCountry('CH', true, true, new \DateTimeImmutable('2025-01-01', new \DateTimeZone('Etc/UTC'))));

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -579,12 +579,7 @@ class ObjectNormalizerTest extends TestCase
         $normalizer = new ObjectNormalizer(new ClassMetadataFactory(new AttributeLoader()), null, null, new PropertyInfoExtractor([], [new ReflectionExtractor()]));
 
         $this->expectException(NotNormalizableValueException::class);
-
-        if (class_exists(Type::class) && method_exists(PropertyInfoExtractor::class, 'getType')) {
-            $this->expectExceptionMessage('The type of the "value" attribute for class "Symfony\Component\Serializer\Tests\Fixtures\DummyWithUnion" must be one of "float", "int" ("string" given).');
-        } else {
-            $this->expectExceptionMessage('The type of the "value" attribute for class "Symfony\Component\Serializer\Tests\Fixtures\DummyWithUnion" must be one of "int", "float" ("string" given).');
-        }
+        $this->expectExceptionMessage('The type of the "value" attribute for class "Symfony\Component\Serializer\Tests\Fixtures\DummyWithUnion" must be one of "float", "int" ("string" given).');
 
         $normalizer->denormalize($data, DummyWithUnion::class, 'xml', [
             AbstractNormalizer::ALLOW_EXTRA_ATTRIBUTES => false,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2 for features / 6.4, 7.4, 8.1 for bug fixes
| Bug fix?      | yes/no
| New feature?  | yes/no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | yes/no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

<!--
🛠️ Replace this text with a concise explanation of your change:
- What it does and why it's needed
- A simple example of how it works (include PHP, YAML, etc.)
- If it modifies existing behavior, include a before/after comparison

Contributor guidelines:
- ✅ Add tests and ensure they pass
- 🐞 Bug fixes must target the **lowest maintained** branch where they apply
  https://symfony.com/releases#maintained-symfony-branches
- ✨ New features and deprecations must target the **feature** branch
  and must add an entry to the changelog file of the patched component:
  https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
- 🔒 Do not break backward compatibility:
  https://symfony.com/bc
-->
