### PR TITLE
[Intl] Honor the expiry date of currencies that have no start date

### DIFF
--- a/src/Symfony/Component/Intl/Currencies.php
+++ b/src/Symfony/Component/Intl/Currencies.php
@@ -219,20 +219,19 @@ final class Currencies extends ResourceBundle
      */
     private static function isDateActive(array $currencyMetadata, \DateTimeInterface $date, bool $includeUndated): bool
     {
-        if (!\array_key_exists('from', $currencyMetadata)) {
+        $hasFrom = \array_key_exists('from', $currencyMetadata);
+        $hasTo = \array_key_exists('to', $currencyMetadata);
+
+        if (!$hasFrom && !$hasTo) {
             // Note: currencies that are not legal tender don't have often validity dates.
             return $includeUndated;
         }
 
-        $from = \DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s', $currencyMetadata['from'], new \DateTimeZone('Etc/UTC'));
+        $utc = new \DateTimeZone('Etc/UTC');
+        $from = $hasFrom ? \DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s', $currencyMetadata['from'], $utc) : null;
+        $to = $hasTo ? \DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s', $currencyMetadata['to'], $utc) : null;
 
-        if (\array_key_exists('to', $currencyMetadata)) {
-            $to = \DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s', $currencyMetadata['to'], new \DateTimeZone('Etc/UTC'));
-        } else {
-            $to = null;
-        }
-
-        return $from <= $date && (null === $to || $to >= $date);
+        return (null === $from || $from <= $date) && (null === $to || $to >= $date);
     }
 
     /**

--- a/src/Symfony/Component/Intl/Tests/CurrenciesTest.php
+++ b/src/Symfony/Component/Intl/Tests/CurrenciesTest.php
@@ -827,6 +827,30 @@ class CurrenciesTest extends ResourceBundleTestCase
         $this->assertFalse(Currencies::isValidInAnyCountry('ESB', true, null));
     }
 
+    /**
+     * USS is only described by an expiry date: it has a "to" but no "from".
+     * Such a currency is not undated, so its expiry must still be honored.
+     */
+    public function testUssCurrencyIsExpiredAfterItsEndDate()
+    {
+        $this->assertFalse(Currencies::isValidInAnyCountry('USS', null, true, new \DateTimeImmutable('2025-01-01', new \DateTimeZone('Etc/UTC'))));
+    }
+
+    public function testUssCurrencyIsActiveBeforeItsEndDate()
+    {
+        $this->assertTrue(Currencies::isValidInAnyCountry('USS', null, true, new \DateTimeImmutable('2010-01-01', new \DateTimeZone('Etc/UTC'))));
+    }
+
+    public function testUssCurrencyIsReportedAsInactiveAfterItsEndDate()
+    {
+        $this->assertTrue(Currencies::isValidInAnyCountry('USS', null, false, new \DateTimeImmutable('2025-01-01', new \DateTimeZone('Etc/UTC'))));
+    }
+
+    public function testExpiredUndatedStartCurrenciesAreExcludedFromTheirCountry()
+    {
+        $this->assertNotContains('USS', Currencies::forCountry('US', null, true, new \DateTimeImmutable('2025-01-01', new \DateTimeZone('Etc/UTC'))));
+    }
+
     public function testCurrenciesOfSwitzerlandIn2025()
     {
         $this->assertSame(['CHF'], Currencies::forCountry('CH', true, true, new \DateTimeImmutable('2025-01-01', new \DateTimeZone('Etc/UTC'))));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`Currencies::isDateActive()` treats any entry without a `from` key as undated and returns `$includeUndated`, without looking at a `to` key that may still be present.

Three currency associations in the ICU data carry an expiry date but no start date:

| Country | Currency | to                  |
| ------- | -------- | ------------------- |
| US      | USS      | 2014-03-01T23:59:59 |
| ZZ      | XFU      | 2013-11-30T23:59:59 |
| ZZ      | XRE      | 1999-11-30T23:59:59 |

They are therefore reported as active forever:

```php
// before
Currencies::isValidInAnyCountry('USS', null, true); // true
Currencies::forCountry('US', null, true);           // ['USD', 'USN', 'USS']

// after
Currencies::isValidInAnyCountry('USS', null, true); // false
Currencies::forCountry('US', null, true);           // ['USD', 'USN']
```

An entry is only undated when it has neither bound. When a single bound is missing the range is open-ended on that side, and the bound that *is* present still applies.

These currencies are not legal tender, so the default `$legalTender = true` hides the problem; it shows up as soon as `null` or `false` is passed.
