### PR TITLE
[Form] Distinguish active_at from not_active_at in the CurrencyType choice list cache

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/CurrencyType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CurrencyType.php
@@ -47,6 +47,14 @@ class CurrencyType extends AbstractType
                     false => '0',
                 };
 
+                // The date alone is ambiguous: "active_at" and "not_active_at" select opposite
+                // sets of currencies, so the key must record which one the date came from.
+                $dateCacheKey = match (true) {
+                    null !== $activeAt => 'A'.$activeAt->format('Y-m-d\TH:i:s'),
+                    null !== $notActiveAt => 'N'.$notActiveAt->format('Y-m-d\TH:i:s'),
+                    default => 'X',
+                };
+
                 return ChoiceList::loader(
                     $this,
                     new IntlCallbackChoiceLoader(
@@ -74,7 +82,7 @@ class CurrencyType extends AbstractType
                             return array_flip($filteredCurrencyNames);
                         },
                     ),
-                    $choiceTranslationLocale.($activeAt ?? $notActiveAt)?->format('Y-m-d\TH:i:s').$legalTenderCacheKey.(int) $includeUndated,
+                    $choiceTranslationLocale.$dateCacheKey.$legalTenderCacheKey.(int) $includeUndated,
                 );
             },
             'choice_translation_domain' => false,

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CurrencyTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CurrencyTypeTest.php
@@ -106,6 +106,39 @@ class CurrencyTypeTest extends BaseTypeTestCase
         $this->assertContainsEquals(new ChoiceView('SIT', 'SIT', 'tolar slovène'), $choices);
     }
 
+    /**
+     * The choice loader is cached per process on a key built from the options. "active_at" and
+     * "not_active_at" select opposite sets of currencies, so building both in the same process
+     * must not make the second form reuse the choice list of the first one.
+     */
+    #[RequiresPhpExtension('intl')]
+    public function testActiveAtAndNotActiveAtDoNotShareTheirChoiceListForTheSameDate()
+    {
+        // The SIT currency expired on 2007-01-14.
+        $date = new \DateTimeImmutable('2007-01-15', new \DateTimeZone('Etc/UTC'));
+        $sit = new ChoiceView('SIT', 'SIT', 'tolar slovène');
+
+        $activeChoices = $this->factory
+            ->create(static::TESTED_TYPE, null, [
+                'choice_translation_locale' => 'fr',
+                'legal_tender' => true,
+                'active_at' => $date,
+            ])
+            ->createView()->vars['choices'];
+
+        $notActiveChoices = $this->factory
+            ->create(static::TESTED_TYPE, null, [
+                'choice_translation_locale' => 'fr',
+                'legal_tender' => true,
+                'active_at' => null,
+                'not_active_at' => $date,
+            ])
+            ->createView()->vars['choices'];
+
+        $this->assertNotContainsEquals($sit, $activeChoices);
+        $this->assertContainsEquals($sit, $notActiveChoices);
+    }
+
     public function testAnExceptionShouldBeThrownWhenTheActiveAtAndNotActiveAtOptionsAreBothSet()
     {
         $this->expectException(InvalidOptionsException::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The `active_at` / `not_active_at` options added in 7.4 vary the cached choice loader on the date alone:

```php
$choiceTranslationLocale.($activeAt ?? $notActiveAt)?->format('Y-m-d\TH:i:s').$legalTenderCacheKey.(int) $includeUndated
```

The two options select opposite sets of currencies, but for the same date they produce the same key. The loader is memoized process-wide in `AbstractStaticOption::$options`, so when both forms are built in the same process the first one wins and the second silently renders the other one's list:

```php
$date = new \DateTimeImmutable('2007-01-15', new \DateTimeZone('Etc/UTC')); // SIT expired 2007-01-14

$active = $factory->create(CurrencyType::class, null, [
    'active_at' => $date,
]);
$expired = $factory->create(CurrencyType::class, null, [
    'active_at' => null,
    'not_active_at' => $date,
]);

// before: both lists hold the same 161 active currencies, SIT missing from $expired
// after:  161 and 127 respectively, SIT present in $expired
```

`testAnExpiredCurrencyIn2007()` and `testRetrieveExpiredCurrenciesIn2007()` are exactly this pair of options with the same date; they pass today only because the static cache is reset between test cases. The test added here builds both forms inside one test method, the way a single request would.

The cache key now records which of the two options the date came from.
