### PR TITLE
[Form] Deprecate the TimezoneType regions option

### DIFF
--- a/UPGRADE-8.2.md
+++ b/UPGRADE-8.2.md
@@ -25,6 +25,11 @@ DoctrineBridge
    association and the default `findBy` repository method is used. Such fields were silently validated against a
    query that could not match. Use the `repositoryMethod` option to provide a method that can query them
 
+Form
+----
+
+ * Deprecate the `regions` option of `TimezoneType`, it has had no effect since 5.0 and will be removed in 9.0
+
 FrameworkBundle
 ---------------
 

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.2
 ---
 
+ * Deprecate the `regions` option of `TimezoneType`, it has had no effect since 5.0
  * Add `inputmode="numeric"` to `IntegerType` when the `grouping` option is enabled
  * Add the `choice_help` option to `ChoiceType`
  * Add `$help` parameter to `ChoiceListFactoryInterface::createView()`

--- a/src/Symfony/Component/Form/Extension/Core/Type/TimezoneType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TimezoneType.php
@@ -60,6 +60,8 @@ class TimezoneType extends AbstractType
             'regions' => \DateTimeZone::ALL,
         ]);
 
+        $resolver->setDeprecated('regions', 'symfony/form', '8.2', 'The "%name%" option is deprecated. It has had no effect since 5.0 and will be removed in 9.0.');
+
         $resolver->setAllowedTypes('intl', ['bool']);
 
         $resolver->setAllowedTypes('choice_translation_locale', ['null', 'string']);

--- a/src/Symfony/Component/Form/Tests/Command/DebugCommandTest.php
+++ b/src/Symfony/Component/Form/Tests/Command/DebugCommandTest.php
@@ -46,6 +46,11 @@ class DebugCommandTest extends TestCase
         $this->assertEquals(0, $ret, 'Returns 0 in case of success');
         $this->assertSame(<<<TXT
 
+            Built-in form types (Symfony\Component\Form\Extension\Core\Type)
+            ----------------------------------------------------------------
+
+             TimezoneType
+
             Service form types
             ------------------
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimezoneTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimezoneTypeTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use Symfony\Component\Form\ChoiceList\View\ChoiceView;
 use Symfony\Component\Form\Exception\LogicException;
@@ -28,6 +30,15 @@ class TimezoneTypeTest extends BaseTypeTestCase
 
         $this->assertContainsEquals(new ChoiceView('Africa/Kinshasa', 'Africa/Kinshasa', 'Africa / Kinshasa'), $choices);
         $this->assertContainsEquals(new ChoiceView('America/New_York', 'America/New_York', 'America / New York'), $choices);
+    }
+
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
+    public function testRegionsOptionIsDeprecated()
+    {
+        $this->expectUserDeprecationMessage('Since symfony/form 8.2: The "regions" option is deprecated. It has had no effect since 5.0 and will be removed in 9.0.');
+
+        $this->factory->create(static::TESTED_TYPE, null, ['regions' => \DateTimeZone::EUROPE]);
     }
 
     public function testSubmitNull($expected = null, $norm = null, $view = null)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Issues        | -
| License       | MIT

The `regions` option of `TimezoneType` was removed in 5.0, but its default was left behind in `setDefaults()`:

```php
'invalid_message' => 'Please select a valid timezone.',
'regions' => \DateTimeZone::ALL,
```

`OptionsResolver` still accepts the option and lists it among the defined options, while nothing reads it: `getPhpTimezones()` hardcodes `\DateTimeZone::ALL`.

Passing it is therefore ignored without any signal:

```php
$factory->create(TimezoneType::class, null, ['regions' => \DateTimeZone::EUROPE]);
// 419 choices, America/New_York included, the same as passing nothing
```

Code carrying the option over from 4.x gets every timezone instead of the requested region, with nothing to indicate the option stopped working six major versions ago.

It now triggers a deprecation so the leftover can be removed in 9.0:

```
Since symfony/form 8.2: The "regions" option is deprecated. It has had no effect since 5.0 and will be removed in 9.0.
```

The deprecation fires only when the option is passed explicitly. Building a `TimezoneType` normally triggers nothing. `DebugCommandTest::testDebugDeprecatedDefaults` is updated because `TimezoneType` now appears under `--show-deprecated`.
