### PR TITLE
[HttpFoundation] Reject non-integer netmasks in IpUtils

### DIFF
--- a/src/Symfony/Component/HttpFoundation/IpUtils.php
+++ b/src/Symfony/Component/HttpFoundation/IpUtils.php
@@ -23,7 +23,7 @@ class IpUtils
         '10.0.0.0/8',     // RFC1918
         '192.168.0.0/16', // RFC1918
         '192.0.2.0/24',   // Documentation Ranges TEST-NET-1 (RFC 5737)
-        '198.51.100.0/24',// Documentation Ranges TEST-NET-2 (RFC 5737)
+        '198.51.100.0/24', // Documentation Ranges TEST-NET-2 (RFC 5737)
         '203.0.113.0/24', // Documentation Ranges TEST-NET-3 (RFC 5737)
         '172.16.0.0/12',  // RFC1918
         '169.254.0.0/16', // RFC3927
@@ -102,9 +102,11 @@ class IpUtils
                 return self::setCacheResult($cacheKey, false !== filter_var($address, \FILTER_VALIDATE_IP, \FILTER_FLAG_IPV4));
             }
 
-            if ($netmask < 0 || $netmask > 32) {
+            if (!ctype_digit($netmask) || 32 < (int) $netmask) {
                 return self::setCacheResult($cacheKey, false);
             }
+
+            $netmask = (int) $netmask;
         } else {
             $address = $ip;
             $netmask = 32;
@@ -156,9 +158,11 @@ class IpUtils
                 return (bool) unpack('n*', @inet_pton($address));
             }
 
-            if ($netmask < 1 || $netmask > 128) {
+            if (!ctype_digit($netmask) || 1 > (int) $netmask || 128 < (int) $netmask) {
                 return self::setCacheResult($cacheKey, false);
             }
+
+            $netmask = (int) $netmask;
         } else {
             if (!filter_var($ip, \FILTER_VALIDATE_IP, \FILTER_FLAG_IPV6)) {
                 return self::setCacheResult($cacheKey, false);

--- a/src/Symfony/Component/HttpFoundation/Tests/IpUtilsTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/IpUtilsTest.php
@@ -55,6 +55,11 @@ class IpUtilsTest extends TestCase
             [false, '1.2.3.4', '256.256.256/0'], // invalid CIDR notation
             [false, 'an_invalid_ip', '192.168.1.0/24'],
             [false, '', '1.2.3.4/1'],
+            [false, '10.5.5.5', '10.0.0.0/8.5'], // non-integer netmask
+            [false, '10.5.5.5', '10.0.0.0/8e0'], // non-integer netmask
+            [false, '10.5.5.5', '10.0.0.0/ 8'],  // non-integer netmask
+            [false, '10.5.5.5', '10.0.0.0/+8'],  // non-integer netmask
+            [false, '10.5.5.5', '10.0.0.0/-1'],  // negative netmask
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`IpUtils::checkIp4()` compares the netmask as a string, so anything PHP reads as a number in range is accepted and then used as the `length` argument of `substr_compare()`:

```php
IpUtils::checkIp('10.5.5.5', '10.0.0.0/8.5');  // true  - treated as /8
IpUtils::checkIp('10.5.5.5', '10.0.0.0/8e0');  // true  - treated as /8
IpUtils::checkIp('10.5.5.5', '10.0.0.0/ 8');   // true  - treated as /8
IpUtils::checkIp('10.5.5.5', '10.0.0.0/33');   // false - correctly rejected
IpUtils::checkIp('10.5.5.5', '10.0.0.0/abc');  // false - correctly rejected
```

A typo in a subnet therefore silently widens it to a different range instead of being rejected like the other malformed forms. The float case additionally emits:

```
Deprecated: Implicit conversion from float-string "8.5" to int loses precision
```

`checkIp6()` had the same loose comparison. Both now require the netmask to be a plain integer, and it is cast once before use.

The CIDR maths itself is unchanged: I re-ran a differential fuzz of ~101,000 cases (random IPv4/IPv6 addresses across every netmask, plus byte-boundary cases) against an independent bitmask implementation, before and after — zero mismatches both times, so only the previously-malformed inputs change behaviour.

Subnets come from configuration rather than requests, so there is no attack surface here; it is a correctness and diagnosability fix.

**On the target branch:** opened against 8.2 because input that used to be accepted is now rejected. Happy to recut against 6.4 if you would rather have it as a plain bug fix.

The one unrelated line in `PRIVATE_SUBNETS` (a missing space before a comment on `198.51.100.0/24`) is there because Fabbot runs PHP-CS-Fixer over the whole touched file and fails the build on it. It predates this PR and is present on every branch from 6.4 up.
