### PR TITLE
[HttpFoundation] Treat a UriSigner expiration of 0 as a date, not as no expiry

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Tests/UriSignerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/UriSignerTest.php
@@ -39,6 +39,15 @@ class UriSignerTest extends TestCase
         $this->assertStringContainsString('&foo=', $signer->sign('http://example.com/foo?foo=bar', 1));
     }
 
+    public function testCheckWithExpirationAtTheUnixEpoch()
+    {
+        $signer = new UriSigner('foobar');
+
+        // "0" is a real expiration date, not the absence of one
+        $this->assertFalse($signer->check($signer->sign('http://example.com/foo', 0)));
+        $this->assertFalse($signer->check($signer->sign('http://example.com/foo', new \DateTimeImmutable('@0'))));
+    }
+
     public function testCheck()
     {
         $signer = new UriSigner('foobar');

--- a/src/Symfony/Component/HttpFoundation/UriSigner.php
+++ b/src/Symfony/Component/HttpFoundation/UriSigner.php
@@ -192,7 +192,7 @@ class UriSigner
             return self::STATUS_INVALID;
         }
 
-        if (!$expiration = $params[$this->expirationParameter] ?? false) {
+        if (null === $expiration = $params[$this->expirationParameter] ?? null) {
             return self::STATUS_VALID;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`UriSigner::doVerify()` tests the expiration parameter for truthiness:

```php
if (!$expiration = $params[$this->expirationParameter] ?? false) {
    return self::STATUS_VALID;
}
```

`"0"` is falsy in PHP, so an expiration of the Unix epoch takes the "no expiration was set" branch and the URI never expires:

```php
$signer->check($signer->sign($uri, 0));                             // true, forever
$signer->check($signer->sign($uri, new \DateTimeImmutable('@0')));  // true, forever
$signer->check($signer->sign($uri, 946684800));                     // false, correct
```

Every other past timestamp expires correctly, so this is specific to 0. A signature check failing open is the wrong direction, and 0 is easy to arrive at accidentally — an unset config value, `(int) $null`, or a `strtotime()` that returned false — where the intent was "already expired" and the result is a permanently valid URL.

Distinguishing "absent" from "0" is enough:

```php
if (null === $expiration = $params[$this->expirationParameter] ?? null) {
```

**Not reachable by tampering.** The expiration parameter is covered by the HMAC, so rewriting `_expiration=0` onto a legitimately signed URI is rejected (verified). Only a URI actually signed with 0 is affected, which is why this is a regular bug report rather than a security report.

6.4 does not have the expiration feature, so 7.4 is the lowest maintained branch where this applies.
