### PR TITLE
[PhpUnitBridge] Don't return a non-callable from getPhpUnitErrorHandler()

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
@@ -377,8 +377,12 @@ class DeprecationErrorHandler
                 $eh = self::$errorHandler = UtilErrorHandler::class;
             } elseif (method_exists(ErrorHandler::class, '__invoke')) {
                 $eh = self::$errorHandler = ErrorHandler::class;
-            } else {
+            } elseif (method_exists(UtilErrorHandler::class, 'handleError')) {
                 return self::$errorHandler = 'PHPUnit\Util\ErrorHandler::handleError';
+            } else {
+                // PHPUnit is not loadable in this process, so there is no handler to
+                // delegate to; leave the error to PHP
+                return static function () { return false; };
             }
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`DeprecationErrorHandler::getPhpUnitErrorHandler()` is typed `: callable`. When none of the three PHPUnit handlers can be found it falls back to:

```php
return self::$errorHandler = 'PHPUnit\Util\ErrorHandler::handleError';
```

`PHPUnit\Util\ErrorHandler` was removed in PHPUnit 10, so on recent versions that string is not callable and the first deprecation becomes a fatal error:

```
TypeError: Symfony\Bridge\PhpUnit\DeprecationErrorHandler::getPhpUnitErrorHandler():
Return value must be of type callable, string returned
```

The branch is only reached when *no* PHPUnit handler class is loadable — which is exactly when that string cannot be callable either, so the fallback can never be valid at that point.

It is reachable in practice: the bridge's own `.phpt` tests define `PHPUnit_COMPOSER_INSTALL` from the root autoloader while PHPUnit itself lives in `.phpunit/`, so inside those subprocesses no PHPUnit class is autoloadable. `Tests/DeprecationErrorHandler/disabled_1.phpt` currently fails this way on `Unit Tests (8.4)`, `(8.5)`, `(8.6)` and the `high-deps`/`low-deps` jobs.

Reproduced in isolation by loading the handler with PHPUnit absent and triggering one deprecation — same stack trace as CI, fatal before, clean after.

The string is now returned only when the method it names exists; otherwise the error is left to PHP, matching the other fallback at the end of the same method. Behaviour with PHPUnit loaded is unchanged — verified against PHPUnit 13.3, where the resolver still selects `PHPUnit\Runner\ErrorHandler` exactly as before.
