### PR TITLE
[Form] Keep the canonical identifier when ICU timezone names collide

### DIFF
--- a/UPGRADE-8.2.md
+++ b/UPGRADE-8.2.md
@@ -29,6 +29,9 @@ Form
 ----
 
  * Deprecate the `regions` option of `TimezoneType`, it has had no effect since 5.0 and will be removed in 9.0
+ * `TimezoneType` with the `intl` option enabled now offers the timezone identifier that PHP reports as
+   canonical instead of the ICU one, so `Asia/Kolkata` replaces `Asia/Calcutta` and six other legacy aliases.
+   A stored value that came from the previous list is no longer among the choices
 
 FrameworkBundle
 ---------------

--- a/src/Symfony/Component/Form/Extension/Core/Type/TimezoneType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TimezoneType.php
@@ -110,7 +110,15 @@ class TimezoneType extends AbstractType
 
     private static function getIntlTimezones(string $input, ?string $locale = null): array
     {
-        $timezones = array_flip(Timezones::getNames($locale));
+        // an IANA identifier and its legacy alias share one display name, so keep the canonical one
+        $canonical = array_flip(\DateTimeZone::listIdentifiers(\DateTimeZone::ALL));
+        $timezones = [];
+
+        foreach (Timezones::getNames($locale) as $timezone => $name) {
+            if (!isset($timezones[$name]) || isset($canonical[$timezone])) {
+                $timezones[$name] = $timezone;
+            }
+        }
 
         if ('intltimezone' === $input) {
             foreach ($timezones as $name => $timezone) {

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimezoneTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimezoneTypeTest.php
@@ -159,6 +159,35 @@ class TimezoneTypeTest extends BaseTypeTestCase
         $this->assertContainsEquals(new ChoiceView('Etc/UTC', 'Etc/UTC', 'Coordinated Universal Time'), $choices);
     }
 
+    /**
+     * ICU lists an IANA identifier and its legacy alias under one display name, so the
+     * choices must not be keyed by that name: it would drop one of the two at random.
+     */
+    #[RequiresPhpExtension('intl')]
+    public function testIntlTimezonesKeepTheCanonicalIdentifierOfAnAliasPair()
+    {
+        $choices = $this->factory->create(static::TESTED_TYPE, null, ['intl' => true])
+            ->createView()->vars['choices'];
+
+        $values = array_map(static fn (ChoiceView $choice) => $choice->value, $choices);
+
+        $this->assertContains('Asia/Kolkata', $values);
+        $this->assertNotContains('Asia/Calcutta', $values);
+
+        $this->assertContains('Pacific/Chuuk', $values);
+        $this->assertNotContains('Pacific/Truk', $values);
+    }
+
+    #[RequiresPhpExtension('intl')]
+    public function testIntlTimezonesAreSubmittableWithTheirCanonicalIdentifier()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, ['intl' => true]);
+        $form->submit('Asia/Kolkata');
+
+        $this->assertSame('Asia/Kolkata', $form->getData());
+        $this->assertTrue($form->isValid());
+    }
+
     #[RequiresPhpExtension('intl')]
     public function testChoiceTranslationLocaleOptionWithIntl()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`TimezoneType::getIntlTimezones()` builds its choices with:

```php
$timezones = array_flip(Timezones::getNames($locale));
```

`Timezones::getNames()` is keyed by identifier and valued by display name. ICU lists both the IANA identifier and its legacy alias, and the two share one display name: `"India Standard Time (Kolkata)"` is the name of `Asia/Kolkata` and of `Asia/Calcutta`. Flipping the array therefore keeps only one identifier per name:

```
before flip: 439 identifiers
after  flip: 420 identifiers, 19 lost
```

Which identifier survives depends on the collator ordering. For 7 pairs it is the legacy alias, so `intl => true` offers the deprecated identifier and rejects the modern one:

| dropped | kept |
| --- | --- |
| `Asia/Kolkata` | `Asia/Calcutta` |
| `Asia/Kathmandu` | `Asia/Katmandu` |
| `Asia/Yangon` | `Asia/Rangoon` |
| `Pacific/Chuuk` | `Pacific/Truk` |
| `America/Argentina/Buenos_Aires` | `America/Buenos_Aires` |
| `America/Argentina/Mendoza` | `America/Mendoza` |
| `America/Kentucky/Louisville` | `America/Louisville` |

A value produced by `\DateTimeZone`, or taken from the default `intl => false` list, then fails validation once `intl` is enabled:

```php
$form = $factory->create(TimezoneType::class, null, ['intl' => true]);
$form->submit('Asia/Kolkata');
$form->isValid();   // false, "Please select a valid timezone."
```

The choices are now built by iterating the names and keeping the identifier that PHP reports as canonical. Both modes then agree: the only remaining difference is `UTC`, which the ICU data does not carry (it has `Etc/UTC`).

The values offered for `intl => true` change for those 7 pairs, so a value stored from the old list is no longer among the choices. That is a behavior change, hence the dev branch.
