### PR TITLE
[RateLimiter] Cap the burst size and the duration computed from it

### DIFF
--- a/src/Symfony/Component/RateLimiter/Policy/Rate.php
+++ b/src/Symfony/Component/RateLimiter/Policy/Rate.php
@@ -20,6 +20,11 @@ use Symfony\Component\RateLimiter\Util\TimeUtil;
  */
 final class Rate
 {
+    /**
+     * ~68 years, the largest duration that still fits an int on 32-bit platforms.
+     */
+    private const MAX_SECONDS = 2147483647;
+
     private \DateInterval $refillTime;
     private int $refillAmount;
 
@@ -71,12 +76,15 @@ final class Rate
 
     /**
      * Calculates the time needed to free up the provided number of tokens in seconds.
+     *
+     * The result is capped at self::MAX_SECONDS, as the exact value overflows the
+     * integer range for very large numbers of tokens.
      */
     public function calculateTimeForTokens(int $tokens): int
     {
         $cyclesRequired = ceil($tokens / $this->refillAmount);
 
-        return TimeUtil::dateIntervalToSeconds($this->refillTime) * $cyclesRequired;
+        return (int) min(self::MAX_SECONDS, TimeUtil::dateIntervalToSeconds($this->refillTime) * $cyclesRequired);
     }
 
     /**

--- a/src/Symfony/Component/RateLimiter/Policy/TokenBucket.php
+++ b/src/Symfony/Component/RateLimiter/Policy/TokenBucket.php
@@ -20,6 +20,12 @@ use Symfony\Component\RateLimiter\LimiterStateInterface;
  */
 final class TokenBucket implements LimiterStateInterface
 {
+    /**
+     * __serialize() stores the burst size in a 32-bit field; 2^31-1 is the
+     * largest value that also survives the round trip on 32-bit platforms.
+     */
+    public const MAX_BURST_SIZE = 2147483647;
+
     private string $id;
     private Rate $rate;
     private int $tokens;
@@ -28,7 +34,7 @@ final class TokenBucket implements LimiterStateInterface
 
     /**
      * @param string     $id            unique identifier for this bucket
-     * @param int        $initialTokens the initial number of tokens in the bucket (i.e. the max burst size)
+     * @param int        $initialTokens the initial number of tokens in the bucket (i.e. the max burst size), capped at self::MAX_BURST_SIZE
      * @param Rate       $rate          the fill rate and time of this bucket
      * @param float|null $timer         the current timer of the bucket, defaulting to microtime(true)
      */
@@ -39,7 +45,7 @@ final class TokenBucket implements LimiterStateInterface
         }
 
         $this->id = $id;
-        $this->tokens = $this->burstSize = $initialTokens;
+        $this->tokens = $this->burstSize = min($initialTokens, self::MAX_BURST_SIZE);
         $this->rate = $rate;
         $this->timer = $timer ?? microtime(true);
     }

--- a/src/Symfony/Component/RateLimiter/Policy/TokenBucketLimiter.php
+++ b/src/Symfony/Component/RateLimiter/Policy/TokenBucketLimiter.php
@@ -31,7 +31,7 @@ final class TokenBucketLimiter implements LimiterInterface
     public function __construct(string $id, int $maxBurst, Rate $rate, StorageInterface $storage, ?LockInterface $lock = null)
     {
         $this->id = $id;
-        $this->maxBurst = $maxBurst;
+        $this->maxBurst = min($maxBurst, TokenBucket::MAX_BURST_SIZE);
         $this->rate = $rate;
         $this->storage = $storage;
         $this->lock = $lock;

--- a/src/Symfony/Component/RateLimiter/Tests/Policy/RateTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/Policy/RateTest.php
@@ -34,4 +34,25 @@ class RateTest extends TestCase
         yield [Rate::perMonth(10)];
         yield [Rate::perYear(10)];
     }
+
+    /**
+     * @dataProvider provideOverflowingRate
+     */
+    public function testCalculateTimeForTokensIsCappedOnOverflow(Rate $rate, int $tokens)
+    {
+        self::assertSame(2147483647, $rate->calculateTimeForTokens($tokens));
+    }
+
+    public static function provideOverflowingRate(): iterable
+    {
+        yield 'product far above the int range' => [Rate::perHour(1), \PHP_INT_MAX];
+        yield 'product rounding to exactly the int range bound' => [new Rate(new \DateInterval('PT10S'), 10), \PHP_INT_MAX];
+        yield 'product just above the cap' => [Rate::perSecond(1), 2147483648];
+    }
+
+    public function testCalculateTimeForTokensBelowTheCapIsNotChanged()
+    {
+        self::assertSame(2147483647, Rate::perSecond(1)->calculateTimeForTokens(2147483647));
+        self::assertSame(3600, Rate::perHour(1)->calculateTimeForTokens(1));
+    }
 }

--- a/src/Symfony/Component/RateLimiter/Tests/Policy/TokenBucketLimiterTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/Policy/TokenBucketLimiterTest.php
@@ -255,6 +255,27 @@ class TokenBucketLimiterTest extends TestCase
         $this->assertEquals(10, $limiter->reserve(1)->getWaitDuration());
     }
 
+    public function testEffectivelyInfiniteBurstSizeIsCapped()
+    {
+        $limiter = $this->createLimiter(\PHP_INT_MAX, new Rate(new \DateInterval('PT10S'), 10));
+
+        $rateLimit = $limiter->consume(1);
+
+        $this->assertTrue($rateLimit->isAccepted());
+        $this->assertSame(TokenBucket::MAX_BURST_SIZE, $rateLimit->getLimit());
+        $this->assertSame(TokenBucket::MAX_BURST_SIZE - 1, $rateLimit->getRemainingTokens());
+    }
+
+    public function testCappedBurstSizeSurvivesTheStorageRoundTrip()
+    {
+        $limiter = $this->createLimiter(\PHP_INT_MAX, new Rate(new \DateInterval('PT10S'), 10));
+
+        $limiter->consume(1);
+        $rateLimit = $limiter->consume(1);
+
+        $this->assertSame(TokenBucket::MAX_BURST_SIZE - 2, $rateLimit->getRemainingTokens());
+    }
+
     private function createLimiter($initialTokens = 10, ?Rate $rate = null)
     {
         return new TokenBucketLimiter('test', $initialTokens, $rate ?? Rate::perSecond(10), $this->storage);

--- a/src/Symfony/Component/RateLimiter/Tests/Policy/TokenBucketTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/Policy/TokenBucketTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\RateLimiter\Tests\Policy;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\RateLimiter\Policy\Rate;
 use Symfony\Component\RateLimiter\Policy\TokenBucket;
 
 class TokenBucketTestToStringGadget
@@ -51,5 +52,22 @@ class TokenBucketTest extends TestCase
         }
 
         $this->assertFalse(TokenBucketTestToStringGadget::$fired, '__toString gadget must not fire during unserialize');
+    }
+
+    public function testBurstSizeIsCappedToWhatSerializationCanStore()
+    {
+        $bucket = new TokenBucket('test', \PHP_INT_MAX, Rate::perSecond(10));
+
+        $this->assertSame(TokenBucket::MAX_BURST_SIZE, $bucket->getAvailableTokens(microtime(true)));
+    }
+
+    public function testCappedBurstSizeRoundTripsThroughSerialization()
+    {
+        $bucket = new TokenBucket('test', \PHP_INT_MAX, Rate::perSecond(10));
+        $bucket->setTokens(TokenBucket::MAX_BURST_SIZE - 5);
+
+        $restored = unserialize(serialize($bucket));
+
+        $this->assertSame(TokenBucket::MAX_BURST_SIZE - 5, $restored->getAvailableTokens($restored->getTimer()));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | n/a
| License       | MIT

Configuring a `TokenBucketLimiter` with an enormous burst size broke in two ways.

**The expiration time overflowed.** `Rate::calculateTimeForTokens()` computes its result with `ceil()`, so the arithmetic happens in floating point. For a large enough number of tokens the product leaves the integer range and the declared `int` return type fatals:

```php
$limiter = new TokenBucketLimiter('test', \PHP_INT_MAX, new Rate(new \DateInterval('PT10S'), 10), $storage);
$limiter->consume(1);

// TypeError: Rate::calculateTimeForTokens(): Return value must be of type int, float returned
```

It is reached from `TokenBucket::getExpirationTime()`, which asks for the time needed to refill a full bucket and hands the answer to the storage layer as a TTL, so it fires on every `save()`.

**The burst size wrapped.** `TokenBucket::__serialize()` stores it with `pack('N', ...)`, a 32-bit field. Any larger value was silently truncated on the first round trip through storage, and the limiter then handed out a different number of tokens than configured:

```php
// before
consume #1: limit=9223372036854775807 remaining=9223372036854775806
consume #2: limit=9223372036854775807 remaining=4294967294          // 2^32-2
```

Both are now capped at `2147483647`, about 68 years for the duration and 2.1e9 tokens for the burst:

* the value stays inside the integer range on 32-bit platforms as well, where `PHP_INT_MAX` is exactly that bound, and it round-trips through `pack('N')`/`unpack('N')` on both;
* it is a TTL that `CacheStorage` can actually use. Capping at `PHP_INT_MAX` instead would make `AbstractAdapter` compute a lifetime of `9223372036854774784`, which Redis rejects as an invalid expire time.

```php
// after
consume #1: limit=2147483647 remaining=2147483646
consume #2: limit=2147483647 remaining=2147483645
```

Ordinary configurations are unaffected. A burst above 2.1e9 is not rate limiting any more, and the overflow needed even more than that: the product is `seconds_per_refill * ceil($tokens / $refill_amount)`, so with a rate of one token per hour it took a limit around 2.6e15. `policy: no_limit` remains the way to express "no limit".
