### PR TITLE
[RateLimiter] Fix the overflow test on 32-bit platforms

### DIFF
--- a/src/Symfony/Component/RateLimiter/Tests/Policy/RateTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/Policy/RateTest.php
@@ -47,7 +47,8 @@ class RateTest extends TestCase
     {
         yield 'product far above the int range' => [Rate::perHour(1), \PHP_INT_MAX];
         yield 'product rounding to exactly the int range bound' => [new Rate(new \DateInterval('PT10S'), 10), \PHP_INT_MAX];
-        yield 'product just above the cap' => [Rate::perSecond(1), 2147483648];
+        // the token count stays within the int range on 32-bit platforms, only the product exceeds the cap
+        yield 'product just above the cap' => [new Rate(new \DateInterval('PT2S'), 1), 1073741824];
     }
 
     public function testCalculateTimeForTokensBelowTheCapIsNotChanged()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`RateTest::testCalculateTimeForTokensIsCappedOnOverflow` cannot run on 32-bit platforms, which is where the cap it covers actually matters. The `Windows` job fails on `x86 / minimal-exts / lowest-php`, on 6.4 and on every branch the merge-up carries it to:

```
TypeError: RateTest::testCalculateTimeForTokensIsCappedOnOverflow(): Argument #2 ($tokens)
must be of type int, float given
```

The third data set passes the literal `2147483648` as the token count. That is one above `PHP_INT_MAX` on a 32-bit build, so PHP parses it as a float and it cannot bind to the `int $tokens` parameter, nor to `Rate::calculateTimeForTokens(int $tokens)` behind it. The other two sets use `\PHP_INT_MAX`, which adapts to the platform, so only this one breaks.

The intent is a product of exactly one second above the cap. That is reachable without an out-of-range token count, by moving the factor into the refill time:

```php
yield 'product just above the cap' => [new Rate(new \DateInterval('PT2S'), 1), 1073741824];
```

`2 * 2^30` is still `2147483648`, so the case covers the same boundary, and `2^30` is comfortably inside the int range on both 32-bit and 64-bit. The product itself never needs to be an int: `ceil()` already returns a float, and `min()` picks the cap from it.
