### PR TITLE
[Console] Fix decoding chunked Kitty graphics payloads

### DIFF
--- a/src/Symfony/Component/Console/Helper/FileInputHelper.php
+++ b/src/Symfony/Component/Console/Helper/FileInputHelper.php
@@ -159,9 +159,12 @@ final class FileInputHelper
         if ('' !== $pasteBuffer) {
             if (null !== $this->protocol && $this->protocol->detectPastedImage($pasteBuffer)) {
                 $decoded = $this->protocol->decode($pasteBuffer);
-                if ('' !== $decoded['data']) {
-                    return InputFile::fromData($decoded['data'], $decoded['format']);
+
+                if ('' === $decoded['data']) {
+                    throw new InvalidFileException('The pasted image could not be decoded.');
                 }
+
+                return InputFile::fromData($decoded['data'], $decoded['format']);
             }
 
             $path = trim($pasteBuffer);

--- a/src/Symfony/Component/Console/Terminal/Image/KittyGraphicsProtocol.php
+++ b/src/Symfony/Component/Console/Terminal/Image/KittyGraphicsProtocol.php
@@ -30,6 +30,7 @@ final class KittyGraphicsProtocol implements ImageProtocolInterface
 {
     public const APC_START = "\x1b_G";
     public const ST = "\x1b\\";
+    public const BEL = "\x07";
 
     public function detectPastedImage(string $data): bool
     {
@@ -42,29 +43,55 @@ final class KittyGraphicsProtocol implements ImageProtocolInterface
             return ['data' => '', 'format' => null];
         }
 
-        if (false === $end = strpos($data, self::ST, $start)) {
-            $end = strpos($data, "\x07", $start);
+        $offset = $start;
+        $payload = '';
+        $format = null;
+
+        // A single image is split into several APC sequences when its payload is
+        // larger than the maximum chunk size; all of them but the last one carry
+        // "m=1" in their control data.
+        while (true) {
+            // the sequence ends at whichever terminator comes first
+            $st = strpos($data, self::ST, $offset);
+            $bel = strpos($data, self::BEL, $offset);
+
+            if (false === $end = match (true) {
+                false === $st => $bel,
+                false === $bel => $st,
+                default => min($st, $bel),
+            }) {
+                return ['data' => '', 'format' => null];
+            }
+
+            $terminator = $end === $st ? self::ST : self::BEL;
+
+            $content = substr($data, $offset + \strlen(self::APC_START), $end - $offset - \strlen(self::APC_START));
+
+            if (false === $semicolonPos = strpos($content, ';')) {
+                return ['data' => '', 'format' => null];
+            }
+
+            $controlData = substr($content, 0, $semicolonPos);
+            $payload .= substr($content, $semicolonPos + 1);
+            $format ??= $this->parseFormat($controlData);
+            $offset = $end + \strlen($terminator);
+
+            if ('1' !== $this->parseControlValue($controlData, 'm')) {
+                break;
+            }
+
+            if (self::APC_START !== substr($data, $offset, \strlen(self::APC_START))) {
+                // more chunks were announced but none follows: the image is incomplete
+                return ['data' => '', 'format' => null];
+            }
         }
-
-        if (false === $end) {
-            return ['data' => '', 'format' => null];
-        }
-
-        $content = substr($data, $start + \strlen(self::APC_START), $end - $start - \strlen(self::APC_START));
-
-        if (false === $semicolonPos = strpos($content, ';')) {
-            return ['data' => '', 'format' => null];
-        }
-
-        $controlData = substr($content, 0, $semicolonPos);
-        $payload = substr($content, $semicolonPos + 1);
 
         $decodedData = base64_decode($payload, true);
         if (false === $decodedData) {
             return ['data' => '', 'format' => null];
         }
 
-        return ['data' => $decodedData, 'format' => $this->parseFormat($controlData)];
+        return ['data' => $decodedData, 'format' => $format];
     }
 
     public function encode(string $imageData, ?int $maxWidth = null): string
@@ -106,15 +133,20 @@ final class KittyGraphicsProtocol implements ImageProtocolInterface
 
     private function parseFormat(string $controlData): ?string
     {
+        return match ($this->parseControlValue($controlData, 'f')) {
+            '24' => 'rgb',
+            '32' => 'rgba',
+            '100' => 'png',
+            default => null,
+        };
+    }
+
+    private function parseControlValue(string $controlData, string $key): ?string
+    {
         foreach (explode(',', $controlData) as $pair) {
             $parts = explode('=', $pair, 2);
-            if (2 === \count($parts) && 'f' === $parts[0]) {
-                return match ($parts[1]) {
-                    '24' => 'rgb',
-                    '32' => 'rgba',
-                    '100' => 'png',
-                    default => null,
-                };
+            if (2 === \count($parts) && $key === $parts[0]) {
+                return $parts[1];
             }
         }
 

--- a/src/Symfony/Component/Console/Tests/Helper/FileInputHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/FileInputHelperTest.php
@@ -19,6 +19,8 @@ use Symfony\Component\Console\Helper\TerminalInputHelper;
 use Symfony\Component\Console\Input\File\InputFile;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Question\FileQuestion;
+use Symfony\Component\Console\Terminal\Image\ImageProtocolInterface;
+use Symfony\Component\Console\Terminal\Image\KittyGraphicsProtocol;
 
 class FileInputHelperTest extends TestCase
 {
@@ -188,6 +190,17 @@ class FileInputHelperTest extends TestCase
         }
     }
 
+    public function testReadWithPasteDetectionRejectsAnUndecodablePastedImage()
+    {
+        $truncated = "\x1b_Ga=T,f=100,m=1;".base64_encode('chunk one')."\x1b\\";
+        $input = $this->pasteMarker('PASTE_START').$truncated.$this->pasteMarker('PASTE_END');
+
+        $this->expectException(InvalidFileException::class);
+        $this->expectExceptionMessage('The pasted image could not be decoded.');
+
+        $this->readWithPasteDetection($this->streamOf($input), new KittyGraphicsProtocol());
+    }
+
     public function testReadWithPasteDetectionAbortsBeyondMaxBytes()
     {
         $cap = (new \ReflectionClassConstant(FileInputHelper::class, 'MAX_PASTE_BYTES'))->getValue();
@@ -255,9 +268,10 @@ class FileInputHelperTest extends TestCase
     /**
      * @param resource $stream
      */
-    private function readWithPasteDetection($stream): InputFile
+    private function readWithPasteDetection($stream, ?ImageProtocolInterface $protocol = null): InputFile
     {
-        $method = (new \ReflectionClass(FileInputHelper::class))->getMethod('readWithPasteDetection');
+        $reflection = new \ReflectionClass(FileInputHelper::class);
+        $method = $reflection->getMethod('readWithPasteDetection');
 
         $terminalReflection = new \ReflectionClass(TerminalInputHelper::class);
         $inputHelper = $terminalReflection->newInstanceWithoutConstructor();
@@ -265,6 +279,12 @@ class FileInputHelperTest extends TestCase
             $terminalReflection->getProperty($name)->setValue($inputHelper, $value);
         }
 
-        return $method->invoke(new FileInputHelper(), $stream, new BufferedOutput(), new FileQuestion('?'), $inputHelper);
+        $helper = new FileInputHelper();
+
+        if (null !== $protocol) {
+            $reflection->getProperty('protocol')->setValue($helper, $protocol);
+        }
+
+        return $method->invoke($helper, $stream, new BufferedOutput(), new FileQuestion('?'), $inputHelper);
     }
 }

--- a/src/Symfony/Component/Console/Tests/Terminal/Image/KittyGraphicsProtocolTest.php
+++ b/src/Symfony/Component/Console/Tests/Terminal/Image/KittyGraphicsProtocolTest.php
@@ -58,6 +58,17 @@ class KittyGraphicsProtocolTest extends TestCase
         $this->assertSame($imageData, $result['data']);
     }
 
+    public function testDecodeWithBellTerminatorFollowedByAnEscapeSequence()
+    {
+        $imageData = 'test image data';
+        $base64 = base64_encode($imageData);
+        $data = "\x1b_Ga=T,f=100;{$base64}\x07 and some text\x1b\\";
+
+        $result = (new KittyGraphicsProtocol())->decode($data);
+
+        $this->assertSame($imageData, $result['data']);
+    }
+
     public function testDecodeInvalidBase64()
     {
         $data = "\x1b_Ga=T,f=100;not-valid-base64!!!\x1b\\";
@@ -132,6 +143,51 @@ class KittyGraphicsProtocolTest extends TestCase
         $this->assertSame('', $protocol->encode('GIF89a'.str_repeat("\x00", 4)));
         $this->assertSame('', $protocol->encode('RIFF    WEBP'.str_repeat("\x00", 4)));
         $this->assertSame('', $protocol->encode('not an image'));
+    }
+
+    public function testDecodeChunkedPayload()
+    {
+        $first = base64_encode('chunk one');
+        $second = base64_encode('chunk two');
+        $data = "\x1b_Ga=T,f=100,m=1;{$first}\x1b\\\x1b_Gm=0;{$second}\x1b\\";
+
+        $result = (new KittyGraphicsProtocol())->decode($data);
+
+        $this->assertSame('chunk onechunk two', $result['data']);
+        $this->assertSame('png', $result['format']);
+    }
+
+    public function testDecodeIncompleteChunkedPayload()
+    {
+        $data = "\x1b_Ga=T,f=100,m=1;".base64_encode('chunk one')."\x1b\\";
+
+        $result = (new KittyGraphicsProtocol())->decode($data);
+
+        $this->assertSame('', $result['data']);
+        $this->assertNull($result['format']);
+    }
+
+    public function testDecodeStopsAtTheEndOfTheImage()
+    {
+        $payload = base64_encode('image data');
+        $data = "\x1b_Ga=T,f=100,m=0;{$payload}\x1b\\\x1b_Ga=T,f=100;".base64_encode('another image')."\x1b\\";
+
+        $result = (new KittyGraphicsProtocol())->decode($data);
+
+        $this->assertSame('image data', $result['data']);
+    }
+
+    public function testEncodedChunkedPayloadCanBeDecoded()
+    {
+        $imageData = "\x89PNG\r\n\x1a\n".str_repeat("\x01", 10000);
+        $protocol = new KittyGraphicsProtocol();
+
+        $encoded = $protocol->encode($imageData);
+        $result = $protocol->decode($encoded);
+
+        $this->assertGreaterThan(1, substr_count($encoded, "\x1b_G"));
+        $this->assertSame($imageData, $result['data']);
+        $this->assertSame('png', $result['format']);
     }
 
     public function testDecodeDifferentFormats()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The Kitty graphics protocol splits a payload larger than the maximum chunk size (4096 base64 chars) into several APC sequences, all of them but the last one carrying `m=1` in their control data. `KittyGraphicsProtocol::decode()` only read the first sequence, so a pasted image bigger than ~3KB was silently truncated to its first chunk, and `FileInputHelper` happily wrote that corrupt blob to a temporary file.

`encode()` produces such chunked sequences itself, so this was visible on a plain round-trip:

```php
$png = "\x89PNG\r\n\x1a\n".str_repeat("\x01", 10000);
$protocol = new KittyGraphicsProtocol();

$protocol->decode($protocol->encode($png))['data']; // 3072 bytes instead of 10008
```

`decode()` now walks the consecutive chunks while `m=1` and concatenates their payloads before decoding them.

Two further changes to how a malformed sequence is read:

 * a sequence announcing a follow-up chunk that never comes is reported as no image at all, rather than as a truncated one, since an incomplete transmission should not end up written to disk as a broken file;
 * a sequence ends at whichever terminator comes first, instead of preferring an ST that may sit far past the BEL that actually closes it, so a BEL-terminated paste followed anywhere later by an escape sequence no longer decodes to nothing.

Finally, a paste that announces an image but cannot be decoded no longer falls through to the path handling. It used to be reported as a missing file named after the undecodable payload:

```
File "_Ga=T,f=100,m=1;Y2h1bmsgb25l\" does not exist.
```

which named neither the problem nor anything the user typed. It now fails with `The pasted image could not be decoded.` That covers every decode failure, not just the incomplete-chunk one added here, so an invalid base64 paste reports the same way.
