### PR TITLE
[Console] Fix writing one-shot iterables to a CombinedOutput

### DIFF
--- a/src/Symfony/Component/Console/Output/CombinedOutput.php
+++ b/src/Symfony/Component/Console/Output/CombinedOutput.php
@@ -32,15 +32,21 @@ final class CombinedOutput implements OutputInterface
 
     public function write(iterable|string $messages, bool $newline = false, int $options = 0): void
     {
+        $args = \func_get_args();
+        $args[0] = $this->buffer($messages, $options);
+
         foreach ($this->outputs as $output) {
-            $output->write(...\func_get_args());
+            $output->write(...$args);
         }
     }
 
     public function writeln(iterable|string $messages, int $options = 0): void
     {
+        $args = \func_get_args();
+        $args[0] = $this->buffer($messages, $options);
+
         foreach ($this->outputs as $output) {
-            $output->writeln(...\func_get_args());
+            $output->writeln(...$args);
         }
     }
 
@@ -103,5 +109,28 @@ final class CombinedOutput implements OutputInterface
     public function getFormatter(): OutputFormatterInterface
     {
         return array_first($this->outputs)->getFormatter();
+    }
+
+    /**
+     * Buffers one-shot iterables, as writing them to the first output would otherwise
+     * leave nothing to write to the next ones. Iterables that no output would write
+     * are not consumed at all.
+     */
+    private function buffer(iterable|string $messages, int $options): iterable|string
+    {
+        if (!$messages instanceof \Traversable) {
+            return $messages;
+        }
+
+        $verbosities = self::VERBOSITY_QUIET | self::VERBOSITY_NORMAL | self::VERBOSITY_VERBOSE | self::VERBOSITY_VERY_VERBOSE | self::VERBOSITY_DEBUG;
+        $verbosity = $verbosities & $options ?: self::VERBOSITY_NORMAL;
+
+        foreach ($this->outputs as $output) {
+            if ($verbosity <= $output->getVerbosity()) {
+                return iterator_to_array($messages, false);
+            }
+        }
+
+        return [];
     }
 }

--- a/src/Symfony/Component/Console/Tests/Tester/CommandTesterTest.php
+++ b/src/Symfony/Component/Console/Tests/Tester/CommandTesterTest.php
@@ -700,6 +700,44 @@ class CommandTesterTest extends TestCase
         $this->assertSame("bar\n", $result->getDisplay());
     }
 
+    public function testItCanTestACommandWritingAGenerator()
+    {
+        $command = new Command('foo');
+        $command->setCode(static function (InputInterface $input, OutputInterface $output) {
+            $output->writeln((static function () {
+                yield 'bar';
+                yield 'baz';
+            })());
+
+            return 0;
+        });
+
+        $result = (new CommandTester($command))->run();
+
+        $this->assertSame("bar\nbaz\n", $result->getOutput(true));
+        $this->assertSame("bar\nbaz\n", $result->getDisplay());
+    }
+
+    public function testItDoesNotConsumeAGeneratorDiscardedByVerbosity()
+    {
+        $consumed = false;
+        $command = new Command('foo');
+        $command->setCode(static function (OutputInterface $output) use (&$consumed): int {
+            $output->writeln((static function () use (&$consumed) {
+                $consumed = true;
+
+                yield 'bar';
+            })(), OutputInterface::VERBOSITY_VERBOSE);
+
+            return 0;
+        });
+
+        $result = (new CommandTester($command))->run();
+
+        $this->assertFalse($consumed);
+        $this->assertSame('', $result->getDisplay());
+    }
+
     public function testItProvidesUserInputs()
     {
         $questions = [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`CombinedOutput` forwards the very same `$messages` iterable to each of its outputs. With a `Generator`, the first output exhausts it and the second one fails with `Cannot traverse an already closed generator`, so any command writing a generator crashes when tested through `CommandTester::run()`:

```php
$command->setCode(function (OutputInterface $output) {
    $output->writeln((function () { yield 'bar'; yield 'baz'; })());

    return 0;
});

(new CommandTester($command))->run(); // Exception: Cannot traverse an already closed generator
```

One-shot iterables are now buffered into an array so that every output can traverse them. Buffering is skipped when no output would write the messages, so a generator rejected by the verbosity filter is not consumed, matching what happens when writing to a single output.
