### PR TITLE
[Console] Fix decoding chunked Kitty graphics payloads

### DIFF
--- a/src/Symfony/Component/Console/Terminal/Image/KittyGraphicsProtocol.php
+++ b/src/Symfony/Component/Console/Terminal/Image/KittyGraphicsProtocol.php
@@ -30,6 +30,7 @@ final class KittyGraphicsProtocol implements ImageProtocolInterface
 {
     public const APC_START = "\x1b_G";
     public const ST = "\x1b\\";
+    public const BEL = "\x07";
 
     public function detectPastedImage(string $data): bool
     {
@@ -42,29 +43,55 @@ final class KittyGraphicsProtocol implements ImageProtocolInterface
             return ['data' => '', 'format' => null];
         }
 
-        if (false === $end = strpos($data, self::ST, $start)) {
-            $end = strpos($data, "\x07", $start);
+        $offset = $start;
+        $payload = '';
+        $format = null;
+
+        // A single image is split into several APC sequences when its payload is
+        // larger than the maximum chunk size; all of them but the last one carry
+        // "m=1" in their control data.
+        while (true) {
+            // the sequence ends at whichever terminator comes first
+            $st = strpos($data, self::ST, $offset);
+            $bel = strpos($data, self::BEL, $offset);
+
+            if (false === $end = match (true) {
+                false === $st => $bel,
+                false === $bel => $st,
+                default => min($st, $bel),
+            }) {
+                return ['data' => '', 'format' => null];
+            }
+
+            $terminator = $end === $st ? self::ST : self::BEL;
+
+            $content = substr($data, $offset + \strlen(self::APC_START), $end - $offset - \strlen(self::APC_START));
+
+            if (false === $semicolonPos = strpos($content, ';')) {
+                return ['data' => '', 'format' => null];
+            }
+
+            $controlData = substr($content, 0, $semicolonPos);
+            $payload .= substr($content, $semicolonPos + 1);
+            $format ??= $this->parseFormat($controlData);
+            $offset = $end + \strlen($terminator);
+
+            if ('1' !== $this->parseControlValue($controlData, 'm')) {
+                break;
+            }
+
+            if (self::APC_START !== substr($data, $offset, \strlen(self::APC_START))) {
+                // more chunks were announced but none follows: the image is incomplete
+                return ['data' => '', 'format' => null];
+            }
         }
-
-        if (false === $end) {
-            return ['data' => '', 'format' => null];
-        }
-
-        $content = substr($data, $start + \strlen(self::APC_START), $end - $start - \strlen(self::APC_START));
-
-        if (false === $semicolonPos = strpos($content, ';')) {
-            return ['data' => '', 'format' => null];
-        }
-
-        $controlData = substr($content, 0, $semicolonPos);
-        $payload = substr($content, $semicolonPos + 1);
 
         $decodedData = base64_decode($payload, true);
         if (false === $decodedData) {
             return ['data' => '', 'format' => null];
         }
 
-        return ['data' => $decodedData, 'format' => $this->parseFormat($controlData)];
+        return ['data' => $decodedData, 'format' => $format];
     }
 
     public function encode(string $imageData, ?int $maxWidth = null): string
@@ -106,15 +133,20 @@ final class KittyGraphicsProtocol implements ImageProtocolInterface
 
     private function parseFormat(string $controlData): ?string
     {
+        return match ($this->parseControlValue($controlData, 'f')) {
+            '24' => 'rgb',
+            '32' => 'rgba',
+            '100' => 'png',
+            default => null,
+        };
+    }
+
+    private function parseControlValue(string $controlData, string $key): ?string
+    {
         foreach (explode(',', $controlData) as $pair) {
             $parts = explode('=', $pair, 2);
-            if (2 === \count($parts) && 'f' === $parts[0]) {
-                return match ($parts[1]) {
-                    '24' => 'rgb',
-                    '32' => 'rgba',
-                    '100' => 'png',
-                    default => null,
-                };
+            if (2 === \count($parts) && $key === $parts[0]) {
+                return $parts[1];
             }
         }
 

--- a/src/Symfony/Component/Console/Tests/Terminal/Image/KittyGraphicsProtocolTest.php
+++ b/src/Symfony/Component/Console/Tests/Terminal/Image/KittyGraphicsProtocolTest.php
@@ -58,6 +58,17 @@ class KittyGraphicsProtocolTest extends TestCase
         $this->assertSame($imageData, $result['data']);
     }
 
+    public function testDecodeWithBellTerminatorFollowedByAnEscapeSequence()
+    {
+        $imageData = 'test image data';
+        $base64 = base64_encode($imageData);
+        $data = "\x1b_Ga=T,f=100;{$base64}\x07 and some text\x1b\\";
+
+        $result = (new KittyGraphicsProtocol())->decode($data);
+
+        $this->assertSame($imageData, $result['data']);
+    }
+
     public function testDecodeInvalidBase64()
     {
         $data = "\x1b_Ga=T,f=100;not-valid-base64!!!\x1b\\";
@@ -132,6 +143,51 @@ class KittyGraphicsProtocolTest extends TestCase
         $this->assertSame('', $protocol->encode('GIF89a'.str_repeat("\x00", 4)));
         $this->assertSame('', $protocol->encode('RIFF    WEBP'.str_repeat("\x00", 4)));
         $this->assertSame('', $protocol->encode('not an image'));
+    }
+
+    public function testDecodeChunkedPayload()
+    {
+        $first = base64_encode('chunk one');
+        $second = base64_encode('chunk two');
+        $data = "\x1b_Ga=T,f=100,m=1;{$first}\x1b\\\x1b_Gm=0;{$second}\x1b\\";
+
+        $result = (new KittyGraphicsProtocol())->decode($data);
+
+        $this->assertSame('chunk onechunk two', $result['data']);
+        $this->assertSame('png', $result['format']);
+    }
+
+    public function testDecodeIncompleteChunkedPayload()
+    {
+        $data = "\x1b_Ga=T,f=100,m=1;".base64_encode('chunk one')."\x1b\\";
+
+        $result = (new KittyGraphicsProtocol())->decode($data);
+
+        $this->assertSame('', $result['data']);
+        $this->assertNull($result['format']);
+    }
+
+    public function testDecodeStopsAtTheEndOfTheImage()
+    {
+        $payload = base64_encode('image data');
+        $data = "\x1b_Ga=T,f=100,m=0;{$payload}\x1b\\\x1b_Ga=T,f=100;".base64_encode('another image')."\x1b\\";
+
+        $result = (new KittyGraphicsProtocol())->decode($data);
+
+        $this->assertSame('image data', $result['data']);
+    }
+
+    public function testEncodedChunkedPayloadCanBeDecoded()
+    {
+        $imageData = "\x89PNG\r\n\x1a\n".str_repeat("\x01", 10000);
+        $protocol = new KittyGraphicsProtocol();
+
+        $encoded = $protocol->encode($imageData);
+        $result = $protocol->decode($encoded);
+
+        $this->assertGreaterThan(1, substr_count($encoded, "\x1b_G"));
+        $this->assertSame($imageData, $result['data']);
+        $this->assertSame('png', $result['format']);
     }
 
     public function testDecodeDifferentFormats()


### PR DESCRIPTION
The Kitty graphics protocol splits payloads larger than 4096 bytes into several APC sequences, all but the last one carrying `m=1`. `decode()` only read the first sequence, so any pasted image bigger than ~3KB was silently truncated to its first chunk (`encode()` produces such chunked sequences itself, so a round-trip lost data too).

A sequence announcing a follow-up chunk that never comes is now reported as no image at all, rather than as a truncated one, and a sequence ends at whichever terminator comes first instead of preferring a possibly much later ST over the BEL that actually closes it.

| Q             | A
| ------------- | ---
| Branch?       | 8.2 for features / 6.4, 7.4, 8.1 for bug fixes
| Bug fix?      | yes/no
| New feature?  | yes/no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | yes/no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

<!--
🛠️ Replace this text with a concise explanation of your change:
- What it does and why it's needed
- A simple example of how it works (include PHP, YAML, etc.)
- If it modifies existing behavior, include a before/after comparison

Contributor guidelines:
- ✅ Add tests and ensure they pass
- 🐞 Bug fixes must target the **lowest maintained** branch where they apply
  https://symfony.com/releases#maintained-symfony-branches
- ✨ New features and deprecations must target the **feature** branch
  and must add an entry to the changelog file of the patched component:
  https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
- 🔒 Do not break backward compatibility:
  https://symfony.com/bc
-->
