### PR TITLE
[Form][Validator] Review Afrikaans (af) translations

### DIFF
--- a/src/Symfony/Component/Form/Resources/translations/validators.af.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.af.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="129">
                 <source>Please enter a valid UUID.</source>
-                <target state="needs-review-translation">Voer assblief 'n geldige UUID in.</target>
+                <target>Voer asseblief 'n geldige UUID in.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.af.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.af.xlf
@@ -556,19 +556,19 @@
             </trans-unit>
             <trans-unit id="143">
                 <source>This value is not valid XML.</source>
-                <target state="needs-review-translation">Hierdie waarde is nie geldige XML nie.</target>
+                <target>Hierdie waarde is nie geldige XML nie.</target>
             </trans-unit>
             <trans-unit id="144">
                 <source>This value does not conform to the expected XSD schema.</source>
-                <target state="needs-review-translation">Hierdie waarde voldoen nie aan die verwagte XSD-skema nie.</target>
+                <target>Hierdie waarde voldoen nie aan die verwagte XSD-skema nie.</target>
             </trans-unit>
             <trans-unit id="145">
                 <source>This XML payload is too large ({{ size }} bytes): it exceeds the limit of {{ limit }} bytes.</source>
-                <target state="needs-review-translation">Hierdie XML-loonvrag is te groot ({{ size }} grepe): dit oorskry die limiet van {{ limit }} grepe.</target>
+                <target>Hierdie XML-loonvrag is te groot ({{ size }} grepe): dit oorskry die limiet van {{ limit }} grepe.</target>
             </trans-unit>
             <trans-unit id="146">
                 <source>This value is not a valid cron expression.</source>
-                <target state="needs-review-translation">Hierdie waarde is nie 'n geldige cron-uitdrukking nie.</target>
+                <target>Hierdie waarde is nie 'n geldige cron-uitdrukking nie.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64478
| License       | MIT

Reviews the 5 Afrikaans translations flagged `needs-review-translation`: each string was checked against the English source and the established (already-reviewed) entries of the same catalog for terminology, grammar, placeholders and punctuation conventions. 4 were confirmed as-is; 1 was corrected.

Note: I am not a native speaker — happy to adjust any wording that native speakers flag.


<details><summary>Form — reviewed strings</summary>

| Id | English | Translation | Result |
| -- | -- | -- | -- |
| 129 | Please enter a valid UUID. | Voer asseblief 'n geldige UUID in. | corrected (was: Voer assblief 'n geldige UUID in.) |

</details>

<details><summary>Validator — reviewed strings</summary>

| Id | English | Translation | Result |
| -- | -- | -- | -- |
| 143 | This value is not valid XML. | Hierdie waarde is nie geldige XML nie. | confirmed |
| 144 | This value does not conform to the expected XSD schema. | Hierdie waarde voldoen nie aan die verwagte XSD-skema nie. | confirmed |
| 145 | This XML payload is too large ({{ size }} bytes): it exceeds the limit of {{ limit }} bytes. | Hierdie XML-loonvrag is te groot ({{ size }} grepe): dit oorskry die limiet van {{ limit }} grepe. | confirmed |
| 146 | This value is not a valid cron expression. | Hierdie waarde is nie 'n geldige cron-uitdrukking nie. | confirmed |

</details>

