### PR TITLE
[Form][Validator] Review Armenian (hy) translations

### DIFF
--- a/src/Symfony/Component/Form/Resources/translations/validators.hy.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.hy.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="129">
                 <source>Please enter a valid UUID.</source>
-                <target state="needs-review-translation">Մուտքագրեք վավեր UUID։</target>
+                <target>Մուտքագրեք վավեր UUID։</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.hy.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.hy.xlf
@@ -556,19 +556,19 @@
             </trans-unit>
             <trans-unit id="143">
                 <source>This value is not valid XML.</source>
-                <target state="needs-review-translation">Այս արժեքը վավեր XML չէ։</target>
+                <target>Այս արժեքը վավեր XML չէ։</target>
             </trans-unit>
             <trans-unit id="144">
                 <source>This value does not conform to the expected XSD schema.</source>
-                <target state="needs-review-translation">Այս արժեքը չի համապատասխանում սպասվող XSD սխեմային։</target>
+                <target>Այս արժեքը չի համապատասխանում սպասվող XSD սխեմային։</target>
             </trans-unit>
             <trans-unit id="145">
                 <source>This XML payload is too large ({{ size }} bytes): it exceeds the limit of {{ limit }} bytes.</source>
-                <target state="needs-review-translation">Այս XML բեռնվածքը չափազանց մեծ է ({{ size }} բայթ)՝ այն գերազանցում է {{ limit }} բայթ սահմանը։</target>
+                <target>Այս XML բեռնվածքը չափազանց մեծ է ({{ size }} բայթ)՝ այն գերազանցում է {{ limit }} բայթ սահմանը։</target>
             </trans-unit>
             <trans-unit id="146">
                 <source>This value is not a valid cron expression.</source>
-                <target state="needs-review-translation">Այս արժեքը վավեր cron արտահայտություն չէ։</target>
+                <target>Այս արժեքը վավեր cron արտահայտություն չէ։</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64481
| License       | MIT

Reviews the 5 Armenian translations flagged `needs-review-translation`: each string was checked against the English source and the established (already-reviewed) entries of the same catalog for terminology, grammar, placeholders and punctuation conventions. 5 were confirmed as-is; none required changes.

Note: I am not a native speaker — happy to adjust any wording that native speakers flag.


<details><summary>Form — reviewed strings</summary>

| Id | English | Translation | Result |
| -- | -- | -- | -- |
| 129 | Please enter a valid UUID. | Մուտքագրեք վավեր UUID։ | confirmed |

</details>

<details><summary>Validator — reviewed strings</summary>

| Id | English | Translation | Result |
| -- | -- | -- | -- |
| 143 | This value is not valid XML. | Այս արժեքը վավեր XML չէ։ | confirmed |
| 144 | This value does not conform to the expected XSD schema. | Այս արժեքը չի համապատասխանում սպասվող XSD սխեմային։ | confirmed |
| 145 | This XML payload is too large ({{ size }} bytes): it exceeds the limit of {{ limit }} bytes. | Այս XML բեռնվածքը չափազանց մեծ է ({{ size }} բայթ)՝ այն գերազանցում է {{ limit }} բայթ սահմանը։ | confirmed |
| 146 | This value is not a valid cron expression. | Այս արժեքը վավեր cron արտահայտություն չէ։ | confirmed |

</details>

