### PR TITLE
[Form][Validator] Review Belarusian (be) translations

### DIFF
--- a/src/Symfony/Component/Form/Resources/translations/validators.be.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.be.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="129">
                 <source>Please enter a valid UUID.</source>
-                <target state="needs-review-translation">Калі ласка, увядзіце карэктны UUID.</target>
+                <target>Калі ласка, увядзіце карэктны UUID.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.be.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.be.xlf
@@ -556,19 +556,19 @@
             </trans-unit>
             <trans-unit id="143">
                 <source>This value is not valid XML.</source>
-                <target state="needs-review-translation">Гэта значэнне не з'яўляецца сапраўдным XML.</target>
+                <target>Гэта значэнне не з'яўляецца сапраўдным XML.</target>
             </trans-unit>
             <trans-unit id="144">
                 <source>This value does not conform to the expected XSD schema.</source>
-                <target state="needs-review-translation">Гэта значэнне не адпавядае чаканай схеме XSD.</target>
+                <target>Гэта значэнне не адпавядае чаканай схеме XSD.</target>
             </trans-unit>
             <trans-unit id="145">
                 <source>This XML payload is too large ({{ size }} bytes): it exceeds the limit of {{ limit }} bytes.</source>
-                <target state="needs-review-translation">Гэтая XML-нагрузка занадта вялікая ({{ size }} байт): яна перавышае ліміт у {{ limit }} байт.</target>
+                <target>Гэтая XML-нагрузка занадта вялікая ({{ size }} байт): яна перавышае ліміт у {{ limit }} байт.</target>
             </trans-unit>
             <trans-unit id="146">
                 <source>This value is not a valid cron expression.</source>
-                <target state="needs-review-translation">Гэта значэнне не з'яўляецца сапраўдным выразам cron.</target>
+                <target>Гэта значэнне не з'яўляецца сапраўдным выразам cron.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64483
| License       | MIT

Reviews the 5 Belarusian translations flagged `needs-review-translation`: each string was checked against the English source and the established (already-reviewed) entries of the same catalog for terminology, grammar, placeholders and punctuation conventions. 5 were confirmed as-is; none required changes.

Note: I am not a native speaker — happy to adjust any wording that native speakers flag.


<details><summary>Form — reviewed strings</summary>

| Id | English | Translation | Result |
| -- | -- | -- | -- |
| 129 | Please enter a valid UUID. | Калі ласка, увядзіце карэктны UUID. | confirmed |

</details>

<details><summary>Validator — reviewed strings</summary>

| Id | English | Translation | Result |
| -- | -- | -- | -- |
| 143 | This value is not valid XML. | Гэта значэнне не з'яўляецца сапраўдным XML. | confirmed |
| 144 | This value does not conform to the expected XSD schema. | Гэта значэнне не адпавядае чаканай схеме XSD. | confirmed |
| 145 | This XML payload is too large ({{ size }} bytes): it exceeds the limit of {{ limit }} bytes. | Гэтая XML-нагрузка занадта вялікая ({{ size }} байт): яна перавышае ліміт у {{ limit }} байт. | confirmed |
| 146 | This value is not a valid cron expression. | Гэта значэнне не з'яўляецца сапраўдным выразам cron. | confirmed |

</details>

