### PR TITLE
[Form][Validator] Review Catalan (ca) translations

### DIFF
--- a/src/Symfony/Component/Form/Resources/translations/validators.ca.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.ca.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="129">
                 <source>Please enter a valid UUID.</source>
-                <target state="needs-review-translation">Introduïu un UUID vàlid.</target>
+                <target>Introduïu un UUID vàlid.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.ca.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.ca.xlf
@@ -556,19 +556,19 @@
             </trans-unit>
             <trans-unit id="143">
                 <source>This value is not valid XML.</source>
-                <target state="needs-review-translation">Aquest valor no és un XML vàlid.</target>
+                <target>Aquest valor no és un XML vàlid.</target>
             </trans-unit>
             <trans-unit id="144">
                 <source>This value does not conform to the expected XSD schema.</source>
-                <target state="needs-review-translation">Aquest valor no s'ajusta a l'esquema XSD esperat.</target>
+                <target>Aquest valor no s'ajusta a l'esquema XSD esperat.</target>
             </trans-unit>
             <trans-unit id="145">
                 <source>This XML payload is too large ({{ size }} bytes): it exceeds the limit of {{ limit }} bytes.</source>
-                <target state="needs-review-translation">Aquesta càrrega XML és massa gran ({{ size }} bytes): supera el límit de {{ limit }} bytes.</target>
+                <target>Aquesta càrrega XML és massa gran ({{ size }} bytes): supera el límit de {{ limit }} bytes.</target>
             </trans-unit>
             <trans-unit id="146">
                 <source>This value is not a valid cron expression.</source>
-                <target state="needs-review-translation">Aquest valor no és una expressió cron vàlida.</target>
+                <target>Aquest valor no és una expressió cron vàlida.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64486
| License       | MIT

Reviews the 5 Catalan translations flagged `needs-review-translation`: each string was checked against the English source and the established (already-reviewed) entries of the same catalog for terminology, grammar, placeholders and punctuation conventions. 5 were confirmed as-is; none required changes.

Note: I am not a native speaker — happy to adjust any wording that native speakers flag.


<details><summary>Form — reviewed strings</summary>

| Id | English | Translation | Result |
| -- | -- | -- | -- |
| 129 | Please enter a valid UUID. | Introduïu un UUID vàlid. | confirmed |

</details>

<details><summary>Validator — reviewed strings</summary>

| Id | English | Translation | Result |
| -- | -- | -- | -- |
| 143 | This value is not valid XML. | Aquest valor no és un XML vàlid. | confirmed |
| 144 | This value does not conform to the expected XSD schema. | Aquest valor no s'ajusta a l'esquema XSD esperat. | confirmed |
| 145 | This XML payload is too large ({{ size }} bytes): it exceeds the limit of {{ limit }} bytes. | Aquesta càrrega XML és massa gran ({{ size }} bytes): supera el límit de {{ limit }} bytes. | confirmed |
| 146 | This value is not a valid cron expression. | Aquest valor no és una expressió cron vàlida. | confirmed |

</details>

