### PR TITLE
[Form][Validator] Review Simplified Chinese (zh_CN) translations

### DIFF
--- a/src/Symfony/Component/Form/Resources/translations/validators.zh_CN.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.zh_CN.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="129">
                 <source>Please enter a valid UUID.</source>
-                <target state="needs-review-translation">请输入有效的 UUID。</target>
+                <target>请输入有效的 UUID。</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.zh_CN.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.zh_CN.xlf
@@ -556,19 +556,19 @@
             </trans-unit>
             <trans-unit id="143">
                 <source>This value is not valid XML.</source>
-                <target state="needs-review-translation">该值不是有效的 XML。</target>
+                <target>该值不是有效的 XML。</target>
             </trans-unit>
             <trans-unit id="144">
                 <source>This value does not conform to the expected XSD schema.</source>
-                <target state="needs-review-translation">该值不符合预期的 XSD 架构。</target>
+                <target>该值不符合预期的 XSD 架构。</target>
             </trans-unit>
             <trans-unit id="145">
                 <source>This XML payload is too large ({{ size }} bytes): it exceeds the limit of {{ limit }} bytes.</source>
-                <target state="needs-review-translation">此 XML 负载过大（{{ size }} 字节）：超过了 {{ limit }} 字节的限制。</target>
+                <target>此 XML 负载过大（{{ size }} 字节）：超过了 {{ limit }} 字节的限制。</target>
             </trans-unit>
             <trans-unit id="146">
                 <source>This value is not a valid cron expression.</source>
-                <target state="needs-review-translation">该值不是有效的 cron 表达式。</target>
+                <target>该值不是有效的 cron 表达式。</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64487
| License       | MIT

Reviews the 5 Simplified Chinese translations flagged `needs-review-translation`: each string was checked against the English source and the established (already-reviewed) entries of the same catalog for terminology, grammar, placeholders and punctuation conventions. 5 were confirmed as-is; none required changes.

Note: I am not a native speaker — happy to adjust any wording that native speakers flag.


<details><summary>Form — reviewed strings</summary>

| Id | English | Translation | Result |
| -- | -- | -- | -- |
| 129 | Please enter a valid UUID. | 请输入有效的 UUID。 | confirmed |

</details>

<details><summary>Validator — reviewed strings</summary>

| Id | English | Translation | Result |
| -- | -- | -- | -- |
| 143 | This value is not valid XML. | 该值不是有效的 XML。 | confirmed |
| 144 | This value does not conform to the expected XSD schema. | 该值不符合预期的 XSD 架构。 | confirmed |
| 145 | This XML payload is too large ({{ size }} bytes): it exceeds the limit of {{ limit }} bytes. | 此 XML 负载过大（{{ size }} 字节）：超过了 {{ limit }} 字节的限制。 | confirmed |
| 146 | This value is not a valid cron expression. | 该值不是有效的 cron 表达式。 | confirmed |

</details>

