### PR TITLE
[Form][Validator] Review Czech (cs) translations

### DIFF
--- a/src/Symfony/Component/Form/Resources/translations/validators.cs.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.cs.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="129">
                 <source>Please enter a valid UUID.</source>
-                <target state="needs-review-translation">Prosím zadejte platný UUID.</target>
+                <target>Prosím zadejte platný UUID.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.cs.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.cs.xlf
@@ -556,19 +556,19 @@
             </trans-unit>
             <trans-unit id="143">
                 <source>This value is not valid XML.</source>
-                <target state="needs-review-translation">Tato hodnota není platné XML.</target>
+                <target>Tato hodnota není platné XML.</target>
             </trans-unit>
             <trans-unit id="144">
                 <source>This value does not conform to the expected XSD schema.</source>
-                <target state="needs-review-translation">Tato hodnota neodpovídá očekávanému schématu XSD.</target>
+                <target>Tato hodnota neodpovídá očekávanému schématu XSD.</target>
             </trans-unit>
             <trans-unit id="145">
                 <source>This XML payload is too large ({{ size }} bytes): it exceeds the limit of {{ limit }} bytes.</source>
-                <target state="needs-review-translation">Tato datová část XML je příliš velká ({{ size }} bajtů): překračuje limit {{ limit }} bajtů.</target>
+                <target>Tato datová část XML je příliš velká ({{ size }} bajtů): překračuje limit {{ limit }} bajtů.</target>
             </trans-unit>
             <trans-unit id="146">
                 <source>This value is not a valid cron expression.</source>
-                <target state="needs-review-translation">Tato hodnota není platný výraz cron.</target>
+                <target>Tato hodnota není platný výraz cron.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64490
| License       | MIT

Reviews the 5 Czech translations flagged `needs-review-translation`: each string was checked against the English source and the established (already-reviewed) entries of the same catalog for terminology, grammar, placeholders and punctuation conventions. 5 were confirmed as-is; none required changes.

Note: I am not a native speaker — happy to adjust any wording that native speakers flag.


<details><summary>Form — reviewed strings</summary>

| Id | English | Translation | Result |
| -- | -- | -- | -- |
| 129 | Please enter a valid UUID. | Prosím zadejte platný UUID. | confirmed |

</details>

<details><summary>Validator — reviewed strings</summary>

| Id | English | Translation | Result |
| -- | -- | -- | -- |
| 143 | This value is not valid XML. | Tato hodnota není platné XML. | confirmed |
| 144 | This value does not conform to the expected XSD schema. | Tato hodnota neodpovídá očekávanému schématu XSD. | confirmed |
| 145 | This XML payload is too large ({{ size }} bytes): it exceeds the limit of {{ limit }} bytes. | Tato datová část XML je příliš velká ({{ size }} bajtů): překračuje limit {{ limit }} bajtů. | confirmed |
| 146 | This value is not a valid cron expression. | Tato hodnota není platný výraz cron. | confirmed |

</details>

