### PR TITLE
[Form][Validator] Review Estonian (et) translations

### DIFF
--- a/src/Symfony/Component/Form/Resources/translations/validators.et.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.et.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="129">
                 <source>Please enter a valid UUID.</source>
-                <target state="needs-review-translation">Palun sisesta korrektne UUID.</target>
+                <target>Palun sisesta korrektne UUID.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.et.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.et.xlf
@@ -556,19 +556,19 @@
             </trans-unit>
             <trans-unit id="143">
                 <source>This value is not valid XML.</source>
-                <target state="needs-review-translation">See väärtus ei ole kehtiv XML.</target>
+                <target>See väärtus ei ole kehtiv XML.</target>
             </trans-unit>
             <trans-unit id="144">
                 <source>This value does not conform to the expected XSD schema.</source>
-                <target state="needs-review-translation">See väärtus ei vasta oodatud XSD-skeemile.</target>
+                <target>See väärtus ei vasta oodatud XSD-skeemile.</target>
             </trans-unit>
             <trans-unit id="145">
                 <source>This XML payload is too large ({{ size }} bytes): it exceeds the limit of {{ limit }} bytes.</source>
-                <target state="needs-review-translation">See XML-i kasulik koormus on liiga suur ({{ size }} baiti): see ületab {{ limit }} baidi piiri.</target>
+                <target>See XML-i kasulik koormus on liiga suur ({{ size }} baiti): see ületab {{ limit }} baidi piiri.</target>
             </trans-unit>
             <trans-unit id="146">
                 <source>This value is not a valid cron expression.</source>
-                <target state="needs-review-translation">See väärtus ei ole kehtiv cron-avaldis.</target>
+                <target>See väärtus ei ole kehtiv cron-avaldis.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64493
| License       | MIT

Reviews the 5 Estonian translations flagged `needs-review-translation`: each string was checked against the English source and the established (already-reviewed) entries of the same catalog for terminology, grammar, placeholders and punctuation conventions. 5 were confirmed as-is; none required changes.

Note: I am not a native speaker — happy to adjust any wording that native speakers flag.


<details><summary>Form — reviewed strings</summary>

| Id | English | Translation | Result |
| -- | -- | -- | -- |
| 129 | Please enter a valid UUID. | Palun sisesta korrektne UUID. | confirmed |

</details>

<details><summary>Validator — reviewed strings</summary>

| Id | English | Translation | Result |
| -- | -- | -- | -- |
| 143 | This value is not valid XML. | See väärtus ei ole kehtiv XML. | confirmed |
| 144 | This value does not conform to the expected XSD schema. | See väärtus ei vasta oodatud XSD-skeemile. | confirmed |
| 145 | This XML payload is too large ({{ size }} bytes): it exceeds the limit of {{ limit }} bytes. | See XML-i kasulik koormus on liiga suur ({{ size }} baiti): see ületab {{ limit }} baidi piiri. | confirmed |
| 146 | This value is not a valid cron expression. | See väärtus ei ole kehtiv cron-avaldis. | confirmed |

</details>

