### PR TITLE
[Form][Validator] Review Finnish (fi) translations

### DIFF
--- a/src/Symfony/Component/Form/Resources/translations/validators.fi.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.fi.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="129">
                 <source>Please enter a valid UUID.</source>
-                <target state="needs-review-translation">Syötä kelvollinen UUID.</target>
+                <target>Syötä kelvollinen UUID.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.fi.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.fi.xlf
@@ -556,19 +556,19 @@
             </trans-unit>
             <trans-unit id="143">
                 <source>This value is not valid XML.</source>
-                <target state="needs-review-translation">Tämä arvo ei ole kelvollista XML:ää.</target>
+                <target>Tämä arvo ei ole kelvollista XML:ää.</target>
             </trans-unit>
             <trans-unit id="144">
                 <source>This value does not conform to the expected XSD schema.</source>
-                <target state="needs-review-translation">Tämä arvo ei vastaa odotettua XSD-skeemaa.</target>
+                <target>Tämä arvo ei vastaa odotettua XSD-skeemaa.</target>
             </trans-unit>
             <trans-unit id="145">
                 <source>This XML payload is too large ({{ size }} bytes): it exceeds the limit of {{ limit }} bytes.</source>
-                <target state="needs-review-translation">Tämä XML-data on liian suuri ({{ size }} tavua): se ylittää {{ limit }} tavun rajan.</target>
+                <target>Tämä XML-data on liian suuri ({{ size }} tavua): se ylittää {{ limit }} tavun rajan.</target>
             </trans-unit>
             <trans-unit id="146">
                 <source>This value is not a valid cron expression.</source>
-                <target state="needs-review-translation">Tämä arvo ei ole kelvollinen cron-lauseke.</target>
+                <target>Tämä arvo ei ole kelvollinen cron-lauseke.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64494
| License       | MIT

Reviews the 5 Finnish translations flagged `needs-review-translation`: each string was checked against the English source and the established (already-reviewed) entries of the same catalog for terminology, grammar, placeholders and punctuation conventions. 5 were confirmed as-is; none required changes.

Note: I am not a native speaker — happy to adjust any wording that native speakers flag.


<details><summary>Form — reviewed strings</summary>

| Id | English | Translation | Result |
| -- | -- | -- | -- |
| 129 | Please enter a valid UUID. | Syötä kelvollinen UUID. | confirmed |

</details>

<details><summary>Validator — reviewed strings</summary>

| Id | English | Translation | Result |
| -- | -- | -- | -- |
| 143 | This value is not valid XML. | Tämä arvo ei ole kelvollista XML:ää. | confirmed |
| 144 | This value does not conform to the expected XSD schema. | Tämä arvo ei vastaa odotettua XSD-skeemaa. | confirmed |
| 145 | This XML payload is too large ({{ size }} bytes): it exceeds the limit of {{ limit }} bytes. | Tämä XML-data on liian suuri ({{ size }} tavua): se ylittää {{ limit }} tavun rajan. | confirmed |
| 146 | This value is not a valid cron expression. | Tämä arvo ei ole kelvollinen cron-lauseke. | confirmed |

</details>

