### PR TITLE
[Form][Validator] Review Galician (gl) translations

### DIFF
--- a/src/Symfony/Component/Form/Resources/translations/validators.gl.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.gl.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="129">
                 <source>Please enter a valid UUID.</source>
-                <target state="needs-review-translation">Por favor, introduce un UUID válido.</target>
+                <target>Por favor, introduce un UUID válido.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.gl.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.gl.xlf
@@ -556,19 +556,19 @@
             </trans-unit>
             <trans-unit id="143">
                 <source>This value is not valid XML.</source>
-                <target state="needs-review-translation">Este valor non é un XML válido.</target>
+                <target>Este valor non é un XML válido.</target>
             </trans-unit>
             <trans-unit id="144">
                 <source>This value does not conform to the expected XSD schema.</source>
-                <target state="needs-review-translation">Este valor non se axusta ao esquema XSD esperado.</target>
+                <target>Este valor non se axusta ao esquema XSD esperado.</target>
             </trans-unit>
             <trans-unit id="145">
                 <source>This XML payload is too large ({{ size }} bytes): it exceeds the limit of {{ limit }} bytes.</source>
-                <target state="needs-review-translation">Esta carga útil XML é demasiado grande ({{ size }} bytes): supera o límite de {{ limit }} bytes.</target>
+                <target>Esta carga útil XML é demasiado grande ({{ size }} bytes): supera o límite de {{ limit }} bytes.</target>
             </trans-unit>
             <trans-unit id="146">
                 <source>This value is not a valid cron expression.</source>
-                <target state="needs-review-translation">Este valor non é unha expresión cron válida.</target>
+                <target>Este valor non é unha expresión cron válida.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64496
| License       | MIT

Reviews the 5 Galician translations flagged `needs-review-translation`: each string was checked against the English source and the established (already-reviewed) entries of the same catalog for terminology, grammar, placeholders and punctuation conventions. 5 were confirmed as-is; none required changes.

Note: I am not a native speaker — happy to adjust any wording that native speakers flag.


<details><summary>Form — reviewed strings</summary>

| Id | English | Translation | Result |
| -- | -- | -- | -- |
| 129 | Please enter a valid UUID. | Por favor, introduce un UUID válido. | confirmed |

</details>

<details><summary>Validator — reviewed strings</summary>

| Id | English | Translation | Result |
| -- | -- | -- | -- |
| 143 | This value is not valid XML. | Este valor non é un XML válido. | confirmed |
| 144 | This value does not conform to the expected XSD schema. | Este valor non se axusta ao esquema XSD esperado. | confirmed |
| 145 | This XML payload is too large ({{ size }} bytes): it exceeds the limit of {{ limit }} bytes. | Esta carga útil XML é demasiado grande ({{ size }} bytes): supera o límite de {{ limit }} bytes. | confirmed |
| 146 | This value is not a valid cron expression. | Este valor non é unha expresión cron válida. | confirmed |

</details>

