### PR TITLE
[Form][Validator] Review Greek (el) translations

### DIFF
--- a/src/Symfony/Component/Form/Resources/translations/validators.el.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.el.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="129">
                 <source>Please enter a valid UUID.</source>
-                <target state="needs-review-translation">Παρακαλούμε εισάγετε ένα έγκυρο UUID.</target>
+                <target>Παρακαλούμε εισάγετε ένα έγκυρο UUID.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.el.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.el.xlf
@@ -556,19 +556,19 @@
             </trans-unit>
             <trans-unit id="143">
                 <source>This value is not valid XML.</source>
-                <target state="needs-review-translation">Αυτή η τιμή δεν είναι έγκυρη XML.</target>
+                <target>Αυτή η τιμή δεν είναι έγκυρη XML.</target>
             </trans-unit>
             <trans-unit id="144">
                 <source>This value does not conform to the expected XSD schema.</source>
-                <target state="needs-review-translation">Αυτή η τιμή δεν συμμορφώνεται με το αναμενόμενο σχήμα XSD.</target>
+                <target>Αυτή η τιμή δεν συμμορφώνεται με το αναμενόμενο σχήμα XSD.</target>
             </trans-unit>
             <trans-unit id="145">
                 <source>This XML payload is too large ({{ size }} bytes): it exceeds the limit of {{ limit }} bytes.</source>
-                <target state="needs-review-translation">Αυτό το ωφέλιμο φορτίο XML είναι πολύ μεγάλο ({{ size }} bytes): υπερβαίνει το όριο των {{ limit }} bytes.</target>
+                <target>Αυτό το ωφέλιμο φορτίο XML είναι πολύ μεγάλο ({{ size }} bytes): υπερβαίνει το όριο των {{ limit }} bytes.</target>
             </trans-unit>
             <trans-unit id="146">
                 <source>This value is not a valid cron expression.</source>
-                <target state="needs-review-translation">Αυτή η τιμή δεν είναι έγκυρη έκφραση cron.</target>
+                <target>Αυτή η τιμή δεν είναι έγκυρη έκφραση cron.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64498
| License       | MIT

Reviews the 5 Greek translations flagged `needs-review-translation`: each string was checked against the English source and the established (already-reviewed) entries of the same catalog for terminology, grammar, placeholders and punctuation conventions. 5 were confirmed as-is; none required changes.

Note: I am not a native speaker — happy to adjust any wording that native speakers flag.


<details><summary>Form — reviewed strings</summary>

| Id | English | Translation | Result |
| -- | -- | -- | -- |
| 129 | Please enter a valid UUID. | Παρακαλούμε εισάγετε ένα έγκυρο UUID. | confirmed |

</details>

<details><summary>Validator — reviewed strings</summary>

| Id | English | Translation | Result |
| -- | -- | -- | -- |
| 143 | This value is not valid XML. | Αυτή η τιμή δεν είναι έγκυρη XML. | confirmed |
| 144 | This value does not conform to the expected XSD schema. | Αυτή η τιμή δεν συμμορφώνεται με το αναμενόμενο σχήμα XSD. | confirmed |
| 145 | This XML payload is too large ({{ size }} bytes): it exceeds the limit of {{ limit }} bytes. | Αυτό το ωφέλιμο φορτίο XML είναι πολύ μεγάλο ({{ size }} bytes): υπερβαίνει το όριο των {{ limit }} bytes. | confirmed |
| 146 | This value is not a valid cron expression. | Αυτή η τιμή δεν είναι έγκυρη έκφραση cron. | confirmed |

</details>

