### PR TITLE
[Form][Validator] Review Hebrew (he) translations

### DIFF
--- a/src/Symfony/Component/Form/Resources/translations/validators.he.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.he.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="129">
                 <source>Please enter a valid UUID.</source>
-                <target state="needs-review-translation">אנא הזן UUID תקף.</target>
+                <target>אנא הזן UUID תקני.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.he.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.he.xlf
@@ -556,19 +556,19 @@
             </trans-unit>
             <trans-unit id="143">
                 <source>This value is not valid XML.</source>
-                <target state="needs-review-translation">ערך זה אינו XML תקין.</target>
+                <target>ערך זה אינו XML תקין.</target>
             </trans-unit>
             <trans-unit id="144">
                 <source>This value does not conform to the expected XSD schema.</source>
-                <target state="needs-review-translation">ערך זה אינו תואם לסכמת ה-XSD הצפויה.</target>
+                <target>ערך זה אינו תואם לסכמת ה-XSD הצפויה.</target>
             </trans-unit>
             <trans-unit id="145">
                 <source>This XML payload is too large ({{ size }} bytes): it exceeds the limit of {{ limit }} bytes.</source>
-                <target state="needs-review-translation">מטען ה-XML הזה גדול מדי ({{ size }} בתים): הוא חורג מהמגבלה של {{ limit }} בתים.</target>
+                <target>מטען ה-XML הזה גדול מדי ({{ size }} בתים): הוא חורג מהמגבלה של {{ limit }} בתים.</target>
             </trans-unit>
             <trans-unit id="146">
                 <source>This value is not a valid cron expression.</source>
-                <target state="needs-review-translation">ערך זה אינו ביטוי cron תקין.</target>
+                <target>ערך זה אינו ביטוי cron תקין.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64499
| License       | MIT

Reviews the 5 Hebrew translations flagged `needs-review-translation`: each string was checked against the English source and the established (already-reviewed) entries of the same catalog for terminology, grammar, placeholders and punctuation conventions. 4 were confirmed as-is; 1 was corrected.

Note: I am not a native speaker — happy to adjust any wording that native speakers flag.


<details><summary>Form — reviewed strings</summary>

| Id | English | Translation | Result |
| -- | -- | -- | -- |
| 129 | Please enter a valid UUID. | אנא הזן UUID תקני. | corrected (was: אנא הזן UUID תקף.) |

</details>

<details><summary>Validator — reviewed strings</summary>

| Id | English | Translation | Result |
| -- | -- | -- | -- |
| 143 | This value is not valid XML. | ערך זה אינו XML תקין. | confirmed |
| 144 | This value does not conform to the expected XSD schema. | ערך זה אינו תואם לסכמת ה-XSD הצפויה. | confirmed |
| 145 | This XML payload is too large ({{ size }} bytes): it exceeds the limit of {{ limit }} bytes. | מטען ה-XML הזה גדול מדי ({{ size }} בתים): הוא חורג מהמגבלה של {{ limit }} בתים. | confirmed |
| 146 | This value is not a valid cron expression. | ערך זה אינו ביטוי cron תקין. | confirmed |

</details>

