### PR TITLE
[Form][Validator] Review Japanese (ja) translations

### DIFF
--- a/src/Symfony/Component/Form/Resources/translations/validators.ja.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.ja.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="129">
                 <source>Please enter a valid UUID.</source>
-                <target state="needs-review-translation">有効なUUIDを入力してください。</target>
+                <target>有効なUUIDを入力してください。</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.ja.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.ja.xlf
@@ -556,19 +556,19 @@
             </trans-unit>
             <trans-unit id="143">
                 <source>This value is not valid XML.</source>
-                <target state="needs-review-translation">この値は有効なXMLではありません。</target>
+                <target>この値は有効なXMLではありません。</target>
             </trans-unit>
             <trans-unit id="144">
                 <source>This value does not conform to the expected XSD schema.</source>
-                <target state="needs-review-translation">この値は期待されるXSDスキーマに準拠していません。</target>
+                <target>この値は期待されるXSDスキーマに準拠していません。</target>
             </trans-unit>
             <trans-unit id="145">
                 <source>This XML payload is too large ({{ size }} bytes): it exceeds the limit of {{ limit }} bytes.</source>
-                <target state="needs-review-translation">このXMLペイロードは大きすぎます（{{ size }}バイト）。{{ limit }}バイトの制限を超えています。</target>
+                <target>このXMLペイロードは大きすぎます（{{ size }}バイト）。{{ limit }}バイトの制限を超えています。</target>
             </trans-unit>
             <trans-unit id="146">
                 <source>This value is not a valid cron expression.</source>
-                <target state="needs-review-translation">この値は有効なcron式ではありません。</target>
+                <target>この値は有効なcron式ではありません。</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64502
| License       | MIT

Reviews the 5 Japanese translations flagged `needs-review-translation`: each string was checked against the English source and the established (already-reviewed) entries of the same catalog for terminology, grammar, placeholders and punctuation conventions. 5 were confirmed as-is; none required changes.

Note: I am not a native speaker — happy to adjust any wording that native speakers flag.


<details><summary>Form — reviewed strings</summary>

| Id | English | Translation | Result |
| -- | -- | -- | -- |
| 129 | Please enter a valid UUID. | 有効なUUIDを入力してください。 | confirmed |

</details>

<details><summary>Validator — reviewed strings</summary>

| Id | English | Translation | Result |
| -- | -- | -- | -- |
| 143 | This value is not valid XML. | この値は有効なXMLではありません。 | confirmed |
| 144 | This value does not conform to the expected XSD schema. | この値は期待されるXSDスキーマに準拠していません。 | confirmed |
| 145 | This XML payload is too large ({{ size }} bytes): it exceeds the limit of {{ limit }} bytes. | このXMLペイロードは大きすぎます（{{ size }}バイト）。{{ limit }}バイトの制限を超えています。 | confirmed |
| 146 | This value is not a valid cron expression. | この値は有効なcron式ではありません。 | confirmed |

</details>

