### PR TITLE
[Form][Validator] Review Latvian (lv) translations

### DIFF
--- a/src/Symfony/Component/Form/Resources/translations/validators.lv.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.lv.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="129">
                 <source>Please enter a valid UUID.</source>
-                <target state="needs-review-translation">Lūdzu, ievadiet derīgu UUID.</target>
+                <target>Lūdzu, ievadiet derīgu UUID.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.lv.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.lv.xlf
@@ -556,19 +556,19 @@
             </trans-unit>
             <trans-unit id="143">
                 <source>This value is not valid XML.</source>
-                <target state="needs-review-translation">Šī vērtība nav derīgs XML.</target>
+                <target>Šī vērtība nav derīgs XML.</target>
             </trans-unit>
             <trans-unit id="144">
                 <source>This value does not conform to the expected XSD schema.</source>
-                <target state="needs-review-translation">Šī vērtība neatbilst gaidītajai XSD shēmai.</target>
+                <target>Šī vērtība neatbilst gaidītajai XSD shēmai.</target>
             </trans-unit>
             <trans-unit id="145">
                 <source>This XML payload is too large ({{ size }} bytes): it exceeds the limit of {{ limit }} bytes.</source>
-                <target state="needs-review-translation">Šī XML slodze ir pārāk liela ({{ size }} baiti): tā pārsniedz {{ limit }} baitu ierobežojumu.</target>
+                <target>Šī XML slodze ir pārāk liela ({{ size }} baiti): tā pārsniedz {{ limit }} baitu ierobežojumu.</target>
             </trans-unit>
             <trans-unit id="146">
                 <source>This value is not a valid cron expression.</source>
-                <target state="needs-review-translation">Šī vērtība nav derīga cron izteiksme.</target>
+                <target>Šī vērtība nav derīga cron izteiksme.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64503
| License       | MIT

Reviews the 5 Latvian translations flagged `needs-review-translation`: each string was checked against the English source and the established (already-reviewed) entries of the same catalog for terminology, grammar, placeholders and punctuation conventions. 5 were confirmed as-is; none required changes.

Note: I am not a native speaker — happy to adjust any wording that native speakers flag.


<details><summary>Form — reviewed strings</summary>

| Id | English | Translation | Result |
| -- | -- | -- | -- |
| 129 | Please enter a valid UUID. | Lūdzu, ievadiet derīgu UUID. | confirmed |

</details>

<details><summary>Validator — reviewed strings</summary>

| Id | English | Translation | Result |
| -- | -- | -- | -- |
| 143 | This value is not valid XML. | Šī vērtība nav derīgs XML. | confirmed |
| 144 | This value does not conform to the expected XSD schema. | Šī vērtība neatbilst gaidītajai XSD shēmai. | confirmed |
| 145 | This XML payload is too large ({{ size }} bytes): it exceeds the limit of {{ limit }} bytes. | Šī XML slodze ir pārāk liela ({{ size }} baiti): tā pārsniedz {{ limit }} baitu ierobežojumu. | confirmed |
| 146 | This value is not a valid cron expression. | Šī vērtība nav derīga cron izteiksme. | confirmed |

</details>

