### PR TITLE
[Form][Validator] Review Luxembourgish (lb) translations

### DIFF
--- a/src/Symfony/Component/Form/Resources/translations/validators.lb.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.lb.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="129">
                 <source>Please enter a valid UUID.</source>
-                <target state="needs-review-translation">W.e.g. eng gëlteg UUID aginn.</target>
+                <target>W.e.g. eng gëlteg UUID aginn.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.lb.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.lb.xlf
@@ -556,19 +556,19 @@
             </trans-unit>
             <trans-unit id="143">
                 <source>This value is not valid XML.</source>
-                <target state="needs-review-translation">Dëse Wert ass keen valabelt XML.</target>
+                <target>Dëse Wäert ass kee gëltegt XML.</target>
             </trans-unit>
             <trans-unit id="144">
                 <source>This value does not conform to the expected XSD schema.</source>
-                <target state="needs-review-translation">Dëse Wert entsprécht net dem erwaarte XSD-Schema.</target>
+                <target>Dëse Wäert entsprécht net dem erwaarte XSD-Schema.</target>
             </trans-unit>
             <trans-unit id="145">
                 <source>This XML payload is too large ({{ size }} bytes): it exceeds the limit of {{ limit }} bytes.</source>
-                <target state="needs-review-translation">Dës XML-Nutzlaascht ass ze grouss ({{ size }} Bytes): si iwwerschreift d'Limitt vu {{ limit }} Bytes.</target>
+                <target>Dës XML-Nutzlaascht ass ze grouss ({{ size }} Bytes): si iwwerschreit d'Limitt vu {{ limit }} Bytes.</target>
             </trans-unit>
             <trans-unit id="146">
                 <source>This value is not a valid cron expression.</source>
-                <target state="needs-review-translation">Dëse Wäert ass keen gültegen Cron-Ausdrock.</target>
+                <target>Dëse Wäert ass kee gëltege Cron-Ausdrock.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64505
| License       | MIT

Reviews the 5 Luxembourgish translations flagged `needs-review-translation`: each string was checked against the English source and the established (already-reviewed) entries of the same catalog for terminology, grammar, placeholders and punctuation conventions. 1 were confirmed as-is; 4 were corrected.

Note: I am not a native speaker — happy to adjust any wording that native speakers flag.


<details><summary>Form — reviewed strings</summary>

| Id | English | Translation | Result |
| -- | -- | -- | -- |
| 129 | Please enter a valid UUID. | W.e.g. eng gëlteg UUID aginn. | confirmed |

</details>

<details><summary>Validator — reviewed strings</summary>

| Id | English | Translation | Result |
| -- | -- | -- | -- |
| 143 | This value is not valid XML. | Dëse Wäert ass kee gëltegt XML. | corrected (was: Dëse Wert ass keen valabelt XML.) |
| 144 | This value does not conform to the expected XSD schema. | Dëse Wäert entsprécht net dem erwaarte XSD-Schema. | corrected (was: Dëse Wert entsprécht net dem erwaarte XSD-Schema.) |
| 145 | This XML payload is too large ({{ size }} bytes): it exceeds the limit of {{ limit }} bytes. | Dës XML-Nutzlaascht ass ze grouss ({{ size }} Bytes): si iwwerschreit d'Limitt vu {{ limit }} Bytes. | corrected (was: Dës XML-Nutzlaascht ass ze grouss ({{ size }} Bytes): si iwwerschreift d'Limitt vu {{ limit }} Bytes.) |
| 146 | This value is not a valid cron expression. | Dëse Wäert ass kee gëltege Cron-Ausdrock. | corrected (was: Dëse Wäert ass keen gültegen Cron-Ausdrock.) |

</details>

