### PR TITLE
[Form][Validator] Review Persian (fa) translations

### DIFF
--- a/src/Symfony/Component/Form/Resources/translations/validators.fa.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.fa.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="129">
                 <source>Please enter a valid UUID.</source>
-                <target state="needs-review-translation">لطفاً یک UUID معتبر وارد کنید.</target>
+                <target>لطفاً یک UUID معتبر وارد کنید.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.fa.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.fa.xlf
@@ -556,19 +556,19 @@
             </trans-unit>
             <trans-unit id="143">
                 <source>This value is not valid XML.</source>
-                <target state="needs-review-translation">این مقدار یک XML معتبر نیست.</target>
+                <target>این مقدار یک XML معتبر نیست.</target>
             </trans-unit>
             <trans-unit id="144">
                 <source>This value does not conform to the expected XSD schema.</source>
-                <target state="needs-review-translation">این مقدار با طرح‌وارهٔ XSD مورد انتظار مطابقت ندارد.</target>
+                <target>این مقدار با طرح‌وارهٔ XSD مورد انتظار مطابقت ندارد.</target>
             </trans-unit>
             <trans-unit id="145">
                 <source>This XML payload is too large ({{ size }} bytes): it exceeds the limit of {{ limit }} bytes.</source>
-                <target state="needs-review-translation">این محتوای XML بیش از حد بزرگ است ({{ size }} بایت): از محدودیت {{ limit }} بایت فراتر می‌رود.</target>
+                <target>این محتوای XML بیش از حد بزرگ است ({{ size }} بایت): از محدودیت {{ limit }} بایت فراتر می‌رود.</target>
             </trans-unit>
             <trans-unit id="146">
                 <source>This value is not a valid cron expression.</source>
-                <target state="needs-review-translation">این مقدار یک عبارت cron معتبر نیست.</target>
+                <target>این مقدار یک عبارت cron معتبر نیست.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64508
| License       | MIT

Reviews the 5 Persian translations flagged `needs-review-translation`: each string was checked against the English source and the established (already-reviewed) entries of the same catalog for terminology, grammar, placeholders and punctuation conventions. 5 were confirmed as-is; none required changes.

Note: I am not a native speaker — happy to adjust any wording that native speakers flag.


<details><summary>Form — reviewed strings</summary>

| Id | English | Translation | Result |
| -- | -- | -- | -- |
| 129 | Please enter a valid UUID. | لطفاً یک UUID معتبر وارد کنید. | confirmed |

</details>

<details><summary>Validator — reviewed strings</summary>

| Id | English | Translation | Result |
| -- | -- | -- | -- |
| 143 | This value is not valid XML. | این مقدار یک XML معتبر نیست. | confirmed |
| 144 | This value does not conform to the expected XSD schema. | این مقدار با طرح‌وارهٔ XSD مورد انتظار مطابقت ندارد. | confirmed |
| 145 | This XML payload is too large ({{ size }} bytes): it exceeds the limit of {{ limit }} bytes. | این محتوای XML بیش از حد بزرگ است ({{ size }} بایت): از محدودیت {{ limit }} بایت فراتر می‌رود. | confirmed |
| 146 | This value is not a valid cron expression. | این مقدار یک عبارت cron معتبر نیست. | confirmed |

</details>

