### PR TITLE
[Form][Validator] Review Romanian (ro) translations

### DIFF
--- a/src/Symfony/Component/Form/Resources/translations/validators.ro.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.ro.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="129">
                 <source>Please enter a valid UUID.</source>
-                <target state="needs-review-translation">Vă rugăm să introduceți un UUID valid.</target>
+                <target>Vă rugăm să introduceți un UUID valid.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.ro.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.ro.xlf
@@ -556,19 +556,19 @@
             </trans-unit>
             <trans-unit id="143">
                 <source>This value is not valid XML.</source>
-                <target state="needs-review-translation">Această valoare nu este un XML valid.</target>
+                <target>Această valoare nu este un XML valid.</target>
             </trans-unit>
             <trans-unit id="144">
                 <source>This value does not conform to the expected XSD schema.</source>
-                <target state="needs-review-translation">Această valoare nu este conformă cu schema XSD așteptată.</target>
+                <target>Această valoare nu este conformă cu schema XSD așteptată.</target>
             </trans-unit>
             <trans-unit id="145">
                 <source>This XML payload is too large ({{ size }} bytes): it exceeds the limit of {{ limit }} bytes.</source>
-                <target state="needs-review-translation">Această încărcătură utilă XML este prea mare ({{ size }} octeți): depășește limita de {{ limit }} octeți.</target>
+                <target>Această încărcătură utilă XML este prea mare ({{ size }} octeți): depășește limita de {{ limit }} octeți.</target>
             </trans-unit>
             <trans-unit id="146">
                 <source>This value is not a valid cron expression.</source>
-                <target state="needs-review-translation">Această valoare nu este o expresie cron validă.</target>
+                <target>Această valoare nu este o expresie cron validă.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64511
| License       | MIT

Reviews the 5 Romanian translations flagged `needs-review-translation`: each string was checked against the English source and the established (already-reviewed) entries of the same catalog for terminology, grammar, placeholders and punctuation conventions. 5 were confirmed as-is; none required changes.

Note: I am not a native speaker — happy to adjust any wording that native speakers flag.


<details><summary>Form — reviewed strings</summary>

| Id | English | Translation | Result |
| -- | -- | -- | -- |
| 129 | Please enter a valid UUID. | Vă rugăm să introduceți un UUID valid. | confirmed |

</details>

<details><summary>Validator — reviewed strings</summary>

| Id | English | Translation | Result |
| -- | -- | -- | -- |
| 143 | This value is not valid XML. | Această valoare nu este un XML valid. | confirmed |
| 144 | This value does not conform to the expected XSD schema. | Această valoare nu este conformă cu schema XSD așteptată. | confirmed |
| 145 | This XML payload is too large ({{ size }} bytes): it exceeds the limit of {{ limit }} bytes. | Această încărcătură utilă XML este prea mare ({{ size }} octeți): depășește limita de {{ limit }} octeți. | confirmed |
| 146 | This value is not a valid cron expression. | Această valoare nu este o expresie cron validă. | confirmed |

</details>

