### PR TITLE
[Form][Validator] Review Slovenian (sl) translations

### DIFF
--- a/src/Symfony/Component/Form/Resources/translations/validators.sl.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.sl.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="129">
                 <source>Please enter a valid UUID.</source>
-                <target state="needs-review-translation">Prosimo, vnesite veljaven UUID.</target>
+                <target>Prosimo, vnesite veljaven UUID.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.sl.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.sl.xlf
@@ -556,19 +556,19 @@
             </trans-unit>
             <trans-unit id="143">
                 <source>This value is not valid XML.</source>
-                <target state="needs-review-translation">Ta vrednost ni veljaven XML.</target>
+                <target>Ta vrednost ni veljaven XML.</target>
             </trans-unit>
             <trans-unit id="144">
                 <source>This value does not conform to the expected XSD schema.</source>
-                <target state="needs-review-translation">Ta vrednost ni skladna s pričakovano shemo XSD.</target>
+                <target>Ta vrednost ni skladna s pričakovano shemo XSD.</target>
             </trans-unit>
             <trans-unit id="145">
                 <source>This XML payload is too large ({{ size }} bytes): it exceeds the limit of {{ limit }} bytes.</source>
-                <target state="needs-review-translation">Ta vsebina XML je prevelika ({{ size }} bajtov): presega omejitev {{ limit }} bajtov.</target>
+                <target>Ta vsebina XML je prevelika ({{ size }} bajtov): presega omejitev {{ limit }} bajtov.</target>
             </trans-unit>
             <trans-unit id="146">
                 <source>This value is not a valid cron expression.</source>
-                <target state="needs-review-translation">Ta vrednost ni veljaven izraz cron.</target>
+                <target>Ta vrednost ni veljaven izraz cron.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64516
| License       | MIT

Reviews the 5 Slovenian translations flagged `needs-review-translation`: each string was checked against the English source and the established (already-reviewed) entries of the same catalog for terminology, grammar, placeholders and punctuation conventions. 5 were confirmed as-is; none required changes.

Note: I am not a native speaker — happy to adjust any wording that native speakers flag.


<details><summary>Form — reviewed strings</summary>

| Id | English | Translation | Result |
| -- | -- | -- | -- |
| 129 | Please enter a valid UUID. | Prosimo, vnesite veljaven UUID. | confirmed |

</details>

<details><summary>Validator — reviewed strings</summary>

| Id | English | Translation | Result |
| -- | -- | -- | -- |
| 143 | This value is not valid XML. | Ta vrednost ni veljaven XML. | confirmed |
| 144 | This value does not conform to the expected XSD schema. | Ta vrednost ni skladna s pričakovano shemo XSD. | confirmed |
| 145 | This XML payload is too large ({{ size }} bytes): it exceeds the limit of {{ limit }} bytes. | Ta vsebina XML je prevelika ({{ size }} bajtov): presega omejitev {{ limit }} bajtov. | confirmed |
| 146 | This value is not a valid cron expression. | Ta vrednost ni veljaven izraz cron. | confirmed |

</details>

