### PR TITLE
[Form][Validator] Review Swedish (sv) translations

### DIFF
--- a/src/Symfony/Component/Form/Resources/translations/validators.sv.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.sv.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="129">
                 <source>Please enter a valid UUID.</source>
-                <target state="needs-review-translation">Ange ett giltigt UUID.</target>
+                <target>Ange ett giltigt UUID.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.sv.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.sv.xlf
@@ -556,19 +556,19 @@
             </trans-unit>
             <trans-unit id="143">
                 <source>This value is not valid XML.</source>
-                <target state="needs-review-translation">Detta värde är inte giltig XML.</target>
+                <target>Detta värde är inte giltig XML.</target>
             </trans-unit>
             <trans-unit id="144">
                 <source>This value does not conform to the expected XSD schema.</source>
-                <target state="needs-review-translation">Detta värde överensstämmer inte med det förväntade XSD-schemat.</target>
+                <target>Detta värde överensstämmer inte med det förväntade XSD-schemat.</target>
             </trans-unit>
             <trans-unit id="145">
                 <source>This XML payload is too large ({{ size }} bytes): it exceeds the limit of {{ limit }} bytes.</source>
-                <target state="needs-review-translation">Denna XML-nyttolast är för stor ({{ size }} byte): den överskrider gränsen på {{ limit }} byte.</target>
+                <target>Denna XML-nyttolast är för stor ({{ size }} byte): den överskrider gränsen på {{ limit }} byte.</target>
             </trans-unit>
             <trans-unit id="146">
                 <source>This value is not a valid cron expression.</source>
-                <target state="needs-review-translation">Detta värde är inte ett giltigt cron-uttryck.</target>
+                <target>Detta värde är inte ett giltigt cron-uttryck.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64518
| License       | MIT

Reviews the 5 Swedish translations flagged `needs-review-translation`: each string was checked against the English source and the established (already-reviewed) entries of the same catalog for terminology, grammar, placeholders and punctuation conventions. 5 were confirmed as-is; none required changes.

Note: I am not a native speaker — happy to adjust any wording that native speakers flag.


<details><summary>Form — reviewed strings</summary>

| Id | English | Translation | Result |
| -- | -- | -- | -- |
| 129 | Please enter a valid UUID. | Ange ett giltigt UUID. | confirmed |

</details>

<details><summary>Validator — reviewed strings</summary>

| Id | English | Translation | Result |
| -- | -- | -- | -- |
| 143 | This value is not valid XML. | Detta värde är inte giltig XML. | confirmed |
| 144 | This value does not conform to the expected XSD schema. | Detta värde överensstämmer inte med det förväntade XSD-schemat. | confirmed |
| 145 | This XML payload is too large ({{ size }} bytes): it exceeds the limit of {{ limit }} bytes. | Denna XML-nyttolast är för stor ({{ size }} byte): den överskrider gränsen på {{ limit }} byte. | confirmed |
| 146 | This value is not a valid cron expression. | Detta värde är inte ett giltigt cron-uttryck. | confirmed |

</details>

