### PR TITLE
[Validator] Review Hungarian (hu) translations

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.hu.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.hu.xlf
@@ -568,7 +568,7 @@
             </trans-unit>
             <trans-unit id="146">
                 <source>This value is not a valid cron expression.</source>
-                <target state="needs-review-translation">Ez az érték nem érvényes cron kifejezés.</target>
+                <target>Ez az érték nem érvényes cron kifejezés.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64681
| License       | MIT

Reviews the 1 Hungarian translations flagged `needs-review-translation`: each string was checked against the English source and the established (already-reviewed) entries of the same catalog for terminology, grammar, placeholders and punctuation conventions. 1 were confirmed as-is; none required changes.

Note: I am not a native speaker — happy to adjust any wording that native speakers flag.


<details><summary>Validator — reviewed strings</summary>

| Id | English | Translation | Result |
| -- | -- | -- | -- |
| 146 | This value is not a valid cron expression. | Ez az érték nem érvényes cron kifejezés. | confirmed |

</details>

