### PR TITLE
[Form][Security][Validator] Review Norwegian Nynorsk (nn) translations

### DIFF
--- a/src/Symfony/Component/Form/Resources/translations/validators.nn.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.nn.xlf
@@ -12,7 +12,7 @@
             </trans-unit>
             <trans-unit id="30">
                 <source>The CSRF token is invalid. Please try to resubmit the form.</source>
-                <target state="needs-review-translation">CSRF-teiknet er ugyldig. Ver venleg og prøv å sende inn skjemaet på nytt.</target>
+                <target>CSRF-teiknet er ugyldig. Prøv å sende inn skjemaet på nytt.</target>
             </trans-unit>
             <trans-unit id="99">
                 <source>This value is not a valid HTML5 color.</source>
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="129">
                 <source>Please enter a valid UUID.</source>
-                <target state="needs-review-translation">Gje opp ein gyldig UUID.</target>
+                <target>Gje opp ein gyldig UUID.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.nn.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.nn.xlf
@@ -76,7 +76,7 @@
             </trans-unit>
             <trans-unit id="20">
                 <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
-                <target state="needs-review-translation">For mange mislukka innloggingsforsøk, prøv igjen om %minutes% minutt.</target>
+                <target>For mange mislukka innloggingsforsøk, prøv igjen om %minutes% minutt.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.nn.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.nn.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="37" resname="This is not a valid IP address.">
                 <source>This value is not a valid IP address.</source>
-                <target state="needs-review-translation">Denne verdien er ikkje ein gyldig IP-adresse.</target>
+                <target>Verdien er ikkje ei gyldig IP-adresse.</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
@@ -192,7 +192,7 @@
             </trans-unit>
             <trans-unit id="51" resname="No temporary folder was configured in php.ini.">
                 <source>No temporary folder was configured in php.ini, or the configured folder does not exist.</source>
-                <target state="needs-review-translation">Ingen midlertidig mappe var konfigurert i php.ini, eller den konfigurerte mappa eksisterer ikkje.</target>
+                <target>Inga mellombels mappe var konfigurert i php.ini, eller den konfigurerte mappa eksisterer ikkje.</target>
             </trans-unit>
             <trans-unit id="52">
                 <source>Cannot write temporary file to disk.</source>
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59" resname="This is not a valid International Bank Account Number (IBAN).">
                 <source>This value is not a valid International Bank Account Number (IBAN).</source>
-                <target state="needs-review-translation">Denne verdien er ikkje eit gyldig internasjonalt bankkontonummer (IBAN).</target>
+                <target>Verdien er ikkje eit gyldig internasjonalt bankkontonummer (IBAN).</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81" resname="This is not a valid Business Identifier Code (BIC).">
                 <source>This value is not a valid Business Identifier Code (BIC).</source>
-                <target state="needs-review-translation">Denne verdien er ikkje ein gyldig forretningsidentifikasjonskode (BIC).</target>
+                <target>Verdien er ikkje ein gyldig forretningsidentifikasjonskode (BIC).</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="83" resname="This is not a valid UUID.">
                 <source>This value is not a valid UUID.</source>
-                <target state="needs-review-translation">Denne verdien er ikkje ein gyldig UUID.</target>
+                <target>Verdien er ikkje ein gyldig UUID.</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -404,171 +404,171 @@
             </trans-unit>
             <trans-unit id="104">
                 <source>The filename is too long. It should have {{ filename_max_length }} character or less.|The filename is too long. It should have {{ filename_max_length }} characters or less.</source>
-                <target state="needs-review-translation">Filnamnet er for langt. Det bør ha {{ filename_max_length }} teikn eller færre.|Filnamnet er for langt. Det bør ha {{ filename_max_length }} teikn eller færre.</target>
+                <target>Filnamnet er for langt. Det bør ha {{ filename_max_length }} teikn eller færre.|Filnamnet er for langt. Det bør ha {{ filename_max_length }} teikn eller færre.</target>
             </trans-unit>
             <trans-unit id="105">
                 <source>The password strength is too low. Please use a stronger password.</source>
-                <target state="needs-review-translation">Passordstyrken er for låg. Vennligst bruk eit sterkare passord.</target>
+                <target>Passordstyrken er for låg. Bruk eit sterkare passord.</target>
             </trans-unit>
             <trans-unit id="106">
                 <source>This value contains characters that are not allowed by the current restriction-level.</source>
-                <target state="needs-review-translation">Denne verdien inneheld teikn som ikkje er tillatne av det gjeldande restriksjonsnivået.</target>
+                <target>Verdien inneheld teikn som ikkje er tillatne av det gjeldande restriksjonsnivået.</target>
             </trans-unit>
             <trans-unit id="107">
                 <source>Using invisible characters is not allowed.</source>
-                <target state="needs-review-translation">Det er ikkje tillate å bruke usynlege teikn.</target>
+                <target>Det er ikkje tillate å bruke usynlege teikn.</target>
             </trans-unit>
             <trans-unit id="108">
                 <source>Mixing numbers from different scripts is not allowed.</source>
-                <target state="needs-review-translation">Det er ikkje tillate å blande tal frå forskjellige skript.</target>
+                <target>Det er ikkje tillate å blande tal frå forskjellige skript.</target>
             </trans-unit>
             <trans-unit id="109">
                 <source>Using hidden overlay characters is not allowed.</source>
-                <target state="needs-review-translation">Det er ikkje tillate å bruke skjulte overleggsteikn.</target>
+                <target>Det er ikkje tillate å bruke skjulte overleggsteikn.</target>
             </trans-unit>
             <trans-unit id="110">
                 <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
-                <target state="needs-review-translation">Filutvidinga er ugyldig ({{ extension }}). Tillatne utvidingar er {{ extensions }}.</target>
+                <target>Filutvidinga er ugyldig ({{ extension }}). Tillatne utvidingar er {{ extensions }}.</target>
             </trans-unit>
             <trans-unit id="111">
                 <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
-                <target state="needs-review-translation">Den oppdaga teiknkodinga er ugyldig ({{ detected }}). Tillatne kodingar er {{ encodings }}.</target>
+                <target>Den oppdaga teiknkodinga er ugyldig ({{ detected }}). Tillatne kodingar er {{ encodings }}.</target>
             </trans-unit>
             <trans-unit id="112">
                 <source>This value is not a valid MAC address.</source>
-                <target state="needs-review-translation">Denne verdien er ikkje ein gyldig MAC-adresse.</target>
+                <target>Verdien er ikkje ei gyldig MAC-adresse.</target>
             </trans-unit>
             <trans-unit id="113">
                 <source>This URL is missing a top-level domain.</source>
-                <target state="needs-review-translation">Denne URL-en manglar eit toppnivådomene.</target>
+                <target>Denne URL-en manglar eit toppnivådomene.</target>
             </trans-unit>
             <trans-unit id="114">
                 <source>This value is too short. It should contain at least one word.|This value is too short. It should contain at least {{ min }} words.</source>
-                <target state="needs-review-translation">Denne verdien er for kort. Han bør innehalde minst eitt ord.|Denne verdien er for kort. Han bør innehalde minst {{ min }} ord.</target>
+                <target>Verdien er for kort. Den bør innehalde minst eitt ord.|Verdien er for kort. Den bør innehalde minst {{ min }} ord.</target>
             </trans-unit>
             <trans-unit id="115">
                 <source>This value is too long. It should contain one word.|This value is too long. It should contain {{ max }} words or less.</source>
-                <target state="needs-review-translation">Denne verdien er for lang. Han bør innehalde berre eitt ord.|Denne verdien er for lang. Han bør innehalde {{ max }} ord eller færre.</target>
+                <target>Verdien er for lang. Den bør innehalde berre eitt ord.|Verdien er for lang. Den bør innehalde {{ max }} ord eller færre.</target>
             </trans-unit>
             <trans-unit id="116">
                 <source>This value does not represent a valid week in the ISO 8601 format.</source>
-                <target state="needs-review-translation">Denne verdien representerer ikkje ein gyldig veke i ISO 8601-formatet.</target>
+                <target>Verdien representerer ikkje ei gyldig veke i ISO 8601-formatet.</target>
             </trans-unit>
             <trans-unit id="117">
                 <source>This value is not a valid week.</source>
-                <target state="needs-review-translation">Denne verdien er ikkje ei gyldig veke.</target>
+                <target>Verdien er ikkje ei gyldig veke.</target>
             </trans-unit>
             <trans-unit id="118">
                 <source>This value should not be before week "{{ min }}".</source>
-                <target state="needs-review-translation">Denne verdien bør ikkje vere før veke "{{ min }}".</target>
+                <target>Verdien bør ikkje vere før veke "{{ min }}".</target>
             </trans-unit>
             <trans-unit id="119">
                 <source>This value should not be after week "{{ max }}".</source>
-                <target state="needs-review-translation">Denne verdien bør ikkje vere etter veke "{{ max }}".</target>
+                <target>Verdien bør ikkje vere etter veke "{{ max }}".</target>
             </trans-unit>
             <trans-unit id="121">
                 <source>This value is not a valid Twig template.</source>
-                <target state="needs-review-translation">Denne verdien er ikkje ein gyldig Twig-mal.</target>
+                <target>Verdien er ikkje ein gyldig Twig-mal.</target>
             </trans-unit>
             <trans-unit id="122">
                 <source>This file is not a valid video.</source>
-                <target state="needs-review-translation">Denne fila er ikkje ein gyldig video.</target>
+                <target>Denne fila er ikkje ein gyldig video.</target>
             </trans-unit>
             <trans-unit id="123">
                 <source>The size of the video could not be detected.</source>
-                <target state="needs-review-translation">Storleiken på videoen kunne ikkje oppdagast.</target>
+                <target>Storleiken på videoen kunne ikkje oppdagast.</target>
             </trans-unit>
             <trans-unit id="124">
                 <source>The video width is too big ({{ width }}px). Allowed maximum width is {{ max_width }}px.</source>
-                <target state="needs-review-translation">Videobreidda er for stor ({{ width }}px). Tillaten maksimal breidde er {{ max_width }}px.</target>
+                <target>Videobreidda er for stor ({{ width }}px). Tillaten maksimal breidde er {{ max_width }}px.</target>
             </trans-unit>
             <trans-unit id="125">
                 <source>The video width is too small ({{ width }}px). Minimum width expected is {{ min_width }}px.</source>
-                <target state="needs-review-translation">Videobreidda er for lita ({{ width }}px). Forventa minimumsbreidde er {{ min_width }}px.</target>
+                <target>Videobreidda er for lita ({{ width }}px). Forventa minimumsbreidde er {{ min_width }}px.</target>
             </trans-unit>
             <trans-unit id="126">
                 <source>The video height is too big ({{ height }}px). Allowed maximum height is {{ max_height }}px.</source>
-                <target state="needs-review-translation">Videoen si høgd er for stor ({{ height }}px). Tillaten maksimal høgd er {{ max_height }}px.</target>
+                <target>Videohøgda er for stor ({{ height }}px). Tillaten maksimal høgd er {{ max_height }}px.</target>
             </trans-unit>
             <trans-unit id="127">
                 <source>The video height is too small ({{ height }}px). Minimum height expected is {{ min_height }}px.</source>
-                <target state="needs-review-translation">Videohøgda er for lita ({{ height }}px). Forventa minstehøgd er {{ min_height }}px.</target>
+                <target>Videohøgda er for lita ({{ height }}px). Forventa minimumshøgd er {{ min_height }}px.</target>
             </trans-unit>
             <trans-unit id="128">
                 <source>The video has too few pixels ({{ pixels }} pixels). Minimum amount expected is {{ min_pixels }} pixels.</source>
-                <target state="needs-review-translation">Videoen har for få pikslar ({{ pixels }}). Forventa minimum er {{ min_pixels }}.</target>
+                <target>Videoen har for få pikslar ({{ pixels }} pikslar). Forventa minimum er {{ min_pixels }} pikslar.</target>
             </trans-unit>
             <trans-unit id="129">
                 <source>The video has too many pixels ({{ pixels }} pixels). Maximum amount expected is {{ max_pixels }} pixels.</source>
-                <target state="needs-review-translation">Videoen har for mange pikslar ({{ pixels }}). Forventa maksimalt tal er {{ max_pixels }}.</target>
+                <target>Videoen har for mange pikslar ({{ pixels }} pikslar). Forventa maksimalt tal er {{ max_pixels }} pikslar.</target>
             </trans-unit>
             <trans-unit id="130">
                 <source>The video ratio is too big ({{ ratio }}). Allowed maximum ratio is {{ max_ratio }}.</source>
-                <target state="needs-review-translation">Videoforholdet er for stort ({{ ratio }}). Tillaten maksimal forhold er {{ max_ratio }}.</target>
+                <target>Videoforholdet er for stort ({{ ratio }}). Tillate maksimalt forhold er {{ max_ratio }}.</target>
             </trans-unit>
             <trans-unit id="131">
                 <source>The video ratio is too small ({{ ratio }}). Minimum ratio expected is {{ min_ratio }}.</source>
-                <target state="needs-review-translation">Videoforholdet er for lite ({{ ratio }}). Forventa minimumsforhold er {{ min_ratio }}.</target>
+                <target>Videoforholdet er for lite ({{ ratio }}). Forventa minimumsforhold er {{ min_ratio }}.</target>
             </trans-unit>
             <trans-unit id="132">
                 <source>The video is square ({{ width }}x{{ height }}px). Square videos are not allowed.</source>
-                <target state="needs-review-translation">Videoen er kvadratisk ({{ width }}x{{ height }}px). Kvadratiske videoar er ikkje tillatne.</target>
+                <target>Videoen er kvadratisk ({{ width }}x{{ height }}px). Kvadratiske videoar er ikkje tillatne.</target>
             </trans-unit>
             <trans-unit id="133">
                 <source>The video is landscape oriented ({{ width }}x{{ height }}px). Landscape oriented videos are not allowed.</source>
-                <target state="needs-review-translation">Videoen er i liggjande format ({{ width }}x{{ height }} px). Liggjande videoar er ikkje tillatne.</target>
+                <target>Videoen er i liggjande format ({{ width }}x{{ height }}px). Liggjande videoar er ikkje tillatne.</target>
             </trans-unit>
             <trans-unit id="134">
                 <source>The video is portrait oriented ({{ width }}x{{ height }}px). Portrait oriented videos are not allowed.</source>
-                <target state="needs-review-translation">Videoen er i portrettformat ({{ width }}x{{ height }}px). Portrettvideoar er ikkje tillatne.</target>
+                <target>Videoen er i portrettformat ({{ width }}x{{ height }}px). Portrettvideoar er ikkje tillatne.</target>
             </trans-unit>
             <trans-unit id="135">
                 <source>The video file is corrupted.</source>
-                <target state="needs-review-translation">Videofila er skadd.</target>
+                <target>Videofila er skadd.</target>
             </trans-unit>
             <trans-unit id="136">
                 <source>The video contains multiple streams. Only one stream is allowed.</source>
-                <target state="needs-review-translation">Videoen inneheld fleire straumar. Berre éin straum er tillaten.</target>
+                <target>Videoen inneheld fleire straumar. Berre éin straum er tillaten.</target>
             </trans-unit>
             <trans-unit id="137">
                 <source>Unsupported video codec "{{ codec }}".</source>
-                <target state="needs-review-translation">Ikkje støtta videokodek «{{ codec }}».</target>
+                <target>Ikkje støtta videokodek "{{ codec }}".</target>
             </trans-unit>
             <trans-unit id="138">
                 <source>Unsupported video container "{{ container }}".</source>
-                <target state="needs-review-translation">Ikkje-støtta videokontainer "{{ container }}".</target>
+                <target>Ikkje støtta videokontainer "{{ container }}".</target>
             </trans-unit>
             <trans-unit id="139">
                 <source>The image file is corrupted.</source>
-                <target state="needs-review-translation">Bildefila er skadd.</target>
+                <target>Biletfila er skadd.</target>
             </trans-unit>
             <trans-unit id="140">
                 <source>The image has too few pixels ({{ pixels }} pixels). Minimum amount expected is {{ min_pixels }} pixels.</source>
-                <target state="needs-review-translation">Biletet har for få pikslar ({{ pixels }}). Forventa minimum er {{ min_pixels }}.</target>
+                <target>Biletet har for få pikslar ({{ pixels }} pikslar). Forventa minimum er {{ min_pixels }} pikslar.</target>
             </trans-unit>
             <trans-unit id="141">
                 <source>The image has too many pixels ({{ pixels }} pixels). Maximum amount expected is {{ max_pixels }} pixels.</source>
-                <target state="needs-review-translation">Biletet har for mange pikslar ({{ pixels }}). Forventa maksimalt tal er {{ max_pixels }}.</target>
+                <target>Biletet har for mange pikslar ({{ pixels }} pikslar). Forventa maksimalt tal er {{ max_pixels }} pikslar.</target>
             </trans-unit>
             <trans-unit id="142">
                 <source>This filename does not match the expected charset.</source>
-                <target state="needs-review-translation">Dette filnamnet samsvarar ikkje med forventa teiknsett.</target>
+                <target>Dette filnamnet samsvarar ikkje med forventa teiknsett.</target>
             </trans-unit>
             <trans-unit id="143">
                 <source>This value is not valid XML.</source>
-                <target state="needs-review-translation">Denne verdien er ikkje gyldig XML.</target>
+                <target>Verdien er ikkje gyldig XML.</target>
             </trans-unit>
             <trans-unit id="144">
                 <source>This value does not conform to the expected XSD schema.</source>
-                <target state="needs-review-translation">Denne verdien samsvarar ikkje med det forventa XSD-skjemaet.</target>
+                <target>Verdien samsvarar ikkje med det forventa XSD-skjemaet.</target>
             </trans-unit>
             <trans-unit id="145">
                 <source>This XML payload is too large ({{ size }} bytes): it exceeds the limit of {{ limit }} bytes.</source>
-                <target state="needs-review-translation">Denne XML-nyttelasta er for stor ({{ size }} byte): ho overskrid grensa på {{ limit }} byte.</target>
+                <target>Denne XML-nyttelasta er for stor ({{ size }} byte): ho overskrid grensa på {{ limit }} byte.</target>
             </trans-unit>
             <trans-unit id="146">
                 <source>This value is not a valid cron expression.</source>
-                <target state="needs-review-translation">Denne verdien er ikkje eit gyldig cron-uttrykk.</target>
+                <target>Verdien er ikkje eit gyldig cron-uttrykk.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #45130
| License       | MIT

Reviews the 50 Norwegian Nynorsk translations flagged `needs-review-translation`: each string was checked against the English source and the established (already-reviewed) entries of the same catalog for terminology, grammar, placeholders and punctuation conventions. 20 were confirmed as-is; 30 were corrected.

Note: I am not a native speaker — happy to adjust any wording that native speakers flag.


<details><summary>Form — reviewed strings</summary>

| Id | English | Translation | Result |
| -- | -- | -- | -- |
| 30 | The CSRF token is invalid. Please try to resubmit the form. | CSRF-teiknet er ugyldig. Prøv å sende inn skjemaet på nytt. | corrected (was: CSRF-teiknet er ugyldig. Ver venleg og prøv å sende inn skjemaet på nytt.) |
| 129 | Please enter a valid UUID. | Gje opp ein gyldig UUID. | confirmed |

</details>

<details><summary>Security/Core — reviewed strings</summary>

| Id | English | Translation | Result |
| -- | -- | -- | -- |
| 20 | Too many failed login attempts, please try again in %minutes% minutes. | For mange mislukka innloggingsforsøk, prøv igjen om %minutes% minutt. | confirmed |

</details>

<details><summary>Validator — reviewed strings</summary>

| Id | English | Translation | Result |
| -- | -- | -- | -- |
| 37 | This value is not a valid IP address. | Verdien er ikkje ei gyldig IP-adresse. | corrected (was: Denne verdien er ikkje ein gyldig IP-adresse.) |
| 51 | No temporary folder was configured in php.ini, or the configured folder does not exist. | Inga mellombels mappe var konfigurert i php.ini, eller den konfigurerte mappa eksisterer ikkje. | corrected (was: Ingen midlertidig mappe var konfigurert i php.ini, eller den konfigurerte mappa eksisterer ikkje.) |
| 59 | This value is not a valid International Bank Account Number (IBAN). | Verdien er ikkje eit gyldig internasjonalt bankkontonummer (IBAN). | corrected (was: Denne verdien er ikkje eit gyldig internasjonalt bankkontonummer (IBAN).) |
| 81 | This value is not a valid Business Identifier Code (BIC). | Verdien er ikkje ein gyldig forretningsidentifikasjonskode (BIC). | corrected (was: Denne verdien er ikkje ein gyldig forretningsidentifikasjonskode (BIC).) |
| 83 | This value is not a valid UUID. | Verdien er ikkje ein gyldig UUID. | corrected (was: Denne verdien er ikkje ein gyldig UUID.) |
| 104 | The filename is too long. It should have {{ filename_max_length }} character or less.\|The filename is too long. It should have {{ filename_max_length }} characters or less. | Filnamnet er for langt. Det bør ha {{ filename_max_length }} teikn eller færre.\|Filnamnet er for langt. Det bør ha {{ filename_max_length }} teikn eller færre. | confirmed |
| 105 | The password strength is too low. Please use a stronger password. | Passordstyrken er for låg. Bruk eit sterkare passord. | corrected (was: Passordstyrken er for låg. Vennligst bruk eit sterkare passord.) |
| 106 | This value contains characters that are not allowed by the current restriction-level. | Verdien inneheld teikn som ikkje er tillatne av det gjeldande restriksjonsnivået. | corrected (was: Denne verdien inneheld teikn som ikkje er tillatne av det gjeldande restriksjonsnivået.) |
| 107 | Using invisible characters is not allowed. | Det er ikkje tillate å bruke usynlege teikn. | confirmed |
| 108 | Mixing numbers from different scripts is not allowed. | Det er ikkje tillate å blande tal frå forskjellige skript. | confirmed |
| 109 | Using hidden overlay characters is not allowed. | Det er ikkje tillate å bruke skjulte overleggsteikn. | confirmed |
| 110 | The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}. | Filutvidinga er ugyldig ({{ extension }}). Tillatne utvidingar er {{ extensions }}. | confirmed |
| 111 | The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}. | Den oppdaga teiknkodinga er ugyldig ({{ detected }}). Tillatne kodingar er {{ encodings }}. | confirmed |
| 112 | This value is not a valid MAC address. | Verdien er ikkje ei gyldig MAC-adresse. | corrected (was: Denne verdien er ikkje ein gyldig MAC-adresse.) |
| 113 | This URL is missing a top-level domain. | Denne URL-en manglar eit toppnivådomene. | confirmed |
| 114 | This value is too short. It should contain at least one word.\|This value is too short. It should contain at least {{ min }} words. | Verdien er for kort. Den bør innehalde minst eitt ord.\|Verdien er for kort. Den bør innehalde minst {{ min }} ord. | corrected (was: Denne verdien er for kort. Han bør innehalde minst eitt ord.\|Denne verdien er for kort. Han bør innehalde minst {{ min }} ord.) |
| 115 | This value is too long. It should contain one word.\|This value is too long. It should contain {{ max }} words or less. | Verdien er for lang. Den bør innehalde berre eitt ord.\|Verdien er for lang. Den bør innehalde {{ max }} ord eller færre. | corrected (was: Denne verdien er for lang. Han bør innehalde berre eitt ord.\|Denne verdien er for lang. Han bør innehalde {{ max }} ord eller færre.) |
| 116 | This value does not represent a valid week in the ISO 8601 format. | Verdien representerer ikkje ei gyldig veke i ISO 8601-formatet. | corrected (was: Denne verdien representerer ikkje ein gyldig veke i ISO 8601-formatet.) |
| 117 | This value is not a valid week. | Verdien er ikkje ei gyldig veke. | corrected (was: Denne verdien er ikkje ei gyldig veke.) |
| 118 | This value should not be before week "{{ min }}". | Verdien bør ikkje vere før veke "{{ min }}". | corrected (was: Denne verdien bør ikkje vere før veke "{{ min }}".) |
| 119 | This value should not be after week "{{ max }}". | Verdien bør ikkje vere etter veke "{{ max }}". | corrected (was: Denne verdien bør ikkje vere etter veke "{{ max }}".) |
| 121 | This value is not a valid Twig template. | Verdien er ikkje ein gyldig Twig-mal. | corrected (was: Denne verdien er ikkje ein gyldig Twig-mal.) |
| 122 | This file is not a valid video. | Denne fila er ikkje ein gyldig video. | confirmed |
| 123 | The size of the video could not be detected. | Storleiken på videoen kunne ikkje oppdagast. | confirmed |
| 124 | The video width is too big ({{ width }}px). Allowed maximum width is {{ max_width }}px. | Videobreidda er for stor ({{ width }}px). Tillaten maksimal breidde er {{ max_width }}px. | confirmed |
| 125 | The video width is too small ({{ width }}px). Minimum width expected is {{ min_width }}px. | Videobreidda er for lita ({{ width }}px). Forventa minimumsbreidde er {{ min_width }}px. | confirmed |
| 126 | The video height is too big ({{ height }}px). Allowed maximum height is {{ max_height }}px. | Videohøgda er for stor ({{ height }}px). Tillaten maksimal høgd er {{ max_height }}px. | corrected (was: Videoen si høgd er for stor ({{ height }}px). Tillaten maksimal høgd er {{ max_height }}px.) |
| 127 | The video height is too small ({{ height }}px). Minimum height expected is {{ min_height }}px. | Videohøgda er for lita ({{ height }}px). Forventa minimumshøgd er {{ min_height }}px. | corrected (was: Videohøgda er for lita ({{ height }}px). Forventa minstehøgd er {{ min_height }}px.) |
| 128 | The video has too few pixels ({{ pixels }} pixels). Minimum amount expected is {{ min_pixels }} pixels. | Videoen har for få pikslar ({{ pixels }} pikslar). Forventa minimum er {{ min_pixels }} pikslar. | corrected (was: Videoen har for få pikslar ({{ pixels }}). Forventa minimum er {{ min_pixels }}.) |
| 129 | The video has too many pixels ({{ pixels }} pixels). Maximum amount expected is {{ max_pixels }} pixels. | Videoen har for mange pikslar ({{ pixels }} pikslar). Forventa maksimalt tal er {{ max_pixels }} pikslar. | corrected (was: Videoen har for mange pikslar ({{ pixels }}). Forventa maksimalt tal er {{ max_pixels }}.) |
| 130 | The video ratio is too big ({{ ratio }}). Allowed maximum ratio is {{ max_ratio }}. | Videoforholdet er for stort ({{ ratio }}). Tillate maksimalt forhold er {{ max_ratio }}. | corrected (was: Videoforholdet er for stort ({{ ratio }}). Tillaten maksimal forhold er {{ max_ratio }}.) |
| 131 | The video ratio is too small ({{ ratio }}). Minimum ratio expected is {{ min_ratio }}. | Videoforholdet er for lite ({{ ratio }}). Forventa minimumsforhold er {{ min_ratio }}. | confirmed |
| 132 | The video is square ({{ width }}x{{ height }}px). Square videos are not allowed. | Videoen er kvadratisk ({{ width }}x{{ height }}px). Kvadratiske videoar er ikkje tillatne. | confirmed |
| 133 | The video is landscape oriented ({{ width }}x{{ height }}px). Landscape oriented videos are not allowed. | Videoen er i liggjande format ({{ width }}x{{ height }}px). Liggjande videoar er ikkje tillatne. | corrected (was: Videoen er i liggjande format ({{ width }}x{{ height }} px). Liggjande videoar er ikkje tillatne.) |
| 134 | The video is portrait oriented ({{ width }}x{{ height }}px). Portrait oriented videos are not allowed. | Videoen er i portrettformat ({{ width }}x{{ height }}px). Portrettvideoar er ikkje tillatne. | confirmed |
| 135 | The video file is corrupted. | Videofila er skadd. | confirmed |
| 136 | The video contains multiple streams. Only one stream is allowed. | Videoen inneheld fleire straumar. Berre éin straum er tillaten. | confirmed |
| 137 | Unsupported video codec "{{ codec }}". | Ikkje støtta videokodek "{{ codec }}". | corrected (was: Ikkje støtta videokodek «{{ codec }}».) |
| 138 | Unsupported video container "{{ container }}". | Ikkje støtta videokontainer "{{ container }}". | corrected (was: Ikkje-støtta videokontainer "{{ container }}".) |
| 139 | The image file is corrupted. | Biletfila er skadd. | corrected (was: Bildefila er skadd.) |
| 140 | The image has too few pixels ({{ pixels }} pixels). Minimum amount expected is {{ min_pixels }} pixels. | Biletet har for få pikslar ({{ pixels }} pikslar). Forventa minimum er {{ min_pixels }} pikslar. | corrected (was: Biletet har for få pikslar ({{ pixels }}). Forventa minimum er {{ min_pixels }}.) |
| 141 | The image has too many pixels ({{ pixels }} pixels). Maximum amount expected is {{ max_pixels }} pixels. | Biletet har for mange pikslar ({{ pixels }} pikslar). Forventa maksimalt tal er {{ max_pixels }} pikslar. | corrected (was: Biletet har for mange pikslar ({{ pixels }}). Forventa maksimalt tal er {{ max_pixels }}.) |
| 142 | This filename does not match the expected charset. | Dette filnamnet samsvarar ikkje med forventa teiknsett. | confirmed |
| 143 | This value is not valid XML. | Verdien er ikkje gyldig XML. | corrected (was: Denne verdien er ikkje gyldig XML.) |
| 144 | This value does not conform to the expected XSD schema. | Verdien samsvarar ikkje med det forventa XSD-skjemaet. | corrected (was: Denne verdien samsvarar ikkje med det forventa XSD-skjemaet.) |
| 145 | This XML payload is too large ({{ size }} bytes): it exceeds the limit of {{ limit }} bytes. | Denne XML-nyttelasta er for stor ({{ size }} byte): ho overskrid grensa på {{ limit }} byte. | confirmed |
| 146 | This value is not a valid cron expression. | Verdien er ikkje eit gyldig cron-uttrykk. | corrected (was: Denne verdien er ikkje eit gyldig cron-uttrykk.) |

</details>

