### PR TITLE
[Form][Validator] Review Norwegian (nb, no) translations

### DIFF
--- a/src/Symfony/Component/Form/Resources/translations/validators.nb.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.nb.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="129">
                 <source>Please enter a valid UUID.</source>
-                <target state="needs-review-translation">Vennligst skriv inn en gyldig UUID.</target>
+                <target>Vennligst skriv inn en gyldig UUID.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Form/Resources/translations/validators.no.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.no.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="129">
                 <source>Please enter a valid UUID.</source>
-                <target state="needs-review-translation">Vennligst skriv inn en gyldig UUID.</target>
+                <target>Vennligst skriv inn en gyldig UUID.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.nb.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.nb.xlf
@@ -556,19 +556,19 @@
             </trans-unit>
             <trans-unit id="143">
                 <source>This value is not valid XML.</source>
-                <target state="needs-review-translation">Denne verdien er ikke gyldig XML.</target>
+                <target>Denne verdien er ikke gyldig XML.</target>
             </trans-unit>
             <trans-unit id="144">
                 <source>This value does not conform to the expected XSD schema.</source>
-                <target state="needs-review-translation">Denne verdien samsvarer ikke med det forventede XSD-skjemaet.</target>
+                <target>Denne verdien samsvarer ikke med det forventede XSD-skjemaet.</target>
             </trans-unit>
             <trans-unit id="145">
                 <source>This XML payload is too large ({{ size }} bytes): it exceeds the limit of {{ limit }} bytes.</source>
-                <target state="needs-review-translation">Denne XML-nyttelasten er for stor ({{ size }} byte): den overskrider grensen på {{ limit }} byte.</target>
+                <target>Denne XML-nyttelasten er for stor ({{ size }} byte): den overskrider grensen på {{ limit }} byte.</target>
             </trans-unit>
             <trans-unit id="146">
                 <source>This value is not a valid cron expression.</source>
-                <target state="needs-review-translation">Denne verdien er ikke et gyldig cron-uttrykk.</target>
+                <target>Denne verdien er ikke et gyldig cron-uttrykk.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.no.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.no.xlf
@@ -556,19 +556,19 @@
             </trans-unit>
             <trans-unit id="143">
                 <source>This value is not valid XML.</source>
-                <target state="needs-review-translation">Denne verdien er ikke gyldig XML.</target>
+                <target>Denne verdien er ikke gyldig XML.</target>
             </trans-unit>
             <trans-unit id="144">
                 <source>This value does not conform to the expected XSD schema.</source>
-                <target state="needs-review-translation">Denne verdien samsvarer ikke med det forventede XSD-skjemaet.</target>
+                <target>Denne verdien samsvarer ikke med det forventede XSD-skjemaet.</target>
             </trans-unit>
             <trans-unit id="145">
                 <source>This XML payload is too large ({{ size }} bytes): it exceeds the limit of {{ limit }} bytes.</source>
-                <target state="needs-review-translation">Denne XML-nyttelasten er for stor ({{ size }} byte): den overskrider grensen på {{ limit }} byte.</target>
+                <target>Denne XML-nyttelasten er for stor ({{ size }} byte): den overskrider grensen på {{ limit }} byte.</target>
             </trans-unit>
             <trans-unit id="146">
                 <source>This value is not a valid cron expression.</source>
-                <target state="needs-review-translation">Denne verdien er ikke et gyldig cron-uttrykk.</target>
+                <target>Denne verdien er ikke et gyldig cron-uttrykk.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64507, Fix #64506
| License       | MIT

Reviews the 5 Norwegian Bokmål translations flagged `needs-review-translation`: each string was checked against the English source and the established (already-reviewed) entries of the same catalog for terminology, grammar, placeholders and punctuation conventions. 5 were confirmed as-is; none required changes. The `no` catalogs are kept byte-identical to `nb` as required by `TranslationFilesTest::testNorwegianAlias`.

Note: I am not a native speaker — happy to adjust any wording that native speakers flag.


<details><summary>Form — reviewed strings</summary>

| Id | English | Translation | Result |
| -- | -- | -- | -- |
| 129 | Please enter a valid UUID. | Vennligst skriv inn en gyldig UUID. | confirmed |

</details>

<details><summary>Validator — reviewed strings</summary>

| Id | English | Translation | Result |
| -- | -- | -- | -- |
| 143 | This value is not valid XML. | Denne verdien er ikke gyldig XML. | confirmed |
| 144 | This value does not conform to the expected XSD schema. | Denne verdien samsvarer ikke med det forventede XSD-skjemaet. | confirmed |
| 145 | This XML payload is too large ({{ size }} bytes): it exceeds the limit of {{ limit }} bytes. | Denne XML-nyttelasten er for stor ({{ size }} byte): den overskrider grensen på {{ limit }} byte. | confirmed |
| 146 | This value is not a valid cron expression. | Denne verdien er ikke et gyldig cron-uttrykk. | confirmed |

</details>

