### PR TITLE
[Form][Security][Validator] Revert " Finalize Urdu (ur) translations"

### DIFF
--- a/src/Symfony/Component/Form/Resources/translations/validators.ur.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.ur.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="129">
                 <source>Please enter a valid UUID.</source>
-                <target>براۓ کرم ایک درست UUID درج کریں</target>
+                <target state="needs-review-translation">براۓ کرم ایک درست UUID درج کریں</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.ur.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.ur.xlf
@@ -76,7 +76,7 @@
             </trans-unit>
             <trans-unit id="20">
                 <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
-                <target>بہت زیادہ ناکام لاگ ان کوششیں، براہ کرم %minutes% منٹ میں دوبارہ کوشش کریں۔</target>
+                <target state="needs-review-translation">بہت زیادہ ناکام لاگ ان کوششیں، براہ کرم %minutes% منٹ میں دوبارہ کوشش کریں۔</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.ur.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.ur.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="37" resname="This is not a valid IP address.">
                 <source>This value is not a valid IP address.</source>
-                <target>یہ ویلیو درست IP پتہ نہیں ہے</target>
+                <target state="needs-review-translation">یہ قیمت کوئی درست IP پتہ نہیں ہے۔</target>
             </trans-unit>
             <trans-unit id="38">
                 <source>This value is not a valid language.</source>
@@ -192,7 +192,7 @@
             </trans-unit>
             <trans-unit id="51" resname="No temporary folder was configured in php.ini.">
                 <source>No temporary folder was configured in php.ini, or the configured folder does not exist.</source>
-                <target>php.ini میں کوئی عارضی فولڈر ترتیب نہیں دیا گیا تھا، یا ترتیب دیا گیا فولڈر موجود نہیں ہے۔</target>
+                <target state="needs-review-translation">php.ini میں کوئی عارضی فولڈر ترتیب نہیں دیا گیا تھا، یا ترتیب دیا گیا فولڈر موجود نہیں ہے۔</target>
             </trans-unit>
             <trans-unit id="52">
                 <source>Cannot write temporary file to disk.</source>
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59" resname="This is not a valid International Bank Account Number (IBAN).">
                 <source>This value is not a valid International Bank Account Number (IBAN).</source>
-                <target>یہ ویلیو درست بین الاقوامی بینک اکاؤنٹ نمبر (IBAN) نہیں ہے</target>
+                <target state="needs-review-translation">یہ قیمت کوئی درست بین الاقوامی بینک اکاؤنٹ نمبر (IBAN) نہیں ہے۔</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>
@@ -312,7 +312,7 @@
             </trans-unit>
             <trans-unit id="81" resname="This is not a valid Business Identifier Code (BIC).">
                 <source>This value is not a valid Business Identifier Code (BIC).</source>
-                <target>یہ ویلیو درست کاروباری شناختی کوڈ (BIC) نہیں ہے</target>
+                <target state="needs-review-translation">یہ قیمت کوئی درست بزنس شناختی کوڈ (BIC) نہیں ہے۔</target>
             </trans-unit>
             <trans-unit id="82">
                 <source>Error</source>
@@ -320,7 +320,7 @@
             </trans-unit>
             <trans-unit id="83" resname="This is not a valid UUID.">
                 <source>This value is not a valid UUID.</source>
-                <target>یہ ویلیو درست UUID نہیں ہے</target>
+                <target state="needs-review-translation">یہ قیمت کوئی درست UUID نہیں ہے۔</target>
             </trans-unit>
             <trans-unit id="84">
                 <source>This value should be a multiple of {{ compared_value }}.</source>
@@ -404,171 +404,171 @@
             </trans-unit>
             <trans-unit id="104">
                 <source>The filename is too long. It should have {{ filename_max_length }} character or less.|The filename is too long. It should have {{ filename_max_length }} characters or less.</source>
-                <target>فائل کا نام بہت لمبا ہے۔ اس میں {{ filename_max_length }} حرف یا اس سے کم ہونے چاہئیں۔|فائل کا نام بہت لمبا ہے۔ اس میں {{ filename_max_length }} حروف یا اس سے کم ہونے چاہئیں۔</target>
+                <target state="needs-review-translation">فائل کا نام بہت لمبا ہے۔ اس میں {{ filename_max_length }} حرف یا اس سے کم ہونے چاہئیں۔|فائل کا نام بہت لمبا ہے۔ اس میں {{ filename_max_length }} حروف یا اس سے کم ہونے چاہئیں۔</target>
             </trans-unit>
             <trans-unit id="105">
                 <source>The password strength is too low. Please use a stronger password.</source>
-                <target>پاس ورڈ کی طاقت بہت کم ہے۔ براہ کرم مضبوط پاس ورڈ استعمال کریں۔</target>
+                <target state="needs-review-translation">پاس ورڈ کی طاقت بہت کم ہے۔ براہ کرم مضبوط پاس ورڈ استعمال کریں۔</target>
             </trans-unit>
             <trans-unit id="106">
                 <source>This value contains characters that are not allowed by the current restriction-level.</source>
-                <target>اس ویلیو میں ایسے حروف موجود ہیں جو موجودہ پابندی کی سطح کی طرف سے اجازت نہیں ہیں۔</target>
+                <target state="needs-review-translation">اس قدر میں ایسے حروف موجود ہیں جو موجودہ پابندی کی سطح کی طرف سے اجازت نہیں ہیں۔</target>
             </trans-unit>
             <trans-unit id="107">
                 <source>Using invisible characters is not allowed.</source>
-                <target>نادیدہ حروف استعمال کرنے کی اجازت نہیں ہے۔</target>
+                <target state="needs-review-translation">نادیدہ حروف استعمال کرنے کی اجازت نہیں ہے۔</target>
             </trans-unit>
             <trans-unit id="108">
                 <source>Mixing numbers from different scripts is not allowed.</source>
-                <target>مختلف اسکرپٹس سے نمبروں کو ملا کر استعمال کرنے کی اجازت نہیں ہے۔</target>
+                <target state="needs-review-translation">مختلف اسکرپٹس سے نمبروں کو ملا کر استعمال کرنے کی اجازت نہیں ہے۔</target>
             </trans-unit>
             <trans-unit id="109">
                 <source>Using hidden overlay characters is not allowed.</source>
-                <target>چھپے ہوئے اوورلے کریکٹرز کا استعمال کرنے کی اجازت نہیں ہے۔</target>
+                <target state="needs-review-translation">چھپے ہوئے اوورلے کریکٹرز کا استعمال کرنے کی اجازت نہیں ہے۔</target>
             </trans-unit>
             <trans-unit id="110">
                 <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
-                <target>فائل کی توسیع نامناسب ہے ({{ extension }})۔ اجازت شدہ توسیعات {{ extensions }} ہیں۔</target>
+                <target state="needs-review-translation">فائل کی توسیع نامناسب ہے ({{ extension }})۔ اجازت شدہ توسیعات {{ extensions }} ہیں۔</target>
             </trans-unit>
             <trans-unit id="111">
                 <source>The detected character encoding is invalid ({{ detected }}). Allowed encodings are {{ encodings }}.</source>
-                <target>پتہ چلنے والی کریکٹر انکوڈنگ نامناسب ہے ({{ detected }})۔ اجازت شدہ انکوڈنگز {{ encodings }} ہیں۔</target>
+                <target state="needs-review-translation">پتہ چلنے والی کریکٹر انکوڈنگ نامناسب ہے ({{ detected }})۔ اجازت شدہ انکوڈنگز {{ encodings }} ہیں۔</target>
             </trans-unit>
             <trans-unit id="112">
                 <source>This value is not a valid MAC address.</source>
-                <target>یہ ویلیو درست MAC پتہ نہیں ہے</target>
+                <target state="needs-review-translation">یہ قیمت کوئی درست MAC پتہ نہیں ہے۔</target>
             </trans-unit>
             <trans-unit id="113">
                 <source>This URL is missing a top-level domain.</source>
-                <target>اس URL میں ٹاپ لیول ڈومین موجود نہیں ہے۔</target>
+                <target state="needs-review-translation">اس URL میں ٹاپ لیول ڈومین موجود نہیں ہے۔</target>
             </trans-unit>
             <trans-unit id="114">
                 <source>This value is too short. It should contain at least one word.|This value is too short. It should contain at least {{ min }} words.</source>
-                <target>یہ ویلیو بہت مختصر ہے۔ اس میں کم از کم ایک لفظ ہونا چاہیے۔|یہ ویلیو بہت مختصر ہے۔ اس میں کم از کم {{ min }} الفاظ ہونے چاہئیں۔</target>
+                <target state="needs-review-translation">یہ قدر بہت مختصر ہے۔ اس میں کم از کم ایک لفظ ہونا چاہیے۔|یہ قدر بہت مختصر ہے۔ اس میں کم از کم {{ min }} الفاظ ہونے چاہئیں۔</target>
             </trans-unit>
             <trans-unit id="115">
                 <source>This value is too long. It should contain one word.|This value is too long. It should contain {{ max }} words or less.</source>
-                <target>یہ ویلیو بہت طویل ہے۔ اس میں صرف ایک لفظ ہونا چاہیے۔|یہ ویلیو بہت طویل ہے۔ اس میں {{ max }} الفاظ یا اس سے کم ہونے چاہئیں۔</target>
+                <target state="needs-review-translation">یہ قدر بہت طویل ہے۔ اس میں صرف ایک لفظ ہونا چاہیے۔|یہ قدر بہت طویل ہے۔ اس میں {{ max }} الفاظ یا اس سے کم ہونے چاہئیں۔</target>
             </trans-unit>
             <trans-unit id="116">
                 <source>This value does not represent a valid week in the ISO 8601 format.</source>
-                <target>یہ ویلیو آئی ایس او 8601 فارمیٹ میں ایک درست ہفتے کی نمائندگی نہیں کرتی ہے۔</target>
+                <target state="needs-review-translation">یہ قدر آئی ایس او 8601 فارمیٹ میں ایک درست ہفتے کی نمائندگی نہیں کرتی ہے۔</target>
             </trans-unit>
             <trans-unit id="117">
                 <source>This value is not a valid week.</source>
-                <target>یہ ویلیو درست ہفتہ نہیں ہے</target>
+                <target state="needs-review-translation">یہ قدر ایک درست ہفتہ نہیں ہے۔</target>
             </trans-unit>
             <trans-unit id="118">
                 <source>This value should not be before week "{{ min }}".</source>
-                <target>یہ ویلیو ہفتہ "{{ min }}" سے پہلے نہیں ہونا چاہیے۔</target>
+                <target state="needs-review-translation">یہ قدر ہفتہ "{{ min }}" سے پہلے نہیں ہونا چاہیے۔</target>
             </trans-unit>
             <trans-unit id="119">
                 <source>This value should not be after week "{{ max }}".</source>
-                <target>یہ ویلیو ہفتہ "{{ max }}" کے بعد نہیں ہونا چاہیے۔</target>
+                <target state="needs-review-translation">یہ قدر ہفتہ "{{ max }}" کے بعد نہیں ہونا چاہیے۔</target>
             </trans-unit>
             <trans-unit id="121">
                 <source>This value is not a valid Twig template.</source>
-                <target>یہ ویلیو درست Twig سانچہ نہیں ہے</target>
+                <target state="needs-review-translation">یہ قدر ایک درست Twig سانچہ نہیں ہے۔</target>
             </trans-unit>
             <trans-unit id="122">
                 <source>This file is not a valid video.</source>
-                <target>یہ فائل درست ویڈیو نہیں ہے</target>
+                <target state="needs-review-translation">یہ فائل ایک درست ویڈیو نہیں ہے۔</target>
             </trans-unit>
             <trans-unit id="123">
                 <source>The size of the video could not be detected.</source>
-                <target>ویڈیو کا سائز معلوم نہیں کیا جا سکا۔</target>
+                <target state="needs-review-translation">ویڈیو کا سائز معلوم نہیں کیا جا سکا۔</target>
             </trans-unit>
             <trans-unit id="124">
                 <source>The video width is too big ({{ width }}px). Allowed maximum width is {{ max_width }}px.</source>
-                <target>ویڈیو کی چوڑائی بہت زیادہ ہے ({{ width }}px)۔ اجازت شدہ زیادہ سے زیادہ چوڑائی {{ max_width }}px ہے۔</target>
+                <target state="needs-review-translation">ویڈیو کی چوڑائی بہت زیادہ ہے ({{ width }}px)۔ اجازت شدہ زیادہ سے زیادہ چوڑائی {{ max_width }}px ہے۔</target>
             </trans-unit>
             <trans-unit id="125">
                 <source>The video width is too small ({{ width }}px). Minimum width expected is {{ min_width }}px.</source>
-                <target>ویڈیو کی چوڑائی بہت کم ہے ({{ width }}px)۔ متوقع کم از کم چوڑائی {{ min_width }} پکسل ہے۔</target>
+                <target state="needs-review-translation">ویڈیو کی چوڑائی بہت کم ہے ({{ width }}px)۔ متوقع کم از کم چوڑائی {{ min_width }} پکسل ہے۔</target>
             </trans-unit>
             <trans-unit id="126">
                 <source>The video height is too big ({{ height }}px). Allowed maximum height is {{ max_height }}px.</source>
-                <target>ویڈیو کی اونچائی بہت زیادہ ہے ({{ height }}px)۔ مجاز زیادہ سے زیادہ اونچائی {{ max_height }}px ہے۔</target>
+                <target state="needs-review-translation">ویڈیو کی اونچائی بہت زیادہ ہے ({{ height }}px)۔ مجاز زیادہ سے زیادہ اونچائی {{ max_height }}px ہے۔</target>
             </trans-unit>
             <trans-unit id="127">
                 <source>The video height is too small ({{ height }}px). Minimum height expected is {{ min_height }}px.</source>
-                <target>ویڈیو کی اونچائی بہت کم ہے ({{ height }}px)۔ متوقع کم از کم اونچائی {{ min_height }}px ہے۔</target>
+                <target state="needs-review-translation">ویڈیو کی اونچائی بہت کم ہے ({{ height }}px)۔ متوقع کم از کم اونچائی {{ min_height }}px ہے۔</target>
             </trans-unit>
             <trans-unit id="128">
                 <source>The video has too few pixels ({{ pixels }} pixels). Minimum amount expected is {{ min_pixels }} pixels.</source>
-                <target>ویڈیو میں پکسل بہت کم ہیں ({{ pixels }}). متوقع کم از کم مقدار {{ min_pixels }} ہے۔</target>
+                <target state="needs-review-translation">ویڈیو میں پکسل بہت کم ہیں ({{ pixels }}). متوقع کم از کم مقدار {{ min_pixels }} ہے۔</target>
             </trans-unit>
             <trans-unit id="129">
                 <source>The video has too many pixels ({{ pixels }} pixels). Maximum amount expected is {{ max_pixels }} pixels.</source>
-                <target>ویڈیو میں پکسلز بہت زیادہ ہیں ({{ pixels }}). متوقع زیادہ سے زیادہ مقدار {{ max_pixels }} ہے۔</target>
+                <target state="needs-review-translation">ویڈیو میں پکسلز بہت زیادہ ہیں ({{ pixels }}). متوقع زیادہ سے زیادہ مقدار {{ max_pixels }} ہے۔</target>
             </trans-unit>
             <trans-unit id="130">
                 <source>The video ratio is too big ({{ ratio }}). Allowed maximum ratio is {{ max_ratio }}.</source>
-                <target>ویڈیو کا تناسب بہت بڑا ہے ({{ ratio }}). اجازت شدہ زیادہ سے زیادہ تناسب {{ max_ratio }} ہے۔</target>
+                <target state="needs-review-translation">ویڈیو کا تناسب بہت بڑا ہے ({{ ratio }}). اجازت شدہ زیادہ سے زیادہ تناسب {{ max_ratio }} ہے۔</target>
             </trans-unit>
             <trans-unit id="131">
                 <source>The video ratio is too small ({{ ratio }}). Minimum ratio expected is {{ min_ratio }}.</source>
-                <target>ویڈیو کا تناسب بہت چھوٹا ہے ({{ ratio }}). متوقع کم از کم تناسب {{ min_ratio }} ہے۔</target>
+                <target state="needs-review-translation">ویڈیو کا تناسب بہت چھوٹا ہے ({{ ratio }}). متوقع کم از کم تناسب {{ min_ratio }} ہے۔</target>
             </trans-unit>
             <trans-unit id="132">
                 <source>The video is square ({{ width }}x{{ height }}px). Square videos are not allowed.</source>
-                <target>ویڈیو مربع ہے ({{ width }}x{{ height }}px). مربع ویڈیوز کی اجازت نہیں ہے۔</target>
+                <target state="needs-review-translation">ویڈیو مربع ہے ({{ width }}x{{ height }}px). مربع ویڈیوز کی اجازت نہیں ہے۔</target>
             </trans-unit>
             <trans-unit id="133">
                 <source>The video is landscape oriented ({{ width }}x{{ height }}px). Landscape oriented videos are not allowed.</source>
-                <target>ویڈیو افقی سمت میں ہے ({{ width }}x{{ height }} پکسل). افقی ویڈیوز کی اجازت نہیں ہے۔</target>
+                <target state="needs-review-translation">ویڈیو افقی سمت میں ہے ({{ width }}x{{ height }} پکسل). افقی ویڈیوز کی اجازت نہیں ہے۔</target>
             </trans-unit>
             <trans-unit id="134">
                 <source>The video is portrait oriented ({{ width }}x{{ height }}px). Portrait oriented videos are not allowed.</source>
-                <target>ویڈیو عمودی رخ پر ہے ({{ width }}x{{ height }}px). عمودی رخ والی ویڈیوز کی اجازت نہیں ہے۔</target>
+                <target state="needs-review-translation">ویڈیو عمودی رخ پر ہے ({{ width }}x{{ height }}px). عمودی رخ والی ویڈیوز کی اجازت نہیں ہے۔</target>
             </trans-unit>
             <trans-unit id="135">
                 <source>The video file is corrupted.</source>
-                <target>ویڈیو فائل خراب ہے۔</target>
+                <target state="needs-review-translation">ویڈیو فائل خراب ہے۔</target>
             </trans-unit>
             <trans-unit id="136">
                 <source>The video contains multiple streams. Only one stream is allowed.</source>
-                <target>ویڈیو میں متعدد اسٹریمز ہیں۔ صرف ایک اسٹریم کی اجازت ہے۔</target>
+                <target state="needs-review-translation">ویڈیو میں متعدد اسٹریمز ہیں۔ صرف ایک اسٹریم کی اجازت ہے۔</target>
             </trans-unit>
             <trans-unit id="137">
                 <source>Unsupported video codec "{{ codec }}".</source>
-                <target>غیر معاون ویڈیو کوڈیک "{{ codec }}"۔</target>
+                <target state="needs-review-translation">غیر معاون ویڈیو کوڈیک "{{ codec }}"۔</target>
             </trans-unit>
             <trans-unit id="138">
                 <source>Unsupported video container "{{ container }}".</source>
-                <target>غیر معاونت یافتہ ویڈیو کنٹینر "{{ container }}".</target>
+                <target state="needs-review-translation">غیر معاونت یافتہ ویڈیو کنٹینر "{{ container }}".</target>
             </trans-unit>
             <trans-unit id="139">
                 <source>The image file is corrupted.</source>
-                <target>تصویری فائل خراب ہے۔</target>
+                <target state="needs-review-translation">تصویری فائل خراب ہے۔</target>
             </trans-unit>
             <trans-unit id="140">
                 <source>The image has too few pixels ({{ pixels }} pixels). Minimum amount expected is {{ min_pixels }} pixels.</source>
-                <target>تصویر میں پکسلز بہت کم ہیں ({{ pixels }})۔ متوقع کم سے کم مقدار {{ min_pixels }} ہے۔</target>
+                <target state="needs-review-translation">تصویر میں پکسلز بہت کم ہیں ({{ pixels }})۔ متوقع کم سے کم مقدار {{ min_pixels }} ہے۔</target>
             </trans-unit>
             <trans-unit id="141">
                 <source>The image has too many pixels ({{ pixels }} pixels). Maximum amount expected is {{ max_pixels }} pixels.</source>
-                <target>تصویر میں پکسلز بہت زیادہ ہیں ({{ pixels }}). متوقع زیادہ سے زیادہ مقدار {{ max_pixels }} ہے.</target>
+                <target state="needs-review-translation">تصویر میں پکسلز بہت زیادہ ہیں ({{ pixels }}). متوقع زیادہ سے زیادہ مقدار {{ max_pixels }} ہے.</target>
             </trans-unit>
             <trans-unit id="142">
                 <source>This filename does not match the expected charset.</source>
-                <target>اس فائل کا نام متوقع حرفوں کے مجموعے سے مطابقت نہیں رکھتا۔</target>
+                <target state="needs-review-translation">اس فائل کا نام متوقع حرفوں کے مجموعے سے مطابقت نہیں رکھتا۔</target>
             </trans-unit>
             <trans-unit id="143">
                 <source>This value is not valid XML.</source>
-                <target>یہ ویلیو درست XML نہیں ہے۔</target>
+                <target state="needs-review-translation">یہ ویلیو درست XML نہیں ہے۔</target>
             </trans-unit>
             <trans-unit id="144">
                 <source>This value does not conform to the expected XSD schema.</source>
-                <target>یہ ویلیو متوقع XSD اسکیما کے مطابق نہیں ہے۔</target>
+                <target state="needs-review-translation">یہ ویلیو متوقع XSD اسکیما کے مطابق نہیں ہے۔</target>
             </trans-unit>
             <trans-unit id="145">
                 <source>This XML payload is too large ({{ size }} bytes): it exceeds the limit of {{ limit }} bytes.</source>
-                <target>یہ XML پے لوڈ بہت بڑا ہے ({{ size }} بائٹس): یہ {{ limit }} بائٹس کی حد سے تجاوز کرتا ہے۔</target>
+                <target state="needs-review-translation">یہ XML پے لوڈ بہت بڑا ہے ({{ size }} بائٹس): یہ {{ limit }} بائٹس کی حد سے تجاوز کرتا ہے۔</target>
             </trans-unit>
             <trans-unit id="146">
                 <source>This value is not a valid cron expression.</source>
-                <target>یہ ویلیو درست cron ایکسپریشن نہیں ہے</target>
+                <target state="needs-review-translation">یہ قدر ایک درست cron ایکسپریشن نہیں ہے۔</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Revert #64882
| License       | MIT

The `state="needs-review-translation"` marker requests a review by a native speaker.

#64882 removed it from 49 targets. The review it describes was not done by a native speaker, and most of the targets were left textually unchanged, so the strings ended up indistinguishable from reviewed ones without having been validated. Reverting restores the markers so the Urdu catalogs can still be picked up by a native speaker.

Same reason as the closure of #65199 to #65231, which applied the same change to 33 other locales.