### PR TITLE
[Form] Keep equivalent timezone identifiers submittable

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/TimezoneType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TimezoneType.php
@@ -13,6 +13,9 @@ namespace Symfony\Component\Form\Extension\Core\Type;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\ChoiceList\ChoiceList;
+use Symfony\Component\Form\ChoiceList\ChoiceListInterface;
+use Symfony\Component\Form\ChoiceList\Loader\CallbackChoiceLoader;
+use Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface;
 use Symfony\Component\Form\ChoiceList\Loader\IntlCallbackChoiceLoader;
 use Symfony\Component\Form\Exception\LogicException;
 use Symfony\Component\Form\Extension\Core\DataTransformer\DateTimeZoneToStringTransformer;
@@ -54,10 +57,16 @@ class TimezoneType extends AbstractType
 
                     $choiceTranslationLocale = $options['choice_translation_locale'];
 
-                    return ChoiceList::loader($this, new IntlCallbackChoiceLoader(static fn () => self::getIntlTimezones($input, $choiceTranslationLocale)), [$input, $choiceTranslationLocale]);
+                    return ChoiceList::loader($this, self::acceptEquivalentIdentifiers(
+                        new IntlCallbackChoiceLoader(static fn () => self::getIntlTimezones($input, $choiceTranslationLocale)),
+                        $input,
+                    ), [$input, $choiceTranslationLocale]);
                 }
 
-                return ChoiceList::lazy($this, static fn () => self::getPhpTimezones($input), $input);
+                return ChoiceList::loader($this, self::acceptEquivalentIdentifiers(
+                    new CallbackChoiceLoader(static fn () => self::getPhpTimezones($input)),
+                    $input,
+                ), $input);
             },
             'choice_translation_domain' => false,
             'choice_translation_locale' => null,
@@ -125,5 +134,64 @@ class TimezoneType extends AbstractType
         }
 
         return $timezones;
+    }
+
+    /**
+     * A zone can be designated by several identifiers, of which the choice list can
+     * offer only one: identifiers are unique but the labels they are keyed by are not.
+     * The ones left out still designate an offered zone, so they must stay submittable.
+     *
+     * @return array<string, true>
+     */
+    private static function getSubmittableTimezones(string $input): array
+    {
+        $timezones = [];
+
+        foreach (\DateTimeZone::listIdentifiers(\DateTimeZone::ALL_WITH_BC) as $timezone) {
+            if ('intltimezone' === $input && 'Etc/Unknown' === \IntlTimeZone::createTimeZone($timezone)->getID()) {
+                continue;
+            }
+
+            $timezones[$timezone] = true;
+        }
+
+        return $timezones;
+    }
+
+    private static function acceptEquivalentIdentifiers(ChoiceLoaderInterface $loader, string $input): ChoiceLoaderInterface
+    {
+        return new class($loader, static fn () => self::getSubmittableTimezones($input)) implements ChoiceLoaderInterface {
+            private ?array $submittable = null;
+
+            public function __construct(
+                private ChoiceLoaderInterface $loader,
+                private \Closure $timezones,
+            ) {
+            }
+
+            public function loadChoiceList(?callable $value = null): ChoiceListInterface
+            {
+                return $this->loader->loadChoiceList($value);
+            }
+
+            public function loadChoicesForValues(array $values, ?callable $value = null): array
+            {
+                $choices = $this->loader->loadChoicesForValues($values, $value);
+                $this->submittable ??= ($this->timezones)();
+
+                foreach ($values as $i => $submitted) {
+                    if (!isset($choices[$i]) && isset($this->submittable[$submitted])) {
+                        $choices[$i] = $submitted;
+                    }
+                }
+
+                return $choices;
+            }
+
+            public function loadValuesForChoices(array $choices, ?callable $value = null): array
+            {
+                return $this->loader->loadValuesForChoices($choices, $value);
+            }
+        };
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimezoneTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimezoneTypeTest.php
@@ -153,6 +153,79 @@ class TimezoneTypeTest extends BaseTypeTestCase
     }
 
     /**
+     * @dataProvider provideEquivalentIdentifiers
+     */
+    public function testEquivalentIdentifiersAreSubmittable(bool $intl, string $timezone)
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, ['intl' => $intl]);
+        $form->submit($timezone);
+
+        $this->assertTrue($form->isValid());
+        $this->assertSame($timezone, $form->getData());
+    }
+
+    public static function provideEquivalentIdentifiers()
+    {
+        yield 'canonical identifier sharing an ICU name with its alias' => [true, 'Asia/Kolkata'];
+        yield 'identifier absent from the ICU data' => [true, 'UTC'];
+
+        if (null !== $legacy = self::findLegacyIdentifier()) {
+            yield 'legacy alias, intl' => [true, $legacy];
+            yield 'legacy alias, php' => [false, $legacy];
+        }
+    }
+
+    /**
+     * @dataProvider provideIntlOption
+     */
+    public function testUnknownIdentifierIsNotSubmittable(bool $intl)
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, ['intl' => $intl]);
+        $form->submit('Not/AZone');
+
+        $this->assertFalse($form->isValid());
+        $this->assertNull($form->getData());
+    }
+
+    /**
+     * @dataProvider provideIntlOption
+     */
+    public function testEquivalentIdentifiersAreNotOffered(bool $intl)
+    {
+        if (null === $legacy = self::findLegacyIdentifier()) {
+            $this->markTestSkipped('The timezone database carries no backward compatibility identifier.');
+        }
+
+        $values = $this->factory->create(static::TESTED_TYPE, null, ['intl' => $intl])
+            ->getConfig()->getAttribute('choice_list')->getValues();
+
+        $this->assertNotContains($legacy, $values);
+        $this->assertContains('Europe/Paris', $values);
+    }
+
+    public static function provideIntlOption()
+    {
+        yield 'intl' => [true];
+        yield 'php' => [false];
+    }
+
+    private static function findLegacyIdentifier(): ?string
+    {
+        $legacy = array_diff(
+            \DateTimeZone::listIdentifiers(\DateTimeZone::ALL_WITH_BC),
+            \DateTimeZone::listIdentifiers(\DateTimeZone::ALL)
+        );
+
+        foreach ($legacy as $timezone) {
+            if (str_contains($timezone, '/') && !str_starts_with($timezone, 'Etc/')) {
+                return $timezone;
+            }
+        }
+
+        return null;
+    }
+
+    /**
      * @requires extension intl
      */
     public function testChoiceTranslationLocaleOptionWithIntl()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | #65194, related to #65192
| License       | MIT

A zone can be designated by several identifiers, of which the choice list can offer only one: identifiers are unique, but the labels they are keyed by are not. The ones left out were rejected on submit.

With `intl => true`, `Timezones::getNames()` keys a zone and its legacy aliases under one display name, so `array_flip()` keeps a single identifier per name and drops 19 of 439. With `intl => false`, the list is built from `\DateTimeZone::ALL`, which excludes the backward compatibility identifiers.

Either way a value that designates an offered zone failed validation:

```php
$form = $factory->create(TimezoneType::class, null, ['intl' => true]);
$form->submit('Asia/Kolkata');
$form->isValid();   // false, "Please select a valid timezone."
```

Affected in the `intl => true` mode: the identifier ICU dropped from each of the 19 colliding pairs, plus `UTC`, which the ICU data does not carry at all (#65194). Affected in the `intl => false` mode: every backward compatibility identifier.

Any identifier the timezone database recognizes is now submittable in both modes. The offered lists are left untouched, so nothing renders differently, and the submitted value is returned as is.
