### PR TITLE
[Form] Offer the canonical timezone identifier when ICU names collide

### DIFF
--- a/UPGRADE-8.2.md
+++ b/UPGRADE-8.2.md
@@ -29,6 +29,12 @@ Form
 ----
 
  * Deprecate the `regions` option of `TimezoneType`, it has had no effect since 5.0 and will be removed in 9.0
+ * `TimezoneType` with the `intl` option enabled now offers the identifier PHP reports as canonical when ICU
+   keys a zone and its legacy aliases under one display name, so `Asia/Kolkata` is offered where `Asia/Calcutta`
+   used to be. The aliases stay submittable and are resolved to the offered identifier, so a stored value keeps
+   designating the same choice, but reading it back returns the offered identifier
+ * `TimezoneType` now resolves `UTC` and `Etc/UTC` to each other, the `intl` option deciding which one is
+   offered, where submitting the one the option does not offer used to be rejected
 
 FrameworkBundle
 ---------------

--- a/src/Symfony/Component/Form/Extension/Core/Type/TimezoneType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TimezoneType.php
@@ -13,6 +13,9 @@ namespace Symfony\Component\Form\Extension\Core\Type;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\ChoiceList\ChoiceList;
+use Symfony\Component\Form\ChoiceList\ChoiceListInterface;
+use Symfony\Component\Form\ChoiceList\Loader\CallbackChoiceLoader;
+use Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface;
 use Symfony\Component\Form\ChoiceList\Loader\IntlCallbackChoiceLoader;
 use Symfony\Component\Form\Exception\LogicException;
 use Symfony\Component\Form\Extension\Core\DataTransformer\DateTimeZoneToStringTransformer;
@@ -48,10 +51,16 @@ class TimezoneType extends AbstractType
 
                     $choiceTranslationLocale = $options['choice_translation_locale'];
 
-                    return ChoiceList::loader($this, new IntlCallbackChoiceLoader(static fn () => self::getIntlTimezones($input, $choiceTranslationLocale)), [$input, $choiceTranslationLocale]);
+                    return ChoiceList::loader($this, self::resolveIdentifiers(
+                        new IntlCallbackChoiceLoader(static fn () => self::getIntlTimezones($input, $choiceTranslationLocale)),
+                        static fn () => self::getIntlIdentifierAliases($input, $choiceTranslationLocale),
+                    ), [$input, $choiceTranslationLocale]);
                 }
 
-                return ChoiceList::lazy($this, static fn () => self::getPhpTimezones($input), $input);
+                return ChoiceList::loader($this, self::resolveIdentifiers(
+                    new CallbackChoiceLoader(static fn () => self::getPhpTimezones($input)),
+                    static fn () => self::getPhpIdentifierAliases($input),
+                ), $input);
             },
             'choice_translation_domain' => false,
             'choice_translation_locale' => null,
@@ -110,16 +119,142 @@ class TimezoneType extends AbstractType
 
     private static function getIntlTimezones(string $input, ?string $locale = null): array
     {
-        $timezones = array_flip(Timezones::getNames($locale));
+        return self::getOfferedIntlTimezones(self::getIntlZones($locale), $input);
+    }
 
-        if ('intltimezone' === $input) {
-            foreach ($timezones as $name => $timezone) {
-                if ('Etc/Unknown' === \IntlTimeZone::createTimeZone($timezone)->getID()) {
-                    unset($timezones[$name]);
+    /**
+     * @return array<string, list<string>>
+     */
+    private static function getIntlZones(?string $locale = null): array
+    {
+        $zones = [];
+
+        foreach (Timezones::getNames($locale) as $timezone => $name) {
+            $zones[$name][] = $timezone;
+        }
+
+        return $zones;
+    }
+
+    /**
+     * @param array<string, list<string>> $zones
+     *
+     * @return array<string, string>
+     */
+    private static function getOfferedIntlTimezones(array $zones, string $input): array
+    {
+        $canonical = array_flip(\DateTimeZone::listIdentifiers(\DateTimeZone::ALL));
+        $timezones = [];
+
+        foreach ($zones as $name => $identifiers) {
+            $timezone = $identifiers[0];
+
+            foreach ($identifiers as $identifier) {
+                if (isset($canonical[$identifier])) {
+                    $timezone = $identifier;
                 }
+            }
+
+            if ('intltimezone' !== $input || 'Etc/Unknown' !== \IntlTimeZone::createTimeZone($timezone)->getID()) {
+                $timezones[$name] = $timezone;
             }
         }
 
         return $timezones;
+    }
+
+    /**
+     * ICU keys a zone and its legacy aliases under one display name, of which the choice
+     * list can offer only one identifier. The others are mapped to the offered one so that
+     * a value stored before it was picked keeps designating the same choice.
+     *
+     * "UTC" is the only identifier of the PHP list the ICU data does not carry; it lists
+     * "Etc/UTC" for that zone instead, so the pair has to be told apart from the data.
+     *
+     * @return array<string, string>
+     */
+    private static function getIntlIdentifierAliases(string $input, ?string $locale = null): array
+    {
+        $zones = self::getIntlZones($locale);
+        $offered = array_flip(self::getOfferedIntlTimezones($zones, $input));
+
+        $groups = array_values($zones);
+        $groups[] = ['UTC', 'Etc/UTC'];
+
+        return self::mapToOfferedIdentifier($groups, $offered);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private static function getPhpIdentifierAliases(string $input): array
+    {
+        return self::mapToOfferedIdentifier([['UTC', 'Etc/UTC']], array_flip(self::getPhpTimezones($input)));
+    }
+
+    /**
+     * @param list<list<string>>   $groups
+     * @param array<string, mixed> $offered
+     *
+     * @return array<string, string>
+     */
+    private static function mapToOfferedIdentifier(array $groups, array $offered): array
+    {
+        $aliases = [];
+
+        foreach ($groups as $group) {
+            foreach ($group as $timezone) {
+                if (!isset($offered[$timezone])) {
+                    continue;
+                }
+
+                foreach ($group as $alias) {
+                    if ($alias !== $timezone) {
+                        $aliases[$alias] = $timezone;
+                    }
+                }
+
+                break;
+            }
+        }
+
+        return $aliases;
+    }
+
+    private static function resolveIdentifiers(ChoiceLoaderInterface $loader, \Closure $aliases): ChoiceLoaderInterface
+    {
+        return new class($loader, $aliases) implements ChoiceLoaderInterface {
+            private ?array $aliases = null;
+
+            public function __construct(
+                private ChoiceLoaderInterface $loader,
+                private \Closure $identifiers,
+            ) {
+            }
+
+            public function loadChoiceList(?callable $value = null): ChoiceListInterface
+            {
+                return $this->loader->loadChoiceList($value);
+            }
+
+            public function loadChoicesForValues(array $values, ?callable $value = null): array
+            {
+                return $this->loader->loadChoicesForValues($this->resolve($values), $value);
+            }
+
+            public function loadValuesForChoices(array $choices, ?callable $value = null): array
+            {
+                return $this->loader->loadValuesForChoices($this->resolve($choices), $value);
+            }
+
+            private function resolve(array $timezones): array
+            {
+                if (!$this->aliases ??= ($this->identifiers)()) {
+                    return $timezones;
+                }
+
+                return array_map(fn ($timezone) => \is_string($timezone) ? ($this->aliases[$timezone] ?? $timezone) : $timezone, $timezones);
+            }
+        };
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimezoneTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimezoneTypeTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
@@ -157,6 +158,58 @@ class TimezoneTypeTest extends BaseTypeTestCase
 
         $this->assertContainsEquals(new ChoiceView('Europe/Amsterdam', 'Europe/Amsterdam', 'Central European Time (Amsterdam)'), $choices);
         $this->assertContainsEquals(new ChoiceView('Etc/UTC', 'Etc/UTC', 'Coordinated Universal Time'), $choices);
+    }
+
+    public function testIntlTimezonesOfferTheCanonicalIdentifier()
+    {
+        $values = $this->factory->create(static::TESTED_TYPE, null, ['intl' => true])
+            ->getConfig()->getAttribute('choice_list')->getValues();
+
+        $this->assertContains('Asia/Kolkata', $values);
+        $this->assertNotContains('Asia/Calcutta', $values);
+
+        $this->assertContains('Pacific/Chuuk', $values);
+        $this->assertNotContains('Pacific/Truk', $values);
+    }
+
+    #[DataProvider('provideAliasedIdentifiers')]
+    public function testAnAliasIsResolvedToTheOfferedIdentifier(bool $intl, string $alias, string $offered)
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, ['intl' => $intl]);
+        $form->submit($alias);
+
+        $this->assertTrue($form->isValid());
+        $this->assertSame($offered, $form->getData());
+
+        $view = $this->factory->create(static::TESTED_TYPE, $alias, ['intl' => $intl])->createView();
+
+        $this->assertSame($offered, $view->vars['value']);
+        $this->assertContains($offered, $form->getConfig()->getAttribute('choice_list')->getValues());
+    }
+
+    public static function provideAliasedIdentifiers()
+    {
+        yield 'alias offered before' => [true, 'Asia/Calcutta', 'Asia/Kolkata'];
+        yield 'canonical offered before' => [true, 'Europe/Kiev', 'Europe/Kyiv'];
+        yield 'offered identifier is left alone' => [true, 'Asia/Kolkata', 'Asia/Kolkata'];
+        yield 'identifier absent from the ICU data' => [true, 'UTC', 'Etc/UTC'];
+        yield 'identifier absent from the PHP list' => [false, 'Etc/UTC', 'UTC'];
+    }
+
+    #[DataProvider('provideIntlOption')]
+    public function testUnknownIdentifierIsNotSubmittable(bool $intl)
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, ['intl' => $intl]);
+        $form->submit('Not/AZone');
+
+        $this->assertFalse($form->isValid());
+        $this->assertNull($form->getData());
+    }
+
+    public static function provideIntlOption()
+    {
+        yield 'intl' => [true];
+        yield 'php' => [false];
     }
 
     #[RequiresPhpExtension('intl')]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65194, supersedes #65192
| License       | MIT

Reworked from #65192 by @sadiqk2.

ICU keys a zone and its legacy aliases under one display name, and the choice list can offer only one of them: identifiers are unique, but the labels they are keyed by are not. Which one survived depended on the collator ordering, so of the 19 colliding pairs, 12 offered the canonical identifier and 7 offered the legacy alias.

| display name | canonical | offered before |
| --- | --- | --- |
| India Standard Time (Kolkata) | `Asia/Kolkata` | `Asia/Calcutta` |
| Chuuk Time | `Pacific/Chuuk` | `Pacific/Truk` |
| Myanmar Time (Yangon) | `Asia/Yangon` | `Asia/Rangoon` |
| Nepal Time (Kathmandu) | `Asia/Kathmandu` | `Asia/Katmandu` |
| Argentina Time (Buenos Aires) | `America/Argentina/Buenos_Aires` | `America/Buenos_Aires` |
| Argentina Time (Mendoza) | `America/Argentina/Mendoza` | `America/Mendoza` |
| Eastern Time (Louisville) | `America/Kentucky/Louisville` | `America/Louisville` |

The canonical identifier is now the one offered, which makes those 7 consistent with the 12 that already were.

Swapping the offered identifier on its own would break the values stored from the previous list, which is not acceptable on a minor. Every other identifier of a zone is therefore resolved to the one the list offers, in both directions: a stored `Asia/Calcutta` renders as the selected `Asia/Kolkata` instead of leaving the field with nothing selected, and submitting it validates. Reading the value back returns the offered identifier, so stored data migrates towards it.

The same rule tells `UTC` and `Etc/UTC` apart, which fixes #65194. They designate one zone but each list carries only one of them: `UTC` is the sole identifier of the PHP list the ICU data does not have, and ICU offers `Etc/UTC` instead. Whichever the `intl` option does not offer is now resolved to the other one, rather than being rejected.
