### PR TITLE
[Console] Fix terminator handling in the image protocols

### DIFF
--- a/src/Symfony/Component/Console/Terminal/Image/ITerm2Protocol.php
+++ b/src/Symfony/Component/Console/Terminal/Image/ITerm2Protocol.php
@@ -43,13 +43,14 @@ final class ITerm2Protocol implements ImageProtocolInterface
             return ['data' => '', 'format' => null];
         }
 
-        if (false === $end = strpos($data, self::BEL, $start)) {
-            $end = strpos($data, self::ST, $start);
-        }
+        // OSC accepts either terminator, so the sequence ends at the first one of them
+        $terminators = array_filter([strpos($data, self::BEL, $start), strpos($data, self::ST, $start)], \is_int(...));
 
-        if (false === $end) {
+        if (!$terminators) {
             return ['data' => '', 'format' => null];
         }
+
+        $end = min($terminators);
 
         $content = substr($data, $start + \strlen(self::OSC_START), $end - $start - \strlen(self::OSC_START));
 

--- a/src/Symfony/Component/Console/Terminal/Image/KittyGraphicsProtocol.php
+++ b/src/Symfony/Component/Console/Terminal/Image/KittyGraphicsProtocol.php
@@ -30,7 +30,6 @@ final class KittyGraphicsProtocol implements ImageProtocolInterface
 {
     public const APC_START = "\x1b_G";
     public const ST = "\x1b\\";
-    public const BEL = "\x07";
 
     public function detectPastedImage(string $data): bool
     {
@@ -51,19 +50,9 @@ final class KittyGraphicsProtocol implements ImageProtocolInterface
         // larger than the maximum chunk size; all of them but the last one carry
         // "m=1" in their control data.
         while (true) {
-            // the sequence ends at whichever terminator comes first
-            $st = strpos($data, self::ST, $offset);
-            $bel = strpos($data, self::BEL, $offset);
-
-            if (false === $end = match (true) {
-                false === $st => $bel,
-                false === $bel => $st,
-                default => min($st, $bel),
-            }) {
+            if (false === $end = strpos($data, self::ST, $offset)) {
                 return ['data' => '', 'format' => null];
             }
-
-            $terminator = $end === $st ? self::ST : self::BEL;
 
             $content = substr($data, $offset + \strlen(self::APC_START), $end - $offset - \strlen(self::APC_START));
 
@@ -74,7 +63,7 @@ final class KittyGraphicsProtocol implements ImageProtocolInterface
             $controlData = substr($content, 0, $semicolonPos);
             $payload .= substr($content, $semicolonPos + 1);
             $format ??= $this->parseFormat($controlData);
-            $offset = $end + \strlen($terminator);
+            $offset = $end + \strlen(self::ST);
 
             if ('1' !== $this->parseControlValue($controlData, 'm')) {
                 break;

--- a/src/Symfony/Component/Console/Tests/Terminal/Image/ITerm2ProtocolTest.php
+++ b/src/Symfony/Component/Console/Tests/Terminal/Image/ITerm2ProtocolTest.php
@@ -57,6 +57,27 @@ class ITerm2ProtocolTest extends TestCase
         $this->assertSame($imageData, $result['data']);
     }
 
+    public function testDecodeWithStTerminatorFollowedByABell()
+    {
+        $imageData = 'test image data';
+        $data = "\x1b]1337;File=inline=1:".base64_encode($imageData)."\x1b\\ trailing \x07";
+
+        $result = (new ITerm2Protocol())->decode($data);
+
+        $this->assertSame($imageData, $result['data']);
+    }
+
+    public function testDecodeStopsAtTheEndOfTheImage()
+    {
+        $imageData = 'test image data';
+        $data = "\x1b]1337;File=inline=1:".base64_encode($imageData)."\x1b\\"
+            ."\x1b]1337;File=inline=1:".base64_encode('another image')."\x07";
+
+        $result = (new ITerm2Protocol())->decode($data);
+
+        $this->assertSame($imageData, $result['data']);
+    }
+
     public function testDecodeInvalidBase64()
     {
         $data = "\x1b]1337;File=inline=1:not-valid-base64!!!\x07";

--- a/src/Symfony/Component/Console/Tests/Terminal/Image/KittyGraphicsProtocolTest.php
+++ b/src/Symfony/Component/Console/Tests/Terminal/Image/KittyGraphicsProtocolTest.php
@@ -47,26 +47,24 @@ class KittyGraphicsProtocolTest extends TestCase
         $this->assertSame('png', $result['format']);
     }
 
-    public function testDecodeWithBellTerminator()
+    public function testDecodeRejectsABellTerminator()
     {
-        $imageData = 'test image data';
-        $base64 = base64_encode($imageData);
-        $data = "\x1b_Ga=T,f=100;{$base64}\x07";
+        $data = "\x1b_Ga=T,f=100;".base64_encode('test image data')."\x07";
 
         $result = (new KittyGraphicsProtocol())->decode($data);
 
-        $this->assertSame($imageData, $result['data']);
+        $this->assertSame('', $result['data']);
+        $this->assertNull($result['format']);
     }
 
-    public function testDecodeWithBellTerminatorFollowedByAnEscapeSequence()
+    public function testDecodeStopsAtTheStringTerminatorWhenThePayloadHoldsABell()
     {
-        $imageData = 'test image data';
-        $base64 = base64_encode($imageData);
-        $data = "\x1b_Ga=T,f=100;{$base64}\x07 and some text\x1b\\";
+        $data = "\x1b_Ga=T,f=100;".base64_encode('test image data')."\x07junk\x1b\\";
 
         $result = (new KittyGraphicsProtocol())->decode($data);
 
-        $this->assertSame($imageData, $result['data']);
+        $this->assertSame('', $result['data']);
+        $this->assertNull($result['format']);
     }
 
     public function testDecodeInvalidBase64()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Both image protocol decoders searched for their preferred terminator anywhere after the start of the sequence, falling back to the other one only when it was missing entirely. Neither stopped at the end of the sequence it was reading, so a terminator belonging to something else could be picked up instead.

`ITerm2Protocol` prefers BEL:

```php
if (false === $end = strpos($data, self::BEL, $start)) {
    $end = strpos($data, self::ST, $start);
}
```

An ST-terminated image therefore decodes to nothing as soon as a BEL appears anywhere later, including in a second pasted image:

```php
$protocol = new ITerm2Protocol();
$first = "\x1b]1337;File=inline=1:".base64_encode('IMAGE')."\x1b\\";

$protocol->decode($first)['data'];                    // 'IMAGE'
$protocol->decode($first."\x1b]1337;File=inline=1:".base64_encode('SECOND')."\x07")['data']; // ''
```

OSC accepts BEL and ST alike, so the sequence now ends at whichever of the two comes first.

`KittyGraphicsProtocol` had the mirror of that, fixed in #65196 by taking the first terminator as well. That left the question of whether BEL should be one of the candidates at all, and it should not:

 * APC sequences are closed by ST. BEL terminates OSC by an xterm convention, which is why iTerm2 uses it, but it is not a string terminator for APC;
 * the class already documents `End: ESC \ (0x1B 0x5C)` and nothing else, and `encode()` only ever emits ST.

Accepting it was not merely redundant. A payload holding that byte was cut there, so corrupt input decoded to a silently truncated image rather than being rejected:

```php
$data = "\x1b_Ga=T,f=100;".base64_encode('IMAGE')."\x07junk\x1b\\";

(new KittyGraphicsProtocol())->decode($data)['data']; // 'IMAGE', dropping the rest
```

That is the same hazard #65196 closed for chunk sequences that end early: an incomplete image should not reach `FileInputHelper` as a shorter valid one. With BEL gone the payload runs to the ST, fails the strict base64 check and is rejected.

Note that this narrows what the Kitty decoder accepts, and BEL has been accepted there since 8.1.0. A terminal sending a BEL-terminated APC sequence would be violating the protocol, and none is known to, but the change is listed here rather than buried since it is not purely internal. The `KittyGraphicsProtocol::BEL` constant that carried it is removed; it was introduced in #65196 and is not in any release.
