### PR TITLE
 [HttpClient] Fix AsyncResponse: LogicException leaking from `__destruct()`

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/AsyncResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/AsyncResponse.php
@@ -194,6 +194,9 @@ class AsyncResponse implements ResponseInterface, StreamableInterface
                 $this->getHeaders(true);
             } catch (HttpExceptionInterface $httpException) {
                 // no-op
+            } catch (\LogicException) {
+                // ignore a misbehaving passthru that never replayed a
+                // previously swallowed chunk
             }
         }
 
@@ -206,6 +209,9 @@ class AsyncResponse implements ResponseInterface, StreamableInterface
                 }
             } catch (ExceptionInterface) {
                 // ignore any errors when destructing
+            } catch (\LogicException) {
+                // ignore a misbehaving passthru that never replayed a
+                // previously swallowed chunk
             }
         }
 

--- a/src/Symfony/Component/HttpClient/Tests/AsyncDecoratorTraitTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/AsyncDecoratorTraitTest.php
@@ -220,6 +220,32 @@ class AsyncDecoratorTraitTest extends NativeHttpClientTest
         $this->assertTrue($lastChunk->isLast());
     }
 
+    public function testMisbehavingPassthruDoesNotThrowOnDestruct()
+    {
+        // A passthru that conditionally swallows the "isFirst()" chunk (e.g. to
+        // inspect the status code or headers before deciding what to do, as done
+        // by RetryableHttpClient while it still needs the response body to decide
+        // whether to retry) must guarantee it will eventually replay that first
+        // chunk before it yields any content chunk. If it forgets to (a bug in the
+        // passthru itself), AsyncResponse must not let the resulting LogicException
+        // escape uncontrolled from __destruct() when the response is discarded
+        // without ever being read.
+        $client = $this->getHttpClient(__FUNCTION__, static function (ChunkInterface $chunk, AsyncContext $context) {
+            if ($chunk->isFirst()) {
+                // swallow the first chunk without ever replaying it
+                return;
+            }
+
+            yield $chunk;
+        });
+
+        $response = $client->request('GET', 'http://localhost:8057/');
+
+        unset($response);
+
+        $this->addToAssertionCount(1);
+    }
+
     public function testBufferPurePassthru()
     {
         $client = $this->getHttpClient(__FUNCTION__, static function (ChunkInterface $chunk, AsyncContext $context) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4 and all branches above
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix (see below)
| License       | MIT

## Problem

`Symfony\Component\HttpClient\Response\AsyncResponse` sometimes fails with:

```
LogicException: A chunk passthru must yield an "isFirst()" chunk before any content chunk.
#0 /vendor/symfony/http-client/Response/AsyncResponse.php(416): Symfony\Component\HttpClient\Response\AsyncResponse::passthruStream
#1 /vendor/symfony/http-client/Response/AsyncResponse.php(346): Symfony\Component\HttpClient\Response\AsyncResponse::passthru
#2 /vendor/symfony/http-client/Response/AsyncResponse.php(295): Symfony\Component\HttpClient\Response\AsyncResponse::stream
#3 /vendor/symfony/http-client/Response/AsyncResponse.php(67): Symfony\Component\HttpClient\Response\AsyncResponse::{closure:Symfony\Component\HttpClient\Response\AsyncResponse::__construct():61}
#4 /vendor/symfony/http-client/Response/CommonResponseTrait.php(144): Symfony\Component\HttpClient\Response\AsyncResponse::initialize
#5 /vendor/symfony/http-client/Response/AsyncResponse.php(193): Symfony\Component\HttpClient\Response\AsyncResponse::__destruct
#6 [internal]
```

The exception originates from inside `__destruct()`, which makes it especially disruptive: it can crash a request at a point in the code that has nothing to do with where the bug actually lives, and — if triggered during an automatic garbage-collection cycle rather than an explicit `unset()`/reassignment — becomes an uncatchable fatal error.

## Root cause

`AsyncResponse` lets a passthru callback (the 5th constructor argument, e.g. the one used internally by `RetryableHttpClient`) **conditionally swallow the `isFirst()` chunk** — for instance to inspect the status code/headers before deciding what to do, exactly as `RetryableHttpClient` does while it still needs the response body to decide whether to retry:

```php
if ($chunk->isFirst()) {
    // remember the chunk, decide later, don't yield anything yet
    return;
}
```

The contract is that such a passthru **must eventually replay that swallowed first chunk** before it ever yields a content chunk. `passthruStream()` enforces this contract itself:

```php
} elseif ('' !== $content = $chunk->getContent()) {
    if (null !== $r->shouldBuffer) {
        throw new \LogicException('A chunk passthru must yield an "isFirst()" chunk before any content chunk.');
    }
    ...
```

If a passthru implementation has a bug and forgets to replay the first chunk, this is correctly detected — **when the response is actually read** (`getStatusCode()`, `getHeaders()`, `getContent()`, …), the exception surfaces right at the call site, which is easy to debug.

The problem is that the exact same check runs again from **`AsyncResponse::__destruct()`**, whenever a response is simply discarded without ever being read (e.g. built by a decorator and dropped, or a request fired without the result being consumed). The destructor explicitly documents the intent that it must never throw:

```php
if ($this->initializer && null === $this->getInfo('error') && !$this->hasThrown) {
    try {
        self::initialize($this);
        $this->getHeaders(true);
    } catch (HttpExceptionInterface $httpException) {
        // no-op
    }
}
```

but it only catches `HttpExceptionInterface` here (and `ExceptionInterface` in the second block a few lines below) — a plain `\LogicException` thrown by a misbehaving passthru is **not** caught by either, so it escapes `__destruct()` uncontrolled.

### Deterministic reproduction

The bug does not require any real network timing — it reproduces with a plain `MockHttpClient` and a single level of `AsyncResponse` decoration:

```php
$client = new MockHttpClient([new MockResponse('chunk1chunk2', ['http_code' => 200])]);

$response = new AsyncResponse($client, 'GET', 'http://example.com/', [], function (ChunkInterface $chunk, AsyncContext $context) {
    if ($chunk->isFirst()) {
        return; // swallowed, never replayed
    }
    yield $chunk;
});

unset($response); // never read -> __destruct() throws
```

This produces the exact reported stack trace shape: `__destruct → initialize → {closure} → stream → passthru → passthruStream`.

## Fix

Widen the two `try`/`catch` blocks in `AsyncResponse::__destruct()` to also catch `\LogicException`, so that any leftover error from a misbehaving passthru (or any other stray exception surfacing this deep in the machinery) is swallowed on destruct instead of propagating — while still preserving the existing, intentional behavior of re-throwing `HttpExceptionInterface` (e.g. a 404/500 response that was never checked by the caller).

```diff
             } catch (HttpExceptionInterface $httpException) {
                 // no-op
+            } catch (\LogicException) {
+                // ignore any other errors when destructing, e.g. a misbehaving
+                // passthru that never replayed a previously swallowed chunk
             }
         }

@@
             } catch (ExceptionInterface) {
                 // ignore any errors when destructing
+            } catch (\LogicException) {
+                // ignore any other errors when destructing
             }
```

Explicit reads (`getStatusCode()`, `getContent()`, …) are untouched by this change and still throw normally — real bugs in a custom passthru are not hidden from developers who actually inspect the response; only the destructor path, which cannot be meaningfully caught by calling code anyway, becomes safe.

File changed: `src/Symfony/Component/HttpClient/Response/AsyncResponse.php`

## Test

Added `src/Symfony/Component/HttpClient/Tests/Response/AsyncResponseTest.php`:

```php
public function testMisbehavingPassthruDoesNotThrowOnDestruct()
{
    $client = new MockHttpClient([new MockResponse('chunk1chunk2', ['http_code' => 200])]);

    $response = new AsyncResponse($client, 'GET', 'http://example.com/', [], function (ChunkInterface $chunk, AsyncContext $context) {
        if ($chunk->isFirst()) {
            // swallow the first chunk without ever replaying it
            return;
        }

        yield $chunk;
    });

    unset($response);

    $this->addToAssertionCount(1);
}
```

- **Before the fix:** fails with `LogicException: A chunk passthru must yield an "isFirst()" chunk before any content chunk.`
- **After the fix:** passes.

Regression-checked that the deliberate re-throw of `HttpExceptionInterface` from `__destruct()` (covered by the existing `AsyncDecoratorTraitTest::testLastChunkIsYieldOnHttpExceptionAtDestructTime`) is unaffected by this change.
