### PR TITLE
[Console] Fix parsing `#[Target]` attribute on arguments of invokable commands

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ConsoleArgumentResolver/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ConsoleArgumentResolver/config.yml
@@ -22,6 +22,8 @@ services:
     test_service:
         class: Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Console\TestService
 
+    Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Console\TestService $testService: '@test_service'
+
     Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Console\AdvancedCommand:
         autowire: true
         autoconfigure: true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/RunCommand/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/RunCommand/config.yml
@@ -7,6 +7,8 @@ services:
     test_service:
         class: Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Console\TestService
 
+    Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Console\TestService $testService: '@test_service'
+
     Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Console\AdvancedCommand:
         autowire: true
         autoconfigure: true

--- a/src/Symfony/Component/Console/DependencyInjection/RegisterCommandArgumentLocatorsPass.php
+++ b/src/Symfony/Component/Console/DependencyInjection/RegisterCommandArgumentLocatorsPass.php
@@ -173,8 +173,10 @@ final class RegisterCommandArgumentLocatorsPass implements CompilerPassInterface
                         $arguments[$p->name] = new Reference($erroredId, ContainerInterface::RUNTIME_EXCEPTION_ON_INVALID_REFERENCE);
                         ++$erroredIds;
                     } else {
+                        $targetAttribute = null;
+                        $name = Target::parseName($p, $targetAttribute);
                         $target = preg_replace('/(^|[(|&])\\\\/', '\1', $target);
-                        $arguments[$p->name] = $type ? new TypedReference($target, $type, $invalidBehavior, Target::parseName($p)) : new Reference($target, $invalidBehavior);
+                        $arguments[$p->name] = $type ? new TypedReference($target, $type, $invalidBehavior, $name, $targetAttribute ? [$targetAttribute] : []) : new Reference($target, $invalidBehavior);
                     }
                 }
 

--- a/src/Symfony/Component/Console/Tests/DependencyInjection/RegisterCommandArgumentLocatorsPassTest.php
+++ b/src/Symfony/Component/Console/Tests/DependencyInjection/RegisterCommandArgumentLocatorsPassTest.php
@@ -14,13 +14,18 @@ namespace Symfony\Component\Console\Tests\DependencyInjection;
 use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Symfony\Component\Console\DependencyInjection\RegisterCommandArgumentLocatorsPass;
+use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\DependencyInjection\Attribute\Target;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\ServiceLocator;
+use Symfony\Component\DependencyInjection\TypedReference;
 
 class RegisterCommandArgumentLocatorsPassTest extends TestCase
 {
@@ -190,6 +195,55 @@ class RegisterCommandArgumentLocatorsPassTest extends TestCase
         $this->assertArrayHasKey('test:cmd2', $commands);
     }
 
+    public function testProcessForwardsTargetAttribute()
+    {
+        $container = new ContainerBuilder();
+        $container->register('console.argument_resolver.service')->addArgument(null);
+
+        $command = new Definition(CommandWithTarget::class);
+        $command->setAutowired(true);
+        $command->addTag('console.command', ['command' => 'test:command']);
+        $command->addTag('console.command.service_arguments');
+        $container->setDefinition('test.command', $command);
+
+        $pass = new RegisterCommandArgumentLocatorsPass();
+        $pass->process($container);
+
+        $serviceResolverDef = $container->getDefinition('console.argument_resolver.service');
+        $commands = $container->getDefinition((string) $serviceResolverDef->getArgument(0))->getArgument(0);
+        $locator = $container->getDefinition((string) $commands['test:command']->getValues()[0]);
+        $locator = $container->getDefinition((string) $locator->getFactory()[0]);
+
+        $expected = ['logger' => new ServiceClosureArgument(new TypedReference(LoggerInterface::class, LoggerInterface::class, ContainerInterface::RUNTIME_EXCEPTION_ON_INVALID_REFERENCE, 'requestLogger', [new Target('request.logger')]))];
+        $this->assertEquals($expected, $locator->getArgument(0));
+    }
+
+    public function testProcessTargetedArgumentIsAutowired()
+    {
+        $container = new ContainerBuilder();
+        $resolver = $container->register('console.argument_resolver.service', 'stdClass')->addArgument(null);
+
+        $container->register('request.logger', NullLogger::class);
+        $container->registerAliasForArgument('request.logger', LoggerInterface::class);
+
+        $command = new Definition(CommandWithTarget::class);
+        $command->setAutowired(true);
+        $command->addTag('console.command', ['command' => 'test:command']);
+        $command->addTag('console.command.service_arguments');
+        $container->setDefinition('test.command', $command);
+
+        $pass = new RegisterCommandArgumentLocatorsPass();
+        $pass->process($container);
+
+        $locatorId = (string) $resolver->getArgument(0);
+        $container->getDefinition($locatorId)->setPublic(true);
+
+        $container->compile();
+
+        $locator = $container->get($locatorId)->get('test:command');
+        $this->assertInstanceOf(NullLogger::class, $locator->get('logger'));
+    }
+
     public function testProcessThrowsOnMissingArgumentAttribute()
     {
         $container = new ContainerBuilder();
@@ -258,6 +312,15 @@ class CommandWithAutowireAttributeNullableInvalidReference
         #[Autowire(service: 'invalid.id')]
         ?\stdClass $service2 = null,
     ) {
+    }
+}
+
+class CommandWithTarget
+{
+    public function __invoke(
+        #[Target('request.logger')]
+        LoggerInterface $logger,
+    ): void {
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Same as #63234 but for invokable commands. Without this fix the following doesn't work:

```yaml
framework:
    rate_limiter:
        anonymous_api:
            policy: 'fixed_window'
            limit: 100
            interval: '60 minutes'
```

```php
class TestCommand
{
    public function __invoke(
        #[Target('anonymous_api')] RateLimiterFactoryInterface $limiterFactory,
    ): int {
        // ...

        return Command::SUCCESS;
    }
}
```
 
> In ArgumentResolver.php line 136:
>                                                                                                                                                                                                                                    
>   Could not resolve parameter "$limiterFactory" of command "App\Command\TestCommand::__invoke()".                                                                                                                                  
>                                                                                                                                                                                                                                    
>   Possible reasons:                                                                                                                                                                                                                
>     • Cannot autowire argument $limiterFactory of command "app:test": it references interface "Symfony\Component\RateLimiter\RateLimiterFactoryInterface" but no such service exists. Did you mean to target "anonymous_api" instead?                                                                                                                                                                                                                             