### PR TITLE
[Yaml] Add support for int, null, bool yaml tags including quotes

### DIFF
--- a/src/Symfony/Component/Yaml/CHANGELOG.md
+++ b/src/Symfony/Component/Yaml/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add support for the `!!null`, `!!bool` and `!!int` tags, and accept quoted values for them and for `!!float`
+ * Throw a `ParseException` when the value of a `!!float` tag is not a valid float, instead of casting it to `0.0`
+
 8.0
 ---
 

--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -283,11 +283,9 @@ class Inline
      */
     public static function parseScalar(string $scalar, int $flags = 0, ?array $delimiters = null, int &$i = 0, bool $evaluate = true, array &$references = [], ?bool &$isQuoted = null, ?ParserState $state = null): mixed
     {
-        if (\in_array($scalar[$i], ['"', "'"], true)) {
-            // quoted scalar
-            $isQuoted = true;
-            $output = self::parseQuotedScalar($scalar, $i);
+        $output = self::parseQuotedScalar($scalar, $i, $isQuoted);
 
+        if (null !== $output) {
             if (null !== $delimiters) {
                 $tmp = ltrim(substr($scalar, $i), " \n");
                 if ('' === $tmp) {
@@ -336,8 +334,14 @@ class Inline
      *
      * @throws ParseException When malformed inline YAML string is parsed
      */
-    private static function parseQuotedScalar(string $scalar, int &$i = 0): string
+    private static function parseQuotedScalar(string $scalar, int &$i = 0, ?bool &$isQuoted = null): ?string
     {
+        if (!\in_array($scalar[$i] ?? '', ['"', "'"], true)) {
+            $isQuoted = false;
+
+            return null;
+        }
+
         if (!Parser::preg_match('/'.self::REGEX_QUOTED_STRING.'/A', substr($scalar, $i), $match)) {
             throw new ParseException(\sprintf('Malformed inline YAML string: "%s".', substr($scalar, $i)), self::$parsedLineNumber + 1, $scalar, self::$parsedFilename);
         }
@@ -345,13 +349,14 @@ class Inline
         $output = substr($match[0], 1, -1);
 
         $unescaper = new Unescaper();
-        if ('"' == $scalar[$i]) {
+        if ('"' === $scalar[$i]) {
             $output = $unescaper->unescapeDoubleQuotedString($output);
         } else {
             $output = $unescaper->unescapeSingleQuotedString($output);
         }
 
         $i += \strlen($match[0]);
+        $isQuoted = true;
 
         return $output;
     }
@@ -691,13 +696,10 @@ class Inline
                 switch (true) {
                     case str_starts_with($scalar, '!!str '):
                         $s = substr($scalar, 6);
+                        $i = 0;
+                        $parsed = self::parseQuotedScalar($s, $i, $isQuotedString);
 
-                        if (\in_array($s[0] ?? '', ['"', "'"], true)) {
-                            $isQuotedString = true;
-                            $s = self::parseQuotedScalar($s);
-                        }
-
-                        return $s;
+                        return $parsed ?? $s;
                     case str_starts_with($scalar, '! '):
                         return substr($scalar, 2);
                     case str_starts_with($scalar, '!php/object'):
@@ -793,8 +795,16 @@ class Inline
                         }
 
                         return null;
+                    case '!!null' === $scalar:
+                        return null;
+                    case str_starts_with($scalar, '!!null '):
+                        return self::resolveTaggedNull(self::parseTaggedValue($scalar, 7));
+                    case str_starts_with($scalar, '!!bool '):
+                        return self::resolveTaggedBool(self::parseTaggedValue($scalar, 7));
+                    case str_starts_with($scalar, '!!int '):
+                        return self::resolveTaggedInt(self::parseTaggedValue($scalar, 6));
                     case str_starts_with($scalar, '!!float '):
-                        return (float) substr($scalar, 8);
+                        return self::resolveTaggedFloat(self::parseTaggedValue($scalar, 8));
                     case str_starts_with($scalar, '!!binary '):
                         return self::evaluateBinaryScalar(substr($scalar, 9));
                 }
@@ -982,5 +992,97 @@ class Inline
     private static function getHexRegex(): string
     {
         return '~^0x[0-9a-f_]++$~i';
+    }
+
+    /**
+     * Strips a built-in tag and unquotes the value it applies to.
+     *
+     * A tag applies to the content of the scalar, so "!!int 1" and "!!int \"1\"" both give the integer 1.
+     *
+     * @throws ParseException When anything follows the closing quote
+     */
+    private static function parseTaggedValue(string $scalar, int $offset): string
+    {
+        $value = substr($scalar, $offset);
+        $i = 0;
+
+        if (null === $unquoted = self::parseQuotedScalar($value, $i)) {
+            return $value;
+        }
+
+        if ($i !== \strlen($value)) {
+            throw new ParseException(\sprintf('Unexpected characters near "%s".', substr($value, $i)), self::$parsedLineNumber + 1, $scalar, self::$parsedFilename);
+        }
+
+        return $unquoted;
+    }
+
+    /**
+     * @see https://yaml.org/spec/1.2.2/#10211-null
+     */
+    private static function resolveTaggedNull(string $value): null
+    {
+        if (\in_array($value, ['', '~', 'null', 'Null', 'NULL'], true)) {
+            return null;
+        }
+
+        throw self::createInvalidTagValueException('!!null', $value);
+    }
+
+    /**
+     * @see https://yaml.org/spec/1.2.2/#10212-boolean
+     */
+    private static function resolveTaggedBool(string $value): bool
+    {
+        return match ($value) {
+            'true', 'True', 'TRUE' => true,
+            'false', 'False', 'FALSE' => false,
+            default => throw self::createInvalidTagValueException('!!bool', $value),
+        };
+    }
+
+    /**
+     * @see https://yaml.org/spec/1.2.2/#10213-integer
+     */
+    private static function resolveTaggedInt(string $value): int
+    {
+        if (Parser::preg_match('~^0o[0-7]++$~', $value)) {
+            $int = octdec(substr($value, 2));
+        } elseif (Parser::preg_match('~^0x[0-9a-fA-F]++$~', $value)) {
+            $int = hexdec(substr($value, 2));
+        } elseif (Parser::preg_match('~^[+-]?[0-9]++$~', $value)) {
+            $int = $value < \PHP_INT_MIN || \PHP_INT_MAX < $value ? \INF : (int) $value;
+        } else {
+            throw self::createInvalidTagValueException('!!int', $value);
+        }
+
+        // octdec() and hexdec() return a float when the value overflows
+        if (!\is_int($int)) {
+            throw new ParseException(\sprintf('The integer "%s" is out of range.', $value), self::$parsedLineNumber + 1, $value, self::$parsedFilename);
+        }
+
+        return $int;
+    }
+
+    /**
+     * @see https://yaml.org/spec/1.2.2/#10214-floating-point
+     */
+    private static function resolveTaggedFloat(string $value): float
+    {
+        if (Parser::preg_match('~^[+-]?(?:\.[0-9]++|[0-9]++(?:\.[0-9]*+)?)(?:[eE][+-]?[0-9]++)?$~', $value)) {
+            return (float) $value;
+        }
+
+        return match ($value) {
+            '.inf', '.Inf', '.INF', '+.inf', '+.Inf', '+.INF' => \INF,
+            '-.inf', '-.Inf', '-.INF' => -\INF,
+            '.nan', '.NaN', '.NAN' => \NAN,
+            default => throw self::createInvalidTagValueException('!!float', $value),
+        };
+    }
+
+    private static function createInvalidTagValueException(string $tag, string $value): ParseException
+    {
+        return new ParseException(\sprintf('The value "%s" is not a valid "%s" value.', $value, $tag), self::$parsedLineNumber + 1, $value, self::$parsedFilename);
     }
 }

--- a/src/Symfony/Component/Yaml/Tests/InlineTest.php
+++ b/src/Symfony/Component/Yaml/Tests/InlineTest.php
@@ -1111,14 +1111,85 @@ class InlineTest extends TestCase
         ];
     }
 
-    public function testParseSingleQuotedTaggedString()
+    #[DataProvider('parseYamlProvider')]
+    public function testParseYaml(string $yaml, mixed $expected)
     {
-        $this->assertSame('foo', Inline::parse("!!str 'foo'"));
+        $this->assertSame($expected, Inline::parse($yaml));
     }
 
-    public function testParseDoubleQuotedTaggedString()
+    public static function parseYamlProvider(): iterable
     {
-        $this->assertSame('foo', Inline::parse('!!str "foo"'));
+        yield 'single quoted tagged string' => ["!!str 'foo'", 'foo'];
+        yield 'double quoted tagged string' => ['!!str "foo"', 'foo'];
+        yield 'plain tagged string' => ['!!str foo', 'foo'];
+        yield 'tagged string from a number' => ['!!str 1', '1'];
+
+        yield 'empty null' => ['!!null', null];
+        yield 'canonical null' => ['!!null null', null];
+        yield 'capitalized null' => ['!!null Null', null];
+        yield 'uppercase null' => ['!!null NULL', null];
+        yield 'tilde null' => ['!!null ~', null];
+        yield 'quoted null' => ['!!null "null"', null];
+
+        yield 'canonical true' => ['!!bool true', true];
+        yield 'capitalized true' => ['!!bool True', true];
+        yield 'uppercase true' => ['!!bool TRUE', true];
+        yield 'canonical false' => ['!!bool false', false];
+        yield 'capitalized false' => ['!!bool False', false];
+        yield 'uppercase false' => ['!!bool FALSE', false];
+        yield 'quoted bool' => ['!!bool "true"', true];
+
+        yield 'int' => ['!!int 1', 1];
+        yield 'quoted int' => ['!!int "1"', 1];
+        yield 'signed int' => ['!!int -42', -42];
+        yield 'explicitly positive int' => ['!!int +42', 42];
+        yield 'octal int' => ['!!int 0o17', 15];
+        yield 'hexadecimal int' => ['!!int 0x1F', 31];
+
+        yield 'float' => ['!!float 0.01', 0.01];
+        yield 'quoted float' => ['!!float "0.01"', 0.01];
+        yield 'float without fractional part' => ['!!float 1', 1.0];
+        yield 'float without integer part' => ['!!float .5', 0.5];
+        yield 'float with exponent' => ['!!float 1.2e3', 1200.0];
+        yield 'positive infinity' => ['!!float .inf', \INF];
+        yield 'negative infinity' => ['!!float -.INF', -\INF];
+    }
+
+    #[DataProvider('parseInvalidTaggedValueProvider')]
+    public function testParseInvalidTaggedValue(string $yaml, string $message)
+    {
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage($message);
+
+        Inline::parse($yaml);
+    }
+
+    public static function parseInvalidTaggedValueProvider(): iterable
+    {
+        // the core schema resolves booleans from "true" and "false" only, not from
+        // the integers or the YAML 1.1 spellings that PHP would happily cast
+        yield 'bool from int' => ['!!bool 1', 'The value "1" is not a valid "!!bool" value'];
+        yield 'bool from negative int' => ['!!bool -1', 'The value "-1" is not a valid "!!bool" value'];
+        yield 'bool from yes' => ['!!bool yes', 'The value "yes" is not a valid "!!bool" value'];
+        yield 'bool from on' => ['!!bool on', 'The value "on" is not a valid "!!bool" value'];
+        yield 'bool with mixed case' => ['!!bool tRue', 'The value "tRue" is not a valid "!!bool" value'];
+
+        yield 'null from a word' => ['!!null foo', 'The value "foo" is not a valid "!!null" value'];
+
+        yield 'int from a word' => ['!!int foo', 'The value "foo" is not a valid "!!int" value'];
+        yield 'int from a float' => ['!!int 1.22', 'The value "1.22" is not a valid "!!int" value'];
+        yield 'int with underscores' => ['!!int 1_000', 'The value "1_000" is not a valid "!!int" value'];
+        yield 'out of range int' => ['!!int 99999999999999999999', 'The integer "99999999999999999999" is out of range'];
+
+        yield 'float from a word' => ['!!float foo', 'The value "foo" is not a valid "!!float" value'];
+        yield 'float from an empty value' => ['!!float ""', 'The value "" is not a valid "!!float" value'];
+
+        yield 'trailing characters after a quoted value' => ['!!int "1" 2', 'Unexpected characters near " 2"'];
+    }
+
+    public function testParseNanTaggedValue()
+    {
+        $this->assertNan(Inline::parse('!!float .NaN'));
     }
 
     public function testParseQuotedReferenceLikeStringsInMapping()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      |  no
| New feature?  | yes
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

Added `!!int, !!null, !!bool` yaml tags support by Yaml specification https://yaml.org/spec/1.2.2/
Also `!!float` tag now support quoted string

Examples:
```
value: !!float "1.22"; 
value: !!int 1; 
value: !!int "1"; 
value: !!null;
value: !!bool 1;
value: !!bool "1";
```

p.s. just after MR merged we also need to exclude these tags from documentation https://github.com/symfony/symfony-docs/blob/8.1/reference/formats/yaml.rst#unsupported-yaml-features