### PR TITLE
[Tui] Fix stop() scrolling the top of the frame off the screen

### DIFF
--- a/src/Symfony/Component/Tui/Tests/TuiTest.php
+++ b/src/Symfony/Component/Tui/Tests/TuiTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Tui\Tests;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Tui\Ansi\AnsiUtils;
 use Symfony\Component\Tui\Event\InputEvent;
@@ -21,6 +22,7 @@ use Symfony\Component\Tui\Input\Keybindings;
 use Symfony\Component\Tui\Render\Renderer;
 use Symfony\Component\Tui\Style\Style;
 use Symfony\Component\Tui\Style\StyleSheet;
+use Symfony\Component\Tui\Terminal\ScreenBuffer;
 use Symfony\Component\Tui\Terminal\VirtualTerminal;
 use Symfony\Component\Tui\Tui;
 use Symfony\Component\Tui\Widget\ContainerWidget;
@@ -302,6 +304,53 @@ class TuiTest extends TestCase
         }
 
         $this->assertSame(0, $headerLineIndex, 'Content should be on the first line by default (top-aligned)');
+    }
+
+    /**
+     * @return iterable<string, array{int, int}>
+     */
+    public static function frameHeightProvider(): iterable
+    {
+        // [terminal rows, rendered lines]
+        yield 'frame shorter than the screen' => [6, 3];
+        yield 'frame one line short of the screen' => [6, 5];
+        yield 'frame filling the screen' => [6, 6];
+    }
+
+    /**
+     * stop() must leave the cursor on the line directly below the frame.
+     * One line further leaves a blank line behind and, once the frame is
+     * tall enough, scrolls the top of it off the screen.
+     */
+    #[DataProvider('frameHeightProvider')]
+    public function testStopLeavesCursorOnTheLineBelowTheFrame(int $rows, int $lines)
+    {
+        $terminal = new VirtualTerminal(40, $rows);
+        $tui = new Tui(terminal: $terminal);
+        for ($i = 1; $i <= $lines; ++$i) {
+            $tui->add(new TextWidget("line $i"));
+        }
+
+        $tui->start();
+        $tui->processRender();
+        $tui->stop();
+
+        $screen = new ScreenBuffer(40, $rows);
+        $screen->write($terminal->getOutput());
+        // Stands in for the shell prompt printed once the process exits
+        $screen->write('PROMPT');
+
+        $screenLines = array_map(rtrim(...), explode("\n", $screen->getScreen()));
+
+        // The frame and the prompt need $lines + 1 rows, so a frame filling the
+        // screen legitimately scrolls by one line — but never by more than that
+        $scrolled = max(0, $lines + 1 - $rows);
+
+        for ($i = $scrolled + 1; $i <= $lines; ++$i) {
+            $this->assertSame("line $i", $screenLines[$i - 1 - $scrolled]);
+        }
+
+        $this->assertSame('PROMPT', $screenLines[$lines - $scrolled], 'The prompt should follow the frame without a blank line in between');
     }
 
     public function testSimulateResizeTriggersRender()

--- a/src/Symfony/Component/Tui/Tui.php
+++ b/src/Symfony/Component/Tui/Tui.php
@@ -276,7 +276,8 @@ class Tui implements RenderRequestorInterface, TickRuntimeInterface
         // Move cursor to end of content
         $state = $this->screenWriter->getState();
         if ($state['line_count'] > 0) {
-            $lineDiff = $state['line_count'] - $state['cursor_row'];
+            // cursor_row is a zero-based index, line_count a count
+            $lineDiff = $state['line_count'] - 1 - $state['cursor_row'];
 
             if ($lineDiff > 0) {
                 $this->terminal->write("\x1b[{$lineDiff}B");


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        |
| License       | MIT

`Tui::stop()` moves the cursor one line further down than it should, so every application leaves a blank line behind on exit, and a tall enough frame loses its top line to scrolling even when it would have fit.

`ScreenWriter::getState()` returns `line_count` as a count and `cursor_row` as a zero-based index, so `line_count - cursor_row` already puts the cursor on the line below the last rendered one. The `\r\n` written right after moves it down once more.

Rendering five lines in a six-row terminal shows it: the frame plus the shell prompt needs six rows and has exactly six, but the first line is gone anyway.

    before      after
    line 2      line 1     <- line 1 is missing before the fix
    line 3      line 2
    line 4      line 3
    line 5      line 4
                line 5
    $           $

A frame that fills the whole screen still scrolls by one line, which is correct: the frame and the prompt together need one row more than the terminal has. The test covers that case separately so the fix cannot overcorrect.

I found this while taking terminal screenshots of an application built on the component, and spent a while blaming my own widget before the same one-line shift showed up with a plain `TextWidget`.

One thing I left alone: with `cursorRow` set to `max(0, count - 1)`, I cannot see how `$lineDiff` ends up negative, so the `elseif` branch looks unreachable both before and after this change. It seemed out of scope here, but I might be misreading it.