### PR TITLE
[Tui] Treat a zero terminal size as unknown

### DIFF
--- a/src/Symfony/Component/Tui/Terminal/Terminal.php
+++ b/src/Symfony/Component/Tui/Terminal/Terminal.php
@@ -164,7 +164,7 @@ final class Terminal implements TerminalInterface
             $this->refreshDimensions();
         }
 
-        return $this->cachedColumns ?? 80;
+        return $this->cachedColumns ?: 80;
     }
 
     public function getRows(): int
@@ -173,7 +173,7 @@ final class Terminal implements TerminalInterface
             $this->refreshDimensions();
         }
 
-        return $this->cachedRows ?? 24;
+        return $this->cachedRows ?: 24;
     }
 
     public function isKittyProtocolActive(): bool

--- a/src/Symfony/Component/Tui/Tests/Terminal/TerminalTest.php
+++ b/src/Symfony/Component/Tui/Tests/Terminal/TerminalTest.php
@@ -59,4 +59,29 @@ class TerminalTest extends TestCase
         $this->assertFileExists($marker);
         @unlink($marker);
     }
+
+    /**
+     * A pseudo-terminal whose window size was never set makes "stty size"
+     * report "0 0". A zero size means the size is unknown, not that the
+     * terminal is zero cells wide.
+     */
+    public function testZeroDimensionsFallBackToTheDefaultSize()
+    {
+        $terminal = new Terminal();
+        $columns = new \ReflectionProperty($terminal, 'cachedColumns');
+        $rows = new \ReflectionProperty($terminal, 'cachedRows');
+
+        $columns->setValue($terminal, 0);
+        $rows->setValue($terminal, 0);
+
+        $this->assertSame(80, $terminal->getColumns());
+        $this->assertSame(24, $terminal->getRows());
+
+        // Only zero is special-cased: a reported size is returned as is
+        $columns->setValue($terminal, 120);
+        $rows->setValue($terminal, 40);
+
+        $this->assertSame(120, $terminal->getColumns());
+        $this->assertSame(40, $terminal->getRows());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        |
| License       | MIT

An application dies with an uncaught `RenderException` when the terminal reports a width of zero:

    PHP Fatal error:  Uncaught Symfony\Component\Tui\Exception\RenderException:
    Widget "Symfony\Component\Tui\Widget\ContainerWidget" rendered line 0 with
    width 1, exceeding the available 0 columns.
      .../Render/Renderer.php:176
    #1 .../Tui.php(475): Symfony\Component\Tui\Render\Renderer->render(..., 0, 0)

A pseudo-terminal whose window size was never set reports `0 0` for `stty size`, and `Terminal::refreshDimensions()` accepts that as a real size. From there `computeInnerDimensions()` floors the content area at one column, and the width check rejects that single column against the zero columns available. This is not exotic: wrappers around `pty.fork()`, some CI harnesses and screenshot scripts all leave the window size unset.

`Console\Terminal` already treats a zero as "size unknown" and falls back:

    return self::$width ?: 80;

The Tui terminal does the same fallback but with `??`, so a zero passes through. Changing the two getters to `?:` lines it up. `cachedColumns` and `cachedRows` are read only by these two getters, so nothing else needs to change, and 80x24 are the numbers the class already falls back to when `stty` fails outright.

Before, on a pty with no window size, the process exits 255 with the trace above. After, it renders at 80x24 and exits 0.

One wart worth naming: `getColumns()` now returns 80 while `cachedColumns` stays 0. Nothing outside the getters reads those properties today, so it is invisible, but rejecting the zeros while parsing `stty` output would be tidier. I did not go that way because the parser is private and inlined, and pulling it out only to make it testable felt like more surgery than the bug deserves. Happy to do it that way if you prefer.