### PR TITLE
[HttpKernel] Fix undefined variable when locking the container build fails early

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -436,6 +436,8 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
 
         $oldContainer = \is_object($this->container) ? new \ReflectionClass($this->container) : $this->container = null;
 
+        $lock = null;
+
         try {
             is_dir($buildDir) ?: mkdir($buildDir, 0o777, true);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

In `Kernel::initializeContainer()`, if a `Throwable` is thrown before `$lock = fopen($cachePath.'.lock', 'w+')` is assigned (e.g. an error handler that turns the `mkdir()` warning into an exception during a directory creation race, or a throwing stream wrapper), the `catch (\Throwable $e)` block swallows it and the container is built without the lock.

When execution later reaches `if ($lock)`, PHP emits an "Undefined variable $lock" warning ... and if the application converts warnings into exceptions, kernel boot fails right after the container was successfully dumped.

This PR initializes `$lock` to `null` before the `try` block to fix that undefined variable error.