### PR TITLE
[DependencyInjection] Fix class-level tag attributes being overridden by interface-level ones

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveInstanceofConditionalsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveInstanceofConditionalsPass.php
@@ -120,6 +120,16 @@ class ResolveInstanceofConditionalsPass implements CompilerPassInterface
                 $definition->setShared($shared);
             }
 
+            // Tags are added from the most specific type to the least specific one
+            if (1 < \count($instanceofTags)) {
+                $depths = [];
+                foreach ($instanceofTags as [$interface]) {
+                    $depths[$interface] ??= \count(class_parents($interface) ?: []) + \count(class_implements($interface) ?: []);
+                }
+                uasort($instanceofTags, static fn ($a, $b) => $depths[$a[0]] <=> $depths[$b[0]]);
+                $instanceofTags = array_values($instanceofTags);
+            }
+
             // Don't add tags to service decorators
             $i = \count($instanceofTags);
             while (0 <= --$i) {

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveInstanceofConditionalsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveInstanceofConditionalsPassTest.php
@@ -22,6 +22,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\TypedReference;
 use Symfony\Contracts\Service\ResetInterface;
 use Symfony\Contracts\Service\ServiceSubscriberInterface;
 
@@ -136,6 +137,32 @@ class ResolveInstanceofConditionalsPassTest extends TestCase
         $this->assertEquals('locally_set_factory', $def->getFactory());
         // tags are merged, the locally set one is first
         $this->assertSame(['local_instanceof_tag' => [[]], 'autoconfigured_tag' => [[]]], $def->getTags());
+    }
+
+    public function testAutoconfigurationOfTheClassWinsOverTheInheritedOne()
+    {
+        $container = new ContainerBuilder();
+        $container->register('normal_service', self::class)->setAutoconfigured(true);
+        $container->registerForAutoconfiguration(self::class)->addTag('some_tag', ['priority' => 100]);
+        $container->registerForAutoconfiguration(parent::class)->addTag('some_tag');
+
+        (new ResolveInstanceofConditionalsPass())->process($container);
+
+        $this->assertSame([['priority' => 100], []], $container->getDefinition('normal_service')->getTag('some_tag'));
+    }
+
+    public function testAutoconfiguredTagsAreOrderedFromTheMostSpecificType()
+    {
+        $container = new ContainerBuilder();
+        $container->register('normal_service', TypedReference::class)->setAutoconfigured(true);
+        $container->registerForAutoconfiguration(Reference::class)->addTag('some_tag', ['from' => 'parent']);
+        $container->registerForAutoconfiguration(\Stringable::class)->addTag('some_tag', ['from' => 'interface']);
+        $container->registerForAutoconfiguration(TypedReference::class)->addTag('some_tag', ['from' => 'class']);
+
+        (new ResolveInstanceofConditionalsPass())->process($container);
+
+        $expected = [['from' => 'class'], ['from' => 'parent'], ['from' => 'interface']];
+        $this->assertSame($expected, $container->getDefinition('normal_service')->getTag('some_tag'));
     }
 
     public function testAutoconfigureInstanceofDoesNotDuplicateTags()

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/PrototypeTaggedPriority/FirstHandler.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/PrototypeTaggedPriority/FirstHandler.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeTaggedPriority;
+
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+#[AutoconfigureTag('app.handler', ['priority' => 10])]
+class FirstHandler implements TaggedHandlerInterface
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/PrototypeTaggedPriority/SecondHandler.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/PrototypeTaggedPriority/SecondHandler.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeTaggedPriority;
+
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+#[AutoconfigureTag('app.handler', ['priority' => 100])]
+class SecondHandler implements TaggedHandlerInterface
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/PrototypeTaggedPriority/TaggedHandlerInterface.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/PrototypeTaggedPriority/TaggedHandlerInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeTaggedPriority;
+
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+#[AutoconfigureTag('app.handler')]
+interface TaggedHandlerInterface
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/FileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/FileLoaderTest.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Loader\LoaderResolver;
 use Symfony\Component\DependencyInjection\Alias;
+use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\RegisterAutoconfigureAttributesPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -48,6 +49,8 @@ use Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeAsAlias\WithAs
 use Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeAsAlias\WithAsAliasProdEnv;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeAsAlias\WithCustomAsAlias;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeAutoconfigure\AutoconfiguredService;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeTaggedPriority\FirstHandler;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeTaggedPriority\SecondHandler;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\Utils\NotAService;
 
 class FileLoaderTest extends TestCase
@@ -247,6 +250,29 @@ class FileLoaderTest extends TestCase
 
         $this->assertCount(1, $container->getDefinition(AutoconfiguredService::class)->getMethodCalls());
         $this->assertSame(['from_interface'], $container->get(AutoconfiguredService::class)->calls);
+    }
+
+    public function testRegisterClassesKeepsTagAttributesFromTheClassOverThoseFromTheInterface()
+    {
+        $container = new ContainerBuilder();
+        $loader = new TestFileLoader($container, new FileLocator(self::$fixturesPath.'/Fixtures'));
+
+        $loader->registerClasses(
+            (new Definition())->setAutoconfigured(true)->setPublic(true),
+            'Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeTaggedPriority\\',
+            'PrototypeTaggedPriority/*'
+        );
+        $container->register('handlers', \ArrayObject::class)
+            ->setPublic(true)
+            ->addArgument(new TaggedIteratorArgument('app.handler'));
+
+        $container->compile();
+
+        $this->assertSame([['priority' => 10], []], $container->getDefinition(FirstHandler::class)->getTag('app.handler'));
+        $this->assertSame([['priority' => 100], []], $container->getDefinition(SecondHandler::class)->getTag('app.handler'));
+
+        $handlers = array_map(strval(...), $container->getDefinition('handlers')->getArgument(0)->getValues());
+        $this->assertSame([SecondHandler::class, FirstHandler::class], $handlers);
     }
 
     public function testMissingParentClass()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65246
| License       | MIT

When the same tag is declared on several types a service matches, the declaration on the most specific type now wins, whatever order the autoconfigurations were registered in.

`ResolveInstanceofConditionalsPass` merges the tags of every matching `_instanceof` conditional into the definition. It walks the conditionals backwards, so the one processed last ends up first in the tag list. For a plain tagged iterator, `PriorityTaggedServiceTrait` stops at the first entry, so that entry alone decides the priority. Until now the conditionals were processed in the order they had been registered, so the winning declaration depended on registration order instead of on specificity.

With `#[AutoconfigureTag('app.handler')]` on an interface and `#[AutoconfigureTag('app.handler', ['priority' => 100])]` on a class implementing it, this dropped the priority and the tagged iterator came back unsorted, with nothing failing or warning. Iterators that index their services are not affected: they read every tag entry, so the highest priority wins there whatever the order.

#65120 made this reachable through PSR-4 discovery: attributes on discovered interfaces are now read by the compiler pass, in definition order, so the interface is no longer guaranteed to be registered before the classes implementing it. The flaw itself is older and can be reached on any branch by calling `registerForAutoconfiguration()` for a class before calling it for one of its interfaces.

This PR sorts the merged tags by the number of ancestors of the type that declared them. That is a linear extension of the inheritance order, so the tags of a subtype always come before those of its supertypes, and unrelated types keep registration order. Only tags are reordered. The parent chain, the bindings, the `shared` flag and the configured method calls also give authority to the conditional processed last, so ordering the conditionals themselves would be more thorough, but that reorders configured method calls and does not belong in a patch release.
