### PR TITLE
[DependencyInjection] Keep class-level tag priority over interface-level #[AutoconfigureTag]

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveInstanceofConditionalsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveInstanceofConditionalsPass.php
@@ -120,6 +120,13 @@ class ResolveInstanceofConditionalsPass implements CompilerPassInterface
                 $definition->setShared($shared);
             }
 
+            // Tags declared on the concrete class take precedence over the same tags
+            // inherited from an interface/parent (e.g. a class-level tag "priority" must
+            // win over a priority-less interface declaration). Since the loop below merges
+            // tags in reverse and the first-merged attributes win, apply the class-level
+            // conditional last so its ordering is not left to registration order.
+            usort($instanceofTags, static fn ($a, $b) => ($a[0] === $class) <=> ($b[0] === $class));
+
             // Don't add tags to service decorators
             $i = \count($instanceofTags);
             while (0 <= --$i) {

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/PrototypeTagPriority/Collector.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/PrototypeTagPriority/Collector.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeTagPriority;
+
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
+
+final class Collector
+{
+    public function __construct(
+        #[AutowireIterator('app.handler')] private iterable $handlers,
+    ) {
+    }
+
+    public function order(): array
+    {
+        return array_map(static fn (HandlerInterface $h) => $h->name(), iterator_to_array($this->handlers, false));
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/PrototypeTagPriority/FirstHandler.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/PrototypeTagPriority/FirstHandler.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeTagPriority;
+
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+#[AutoconfigureTag(name: 'app.handler', attributes: ['priority' => 100])]
+final class FirstHandler implements HandlerInterface
+{
+    public function name(): string
+    {
+        return 'first';
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/PrototypeTagPriority/HandlerInterface.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/PrototypeTagPriority/HandlerInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeTagPriority;
+
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+#[AutoconfigureTag(name: 'app.handler')]
+interface HandlerInterface
+{
+    public function name(): string;
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/PrototypeTagPriority/SecondHandler.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/PrototypeTagPriority/SecondHandler.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeTagPriority;
+
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+#[AutoconfigureTag(name: 'app.handler', attributes: ['priority' => 50])]
+final class SecondHandler implements HandlerInterface
+{
+    public function name(): string
+    {
+        return 'second';
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/PrototypeTagPriority/ThirdHandler.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/PrototypeTagPriority/ThirdHandler.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeTagPriority;
+
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+
+#[AutoconfigureTag(name: 'app.handler', attributes: ['priority' => 10])]
+final class ThirdHandler implements HandlerInterface
+{
+    public function name(): string
+    {
+        return 'third';
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/FileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/FileLoaderTest.php
@@ -48,6 +48,7 @@ use Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeAsAlias\WithAs
 use Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeAsAlias\WithAsAliasProdEnv;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeAsAlias\WithCustomAsAlias;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeAutoconfigure\AutoconfiguredService;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeTagPriority\Collector;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\Utils\NotAService;
 
 class FileLoaderTest extends TestCase
@@ -247,6 +248,22 @@ class FileLoaderTest extends TestCase
 
         $this->assertCount(1, $container->getDefinition(AutoconfiguredService::class)->getMethodCalls());
         $this->assertSame(['from_interface'], $container->get(AutoconfiguredService::class)->calls);
+    }
+
+    public function testRegisterClassesKeepsClassLevelTagPriorityOverInterfaceDeclaration()
+    {
+        $container = new ContainerBuilder();
+        $loader = new TestFileLoader($container, new FileLocator(self::$fixturesPath.'/Fixtures'));
+
+        $loader->registerClasses(
+            (new Definition())->setAutoconfigured(true)->setAutowired(true)->setPublic(true),
+            'Symfony\Component\DependencyInjection\Tests\Fixtures\PrototypeTagPriority\\',
+            'PrototypeTagPriority/*'
+        );
+
+        $container->compile();
+
+        $this->assertSame(['first', 'second', 'third'], $container->get(Collector::class)->order());
     }
 
     public function testMissingParentClass()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65246
| License       | MIT

Regression since 7.4.16 / 8.1.4: when the same tag is declared **both** on an interface via `#[AutoconfigureTag('app.handler')]` (so implementations are tagged automatically) **and** on the implementing classes with a `priority` attribute, the class-level priority is silently ignored. A tagged iterator then comes back unsorted.

### Reproduces with

Given an interface `#[AutoconfigureTag('app.handler')]` and three implementations tagged `#[AutoconfigureTag('app.handler', attributes: ['priority' => 100 | 50 | 10])]`, an `#[AutowireIterator('app.handler')]` yields:

| version | order |
|---|---|
| 7.4.15 | first (100), second (50), third (10) |
| **7.4.16** | **second (50), third (10), first (100)** |

### Root cause

#65120 removed the eager `$autoconfigureAttributes?->processClass(...)` call for abstract/interface types in `FileLoader::registerClasses()`, deferring the interface's `#[AutoconfigureTag]` registration to `RegisterAutoconfigureAttributesPass`. This changed the **relative registration order** of the interface's instanceof vs the class's instanceof in `getAutoconfiguredInstanceof()`.

In `ResolveInstanceofConditionalsPass::processDefinition()` the tags from every matching instanceof conditional (interface + concrete class) are merged into the service. The merge loop iterates `$instanceofTags` in reverse and `addTag()` appends, so the first-merged tag instance ends up at attribute index `0`. `PriorityTaggedServiceTrait::findAndSortTaggedServices()` (no-index path) uses `continue 2` and reads only `attributes[0]` to determine a service's priority. So whichever instanceof source is merged first wins — and after #65120 that could be the priority-less interface declaration, depending on registration order.

### Fix

Apply the concrete class's own conditional last so its tags are merged first and win at index `0`, independently of registration order. This makes the concrete class take precedence over the same tag inherited from an interface/parent — restoring the pre-7.4.16 behavior and matching the usual most-specific-wins semantics. Only tag ordering is affected: method calls and bindings are collected in a separate loop that is untouched.

### Test verification (RED → GREEN)

New test `FileLoaderTest::testRegisterClassesKeepsClassLevelTagPriorityOverInterfaceDeclaration` builds the exact scenario end-to-end (interface tag + class-level priorities, `AutowireIterator`, `compile()`) and asserts `['first', 'second', 'third']`.

RED — on unmodified 7.4, before the fix:

```
1) Symfony\Component\DependencyInjection\Tests\Loader\FileLoaderTest::testRegisterClassesKeepsClassLevelTagPriorityOverInterfaceDeclaration
Failed asserting that two arrays are identical.
--- Expected
+++ Actual
@@ @@
 Array &0 [
-    0 => 'first',
-    1 => 'second',
-    2 => 'third',
+    0 => 'second',
+    1 => 'third',
+    2 => 'first',
 ]
```

GREEN — with the fix:

```
OK (1 test, 1 assertion)
```

Full `DependencyInjection` suite stays iso-baseline (`Tests: 1717`, no new failures).
