### PR TITLE
[HttpFoundation] Combine trusted host patterns into a single regexp

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -217,6 +217,8 @@ class Request
 
     private static int $trustedHeaderSet = -1;
 
+    private static ?string $trustedHostsRegexp = null;
+
     private const FORWARDED_PARAMS = [
         self::HEADER_X_FORWARDED_FOR => 'for',
         self::HEADER_X_FORWARDED_HOST => 'host',
@@ -658,8 +660,8 @@ class Request
     public static function setTrustedHosts(array $hostPatterns)
     {
         self::$trustedHostPatterns = array_map(static fn ($hostPattern) => \sprintf('{%s}i', $hostPattern), $hostPatterns);
-        // we need to reset trusted hosts on trusted host patterns change
-        self::$trustedHosts = [];
+        // the branch reset group keeps capturing groups, back references and inline modifiers local to each pattern
+        self::$trustedHostsRegexp = $hostPatterns ? \sprintf('{(?|(?:%s))}i', implode(')|(?:', $hostPatterns)) : null;
     }
 
     /**
@@ -1176,19 +1178,11 @@ class Request
             throw new SuspiciousOperationException(\sprintf('Invalid Host "%s".', $host));
         }
 
-        if (\count(self::$trustedHostPatterns) > 0) {
+        if (self::$trustedHostsRegexp) {
             // to avoid host header injection attacks, you should provide a list of trusted host patterns
 
-            if (\in_array($host, self::$trustedHosts)) {
+            if (preg_match(self::$trustedHostsRegexp, $host)) {
                 return $host;
-            }
-
-            foreach (self::$trustedHostPatterns as $pattern) {
-                if (preg_match($pattern, $host)) {
-                    self::$trustedHosts[] = $host;
-
-                    return $host;
-                }
             }
 
             if (!$this->isHostValid) {

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -2240,6 +2240,28 @@ class RequestTest extends TestCase
         $this->assertSame('localhost', $request->getHost());
     }
 
+    public function testSetTrustedHostsKeepsPatternsIndependent()
+    {
+        Request::setTrustedHosts(['^(a)\.example\.com$', '^(b)\.\1\.example\.com$']);
+
+        $request = Request::create('/');
+        $request->headers->set('host', 'b.b.example.com');
+        $this->assertSame('b.b.example.com', $request->getHost());
+    }
+
+    public function testTrustedHostsAreNotAccumulated()
+    {
+        Request::setTrustedHosts(['^[a-z]+\.example\.com$']);
+
+        $request = Request::create('/');
+        $request->headers->set('host', 'a.example.com');
+        $this->assertSame('a.example.com', $request->getHost());
+        $request->headers->set('host', 'b.example.com');
+        $this->assertSame('b.example.com', $request->getHost());
+
+        $this->assertSame([], (new \ReflectionProperty(Request::class, 'trustedHosts'))->getValue());
+    }
+
     public function testFactory()
     {
         Request::setFactory(static fn (array $query = [], array $request = [], array $attributes = [], array $cookies = [], array $files = [], array $server = [], $content = null) => new NewRequest());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65247
| License       | MIT

`Request::setTrustedHosts()` takes a list of regexps. Until now, `Request::getHost()` looped over them one by one and remembered in a static list every host that matched, so that the next request for the same host could skip the regexps and hit an `in_array()` fast path instead.

Nothing ever removes entries from that list except a new call to `setTrustedHosts()`. Under FPM the process dies at the end of the request, but in long-running runtimes (FrankenPHP worker mode, RoadRunner, Swoole, Workerman) the kernel is booted once and the list keeps one entry per distinct host any client ever sent. With a wildcard pattern such as `^.+\.example\.com$`, anyone can make it grow by sending `a1.example.com`, `a2.example.com`, and so on: memory grows without bound, and the `in_array()` fast path degrades into a linear scan run on every request.

This PR combines the patterns into a single regexp when they are set, and replaces the loop plus the memoization by one `preg_match()`. The memoization is not replaced by a bounded cache because it was a pessimization to begin with: scanning a list of strings is slower than matching one regexp, even when the list is empty.

Cost of the trusted host check in `getHost()`, 3 patterns, host not in the list yet:

| hosts memoized | before | after |
| --- | --- | --- |
| 0 | 0.32 µs | 0.17 µs |
| 100 | 0.88 µs | 0.13 µs |
| 1 000 | 4.29 µs | 0.13 µs |
| 10 000 | 45.19 µs | 0.11 µs |

Patterns are combined as `{(?|(?:p1)|(?:p2))}i`. The branch reset group `(?|` restarts capturing group numbering in each alternative, so back references keep pointing at the group of their own pattern and two patterns may declare the same named group; the `(?:` wrappers keep inline modifiers such as `(?s)` local to the pattern that sets them. Without them, patterns that work today would silently stop matching, or fail to compile and reject every host.

`Request::getTrustedHosts()` still returns the list of individual patterns, unchanged.

The now unused `Request::$trustedHosts` property is left in place because it is `protected`, so removing it would be a BC break. It can be removed on the feature branch. For the same reason, note that assigning the `$trustedHostPatterns` property directly instead of calling `setTrustedHosts()` no longer enables the check.
