### PR TITLE
[HttpFoundation] Deprecate the unused `Request::$trustedHosts` property

### DIFF
--- a/UPGRADE-8.2.md
+++ b/UPGRADE-8.2.md
@@ -50,6 +50,10 @@ HttpFoundation
 --------------
 
  * Add argument `$version` to `UriSigner::sign()`, `UriSigner::check()`, `UriSigner::checkRequest()`, and `UriSigner::verify()`
+ * Deprecate the `Request::$trustedHosts` property, it is never populated anymore since trusted hosts are
+   matched against a single combined regexp, and will be removed in 9.0. Populating it makes `getHost()`
+   trigger a deprecation; reading it is not reported, since PHP provides no way to intercept access to a
+   static property
 
 Lock
 ----

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Add argument `$version` to `UriSigner::sign()`, `UriSigner::check()`, `UriSigner::checkRequest()`, and `UriSigner::verify()` to bind a signed URI to a state token, folded into the signature
  * Add `ParameterBag::filterCallback()` to filter a parameter value through a callback
  * Reject a `Cookie` whose name uses the `__Secure-`/`__Host-` prefix when its attributes break the prefix contract
+ * Deprecate the `Request::$trustedHosts` property, it is never populated anymore
 
 8.1
 ---

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -246,6 +246,8 @@ class Request
 
     /**
      * @var string[]
+     *
+     * @deprecated since Symfony 8.2, this property is never populated anymore
      */
     protected static array $trustedHosts = [];
 
@@ -1197,6 +1199,10 @@ class Request
 
         if (self::$trustedHostsRegexp) {
             // to avoid host header injection attacks, you should provide a list of trusted host patterns
+
+            if (self::$trustedHosts) {
+                trigger_deprecation('symfony/http-foundation', '8.2', 'Populating the "%s::$trustedHosts" property is deprecated; it has no effect anymore.', self::class);
+            }
 
             if (preg_match(self::$trustedHostsRegexp, $host)) {
                 return $host;

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -39,7 +39,10 @@ class RequestTest extends TestCase
         Request::setTrustedHosts([]);
         Request::setAllowedHttpMethodOverride(null);
         Request::setFactory(null);
-        \Closure::bind(static fn () => self::$formats = null, null, Request::class)();
+        \Closure::bind(static function () {
+            self::$formats = null;
+            self::$trustedHosts = [];
+        }, null, Request::class)();
     }
 
     public function testInitialize()
@@ -3064,6 +3067,21 @@ b'])]
         $this->expectUserDeprecationMessage('Since symfony/http-foundation 8.1: Directly setting property "query" of "Symfony\Component\HttpFoundation\Tests\NewRequest" is deprecated; pass query parameters as a constructor argument or call "initialize()" instead.');
 
         $request->query = new InputBag(['k' => 'v']);
+    }
+
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
+    public function testPopulatingTrustedHostsIsDeprecated()
+    {
+        Request::setTrustedHosts(['^trusted\.com$']);
+        \Closure::bind(static fn () => self::$trustedHosts = ['untrusted.com'], null, Request::class)();
+
+        $request = Request::create('/');
+        $request->headers->set('host', 'trusted.com');
+
+        $this->expectUserDeprecationMessage('Since symfony/http-foundation 8.2: Populating the "Symfony\Component\HttpFoundation\Request::$trustedHosts" property is deprecated; it has no effect anymore.');
+
+        $this->assertSame('trusted.com', $request->getHost());
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Issues        | -
| License       | MIT

Since #65252, trusted hosts are matched against a single combined regexp, so `Request::$trustedHosts` is never populated nor read anymore. Code reading it gets an empty array, code writing to it has no effect. This deprecates the property, for removal in 9.0.

PHP offers no way to intercept access to a static property, so there is no direct equivalent of the property hooks that 8.1 used to deprecate direct writes to the public properties of `Request`:

 * `__get()`/`__set()` cover instance properties only, and there is no `__getStatic()`/`__setStatic()`;
 * property hooks are rejected on static properties, `Cannot declare hooks for static property`;
 * `#[\Deprecated]` does not target properties, `allowed targets: class, function, method, class constant, constant`.

What can still be reported is the case that actually changed behavior: code that populates the property. Since nothing populates it internally anymore, a non-empty value can only come from the outside, so `getHost()` triggers the deprecation when it finds one, at the point where the property used to be read:

```php
if (self::$trustedHosts) {
    trigger_deprecation('symfony/http-foundation', '8.2', 'Populating the "%s::$trustedHosts" property is deprecated; it has no effect anymore.', self::class);
}
```

Reading the property stays silent, and is covered by the `@deprecated` annotation that IDEs and static analysers report, together with the CHANGELOG and UPGRADE entries.
