### PR TITLE
[Tui] Fix stdin framing and key id decoding

### DIFF
--- a/src/Symfony/Component/Tui/Input/KeyParser.php
+++ b/src/Symfony/Component/Tui/Input/KeyParser.php
@@ -226,11 +226,13 @@ final class KeyParser
         $key = $parsed['key'];
         $modifiers = [];
 
-        if (str_contains($key, '+')) {
+        if (str_ends_with($key, '++')) {
+            // The '+' key behind modifiers, so only the modifiers are split off
+            $modifiers = explode('+', substr($key, 0, -2));
+        } elseif ('+' !== $key && str_contains($key, '+')) {
             $parts = explode('+', $key);
-            $keyPart = array_pop($parts);
+            array_pop($parts);
             $modifiers = $parts;
-            $key = $parts ? implode('+', $parts).'+'.$keyPart : $keyPart;
         }
 
         return [
@@ -287,7 +289,9 @@ final class KeyParser
         ) {
             $kitty = $this->parseKittySequence($data);
             if (null !== $kitty && null !== $keyName = $this->keyNameFromCodepoint($kitty['codepoint'])) {
-                $mods = $this->modsFromFlags($kitty['modifier']);
+                if (null === $mods = $this->modsFromFlags($kitty['modifier'])) {
+                    return null;
+                }
                 $key = $mods ? implode('+', $mods).'+'.$keyName : $keyName;
 
                 return ['key' => $key, 'event_type' => $kitty['event_type']];
@@ -504,12 +508,15 @@ final class KeyParser
     }
 
     /**
-     * @return string[]
+     * @return string[]|null Null when a modifier is set that has no key id
      */
-    private function modsFromFlags(int $modifier): array
+    private function modsFromFlags(int $modifier): ?array
     {
         $mods = [];
         $effective = $modifier & ~self::LOCK_MASK;
+        if ($effective & ~(self::MOD_SHIFT | self::MOD_ALT | self::MOD_CTRL)) {
+            return null;
+        }
         if ($effective & self::MOD_SHIFT) {
             $mods[] = 'shift';
         }
@@ -831,7 +838,9 @@ final class KeyParser
             }
 
             if ($shift && !$ctrl && !$alt) {
-                if (strtoupper($key) === $data) {
+                // Only letters have a layout independent shifted byte; the
+                // shifted form of a digit or a symbol depends on the layout.
+                if ($key >= 'a' && $key <= 'z' && strtoupper($key) === $data) {
                     return true;
                 }
 
@@ -937,15 +946,16 @@ final class KeyParser
      */
     private function parseKeyId(string $keyId): ?array
     {
-        // Special case: the '+' key itself
-        if ('+' === $keyId) {
-            return ['key' => '+', 'ctrl' => false, 'shift' => false, 'alt' => false];
-        }
-
-        $parts = explode('+', strtolower($keyId));
-        $key = $parts[\count($parts) - 1] ?? '';
-        if ('' === $key) {
-            return null;
+        // Special case: the '+' key itself, alone or behind modifiers
+        if ('+' === $keyId || str_ends_with($keyId, '++')) {
+            $key = '+';
+            $parts = '+' === $keyId ? [] : explode('+', strtolower(substr($keyId, 0, -2)));
+        } else {
+            $parts = explode('+', strtolower($keyId));
+            $key = $parts[\count($parts) - 1] ?? '';
+            if ('' === $key) {
+                return null;
+            }
         }
 
         return [

--- a/src/Symfony/Component/Tui/Input/StdinBuffer.php
+++ b/src/Symfony/Component/Tui/Input/StdinBuffer.php
@@ -77,8 +77,10 @@ final class StdinBuffer
         $this->buffer .= $data;
 
         while ('' !== $this->buffer) {
-            // Check for bracketed paste start
-            if (str_starts_with($this->buffer, "\x1b[200~")) {
+            // Check for bracketed paste start. While a paste is running the
+            // marker is content, not a new paste: the end marker is the only
+            // thing that closes it.
+            if (!$this->inPaste && str_starts_with($this->buffer, "\x1b[200~")) {
                 $this->inPaste = true;
                 $this->pasteBuffer = '';
                 $this->buffer = substr($this->buffer, 6);
@@ -97,7 +99,24 @@ final class StdinBuffer
                     }
                     $this->pasteBuffer = '';
                 } else {
-                    // Still waiting for end marker
+                    // Still waiting for the end marker. A read can split it, so
+                    // hold back a trailing part of it instead of moving it into
+                    // the content, where it can no longer close the paste.
+                    $hold = 0;
+                    for ($n = min(5, \strlen($this->buffer)); $n > 0; --$n) {
+                        if (str_starts_with("\x1b[201~", substr($this->buffer, -$n))) {
+                            $hold = $n;
+                            break;
+                        }
+                    }
+
+                    if (0 < $hold) {
+                        $this->pasteBuffer .= substr($this->buffer, 0, -$hold);
+                        $this->buffer = substr($this->buffer, -$hold);
+
+                        break;
+                    }
+
                     $this->pasteBuffer .= $this->buffer;
                     $this->buffer = '';
 
@@ -285,15 +304,6 @@ final class StdinBuffer
             // CSI terminators: @ through ~
             if ($char >= '@' && $char <= '~') {
                 $sequence = substr($this->buffer, 0, $i + 1);
-                $payload = substr($this->buffer, 2, $i - 1);
-
-                // Special handling for SGR mouse sequences ESC[<B;X;Ym or ESC[<B;X;YM
-                if (str_starts_with($payload, '<')) {
-                    if (!preg_match('/^<\d+;\d+;\d+[Mm]$/', $payload)) {
-                        return null;
-                    }
-                }
-
                 $this->buffer = substr($this->buffer, $i + 1);
 
                 return $sequence;

--- a/src/Symfony/Component/Tui/Tests/Input/KeyParserTest.php
+++ b/src/Symfony/Component/Tui/Tests/Input/KeyParserTest.php
@@ -228,4 +228,66 @@ class KeyParserTest extends TestCase
         $result = $this->parser->parse("\x1b[122::119;5u");
         $this->assertSame('ctrl+z', $result['key']);
     }
+
+    public function testShiftedDigitsAndSymbolsDoNotMatchTheUnshiftedKey()
+    {
+        $this->assertFalse($this->parser->matches('1', 'shift+1'));
+        $this->assertFalse($this->parser->matches('-', 'shift+-'));
+        $this->assertFalse($this->parser->matches('/', 'shift+/'));
+    }
+
+    public function testShiftedLettersStillMatchTheUppercaseByte()
+    {
+        $this->assertTrue($this->parser->matches('A', 'shift+a'));
+        $this->assertFalse($this->parser->matches('a', 'shift+a'));
+    }
+
+    public function testUnnameableModifierIsNotReportedAsAnUnmodifiedKey()
+    {
+        $this->parser->setKittyProtocolActive(true);
+
+        // Modifier value 9 means the super bit is set, which has no key id.
+        $this->assertNull($this->parser->parse("\x1b[97;9u"));
+        $this->assertFalse($this->parser->matches("\x1b[97;9u", 'a'));
+    }
+
+    public function testLockModifiersAreStillIgnored()
+    {
+        $this->parser->setKittyProtocolActive(true);
+
+        // Caps Lock (64) and Num Lock (128) are reported but carry no key id.
+        $result = $this->parser->parse("\x1b[97;65u");
+        $this->assertSame('a', $result['key']);
+        $this->assertSame([], $result['modifiers']);
+    }
+
+    public function testPlusKeyIsReportedWithoutModifiers()
+    {
+        $result = $this->parser->parse('+');
+
+        $this->assertSame('+', $result['key']);
+        $this->assertSame([], $result['modifiers']);
+    }
+
+    public function testModifiedPlusKeyKeepsThePlusAsTheKey()
+    {
+        $this->parser->setKittyProtocolActive(true);
+
+        $result = $this->parser->parse("\x1b[43;5u");
+        $this->assertSame('ctrl++', $result['key']);
+        $this->assertSame(['ctrl'], $result['modifiers']);
+
+        $result = $this->parser->parse("\x1b[43;4u");
+        $this->assertSame('shift+alt++', $result['key']);
+        $this->assertSame(['shift', 'alt'], $result['modifiers']);
+    }
+
+    public function testModifiedPlusKeyCanBeBound()
+    {
+        $this->parser->setKittyProtocolActive(true);
+
+        $this->assertTrue($this->parser->matches("\x1b[43;5u", 'ctrl++'));
+        $this->assertFalse($this->parser->matches("\x1b[43;5u", 'ctrl+a'));
+        $this->assertFalse($this->parser->matches("\x1b[97;5u", 'ctrl++'));
+    }
 }

--- a/src/Symfony/Component/Tui/Tests/Input/StdinBufferTest.php
+++ b/src/Symfony/Component/Tui/Tests/Input/StdinBufferTest.php
@@ -451,4 +451,85 @@ class StdinBufferTest extends TestCase
         $buffer->process('B');
         $this->assertSame(['B'], $sequences, 'Buffer should accept new input after abort');
     }
+
+    public function testMalformedSgrMouseSequenceDoesNotBlockLaterInput()
+    {
+        $buffer = new StdinBuffer();
+        $sequences = [];
+
+        $buffer->onData(static function (string $data) use (&$sequences) { $sequences[] = $data; });
+
+        // Four parameters instead of three: the terminator is already there, so
+        // more data can never make this sequence valid.
+        $buffer->process("\x1b[<3;1;1;1M");
+        $buffer->process('ab');
+
+        $this->assertSame(["\x1b[<3;1;1;1M", 'a', 'b'], $sequences);
+        $this->assertSame('', $buffer->getBuffer());
+    }
+
+    public function testNestedPasteStartMarkerIsKeptAsPastedContent()
+    {
+        $buffer = new StdinBuffer();
+        $pastes = [];
+
+        $buffer->onPaste(static function (string $data) use (&$pastes) { $pastes[] = $data; });
+
+        $buffer->process("\x1b[200~AAA");
+        $buffer->process("\x1b[200~BBB\x1b[201~");
+
+        $this->assertSame(["AAA\x1b[200~BBB"], $pastes);
+    }
+
+    public function testNestedPasteStartMarkerInASingleReadIsKeptAsPastedContent()
+    {
+        $buffer = new StdinBuffer();
+        $pastes = [];
+
+        $buffer->onPaste(static function (string $data) use (&$pastes) { $pastes[] = $data; });
+
+        $buffer->process("\x1b[200~AAA\x1b[200~BBB\x1b[201~");
+
+        $this->assertSame(["AAA\x1b[200~BBB"], $pastes);
+    }
+
+    #[DataProvider('provideSplitPasteEndMarkers')]
+    public function testPasteEndMarkerSplitAcrossReadsStillClosesThePaste(string $first, string $second)
+    {
+        $buffer = new StdinBuffer();
+        $pastes = [];
+        $sequences = [];
+
+        $buffer->onPaste(static function (string $data) use (&$pastes) { $pastes[] = $data; });
+        $buffer->onData(static function (string $data) use (&$sequences) { $sequences[] = $data; });
+
+        $buffer->process($first);
+        $buffer->process($second);
+        $buffer->process('x');
+
+        $this->assertSame(['AABB'], $pastes);
+        $this->assertSame(['x'], $sequences, 'Buffer should accept new input after the paste');
+    }
+
+    public static function provideSplitPasteEndMarkers(): array
+    {
+        return [
+            'split after ESC' => ["\x1b[200~AABB\x1b", '[201~'],
+            'split mid marker' => ["\x1b[200~AABB\x1b[2", '01~'],
+            'split before terminator' => ["\x1b[200~AABB\x1b[201", '~'],
+        ];
+    }
+
+    public function testPasteContentThatLooksLikeAPartialEndMarkerIsKept()
+    {
+        $buffer = new StdinBuffer();
+        $pastes = [];
+
+        $buffer->onPaste(static function (string $data) use (&$pastes) { $pastes[] = $data; });
+
+        $buffer->process("\x1b[200~AA\x1b[2");
+        $buffer->process("XX\x1b[201~");
+
+        $this->assertSame(["AA\x1b[2XX"], $pastes);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        |
| License       | MIT

Six input decoding defects, all present since the component was added. Each one is covered by a test that fails on 8.1 without the fix.

**A malformed SGR mouse report stops all further input**

`StdinBuffer::extractCsiSequence()` validated `CSI < ... M` payloads against `^<\d+;\d+;\d+[Mm]$` and returned `null` when the payload did not match. `null` means "this sequence is incomplete, wait for more data", but the terminator is already in the buffer at that point, so more data can never make the payload valid. The sequence stays at the head of the buffer and every later keystroke queues behind it. The parser only recovers when the pending buffer passes 1 MiB, and it then drops everything it collected.

Any `CSI <` sequence that does not carry exactly three numeric parameters triggers this, for example `ESC [ < 3;1;1;1 M`.

The check is removed. Generic CSI framing already covers these sequences: `<` is a parameter byte, so it cannot be mistaken for a terminator. Well formed reports were already returned unchanged. Malformed ones are now returned too, and `KeyParser` ignores them like any other sequence it does not recognize.

**A paste that contains the start marker loses its beginning**

`process()` treated `ESC [ 200 ~` as a paste start even while a paste was already running. That reset the paste buffer and dropped the content collected so far. It only happened when the marker landed at the start of a read, so the same paste behaved differently depending on how the terminal split it into reads.

The start marker is now honored only when no paste is running, so the end marker is the only thing that closes a paste. Both read splittings now produce the same result.

**A paste whose end marker is split across reads is lost entirely**

While waiting for `ESC [ 201 ~`, `process()` moved the whole pending buffer into the paste content, including a trailing part of the marker itself. The marker could then never match, so the paste never closed: its content was dropped, and `inPaste` stayed set, so every later keystroke was swallowed as well, until the 1 MiB cap discarded everything and emitted the overflow notice.

Terminals deliver a large paste in several reads and the boundary can fall anywhere inside the six byte marker. The start marker was already handled correctly, so the two ends of the same paste behaved differently.

A trailing part of the end marker is now held back in the pending buffer instead of being moved into the content.

**A shifted digit or symbol matched the unshifted key**

`KeyParser::matches()` compared `strtoupper($key)` with the received byte. That is correct for letters, but `strtoupper()` is the identity function for everything else, so `matches('1', 'shift+1')` returned `true` and a binding on `shift+1` fired on a plain `1`.

The uppercase comparison is now limited to letters. For digits and symbols the shifted byte depends on the keyboard layout, so the Kitty sequence is the only source for it, and it is the only thing left to match.

**A modifier with no key id was reported as an unmodified key**

`modsFromFlags()` decoded shift, alt and ctrl, and silently dropped the super, hyper and meta bits. `parse()` on `ESC [ 97;9 u`, which is Super+A, returned the key `a` with no modifiers, so an input widget inserted the letter. `matches()` already refused the same sequence, so the two methods disagreed about it.

`parse()` now returns `null` when a modifier is set that has no key id. Caps Lock and Num Lock stay ignored, as before. Giving super, hyper and meta their own key ids so they can be bound is a new feature and belongs on the development branch.

**The `+` key was reported with an empty modifier**

`parse()` split the key id on `+` and returned `modifiers => ['']`. With a modifier the same split produced `modifiers => ['ctrl', '']` for `ctrl++`, and `parseKeyId()` rejected that key id outright, so `parse()` and `matches()` disagreed about it and a binding on `ctrl++` could never fire.

Both sides now read a trailing `+` as the key itself rather than as a separator.

The full component suite passes on 8.1: 1677 tests, 4222 assertions. php-cs-fixer reports no change on the touched files.
