### PR TITLE
[Tui] Fix column width accounting

### DIFF
--- a/src/Symfony/Component/Tui/Ansi/AnsiUtils.php
+++ b/src/Symfony/Component/Tui/Ansi/AnsiUtils.php
@@ -48,6 +48,12 @@ final class AnsiUtils
     private const ALL_ESC_PATTERN = '/\x1b(?:\[[\x30-\x3F]*[\x20-\x2F]*[\x40-\x7E]|[P\]_\^X][^\x07\x1b]*(?:\x07|\x1b\\\\)|[\x20-\x2F]+[\x30-\x7E]|[\x30-\x7E])/';
 
     /**
+     * Columns a tab takes. Every part of the component that measures or
+     * slices text must agree on this value.
+     */
+    public const TAB_WIDTH = 3;
+
+    /**
      * Character set for CSI parameter bytes (0x30-0x3F).
      */
     private const CSI_PARAM_CHARS = '0123456789:;<=>?';
@@ -106,7 +112,7 @@ final class AnsiUtils
                 } elseif (str_contains($segment, "\t")) {
                     // Has tabs
                     $tabCount = substr_count($segment, "\t");
-                    $fastWidth += $segLen - $tabCount + ($tabCount * 3);
+                    $fastWidth += $segLen - $tabCount + ($tabCount * self::TAB_WIDTH);
                     $withoutTabs = str_replace("\t", '', $segment);
                     if ('' !== $withoutTabs && !preg_match('/^[\x20-\x7E]*$/', $withoutTabs)) {
                         $fastPath = false;
@@ -144,7 +150,7 @@ final class AnsiUtils
         $clean = $str;
 
         if (str_contains($clean, "\t")) {
-            $clean = str_replace("\t", '   ', $clean);
+            $clean = str_replace("\t", str_repeat(' ', self::TAB_WIDTH), $clean);
         }
 
         if (str_contains($clean, "\x1b")) {
@@ -161,6 +167,18 @@ final class AnsiUtils
 
         if ('' === $clean) {
             return 0;
+        }
+
+        // mb_strwidth() sums codepoints, so it counts a combining mark as its
+        // own column. Only text that carries marks needs the slower per
+        // grapheme walk.
+        if (preg_match('/\p{M}/u', $clean)) {
+            $width = 0;
+            foreach (grapheme_str_split($clean) ?: [] as $grapheme) {
+                $width += self::graphemeWidth($grapheme);
+            }
+
+            return $width;
         }
 
         return mb_strwidth($clean, 'UTF-8');
@@ -443,7 +461,8 @@ final class AnsiUtils
                 // Fast check: if the entire segment fits within range, use mb_strwidth
                 // to skip expensive grapheme_str_split + per-grapheme iteration.
                 // mb_strwidth may overcount for ZWJ sequences; conservative check.
-                $segWidth = mb_strwidth($textPortion, 'UTF-8');
+                // It also counts a tab as one column, so tabs need visibleWidth().
+                $segWidth = str_contains($textPortion, "\t") ? self::visibleWidth($textPortion) : mb_strwidth($textPortion, 'UTF-8');
                 if ($currentCol >= $startCol && $currentCol + $segWidth <= $endCol) {
                     if ('' !== $pendingAnsi) {
                         $result .= $pendingAnsi;
@@ -457,7 +476,7 @@ final class AnsiUtils
                     $graphemes = grapheme_str_split($textPortion) ?: [];
 
                     foreach ($graphemes as $grapheme) {
-                        $w = self::graphemeWidth($grapheme);
+                        $w = "\t" === $grapheme ? self::TAB_WIDTH : self::graphemeWidth($grapheme);
                         $inRange = $currentCol >= $startCol && $currentCol < $endCol;
                         $fits = !$strict || ($currentCol + $w <= $endCol);
 
@@ -612,14 +631,14 @@ final class AnsiUtils
                 $currentCol += $take;
             } else {
                 // Unicode path
-                $segWidth = mb_strwidth($segment, 'UTF-8');
+                $segWidth = str_contains($segment, "\t") ? self::visibleWidth($segment) : mb_strwidth($segment, 'UTF-8');
                 if ($currentCol + $segWidth <= $length) {
                     $result .= $segment;
                     $currentCol += $segWidth;
                 } else {
                     $graphemes = grapheme_str_split($segment) ?: [];
                     foreach ($graphemes as $grapheme) {
-                        $w = self::graphemeWidth($grapheme);
+                        $w = "\t" === $grapheme ? self::TAB_WIDTH : self::graphemeWidth($grapheme);
                         if ($currentCol + $w > $length) {
                             break;
                         }

--- a/src/Symfony/Component/Tui/Render/CellBuffer.php
+++ b/src/Symfony/Component/Tui/Render/CellBuffer.php
@@ -62,6 +62,9 @@ final class CellBuffer
     /** @var int[] Attribute bitmask (bold|dim|italic|underline|blink|reverse|strikethrough) */
     private array $attrs;
 
+    /* Whether a wide character has been placed, so writes have to repair cell pairs */
+    private bool $hasWideChars = false;
+
     /* Row of the cursor marker, or null if not found */
     private ?int $cursorRow = null;
 
@@ -131,17 +134,23 @@ final class CellBuffer
             $i = 0;
             $len = \strlen($line);
             $rowOffset = $row * $width;
+            $hasHighByte = (bool) preg_match('/[\x80-\xFF]/', $line);
 
             while ($i < $len && $col < $width) {
                 $ord = \ord($line[$i]);
 
-                // Fast path: ASCII printable (0x20-0x7E), most common case
-                if ($ord >= 0x20 && $ord <= 0x7E) {
+                // Fast path: ASCII printable (0x20-0x7E), most common case.
+                // A following high byte may be a combining mark that belongs
+                // to this character, so leave that case to grapheme_extract().
+                if ($ord >= 0x20 && $ord <= 0x7E && (!$hasHighByte || !isset($line[$i + 1]) || \ord($line[$i + 1]) < 0x80)) {
                     // In transparent mode, skip fully unstyled spaces (fully transparent cell)
                     if ($transparent && ' ' === $line[$i] && '' === $fgState && '' === $bgState && 0 === $attrState) {
                         ++$col;
                         ++$i;
                         continue;
+                    }
+                    if ($this->hasWideChars) {
+                        $this->blankWideCharAt($rowOffset, $col);
                     }
                     $idx = $rowOffset + $col;
                     $this->chars[$idx] = $line[$i];
@@ -264,11 +273,13 @@ final class CellBuffer
 
                 // Tab
                 if (0x09 === $ord) {
-                    $spaces = 3; // Match AnsiUtils tab width
-                    for ($s = 0; $s < $spaces && $col < $width; ++$s) {
+                    for ($s = 0; $s < AnsiUtils::TAB_WIDTH && $col < $width; ++$s) {
                         if ($transparent && '' === $fgState && '' === $bgState && 0 === $attrState) {
                             ++$col;
                             continue;
+                        }
+                        if ($this->hasWideChars) {
+                            $this->blankWideCharAt($rowOffset, $col);
                         }
                         $idx = $rowOffset + $col;
                         $this->chars[$idx] = ' ';
@@ -301,6 +312,9 @@ final class CellBuffer
                 // Check if it fits
                 if ($col + $charWidth > $width) {
                     while ($col < $width) {
+                        if ($this->hasWideChars) {
+                            $this->blankWideCharAt($rowOffset, $col);
+                        }
                         $idx = $rowOffset + $col;
                         $this->chars[$idx] = ' ';
                         $this->widths[$idx] = 1;
@@ -314,6 +328,12 @@ final class CellBuffer
                 }
 
                 // Place the character
+                if ($this->hasWideChars) {
+                    for ($w = 0; $w < $charWidth && $col + $w < $width; ++$w) {
+                        $this->blankWideCharAt($rowOffset, $col + $w);
+                    }
+                }
+                $this->hasWideChars = $this->hasWideChars || $charWidth > 1;
                 $idx = $rowOffset + $col;
                 $this->chars[$idx] = $grapheme;
                 $this->widths[$idx] = $charWidth;
@@ -336,6 +356,32 @@ final class CellBuffer
                 $col += $charWidth;
                 $i = $nextPos;
             }
+        }
+    }
+
+    /**
+     * Turn the wide character covering the given cell into blanks.
+     *
+     * A wide character owns a lead cell and one continuation cell. Writing
+     * into either of them without clearing the other leaves a lead without
+     * its continuation, or a continuation without its lead, and the row then
+     * renders with the wrong number of columns.
+     */
+    private function blankWideCharAt(int $rowOffset, int $col): void
+    {
+        if (1 === $this->widths[$rowOffset + $col]) {
+            return;
+        }
+
+        $start = $col;
+        while ($start > 0 && 0 === $this->widths[$rowOffset + $start]) {
+            --$start;
+        }
+
+        $end = $start + max(1, $this->widths[$rowOffset + $start]);
+        for ($c = $start; $c < $end && $c < $this->width; ++$c) {
+            $this->chars[$rowOffset + $c] = ' ';
+            $this->widths[$rowOffset + $c] = 1;
         }
     }
 

--- a/src/Symfony/Component/Tui/Tests/Ansi/AnsiUtilsTest.php
+++ b/src/Symfony/Component/Tui/Tests/Ansi/AnsiUtilsTest.php
@@ -543,4 +543,27 @@ class AnsiUtilsTest extends TestCase
         // "Hello " (6) + "Gérard" (6) + " from " (6) + "Café" (4) = 22
         $this->assertSame(22, AnsiUtils::visibleWidth($text));
     }
+
+    public function testVisibleWidthCountsACombiningMarkWithItsBaseCharacter()
+    {
+        $this->assertSame(1, AnsiUtils::visibleWidth("e\u{0301}"));
+        $this->assertSame(4, AnsiUtils::visibleWidth("cafe\u{0301}"));
+        $this->assertSame(2, AnsiUtils::visibleWidth("a\u{0301}\u{0308}b"));
+        $this->assertSame(4, AnsiUtils::visibleWidth("cafe\u{0301}\x1b[0m"));
+    }
+
+    public function testSliceByColumnGivesTabsTheSameWidthAsVisibleWidth()
+    {
+        $this->assertSame('a', AnsiUtils::sliceByColumn("a\tb", 0, 2));
+        $this->assertSame("a\t", AnsiUtils::sliceByColumn("a\tb", 0, 4));
+        $this->assertSame("a\tb", AnsiUtils::sliceByColumn("a\tb", 0, 5));
+    }
+
+    public function testTruncateToWidthNeverExceedsTheWidthWithTabs()
+    {
+        $this->assertSame(3, AnsiUtils::visibleWidth(AnsiUtils::truncateToWidth("\t\t\t", 3, '')));
+        $this->assertSame(4, AnsiUtils::visibleWidth(AnsiUtils::truncateToWidth("a\tb\tc", 4, '')));
+        // A tab is never split, so the result stops below the limit here.
+        $this->assertSame(4, AnsiUtils::visibleWidth(AnsiUtils::truncateToWidth("\tx\t\t", 6, '')));
+    }
 }

--- a/src/Symfony/Component/Tui/Tests/Render/CellBufferTest.php
+++ b/src/Symfony/Component/Tui/Tests/Render/CellBufferTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Tui\Tests\Render;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Tui\Ansi\AnsiUtils;
 use Symfony\Component\Tui\Exception\InvalidArgumentException;
 use Symfony\Component\Tui\Render\CellBuffer;
 
@@ -393,5 +394,48 @@ class CellBufferTest extends TestCase
         $lines = $buf->toLines();
         $plain = preg_replace('/\x1b\[[0-9;]*m/', '', $lines[0]);
         $this->assertSame('ABCD ', $plain);
+    }
+
+    public function testCombiningMarkStaysInTheCellOfItsBaseCharacter()
+    {
+        $buf = new CellBuffer(4, 1);
+        $buf->writeAnsiLines(["e\u{0301}x"]);
+
+        $this->assertSame("e\u{0301}x  ", $buf->toLines()[0]);
+    }
+
+    public function testWritingOverTheSecondCellOfAWideCharKeepsTheLineWidth()
+    {
+        $buf = new CellBuffer(4, 1);
+        $buf->writeAnsiLines(['漢字']);
+        $buf->writeAnsiLines(['x'], 0, 1);
+
+        $this->assertSame(' x字', $buf->toLines()[0]);
+    }
+
+    public function testWritingOverTheFirstCellOfAWideCharKeepsTheLineWidth()
+    {
+        $buf = new CellBuffer(4, 1);
+        $buf->writeAnsiLines(['漢字']);
+        $buf->writeAnsiLines(['x'], 0, 0);
+
+        $this->assertSame('x 字', $buf->toLines()[0]);
+    }
+
+    public function testTabTakesTheSameWidthAsInAnsiUtils()
+    {
+        $buf = new CellBuffer(10, 1);
+        $buf->writeAnsiLines(["a\tb"]);
+
+        $this->assertSame(AnsiUtils::visibleWidth("a\tb"), AnsiUtils::visibleWidth(rtrim($buf->toLines()[0])));
+    }
+
+    public function testWritingAWideCharAcrossTwoWideCharsKeepsTheLineWidth()
+    {
+        $buf = new CellBuffer(4, 1);
+        $buf->writeAnsiLines(['漢字']);
+        $buf->writeAnsiLines(['漢'], 0, 1);
+
+        $this->assertSame(' 漢 ', $buf->toLines()[0]);
     }
 }

--- a/src/Symfony/Component/Tui/Widget/TextWidget.php
+++ b/src/Symfony/Component/Tui/Widget/TextWidget.php
@@ -121,8 +121,7 @@ class TextWidget extends AbstractWidget
      */
     private function renderText(RenderContext $context): array
     {
-        // Replace tabs with 3 spaces
-        $normalizedText = str_replace("\t", '   ', $this->text);
+        $normalizedText = str_replace("\t", str_repeat(' ', AnsiUtils::TAB_WIDTH), $this->text);
 
         // Context already has inner dimensions (chrome subtracted by the Renderer)
         $contentColumns = $context->getColumns();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        |
| License       | MIT

The component measures text in four places and they do not agree with each other. A widget can ask for a line of N columns and get more, which then trips the width check in `Renderer::renderWidget()` and aborts the render with a `RenderException`. Four defects, one per disagreement.

**A tab is three columns to `visibleWidth()` and one column to the slicer**

`visibleWidth()` counts a tab as three columns, `CellBuffer` writes three blanks for it, and `TextWidget` replaces it with three spaces. `slicePrefix()` and `sliceWithWidth()` measure with `mb_strwidth()`, which counts it as one.

`truncateToWidth()` uses the first to decide that the text is too long, then the second to cut it, so it returns more columns than it was given:

```php
AnsiUtils::truncateToWidth("\t\t\t", 3, '');   // 9 columns
AnsiUtils::truncateToWidth("a\tb\tc", 4, '');  // 8 columns
AnsiUtils::sliceByColumn("a\tb", 0, 2);        // "a\t", 4 columns
```

Only `TextWidget` normalizes tabs before measuring, so every other widget can produce such a line. A custom widget that renders `a\tb\tc\td\te\tf` inside a border on a 12 column terminal aborts the render:

```
RenderException: Widget "TabWidget" rendered line 1 with width 18, exceeding the available 12 columns.
```

The two slicers now give a tab the same three columns as the rest of the component. The width is a constant on `AnsiUtils` and `CellBuffer` and `TextWidget` use it, so it has one definition, and a test pins the buffer to what `visibleWidth()` reports.

`ScreenBuffer` is left alone on purpose. It emulates a terminal, so it advances to the next eight column tab stop, which is the right behavior for an emulator and is not a layout measurement.

**`visibleWidth()` counts a combining mark as its own column**

`mb_strwidth()` sums codepoints, so `e` followed by U+0301 measures 2 while the terminal draws one column, and `graphemeWidth()` in the same class already returns 1 for it. Decomposed text is common, for example file names read from a macOS filesystem.

Consequences: `truncateToWidth('cafe' + U+0301, 4)` cut text that already fitted and dropped the accent, and `truncateToWidth(..., 8, pad: true)` padded to a width that was one column short, so every column after it drifted.

Text that carries a mark is now measured per grapheme. Text without marks keeps the `mb_strwidth()` path, so the common case is unchanged. The `\p{M}` test that picks between the two costs about 0.3 us on a line of text; `grapheme_strlen()` against `mb_strlen()` and a byte range prefilter were both measured and are two to ten times more expensive.

This does not change the width of ZWJ emoji sequences. `graphemeWidth()` delegates those to `UnicodeString::width()`, which returns the sum of the parts. That belongs to the String component.

**`CellBuffer` puts a combining mark in its own cell**

The ASCII fast path in `writeAnsiLines()` decides on the current byte alone, so it claims a cell for `e` and leaves U+0301 to the Unicode path, which gives the mark a second cell. The terminal draws the mark on the `e`, so every character after it sits one column left of where the buffer believes it is, and the diff renderer then works from a wrong picture of the screen.

The fast path now yields to `grapheme_extract()` when the next byte is a high byte. Lines with no high byte at all are recognised once per line, so a pure ASCII line does not pay the per character lookahead.

**Writing over a wide character leaves a broken cell pair**

A wide character owns a lead cell with width 2 and a continuation cell with width 0, and `toLines()` skips continuation cells. `Compositor` paints layers into one buffer at any offset, so a layer can land on either half. Nothing repaired the other half: overwriting the lead left a continuation with no lead and the row lost a column, overwriting the continuation left a lead that still claimed two columns and the row gained one.

On a 4 column canvas holding `漢字`, painting a single `x` produced a wrong width at every position: 3, 5, 3, 5. The same overlays on an ASCII base were all correct.

Writing into a cell now blanks the whole wide character that covers it first, so the row keeps its width. A buffer that has never held a wide character skips the repair, so the cost falls on the buffers that need it.

A 200x50 buffer of ASCII text renders in 2.1 ms against 1.9 ms before this change.

Full component suite on 8.1: 1671 tests, 4208 assertions, green. php-cs-fixer reports no change on the touched files.
