### PR TITLE
[Form][TwigBridge] Allow the "group_by" option of ChoiceType to return translatable labels

### DIFF
--- a/src/Symfony/Bridge/Twig/CHANGELOG.md
+++ b/src/Symfony/Bridge/Twig/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Add the `normalize` filter to normalize values with the Serializer component
  * Add the `impersonation_form()` and `impersonation_exit_form()` functions to build a form that switches the user with a POST
  * Render an `id` attribute on the `<form>` element when a child uses `form_attr`, so that the reference resolves
+ * Render `<optgroup>` labels from `ChoiceGroupView::$label`, which allows translatable choice group labels
 
 8.1
 ---

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -97,6 +97,7 @@
 {%- block choice_widget_options -%}
     {% for group_label, choice in options %}
         {%- if choice is iterable -%}
+            {%- set group_label = choice.label is defined ? choice.label : group_label -%}
             <optgroup label="{{ choice_translation_domain is same as(false) ? group_label : group_label|trans({}, choice_translation_domain) }}">
                 {% set options = choice %}
                 {{- block('choice_widget_options') -}}

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractLayoutTestCase.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractLayoutTestCase.php
@@ -932,6 +932,34 @@ abstract class AbstractLayoutTestCase extends FormLayoutTestCase
         );
     }
 
+    public function testSingleChoiceGroupedWithTranslatableGroupLabels()
+    {
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', '&a', [
+            'choices' => ['Choice&A' => '&a', 'Choice&B' => '&b', 'Choice&C' => '&c'],
+            'group_by' => static fn ($choice) => new TranslatableMessage('&c' === $choice ? 'Group&2' : 'Group&1'),
+            'multiple' => false,
+            'expanded' => false,
+        ]);
+
+        $this->assertWidgetMatchesXpath($form->createView(), ['attr' => ['class' => 'my&class']],
+            '/select
+    [@name="name"]
+    [./optgroup[@label="[trans]Group&1[/trans]"]
+        [
+            ./option[@value="&a"][@selected="selected"][.="[trans]Choice&A[/trans]"]
+            /following-sibling::option[@value="&b"][not(@selected)][.="[trans]Choice&B[/trans]"]
+        ]
+        [count(./option)=2]
+    ]
+    [./optgroup[@label="[trans]Group&2[/trans]"]
+        [./option[@value="&c"][not(@selected)][.="[trans]Choice&C[/trans]"]]
+        [count(./option)=1]
+    ]
+    [count(./optgroup)=2]
+'
+        );
+    }
+
     public function testMultipleChoice()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', ['&a'], [

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
  * Add the `choice_help` option to `ChoiceType`
  * Add `$help` parameter to `ChoiceListFactoryInterface::createView()`
  * Add the `form_id` view variable, holding the id to render on the `<form>` element of a root form when a child uses `form_attr`
+ * Allow the `group_by` option of `ChoiceType` to return `TranslatableInterface` instances
 
 8.1
 ---

--- a/src/Symfony/Component/Form/ChoiceList/Factory/DefaultChoiceListFactory.php
+++ b/src/Symfony/Component/Form/ChoiceList/Factory/DefaultChoiceListFactory.php
@@ -298,17 +298,23 @@ class DefaultChoiceListFactory implements ChoiceListFactoryInterface
             return;
         }
 
-        $groupLabels = \is_array($groupLabels) ? array_map('strval', $groupLabels) : [(string) $groupLabels];
+        $groupLabels = \is_array($groupLabels) ? $groupLabels : [$groupLabels];
 
         foreach ($groupLabels as $groupLabel) {
+            if (!$groupLabel instanceof TranslatableInterface) {
+                $groupLabel = (string) $groupLabel;
+            }
+
+            $groupKey = self::getGroupKey($groupLabel, $preferredViews);
+
             // Initialize the group views if necessary. Unnecessarily built group
             // views will be cleaned up at the end of createView()
-            if (!isset($preferredViews[$groupLabel])) {
-                $preferredViews[$groupLabel] = new ChoiceGroupView($groupLabel);
-                $otherViews[$groupLabel] = new ChoiceGroupView($groupLabel);
+            if (!isset($preferredViews[$groupKey])) {
+                $preferredViews[$groupKey] = new ChoiceGroupView($groupLabel);
+                $otherViews[$groupKey] = new ChoiceGroupView($groupLabel);
             }
-            if (!isset($preferredViewsOrder[$groupLabel])) {
-                $preferredViewsOrder[$groupLabel] = [];
+            if (!isset($preferredViewsOrder[$groupKey])) {
+                $preferredViewsOrder[$groupKey] = [];
             }
 
             self::addChoiceView(
@@ -321,11 +327,39 @@ class DefaultChoiceListFactory implements ChoiceListFactoryInterface
                 $labelTranslationParameters,
                 $help,
                 $isPreferred,
-                $preferredViews[$groupLabel]->choices,
-                $preferredViewsOrder[$groupLabel],
-                $otherViews[$groupLabel]->choices,
+                $preferredViews[$groupKey]->choices,
+                $preferredViewsOrder[$groupKey],
+                $otherViews[$groupKey]->choices,
                 $duplicatePreferredChoices,
             );
         }
+    }
+
+    /**
+     * Translatable group labels cannot be used as array keys. An opaque key is
+     * generated for them instead, reusing the one of an equivalent label so that
+     * choices sharing the same group label end up in the same group view.
+     *
+     * @param array<ChoiceGroupView|ChoiceView> $views
+     */
+    private static function getGroupKey(string|TranslatableInterface $groupLabel, array $views): string
+    {
+        if (!$groupLabel instanceof TranslatableInterface) {
+            return $groupLabel;
+        }
+
+        foreach ($views as $key => $view) {
+            if ($view instanceof ChoiceGroupView && $view->label instanceof TranslatableInterface && $view->label == $groupLabel) {
+                return $key;
+            }
+        }
+
+        // Prefixing with a NUL byte avoids clashing with the integer keys of ungrouped choices
+        $i = \count($views);
+        while (isset($views["\0".$i])) {
+            ++$i;
+        }
+
+        return "\0".$i;
     }
 }

--- a/src/Symfony/Component/Form/ChoiceList/View/ChoiceGroupView.php
+++ b/src/Symfony/Component/Form/ChoiceList/View/ChoiceGroupView.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Form\ChoiceList\View;
 
+use Symfony\Contracts\Translation\TranslatableInterface;
+
 /**
  * Represents a group of choices in templates.
  *
@@ -23,10 +25,11 @@ class ChoiceGroupView implements \IteratorAggregate
     /**
      * Creates a new choice group view.
      *
+     * @param string|TranslatableInterface      $label   The label displayed to humans
      * @param array<ChoiceGroupView|ChoiceView> $choices the choice views in the group
      */
     public function __construct(
-        public string $label,
+        public string|TranslatableInterface $label,
         public array $choices = [],
     ) {
     }

--- a/src/Symfony/Component/Form/Tests/ChoiceList/Factory/DefaultChoiceListFactoryTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/Factory/DefaultChoiceListFactoryTest.php
@@ -94,6 +94,13 @@ class DefaultChoiceListFactoryTest extends TestCase
             : new DefaultChoiceListFactoryTest_Castable('Group 2');
     }
 
+    public function getGroupAsTranslatableMessage($object)
+    {
+        return $this->obj1 === $object || $this->obj2 === $object
+            ? new TranslatableMessage('group.1', ['%param%' => 'value'])
+            : new TranslatableMessage('group.2', ['%param%' => 'value']);
+    }
+
     protected function setUp(): void
     {
         $this->obj1 = (object) ['label' => 'A', 'index' => 'w', 'value' => 'a', 'preferred' => false, 'group' => 'Group 1', 'attr' => [], 'labelTranslationParameters' => []];
@@ -577,6 +584,77 @@ class DefaultChoiceListFactoryTest extends TestCase
         );
 
         $this->assertGroupedView($view);
+    }
+
+    public function testCreateViewFlatGroupByTranslatableMessageDoesntCastItToString()
+    {
+        $view = $this->factory->createView(
+            $this->list,
+            [$this->obj2, $this->obj3],
+            null, // label
+            null, // index
+            $this->getGroupAsTranslatableMessage(...)
+        );
+
+        $groups = array_values($view->choices);
+
+        $this->assertCount(2, $groups);
+        $this->assertInstanceOf(TranslatableMessage::class, $groups[0]->label);
+        $this->assertSame('group.1', $groups[0]->label->getMessage());
+        $this->assertSame(['%param%' => 'value'], $groups[0]->label->getParameters());
+        $this->assertEquals([0 => new ChoiceView($this->obj1, '0', 'A'), 1 => new ChoiceView($this->obj2, '1', 'B')], $groups[0]->choices);
+        $this->assertInstanceOf(TranslatableMessage::class, $groups[1]->label);
+        $this->assertSame('group.2', $groups[1]->label->getMessage());
+        $this->assertEquals([2 => new ChoiceView($this->obj3, '2', 'C'), 3 => new ChoiceView($this->obj4, '3', 'D')], $groups[1]->choices);
+
+        $preferredGroups = array_values($view->preferredChoices);
+
+        $this->assertCount(2, $preferredGroups);
+        $this->assertEquals([1 => new ChoiceView($this->obj2, '1', 'B')], $preferredGroups[0]->choices);
+        $this->assertEquals([2 => new ChoiceView($this->obj3, '2', 'C')], $preferredGroups[1]->choices);
+    }
+
+    public function testCreateViewFlatGroupByTranslatableInterfaceDoesntCastItToString()
+    {
+        $group = new class implements TranslatableInterface {
+            public function trans(TranslatorInterface $translator, ?string $locale = null): string
+            {
+                return 'Group 1';
+            }
+        };
+
+        $view = $this->factory->createView(
+            $this->list,
+            [],
+            null, // label
+            null, // index
+            static fn () => $group
+        );
+
+        $groups = array_values($view->choices);
+
+        $this->assertCount(1, $groups);
+        $this->assertSame($group, $groups[0]->label);
+        $this->assertCount(4, $groups[0]->choices);
+    }
+
+    public function testCreateViewFlatGroupByTranslatableMessageDoesNotCollideWithStringGroupKeys()
+    {
+        $view = $this->factory->createView(
+            $this->list,
+            [],
+            null, // label
+            null, // index
+            fn ($object) => $this->obj1 === $object ? "\0".'1' : new TranslatableMessage('group.opaque')
+        );
+
+        $groups = array_values($view->choices);
+
+        $this->assertCount(2, $groups);
+        $this->assertSame("\0".'1', $groups[0]->label);
+        $this->assertCount(1, $groups[0]->choices);
+        $this->assertInstanceOf(TranslatableMessage::class, $groups[1]->label);
+        $this->assertCount(3, $groups[1]->choices);
     }
 
     public function testCreateViewFlatGroupByAsClosure()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

The `group_by` option of `ChoiceType` produces the `<optgroup>` labels, and those labels are already translated by default (`form_div_layout.html.twig` runs them through `|trans` with `choice_translation_domain`). So a translation key already works.

What does not work is a `TranslatableMessage` / any `TranslatableInterface`: `DefaultChoiceListFactory` casts the value returned by `group_by` to a string, which fatals for `TranslatableMessage` (no `__toString()`), and `ChoiceGroupView::$label` is typed `string`. This is inconsistent with `choice_label`, which has accepted `TranslatableInterface` for a while.

```php
$builder->add('country', ChoiceType::class, [
    'choices' => $countries,
    'group_by' => fn (Country $c) => new TranslatableMessage('continent.'.$c->getContinent(), [], 'countries'),
]);
```

### What this PR does

* `ChoiceGroupView::$label` is widened to `string|TranslatableInterface`.
* `DefaultChoiceListFactory` no longer casts group labels to string when they are `TranslatableInterface`. Since such a label cannot be an array key, an opaque key is generated for the group view, and labels that are equal reuse the same key so their choices land in the same group.
* `form_div_layout.html.twig` renders the `<optgroup>` label from `choice.label` (the `ChoiceGroupView` property) instead of the array key it is stored under, falling back to the key when the entry is a plain array.

`TwigBridge`'s `FormExtension::createFieldTranslation()` already accepted `TranslatableInterface` for group labels, so `getFieldChoices()` needed no change.

### BC

Non-BC-breaking: string group labels keep being stored under their own key, so templates overriding `choice_widget_options` and using the loop key keep working unchanged. Only the new translatable case relies on `ChoiceGroupView::$label`.


### For the docs

* `group_by` may return `TranslatableInterface` instances; the group label is then translated like a translatable `choice_label`, so the message's own domain wins over `choice_translation_domain`.
* Custom themes overriding `choice_widget_options` must render the group label from `choice.label`, falling back to the loop key, to support translatable groups: the array key is an opaque placeholder in that case.
