### PR TITLE
[Console] Restore the catchExceptions state after running a command message

### DIFF
--- a/src/Symfony/Component/Console/Messenger/RunCommandMessageHandler.php
+++ b/src/Symfony/Component/Console/Messenger/RunCommandMessageHandler.php
@@ -33,6 +33,7 @@ final class RunCommandMessageHandler
         $input = new StringInput($message->input);
         $output = new BufferedOutput();
 
+        $originalCatchExceptions = $this->application->areExceptionsCaught();
         $this->application->setCatchExceptions($message->catchExceptions);
 
         try {
@@ -41,6 +42,8 @@ final class RunCommandMessageHandler
             throw $e;
         } catch (\Throwable $e) {
             throw new RunCommandFailedException($e, new RunCommandContext($message, Command::FAILURE, $output->fetch()));
+        } finally {
+            $this->application->setCatchExceptions($originalCatchExceptions);
         }
 
         if ($message->throwOnFailure && Command::SUCCESS !== $exitCode) {

--- a/src/Symfony/Component/Console/Tests/Messenger/RunCommandMessageHandlerTest.php
+++ b/src/Symfony/Component/Console/Tests/Messenger/RunCommandMessageHandlerTest.php
@@ -117,6 +117,32 @@ final class RunCommandMessageHandlerTest extends TestCase
         $this->fail('Exception not thrown.');
     }
 
+    public function testCatchExceptionsIsRestored()
+    {
+        $application = $this->createApplicationWithCommand();
+        $application->setCatchExceptions(true);
+
+        $handler = new RunCommandMessageHandler($application);
+        $handler(new RunCommandMessage('test:command'));
+
+        $this->assertTrue($application->areExceptionsCaught());
+    }
+
+    public function testCatchExceptionsIsRestoredWhenCommandFails()
+    {
+        $application = $this->createApplicationWithCommand();
+        $application->setCatchExceptions(true);
+
+        $handler = new RunCommandMessageHandler($application);
+
+        try {
+            $handler(new RunCommandMessage('test:command --throw'));
+        } catch (RunCommandFailedException) {
+        }
+
+        $this->assertTrue($application->areExceptionsCaught());
+    }
+
     private function createApplicationWithCommand(): Application
     {
         $application = new Application();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`RunCommandMessageHandler` applies the `catchExceptions` value carried by the message to the `Application` it wraps, but never restores the previous one. That `Application` is shared and long lived, so the setting leaks to every message handled afterwards: once a message with `catchExceptions: false` (the default) has been handled, exceptions are no longer caught for any subsequent command, even for messages that ask for them to be.

This is only observable in processes that reuse the container across messages, e.g. a `messenger:consume` worker or a runtime such as FrankenPHP, Swoole or RoadRunner. There, the worker crashes on the first exception a command throws instead of letting the application render it.

The handler now reads the current value before overriding it and restores it in a `finally` block, so it is put back whether the command succeeds, fails or throws.

Found with [Igor-PHP](https://github.com/igor-php/igor-php), a static analysis tool auditing service state mutations in persistent runtimes.
