### PR TITLE
 [Clock] Add `#[NoDiscard]` attribute to `DatePoint`

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -27,6 +27,15 @@
     </projectFiles>
 
     <issueHandlers>
+        <MissingImmutableAnnotation>
+            <errorLevel type="suppress">
+                <!--
+                    DatePoint is immutable, but the class cannot be annotated as
+                    such because its constructor reads the clock.
+                -->
+                <file name="src/Symfony/Component/Clock/DatePoint.php" />
+            </errorLevel>
+        </MissingImmutableAnnotation>
         <UndefinedClass>
             <errorLevel type="suppress">
                 <!-- These classes have been added in PHP 8.4 -->

--- a/src/Symfony/Component/Clock/CHANGELOG.md
+++ b/src/Symfony/Component/Clock/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add `#[\NoDiscard]` to the methods of `DatePoint` that return a new instance
+
 7.1
 ---
 

--- a/src/Symfony/Component/Clock/DatePoint.php
+++ b/src/Symfony/Component/Clock/DatePoint.php
@@ -68,11 +68,13 @@ final class DatePoint extends \DateTimeImmutable
         return parent::createFromTimestamp($timestamp);
     }
 
+    #[\NoDiscard('as DatePoint is immutable')]
     public function add(\DateInterval $interval): static
     {
         return parent::add($interval);
     }
 
+    #[\NoDiscard('as DatePoint is immutable')]
     public function sub(\DateInterval $interval): static
     {
         return parent::sub($interval);
@@ -81,31 +83,37 @@ final class DatePoint extends \DateTimeImmutable
     /**
      * @throws \DateMalformedStringException When $modifier is invalid
      */
+    #[\NoDiscard('as DatePoint is immutable')]
     public function modify(string $modifier): static
     {
         return parent::modify($modifier);
     }
 
+    #[\NoDiscard('as DatePoint is immutable')]
     public function setTimestamp(int $value): static
     {
         return parent::setTimestamp($value);
     }
 
+    #[\NoDiscard('as DatePoint is immutable')]
     public function setDate(int $year, int $month, int $day): static
     {
         return parent::setDate($year, $month, $day);
     }
 
+    #[\NoDiscard('as DatePoint is immutable')]
     public function setISODate(int $year, int $week, int $day = 1): static
     {
         return parent::setISODate($year, $week, $day);
     }
 
+    #[\NoDiscard('as DatePoint is immutable')]
     public function setTime(int $hour, int $minute, int $second = 0, int $microsecond = 0): static
     {
         return parent::setTime($hour, $minute, $second, $microsecond);
     }
 
+    #[\NoDiscard('as DatePoint is immutable')]
     public function setTimezone(\DateTimeZone $timezone): static
     {
         return parent::setTimezone($timezone);
@@ -116,6 +124,7 @@ final class DatePoint extends \DateTimeImmutable
         return parent::getTimezone() ?: throw new \DateInvalidTimeZoneException('The DatePoint object has no timezone.');
     }
 
+    #[\NoDiscard('as DatePoint is immutable')]
     public function setMicrosecond(int $microsecond): static
     {
         if ($microsecond < 0 || $microsecond > 999999) {

--- a/src/Symfony/Component/Clock/Tests/DatePointTest.php
+++ b/src/Symfony/Component/Clock/Tests/DatePointTest.php
@@ -94,7 +94,7 @@ class DatePointTest extends TestCase
 
         $this->expectException(\DateMalformedStringException::class);
         $this->expectExceptionMessage('Failed to parse time string (Bad Date)');
-        $date->modify('Bad Date');
+        $_ = $date->modify('Bad Date');
     }
 
     public function testMicrosecond()
@@ -110,7 +110,22 @@ class DatePointTest extends TestCase
 
         $this->expectException(\DateRangeError::class);
         $this->expectExceptionMessage('DatePoint::setMicrosecond(): Argument #1 ($microsecond) must be between 0 and 999999, 1000000 given');
-        $date->setMicrosecond(1000000);
+        $_ = $date->setMicrosecond(1000000);
+    }
+
+    public function testNoDiscard()
+    {
+        $methods = [];
+
+        foreach ((new \ReflectionClass(DatePoint::class))->getMethods() as $method) {
+            if ($method->getAttributes('NoDiscard')) {
+                $methods[] = $method->name;
+            }
+        }
+
+        sort($methods);
+
+        $this->assertSame(['add', 'modify', 'setDate', 'setISODate', 'setMicrosecond', 'setTime', 'setTimestamp', 'setTimezone', 'sub'], $methods);
     }
 
     #[TestWith(['2024-04-01 00:00:00.000000', '2024-04'])]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #65176 
| License       | MIT

Adds `#[NoDiscard]` to `DatePoint` methods to match `DateTimeImmutable`.
