### PR TITLE
[Messenger][AmazonSqs] Support queue URLs from the aws-cn and aws-eusc partitions

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/AmazonSqsTransportFactoryTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/AmazonSqsTransportFactoryTest.php
@@ -22,6 +22,11 @@ class AmazonSqsTransportFactoryTest extends TestCase
 
         $this->assertTrue($factory->supports('sqs://localhost', []));
         $this->assertTrue($factory->supports('https://sqs.us-east-2.amazonaws.com/123456789012/ab1-MyQueue-A2BCDEF3GHI4', []));
+        $this->assertTrue($factory->supports('https://sqs.cn-north-1.amazonaws.com.cn/123456789012/ab1-MyQueue-A2BCDEF3GHI4', []));
+        $this->assertTrue($factory->supports('https://sqs.eusc-de-east-1.amazonaws.eu/123456789012/ab1-MyQueue-A2BCDEF3GHI4', []));
+        $this->assertFalse($factory->supports('https://sqs.us-east-2.notamazon.com/123456789012/queue', []));
+        $this->assertFalse($factory->supports('https://sqs.us-east-2.amazonaws.evil.com/123456789012/queue', []));
+        $this->assertFalse($factory->supports('https://sqs.us-east-2.amazonaws.co.uk/123456789012/queue', []));
         $this->assertFalse($factory->supports('redis://localhost', []));
         $this->assertFalse($factory->supports('invalid-dsn', []));
     }

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/ConnectionTest.php
@@ -133,6 +133,24 @@ class ConnectionTest extends TestCase
         );
     }
 
+    public function testFromDsnWithNonComPartitionDetectsRegionAutomatically()
+    {
+        $httpClient = new MockHttpClient();
+        $this->assertEquals(
+            new Connection(['queue_name' => 'ab1-MyQueue-A2BCDEF3GHI4', 'account' => '123456789012'], new SqsClient(['region' => 'eusc-de-east-1', 'endpoint' => 'https://sqs.eusc-de-east-1.amazonaws.eu', 'accessKeyId' => null, 'accessKeySecret' => null], null, $httpClient), 'https://sqs.eusc-de-east-1.amazonaws.eu/123456789012/ab1-MyQueue-A2BCDEF3GHI4'),
+            Connection::fromDsn('https://sqs.eusc-de-east-1.amazonaws.eu/123456789012/ab1-MyQueue-A2BCDEF3GHI4', [], $httpClient)
+        );
+    }
+
+    public function testFromDsnWithChinaPartitionDetectsRegionAutomatically()
+    {
+        $httpClient = new MockHttpClient();
+        $this->assertEquals(
+            new Connection(['queue_name' => 'ab1-MyQueue-A2BCDEF3GHI4', 'account' => '123456789012'], new SqsClient(['region' => 'cn-north-1', 'endpoint' => 'https://sqs.cn-north-1.amazonaws.com.cn', 'accessKeyId' => null, 'accessKeySecret' => null], null, $httpClient), 'https://sqs.cn-north-1.amazonaws.com.cn/123456789012/ab1-MyQueue-A2BCDEF3GHI4'),
+            Connection::fromDsn('https://sqs.cn-north-1.amazonaws.com.cn/123456789012/ab1-MyQueue-A2BCDEF3GHI4', [], $httpClient)
+        );
+    }
+
     public function testFromDsnWithCustomEndpoint()
     {
         $httpClient = new MockHttpClient();
@@ -412,6 +430,8 @@ class ConnectionTest extends TestCase
         yield ['https://sqs.us-east-2.amazonaws.com/123456/queue', 'https://sqs.us-east-2.amazonaws.com/123456/queue'];
         yield ['https://KEY:SECRET@sqs.us-east-2.amazonaws.com/123456/queue', 'https://sqs.us-east-2.amazonaws.com/123456/queue'];
         yield ['https://sqs.us-east-2.amazonaws.com/123456/queue?auto_setup=1', 'https://sqs.us-east-2.amazonaws.com/123456/queue'];
+        yield ['https://sqs.eusc-de-east-1.amazonaws.eu/123456/queue', 'https://sqs.eusc-de-east-1.amazonaws.eu/123456/queue'];
+        yield ['https://sqs.cn-north-1.amazonaws.com.cn/123456/queue', 'https://sqs.cn-north-1.amazonaws.com.cn/123456/queue'];
     }
 
     /**
@@ -432,6 +452,8 @@ class ConnectionTest extends TestCase
         yield ['https://sqs.us-east-2.amazonaws.com/queue'];
         yield ['https://us-east-2/123456/ab1-MyQueue-A2BCDEF3GHI4'];
         yield ['sqs://default/queue'];
+        yield ['https://sqs.us-east-2.amazonaws.evil.com/123456/queue'];
+        yield ['https://sqs.us-east-2.amazonaws.co.uk/123456/queue'];
     }
 
     public function testGetQueueUrlNotCalled()

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/AmazonSqsTransportFactory.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/AmazonSqsTransportFactory.php
@@ -39,6 +39,6 @@ class AmazonSqsTransportFactory implements TransportFactoryInterface
 
     public function supports(#[\SensitiveParameter] string $dsn, array $options): bool
     {
-        return str_starts_with($dsn, 'sqs://') || preg_match('#^https://sqs\.[\w\-]+\.amazonaws\.com/.+#', $dsn);
+        return str_starts_with($dsn, 'sqs://') || preg_match('#^https://sqs\.[\w\-]+\.amazonaws\.(?:com(?:\.cn)?|eu)/.+#', $dsn);
     }
 }

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
@@ -150,10 +150,13 @@ class Connection
         }
         unset($query['region']);
 
+        $isAwsHost = false;
         if ('default' !== ($params['host'] ?? 'default')) {
             $clientConfiguration['endpoint'] = \sprintf('%s://%s%s', ($query['sslmode'] ?? null) === 'disable' ? 'http' : 'https', $params['host'], ($params['port'] ?? null) ? ':'.$params['port'] : '');
-            if (preg_match(';^sqs\.([^\.]++)\.amazonaws\.com$;', $params['host'], $matches)) {
+            // Every AWS partition that serves SQS under amazonaws: aws, aws-cn and aws-eusc
+            if (preg_match(';^sqs\.([^\.]++)\.amazonaws\.(?:com(?:\.cn)?|eu)$;', $params['host'], $matches)) {
                 $clientConfiguration['region'] = $matches[1];
+                $isAwsHost = true;
             }
         } elseif (self::DEFAULT_OPTIONS['endpoint'] !== $options['endpoint'] ?? self::DEFAULT_OPTIONS['endpoint']) {
             $clientConfiguration['endpoint'] = $options['endpoint'];
@@ -165,12 +168,12 @@ class Connection
         }
         $configuration['account'] = 2 === \count($parsedPath) ? $parsedPath[0] : $options['account'] ?? self::DEFAULT_OPTIONS['account'];
 
-        // When the DNS looks like a QueueUrl, we can directly inject it in the connection
+        // When the DSN looks like a QueueUrl, we can directly inject it in the connection
         // https://sqs.REGION.amazonaws.com/ACCOUNT/QUEUE
         $queueUrl = null;
         if (
-            'https' === $params['scheme']
-            && ($params['host'] ?? 'default') === "sqs.{$clientConfiguration['region']}.amazonaws.com"
+            $isAwsHost
+            && 'https' === $params['scheme']
             && ($params['path'] ?? '/') === "/{$configuration['account']}/{$configuration['queue_name']}"
         ) {
             $queueUrl = 'https://'.$params['host'].$params['path'];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65256
| License       | MIT

The SQS transport hardcoded the `amazonaws.com` host suffix in three places, so a queue URL from any other AWS partition was unusable. AWS serves SQS under `amazonaws` in three partitions: `aws` (`amazonaws.com`), `aws-cn` (`amazonaws.com.cn`) and `aws-eusc`, the European Sovereign Cloud (`amazonaws.eu`). Only the first worked:

1. `AmazonSqsTransportFactory::supports()` rejected the DSN outright, so the queue URL never reached the transport at all and the user got `No transport supports Messenger DSN`.
2. `Connection::fromDsn()` derives the region from the host, and that check was also limited to `.com`, so the region silently fell back to the `eu-west-1` default and requests failed to sign unless `?region=` was passed by hand.
3. The QueueUrl injection, which lets the transport skip a `GetQueueUrl` call and the IAM permission it needs, was limited to `.com` as well, so the other partitions paid for the extra round trip on every connection.

All three now accept the three suffixes AWS actually serves. The pattern stays anchored on them rather than accepting any suffix, so a host such as `sqs.us-east-2.amazonaws.evil.com` is still refused and never has a queue URL injected into it.

The partitions that do not use `amazonaws` at all, `aws-iso` (`c2s.ic.gov`) and `aws-iso-b` (`sc2s.sgov.gov`), were not supported before and are not supported here. They need the `sqs://` scheme with an explicit endpoint and region, which already works.

The third check no longer rebuilds the host from the region. The region is derived from the host a few lines above and overwrites anything passed as `?region=`, so comparing them again could only ever confirm what the first check already established.

Reported by @thedomeffm.
