### PR TITLE
[DependencyInjection] Move the CACHEDIR.TAG test to the component owning the feature

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/Kernel/KernelTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Kernel/KernelTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Kernel;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Kernel\AbstractKernel;
+use Symfony\Component\DependencyInjection\Kernel\KernelTrait;
+
+class KernelTest extends TestCase
+{
+    private string $projectDir;
+
+    protected function setUp(): void
+    {
+        $this->projectDir = sys_get_temp_dir().'/sf_di_kernel_'.bin2hex(random_bytes(6));
+    }
+
+    protected function tearDown(): void
+    {
+        if (!is_dir($this->projectDir)) {
+            return;
+        }
+
+        $files = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($this->projectDir, \FilesystemIterator::SKIP_DOTS), \RecursiveIteratorIterator::CHILD_FIRST);
+
+        foreach ($files as $file) {
+            $file->isDir() ? rmdir($file->getPathname()) : unlink($file->getPathname());
+        }
+
+        rmdir($this->projectDir);
+    }
+
+    public function testBuildContainerWritesCachedirTag()
+    {
+        $kernel = new CachedirTagKernel($this->projectDir);
+        $kernel->boot();
+
+        foreach ([$kernel->getCacheDir(), $kernel->getBuildDir()] as $dir) {
+            $cachedirTag = $dir.'/CACHEDIR.TAG';
+            $this->assertFileExists($cachedirTag);
+            $this->assertStringStartsWith('Signature: 8a477f597d28d172789f06886806bc55', file_get_contents($cachedirTag));
+        }
+    }
+}
+
+class CachedirTagKernel extends AbstractKernel
+{
+    use KernelTrait;
+
+    public function __construct(private string $projectDir)
+    {
+        parent::__construct('test', false);
+    }
+
+    public function getProjectDir(): string
+    {
+        return $this->projectDir;
+    }
+
+    public function getBuildDir(): string
+    {
+        return $this->projectDir.'/var/build';
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -116,18 +116,6 @@ class KernelTest extends TestCase
         $this->assertFileDoesNotExist($legacyContainerDir.'.legacy');
     }
 
-    public function testBuildContainerWritesCachedirTag()
-    {
-        $kernel = new CustomProjectDirKernel();
-        $kernel->boot();
-
-        foreach ([$kernel->getCacheDir(), $kernel->getBuildDir()] as $dir) {
-            $cachedirTag = $dir.'/CACHEDIR.TAG';
-            $this->assertFileExists($cachedirTag);
-            $this->assertStringStartsWith('Signature: 8a477f597d28d172789f06886806bc55', file_get_contents($cachedirTag));
-        }
-    }
-
     public function testBootInitializesBundlesAndContainer()
     {
         $kernel = $this->getKernel(['initializeBundles']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Writing `CACHEDIR.TAG` happens in `KernelTrait`, which lives in DependencyInjection, but the test sat in `HttpKernel\Tests\KernelTest`. HttpKernel allows `symfony/dependency-injection: ^8.1`, so its low-deps job installs 8.1, where the feature does not exist yet:

```
1) Symfony\Component\HttpKernel\Tests\KernelTest::testBuildContainerWritesCachedirTag
Failed asserting that file ".../var/cache/custom/CACHEDIR.TAG" exists.
```

Moving the test to DependencyInjection, on a kernel built from `AbstractKernel` + `KernelTrait`, keeps it scoped to the code it covers. The new fixture also gives the build dir its own path, so both directories are really asserted instead of the same one twice.