### PR TITLE
[AssetMapper] Include front controller in dev asset URLs

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1339,6 +1339,9 @@ class FrameworkExtension extends Extension
 
         if (!$assetEnabled) {
             $container->removeDefinition('asset_mapper.asset_package');
+        } else {
+            $container->getDefinition('asset_mapper.asset_package')
+                ->replaceArgument(3, $config['server'] ? $config['public_prefix'] : null);
         }
 
         if (!$httpClientEnabled) {

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/asset_mapper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/asset_mapper.php
@@ -101,6 +101,8 @@ return static function (ContainerConfigurator $container) {
             ->args([
                 service('.inner'),
                 service('asset_mapper'),
+                service('request_stack'),
+                abstract_arg('dev server public prefix'),
             ])
 
         ->set('asset_mapper.dev_server_subscriber', AssetMapperDevServerSubscriber::class)

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -2524,6 +2524,30 @@ abstract class FrameworkExtensionTestCase extends TestCase
         $this->assertFalse($container->has('assets._default_package'));
     }
 
+    /**
+     * @testWith [true, "/assets_path/"]
+     *           [false, null]
+     */
+    public function testAssetMapperDevServerPrefix(bool $server, ?string $expectedPrefix)
+    {
+        $container = $this->createContainerFromClosure(static function ($container) use ($server) {
+            $container->loadFromExtension('framework', [
+                'annotations' => false,
+                'http_method_override' => false,
+                'handle_all_throwables' => true,
+                'php_errors' => ['log' => true],
+                'assets' => null,
+                'asset_mapper' => [
+                    'server' => $server,
+                    'public_prefix' => '/assets_path/',
+                    'paths' => ['assets/'],
+                ],
+            ]);
+        });
+
+        $this->assertSame($expectedPrefix, $container->getDefinition('asset_mapper.asset_package')->getArgument(3));
+    }
+
     public function testDefaultLock()
     {
         $container = $this->createContainerFromFile('lock');

--- a/src/Symfony/Component/AssetMapper/MapperAwareAssetPackage.php
+++ b/src/Symfony/Component/AssetMapper/MapperAwareAssetPackage.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\AssetMapper;
 
 use Symfony\Component\Asset\PackageInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Decorates asset packages to support resolving assets from the asset mapper.
@@ -20,10 +21,18 @@ use Symfony\Component\Asset\PackageInterface;
  */
 final class MapperAwareAssetPackage implements PackageInterface
 {
+    private readonly ?string $devServerPrefix;
+
+    /**
+     * @param string|null $devServerPublicPrefix The public prefix served by AssetMapperDevServerSubscriber, null when it is disabled
+     */
     public function __construct(
         private readonly PackageInterface $innerPackage,
         private readonly AssetMapperInterface $assetMapper,
+        private readonly ?RequestStack $requestStack = null,
+        ?string $devServerPublicPrefix = null,
     ) {
+        $this->devServerPrefix = null === $devServerPublicPrefix ? null : '/'.trim($devServerPublicPrefix, '/').'/';
     }
 
     public function getVersion(string $path): string
@@ -36,6 +45,16 @@ final class MapperAwareAssetPackage implements PackageInterface
         $publicPath = $this->assetMapper->getPublicPath($path);
         if ($publicPath) {
             $path = ltrim($publicPath, '/');
+        }
+
+        if (null !== $this->devServerPrefix && str_starts_with('/'.$path, $this->devServerPrefix)) {
+            // the dev server serves those assets through the kernel, so the front controller must be part of the URL
+            $request = $this->requestStack?->getMainRequest();
+            $frontController = $request ? trim(substr($request->getBaseUrl(), \strlen($request->getBasePath())), '/') : '';
+
+            if ('' !== $frontController) {
+                $path = $frontController.'/'.$path;
+            }
         }
 
         return $this->innerPackage->getUrl($path);

--- a/src/Symfony/Component/AssetMapper/Tests/MapperAwareAssetPackageTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/MapperAwareAssetPackageTest.php
@@ -12,9 +12,14 @@
 namespace Symfony\Component\AssetMapper\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Asset\Context\RequestStackContext;
 use Symfony\Component\Asset\PackageInterface;
+use Symfony\Component\Asset\PathPackage;
+use Symfony\Component\Asset\VersionStrategy\EmptyVersionStrategy;
 use Symfony\Component\AssetMapper\AssetMapperInterface;
 use Symfony\Component\AssetMapper\MapperAwareAssetPackage;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 class MapperAwareAssetPackageTest extends TestCase
 {
@@ -59,6 +64,93 @@ class MapperAwareAssetPackageTest extends TestCase
         $this->assertSame('/'.$expectedPathSentToInner, $assetMapperPackage->getUrl($path));
     }
 
+    /**
+     * @dataProvider getDevServerUrlTests
+     */
+    public function testGetUrlWithDevServer(string $requestUri, string $scriptName, string $path, string $expectedUrl)
+    {
+        $requestStack = $this->createRequestStack($requestUri, $scriptName);
+        $assetMapperPackage = new MapperAwareAssetPackage(
+            $this->createInnerPackage($requestStack),
+            $this->createAssetMapper(),
+            $requestStack,
+            '/assets/',
+        );
+
+        $this->assertSame($expectedUrl, $assetMapperPackage->getUrl($path));
+    }
+
+    public static function getDevServerUrlTests(): iterable
+    {
+        yield 'front controller at the document root' => [
+            'requestUri' => '/index.php/blog',
+            'scriptName' => '/index.php',
+            'path' => 'images/foo.png',
+            'expectedUrl' => '/index.php/assets/images/foo.123456.png',
+        ];
+
+        yield 'front controller below a base path' => [
+            'requestUri' => '/public/index.php/blog',
+            'scriptName' => '/public/index.php',
+            'path' => 'images/foo.png',
+            'expectedUrl' => '/public/index.php/assets/images/foo.123456.png',
+        ];
+
+        // the import map renders paths that the asset mapper already resolved
+        yield 'already resolved public path' => [
+            'requestUri' => '/index.php/blog',
+            'scriptName' => '/index.php',
+            'path' => 'assets/app.123456.js',
+            'expectedUrl' => '/index.php/assets/app.123456.js',
+        ];
+
+        yield 'remote path' => [
+            'requestUri' => '/index.php/blog',
+            'scriptName' => '/index.php',
+            'path' => 'https://cdn.example.com/assets/app.123456.js',
+            'expectedUrl' => 'https://cdn.example.com/assets/app.123456.js',
+        ];
+
+        yield 'asset outside of the public prefix' => [
+            'requestUri' => '/index.php/blog',
+            'scriptName' => '/index.php',
+            'path' => 'favicon.ico',
+            'expectedUrl' => '/favicon.ico',
+        ];
+
+        yield 'no front controller in the url' => [
+            'requestUri' => '/blog',
+            'scriptName' => '/index.php',
+            'path' => 'images/foo.png',
+            'expectedUrl' => '/assets/images/foo.123456.png',
+        ];
+    }
+
+    public function testGetUrlWithoutDevServer()
+    {
+        $requestStack = $this->createRequestStack('/index.php/blog', '/index.php');
+        $assetMapperPackage = new MapperAwareAssetPackage(
+            $this->createInnerPackage($requestStack),
+            $this->createAssetMapper(),
+            $requestStack,
+        );
+
+        $this->assertSame('/assets/images/foo.123456.png', $assetMapperPackage->getUrl('images/foo.png'));
+    }
+
+    public function testGetUrlWithoutRequest()
+    {
+        $requestStack = new RequestStack();
+        $assetMapperPackage = new MapperAwareAssetPackage(
+            $this->createInnerPackage($requestStack),
+            $this->createAssetMapper(),
+            $requestStack,
+            '/assets/',
+        );
+
+        $this->assertSame('/assets/images/foo.123456.png', $assetMapperPackage->getUrl('images/foo.png'));
+    }
+
     public static function getUrlTests(): iterable
     {
         yield 'path_is_found_in_asset_mapper' => [
@@ -70,5 +162,32 @@ class MapperAwareAssetPackageTest extends TestCase
             'path' => 'styles.css',
             'expectedPathSentToInner' => 'styles.css',
         ];
+    }
+
+    private function createAssetMapper(): AssetMapperInterface
+    {
+        $assetMapper = $this->createStub(AssetMapperInterface::class);
+        $assetMapper->method('getPublicPath')->willReturnCallback(
+            static fn (string $path) => 'images/foo.png' === $path ? '/assets/images/foo.123456.png' : null
+        );
+
+        return $assetMapper;
+    }
+
+    private function createRequestStack(string $requestUri, string $scriptName): RequestStack
+    {
+        $requestStack = new RequestStack();
+        $requestStack->push(new Request([], [], [], [], [], [
+            'SCRIPT_FILENAME' => '/var/www/public/index.php',
+            'SCRIPT_NAME' => $scriptName,
+            'REQUEST_URI' => $requestUri,
+        ]));
+
+        return $requestStack;
+    }
+
+    private function createInnerPackage(RequestStack $requestStack): PackageInterface
+    {
+        return new PathPackage('', new EmptyVersionStrategy(), new RequestStackContext($requestStack));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #53122
| License       | MIT

When an application is reached through a PATH_INFO URL such as `/index.php/blog`, the asset URLs generated in dev miss the front controller: `asset()` and `importmap()` render `/assets/app-1234.js`, which the web server answers with a 404 since that file only exists through `AssetMapperDevServerSubscriber`.

`MapperAwareAssetPackage` now inserts the front controller into the paths that this subscriber serves, that is the paths below the configured `public_prefix`. This covers both the logical paths resolved by `asset()` and the already resolved public paths that `importmap()` renders.

The package only receives the prefix when `framework.asset_mapper.server` is true, so production keeps serving compiled assets straight from the public directory. Assets outside of the prefix, absolute URLs and requests that carry no front controller are left untouched.
