### PR TITLE
[Console] Keep falsy answers when collecting an array with #[Ask]

### DIFF
--- a/src/Symfony/Component/Console/Attribute/Ask.php
+++ b/src/Symfony/Component/Console/Attribute/Ask.php
@@ -69,6 +69,10 @@ class Ask implements InteractiveAttributeInterface
             throw new LogicException(\sprintf('The %s "$%s" of "%s" must have a named type. Untyped, Union or Intersection types are not supported for interactive questions.', $reflection->getMemberName(), $name, $reflection->getSourceName()));
         }
 
+        if ('array' === $type->getName() && null !== $self->default) {
+            throw new LogicException(\sprintf('The "%s::$default" value is not supported for the array "$%s" of "%s", because an empty answer ends the collection.', self::class, $name, $reflection->getSourceName()));
+        }
+
         $self->closure = function (SymfonyStyle $io, InputInterface $input) use ($self, $reflection, $name, $type) {
             if ($reflection->isProperty() && isset($this->{$reflection->getName()})) {
                 return;
@@ -111,8 +115,11 @@ class Ask implements InteractiveAttributeInterface
 
             if ('array' === $type->getName()) {
                 $value = [];
-                while ($v = $io->askQuestion($question)) {
-                    if ("\x4" === $v || \PHP_EOL === $v || ($question->isTrimmable() && '' === $v = trim($v))) {
+                while (null !== $v = $io->askQuestion($question)) {
+                    if ($question->isTrimmable()) {
+                        $v = trim($v);
+                    }
+                    if ("\x4" === $v || \PHP_EOL === $v || '' === $v) {
                         break;
                     }
                     $value[] = $v;

--- a/src/Symfony/Component/Console/Tests/Command/InvokableCommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/InvokableCommandTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Attribute\Argument;
+use Symfony\Component\Console\Attribute\Ask;
 use Symfony\Component\Console\Attribute\Option;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Completion\CompletionInput;
@@ -246,6 +247,17 @@ class InvokableCommandTest extends TestCase
         $command->setCode(static function (#[Option] ?object $any = null) {});
 
         $this->expectException(LogicException::class);
+
+        $command->getDefinition();
+    }
+
+    public function testAskDefaultIsRejectedForArrayArgument()
+    {
+        $command = new Command('foo');
+        $command->setCode(static function (#[Argument] #[Ask('Add a value', default: 0)] array $values) {});
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('The "Symfony\Component\Console\Attribute\Ask::$default" value is not supported for the array "$values"');
 
         $command->getDefinition();
     }

--- a/src/Symfony/Component/Console/Tests/Fixtures/InvokableWithAskArrayCommand.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/InvokableWithAskArrayCommand.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Tests\Fixtures;
+
+use Symfony\Component\Console\Attribute\Argument;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Attribute\Ask;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand('invokable:ask:array')]
+class InvokableWithAskArrayCommand
+{
+    public function __invoke(
+        SymfonyStyle $io,
+
+        #[Argument]
+        #[Ask('Add a value')]
+        array $values,
+    ): int {
+        $io->writeln('Values: '.implode(',', $values));
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Symfony/Component/Console/Tests/Tester/CommandTesterTest.php
+++ b/src/Symfony/Component/Console/Tests/Tester/CommandTesterTest.php
@@ -28,6 +28,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Console\Tests\Fixtures\InvokableExtendingCommandTestCommand;
 use Symfony\Component\Console\Tests\Fixtures\InvokableTestCommand;
+use Symfony\Component\Console\Tests\Fixtures\InvokableWithAskArrayCommand;
 use Symfony\Component\Console\Tests\Fixtures\InvokableWithInputTestCommand;
 use Symfony\Component\Console\Tests\Fixtures\InvokableWithInteractiveAttributesTestCommand;
 use Symfony\Component\Console\Tests\Fixtures\InvokableWithInteractiveHiddenQuestionAttributeTestCommand;
@@ -467,6 +468,16 @@ class CommandTesterTest extends TestCase
 
                 TXT,
         ];
+    }
+
+    public function testInvokableWithFalsyAnswerInArrayQuestion()
+    {
+        $tester = new CommandTester(new InvokableWithAskArrayCommand());
+        $tester->setInputs(['v1', '0', 'v2', '']);
+        $tester->execute([], ['interactive' => true]);
+        $tester->assertCommandIsSuccessful();
+
+        self::assertStringContainsString('Values: v1,0,v2', $tester->getDisplay());
     }
 
     public function testInvokableWithInteractiveQuestionParameter()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Collecting values for an `array`-typed `#[Ask]` argument used the answer itself as the loop condition:

    while ($v = $io->askQuestion($question)) {

so answering `0` was treated like the empty terminator. The value was dropped and the prompt stopped, which silently discarded every later entry too. Answering `" 0 "` behaved the same way, because a trimmable question is already trimmed by the helper before it is returned.

    inputs ["v1", "0", "v2", ""]  =>  ["v1"]   (expected ["v1", "0", "v2"])
    inputs ["0", ""]              =>  []       (expected ["0"])

Loop until the answer is `null` instead, and test the terminator against `''` after trimming. That keeps the existing empty, EOL, Ctrl-D and non-trimmable behaviour unchanged.

A `$default` cannot work on an array member: an empty answer is what ends the collection, but the question helper turns an empty answer into the default, so the default is collected again on every prompt. That was already an infinite loop for a truthy default, and stopping on `null` extends it to falsy ones, which used to end the loop by accident. A non-null default is now rejected for array members.
