### PR TITLE
[Mime] Do not drop the last line of a resource-backed message

### DIFF
--- a/src/Symfony/Component/Mime/RawMessage.php
+++ b/src/Symfony/Component/Mime/RawMessage.php
@@ -70,7 +70,7 @@ class RawMessage
 
         if (\is_resource($this->message)) {
             rewind($this->message);
-            while ($line = fgets($this->message)) {
+            while (false !== $line = fgets($this->message)) {
                 yield $line;
             }
 

--- a/src/Symfony/Component/Mime/Tests/RawMessageTest.php
+++ b/src/Symfony/Component/Mime/Tests/RawMessageTest.php
@@ -89,6 +89,15 @@ class RawMessageTest extends TestCase
         $this->assertSame("line1\nline2\nline3\n", implode('', iterator_to_array($message->toIterable())));
     }
 
+    public function testToIterableOnResourceYieldsAFinalFalsyLine()
+    {
+        $handle = fopen('php://memory', 'r+');
+        fwrite($handle, "line1\n0");
+
+        $message = new RawMessage($handle);
+        $this->assertSame("line1\n0", implode('', iterator_to_array($message->toIterable())));
+    }
+
     public function testDestructClosesResource()
     {
         $handle = fopen('php://memory', 'r+');


### PR DESCRIPTION
`RawMessage::toIterable()` iterated a message resource with

    while ($line = fgets($this->message)) {

which stops on any falsy line. `fgets()` only returns a falsy string for a final `"0"` with no trailing newline. A message ending in such a line had it silently dropped when sent. `toString()` reads the same resource with `stream_get_contents()` and kept it, so the two disagreed:

    $raw = "Subject: x\r\n\r\nbody\r\n0";
    toString():   "Subject: x\r\n\r\nbody\r\n0"
    toIterable(): "Subject: x\r\n\r\nbody\r\n"

Stop on `false`, the end of the stream, so both representations agree.

| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT
