### PR TITLE
[Uid] Compare times by value in MockUuidFactory

### DIFF
--- a/src/Symfony/Component/Uid/Factory/MockUuidFactory.php
+++ b/src/Symfony/Component/Uid/Factory/MockUuidFactory.php
@@ -95,7 +95,7 @@ class MockUuidFactory extends UuidFactory
                     throw new InvalidArgumentException(\sprintf('Next UUID in sequence is not a Uuid and TimeBasedUidInterface: "%s" given.', get_debug_type($uuid)));
                 }
 
-                if (null !== $time && $uuid->getDateTime() !== $time) {
+                if (null !== $time && $uuid->getDateTime() != $time) {
                     throw new InvalidArgumentException(\sprintf('Next UUID in sequence does not match the expected time: "%s" != "%s".', $uuid->getDateTime()->format('@U.uT'), $time->format('@U.uT')));
                 }
 

--- a/src/Symfony/Component/Uid/Tests/Factory/MockUuidFactoryTest.php
+++ b/src/Symfony/Component/Uid/Tests/Factory/MockUuidFactoryTest.php
@@ -206,6 +206,16 @@ class MockUuidFactoryTest extends TestCase
         $timeFactory->create();
     }
 
+    public function testTimeBasedAcceptsMatchingTime()
+    {
+        $uuid = UuidV1::fromString('6ba7b810-9dad-11d1-80b4-00c04fd430c8');
+        $factory = new MockUuidFactory([$uuid, $uuid]);
+        $timeFactory = $factory->timeBased();
+
+        $this->assertSame($uuid, $timeFactory->create($uuid->getDateTime()));
+        $this->assertSame($uuid, $timeFactory->create(\DateTime::createFromInterface($uuid->getDateTime())));
+    }
+
     public function testTimeBasedThrowsExceptionOnMismatchedTime()
     {
         $factory = new MockUuidFactory([


### PR DESCRIPTION
`MockUuidFactory::timeBased()->create($time)` compared the UUID time to the expected one with `!==`. On two `DateTimeInterface` instances that operator tests object identity, not the instant they represent. `getDateTime()` always returns a fresh `DateTimeImmutable`, so the comparison could never hold. Every call passing a non-null `$time` threw, with a message that compared a value to itself:

    Next UUID in sequence does not match the expected time:
    "@886630433.151182GMT+0000" != "@886630433.151182GMT+0000"

Use `!=` so the instants are compared. That is what the check means and what the exception message already reports. The existing test only covers the mismatching case, so the bug went unnoticed. Add the matching one.

| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT
