### PR TITLE
[Tui] Track descendant positions of cached horizontal layout children

### DIFF
--- a/src/Symfony/Component/Tui/Render/LayoutEngine.php
+++ b/src/Symfony/Component/Tui/Render/LayoutEngine.php
@@ -311,6 +311,8 @@ final class LayoutEngine
         );
 
         $childRenders = [];
+        $childContexts = [];
+        $cacheHits = [];
         $maxRows = 0;
         $hasPositionStack = $this->positionTracker->isActive();
 
@@ -326,7 +328,11 @@ final class LayoutEngine
             }
 
             $context = new RenderContext($childColumns, $rows, null, $this->fontRegistry);
+            $revision = $child->getRenderRevision();
+            $hadCachedRender = null !== $child->getRenderCache($childColumns, $rows);
             $childLines = $this->widgetRenderer->renderWidget($child, $context);
+            $cacheHits[$index] = $hadCachedRender && $revision === $child->getRenderRevision();
+            $childContexts[$index] = $context;
             $childRenders[$index] = $childLines;
             $maxRows = max($maxRows, \count($childLines));
 
@@ -359,12 +365,36 @@ final class LayoutEngine
             [$absRow, $absCol] = $this->positionTracker->currentOffset();
             $colOffset = 0;
             foreach ($children as $index => $child) {
-                $this->positionTracker->setWidgetRect($child, new WidgetRect(
-                    $absRow + $childOffsets[$index],
-                    $absCol + $colOffset,
+                $childAbsRow = $absRow + $childOffsets[$index];
+                $childAbsCol = $absCol + $colOffset;
+                $rect = new WidgetRect(
+                    $childAbsRow,
+                    $childAbsCol,
                     $childColumnCounts[$index],
                     \count($childRenders[$index]),
-                ));
+                );
+
+                if ($child instanceof ParentInterface) {
+                    $positionsTracked = true;
+                    if ($cacheHits[$index]) {
+                        // A cached child was not walked, so its descendants still
+                        // carry the previous frame's rects: move them as a block.
+                        $positionsTracked = $this->positionTracker->moveSubtree($child, $rect);
+                    } else {
+                        // They were tracked during the render, before the
+                        // cross-axis offset was known, so only that offset is due.
+                        $this->positionTracker->shiftContentPositions([$child], 0, $childOffsets[$index]);
+                    }
+
+                    if (!$positionsTracked) {
+                        $child->clearRenderCache();
+                        $this->positionTracker->push($childAbsRow, $childAbsCol);
+                        $this->widgetRenderer->renderWidget($child, $childContexts[$index]);
+                        $this->positionTracker->pop();
+                    }
+                }
+
+                $this->positionTracker->setWidgetRect($child, $rect);
                 $colOffset += $childColumnCounts[$index] + $gap;
             }
         }

--- a/src/Symfony/Component/Tui/Render/PositionTracker.php
+++ b/src/Symfony/Component/Tui/Render/PositionTracker.php
@@ -154,41 +154,21 @@ final class PositionTracker
     }
 
     /**
-     * Snapshot the set of widgets currently tracked.
+     * Shift the tracked positions of laid-out content by the given offsets.
      *
-     * @return array<int, true>
-     */
-    public function snapshotKeys(): array
-    {
-        $snapshot = [];
-        foreach ($this->widgetPositions as $widget => $_) {
-            $snapshot[spl_object_id($widget)] = true;
-        }
-
-        return $snapshot;
-    }
-
-    /**
-     * Shift positions for all widgets added since the snapshot.
+     * Called when alignment moves a container's content after layout, so the
+     * children and their descendants keep matching where they are drawn.
      *
-     * @param array<int, true>|null $before
+     * @param AbstractWidget[] $children
      */
-    public function shiftDescendantPositions(?array $before, int $colOffset, int $rowOffset = 0): void
+    public function shiftContentPositions(array $children, int $colOffset, int $rowOffset = 0): void
     {
-        if (null === $before) {
+        if (0 === $colOffset && 0 === $rowOffset) {
             return;
         }
 
-        foreach ($this->widgetPositions as $widget => $rect) {
-            if (isset($before[spl_object_id($widget)])) {
-                continue;
-            }
-            $this->widgetPositions[$widget] = new WidgetRect(
-                $rect->row + $rowOffset,
-                $rect->col + $colOffset,
-                $rect->columns,
-                $rect->rows,
-            );
+        foreach ($children as $child) {
+            $this->shiftSubtree($child, $rowOffset, $colOffset);
         }
     }
 

--- a/src/Symfony/Component/Tui/Render/Renderer.php
+++ b/src/Symfony/Component/Tui/Render/Renderer.php
@@ -173,7 +173,7 @@ final class Renderer implements WidgetRendererInterface
 
             $lineWidth = AnsiUtils::visibleWidth($line);
             if ($lineWidth > $availableColumns) {
-                throw new RenderException(\sprintf("Widget \"%s\" rendered line %d with width %d, exceeding the available %d columns.\nLine preview: %s.", $widget::class, $i, $lineWidth, $availableColumns, mb_substr(AnsiUtils::stripAnsiCodes($line), 0, 100)), $i, $lineWidth, $availableColumns);
+                throw new RenderException(\sprintf("Widget \"%s\" rendered line %d with width %d, exceeding the available %d columns.\nLine preview: \"%s\".", $widget::class, $i, $lineWidth, $availableColumns, mb_substr(AnsiUtils::stripAnsiCodes($line), 0, 100)), $i, $lineWidth, $availableColumns);
             }
         }
 
@@ -287,12 +287,10 @@ final class Renderer implements WidgetRendererInterface
             $this->positionTracker->push($parentRow + $chromeTop, $parentCol + $chromeLeft);
         }
 
-        // Snapshot positions before layout so we can adjust them if alignment shifts content
         $align = $resolvedStyle->getAlign();
         $hasAlign = null !== $align && Align::Left !== $align;
         $verticalAlign = $resolvedStyle->getVerticalAlign();
         $hasVerticalAlign = null !== $verticalAlign;
-        $positionsBeforeLayout = ($hasAlign || $hasVerticalAlign) ? $this->positionTracker->snapshotKeys() : null;
 
         // Render children using layout engine.
         // For horizontal containers, pass verticalAlign so layoutHorizontal can
@@ -317,7 +315,7 @@ final class Renderer implements WidgetRendererInterface
             if (0 < $verticalOffset = $this->layoutEngine->computeVerticalAlignOffset(\count($childLines), $innerRows, $verticalAlign)) {
                 $topPad = array_fill(0, $verticalOffset, '');
                 array_unshift($childLines, ...$topPad);
-                $this->positionTracker->shiftDescendantPositions($positionsBeforeLayout, 0, $verticalOffset);
+                $this->positionTracker->shiftContentPositions($children, 0, $verticalOffset);
             }
         }
 
@@ -341,7 +339,7 @@ final class Renderer implements WidgetRendererInterface
         // Apply horizontal alignment for child widgets and adjust tracked positions
         if ($hasAlign && 0 < $alignOffset = $this->layoutEngine->computeAlignOffset($childLines, $innerColumns, $align)) {
             $childLines = $this->layoutEngine->shiftLines($childLines, $alignOffset);
-            $this->positionTracker->shiftDescendantPositions($positionsBeforeLayout, $alignOffset);
+            $this->positionTracker->shiftContentPositions($children, $alignOffset);
         }
 
         // Apply chrome (padding, border, background)

--- a/src/Symfony/Component/Tui/Tests/Render/PositionTrackerTest.php
+++ b/src/Symfony/Component/Tui/Tests/Render/PositionTrackerTest.php
@@ -116,44 +116,41 @@ final class PositionTrackerTest extends TestCase
     }
 
     // ---------------------------------------------------------------
-    // shiftDescendantPositions
+    // shiftContentPositions
     // ---------------------------------------------------------------
 
-    public function testShiftDescendantPositions()
+    public function testShiftContentPositionsShiftsChildrenAndTheirDescendants()
     {
         $tracker = new PositionTracker();
-        $widgetOld = new TextWidget('old');
-        $widgetNew = new TextWidget('new');
+        $outsider = new TextWidget('outsider');
+        $child = new ContainerWidget();
+        $leaf = new TextWidget('leaf');
+        $child->add($leaf);
 
-        $tracker->setWidgetRect($widgetOld, new WidgetRect(0, 0, 10, 1));
-        $snapshot = $tracker->snapshotKeys();
+        $tracker->setWidgetRect($outsider, new WidgetRect(0, 0, 10, 1));
+        $tracker->setWidgetRect($child, new WidgetRect(2, 3, 10, 1));
+        $tracker->setWidgetRect($leaf, new WidgetRect(2, 3, 10, 1));
 
-        $tracker->setWidgetRect($widgetNew, new WidgetRect(2, 3, 10, 1));
+        $tracker->shiftContentPositions([$child], 5, 10);
 
-        $tracker->shiftDescendantPositions($snapshot, 5, 10);
-
-        // Old widget should be unchanged
-        $oldRect = $tracker->getWidgetRect($widgetOld);
-        $this->assertSame(0, $oldRect->row);
-        $this->assertSame(0, $oldRect->col);
-
-        // New widget should be shifted
-        $newRect = $tracker->getWidgetRect($widgetNew);
-        $this->assertSame(12, $newRect->row);  // 2 + 10
-        $this->assertSame(8, $newRect->col);    // 3 + 5
+        $outsiderRect = $tracker->getWidgetRect($outsider);
+        $this->assertSame([0, 0], [$outsiderRect->row, $outsiderRect->col]);
+        $childRect = $tracker->getWidgetRect($child);
+        $this->assertSame([12, 8], [$childRect->row, $childRect->col]);
+        $leafRect = $tracker->getWidgetRect($leaf);
+        $this->assertSame([12, 8], [$leafRect->row, $leafRect->col]);
     }
 
-    public function testShiftDescendantPositionsWithNullSnapshotIsNoop()
+    public function testShiftContentPositionsWithoutOffsetIsNoop()
     {
         $tracker = new PositionTracker();
         $widget = new TextWidget('a');
         $tracker->setWidgetRect($widget, new WidgetRect(2, 3, 10, 1));
 
-        $tracker->shiftDescendantPositions(null, 5, 10);
+        $tracker->shiftContentPositions([$widget], 0, 0);
 
         $rect = $tracker->getWidgetRect($widget);
-        $this->assertSame(2, $rect->row);
-        $this->assertSame(3, $rect->col);
+        $this->assertSame([2, 3], [$rect->row, $rect->col]);
     }
 
     public function testMoveSubtreeShiftsTrackedDescendants()

--- a/src/Symfony/Component/Tui/Tests/Render/RendererTest.php
+++ b/src/Symfony/Component/Tui/Tests/Render/RendererTest.php
@@ -17,6 +17,7 @@ use Symfony\Component\Tui\Ansi\AnsiUtils;
 use Symfony\Component\Tui\Exception\RenderException;
 use Symfony\Component\Tui\Render\RenderContext;
 use Symfony\Component\Tui\Render\Renderer;
+use Symfony\Component\Tui\Style\Align;
 use Symfony\Component\Tui\Style\Border;
 use Symfony\Component\Tui\Style\Direction;
 use Symfony\Component\Tui\Style\Padding;
@@ -831,6 +832,80 @@ class RendererTest extends TestCase
         $this->assertSame(22, $rightLeafRect->col);
     }
 
+    public function testWidgetPositionTrackingForDescendantsOfHorizontalChildrenInVerticalLayout()
+    {
+        $renderer = new Renderer();
+        $root = new ContainerWidget();
+        $prefix = new TextWidget('Prefix');
+        $row = new ContainerWidget();
+        $row->setStyle(new Style(direction: Direction::Horizontal));
+
+        $leftPane = new ContainerWidget();
+        $leftLeaf = new TextWidget('Left');
+        $leftCounter = new CountingLeafWidget();
+        $leftPane->add($leftLeaf);
+        $leftPane->add($leftCounter);
+        $rightPane = new ContainerWidget();
+        $rightLeaf = new TextWidget('Right');
+        $rightPane->add($rightLeaf);
+        $row->add($leftPane);
+        $row->add($rightPane);
+
+        $root->add($prefix);
+        $root->add($row);
+
+        $renderer->render($root, 40, 10);
+
+        $leftLeafRect = $renderer->getWidgetRect($leftLeaf);
+        $this->assertNotNull($leftLeafRect);
+        $this->assertSame(1, $leftLeafRect->row);
+        $this->assertSame(0, $leftLeafRect->col);
+        $rightLeafRect = $renderer->getWidgetRect($rightLeaf);
+        $this->assertNotNull($rightLeafRect);
+        $this->assertSame(1, $rightLeafRect->row);
+        $this->assertSame(20, $rightLeafRect->col);
+
+        // Shift the row down while the left pane stays cached
+        $prefix->setText("First line\nSecond line");
+        $rightLeaf->setText('Changed');
+        $renderer->render($root, 40, 10);
+
+        $this->assertSame(1, $leftCounter->renderCount);
+        $this->assertSame(2, $renderer->getWidgetRect($leftLeaf)->row);
+        $this->assertSame(2, $renderer->getWidgetRect($rightLeaf)->row);
+    }
+
+    public function testWidgetPositionTrackingForDescendantsOfVerticallyAlignedHorizontalChildren()
+    {
+        $renderer = new Renderer(new StyleSheet([
+            '.row' => new Style(direction: Direction::Horizontal, verticalAlign: VerticalAlign::Center),
+        ]));
+
+        $root = new ContainerWidget();
+        $row = new ContainerWidget();
+        $row->addStyleClass('row');
+
+        $tall = new ContainerWidget();
+        $tall->add(new TextWidget('top'));
+        $tall->add(new TextWidget('mid'));
+        $tall->add(new TextWidget('bot'));
+
+        $shortPane = new ContainerWidget();
+        $shortLeaf = new TextWidget('url');
+        $shortPane->add($shortLeaf);
+
+        $row->add($tall);
+        $row->add($shortPane);
+        $root->add($row);
+
+        $renderer->render($root, 40, 10);
+
+        // shortPane is 1 line centered in 3: floor((3-1)/2) = 1, and its
+        // descendant must carry the same cross-axis offset.
+        $this->assertSame(1, $renderer->getWidgetRect($shortPane)->row);
+        $this->assertSame(1, $renderer->getWidgetRect($shortLeaf)->row);
+    }
+
     public function testWidgetPositionTrackingForHorizontalChildrenWithVerticalAlignCenter()
     {
         // Shorter children in a horizontal container with VerticalAlign::Center must have their
@@ -1093,6 +1168,50 @@ class RendererTest extends TestCase
 
         $this->assertSame(1, $leaf->renderCount);
         $this->assertSame(2, $renderer->getWidgetRect($leaf)->row);
+    }
+
+    public function testAlignedPositionsAreShiftedOnEveryFrame()
+    {
+        $renderer = new Renderer();
+        $root = new ContainerWidget();
+        $root->setStyle(new Style(align: Align::Right));
+        $prefix = new TextWidget('tick 0');
+        $leaf = new TextWidget('abc');
+        $root->add($prefix);
+        $root->add($leaf);
+
+        $renderer->render($root, 20, 5);
+        $this->assertSame(14, $renderer->getWidgetRect($leaf)->col);
+
+        $prefix->setText('tick 1');
+        $renderer->render($root, 20, 5);
+
+        $this->assertSame(14, $renderer->getWidgetRect($leaf)->col);
+    }
+
+    public function testAlignedPositionsFollowCachedChildrenThatStartUnshifted()
+    {
+        $renderer = new Renderer();
+        $root = new ContainerWidget();
+        $root->setStyle(new Style(align: Align::Right));
+        $prefix = new TextWidget(str_repeat('x', 20));
+        $inner = new ContainerWidget();
+        $leaf = new TextWidget('ab');
+        $inner->add($leaf);
+        $root->add($prefix);
+        $root->add($inner);
+
+        // The prefix fills the width, so nothing is shifted on the first frame.
+        $renderer->render($root, 20, 5);
+        $this->assertSame(0, $renderer->getWidgetRect($inner)->col);
+        $this->assertSame(0, $renderer->getWidgetRect($leaf)->col);
+
+        // Shrinking it introduces an offset while the inner container stays cached.
+        $prefix->setText('x');
+        $renderer->render($root, 20, 5);
+
+        $this->assertSame(18, $renderer->getWidgetRect($inner)->col);
+        $this->assertSame(18, $renderer->getWidgetRect($leaf)->col);
     }
 
     // ---------------------------------------------------------------


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | n/a
| License       | MIT

Three position-tracking fixes in the same area, smallest first.

**Alignment offsets reached tracked rects on the first frame only.** `PositionTracker::reset()` keeps widget positions across frames so cached subtrees keep their rects, but `snapshotKeys()` then marked every widget tracked by the previous frame as "before", and `shiftDescendantPositions()` skipped it. From the second frame on, an `align` or `verticalAlign` offset was applied to the drawn output but not to `getWidgetRect()`. Content is now shifted by walking the laid-out children instead of diffing against a snapshot of everything tracked so far, which also covers children whose subtree was reused from the cache without moving.

**Descendants of a horizontal layout child were never tracked when the child came from cache**, e.g. cached during the vertical measurement pass, so `getWidgetRect()` returned `null` or a stale rect for them. `layoutHorizontal()` now mirrors the vertical path: an unchanged child keeps its cached output and its tracked descendants are moved as a block with `moveSubtree()`, while a child that really rendered has its subtree walked.

**The cross-axis offset applied for `align-items` never reached descendants.** It was applied only to each direct child's own rect after layout, so a widget inside a vertically centered pane reported the row of the tallest sibling rather than the row its own parent is drawn at. Clicks landed on the wrong widget.
