### PR TITLE
[DependencyInjection] Add support for conditionally registering services at compile time

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Attribute/WhenClassExists.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/WhenClassExists.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Attribute;
+
+/**
+ * An attribute to register this class as a service only when the given class or interface exists.
+ *
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
+class WhenClassExists
+{
+    /**
+     * @param string       $class          The class or interface that must exist for this service to be registered
+     * @param string|null  $package        When set, the Composer package that provides the class; the condition then
+     *                                     also fails when the package is only installed as a dev dependency and would
+     *                                     be missing after "composer install --no-dev" (same semantics as
+     *                                     ContainerBuilder::willBeAvailable())
+     * @param list<string> $parentPackages The packages the annotated service belongs to; a dev-only $package is
+     *                                     accepted when one of these is a dev dependency too
+     */
+    public function __construct(
+        public string $class,
+        public ?string $package = null,
+        public array $parentPackages = [],
+    ) {
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Attribute/WhenClassMissing.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/WhenClassMissing.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Attribute;
+
+/**
+ * An attribute to register this class as a service only when the given class or interface does not exist.
+ *
+ * This is typically used to register a fallback implementation when an optional package is not installed.
+ *
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
+class WhenClassMissing
+{
+    /**
+     * @param string       $class          The class or interface that must not exist for this service to be registered
+     * @param string|null  $package        When set, the Composer package that provides the class; the condition then
+     *                                     also matches when the package is only installed as a dev dependency and
+     *                                     would be missing after "composer install --no-dev" (inverse semantics of
+     *                                     ContainerBuilder::willBeAvailable())
+     * @param list<string> $parentPackages The packages the annotated service belongs to; a dev-only $package is
+     *                                     still considered available when one of these is a dev dependency too
+     */
+    public function __construct(
+        public string $class,
+        public ?string $package = null,
+        public array $parentPackages = [],
+    ) {
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Attribute/WhenMissingService.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/WhenMissingService.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Attribute;
+
+/**
+ * An attribute to register this class as a service only when no service or alias with the given id exists.
+ *
+ * This makes the service an overridable default: any definition of the given id
+ * coming from the app or from any bundle wins over the annotated class.
+ *
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
+class WhenMissingService
+{
+    /**
+     * @param string $id The service id (or alias) whose absence enables this service
+     */
+    public function __construct(public string $id)
+    {
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Attribute/WhenParameter.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/WhenParameter.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Attribute;
+
+/**
+ * An attribute to register this class as a service only when a container parameter has the given value.
+ *
+ * The condition fails when the parameter is not defined. Parameters resolved from
+ * environment variables cannot be used because their value is not known at compile time.
+ *
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
+class WhenParameter
+{
+    /**
+     * @param string $name  The name of the container parameter
+     * @param mixed  $value The value the parameter must be equal to (defaults to true)
+     */
+    public function __construct(
+        public string $name,
+        public mixed $value = true,
+    ) {
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG
 8.2
 ---
 
+ * Add `#[WhenClassExists]`, `#[WhenClassMissing]`, `#[WhenMissingService]` and `#[WhenParameter]` attributes and the `when` configuration key to conditionally register services at compile time
+ * Add `Definition::setWhenConditions()` and `Definition::getWhenConditions()`
  * Allow computing tag attributes per tagged service when using `#[AutoconfigureTag]`, `#[Autoconfigure]` or `_instanceof`: pass a `\Closure` receiving the concrete class-string (requires PHP 8.5), or a `[class-string, method]` callable resolved against each concrete class (works on PHP 8.4)
  * Call `#[Required]` methods in the order defined by the attribute's `$priority` argument
  * Add support for injecting a service as a lazy proxy on a per-argument basis, using the `!lazy_proxy` YAML tag, the `@~` reference prefix or the `lazy_proxy()` function in the PHP-DSL

--- a/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
@@ -41,6 +41,9 @@ class PassConfig
         $this->mergePass = new MergeExtensionConfigurationPass();
 
         $this->beforeOptimizationPasses = [
+            150 => [
+                new ResolveConditionalDefinitionsPass(pureConditionsOnly: true),
+            ],
             100 => [
                 new ResolveClassPass(),
                 new RegisterAutoconfigureAttributesPass(),
@@ -53,6 +56,7 @@ class PassConfig
         ];
 
         $this->optimizationPasses = [[
+            new ResolveConditionalDefinitionsPass(),
             new AutoAliasServicePass(),
             new ValidateEnvPlaceholdersPass(),
             new ResolveDecoratorStackPass(),

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveConditionalDefinitionsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveConditionalDefinitionsPass.php
@@ -1,0 +1,251 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Argument\ArgumentInterface;
+use Symfony\Component\DependencyInjection\Attribute\WhenClassExists;
+use Symfony\Component\DependencyInjection\Attribute\WhenClassMissing;
+use Symfony\Component\DependencyInjection\Attribute\WhenMissingService;
+use Symfony\Component\DependencyInjection\Attribute\WhenParameter;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Exception\LogicException;
+use Symfony\Component\DependencyInjection\ParameterBag\EnvPlaceholderParameterBag;
+
+/**
+ * Evaluates the "when" conditions attached to definitions and excludes the definitions whose conditions don't match.
+ *
+ * The pass runs twice. Early in the "before optimization" phase, it evaluates pure conditions
+ * (class existence, parameter values) so that rejected definitions never reach class resolution
+ * or attribute autoconfiguration. At the start of the "optimization" phase, once every definition
+ * source has contributed, it evaluates the remaining conditions; "missing service" conditions are
+ * all evaluated in a single sweep against the resulting set of definitions, which makes their
+ * outcome independent from the order in which definitions were registered.
+ *
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ */
+class ResolveConditionalDefinitionsPass implements CompilerPassInterface
+{
+    /**
+     * @param bool $pureConditionsOnly Whether to only evaluate the conditions that don't depend
+     *                                 on the state of the container ("missing service" conditions
+     *                                 are then kept for a later run of this pass)
+     */
+    public function __construct(
+        private bool $pureConditionsOnly = false,
+    ) {
+    }
+
+    public function process(ContainerBuilder $container): void
+    {
+        $conditionalIds = [];
+        $missingServiceConditions = [];
+        $rejected = [];
+
+        foreach ($container->getDefinitions() as $id => $definition) {
+            if (!$this->pureConditionsOnly) {
+                $this->assertNoInlineConditions($definition, $id, false);
+            }
+
+            if (!$conditions = $definition->getWhenConditions()) {
+                continue;
+            }
+
+            $conditionalIds[] = $id;
+
+            if ($definition->hasTag('container.excluded')) {
+                // already rejected by an earlier run of this pass (or excluded for another reason);
+                // re-reject it so that any behavior restored since (e.g. decoration read from
+                // #[AsDecorator] by AutowireAsDecoratorPass) is stripped again
+                $rejected[$id] = $definition->getTag('container.excluded')[0]['source'] ?? 'because of its "when" conditions';
+                continue;
+            }
+
+            foreach ($conditions as $condition) {
+                if ($condition instanceof WhenMissingService) {
+                    $missingServiceConditions[$id][] = $condition;
+                    continue;
+                }
+
+                if (isset($rejected[$id])) {
+                    continue;
+                }
+
+                if (null !== $failure = $this->evaluate($condition, $id, $container)) {
+                    $rejected[$id] = $failure;
+                }
+            }
+        }
+
+        if ($this->pureConditionsOnly) {
+            foreach ($conditionalIds as $id) {
+                if (isset($rejected[$id])) {
+                    // conditions are kept so that the final run of this pass rejects the
+                    // definition again after the attribute-reading passes have run
+                    $this->reject($container, $id, $rejected[$id]);
+                } else {
+                    $container->getDefinition($id)->setWhenConditions($missingServiceConditions[$id] ?? []);
+                }
+            }
+            $this->removeAliasesToRejectedServices($container, $rejected);
+
+            return;
+        }
+
+        $stage1Rejected = $rejected;
+        foreach ($missingServiceConditions as $id => $conditions) {
+            if (isset($stage1Rejected[$id])) {
+                continue;
+            }
+
+            foreach ($conditions as $condition) {
+                $target = $this->resolveAliasTarget($container, $condition->id);
+
+                if ($target === $id || isset($stage1Rejected[$target])) {
+                    continue;
+                }
+
+                if (isset($missingServiceConditions[$target])) {
+                    throw new LogicException(\sprintf('Invalid "when" condition on service "%s": it depends on the absence of service "%s", which itself uses a "missing_service" condition. Conditional services cannot depend on each other\'s absence.', $id, $condition->id));
+                }
+
+                if ($this->serviceExists($container, $target)) {
+                    $rejected[$id] = \sprintf('because the "%s" service is already defined', $condition->id);
+                    break;
+                }
+            }
+        }
+
+        foreach ($conditionalIds as $id) {
+            if (isset($rejected[$id])) {
+                $this->reject($container, $id, $rejected[$id]);
+            }
+            $container->getDefinition($id)->setWhenConditions([]);
+        }
+
+        $this->removeAliasesToRejectedServices($container, $rejected);
+    }
+
+    private function evaluate(object $condition, string $id, ContainerBuilder $container): ?string
+    {
+        if ($condition instanceof WhenClassExists || $condition instanceof WhenClassMissing) {
+            $exists = null !== $container->getReflectionClass($condition->class, false);
+
+            if ($exists && $condition->package) {
+                $exists = ContainerBuilder::willBeAvailable($condition->package, $condition->class, $condition->parentPackages);
+            }
+
+            if ($condition instanceof WhenClassMissing) {
+                return $exists ? \sprintf('because the "%s" class%s is available', $condition->class, $condition->package ? \sprintf(' from package "%s"', $condition->package) : '') : null;
+            }
+
+            return $exists ? null : \sprintf('because the "%s" class%s is not available', $condition->class, $condition->package ? \sprintf(' from package "%s"', $condition->package) : '');
+        }
+
+        if ($condition instanceof WhenParameter) {
+            if (!$container->hasParameter($condition->name)) {
+                return \sprintf('because the "%s" parameter is not defined', $condition->name);
+            }
+
+            $bag = $container->getParameterBag();
+            $value = $bag->resolveValue($container->getParameter($condition->name));
+            $expected = $bag->resolveValue($condition->value);
+
+            if ($bag instanceof EnvPlaceholderParameterBag && str_contains(serialize([$value, $expected]), $bag->getEnvPlaceholderUniquePrefix())) {
+                throw new LogicException(\sprintf('The "when" condition of service "%s" uses parameter "%s", which references an environment variable; its value is not known at compile time. Use a build-time parameter instead, or register the service conditionally in a compiler pass.', $id, $condition->name));
+            }
+
+            return $value === $expected ? null : \sprintf('because the "%s" parameter does not have the expected value', $condition->name);
+        }
+
+        throw new InvalidArgumentException(\sprintf('Unsupported "when" condition of type "%s" on service "%s".', get_debug_type($condition), $id));
+    }
+
+    private function reject(ContainerBuilder $container, string $id, string $reason): void
+    {
+        $definition = $container->getDefinition($id);
+
+        if (null === $definition->getClass()) {
+            // prevent ResolveClassPass from failing on FQCN-looking ids whose class doesn't exist
+            $definition->setClass($id);
+        }
+
+        $definition->setAbstract(true)
+            ->setDecoratedService(null)
+            ->setTags(['container.excluded' => [['source' => $reason]]]);
+    }
+
+    private function assertNoInlineConditions(mixed $value, string $id, bool $isInline): void
+    {
+        if (\is_array($value)) {
+            foreach ($value as $v) {
+                $this->assertNoInlineConditions($v, $id, $isInline);
+            }
+        } elseif ($value instanceof ArgumentInterface) {
+            $this->assertNoInlineConditions($value->getValues(), $id, $isInline);
+        } elseif ($value instanceof Definition) {
+            if ($isInline && $value->getWhenConditions()) {
+                throw new LogicException(\sprintf('Invalid inline definition used in service "%s": "when" conditions are only supported on definitions registered in the container.', $id));
+            }
+
+            $this->assertNoInlineConditions($value->getArguments(), $id, true);
+            $this->assertNoInlineConditions($value->getProperties(), $id, true);
+            $this->assertNoInlineConditions($value->getFactory(), $id, true);
+            $this->assertNoInlineConditions($value->getConfigurator(), $id, true);
+            $this->assertNoInlineConditions($value->getBindings(), $id, true);
+            foreach ($value->getMethodCalls() as $call) {
+                $this->assertNoInlineConditions($call[1] ?? [], $id, true);
+            }
+        }
+    }
+
+    private function removeAliasesToRejectedServices(ContainerBuilder $container, array $rejected): void
+    {
+        if (!$rejected) {
+            return;
+        }
+
+        $removedAliases = [];
+        foreach ($container->getAliases() as $aliasId => $alias) {
+            if (isset($rejected[$this->resolveAliasTarget($container, (string) $alias)])) {
+                $removedAliases[] = $aliasId;
+            }
+        }
+        foreach ($removedAliases as $aliasId) {
+            $container->removeAlias($aliasId);
+        }
+    }
+
+    private function serviceExists(ContainerBuilder $container, string $id): bool
+    {
+        if ($container->hasDefinition($id)) {
+            $definition = $container->getDefinition($id);
+
+            return !$definition->isAbstract() && !$definition->hasTag('container.excluded');
+        }
+
+        // services set at runtime with ContainerBuilder::set() have no definition
+        return $container->has($id);
+    }
+
+    private function resolveAliasTarget(ContainerBuilder $container, string $id): string
+    {
+        $seen = [];
+        while ($container->hasAlias($id) && !isset($seen[$id])) {
+            $seen[$id] = true;
+            $id = (string) $container->getAlias($id);
+        }
+
+        return $id;
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -12,6 +12,10 @@
 namespace Symfony\Component\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\Argument\BoundArgument;
+use Symfony\Component\DependencyInjection\Attribute\WhenClassExists;
+use Symfony\Component\DependencyInjection\Attribute\WhenClassMissing;
+use Symfony\Component\DependencyInjection\Attribute\WhenMissingService;
+use Symfony\Component\DependencyInjection\Attribute\WhenParameter;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Exception\OutOfBoundsException;
 
@@ -32,6 +36,7 @@ class Definition
     private array $properties = [];
     private array $calls = [];
     private array $instanceof = [];
+    private array $whenConditions = [];
     private bool $autoconfigured = false;
     private string|array|null $configurator = null;
     private array $tags = [];
@@ -401,6 +406,33 @@ class Definition
     public function getInstanceofConditionals(): array
     {
         return $this->instanceof;
+    }
+
+    /**
+     * Sets the conditions that must all match for this definition to be kept in the container.
+     *
+     * Conditions only apply to this very definition: they are not inherited by
+     * child definitions that use it as their parent.
+     *
+     * @param list<WhenClassExists|WhenClassMissing|WhenMissingService|WhenParameter> $whenConditions
+     *
+     * @return $this
+     */
+    public function setWhenConditions(array $whenConditions): static
+    {
+        $this->whenConditions = $whenConditions;
+
+        return $this;
+    }
+
+    /**
+     * Gets the conditions that must all match for this definition to be kept in the container.
+     *
+     * @return list<WhenClassExists|WhenClassMissing|WhenMissingService|WhenParameter>
+     */
+    public function getWhenConditions(): array
+    {
+        return $this->whenConditions;
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
@@ -20,6 +20,10 @@ use Symfony\Component\DependencyInjection\Argument\LazyProxyArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
+use Symfony\Component\DependencyInjection\Attribute\WhenClassExists;
+use Symfony\Component\DependencyInjection\Attribute\WhenClassMissing;
+use Symfony\Component\DependencyInjection\Attribute\WhenMissingService;
+use Symfony\Component\DependencyInjection\Attribute\WhenParameter;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Exception\LogicException;
@@ -115,6 +119,34 @@ class YamlDumper extends Dumper
 
         if ($definition->isAbstract()) {
             $code .= "        abstract: true\n";
+        }
+
+        if ($whenConditions = $definition->getWhenConditions()) {
+            $when = [];
+            foreach ($whenConditions as $condition) {
+                if ($condition instanceof WhenClassExists || $condition instanceof WhenClassMissing) {
+                    $key = $condition instanceof WhenClassExists ? 'class_exists' : 'class_missing';
+                    if ($condition->package || $condition->parentPackages) {
+                        $entry = ['class' => $condition->class];
+                        if ($condition->package) {
+                            $entry['package'] = $condition->package;
+                        }
+                        if ($condition->parentPackages) {
+                            $entry['parent_packages'] = $condition->parentPackages;
+                        }
+                        $when[$key][] = $entry;
+                    } else {
+                        $when[$key][] = $condition->class;
+                    }
+                } elseif ($condition instanceof WhenMissingService) {
+                    $when['missing_service'][] = $condition->id;
+                } elseif ($condition instanceof WhenParameter) {
+                    $when['parameter'][] = ['name' => $condition->name, 'value' => $condition->value];
+                } else {
+                    throw new RuntimeException(\sprintf('Unable to dump a service container if a "when" condition is of type "%s".', get_debug_type($condition)));
+                }
+            }
+            $code .= \sprintf("        when: %s\n", $this->dumper->dump($when, 0));
         }
 
         if ($definition->isLazy()) {

--- a/src/Symfony/Component/DependencyInjection/Loader/ContentLoaderTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/ContentLoaderTrait.php
@@ -20,6 +20,10 @@ use Symfony\Component\DependencyInjection\Argument\LazyProxyArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
+use Symfony\Component\DependencyInjection\Attribute\WhenClassExists;
+use Symfony\Component\DependencyInjection\Attribute\WhenClassMissing;
+use Symfony\Component\DependencyInjection\Attribute\WhenMissingService;
+use Symfony\Component\DependencyInjection\Attribute\WhenParameter;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -64,6 +68,7 @@ trait ContentLoaderTrait
         'autoconfigure' => 'autoconfigure',
         'bind' => 'bind',
         'constructor' => 'constructor',
+        'when' => 'when',
     ];
 
     private const PROTOTYPE_KEYWORDS = [
@@ -87,6 +92,7 @@ trait ContentLoaderTrait
         'autoconfigure' => 'autoconfigure',
         'bind' => 'bind',
         'constructor' => 'constructor',
+        'when' => 'when',
     ];
 
     private const INSTANCEOF_KEYWORDS = [
@@ -679,6 +685,17 @@ trait ContentLoaderTrait
             $definition->setAutoconfigured($service['autoconfigure']);
         }
 
+        if (isset($service['when'])) {
+            if ($return) {
+                throw new InvalidArgumentException(\sprintf('The "when" option is only supported on top-level service definitions; it cannot be used on the inline definition "%s" in "%s".', $id, $file));
+            }
+            if (!\is_array($service['when'])) {
+                throw new InvalidArgumentException(\sprintf('Parameter "when" must be an array for service "%s" in "%s".', $id, $file));
+            }
+
+            $definition->setWhenConditions($this->parseWhenConditions($service['when'], $id, $file));
+        }
+
         if (\array_key_exists('namespace', $service) && !\array_key_exists('resource', $service)) {
             throw new InvalidArgumentException(\sprintf('A "resource" attribute must be set when the "namespace" attribute is set for service "%s" in "%s".', $id, $file));
         }
@@ -976,6 +993,78 @@ trait ContentLoaderTrait
                 throw new InvalidArgumentException(\sprintf('The configuration key "%s" is unsupported for definition "%s" in "%s". Allowed configuration keys are "%s".', $key, $id, $file, implode('", "', $keywords)));
             }
         }
+    }
+
+    /**
+     * @return list<WhenClassExists|WhenClassMissing|WhenMissingService|WhenParameter>
+     */
+    private function parseWhenConditions(array $when, string $id, string $file): array
+    {
+        $conditions = [];
+
+        foreach ($when as $type => $config) {
+            switch ($type) {
+                case 'class_exists':
+                case 'class_missing':
+                    foreach (\is_array($config) && array_is_list($config) ? $config : [$config] as $classCondition) {
+                        if (\is_string($classCondition)) {
+                            $classCondition = ['class' => $classCondition];
+                        }
+                        if (!\is_array($classCondition) || !isset($classCondition['class']) || !\is_string($classCondition['class']) || '' === $classCondition['class']) {
+                            throw new InvalidArgumentException(\sprintf('A "when.%s" entry must be a non-empty class name or a map with a "class" key for service "%s" in "%s".', $type, $id, $file));
+                        }
+                        if ($extraKeys = array_diff_key($classCondition, ['class' => true, 'package' => true, 'parent_packages' => true])) {
+                            throw new InvalidArgumentException(\sprintf('Invalid key%s "%s" in "when.%s" for service "%s" in "%s". Allowed keys are "class", "package" and "parent_packages".', 1 < \count($extraKeys) ? 's' : '', implode('", "', array_keys($extraKeys)), $type, $id, $file));
+                        }
+                        if (isset($classCondition['package']) && (!\is_string($classCondition['package']) || '' === $classCondition['package'])) {
+                            throw new InvalidArgumentException(\sprintf('The "package" of a "when.%s" entry must be a non-empty string for service "%s" in "%s".', $type, $id, $file));
+                        }
+                        $parentPackages = $classCondition['parent_packages'] ?? [];
+                        $parentPackages = \is_array($parentPackages) ? $parentPackages : [$parentPackages];
+                        if (!array_is_list($parentPackages)) {
+                            throw new InvalidArgumentException(\sprintf('The "parent_packages" of a "when.%s" entry must be a list of non-empty strings for service "%s" in "%s".', $type, $id, $file));
+                        }
+                        foreach ($parentPackages as $parentPackage) {
+                            if (!\is_string($parentPackage) || '' === $parentPackage) {
+                                throw new InvalidArgumentException(\sprintf('The "parent_packages" of a "when.%s" entry must be a list of non-empty strings for service "%s" in "%s".', $type, $id, $file));
+                            }
+                        }
+                        $conditionClass = 'class_exists' === $type ? WhenClassExists::class : WhenClassMissing::class;
+                        $conditions[] = new $conditionClass($classCondition['class'], $classCondition['package'] ?? null, $parentPackages);
+                    }
+                    break;
+                case 'missing_service':
+                    $missingIds = \is_array($config) ? $config : [$config];
+                    if (!array_is_list($missingIds)) {
+                        throw new InvalidArgumentException(\sprintf('The "when.missing_service" option must be a service id or a list of service ids for service "%s" in "%s".', $id, $file));
+                    }
+                    foreach ($missingIds as $missingId) {
+                        if (!\is_string($missingId) || '' === $missingId) {
+                            throw new InvalidArgumentException(\sprintf('A "when.missing_service" entry must be a non-empty service id for service "%s" in "%s".', $id, $file));
+                        }
+                        $conditions[] = new WhenMissingService($missingId);
+                    }
+                    break;
+                case 'parameter':
+                    foreach (\is_array($config) && array_is_list($config) ? $config : [$config] as $parameter) {
+                        if (\is_string($parameter)) {
+                            $parameter = ['name' => $parameter];
+                        }
+                        if (!\is_array($parameter) || !isset($parameter['name']) || !\is_string($parameter['name']) || '' === $parameter['name']) {
+                            throw new InvalidArgumentException(\sprintf('A "when.parameter" entry must be a non-empty parameter name or a map with a "name" key for service "%s" in "%s".', $id, $file));
+                        }
+                        if ($extraKeys = array_diff_key($parameter, ['name' => true, 'value' => true])) {
+                            throw new InvalidArgumentException(\sprintf('Invalid key%s "%s" in "when.parameter" for service "%s" in "%s". Allowed keys are "name" and "value".', 1 < \count($extraKeys) ? 's' : '', implode('", "', array_keys($extraKeys)), $id, $file));
+                        }
+                        $conditions[] = new WhenParameter($parameter['name'], \array_key_exists('value', $parameter) ? $parameter['value'] : true);
+                    }
+                    break;
+                default:
+                    throw new InvalidArgumentException(\sprintf('The "when" key "%s" is unsupported for service "%s" in "%s". Allowed keys are "class_exists", "class_missing", "missing_service" and "parameter".', $type, $id, $file));
+            }
+        }
+
+        return $conditions;
     }
 
     private function validateAttributes(string $message, array $attributes, array $path = []): void

--- a/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
@@ -22,7 +22,11 @@ use Symfony\Component\DependencyInjection\Attribute\AsAlias;
 use Symfony\Component\DependencyInjection\Attribute\Exclude;
 use Symfony\Component\DependencyInjection\Attribute\Target;
 use Symfony\Component\DependencyInjection\Attribute\When;
+use Symfony\Component\DependencyInjection\Attribute\WhenClassExists;
+use Symfony\Component\DependencyInjection\Attribute\WhenClassMissing;
+use Symfony\Component\DependencyInjection\Attribute\WhenMissingService;
 use Symfony\Component\DependencyInjection\Attribute\WhenNot;
+use Symfony\Component\DependencyInjection\Attribute\WhenParameter;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\RegisterAutoconfigureAttributesPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -134,11 +138,17 @@ abstract class FileLoader extends BaseFileLoader
         $getPrototype = (new DeepCloner($prototype))->clone(...);
 
         foreach ($classes as $class => $errorMessage) {
+            $whenConditions = [];
             if (null === $errorMessage && $autoconfigureAttributes) {
                 $r = $this->container->getReflectionClass($class);
                 if ($r->getAttributes(Exclude::class)[0] ?? null) {
                     $this->addContainerExcludedTag($class, $source);
                     continue;
+                }
+                foreach ([WhenClassExists::class, WhenClassMissing::class, WhenMissingService::class, WhenParameter::class] as $conditionAttribute) {
+                    foreach ($r->getAttributes($conditionAttribute, \ReflectionAttribute::IS_INSTANCEOF) as $attribute) {
+                        $whenConditions[] = $attribute->newInstance();
+                    }
                 }
                 if ($this->env) {
                     $excluded = true;
@@ -191,6 +201,10 @@ abstract class FileLoader extends BaseFileLoader
                 $definition->setAbstract(true)
                     ->addTag('container.excluded', ['source' => 'because the class is abstract']);
                 continue;
+            }
+
+            if ($whenConditions) {
+                $definition->setWhenConditions(array_merge($definition->getWhenConditions(), $whenConditions));
             }
 
             $interfaces = [];

--- a/src/Symfony/Component/DependencyInjection/Loader/PhpFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/PhpFileLoader.php
@@ -12,7 +12,11 @@
 namespace Symfony\Component\DependencyInjection\Loader;
 
 use Symfony\Component\DependencyInjection\Attribute\When;
+use Symfony\Component\DependencyInjection\Attribute\WhenClassExists;
+use Symfony\Component\DependencyInjection\Attribute\WhenClassMissing;
+use Symfony\Component\DependencyInjection\Attribute\WhenMissingService;
 use Symfony\Component\DependencyInjection\Attribute\WhenNot;
+use Symfony\Component\DependencyInjection\Attribute\WhenParameter;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Exception\LogicException;
@@ -149,6 +153,12 @@ class PhpFileLoader extends FileLoader
         $callback = $callback(...);
         $arguments = [];
         $r = new \ReflectionFunction($callback);
+
+        foreach ([WhenClassExists::class, WhenClassMissing::class, WhenMissingService::class, WhenParameter::class] as $conditionAttribute) {
+            if ($r->getAttributes($conditionAttribute, \ReflectionAttribute::IS_INSTANCEOF)) {
+                throw new LogicException(\sprintf('The #[%s] attribute cannot be used on the closure of the "%s" config file; it can only condition service classes. Use the "when" key on a service definition instead.', substr($conditionAttribute, strrpos($conditionAttribute, '\\') + 1), $path));
+            }
+        }
 
         $excluded = true;
         $whenAttributes = $r->getAttributes(When::class, \ReflectionAttribute::IS_INSTANCEOF);

--- a/src/Symfony/Component/DependencyInjection/Loader/schema/services.schema.json
+++ b/src/Symfony/Component/DependencyInjection/Loader/schema/services.schema.json
@@ -121,6 +121,71 @@
         { "type": "object", "additionalProperties": { "$ref": "#/$defs/parameterValue" } }
       ]
     },
+    "when": {
+      "$comment": "Compile-time conditions that must all match for the service to be registered. YAML example:\n- when: { class_exists: 'Redis', missing_service: 'App\\CacheManagerInterface', parameter: { name: 'app.cache.enabled', value: true } }.",
+      "type": "object",
+      "properties": {
+        "class_exists": {
+          "oneOf": [
+            { "$ref": "#/$defs/whenClassExists" },
+            { "type": "array", "items": { "$ref": "#/$defs/whenClassExists" } }
+          ]
+        },
+        "class_missing": {
+          "oneOf": [
+            { "$ref": "#/$defs/whenClassExists" },
+            { "type": "array", "items": { "$ref": "#/$defs/whenClassExists" } }
+          ]
+        },
+        "missing_service": {
+          "oneOf": [
+            { "type": "string" },
+            { "type": "array", "items": { "type": "string" } }
+          ]
+        },
+        "parameter": {
+          "oneOf": [
+            { "$ref": "#/$defs/whenParameter" },
+            { "type": "array", "items": { "$ref": "#/$defs/whenParameter" } }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "whenClassExists": {
+      "oneOf": [
+        { "type": "string" },
+        {
+          "type": "object",
+          "properties": {
+            "class": { "type": "string" },
+            "package": { "type": "string" },
+            "parent_packages": {
+              "oneOf": [
+                { "type": "string" },
+                { "type": "array", "items": { "type": "string" } }
+              ]
+            }
+          },
+          "required": ["class"],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "whenParameter": {
+      "oneOf": [
+        { "type": "string" },
+        {
+          "type": "object",
+          "properties": {
+            "name": { "type": "string" },
+            "value": { "$ref": "#/$defs/parameterValue" }
+          },
+          "required": ["name"],
+          "additionalProperties": false
+        }
+      ]
+    },
     "tags": {
       "$comment": "YAML examples:\n- ['kernel.event_subscriber', { name: 'kernel.event_listener', event: 'kernel.request' }, { my_tag: { attr: 1 } }].",
       "type": "array",
@@ -264,6 +329,7 @@
         "autoconfigure": { "type": "boolean" },
         "bind": { "type": "object", "additionalProperties": { "$ref": "#/$defs/parameterValue" } },
         "constructor": { "type": "string" },
+        "when": { "$ref": "#/$defs/when" },
         "from_callable": { "$ref": "#/$defs/parameterValue", "$comment": "Will be wrapped by factory ['Closure','fromCallable'] and sets lazy=true unless class is 'Closure'." }
       },
       "additionalProperties": false
@@ -296,7 +362,8 @@
         "autowire": { "type": "boolean" },
         "autoconfigure": { "type": "boolean" },
         "bind": { "type": "object", "additionalProperties": { "$ref": "#/$defs/parameterValue" } },
-        "constructor": { "type": "string" }
+        "constructor": { "type": "string" },
+        "when": { "$ref": "#/$defs/when" }
       },
       "required": ["resource"],
       "allOf": [
@@ -311,10 +378,15 @@
         "stack": {
           "type": "array",
           "items": {
-            "oneOf": [
-              { "$ref": "#/$defs/serviceConcrete" },
-              { "$ref": "#/$defs/serviceAliasObject" },
-              { "$ref": "#/$defs/servicePrototype" }
+            "allOf": [
+              {
+                "oneOf": [
+                  { "$ref": "#/$defs/serviceConcrete" },
+                  { "$ref": "#/$defs/serviceAliasObject" },
+                  { "$ref": "#/$defs/servicePrototype" }
+                ]
+              },
+              { "not": { "required": ["when"] }, "$comment": "Conditions are only supported on top-level service definitions." }
             ]
           }
         },

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveConditionalDefinitionsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveConditionalDefinitionsPassTest.php
@@ -1,0 +1,567 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Compiler;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Alias;
+use Symfony\Component\DependencyInjection\Attribute\AsDecorator;
+use Symfony\Component\DependencyInjection\Attribute\WhenClassExists;
+use Symfony\Component\DependencyInjection\Attribute\WhenClassMissing;
+use Symfony\Component\DependencyInjection\Attribute\WhenMissingService;
+use Symfony\Component\DependencyInjection\Attribute\WhenParameter;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\Compiler\ResolveConditionalDefinitionsPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Exception\LogicException;
+
+class ResolveConditionalDefinitionsPassTest extends TestCase
+{
+    public function testClassExistsConditionMatches()
+    {
+        $container = new ContainerBuilder();
+        $container->register('foo', \stdClass::class)
+            ->setWhenConditions([new WhenClassExists(\stdClass::class)]);
+
+        (new ResolveConditionalDefinitionsPass())->process($container);
+
+        $this->assertServiceKept($container, 'foo');
+    }
+
+    public function testClassExistsConditionFails()
+    {
+        $container = new ContainerBuilder();
+        $container->register('foo', \stdClass::class)
+            ->setWhenConditions([new WhenClassExists('App\NotAClass')]);
+
+        (new ResolveConditionalDefinitionsPass())->process($container);
+
+        $this->assertServiceExcluded($container, 'foo', 'because the "App\NotAClass" class is not available');
+    }
+
+    public function testClassMissingConditionMatches()
+    {
+        $container = new ContainerBuilder();
+        $container->register('foo', \stdClass::class)
+            ->setWhenConditions([new WhenClassMissing('App\NotAClass')]);
+
+        (new ResolveConditionalDefinitionsPass())->process($container);
+
+        $this->assertServiceKept($container, 'foo');
+    }
+
+    public function testClassMissingConditionFails()
+    {
+        $container = new ContainerBuilder();
+        $container->register('foo', \stdClass::class)
+            ->setWhenConditions([new WhenClassMissing(\stdClass::class)]);
+
+        (new ResolveConditionalDefinitionsPass())->process($container);
+
+        $this->assertServiceExcluded($container, 'foo', 'because the "stdClass" class is available');
+    }
+
+    public function testParameterConditionMatches()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('app.enabled', true);
+        $container->register('foo', \stdClass::class)
+            ->setWhenConditions([new WhenParameter('app.enabled')]);
+
+        (new ResolveConditionalDefinitionsPass())->process($container);
+
+        $this->assertServiceKept($container, 'foo');
+    }
+
+    public function testParameterConditionMatchesResolvedPlaceholder()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('flag', 'on');
+        $container->setParameter('app.mode', '%flag%');
+        $container->register('foo', \stdClass::class)
+            ->setWhenConditions([new WhenParameter('app.mode', 'on')]);
+
+        (new ResolveConditionalDefinitionsPass())->process($container);
+
+        $this->assertServiceKept($container, 'foo');
+    }
+
+    public function testParameterConditionFailsOnValueMismatch()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('app.enabled', false);
+        $container->register('foo', \stdClass::class)
+            ->setWhenConditions([new WhenParameter('app.enabled')]);
+
+        (new ResolveConditionalDefinitionsPass())->process($container);
+
+        $this->assertServiceExcluded($container, 'foo', 'because the "app.enabled" parameter does not have the expected value');
+    }
+
+    public function testParameterConditionFailsOnMissingParameter()
+    {
+        $container = new ContainerBuilder();
+        $container->register('foo', \stdClass::class)
+            ->setWhenConditions([new WhenParameter('app.enabled')]);
+
+        (new ResolveConditionalDefinitionsPass())->process($container);
+
+        $this->assertServiceExcluded($container, 'foo', 'because the "app.enabled" parameter is not defined');
+    }
+
+    public function testParameterConditionThrowsOnEnvBackedParameter()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('app.enabled', '%env(bool:APP_ENABLED)%');
+        $container->register('foo', \stdClass::class)
+            ->setWhenConditions([new WhenParameter('app.enabled')]);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('references an environment variable; its value is not known at compile time. Use a build-time parameter instead, or register the service conditionally in a compiler pass.');
+
+        (new ResolveConditionalDefinitionsPass())->process($container);
+    }
+
+    public function testMissingServiceConditionFailsWhenServiceExists()
+    {
+        $container = new ContainerBuilder();
+        $container->register('bar', \stdClass::class);
+        $container->register('foo', \stdClass::class)
+            ->setWhenConditions([new WhenMissingService('bar')]);
+
+        (new ResolveConditionalDefinitionsPass())->process($container);
+
+        $this->assertServiceExcluded($container, 'foo', 'because the "bar" service is already defined');
+    }
+
+    public function testMissingServiceConditionMatchesWhenServiceIsMissing()
+    {
+        $container = new ContainerBuilder();
+        $container->register('foo', \stdClass::class)
+            ->setWhenConditions([new WhenMissingService('bar')]);
+
+        (new ResolveConditionalDefinitionsPass())->process($container);
+
+        $this->assertServiceKept($container, 'foo');
+    }
+
+    public function testMissingServiceConditionFailsWhenAliasExists()
+    {
+        $container = new ContainerBuilder();
+        $container->register('bar', \stdClass::class);
+        $container->setAlias('bar_alias', 'bar');
+        $container->register('foo', \stdClass::class)
+            ->setWhenConditions([new WhenMissingService('bar_alias')]);
+
+        (new ResolveConditionalDefinitionsPass())->process($container);
+
+        $this->assertServiceExcluded($container, 'foo', 'because the "bar_alias" service is already defined');
+    }
+
+    public function testMissingServiceConditionIgnoresAbstractAndExcludedTargets()
+    {
+        $container = new ContainerBuilder();
+        $container->register('abstract_bar', \stdClass::class)->setAbstract(true);
+        $container->register('excluded_bar', \stdClass::class)->addTag('container.excluded');
+        $container->register('foo', \stdClass::class)
+            ->setWhenConditions([new WhenMissingService('abstract_bar'), new WhenMissingService('excluded_bar')]);
+
+        (new ResolveConditionalDefinitionsPass())->process($container);
+
+        $this->assertServiceKept($container, 'foo');
+    }
+
+    public function testMissingServiceConditionIgnoresAliasToItself()
+    {
+        $container = new ContainerBuilder();
+        $container->register('foo', \stdClass::class)
+            ->setWhenConditions([new WhenMissingService('foo_interface')]);
+        $container->setAlias('foo_interface', 'foo');
+
+        (new ResolveConditionalDefinitionsPass())->process($container);
+
+        $this->assertServiceKept($container, 'foo');
+        $this->assertTrue($container->hasAlias('foo_interface'));
+    }
+
+    public function testMissingServiceConditionOnAnotherConditionalServiceThrows()
+    {
+        $container = new ContainerBuilder();
+        $container->register('foo', \stdClass::class)
+            ->setWhenConditions([new WhenMissingService('bar')]);
+        $container->register('bar', \stdClass::class)
+            ->setWhenConditions([new WhenMissingService('foo')]);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Conditional services cannot depend on each other\'s absence.');
+
+        (new ResolveConditionalDefinitionsPass())->process($container);
+    }
+
+    public function testMissingServiceConditionSeesStageOneRejections()
+    {
+        $container = new ContainerBuilder();
+        $container->register('bar', \stdClass::class)
+            ->setWhenConditions([new WhenClassExists('App\NotAClass')]);
+        $container->register('foo', \stdClass::class)
+            ->setWhenConditions([new WhenMissingService('bar')]);
+
+        (new ResolveConditionalDefinitionsPass())->process($container);
+
+        $this->assertServiceExcluded($container, 'bar', 'because the "App\NotAClass" class is not available');
+        $this->assertServiceKept($container, 'foo');
+    }
+
+    public function testConditionsAreAndCombined()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('app.enabled', false);
+        $container->register('foo', \stdClass::class)
+            ->setWhenConditions([new WhenClassExists(\stdClass::class), new WhenParameter('app.enabled')]);
+
+        (new ResolveConditionalDefinitionsPass())->process($container);
+
+        $this->assertServiceExcluded($container, 'foo', 'because the "app.enabled" parameter does not have the expected value');
+    }
+
+    public function testAliasesToExcludedServicesAreRemoved()
+    {
+        $container = new ContainerBuilder();
+        $container->register('foo', \stdClass::class)
+            ->setWhenConditions([new WhenClassExists('App\NotAClass')]);
+        $container->setAlias('foo_alias', 'foo');
+        $container->setAlias('foo_alias_alias', new Alias('foo_alias'));
+
+        (new ResolveConditionalDefinitionsPass())->process($container);
+
+        $this->assertFalse($container->hasAlias('foo_alias'));
+        $this->assertFalse($container->hasAlias('foo_alias_alias'));
+    }
+
+    public function testCompiledContainerExcludesRejectedDefinitions()
+    {
+        $container = new ContainerBuilder();
+        $container->register('default_manager', \stdClass::class)
+            ->setPublic(true)
+            ->setWhenConditions([new WhenMissingService('manager')]);
+        $container->register('manager', \stdClass::class)->setPublic(true);
+
+        $container->compile();
+
+        $this->assertTrue($container->has('manager'));
+        $this->assertFalse($container->has('default_manager'));
+    }
+
+    public function testCompiledContainerKeepsDefaultWhenNothingOverridesIt()
+    {
+        $container = new ContainerBuilder();
+        $container->register('default_manager', \stdClass::class)
+            ->setPublic(true)
+            ->setWhenConditions([new WhenMissingService('manager')]);
+
+        $container->compile();
+
+        $this->assertTrue($container->has('default_manager'));
+    }
+
+    public function testRejectedAutoconfiguredDefinitionDoesNotResurrect()
+    {
+        $container = new ContainerBuilder();
+        $container->registerForAutoconfiguration(ConditionalHandlerInterface::class)
+            ->addTag('app.handler');
+        $container->register('conditional', ConditionalHandler::class)
+            ->setAutoconfigured(true)
+            ->setPublic(true)
+            ->setWhenConditions([new WhenClassExists('App\NotAClass')]);
+
+        $container->compile();
+
+        $this->assertFalse($container->has('conditional'));
+        $this->assertSame([], $container->findTaggedServiceIds('app.handler'));
+    }
+
+    public function testAutoconfiguredDefinitionRejectedByMissingServiceDoesNotResurrect()
+    {
+        $container = new ContainerBuilder();
+        $container->registerForAutoconfiguration(ConditionalHandlerInterface::class)
+            ->addTag('app.handler');
+        $container->register('existing', \stdClass::class)->setPublic(true);
+        $container->register('conditional', ConditionalHandler::class)
+            ->setAutoconfigured(true)
+            ->setPublic(true)
+            ->setWhenConditions([new WhenMissingService('existing')]);
+
+        $container->compile();
+
+        $this->assertFalse($container->has('conditional'));
+        $this->assertSame([], $container->findTaggedServiceIds('app.handler'));
+    }
+
+    public function testWhenConditionsAreNotInheritedByChildDefinitions()
+    {
+        $container = new ContainerBuilder();
+        $container->register('parent_def', \stdClass::class)
+            ->setWhenConditions([new WhenClassExists('App\NotAClass')]);
+        $container->setDefinition('child', (new ChildDefinition('parent_def'))->setPublic(true));
+
+        $container->compile();
+
+        $this->assertFalse($container->has('parent_def'));
+        $this->assertInstanceOf(\stdClass::class, $container->get('child'));
+    }
+
+    public function testKeptAutoconfiguredDefinitionIsStillAutoconfigured()
+    {
+        $container = new ContainerBuilder();
+        $container->registerForAutoconfiguration(ConditionalHandlerInterface::class)
+            ->addTag('app.handler');
+        $container->register('conditional', ConditionalHandler::class)
+            ->setAutoconfigured(true)
+            ->setPublic(true)
+            ->setWhenConditions([new WhenClassExists(\stdClass::class)]);
+
+        $container->compile();
+
+        $this->assertTrue($container->has('conditional'));
+        $this->assertSame(['conditional'], array_keys($container->findTaggedServiceIds('app.handler')));
+    }
+
+    public function testStage1RejectedTargetWithOwnMissingServiceConditionDoesNotThrow()
+    {
+        $container = new ContainerBuilder();
+        $container->register('bar', \stdClass::class)
+            ->setWhenConditions([new WhenClassExists('App\NotAClass'), new WhenMissingService('unrelated')]);
+        $container->register('foo', \stdClass::class)
+            ->setWhenConditions([new WhenMissingService('bar')]);
+
+        (new ResolveConditionalDefinitionsPass())->process($container);
+
+        $this->assertServiceExcluded($container, 'bar', 'because the "App\NotAClass" class is not available');
+        $this->assertServiceKept($container, 'foo');
+    }
+
+    public function testMissingServiceConditionSeesRuntimeServices()
+    {
+        $container = new ContainerBuilder();
+        $container->set('override', new \stdClass());
+        $container->setAlias('override_alias', 'override');
+        $container->register('foo', \stdClass::class)
+            ->setWhenConditions([new WhenMissingService('override')]);
+        $container->register('bar', \stdClass::class)
+            ->setWhenConditions([new WhenMissingService('override_alias')]);
+
+        (new ResolveConditionalDefinitionsPass())->process($container);
+
+        $this->assertServiceExcluded($container, 'foo', 'because the "override" service is already defined');
+        $this->assertServiceExcluded($container, 'bar', 'because the "override_alias" service is already defined');
+    }
+
+    public function testRejectedDecoratorDoesNotBreakDecoratedService()
+    {
+        $container = new ContainerBuilder();
+        $container->register('base', \stdClass::class)->setPublic(true);
+        $container->register('decorator', \ArrayObject::class)
+            ->setDecoratedService('base')
+            ->setWhenConditions([new WhenClassExists('App\NotAClass')]);
+
+        $container->compile();
+
+        $this->assertInstanceOf(\stdClass::class, $container->get('base'));
+        $this->assertFalse($container->has('decorator'));
+    }
+
+    public function testKeptDecoratorStillDecorates()
+    {
+        $container = new ContainerBuilder();
+        $container->register('base', \stdClass::class)->setPublic(true);
+        $container->register('decorator', \ArrayObject::class)
+            ->setDecoratedService('base')
+            ->setWhenConditions([new WhenClassExists(\stdClass::class)]);
+
+        $container->compile();
+
+        $this->assertInstanceOf(\ArrayObject::class, $container->get('base'));
+    }
+
+    public function testRejectedTagDecoratorIsInert()
+    {
+        $container = new ContainerBuilder();
+        $container->register('base', \stdClass::class)
+            ->setPublic(true)
+            ->addTag('app.decorable');
+        $container->register('tag_decorator', \ArrayObject::class)
+            ->addResourceTag('container.tag_decorator', ['decorates_tag' => 'app.decorable'])
+            ->setWhenConditions([new WhenClassExists('App\NotAClass')]);
+
+        $container->compile();
+
+        $this->assertInstanceOf(\stdClass::class, $container->get('base'));
+    }
+
+    public function testFqcnServiceIdWithMissingClass()
+    {
+        $container = new ContainerBuilder();
+        $container->register('App\NotInstalled\OptionalService')
+            ->setPublic(true)
+            ->setWhenConditions([new WhenClassExists('App\NotInstalled\OptionalService')]);
+
+        $container->compile();
+
+        $this->assertFalse($container->has('App\NotInstalled\OptionalService'));
+    }
+
+    public function testParameterConditionResolvesExpectedValue()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('actual', 'prod');
+        $container->setParameter('expected', 'prod');
+        $container->register('foo', \stdClass::class)
+            ->setWhenConditions([new WhenParameter('actual', '%expected%')]);
+
+        (new ResolveConditionalDefinitionsPass())->process($container);
+
+        $this->assertServiceKept($container, 'foo');
+    }
+
+    public function testParameterConditionWithArrayValue()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('app.locales', ['es', 'en']);
+        $container->register('foo', \stdClass::class)
+            ->setWhenConditions([new WhenParameter('app.locales', ['es', 'en'])]);
+        $container->register('bar', \stdClass::class)
+            ->setWhenConditions([new WhenParameter('app.locales', ['es'])]);
+
+        (new ResolveConditionalDefinitionsPass())->process($container);
+
+        $this->assertServiceKept($container, 'foo');
+        $this->assertServiceExcluded($container, 'bar', 'because the "app.locales" parameter does not have the expected value');
+    }
+
+    public function testClassConditionsWithPackage()
+    {
+        $container = new ContainerBuilder();
+        $container->register('kept_not_installed_package', \stdClass::class)
+            ->setWhenConditions([new WhenClassExists(\stdClass::class, 'acme/not-a-real-package')]);
+        $container->register('rejected_missing_class', \stdClass::class)
+            ->setWhenConditions([new WhenClassExists('App\NotAClass', 'symfony/yaml')]);
+        $container->register('rejected_available_class', \stdClass::class)
+            ->setWhenConditions([new WhenClassMissing(\stdClass::class, 'acme/not-a-real-package')]);
+        $container->register('kept_missing_class', \stdClass::class)
+            ->setWhenConditions([new WhenClassMissing('App\NotAClass', 'acme/not-a-real-package')]);
+
+        (new ResolveConditionalDefinitionsPass())->process($container);
+
+        $this->assertServiceKept($container, 'kept_not_installed_package');
+        $this->assertServiceExcluded($container, 'rejected_missing_class', 'because the "App\NotAClass" class from package "symfony/yaml" is not available');
+        $this->assertServiceExcluded($container, 'rejected_available_class', 'because the "stdClass" class from package "acme/not-a-real-package" is available');
+        $this->assertServiceKept($container, 'kept_missing_class');
+    }
+
+    public function testRejectedAsDecoratorAttributeDoesNotBreakDecoratedService()
+    {
+        $container = new ContainerBuilder();
+        $container->register('base', \stdClass::class)->setPublic(true);
+        $container->register('decorator', ConditionalAttributeDecorator::class)
+            ->setAutowired(true)
+            ->setWhenConditions([new WhenClassExists('App\NotAClass')]);
+
+        $container->compile();
+
+        $this->assertInstanceOf(\stdClass::class, $container->get('base'));
+        $this->assertFalse($container->has('decorator'));
+    }
+
+    public function testKeptAsDecoratorAttributeStillDecorates()
+    {
+        $container = new ContainerBuilder();
+        $container->register('base', \stdClass::class)->setPublic(true);
+        $container->register('decorator', ConditionalAttributeDecorator::class)
+            ->setAutowired(true)
+            ->setWhenConditions([new WhenClassExists(\stdClass::class)]);
+
+        $container->compile();
+
+        $this->assertInstanceOf(ConditionalAttributeDecorator::class, $container->get('base'));
+    }
+
+    public function testInlineDefinitionWithWhenConditionsThrows()
+    {
+        $container = new ContainerBuilder();
+        $container->register('consumer', \stdClass::class)
+            ->addArgument([
+                (new Definition(\stdClass::class))->setWhenConditions([new WhenClassExists('App\NotAClass')]),
+            ]);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Invalid inline definition used in service "consumer": "when" conditions are only supported on definitions registered in the container.');
+
+        (new ResolveConditionalDefinitionsPass())->process($container);
+    }
+
+    public function testInlineDefinitionInBindingsWithWhenConditionsThrows()
+    {
+        $container = new ContainerBuilder();
+        $container->register('consumer', \stdClass::class)
+            ->setBindings([
+                '$inner' => (new Definition(\stdClass::class))->setWhenConditions([new WhenClassExists('App\NotAClass')]),
+            ]);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Invalid inline definition used in service "consumer"');
+
+        (new ResolveConditionalDefinitionsPass())->process($container);
+    }
+
+    public function testNestedInlineDefinitionWithWhenConditionsThrows()
+    {
+        $inner = (new Definition(\stdClass::class))->setWhenConditions([new WhenMissingService('bar')]);
+        $outer = (new Definition(\stdClass::class))->addArgument($inner);
+        $container = new ContainerBuilder();
+        $container->register('consumer', \stdClass::class)->addArgument($outer);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Invalid inline definition used in service "consumer"');
+
+        (new ResolveConditionalDefinitionsPass())->process($container);
+    }
+
+    private function assertServiceKept(ContainerBuilder $container, string $id)
+    {
+        $definition = $container->getDefinition($id);
+        $this->assertFalse($definition->isAbstract());
+        $this->assertFalse($definition->hasTag('container.excluded'));
+        $this->assertSame([], $definition->getWhenConditions());
+    }
+
+    private function assertServiceExcluded(ContainerBuilder $container, string $id, string $reason)
+    {
+        $definition = $container->getDefinition($id);
+        $this->assertTrue($definition->isAbstract());
+        $this->assertTrue($definition->hasTag('container.excluded'));
+        $this->assertSame([['source' => $reason]], $definition->getTag('container.excluded'));
+        $this->assertSame([], $definition->getWhenConditions());
+    }
+}
+
+interface ConditionalHandlerInterface
+{
+}
+
+class ConditionalHandler implements ConditionalHandlerInterface
+{
+}
+
+#[AsDecorator('base')]
+class ConditionalAttributeDecorator
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/YamlDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/YamlDumperTest.php
@@ -21,6 +21,10 @@ use Symfony\Component\DependencyInjection\Argument\EnvClosureArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
+use Symfony\Component\DependencyInjection\Attribute\WhenClassExists;
+use Symfony\Component\DependencyInjection\Attribute\WhenClassMissing;
+use Symfony\Component\DependencyInjection\Attribute\WhenMissingService;
+use Symfony\Component\DependencyInjection\Attribute\WhenParameter;
 use Symfony\Component\DependencyInjection\Compiler\AutowirePass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -299,6 +303,34 @@ class YamlDumperTest extends TestCase
         $dumper = new YamlDumper($container);
 
         $this->assertStringEqualsGeneratedFile('container_with_env_placeholders.yml', $dumper->dump());
+    }
+
+    public function testDumpWhenConditionsRoundTrip()
+    {
+        $container = new ContainerBuilder();
+        $conditions = [
+            new WhenClassExists('Redis'),
+            new WhenClassExists('Redis', 'ext-redis', ['acme/my-bundle']),
+            new WhenClassExists('Redis', null, ['acme/parent']),
+            new WhenClassMissing('Memcached'),
+            new WhenMissingService('app.manager'),
+            new WhenParameter('app.enabled'),
+            new WhenParameter('app.locales', ['es', 'en']),
+        ];
+        $container->register('conditional', 'stdClass')->setWhenConditions($conditions);
+
+        $yaml = (new YamlDumper($container))->dump();
+
+        $reloadedContainer = new ContainerBuilder();
+        $file = tempnam(sys_get_temp_dir(), 'sf_dumped_when').'.yml';
+        file_put_contents($file, $yaml);
+        try {
+            (new YamlFileLoader($reloadedContainer, new FileLocator()))->load($file);
+        } finally {
+            unlink($file);
+        }
+
+        $this->assertEquals($conditions, $reloadedContainer->getDefinition('conditional')->getWhenConditions());
     }
 
     private function assertEqualYamlStructure(string $expected, string $yaml, string $message = '')

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Conditional/ConditionalService.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Conditional/ConditionalService.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\Conditional;
+
+use Symfony\Component\DependencyInjection\Attribute\WhenClassExists;
+use Symfony\Component\DependencyInjection\Attribute\WhenMissingService;
+use Symfony\Component\DependencyInjection\Attribute\WhenParameter;
+
+#[WhenClassExists(\stdClass::class)]
+#[WhenMissingService('app.manager')]
+#[WhenParameter('app.enabled')]
+class ConditionalService
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/array_config_when.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/array_config_when.php
@@ -1,0 +1,20 @@
+<?php
+
+return [
+    'services' => [
+        'my_conditional_service' => [
+            'class' => \stdClass::class,
+            'when' => [
+                'class_exists' => 'Redis',
+                'missing_service' => 'bar',
+                'parameter' => ['name' => 'app.enabled', 'value' => true],
+            ],
+        ],
+        'Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Sub\\' => [
+            'resource' => '../Prototype/Sub/*',
+            'when' => [
+                'missing_service' => 'app.manager',
+            ],
+        ],
+    ],
+];

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/when_attribute_on_closure.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/when_attribute_on_closure.php
@@ -1,0 +1,7 @@
+<?php
+
+use Symfony\Component\DependencyInjection\Attribute\WhenClassExists;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return #[WhenClassExists('Redis')] function (ContainerConfigurator $container) {
+};

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_when.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_when.yml
@@ -1,0 +1,17 @@
+services:
+    foo:
+        class: stdClass
+        when:
+            class_exists: Redis
+            class_missing: Memcached
+            missing_service: bar
+            parameter: { name: app.enabled, value: true }
+
+    baz:
+        class: stdClass
+        when:
+            class_exists:
+                - PDO
+                - { class: Redis, package: ext-redis, parent_packages: [acme/my-bundle] }
+            missing_service: [service_a, service_b]
+            parameter: app.flag

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_when_in_stack.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_when_in_stack.yml
@@ -1,0 +1,6 @@
+services:
+    my_stack:
+        stack:
+            - class: stdClass
+              when:
+                  class_exists: Redis

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_when_invalid.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_when_invalid.yml
@@ -1,0 +1,5 @@
+services:
+    foo:
+        class: stdClass
+        when:
+            unknown_condition: bar

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/FileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/FileLoaderTest.php
@@ -18,6 +18,9 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Loader\LoaderResolver;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
+use Symfony\Component\DependencyInjection\Attribute\WhenClassExists;
+use Symfony\Component\DependencyInjection\Attribute\WhenMissingService;
+use Symfony\Component\DependencyInjection\Attribute\WhenParameter;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\RegisterAutoconfigureAttributesPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -27,6 +30,7 @@ use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\DependencyInjection\Loader\FileLoader;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\Conditional\ConditionalService;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\AbstractClass;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\BadClasses\MissingParent;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Foo;
@@ -525,6 +529,29 @@ class FileLoaderTest extends TestCase
         $loader->registerClasses($prototype, 'Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\StaticConstructor\\', 'Prototype/StaticConstructor');
 
         $this->assertTrue($container->has(PrototypeStaticConstructor::class));
+    }
+
+    public function testRegisterClassesWithWhenConditionAttributes()
+    {
+        $container = new ContainerBuilder();
+        $loader = new TestFileLoader($container, new FileLocator(self::$fixturesPath.'/Fixtures'));
+
+        $loader->registerClasses(
+            (new Definition())->setAutoconfigured(true),
+            'Symfony\Component\DependencyInjection\Tests\Fixtures\Conditional\\',
+            'Conditional/*'
+        );
+
+        $conditions = $container->getDefinition(ConditionalService::class)->getWhenConditions();
+
+        $this->assertCount(3, $conditions);
+        $this->assertInstanceOf(WhenClassExists::class, $conditions[0]);
+        $this->assertSame(\stdClass::class, $conditions[0]->class);
+        $this->assertInstanceOf(WhenMissingService::class, $conditions[1]);
+        $this->assertSame('app.manager', $conditions[1]->id);
+        $this->assertInstanceOf(WhenParameter::class, $conditions[2]);
+        $this->assertSame('app.enabled', $conditions[2]->name);
+        $this->assertTrue($conditions[2]->value);
     }
 }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
@@ -19,6 +19,9 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Argument\LazyProxyArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
+use Symfony\Component\DependencyInjection\Attribute\WhenClassExists;
+use Symfony\Component\DependencyInjection\Attribute\WhenMissingService;
+use Symfony\Component\DependencyInjection\Attribute\WhenParameter;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Definition;
@@ -151,6 +154,39 @@ class PhpFileLoaderTest extends TestCase
         yield ['array_config_tagged_iterator'];
         yield ['object_array_config'];
         yield ['return_when_env'];
+    }
+
+    public function testWhenConditionAttributesAreNotAllowedOnConfigClosures()
+    {
+        $fixtures = realpath(__DIR__.'/../Fixtures');
+        $loader = new PhpFileLoader(new ContainerBuilder(), new FileLocator());
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('The #[WhenClassExists] attribute cannot be used on the closure');
+
+        $loader->load($fixtures.'/config/when_attribute_on_closure.php');
+    }
+
+    public function testWhenConditionsInArrayConfig()
+    {
+        $fixtures = realpath(__DIR__.'/../Fixtures');
+        $loader = new PhpFileLoader($container = new ContainerBuilder(), new FileLocator());
+        $loader->load($fixtures.'/config/array_config_when.php');
+
+        $conditions = $container->getDefinition('my_conditional_service')->getWhenConditions();
+        $this->assertCount(3, $conditions);
+        $this->assertInstanceOf(WhenClassExists::class, $conditions[0]);
+        $this->assertSame('Redis', $conditions[0]->class);
+        $this->assertInstanceOf(WhenMissingService::class, $conditions[1]);
+        $this->assertSame('bar', $conditions[1]->id);
+        $this->assertInstanceOf(WhenParameter::class, $conditions[2]);
+        $this->assertSame('app.enabled', $conditions[2]->name);
+        $this->assertTrue($conditions[2]->value);
+
+        $prototypeConditions = $container->getDefinition('Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Sub\Bar')->getWhenConditions();
+        $this->assertCount(1, $prototypeConditions);
+        $this->assertInstanceOf(WhenMissingService::class, $prototypeConditions[0]);
+        $this->assertSame('app.manager', $prototypeConditions[0]->id);
     }
 
     public function testConfigLazyProxyArgument()

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -28,6 +28,10 @@ use Symfony\Component\DependencyInjection\Argument\LazyProxyArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
+use Symfony\Component\DependencyInjection\Attribute\WhenClassExists;
+use Symfony\Component\DependencyInjection\Attribute\WhenClassMissing;
+use Symfony\Component\DependencyInjection\Attribute\WhenMissingService;
+use Symfony\Component\DependencyInjection\Attribute\WhenParameter;
 use Symfony\Component\DependencyInjection\Compiler\DecoratorServicePass;
 use Symfony\Component\DependencyInjection\Compiler\ResolveBindingsPass;
 use Symfony\Component\DependencyInjection\Compiler\TagDecoratorPass;
@@ -1417,5 +1421,83 @@ class YamlFileLoaderTest extends TestCase
         $this->assertTrue($container->hasAlias('bar'));
 
         $this->assertStringContainsString('.decorator.foo.', (string) $container->getAlias('foo'));
+    }
+
+    public function testWhenConditions()
+    {
+        $container = new ContainerBuilder();
+        $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
+        $loader->load('services_when.yml');
+
+        $fooConditions = $container->getDefinition('foo')->getWhenConditions();
+        $this->assertCount(4, $fooConditions);
+        $this->assertInstanceOf(WhenClassExists::class, $fooConditions[0]);
+        $this->assertSame('Redis', $fooConditions[0]->class);
+        $this->assertNull($fooConditions[0]->package);
+        $this->assertInstanceOf(WhenClassMissing::class, $fooConditions[1]);
+        $this->assertSame('Memcached', $fooConditions[1]->class);
+        $this->assertInstanceOf(WhenMissingService::class, $fooConditions[2]);
+        $this->assertSame('bar', $fooConditions[2]->id);
+        $this->assertInstanceOf(WhenParameter::class, $fooConditions[3]);
+        $this->assertSame('app.enabled', $fooConditions[3]->name);
+        $this->assertTrue($fooConditions[3]->value);
+
+        $bazConditions = $container->getDefinition('baz')->getWhenConditions();
+        $this->assertCount(5, $bazConditions);
+        $this->assertSame('PDO', $bazConditions[0]->class);
+        $this->assertSame('Redis', $bazConditions[1]->class);
+        $this->assertSame('ext-redis', $bazConditions[1]->package);
+        $this->assertSame(['acme/my-bundle'], $bazConditions[1]->parentPackages);
+        $this->assertSame('service_a', $bazConditions[2]->id);
+        $this->assertSame('service_b', $bazConditions[3]->id);
+        $this->assertSame('app.flag', $bazConditions[4]->name);
+        $this->assertTrue($bazConditions[4]->value);
+    }
+
+    public function testWhenConditionsWithInvalidKey()
+    {
+        $container = new ContainerBuilder();
+        $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "when" key "unknown_condition" is unsupported for service "foo"');
+
+        $loader->load('services_when_invalid.yml');
+    }
+
+    public function testWhenConditionsAreNotAllowedInStackFrames()
+    {
+        $container = new ContainerBuilder();
+        $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "when" option is only supported on top-level service definitions');
+
+        $loader->load('services_when_in_stack.yml');
+    }
+
+    #[DataProvider('provideMalformedWhenConditions')]
+    public function testMalformedWhenConditions(array $when, string $expectedMessage)
+    {
+        $loader = new YamlFileLoader(new ContainerBuilder(), new FileLocator());
+        $reflectionMethod = new \ReflectionMethod($loader, 'parseDefinition');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage($expectedMessage);
+
+        $reflectionMethod->invoke($loader, 'my_service', ['class' => 'stdClass', 'when' => $when], 'services.yaml', []);
+    }
+
+    public static function provideMalformedWhenConditions(): iterable
+    {
+        yield 'empty class' => [['class_exists' => ''], 'must be a non-empty class name'];
+        yield 'empty class in map' => [['class_missing' => ['class' => '']], 'must be a non-empty class name'];
+        yield 'array package' => [['class_exists' => ['class' => 'Redis', 'package' => []]], 'The "package" of a "when.class_exists" entry must be a non-empty string'];
+        yield 'empty package' => [['class_exists' => ['class' => 'Redis', 'package' => '']], 'The "package" of a "when.class_exists" entry must be a non-empty string'];
+        yield 'non-string parent packages' => [['class_missing' => ['class' => 'Redis', 'parent_packages' => [42]]], 'must be a list of non-empty strings'];
+        yield 'empty parameter name' => [['parameter' => ''], 'must be a non-empty parameter name'];
+        yield 'empty missing_service' => [['missing_service' => ''], 'must be a non-empty service id'];
+        yield 'map as parent packages' => [['class_exists' => ['class' => 'Redis', 'parent_packages' => ['named' => 'acme/pkg']]], 'must be a list of non-empty strings'];
+        yield 'map as missing_service' => [['missing_service' => ['named' => 'override']], 'must be a service id or a list of service ids'];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Symfony's service container is one of the best dependency injection containers available in any language. But, there is one small gap left: **declarative conditional registration**. In Java, Spring Boot has `@ConditionalOnClass` / `@ConditionalOnMissingBean` / `@ConditionalOnProperty` and Quarkus has `@DefaultBean` and `@IfBuildProperty`, etc. In .NET, DependecyInjection defines `TryAddSingleton`, `TryAddScoped`, etc.

Symfony only has the env-based `#[When]` / `#[WhenNot]` to conditionally register services based on the current environment. Every other condition _("register this default unless the app defined its own", "only if this package is installed", "only if this parameter is true")_ must be written in an extension or a compiler pass. This works perfectly, but it's cumbersome for common and simple cases: FrameworkExtension alone contains ~40 `willBeAvailable()` calls, ~60 `class_exists()` checks and ~140 conditional `removeDefinition()` calls, and every third-party bundle hand-writes the same patterns.

This PR adds **four attributes** (and a matching `when` option in YAML/PHP config) that make these conditions declarative. All conditions are resolved at **compile time**, so the dumped container stays exactly as static and fast as it is today. You can combine two or more of these conditions on the same service.

### `#[WhenClassExists]` register only when a class is available

```php
#[WhenClassExists(RedisAdapter::class, package: 'symfony/cache')]
class RedisCacheWarmer { }
```

The optional package argument uses `ContainerBuilder::willBeAvailable()` semantics: the condition also fails when the package is only installed as a dev dependency and would vanish after `composer install --no-dev`, so a container compiled with dev dependencies never leaks dev-only services into production.

### `#[WhenClassMissing]` register a fallback when a class is absent

```php
#[WhenClassMissing(\Redis::class)]
class InMemoryCacheFallback { }
```

The mirror condition of `#[WhenClassExists]`, for polyfills and degraded implementations. With `package`: it is the exact inversion of `willBeAvailable()`: the fallback also activates when the real implementation is only reachable through dev dependencies.

### `#[WhenMissingService]` overridable defaults, the app always wins

```php
#[WhenMissingService(CacheManagerInterface::class)]
class DefaultCacheManager implements CacheManagerInterface { }
```

This allows bundle authors to ship working defaults, and any definition of that id coming from the app (or any other bundle) silently replaces them.

This attribute is order-independent (it doesn't depend on _"what has been registered so far"_). Also, two services that each depend on the other's absence are a compile-time LogicException, never a silent order-dependent winner.

### `#[WhenParameter]` config-driven registration

```php
#[WhenParameter('app.cache.enabled')]                 // must be true
#[WhenParameter('app.cache.driver', value: 'redis')]  // must equal a value
class CacheManager { }
```

-----

The same conditions in YAML / PHP config:

```yaml
services:
    App\DefaultCacheManager:
        when:
            class_exists: { class: Symfony\Component\Mailer\Mailer, package: symfony/mailer }
            missing_service: App\CacheManagerInterface
            parameter: { name: app.cache.enabled, value: true }
```

-----

Some comments:

* A failed condition doesn't delete the definition; it turns it into the same excluded state `#[When]` already uses, with a human-readable reason (e.g. _"because the "Redis" class is not available"_). So `debug:container` and the autowiring _"did you forget to?"_ hints keep working.
* Parameters resolved from `%env()%` cannot be used: their value doesn't exist at compile time. The condition fails hard with a message suggesting a build-time parameter or a compiler pass.
* Parameter comparison is strict (`===`), after resolving `%placeholders%` on both sides.
* Conditions apply to top-level definitions only (inline/stack-frame definitions reject them explicitly) and are not inherited by child definitions.
* Complex cases (`OR` predicates, mutating surviving definitions, picking between two implementations) are not implemented and must be kept as compiler passes.