### PR TITLE
[Tui] Reuse cached subtrees during vertical layout

### DIFF
--- a/src/Symfony/Component/Tui/Render/LayoutEngine.php
+++ b/src/Symfony/Component/Tui/Render/LayoutEngine.php
@@ -141,7 +141,7 @@ final class LayoutEngine
         // we don't yet know each child's final absolute row offset.
         $fillChildren = [];
         $nonFillRenders = [];
-        $nonFillNeedsDescendantTracking = [];
+        $nonFillCacheHits = [];
         $savedStack = $this->positionTracker->suppressStack();
 
         foreach ($children as $index => $child) {
@@ -149,12 +149,14 @@ final class LayoutEngine
                 $fillChildren[$index] = $child;
             } else {
                 // Suppress descendant position tracking during measurement.
-                // Children that can have descendants must be re-rendered later
-                // with the final absolute offset to populate descendant rects.
+                // Uncached parent widgets are re-rendered later with their final
+                // absolute offset to populate descendant rects.
                 $context = new RenderContext($columns, $rows, null, $this->fontRegistry);
+                $revision = $child->getRenderRevision();
+                $hadCachedRender = null !== $child->getRenderCache($columns, $rows);
                 $childLines = $this->widgetRenderer->renderWidget($child, $context);
                 $nonFillRenders[$index] = $childLines;
-                $nonFillNeedsDescendantTracking[$index] = $child instanceof ParentInterface;
+                $nonFillCacheHits[$index] = $hadCachedRender && $revision === $child->getRenderRevision();
 
                 $remainingRows -= \count($childLines);
             }
@@ -172,6 +174,7 @@ final class LayoutEngine
         $fillIndex = 0;
         $hasPositionStack = $this->positionTracker->isActive();
         foreach ($children as $index => $child) {
+            $cacheHit = false;
             if (isset($fillChildren[$index])) {
                 // Fill child gets calculated rows, distributing remainder to first children
                 $childFillRows = $baseFillRows + ($fillIndex < $extraRows ? 1 : 0);
@@ -183,6 +186,8 @@ final class LayoutEngine
                 }
 
                 $context = new RenderContext($columns, $childFillRows, null, $this->fontRegistry);
+                $revision = $child->getRenderRevision();
+                $hadCachedRender = null !== $child->getRenderCache($columns, $childFillRows);
 
                 // Push correct absolute position so descendants get proper coordinates
                 if ($hasPositionStack) {
@@ -190,6 +195,7 @@ final class LayoutEngine
                     $this->positionTracker->push($parentAbsRow + \count($lines), $parentAbsCol);
                 }
                 $childLines = $this->widgetRenderer->renderWidget($child, $context);
+                $cacheHit = $hadCachedRender && $revision === $child->getRenderRevision();
                 if ($hasPositionStack) {
                     $this->positionTracker->pop();
                 }
@@ -199,7 +205,9 @@ final class LayoutEngine
                     $childLines[] = '';
                 }
             } else {
-                $childLines = $nonFillRenders[$index] ?? $this->widgetRenderer->renderWidget($child, new RenderContext($columns, $rows, null, $this->fontRegistry));
+                $context = new RenderContext($columns, $rows, null, $this->fontRegistry);
+                $childLines = $nonFillRenders[$index] ?? $this->widgetRenderer->renderWidget($child, $context);
+                $cacheHit = $nonFillCacheHits[$index] ?? false;
 
                 // Skip gap for children that render nothing
                 if (!$childLines) {
@@ -217,22 +225,26 @@ final class LayoutEngine
                 $childAbsRow = $parentAbsRow + \count($lines);
                 $childAbsCol = $parentAbsCol;
 
-                $this->positionTracker->setWidgetRect($child, new WidgetRect(
+                $rect = new WidgetRect(
                     $childAbsRow,
                     $childAbsCol,
                     $columns,
                     \count($childLines),
-                ));
+                );
+                $positionsTracked = isset($fillChildren[$index]) && !$cacheHit;
+                if ($cacheHit && $child instanceof ParentInterface) {
+                    $positionsTracked = $this->positionTracker->moveSubtree($child, $rect);
+                }
 
-                // For non-fill parent widgets rendered during measurement,
-                // re-render to track descendant positions with the correct
-                // absolute offset. Leaf widgets don't need this extra pass.
-                // Clear the render cache first so the re-render walks the
-                // subtree instead of returning the cached measurement output.
-                if (($nonFillNeedsDescendantTracking[$index] ?? false) && !isset($fillChildren[$index])) {
+                $this->positionTracker->setWidgetRect($child, $rect);
+
+                if ($child instanceof ParentInterface && !$positionsTracked) {
+                    // Clear the render cache first so the re-render walks the
+                    // subtree and records descendant rects, instead of
+                    // returning the cached measurement output.
                     $child->clearRenderCache();
                     $this->positionTracker->push($childAbsRow, $childAbsCol);
-                    $this->widgetRenderer->renderWidget($child, new RenderContext($columns, $rows, null, $this->fontRegistry));
+                    $this->widgetRenderer->renderWidget($child, $context);
                     $this->positionTracker->pop();
                 }
             }

--- a/src/Symfony/Component/Tui/Render/PositionTracker.php
+++ b/src/Symfony/Component/Tui/Render/PositionTracker.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Tui\Render;
 
 use Symfony\Component\Tui\Widget\AbstractWidget;
+use Symfony\Component\Tui\Widget\ParentInterface;
 
 /**
  * Tracks absolute positions of rendered widgets on screen.
@@ -69,6 +70,26 @@ final class PositionTracker
     public function setWidgetRect(AbstractWidget $widget, WidgetRect $rect): void
     {
         $this->widgetPositions[$widget] = $rect;
+    }
+
+    /**
+     * Move a previously tracked widget and its descendants to a new position.
+     */
+    public function moveSubtree(AbstractWidget $widget, WidgetRect $rect): bool
+    {
+        if (!isset($this->widgetPositions[$widget])) {
+            return false;
+        }
+
+        $previous = $this->widgetPositions[$widget];
+        $rowOffset = $rect->row - $previous->row;
+        $colOffset = $rect->col - $previous->col;
+        if (0 !== $rowOffset || 0 !== $colOffset) {
+            $this->shiftSubtree($widget, $rowOffset, $colOffset);
+        }
+        $this->widgetPositions[$widget] = $rect;
+
+        return true;
     }
 
     /**
@@ -168,6 +189,27 @@ final class PositionTracker
                 $rect->columns,
                 $rect->rows,
             );
+        }
+    }
+
+    private function shiftSubtree(AbstractWidget $widget, int $rowOffset, int $colOffset): void
+    {
+        if (isset($this->widgetPositions[$widget])) {
+            $rect = $this->widgetPositions[$widget];
+            $this->widgetPositions[$widget] = new WidgetRect(
+                $rect->row + $rowOffset,
+                $rect->col + $colOffset,
+                $rect->columns,
+                $rect->rows,
+            );
+        }
+
+        if (!$widget instanceof ParentInterface) {
+            return;
+        }
+
+        foreach ($widget->all() as $child) {
+            $this->shiftSubtree($child, $rowOffset, $colOffset);
         }
     }
 }

--- a/src/Symfony/Component/Tui/Tests/Render/PositionTrackerTest.php
+++ b/src/Symfony/Component/Tui/Tests/Render/PositionTrackerTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Tui\Tests\Render;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Tui\Render\PositionTracker;
 use Symfony\Component\Tui\Render\WidgetRect;
+use Symfony\Component\Tui\Widget\ContainerWidget;
 use Symfony\Component\Tui\Widget\TextWidget;
 
 /**
@@ -153,5 +154,36 @@ final class PositionTrackerTest extends TestCase
         $rect = $tracker->getWidgetRect($widget);
         $this->assertSame(2, $rect->row);
         $this->assertSame(3, $rect->col);
+    }
+
+    public function testMoveSubtreeShiftsTrackedDescendants()
+    {
+        $tracker = new PositionTracker();
+        $root = new ContainerWidget();
+        $inner = new ContainerWidget();
+        $leaf = new TextWidget('leaf');
+        $inner->add($leaf);
+        $root->add($inner);
+
+        $tracker->setWidgetRect($root, new WidgetRect(1, 2, 20, 4));
+        $tracker->setWidgetRect($inner, new WidgetRect(2, 3, 18, 2));
+        $tracker->setWidgetRect($leaf, new WidgetRect(3, 4, 16, 1));
+
+        $this->assertTrue($tracker->moveSubtree($root, new WidgetRect(5, 7, 20, 4)));
+
+        $rootRect = $tracker->getWidgetRect($root);
+        $this->assertSame([5, 7, 20, 4], [$rootRect->row, $rootRect->col, $rootRect->columns, $rootRect->rows]);
+        $innerRect = $tracker->getWidgetRect($inner);
+        $this->assertSame([6, 8, 18, 2], [$innerRect->row, $innerRect->col, $innerRect->columns, $innerRect->rows]);
+        $leafRect = $tracker->getWidgetRect($leaf);
+        $this->assertSame([7, 9, 16, 1], [$leafRect->row, $leafRect->col, $leafRect->columns, $leafRect->rows]);
+    }
+
+    public function testMoveUntrackedSubtreeReturnsFalse()
+    {
+        $tracker = new PositionTracker();
+        $root = new ContainerWidget();
+
+        $this->assertFalse($tracker->moveSubtree($root, new WidgetRect(5, 7, 20, 4)));
     }
 }

--- a/src/Symfony/Component/Tui/Tests/Render/RendererTest.php
+++ b/src/Symfony/Component/Tui/Tests/Render/RendererTest.php
@@ -908,18 +908,26 @@ class RendererTest extends TestCase
         $this->assertSame(1, $second->renderCount);
     }
 
-    public function testVerticalLayoutStillRerendersNonFillParentChildrenInSecondPass()
+    public function testVerticalLayoutReusesCachedParentChildrenWhenSiblingChanges()
     {
         $renderer = new Renderer();
         $root = new ContainerWidget();
 
+        $prefix = new TextWidget('Prefix');
         $childParent = new CountingParentWidget();
         $childParent->add(new TextWidget('Leaf'));
+        $root->add($prefix);
         $root->add($childParent);
 
         $renderer->render($root, 40, 10);
+        $this->assertSame(2, $childParent->renderCount);
+        $this->assertSame(1, $renderer->getWidgetRect($childParent)->row);
+
+        $prefix->setText("First line\nSecond line");
+        $renderer->render($root, 40, 10);
 
         $this->assertSame(2, $childParent->renderCount);
+        $this->assertSame(2, $renderer->getWidgetRect($childParent)->row);
     }
 
     // ---------------------------------------------------------------
@@ -1034,6 +1042,57 @@ class RendererTest extends TestCase
         $this->assertNotNull($leafRect2);
         $this->assertSame(1, $leafRect2->row);
         $this->assertSame(2, $leafRect2->col);
+    }
+
+    public function testCachedDescendantPositionsMoveWithTheirParent()
+    {
+        $renderer = new Renderer();
+        $root = new ContainerWidget();
+        $prefix = new TextWidget('Prefix');
+        $inner = new ContainerWidget();
+        $inner->setStyle(new Style(padding: new Padding(1, 0, 0, 2)));
+        $leaf = new TextWidget('Nested');
+        $inner->add($leaf);
+        $root->add($prefix);
+        $root->add($inner);
+
+        $renderer->render($root, 40, 20);
+        $leafRect = $renderer->getWidgetRect($leaf);
+        $this->assertSame(2, $leafRect->row);
+        $this->assertSame(2, $leafRect->col);
+
+        $prefix->setText("First line\nSecond line");
+        $renderer->render($root, 40, 20);
+        $leafRect = $renderer->getWidgetRect($leaf);
+        $this->assertSame(3, $leafRect->row);
+        $this->assertSame(2, $leafRect->col);
+    }
+
+    public function testCachedFillChildDescendantPositionsMoveWithTheirParent()
+    {
+        $renderer = new Renderer();
+        $root = new ContainerWidget();
+        $prefix = new TextWidget('Prefix');
+        $fill = new ContainerWidget()->expandVertically(true);
+        $leaf = new CountingLeafWidget();
+        $fill->add($leaf);
+        $second = new ContainerWidget()->expandVertically(true);
+        $second->add(new TextWidget('Other'));
+        $root->add($prefix);
+        $root->add($fill);
+        $root->add($second);
+
+        // 8 remaining rows split 4/4; after the prefix grows, 7 rows split
+        // 4/3, so the first fill child keeps its rows (cache hit) but shifts.
+        $renderer->render($root, 40, 9);
+        $this->assertSame(1, $leaf->renderCount);
+        $this->assertSame(1, $renderer->getWidgetRect($leaf)->row);
+
+        $prefix->setText("First line\nSecond line");
+        $renderer->render($root, 40, 9);
+
+        $this->assertSame(1, $leaf->renderCount);
+        $this->assertSame(2, $renderer->getWidgetRect($leaf)->row);
     }
 
     // ---------------------------------------------------------------

--- a/src/Symfony/Component/Tui/Widget/AbstractWidget.php
+++ b/src/Symfony/Component/Tui/Widget/AbstractWidget.php
@@ -355,10 +355,14 @@ abstract class AbstractWidget
     /**
      * Lifecycle hook: override to sync state before rendering.
      *
-     * Called by the Renderer on every frame, even when the render cache is
-     * valid. Use it to update child widget content, manage overlays, or
-     * perform other pre-render state updates. Keep it lightweight; heavy
-     * work should be guarded by dirty checks.
+     * Called before the Renderer renders this widget, including when its own
+     * render cache is valid. Use it to update child widget content, manage
+     * overlays, or perform other pre-render state updates. Keep it lightweight;
+     * heavy work should be guarded by dirty checks.
+     *
+     * This is not a per-frame tick: when an ancestor's cached subtree is reused,
+     * this widget is not visited at all. Use {@see ScheduledTickTrait} for work
+     * that must run on every frame.
      */
     public function beforeRender(): void
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | n/a
| License       | MIT

The vertical layout second pass cleared the render cache of every non-fill parent child and re-rendered it on each frame just to refresh descendant rects, defeating the render cache for the whole visible subtree.

Unchanged children (valid cache, same revision) are now reused as-is: the new `PositionTracker::moveSubtree()` rigidly shifts the previously tracked descendant rects by the child's offset delta instead of re-rendering. Widgets without prior tracking still fall back to a re-render.

This also fixes stale descendant rects for cached fill children that shift position while keeping their allocated rows: those were never re-rendered for tracking, so `Renderer::getWidgetRect()` kept returning the previous frame's row for everything below them.
