### PR TITLE
[DependencyInjection] Fix circular references through expressions

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/AnalyzeServiceReferencesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AnalyzeServiceReferencesPass.php
@@ -114,7 +114,8 @@ class AnalyzeServiceReferencesPass extends AbstractRecursivePass
                 $this->lazy || ($this->hasProxyDumper && $targetDefinition?->isLazy()),
                 ContainerInterface::IGNORE_ON_UNINITIALIZED_REFERENCE === $value->getInvalidBehavior(),
                 $this->byConstructor,
-                $this->byMultiUseArgument
+                $this->byMultiUseArgument,
+                $inExpression
             );
 
             if ($inExpression) {
@@ -127,7 +128,8 @@ class AnalyzeServiceReferencesPass extends AbstractRecursivePass
                     $this->lazy || $targetDefinition?->isLazy(),
                     true,
                     $this->byConstructor,
-                    $this->byMultiUseArgument
+                    $this->byMultiUseArgument,
+                    true
                 );
             }
 

--- a/src/Symfony/Component/DependencyInjection/Compiler/ServiceReferenceGraph.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ServiceReferenceGraph.php
@@ -74,7 +74,7 @@ class ServiceReferenceGraph
     /**
      * Connects 2 nodes together in the Graph.
      */
-    public function connect(?string $sourceId, mixed $sourceValue, ?string $destId, mixed $destValue = null, ?Reference $reference = null, bool $lazy = false, bool $weak = false, bool $byConstructor = false, bool $byMultiUseArgument = false): void
+    public function connect(?string $sourceId, mixed $sourceValue, ?string $destId, mixed $destValue = null, ?Reference $reference = null, bool $lazy = false, bool $weak = false, bool $byConstructor = false, bool $byMultiUseArgument = false, bool $fromExpression = false): void
     {
         if (null === $sourceId || null === $destId) {
             return;
@@ -82,7 +82,7 @@ class ServiceReferenceGraph
 
         $sourceNode = $this->createNode($sourceId, $sourceValue);
         $destNode = $this->createNode($destId, $destValue);
-        $edge = new ServiceReferenceGraphEdge($sourceNode, $destNode, $reference, $lazy, $weak, $byConstructor, $byMultiUseArgument);
+        $edge = new ServiceReferenceGraphEdge($sourceNode, $destNode, $reference, $lazy, $weak, $byConstructor, $byMultiUseArgument, $fromExpression);
 
         $sourceNode->addOutEdge($edge);
         $destNode->addInEdge($edge);

--- a/src/Symfony/Component/DependencyInjection/Compiler/ServiceReferenceGraphEdge.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ServiceReferenceGraphEdge.php
@@ -27,8 +27,9 @@ class ServiceReferenceGraphEdge
     private bool $weak;
     private bool $byConstructor;
     private bool $byMultiUseArgument;
+    private bool $fromExpression;
 
-    public function __construct(ServiceReferenceGraphNode $sourceNode, ServiceReferenceGraphNode $destNode, mixed $value = null, bool $lazy = false, bool $weak = false, bool $byConstructor = false, bool $byMultiUseArgument = false)
+    public function __construct(ServiceReferenceGraphNode $sourceNode, ServiceReferenceGraphNode $destNode, mixed $value = null, bool $lazy = false, bool $weak = false, bool $byConstructor = false, bool $byMultiUseArgument = false, bool $fromExpression = false)
     {
         $this->sourceNode = $sourceNode;
         $this->destNode = $destNode;
@@ -37,6 +38,7 @@ class ServiceReferenceGraphEdge
         $this->weak = $weak;
         $this->byConstructor = $byConstructor;
         $this->byMultiUseArgument = $byMultiUseArgument;
+        $this->fromExpression = $fromExpression;
     }
 
     /**
@@ -90,5 +92,13 @@ class ServiceReferenceGraphEdge
     public function isFromMultiUseArgument(): bool
     {
         return $this->byMultiUseArgument;
+    }
+
+    /**
+     * Returns true if the edge comes from an expression, which compiles to a container lookup.
+     */
+    public function isFromExpression(): bool
+    {
+        return $this->fromExpression;
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -458,7 +458,13 @@ class PhpDumper extends Dumper
         foreach ($edges as $edge) {
             $node = $edge->getDestNode();
             $id = $node->getId();
-            if (($sourceId === $id && !$edge->isLazy()) || !$node->getValue() instanceof Definition || $edge->isWeak()) {
+
+            // A direct self-reference is dumped as the local $instance, unless it comes from
+            // an expression: that compiles to a container lookup, which re-enters the factory
+            // unless the service is shared before its setup runs.
+            $selfReferenceIsInlined = !$edge->isFromExpression() || $edge->isReferencedByConstructor();
+
+            if (($sourceId === $id && !$edge->isLazy() && $selfReferenceIsInlined) || !$node->getValue() instanceof Definition || $edge->isWeak()) {
                 continue;
             }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -2540,6 +2540,49 @@ class PhpDumperTest extends TestCase
         }
         $this->assertSame('Setup failed.', $second?->getMessage(), '->get() should throw again instead of returning a partially-configured service');
     }
+
+    public function testDumpedContainerSharesBeforeSetupOnExpressionSelfReference()
+    {
+        $container = new ContainerBuilder();
+        $container->register('configuration', PhpDumperTest_ExpressionSelfReference::class)
+            ->setPublic(true)
+            ->addMethodCall('setStrategy', [new Reference('strategy')]);
+        $container->register('strategy', PhpDumperTest_ExpressionSelfReferenceStrategy::class)
+            ->addArgument(new Reference('locator'));
+        $container->register('locator', PhpDumperTest_ExpressionSelfReferenceLocator::class)
+            ->addArgument(new Expression('service("configuration").getDirectory()'));
+        $container->compile();
+
+        $dumper = new PhpDumper($container);
+        $dump = $dumper->dump(['class' => $class = 'Symfony_DI_PhpDumper_Test_Expression_Self_Reference']);
+
+        // the expression dumps to a container lookup rather than to the local $instance,
+        // so the service has to be shared before its setup runs
+        $sharePosition = strpos($dump, '$container->services[\'configuration\'] = $instance;');
+        $setupPosition = strpos($dump, '$instance->setStrategy(');
+
+        $this->assertNotFalse($sharePosition);
+        $this->assertNotFalse($setupPosition);
+        $this->assertLessThan($setupPosition, $sharePosition);
+
+        eval('?>'.$dump);
+
+        $configuration = (new $class())->get('configuration');
+
+        $this->assertInstanceOf(PhpDumperTest_ExpressionSelfReferenceStrategy::class, $configuration->strategy);
+    }
+
+    public function testConstructorExpressionSelfReferenceRemainsCircular()
+    {
+        $container = new ContainerBuilder();
+        $container->register('configuration', PhpDumperTest_ExpressionSelfReference::class)
+            ->setPublic(true)
+            ->addArgument(new Expression('service("configuration").getDirectory()'));
+
+        $this->expectException(ServiceCircularReferenceException::class);
+
+        $container->compile();
+    }
 }
 
 class Rot13EnvVarProcessor implements EnvVarProcessorInterface
@@ -2725,5 +2768,34 @@ class PhpDumperTest_FailsOnceConfigurator
         if (1 === ++self::$calls) {
             throw new \RuntimeException('First attempt fails.');
         }
+    }
+}
+
+class PhpDumperTest_ExpressionSelfReference
+{
+    public $strategy;
+
+    public function setStrategy(PhpDumperTest_ExpressionSelfReferenceStrategy $strategy): void
+    {
+        $this->strategy = $strategy;
+    }
+
+    public function getDirectory(): string
+    {
+        return '/tmp/proxies';
+    }
+}
+
+class PhpDumperTest_ExpressionSelfReferenceStrategy
+{
+    public function __construct(public PhpDumperTest_ExpressionSelfReferenceLocator $locator)
+    {
+    }
+}
+
+class PhpDumperTest_ExpressionSelfReferenceLocator
+{
+    public function __construct(public string $directory)
+    {
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65270
| License       | MIT

Sharing a service before its setup runs is now conditional on the service being part of a circular reference, and `PhpDumper::collectCircularReferences()` deliberately skips a direct self-edge:

```php
if (($sourceId === $id && !$edge->isLazy()) || ...) {
    continue;
}
```

That skip is safe for a plain reference, which the dumper renders inside a setter as the local `$instance`. It is not safe for a reference coming from an expression: `service("foo")` compiles to `$container->get("foo")`, which bypasses the loading guard in `Container::make()` and re-enters the factory. Once `InlineServiceDefinitionsPass` has collapsed the intermediate services, a setter chain looping back through an expression degenerates into exactly such a self-edge, and the dumped container recurses until it runs out of memory.

`CheckCircularReferencesPass` does not catch it either, because it is paired with a constructor-only `AnalyzeServiceReferencesPass`, so compilation succeeds and the breakage only shows up at runtime.

Service-reference graph edges now record whether they come from an expression, and `collectCircularReferences()` stops skipping those self-edges. The service then takes the existing circular-reference path: it is shared before its setup runs, and evicted again if the setup fails. Self-references from a constructor argument keep being reported as circular.

The reported chain (`configuration` -> setter -> inlined strategy -> inlined locator -> expression -> `configuration`) is covered by a test asserting both that the dumped container shares `configuration` before invoking the setter and that resolving it actually works. A second test covers the constructor case still throwing.

Note that the `@=container.get("foo")` expression form is not fixed by this: it compiles to a container lookup without producing any graph edge, so the reference analysis cannot see it at all. It fails loudly with a `ServiceCircularReferenceException` rather than exhausting memory, and covering it would mean teaching the expression compiler to record `container.get()` calls as references, which is a wider change.
