### PR TITLE
[Notifier][Sevenio] Fix successful sends being reported as failures

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Sevenio/SevenIoTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sevenio/SevenIoTransport.php
@@ -81,7 +81,7 @@ final class SevenIoTransport extends AbstractTransport
 
         $success = $response->toArray(false);
 
-        if (false === \in_array($success['success'], [100, 101], true)) {
+        if (false === \in_array((int) $success['success'], [100, 101], true)) {
             throw new TransportException(\sprintf('Unable to send the SMS: "%s".', $success['success']), $response);
         }
 

--- a/src/Symfony/Component/Notifier/Bridge/Sevenio/Tests/SevenIoTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sevenio/Tests/SevenIoTransportTest.php
@@ -12,7 +12,9 @@
 namespace Symfony\Component\Notifier\Bridge\Sevenio\Tests;
 
 use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Notifier\Bridge\Sevenio\SevenIoTransport;
+use Symfony\Component\Notifier\Exception\TransportException;
 use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
@@ -41,5 +43,30 @@ final class SevenIoTransportTest extends TransportTestCase
     {
         yield [new ChatMessage('Hello!')];
         yield [new DummyMessage()];
+    }
+
+    public function testSendWithSuccessCodeReturnedAsString()
+    {
+        $response = new MockResponse(json_encode([
+            'success' => '100',
+            'messages' => [['id' => '1234567890']],
+        ]));
+
+        $transport = self::createTransport(new MockHttpClient($response));
+        $sentMessage = $transport->send(new SmsMessage('0611223344', 'Hello!'));
+
+        $this->assertSame('1234567890', $sentMessage->getMessageId());
+    }
+
+    public function testSendWithErrorCodeThrows()
+    {
+        $response = new MockResponse(json_encode(['success' => '900']));
+
+        $transport = self::createTransport(new MockHttpClient($response));
+
+        $this->expectException(TransportException::class);
+        $this->expectExceptionMessage('Unable to send the SMS: "900".');
+
+        $transport->send(new SmsMessage('0611223344', 'Hello!'));
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Sms77/Sms77Transport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sms77/Sms77Transport.php
@@ -84,7 +84,7 @@ final class Sms77Transport extends AbstractTransport
 
         $success = $response->toArray(false);
 
-        if (false === \in_array($success['success'], [100, 101], true)) {
+        if (false === \in_array((int) $success['success'], [100, 101], true)) {
             throw new TransportException(\sprintf('Unable to send the SMS: "%s".', $success['success']), $response);
         }
 

--- a/src/Symfony/Component/Notifier/Bridge/Sms77/Tests/Sms77TransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sms77/Tests/Sms77TransportTest.php
@@ -14,7 +14,9 @@ namespace Symfony\Component\Notifier\Bridge\Sms77\Tests;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Notifier\Bridge\Sms77\Sms77Transport;
+use Symfony\Component\Notifier\Exception\TransportException;
 use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
@@ -45,5 +47,30 @@ final class Sms77TransportTest extends TransportTestCase
     {
         yield [new ChatMessage('Hello!')];
         yield [new DummyMessage()];
+    }
+
+    public function testSendWithSuccessCodeReturnedAsString()
+    {
+        $response = new MockResponse(json_encode([
+            'success' => '100',
+            'messages' => [['id' => '1234567890']],
+        ]));
+
+        $transport = self::createTransport(new MockHttpClient($response));
+        $sentMessage = $transport->send(new SmsMessage('0611223344', 'Hello!'));
+
+        $this->assertSame('1234567890', $sentMessage->getMessageId());
+    }
+
+    public function testSendWithErrorCodeThrows()
+    {
+        $response = new MockResponse(json_encode(['success' => '900']));
+
+        $transport = self::createTransport(new MockHttpClient($response));
+
+        $this->expectException(TransportException::class);
+        $this->expectExceptionMessage('Unable to send the SMS: "900".');
+
+        $transport->send(new SmsMessage('0611223344', 'Hello!'));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65272
| License       | MIT

The seven.io API returns its status code as a string, `{"success": "100", ...}`, and the success check was tightened to a strict `in_array()`. `\in_array("100", [100, 101], true)` is false, so every accepted send threw:

    Unable to send the SMS: "100".

Comparing as int fixes it. Error codes still throw, which the added tests cover on both sides.

The `sms77` bridge carries the same defect: sms77 is the former name of seven.io and the API is the same. It is deprecated but still shipped on 7.4 and no longer exists on 8.0, so a merge-up would never fix it there. Affected branches are 7.4 and up; 7.2 and 7.3 still use the loose comparison, and the Sevenio bridge does not exist on 6.4.
