### PR TITLE
[Mailer][Notifier] Avoid retaining messages without the profiler

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -651,6 +651,31 @@ class FrameworkExtension extends Extension
         // profiler depends on form, validation, translation, messenger, mailer, http-client, notifier, serializer being registered. console is optional
         $this->registerProfilerConfiguration($config['profiler'], $container, $loader);
 
+        // These listeners keep every message, attachments included, for the
+        // lifetime of the process. Only the profiler and the test assertions
+        // consume them, so drop them when neither is around, and let them skip
+        // messages nobody will collect otherwise. Test mode keeps collecting
+        // unconditionally because the assertions read the listeners directly.
+        if (!($config['test'] ?? false)) {
+            $loggerListeners = [
+                'mailer' => 'mailer.message_logger_listener',
+                'notifier' => 'notifier.notification_logger_listener',
+            ];
+
+            foreach ($loggerListeners as $extension => $id) {
+                if (!$this->isInitializedConfigEnabled($extension)) {
+                    continue;
+                }
+
+                if ($this->isInitializedConfigEnabled('profiler')) {
+                    $container->getDefinition($id)
+                        ->setArgument(0, new Reference('profiler.is_disabled_state_checker', ContainerInterface::NULL_ON_INVALID_REFERENCE));
+                } else {
+                    $container->removeDefinition($id);
+                }
+            }
+        }
+
         if ($this->readConfigEnabled('webhook', $container, $config['webhook'])) {
             $this->registerWebhookConfiguration($config['webhook'], $container, $loader, $this->readConfigEnabled('serializer', $container, $config['serializer']));
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -2506,6 +2506,58 @@ abstract class FrameworkExtensionTestCase extends TestCase
         $this->assertNull($container->getDefinition('mailer.mailer')->getArgument(1));
     }
 
+    /**
+     * @param array{profiler?: bool|array<string, mixed>, test?: bool} $extraConfig
+     */
+    #[DataProvider('provideLoggerListenerRegistration')]
+    public function testLoggerListenerRegistration(string $serviceId, array $extraConfig, bool $expectedRegistered, bool $expectedGated)
+    {
+        $container = $this->createContainerFromClosure(static function (ContainerBuilder $container) use ($extraConfig) {
+            $container->loadFromExtension('framework', array_merge([
+                'annotations' => false,
+                'http_method_override' => false,
+                'handle_all_throwables' => true,
+                'php_errors' => ['log' => true],
+                'secret' => 's3cr3t',
+                'mailer' => ['dsn' => 'smtp://null'],
+                'notifier' => ['texter_transports' => ['twilio' => 'twilio://ACCOUNT:TOKEN@default?from=FROM']],
+            ], $extraConfig));
+        });
+
+        $this->assertSame($expectedRegistered, $container->hasDefinition($serviceId));
+
+        if (!$expectedRegistered) {
+            return;
+        }
+
+        $arguments = $container->getDefinition($serviceId)->getArguments();
+
+        if ($expectedGated) {
+            $this->assertEquals(new Reference('profiler.is_disabled_state_checker', ContainerInterface::NULL_ON_INVALID_REFERENCE), $arguments[0]);
+        } else {
+            $this->assertSame([], $arguments);
+        }
+    }
+
+    public static function provideLoggerListenerRegistration(): iterable
+    {
+        $profiler = ['profiler' => ['enabled' => true, 'collect_serializer_data' => true]];
+
+        foreach (['mailer.message_logger_listener', 'notifier.notification_logger_listener'] as $serviceId) {
+            $name = substr($serviceId, 0, strpos($serviceId, '.'));
+
+            // Nothing consumes the retained messages, so the listener is dropped.
+            yield $name.': neither profiler nor test' => [$serviceId, [], false, false];
+
+            // The profiler consumes them, but only while it is collecting.
+            yield $name.': profiler only' => [$serviceId, $profiler, true, true];
+
+            // The assertions read the listener directly, so it must always collect.
+            yield $name.': test only' => [$serviceId, ['test' => true], true, false];
+            yield $name.': profiler and test' => [$serviceId, $profiler + ['test' => true], true, false];
+        }
+    }
+
     public function testMailerWithSpecificMessageBus()
     {
         $container = $this->createContainerFromFile('mailer_with_specific_message_bus');

--- a/src/Symfony/Component/Mailer/EventListener/MessageLoggerListener.php
+++ b/src/Symfony/Component/Mailer/EventListener/MessageLoggerListener.php
@@ -25,8 +25,9 @@ class MessageLoggerListener implements EventSubscriberInterface, ResetInterface
 {
     private MessageEvents $events;
 
-    public function __construct()
-    {
+    public function __construct(
+        private ?\Closure $disabled = null,
+    ) {
         $this->events = new MessageEvents();
     }
 
@@ -37,6 +38,10 @@ class MessageLoggerListener implements EventSubscriberInterface, ResetInterface
 
     public function onMessage(MessageEvent $event): void
     {
+        if ($this->disabled?->__invoke()) {
+            return;
+        }
+
         $this->events->add($event);
     }
 

--- a/src/Symfony/Component/Mailer/Tests/EventListener/MessageLoggerListenerTest.php
+++ b/src/Symfony/Component/Mailer/Tests/EventListener/MessageLoggerListenerTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Tests\EventListener;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Mailer\Envelope;
+use Symfony\Component\Mailer\Event\MessageEvent;
+use Symfony\Component\Mailer\EventListener\MessageLoggerListener;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\Email;
+
+class MessageLoggerListenerTest extends TestCase
+{
+    public function testMessagesAreLoggedByDefault()
+    {
+        $listener = new MessageLoggerListener();
+        $listener->onMessage($this->createEvent());
+
+        $this->assertCount(1, $listener->getEvents()->getEvents());
+    }
+
+    public function testMessagesAreDiscardedWhileDisabled()
+    {
+        $listener = new MessageLoggerListener(static fn (): bool => true);
+        $listener->onMessage($this->createEvent());
+
+        $this->assertSame([], $listener->getEvents()->getEvents());
+    }
+
+    public function testDisabledStateIsCheckedOnEachMessage()
+    {
+        $disabled = true;
+        $listener = new MessageLoggerListener(static function () use (&$disabled): bool { return $disabled; });
+
+        $listener->onMessage($this->createEvent());
+        $disabled = false;
+        $listener->onMessage($this->createEvent());
+
+        $this->assertCount(1, $listener->getEvents()->getEvents());
+    }
+
+    public function testResetDropsLoggedMessages()
+    {
+        $listener = new MessageLoggerListener();
+        $listener->onMessage($this->createEvent());
+        $listener->reset();
+
+        $this->assertSame([], $listener->getEvents()->getEvents());
+    }
+
+    private function createEvent(): MessageEvent
+    {
+        $email = (new Email())->from('from@example.com')->to('to@example.com')->text('Hello!');
+
+        return new MessageEvent($email, new Envelope(new Address('from@example.com'), [new Address('to@example.com')]), 'smtp');
+    }
+}

--- a/src/Symfony/Component/Notifier/EventListener/NotificationLoggerListener.php
+++ b/src/Symfony/Component/Notifier/EventListener/NotificationLoggerListener.php
@@ -23,8 +23,9 @@ class NotificationLoggerListener implements EventSubscriberInterface, ResetInter
 {
     private NotificationEvents $events;
 
-    public function __construct()
-    {
+    public function __construct(
+        private ?\Closure $disabled = null,
+    ) {
         $this->events = new NotificationEvents();
     }
 
@@ -35,6 +36,10 @@ class NotificationLoggerListener implements EventSubscriberInterface, ResetInter
 
     public function onNotification(MessageEvent $event): void
     {
+        if ($this->disabled?->__invoke()) {
+            return;
+        }
+
         $this->events->add($event);
     }
 

--- a/src/Symfony/Component/Notifier/Tests/EventListener/NotificationLoggerListenerTest.php
+++ b/src/Symfony/Component/Notifier/Tests/EventListener/NotificationLoggerListenerTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Tests\EventListener;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Notifier\Event\MessageEvent;
+use Symfony\Component\Notifier\EventListener\NotificationLoggerListener;
+use Symfony\Component\Notifier\Message\SmsMessage;
+
+class NotificationLoggerListenerTest extends TestCase
+{
+    public function testNotificationsAreLoggedByDefault()
+    {
+        $listener = new NotificationLoggerListener();
+        $listener->onNotification($this->createEvent());
+
+        $this->assertCount(1, $listener->getEvents()->getEvents());
+    }
+
+    public function testNotificationsAreDiscardedWhileDisabled()
+    {
+        $listener = new NotificationLoggerListener(static fn (): bool => true);
+        $listener->onNotification($this->createEvent());
+
+        $this->assertSame([], $listener->getEvents()->getEvents());
+    }
+
+    public function testDisabledStateIsCheckedOnEachNotification()
+    {
+        $disabled = true;
+        $listener = new NotificationLoggerListener(static function () use (&$disabled): bool { return $disabled; });
+
+        $listener->onNotification($this->createEvent());
+        $disabled = false;
+        $listener->onNotification($this->createEvent());
+
+        $this->assertCount(1, $listener->getEvents()->getEvents());
+    }
+
+    public function testResetDropsLoggedNotifications()
+    {
+        $listener = new NotificationLoggerListener();
+        $listener->onNotification($this->createEvent());
+        $listener->reset();
+
+        $this->assertSame([], $listener->getEvents()->getEvents());
+    }
+
+    private function createEvent(): MessageEvent
+    {
+        return new MessageEvent(new SmsMessage('+37255555555', 'Hello!'));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #50580
| License       | MIT

`mailer.message_logger_listener` and `notifier.notification_logger_listener` keep every event, attachments included, for the lifetime of the process. They were registered whenever Mailer or Notifier was enabled, so a long-running process that sends many messages grew without bound even though nobody would ever read those events.

Only two things consume them: the profiler, and the test assertions. So the listeners are dropped when neither is configured, and when the profiler is configured without test mode they now skip events while the profiler is not collecting.

Test mode keeps them collecting unconditionally, because `MailerAssertionsTrait` and `NotificationAssertionsTrait` read them directly and the standard test configuration sets `framework.profiler.collect: false`. That is what makes this BC-free: no test suite changes behaviour, neither trait is touched, and no UPGRADE entry or docs change is needed.

This supersedes the earlier attempt at this fix. #60515 was reverted by #61924 because it removed the listener that `MailerAssertionsTrait` reads, per #61873. Gating on test mode addresses that directly instead of rewriting the trait to read the profiler's collector.

Coverage: the DI gating is tested for all four combinations of profiler and test mode, for both listeners, and each listener gets unit tests for the new skip behaviour, which neither had.
