### PR TITLE
[PropertyInfo] Ignore methods that only look like accessors

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -709,6 +709,12 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
         $pattern = implode('|', array_merge($this->accessorPrefixes, $this->mutatorPrefixes));
 
         if ('' !== $pattern && preg_match('/^('.$pattern.')(.+)$/i', $methodName, $matches)) {
+            // a lowercase first letter means the prefix is part of a longer word rather than a
+            // prefix, e.g. "hash" or "cancel", so the method is not an accessor at all
+            if (ctype_lower($matches[2][0])) {
+                return null;
+            }
+
             if (!\in_array($matches[1], $this->arrayMutatorPrefixes)) {
                 return $matches[2];
             }

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
@@ -23,6 +23,7 @@ use Symfony\Component\PropertyInfo\Tests\Fixtures\DummyWithHasser;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\MultiParameterAdderDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\MultiParameterAdderParentDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\MultiParameterAdderValue;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\NotAnAccessorDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\NotInstantiable;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Php71Dummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Php71DummyExtended;
@@ -168,6 +169,11 @@ class ReflectionExtractorTest extends TestCase
             ],
             $customExtractor->getProperties('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy')
         );
+    }
+
+    public function testGetPropertiesIgnoresMethodsThatOnlyLookLikeAccessors()
+    {
+        $this->assertSame(['real'], $this->extractor->getProperties(NotAnAccessorDummy::class));
     }
 
     public function testGetPropertiesWithNoPrefixes()

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/NotAnAccessorDummy.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/NotAnAccessorDummy.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
+
+class NotAnAccessorDummy
+{
+    public string $real;
+
+    public function getReal(): string
+    {
+    }
+
+    public function hash(): string
+    {
+    }
+
+    public function cancel(): void
+    {
+    }
+
+    public function isolate(): void
+    {
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`ReflectionExtractor::getProperties()` reports a property for any method whose name merely starts with an accessor prefix, even when the prefix is part of a longer word. `hash()` matches `has` and yields the property `h`, `cancel()` matches `can` and yields `cel`:

```php
class Weird
{
    public string $real;
    public function getReal(): string {}
    public function hash(): string {}
    public function cancel(): void {}
}
```

```
before: ['real', 'h', 'cel']
after:  ['real']
```

A lowercase first letter after the prefix means the prefix is part of a word rather than a prefix, so the method is not an accessor. The Serializer has always applied that rule when resolving accessors, in `AccessorCollisionResolverTrait`, with the same reasoning; this brings PropertyInfo in line.

The phantom names reach whatever consumes `getProperties()`, which includes form type guessing and validation auto-mapping, not just the serializer.
