### PR TITLE
[Tui] Clamp borders that do not fit their container

### DIFF
--- a/src/Symfony/Component/Tui/Render/ChromeApplier.php
+++ b/src/Symfony/Component/Tui/Render/ChromeApplier.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Tui\Render;
 
 use Symfony\Component\Tui\Ansi\AnsiUtils;
+use Symfony\Component\Tui\Style\Border;
 use Symfony\Component\Tui\Style\Style;
 use Symfony\Component\Tui\Style\TextAlign;
 use Symfony\Component\Tui\Widget\AbstractWidget;
@@ -70,6 +71,16 @@ final class ChromeApplier
         }
 
         $outerStyle = $this->resolveOuterStyle($widget);
+
+        // Clamp the border the same way, before the padding: a border alone can be
+        // wider than the box (e.g. 1 column each side in a 2-column container, which
+        // a horizontal layout hands out as soon as there are enough children).
+        $maxHorizontalBorder = max(0, $width - 1);
+        if ($borderLeft + $borderRight > $maxHorizontalBorder) {
+            $borderLeft = min($borderLeft, $maxHorizontalBorder);
+            $borderRight = min($borderRight, max(0, $maxHorizontalBorder - $borderLeft));
+            $border = new Border($borderTop, $borderRight, $borderBottom, $borderLeft, $border->pattern, $border->color);
+        }
 
         $innerWidth = max(1, $width - $borderLeft - $borderRight);
 

--- a/src/Symfony/Component/Tui/Tests/Render/ChromeApplierTest.php
+++ b/src/Symfony/Component/Tui/Tests/Render/ChromeApplierTest.php
@@ -226,6 +226,30 @@ final class ChromeApplierTest extends TestCase
         $this->assertCount(2, $result);
     }
 
+    #[DataProvider('borderWiderThanBoxProvider')]
+    public function testApplyClampsBorderToTheAvailableWidth(int $width, Style $style)
+    {
+        $applier = $this->createApplier();
+        $widget = new TextWidget('test');
+
+        $result = $applier->apply(['Hello'], $width, $style, $widget);
+
+        foreach ($result as $line) {
+            $this->assertSame($width, AnsiUtils::visibleWidth($line));
+        }
+    }
+
+    /**
+     * @return iterable<string, array{int, Style}>
+     */
+    public static function borderWiderThanBoxProvider(): iterable
+    {
+        yield 'border leaves no room for content' => [2, new Style(border: Border::all(1, 'none'))];
+        yield 'border wider than the box' => [1, new Style(border: Border::all(1, 'none'))];
+        yield 'thick border wider than the box' => [3, new Style(border: Border::all(2, 'none'))];
+        yield 'border and padding wider than the box' => [2, new Style(padding: Padding::all(1), border: Border::all(1, 'none'))];
+    }
+
     // ---------------------------------------------------------------
     // apply: background
     // ---------------------------------------------------------------

--- a/src/Symfony/Component/Tui/Tests/Render/RendererTest.php
+++ b/src/Symfony/Component/Tui/Tests/Render/RendererTest.php
@@ -1259,6 +1259,30 @@ class RendererTest extends TestCase
         $result = $renderer->render($root, $columns, 10);
         $this->assertSame($expectedWidth, AnsiUtils::visibleWidth($result[0]));
     }
+
+    public function testBorderedChildrenNarrowerThanTheirBorderStayWithinTheirColumns()
+    {
+        $renderer = new Renderer();
+        $root = new ContainerWidget();
+        $row = new ContainerWidget();
+        $row->setStyle(new Style(direction: Direction::Horizontal));
+
+        // 20 children in 40 columns leaves 2 columns each, which a left and a
+        // right border alone would already exceed
+        for ($i = 0; $i < 20; ++$i) {
+            $cell = new ContainerWidget();
+            $cell->setStyle(new Style(border: Border::all(1, 'none')));
+            $cell->add(new TextWidget('x'));
+            $row->add($cell);
+        }
+        $root->add($row);
+
+        $result = $renderer->render($root, 40, 6);
+
+        foreach ($result as $line) {
+            $this->assertLessThanOrEqual(40, AnsiUtils::visibleWidth($line));
+        }
+    }
 }
 
 /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`ChromeApplier::apply()` computed the inner width as `max(1, $width - $borderLeft - $borderRight)`, forcing a content column even when the border alone already filled the box. The lines it returned were then `$borderLeft + 1 + $borderRight` columns wide, overflowing the space the widget was given.

A horizontal layout hands out that little space on its own. Twenty bordered children in 40 columns get 2 columns each, so a single column of border on each side is already too much:

```
RenderException: Widget "Symfony\Component\Tui\Widget\ContainerWidget" rendered
line 0 with width 3, exceeding the available 2 columns.
```

Thirteen children in the same 40 columns render fine, so this is reachable just by adding one more child or by resizing the terminal narrower, and it takes down a running app rather than degrading.

The border is now clamped to the available width the same way the padding right below it already is, keeping at least one column for content, and the clamped border is what wraps the lines so the drawn edges match the reserved space. Cells that cannot fit both edges keep the left one:

```
before:  RenderException
after:   ┌─┌─┌─┌─┌─┌─┌─┌─┌─┌─┌─┌─┌─┌─┌─┌─┌─┌─┌─┌─
         │x│x│x│x│x│x│x│x│x│x│x│x│x│x│x│x│x│x│x│x
         └─└─└─└─└─└─└─└─└─└─└─└─└─└─└─└─└─└─└─└─
```

Found while reviewing #65268: the width validation that catches this is what that PR proposed to skip for `ContainerWidget`, and the hunk was dropped before merging.
