### PR TITLE
[Workflow] Add default generic types to Workflow Events

### DIFF
--- a/src/Symfony/Component/Workflow/Event/AnnounceEvent.php
+++ b/src/Symfony/Component/Workflow/Event/AnnounceEvent.php
@@ -16,7 +16,7 @@ use Symfony\Component\Workflow\Transition;
 use Symfony\Component\Workflow\WorkflowInterface;
 
 /**
- * @template T of object
+ * @template T of object = object
  *
  * @extends Event<T>
  */

--- a/src/Symfony/Component/Workflow/Event/CompletedEvent.php
+++ b/src/Symfony/Component/Workflow/Event/CompletedEvent.php
@@ -16,7 +16,7 @@ use Symfony\Component\Workflow\Transition;
 use Symfony\Component\Workflow\WorkflowInterface;
 
 /**
- * @template T of object
+ * @template T of object= object
  *
  * @extends Event<T>
  */

--- a/src/Symfony/Component/Workflow/Event/EnterEvent.php
+++ b/src/Symfony/Component/Workflow/Event/EnterEvent.php
@@ -16,7 +16,7 @@ use Symfony\Component\Workflow\Transition;
 use Symfony\Component\Workflow\WorkflowInterface;
 
 /**
- * @template T of object
+ * @template T of object = object
  *
  * @extends Event<T>
  */

--- a/src/Symfony/Component/Workflow/Event/EnteredEvent.php
+++ b/src/Symfony/Component/Workflow/Event/EnteredEvent.php
@@ -16,7 +16,7 @@ use Symfony\Component\Workflow\Transition;
 use Symfony\Component\Workflow\WorkflowInterface;
 
 /**
- * @template T of object
+ * @template T of object = object
  *
  * @extends Event<T>
  */

--- a/src/Symfony/Component/Workflow/Event/Event.php
+++ b/src/Symfony/Component/Workflow/Event/Event.php
@@ -21,7 +21,7 @@ use Symfony\Contracts\EventDispatcher\Event as BaseEvent;
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
  * @author Carlos Pereira De Amorim <carlos@shauri.fr>
  *
- * @template T of object
+ * @template T of object = object
  */
 class Event extends BaseEvent
 {

--- a/src/Symfony/Component/Workflow/Event/GuardEvent.php
+++ b/src/Symfony/Component/Workflow/Event/GuardEvent.php
@@ -21,7 +21,7 @@ use Symfony\Component\Workflow\WorkflowInterface;
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
  *
- * @template T of object
+ * @template T of object = object
  *
  * @extends Event<T>
  */

--- a/src/Symfony/Component/Workflow/Event/LeaveEvent.php
+++ b/src/Symfony/Component/Workflow/Event/LeaveEvent.php
@@ -16,7 +16,7 @@ use Symfony\Component\Workflow\Transition;
 use Symfony\Component\Workflow\WorkflowInterface;
 
 /**
- * @template T of object
+ * @template T of object = object
  *
  * @extends Event<T>
  */

--- a/src/Symfony/Component/Workflow/Event/TransitionEvent.php
+++ b/src/Symfony/Component/Workflow/Event/TransitionEvent.php
@@ -16,7 +16,7 @@ use Symfony\Component\Workflow\Transition;
 use Symfony\Component\Workflow\WorkflowInterface;
 
 /**
- * @template T of object
+ * @template T of object = object
  *
  * @extends Event<T>
  */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Add default generic types to Workflow Events. Not all project want or need to define the generic type for this kind of events. Currently it is forced but with `= object` it default to a generic object.

Types where introduced in: https://github.com/symfony/symfony/commit/464a6990bf7c3449c76709c7c54cf5bfd695f67c

Related PRs: https://github.com/symfony/symfony/pull/62701, https://github.com/symfony/symfony/pull/62616

This avoids unneeded template requirement for generic listeners which may not need to know about object / subject type when upgrade 8.0 project to 8.1:

```diff
-    /**
-     * @template T of object
-     *
-     * @param TransitionEvent<T> $transitionEvent
-     */
     public function onPublish(TransitionEvent $transitionEvent): void
```
