### PR TITLE
[FrameworkBundle] Reset the notification logger listener between messages

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/notifier.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/notifier.php
@@ -131,6 +131,7 @@ return static function (ContainerConfigurator $container) {
 
         ->set('notifier.notification_logger_listener', NotificationLoggerListener::class)
             ->tag('kernel.event_subscriber')
+            ->tag('kernel.reset', ['method' => 'reset'])
 
         ->alias('notifier.logger_notification_listener', 'notifier.notification_logger_listener')
             ->deprecate('symfony/framework-bundle', '6.3', 'The "%alias_id%" service is deprecated, use "notifier.notification_logger_listener" instead.')

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -2300,6 +2300,15 @@ abstract class FrameworkExtensionTestCase extends TestCase
         $this->assertFalse($container->getDefinition('notifier.failed_message_listener')->hasTag('kernel.event_subscriber'));
     }
 
+    public function testNotificationLoggerListenerIsResettable()
+    {
+        $container = $this->createContainerFromFile('notifier');
+
+        // Otherwise a worker keeps every notification it ever sent, and the
+        // collector reports the ones from previous messages.
+        $this->assertSame([['method' => 'reset']], $container->getDefinition('notifier.notification_logger_listener')->getTag('kernel.reset'));
+    }
+
     public function testNotifierWithMailerAndMessenger()
     {
         $container = $this->createContainerFromFile('notifier');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`NotificationLoggerListener` implements `ResetInterface`, but `notifier.notification_logger_listener` was never tagged `kernel.reset`, so `reset()` was unused code and the listener kept every notification it had seen. The mailer counterpart, `mailer.message_logger_listener`, has carried the tag all along.

`kernel.reset` is driven by `services_resetter`, and its only per-unit-of-work caller is `messenger.listener.reset_services`. So a `messenger:consume` worker accumulated notifications for its whole lifetime, and the notifier collector reported the ones sent while handling earlier messages.

Tagged in every branch from 6.4 up, so the fix goes here.
