### PR TITLE
[Security][SecurityBundle] Support decorating custom authentication result handlers

### DIFF
--- a/UPGRADE-8.2.md
+++ b/UPGRADE-8.2.md
@@ -98,6 +98,11 @@ SecurityBundle
  * Deprecate the `remember_me` option of the `form_login`, `json_login`, `login_link`, and `access_token` authenticators, as it has no effect
  * Deprecate configuring an access control rule with many `roles`, use `allow_if` or role hierarchy instead
  * Deprecate configuring both an access control rule `allow_if` and `roles`, update `allow_if` instead
+ * A service used as a firewall `success_handler` or `failure_handler` is now wired as-is, so decorating it
+   takes effect where it used to be silently ignored. Such a decorator must forward `setOptions()`, and
+   `setFirewallName()` for success handlers, to the service it decorates whenever that service relies on them,
+   as `DefaultAuthenticationSuccessHandler` and `DefaultAuthenticationFailureHandler` do. Without forwarding,
+   the authenticator options and the session target path are lost, and a successful login redirects to `/`
 
 Serializer
 ----------

--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -13,6 +13,7 @@ CHANGELOG
  * Add `path`, `enable_csrf`, `csrf_token_id`, `csrf_parameter` and `csrf_token_manager` options to the `switch_user` firewall configuration to restrict user switching to a dedicated (POST-only) route protected by a CSRF token
  * Deprecate configuring an access control rule with many `roles`, use `allow_if` or role hierarchy instead
  * Deprecate configuring both an access control rule `allow_if` and `roles`, update `allow_if` instead
+ * Add support for decorating custom authentication failure and success handlers
 
 8.1
 ---

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AbstractFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AbstractFactory.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory;
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>
@@ -78,7 +79,7 @@ abstract class AbstractFactory implements AuthenticatorFactoryInterface
 
         if (isset($config['success_handler'])) {
             $successHandler = $container->setDefinition($successHandlerId, new ChildDefinition('security.authentication.custom_success_handler'));
-            $successHandler->replaceArgument(0, new ChildDefinition($config['success_handler']));
+            $successHandler->replaceArgument(0, new Reference($config['success_handler']));
             $successHandler->replaceArgument(1, $options);
             $successHandler->replaceArgument(2, $id);
         } else {
@@ -97,7 +98,7 @@ abstract class AbstractFactory implements AuthenticatorFactoryInterface
 
         if (isset($config['failure_handler'])) {
             $failureHandler = $container->setDefinition($id, new ChildDefinition('security.authentication.custom_failure_handler'));
-            $failureHandler->replaceArgument(0, new ChildDefinition($config['failure_handler']));
+            $failureHandler->replaceArgument(0, new Reference($config['failure_handler']));
             $failureHandler->replaceArgument(1, $options);
         } else {
             $failureHandler = $container->setDefinition($id, new ChildDefinition('security.authentication.failure_handler'));

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/AbstractFactoryTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/AbstractFactoryTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\AbstractFactory;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
 
 class AbstractFactoryTest extends TestCase
 {
@@ -53,8 +54,8 @@ class AbstractFactoryTest extends TestCase
             $this->assertInstanceOf(ChildDefinition::class, $failureHandler);
             $this->assertEquals('security.authentication.custom_failure_handler', $failureHandler->getParent());
             $failureHandlerArguments = $failureHandler->getArguments();
-            $this->assertInstanceOf(ChildDefinition::class, $failureHandlerArguments['index_0']);
-            $this->assertEquals($serviceId, $failureHandlerArguments['index_0']->getParent());
+            $this->assertInstanceOf(Reference::class, $failureHandlerArguments['index_0']);
+            $this->assertEquals($serviceId, (string) $failureHandlerArguments['index_0']);
             $this->assertEquals($expectedFailureHandlerOptions, $failureHandlerArguments['index_1']);
         }
     }
@@ -97,8 +98,8 @@ class AbstractFactoryTest extends TestCase
             $this->assertInstanceOf(ChildDefinition::class, $successHandler);
             $this->assertEquals('security.authentication.custom_success_handler', $successHandler->getParent());
             $successHandlerArguments = $successHandler->getArguments();
-            $this->assertInstanceOf(ChildDefinition::class, $successHandlerArguments['index_0']);
-            $this->assertEquals($serviceId, $successHandlerArguments['index_0']->getParent());
+            $this->assertInstanceOf(Reference::class, $successHandlerArguments['index_0']);
+            $this->assertEquals($serviceId, (string) $successHandlerArguments['index_0']);
             $this->assertEquals($expectedSuccessHandlerOptions, $successHandlerArguments['index_1']);
             $this->assertEquals($expectedFirewallName, $successHandlerArguments['index_2']);
         }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Fixtures/DecoratingAuthenticationFailureHandler.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Fixtures/DecoratingAuthenticationFailureHandler.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\Fixtures;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface;
+
+class DecoratingAuthenticationFailureHandler implements AuthenticationFailureHandlerInterface
+{
+    public function __construct(private AuthenticationFailureHandlerInterface $handler)
+    {
+    }
+
+    public function setOptions(array $options): void
+    {
+        if (method_exists($this->handler, 'setOptions')) {
+            $this->handler->setOptions($options);
+        }
+    }
+
+    public function onAuthenticationFailure(Request $request, AuthenticationException $exception): Response
+    {
+        $response = $this->handler->onAuthenticationFailure($request, $exception);
+        $response->headers->add([
+            'X-Decorated-Handler' => $this->handler::class,
+            'X-Decorating-Handler' => __CLASS__,
+        ]);
+
+        return $response;
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Fixtures/DecoratingAuthenticationSuccessHandler.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Fixtures/DecoratingAuthenticationSuccessHandler.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\Fixtures;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface;
+
+class DecoratingAuthenticationSuccessHandler implements AuthenticationSuccessHandlerInterface
+{
+    public function __construct(private AuthenticationSuccessHandlerInterface $handler)
+    {
+    }
+
+    public function setOptions(array $options): void
+    {
+        if (method_exists($this->handler, 'setOptions')) {
+            $this->handler->setOptions($options);
+        }
+    }
+
+    public function setFirewallName(string $firewallName): void
+    {
+        if (method_exists($this->handler, 'setFirewallName')) {
+            $this->handler->setFirewallName($firewallName);
+        }
+    }
+
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token): ?Response
+    {
+        $response = $this->handler->onAuthenticationSuccess($request, $token);
+        $response?->headers->add([
+            'X-Decorated-Handler' => $this->handler::class,
+            'X-Decorating-Handler' => __CLASS__,
+            'X-Firewall-Name' => method_exists($this->handler, 'getFirewallName') ? $this->handler->getFirewallName() : null,
+        ]);
+
+        return $response;
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/AuthenticatorTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/AuthenticatorTest.php
@@ -12,6 +12,10 @@
 namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Bundle\SecurityBundle\Tests\Fixtures\DecoratingAuthenticationFailureHandler;
+use Symfony\Bundle\SecurityBundle\Tests\Fixtures\DecoratingAuthenticationSuccessHandler;
+use Symfony\Component\Security\Http\Authentication\DefaultAuthenticationFailureHandler;
+use Symfony\Component\Security\Http\Authentication\DefaultAuthenticationSuccessHandler;
 
 class AuthenticatorTest extends AbstractWebTestCase
 {
@@ -93,12 +97,18 @@ class AuthenticatorTest extends AbstractWebTestCase
             '_password' => 'test',
         ]);
         $this->assertResponseRedirects('http://localhost/firewall1/test');
+        $this->assertResponseHeaderSame('X-Decorated-Handler', DefaultAuthenticationSuccessHandler::class);
+        $this->assertResponseHeaderSame('X-Decorating-Handler', DecoratingAuthenticationSuccessHandler::class);
+        $this->assertResponseHeaderSame('X-Firewall-Name', 'firewall1');
 
         $client->request('POST', '/firewall1/dummy_login', [
             '_username' => 'jane@example.org',
             '_password' => 'test',
         ]);
         $this->assertResponseRedirects('http://localhost/firewall1/dummy');
+        $this->assertResponseHeaderSame('X-Decorated-Handler', DefaultAuthenticationSuccessHandler::class);
+        $this->assertResponseHeaderSame('X-Decorating-Handler', DecoratingAuthenticationSuccessHandler::class);
+        $this->assertResponseHeaderSame('X-Firewall-Name', 'firewall1');
     }
 
     public function testCustomFailureHandler()
@@ -110,11 +120,15 @@ class AuthenticatorTest extends AbstractWebTestCase
             '_password' => 'wrong',
         ]);
         $this->assertResponseRedirects('http://localhost/firewall1/login');
+        $this->assertResponseHeaderSame('X-Decorated-Handler', DefaultAuthenticationFailureHandler::class);
+        $this->assertResponseHeaderSame('X-Decorating-Handler', DecoratingAuthenticationFailureHandler::class);
 
         $client->request('POST', '/firewall1/dummy_login', [
             '_username' => 'jane@example.org',
             '_password' => 'wrong',
         ]);
         $this->assertResponseRedirects('http://localhost/firewall1/dummy_login');
+        $this->assertResponseHeaderSame('X-Decorated-Handler', DefaultAuthenticationFailureHandler::class);
+        $this->assertResponseHeaderSame('X-Decorating-Handler', DecoratingAuthenticationFailureHandler::class);
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Authenticator/custom_handlers.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Authenticator/custom_handlers.yml
@@ -26,8 +26,16 @@ services:
     class: Symfony\Component\Security\Http\Authentication\DefaultAuthenticationSuccessHandler
     arguments:
       - '@security.http_utils'
+  decorating_success_handler:
+    class: Symfony\Bundle\SecurityBundle\Tests\Fixtures\DecoratingAuthenticationSuccessHandler
+    decorates: success_handler
+    arguments: ['@.inner']
   failure_handler:
     class: Symfony\Component\Security\Http\Authentication\DefaultAuthenticationFailureHandler
     arguments:
       - '@http_kernel'
       - '@security.http_utils'
+  decorating_failure_handler:
+    class: Symfony\Bundle\SecurityBundle\Tests\Fixtures\DecoratingAuthenticationFailureHandler
+    decorates: failure_handler
+    arguments: ['@.inner']

--- a/src/Symfony/Component/Security/Http/Authentication/CustomAuthenticationFailureHandler.php
+++ b/src/Symfony/Component/Security/Http/Authentication/CustomAuthenticationFailureHandler.php
@@ -25,15 +25,16 @@ class CustomAuthenticationFailureHandler implements AuthenticationFailureHandler
      */
     public function __construct(
         private AuthenticationFailureHandlerInterface $handler,
-        array $options,
+        private array $options,
     ) {
-        if (method_exists($handler, 'setOptions')) {
-            $this->handler->setOptions($options);
-        }
     }
 
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception): Response
     {
+        if (method_exists($this->handler, 'setOptions')) {
+            $this->handler->setOptions($this->options);
+        }
+
         return $this->handler->onAuthenticationFailure($request, $exception);
     }
 }

--- a/src/Symfony/Component/Security/Http/Authentication/CustomAuthenticationSuccessHandler.php
+++ b/src/Symfony/Component/Security/Http/Authentication/CustomAuthenticationSuccessHandler.php
@@ -25,20 +25,21 @@ class CustomAuthenticationSuccessHandler implements AuthenticationSuccessHandler
      */
     public function __construct(
         private AuthenticationSuccessHandlerInterface $handler,
-        array $options,
-        string $firewallName,
+        private array $options,
+        private string $firewallName,
     ) {
-        if (method_exists($handler, 'setOptions')) {
-            $this->handler->setOptions($options);
-        }
-
-        if (method_exists($handler, 'setFirewallName')) {
-            $this->handler->setFirewallName($firewallName);
-        }
     }
 
     public function onAuthenticationSuccess(Request $request, TokenInterface $token): ?Response
     {
+        if (method_exists($this->handler, 'setOptions')) {
+            $this->handler->setOptions($this->options);
+        }
+
+        if (method_exists($this->handler, 'setFirewallName')) {
+            $this->handler->setFirewallName($this->firewallName);
+        }
+
         return $this->handler->onAuthenticationSuccess($request, $token);
     }
 }

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -13,6 +13,7 @@ CHANGELOG
  * Add `$urlGenerator` and `$csrfTokenManager` arguments to `ImpersonateUrlGenerator` so that the generated URLs follow the `path` and CSRF configuration of the firewall
  * Add `ImpersonateUrlGenerator::generateImpersonationForm()` and `generateExitForm()` to build a form that switches the user with a POST
  * Add `$targetUri` argument to `ImpersonateUrlGenerator::generateImpersonationPath()` and `generateImpersonationUrl()`
+ * Configure the decorated handler of `CustomAuthenticationSuccessHandler` and `CustomAuthenticationFailureHandler` when they are called instead of when they are built, so that a single handler can be shared by several authenticators
 
 8.1
 ---


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #49457
| License       | MIT

Alternative to #64405, same feature without a compiler pass.

A firewall's `success_handler` and `failure_handler` options name a service, but the authenticator's own options (`default_target_path`, `login_path`, `failure_path`...) are pushed into that service through `setOptions()` and `setFirewallName()`. Wiring the same handler into two authenticators therefore made the last one win, so #48937 wired it as a `ChildDefinition` to give each authenticator its own copy. As a side effect, `decorates:` on the handler was silently ignored: a copy inherits the original definition, never the decorator.

`CustomAuthenticationSuccessHandler` and `CustomAuthenticationFailureHandler` now configure the handler they wrap right before delegating to it, instead of when they are built. The handler can then be wired as a plain reference and stay shared: each authenticator configures it for its own call, and decoration applies.

```yaml
services:
    App\Security\SuccessHandlerDecorator:
        decorates: app.success_handler
        arguments: ['@.inner']

security:
    firewalls:
        main:
            form_login:
                success_handler: app.success_handler
                default_target_path: /dashboard
```

A firewall handles a request with a single authenticator and `FirewallListener` ignores sub-requests, so those calls cannot interleave. Nothing in the container is inspected or rewired, so `decorates:`, `#[AsDecorator]` and `stack:` all work, whichever way the handler service is declared.

For the docs: decorating a `success_handler` or a `failure_handler` now works. A decorator must forward `setOptions()`, and `setFirewallName()` for success handlers, to the service it decorates whenever that service relies on them, as `DefaultAuthenticationSuccessHandler` and `DefaultAuthenticationFailureHandler` do. Without forwarding, the authenticator options and the session target path are silently lost.
