### PR TITLE
[FrameworkBundle] Wire the webhook request parser with the configured header names

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -3397,6 +3397,12 @@ class FrameworkExtension extends Extension
         $container->getDefinition('webhook.signer')
             ->replaceArgument(0, $config['signing_algorithm'])
             ->replaceArgument(1, $config['signature_header_name']);
+
+        $container->getDefinition('webhook.request_parser')
+            ->replaceArgument(0, $config['signing_algorithm'])
+            ->replaceArgument(1, $config['signature_header_name'])
+            ->replaceArgument(2, $config['event_header_name'])
+            ->replaceArgument(3, $config['id_header_name']);
     }
 
     private function registerRemoteEventConfiguration(PhpFileLoader $loader): void

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/webhook.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/webhook.php
@@ -62,6 +62,12 @@ return static function (ContainerConfigurator $container) {
             ->tag('messenger.message_handler')
 
         ->set('webhook.request_parser', RequestParser::class)
+            ->args([
+                abstract_arg('signing algorithm'),
+                abstract_arg('signature header name'),
+                abstract_arg('event header name'),
+                abstract_arg('id header name'),
+            ])
         ->alias(RequestParser::class, 'webhook.request_parser')
 
         ->set('webhook.controller', WebhookController::class)

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -2944,6 +2944,31 @@ abstract class FrameworkExtensionTestCase extends TestCase
         $this->assertSame('Webhook-Signature', $container->getDefinition('webhook.signer')->getArgument(1));
     }
 
+    public function testWebhookRequestParserIsWiredWithTheConfiguredHeaderNames()
+    {
+        if (!class_exists(WebhookController::class)) {
+            $this->markTestSkipped('Webhook not available.');
+        }
+
+        $container = $this->createContainerFromClosure(static function (ContainerBuilder $container) {
+            $container->loadFromExtension('framework', [
+                'http_client' => ['enabled' => true],
+                'webhook' => [
+                    'enabled' => true,
+                    'signing_algorithm' => 'sha512',
+                    'signature_header_name' => 'X-Signature',
+                    'event_header_name' => 'X-Event',
+                    'id_header_name' => 'X-Id',
+                ],
+            ]);
+        });
+
+        $this->assertSame(
+            ['sha512', 'X-Signature', 'X-Event', 'X-Id'],
+            $container->getDefinition('webhook.request_parser')->getArguments()
+        );
+    }
+
     public function testWebhookWithoutSerializer()
     {
         if (!class_exists(WebhookController::class)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        |
| License       | MIT

`framework.webhook.signing_algorithm`, `event_header_name`, `id_header_name` and `signature_header_name` became configurable in 8.1, but `webhook.request_parser` is still registered with no arguments, so none of them reach Symfony's own receiver. Renaming a header name today leaves the sender emitting the new name while the parser keeps looking for the old one, and the application fails to verify the webhooks it sends itself.
