### PR TITLE
[Serializer] Fix low-deps tests

### DIFF
--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -1203,6 +1203,11 @@ class ObjectNormalizerTest extends TestCase
     {
         // an extractor written against PropertyInfoExtractorInterface before getProperty() was added to it
         $extractor = new class implements PropertyInfoExtractorInterface {
+            public function getTypes(string $class, string $property, array $context = []): ?array
+            {
+                return null;
+            }
+
             public function getType(string $class, string $property, array $context = []): ?Type
             {
                 return null;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

#63864 added an anonymous implementation of `PropertyInfoExtractorInterface`, but `symfony/serializer` still works with `symfony/property-info` v7 so it must also implement `PropertyTypeExtractorInterface::getTypes()`.