### PR TITLE
[HttpFoundation] Add targeted cache-control support (RFC 9213)

### DIFF
--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.2
 ---
 
+ * Add `Response::cacheControl()` to set the targeted cache directives defined by RFC 9213, e.g. `CDN-Cache-Control`
  * Deprecate not passing an expiry to `UriSigner::sign()`
  * Add the `$defaultExpiration` argument to `UriSigner::__construct()`
  * Add argument `$version` to `UriSigner::sign()`, `UriSigner::check()`, `UriSigner::checkRequest()`, and `UriSigner::verify()` to bind a signed URI to a state token, folded into the signature

--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -581,6 +581,27 @@ class Response
     }
 
     /**
+     * Returns the cache directives addressed to one cache, as defined by RFC 9213.
+     *
+     * The cache identifying itself as the given target reads them instead of
+     * "Cache-Control", so it can be told to keep the response much longer than
+     * the browser is:
+     *
+     *     $response->setMaxAge(0)->setPrivate();
+     *     $response->cacheControl('CDN')->setMaxAge(3600);
+     *
+     * @param string $target The cache the directives are addressed to, e.g. "CDN"
+     *
+     * @throws \InvalidArgumentException When the target is not a valid token
+     *
+     * @final
+     */
+    public function cacheControl(string $target): TargetedCacheControl
+    {
+        return new TargetedCacheControl($this->headers, $target);
+    }
+
+    /**
      * Marks the response as "private".
      *
      * It makes the response ineligible for serving other clients.

--- a/src/Symfony/Component/HttpFoundation/TargetedCacheControl.php
+++ b/src/Symfony/Component/HttpFoundation/TargetedCacheControl.php
@@ -1,0 +1,152 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation;
+
+/**
+ * Cache directives addressed to one cache, as defined by RFC 9213.
+ *
+ * A cache that knows itself as "CDN" reads "CDN-Cache-Control" and ignores
+ * "Cache-Control"; every other cache does the opposite. That makes it possible
+ * to keep a response for hours in a CDN while telling browsers not to store it.
+ *
+ * There is no "s-maxage" counterpart to setMaxAge(): the target already names
+ * the cache the directives are for, and "max-age" is the only one every cache
+ * implementing RFC 9213 is required to honour.
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc9213.html
+ *
+ * @author David Buchmann <mail@davidbu.ch>
+ */
+final class TargetedCacheControl
+{
+    /**
+     * RFC 9213 section 2: the target is a token, matched case-insensitively.
+     */
+    private const TARGET_REGEX = '/^[!#$%&\'*+.^_`|~0-9A-Za-z-]+$/D';
+
+    private readonly string $header;
+
+    /**
+     * @param string $target The cache the directives are addressed to, e.g. "CDN"
+     *
+     * @throws \InvalidArgumentException When the target is not a valid token
+     */
+    public function __construct(
+        private readonly ResponseHeaderBag $headers,
+        string $target,
+    ) {
+        if (!preg_match(self::TARGET_REGEX, $target)) {
+            throw new \InvalidArgumentException(\sprintf('The cache-control target "%s" is not a valid token.', $target));
+        }
+
+        $this->header = $target.'-Cache-Control';
+    }
+
+    public function setMaxAge(int $value): static
+    {
+        return $this->set('max-age', (string) $value);
+    }
+
+    public function setStaleWhileRevalidate(int $value): static
+    {
+        return $this->set('stale-while-revalidate', (string) $value);
+    }
+
+    public function setStaleIfError(int $value): static
+    {
+        return $this->set('stale-if-error', (string) $value);
+    }
+
+    public function setPublic(): static
+    {
+        return $this->set('public')->remove('private');
+    }
+
+    public function setPrivate(): static
+    {
+        return $this->set('private')->remove('public');
+    }
+
+    public function setImmutable(bool $immutable = true): static
+    {
+        return $immutable ? $this->set('immutable') : $this->remove('immutable');
+    }
+
+    public function setNoStore(bool $noStore = true): static
+    {
+        return $noStore ? $this->set('no-store') : $this->remove('no-store');
+    }
+
+    /**
+     * Adds or replaces a directive, for the ones this class does not model.
+     *
+     * Passing false removes the directive.
+     */
+    public function set(string $directive, bool|string $value = true): static
+    {
+        if (false === $value) {
+            return $this->remove($directive);
+        }
+
+        $directives = $this->all();
+        $directives[strtolower($directive)] = $value;
+
+        return $this->write($directives);
+    }
+
+    public function remove(string $directive): static
+    {
+        $directives = $this->all();
+        unset($directives[strtolower($directive)]);
+
+        return $this->write($directives);
+    }
+
+    public function has(string $directive): bool
+    {
+        return \array_key_exists(strtolower($directive), $this->all());
+    }
+
+    public function get(string $directive): bool|string|null
+    {
+        return $this->all()[strtolower($directive)] ?? null;
+    }
+
+    /**
+     * @return array<string, bool|string>
+     */
+    public function all(): array
+    {
+        if (!$header = $this->headers->all($this->header)) {
+            return [];
+        }
+
+        return HeaderUtils::combine(HeaderUtils::split(implode(', ', $header), ',='));
+    }
+
+    /**
+     * @param array<string, bool|string> $directives
+     */
+    private function write(array $directives): static
+    {
+        if (!$directives) {
+            $this->headers->remove($this->header);
+
+            return $this;
+        }
+
+        ksort($directives);
+        $this->headers->set($this->header, HeaderUtils::toString($directives, ','));
+
+        return $this;
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/Tests/TargetedCacheControlTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/TargetedCacheControlTest.php
@@ -1,0 +1,171 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Tests;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+class TargetedCacheControlTest extends TestCase
+{
+    public function testItWritesATargetedHeader()
+    {
+        $response = new Response();
+        $response->cacheControl('CDN')->setMaxAge(3600);
+
+        $this->assertSame('max-age=3600', $response->headers->get('CDN-Cache-Control'));
+    }
+
+    public function testItLeavesTheDefaultCacheControlAlone()
+    {
+        $response = new Response();
+        $response->setMaxAge(60)->setPrivate();
+        $response->cacheControl('CDN')->setMaxAge(3600);
+
+        $this->assertSame('max-age=60, private', $response->headers->get('Cache-Control'));
+        $this->assertSame('max-age=3600', $response->headers->get('CDN-Cache-Control'));
+    }
+
+    public function testTargetsAreIndependent()
+    {
+        $response = new Response();
+        $response->cacheControl('CDN')->setMaxAge(3600);
+        $response->cacheControl('Varnish')->setMaxAge(60);
+
+        $this->assertSame('max-age=3600', $response->headers->get('CDN-Cache-Control'));
+        $this->assertSame('max-age=60', $response->headers->get('Varnish-Cache-Control'));
+    }
+
+    public function testPublicAndPrivateReplaceEachOther()
+    {
+        $response = new Response();
+        $cacheControl = $response->cacheControl('CDN');
+
+        $cacheControl->setPublic();
+        $this->assertSame('public', $response->headers->get('CDN-Cache-Control'));
+
+        $cacheControl->setPrivate();
+        $this->assertSame('private', $response->headers->get('CDN-Cache-Control'));
+
+        $cacheControl->setPublic();
+        $this->assertSame('public', $response->headers->get('CDN-Cache-Control'));
+    }
+
+    public function testImmutableAndNoStoreCanBeUnset()
+    {
+        $response = new Response();
+        $cacheControl = $response->cacheControl('CDN')->setImmutable()->setNoStore();
+
+        $this->assertSame('immutable, no-store', $response->headers->get('CDN-Cache-Control'));
+
+        $cacheControl->setImmutable(false)->setNoStore(false);
+        $this->assertFalse($response->headers->has('CDN-Cache-Control'));
+    }
+
+    public function testTheHeaderIsRemovedWhenTheLastDirectiveGoes()
+    {
+        $response = new Response();
+        $response->cacheControl('CDN')->setMaxAge(10)->remove('max-age');
+
+        $this->assertFalse($response->headers->has('CDN-Cache-Control'));
+    }
+
+    public function testArbitraryDirectives()
+    {
+        $response = new Response();
+        $cacheControl = $response->cacheControl('CDN')->set('stale-while-revalidate', '30')->set('proprietary');
+
+        $this->assertSame('proprietary, stale-while-revalidate=30', $response->headers->get('CDN-Cache-Control'));
+        $this->assertTrue($cacheControl->has('proprietary'));
+        $this->assertSame('30', $cacheControl->get('stale-while-revalidate'));
+        $this->assertNull($cacheControl->get('max-age'));
+        $this->assertSame(['proprietary' => true, 'stale-while-revalidate' => '30'], $cacheControl->all());
+    }
+
+    public function testDirectiveNamesAreCaseInsensitive()
+    {
+        $response = new Response();
+        $cacheControl = $response->cacheControl('CDN')->set('Max-Age', '60');
+
+        $this->assertSame('max-age=60', $response->headers->get('CDN-Cache-Control'));
+        $this->assertTrue($cacheControl->has('MAX-AGE'));
+        $this->assertSame('60', $cacheControl->get('Max-Age'));
+
+        $cacheControl->remove('MAX-Age');
+        $this->assertFalse($response->headers->has('CDN-Cache-Control'));
+    }
+
+    public function testSettingADirectiveToFalseRemovesIt()
+    {
+        $response = new Response();
+        $cacheControl = $response->cacheControl('CDN')->setMaxAge(60)->set('no-store');
+
+        $cacheControl->set('no-store', false);
+        $this->assertSame('max-age=60', $response->headers->get('CDN-Cache-Control'));
+        $this->assertFalse($cacheControl->has('no-store'));
+    }
+
+    public function testItReadsAHeaderSetByHand()
+    {
+        $response = new Response();
+        $response->headers->set('CDN-Cache-Control', 'max-age=120, public');
+
+        $cacheControl = $response->cacheControl('CDN');
+        $this->assertSame('120', $cacheControl->get('max-age'));
+        $this->assertTrue($cacheControl->has('public'));
+
+        $cacheControl->setMaxAge(240);
+        $this->assertSame('max-age=240, public', $response->headers->get('CDN-Cache-Control'));
+    }
+
+    public function testItReadsAHeaderSetAsSeveralFieldLines()
+    {
+        $response = new Response();
+        $response->headers->set('CDN-Cache-Control', 'max-age=120');
+        $response->headers->set('CDN-Cache-Control', 'public', false);
+
+        $cacheControl = $response->cacheControl('CDN');
+        $this->assertSame(['max-age' => '120', 'public' => true], $cacheControl->all());
+
+        $cacheControl->setImmutable();
+        $this->assertSame('immutable, max-age=120, public', $response->headers->get('CDN-Cache-Control'));
+    }
+
+    public function testTheTargetIsCaseInsensitiveForTheCache()
+    {
+        $response = new Response();
+        $response->cacheControl('cdn')->setMaxAge(60);
+
+        // HTTP header names are case insensitive, so the header bag finds it either way
+        $this->assertSame('max-age=60', $response->headers->get('CDN-Cache-Control'));
+    }
+
+    #[DataProvider('provideInvalidTargets')]
+    public function testItRejectsAnInvalidTarget(string $target)
+    {
+        $response = new Response();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('is not a valid token');
+
+        $response->cacheControl($target);
+    }
+
+    public static function provideInvalidTargets(): iterable
+    {
+        yield 'empty' => [''];
+        yield 'space' => ['my cdn'];
+        yield 'colon' => ['CDN:'];
+        yield 'slash' => ['CDN/1'];
+        yield 'trailing newline' => ["CDN\n"];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Supersedes #59219 by @dbu, whose analysis this builds on. He opened that PR after we discussed the topic at a SymfonyCon hackday, asked twice for direction and got none for twenty months, which is on us. He was also right on the one contested design point: the API takes the RFC's *target*, not a full header name.

[RFC 9213](https://www.rfc-editor.org/rfc/rfc9213.html) lets a response carry cache directives addressed to one specific cache. A cache that knows itself as `CDN` reads `CDN-Cache-Control` and ignores `Cache-Control`; every other cache does the opposite. Fastly, Cloudflare and Akamai honour this today. It is what lets you keep a response for an hour in the CDN while telling browsers not to store it at all:

```php
$response->setMaxAge(0)->setPrivate();
$response->cacheControl('CDN')->setMaxAge(3600);
```

```
Cache-Control: max-age=0, private
CDN-Cache-Control: max-age=3600
```

`Response::cacheControl()` returns a `TargetedCacheControl` carrying the same vocabulary as `Response` itself, so there is nothing new to learn:

```php
$response->cacheControl('CDN')
    ->setMaxAge(3600)
    ->setStaleWhileRevalidate(60)
    ->setImmutable();
```

`setMaxAge()`, `setStaleWhileRevalidate()`, `setStaleIfError()`, `setPublic()`, `setPrivate()`, `setImmutable()` and `setNoStore()` behave exactly as their `Response` counterparts, including `public` and `private` replacing each other. For directives Symfony does not model there is `set()`, `get()`, `has()`, `remove()` and `all()`.

Design notes:

* **nothing existing changes.** No method changes signature, nothing is deprecated, and an application that does not use targets sees no difference. The default `Cache-Control` keeps its current API, so there is only ever one way to set `max-age`;
* **`HeaderBag` is untouched.** Both bags special case the exact name `cache-control` only, so `CDN-Cache-Control` already flows through as an ordinary header. The new class is a thin façade that parses and writes it through the public `HeaderUtils`;
* **the target, not the header name.** RFC 9213 defines the target as a token and derives the field name from it, so taking the target makes `My-CacheControl` or `X-CDN-Cache-Control`, which no cache honours, impossible to express. Invalid tokens throw;
* **no `setSharedMaxAge()`, on @alexander-schranz's review.** `s-maxage` exists in `Cache-Control` only to tell shared caches apart from private ones, and the target already draws that line, so `max-age` is the right spelling here. It is also the safe one: RFC 9213 §2.2 requires caches to implement `max-age`, puts `s-maxage` under the SHOULD that follows, and has a cache ignore `Cache-Control` and `Expires` entirely once it reads its own header. Emitting `s-maxage` alone would therefore leave a cache that does not implement it with no freshness information and no fallback. `set('s-maxage', ...)` is still there for anyone whose cache documents it;
* **`setPublic()` stays, though.** RFC 9111 §5.2.2.9 makes `public` unnecessary on a response that is already cacheable, but it is what lets a shared cache store a response to a request carrying `Authorization` (§3.5), which is a real thing to want from a CDN and not from a browser. It is no longer implied by anything, only set on demand;
* **`HttpCache` is deliberately not touched.** Teaching Symfony's own reverse proxy to answer to a target is a separate discussion;
* **`Surrogate-Control` is unrelated.** It predates RFC 9213 and drives ESI/SSI through `AbstractSurrogate`; this does not change it.

Documentation should cover: what a target is, that `Cache-Control` stays the browser-facing header, the `CDN-Cache-Control` convention that the major CDNs implement, that a cache ignores `Cache-Control` entirely once it finds its own targeted header, and that freshness in a targeted field is spelled `max-age`, not `s-maxage`.
