### PR TITLE
[Tui] Reuse unchanged lines across frames

### DIFF
--- a/src/Symfony/Component/Tui/CHANGELOG.md
+++ b/src/Symfony/Component/Tui/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.2
 ---
 
+ * Reuse unchanged rendered line segments during differential updates
  * Add `AbstractWidget::attachChild()` and `AbstractWidget::detachChild()` to wire child widgets
  * Add multi-select support to `SelectListWidget`
  * [BC BREAK] Add `$multiselect` as the third argument of `SelectListWidget::__construct()`, moving `$keybindings` to fourth position

--- a/src/Symfony/Component/Tui/Exception/OutOfBoundsException.php
+++ b/src/Symfony/Component/Tui/Exception/OutOfBoundsException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Exception;
+
+/**
+ * @experimental
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class OutOfBoundsException extends \OutOfBoundsException implements ExceptionInterface
+{
+}

--- a/src/Symfony/Component/Tui/Render/ArrayLineBuffer.php
+++ b/src/Symfony/Component/Tui/Render/ArrayLineBuffer.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Render;
+
+use Symfony\Component\Tui\Ansi\AnsiUtils;
+use Symfony\Component\Tui\Exception\OutOfBoundsException;
+
+/**
+ * @experimental
+ *
+ * @internal
+ */
+final class ArrayLineBuffer implements LineBufferInterface
+{
+    private int $maxVisibleWidth = 0;
+
+    /**
+     * @param list<string> $lines
+     */
+    public function __construct(private readonly array $lines)
+    {
+        foreach ($lines as $line) {
+            if ('' !== $line) {
+                $this->maxVisibleWidth = max($this->maxVisibleWidth, AnsiUtils::visibleWidth($line));
+            }
+        }
+    }
+
+    public function count(): int
+    {
+        return \count($this->lines);
+    }
+
+    public function getLine(int $index): string
+    {
+        return $this->lines[$index] ?? throw new OutOfBoundsException(\sprintf('Line index %d is out of bounds.', $index));
+    }
+
+    public function slice(int $offset, int $length): array
+    {
+        if ($offset < 0 || $length < 0) {
+            throw new OutOfBoundsException('Line slice offset and length must be non-negative.');
+        }
+
+        return \array_slice($this->lines, $offset, $length);
+    }
+
+    public function toArray(): array
+    {
+        return $this->lines;
+    }
+
+    public function getMaxVisibleWidth(): int
+    {
+        return $this->maxVisibleWidth;
+    }
+
+    public function getIterator(): \Traversable
+    {
+        yield from $this->lines;
+    }
+}

--- a/src/Symfony/Component/Tui/Render/ArrayLineBuffer.php
+++ b/src/Symfony/Component/Tui/Render/ArrayLineBuffer.php
@@ -21,18 +21,13 @@ use Symfony\Component\Tui\Exception\OutOfBoundsException;
  */
 final class ArrayLineBuffer implements LineBufferInterface
 {
-    private int $maxVisibleWidth = 0;
+    private ?int $maxVisibleWidth = null;
 
     /**
      * @param list<string> $lines
      */
     public function __construct(private readonly array $lines)
     {
-        foreach ($lines as $line) {
-            if ('' !== $line) {
-                $this->maxVisibleWidth = max($this->maxVisibleWidth, AnsiUtils::visibleWidth($line));
-            }
-        }
     }
 
     public function count(): int
@@ -61,7 +56,18 @@ final class ArrayLineBuffer implements LineBufferInterface
 
     public function getMaxVisibleWidth(): int
     {
-        return $this->maxVisibleWidth;
+        if (null !== $this->maxVisibleWidth) {
+            return $this->maxVisibleWidth;
+        }
+
+        $max = 0;
+        foreach ($this->lines as $line) {
+            if ('' !== $line) {
+                $max = max($max, AnsiUtils::visibleWidth($line));
+            }
+        }
+
+        return $this->maxVisibleWidth = $max;
     }
 
     public function getIterator(): \Traversable

--- a/src/Symfony/Component/Tui/Render/ChromeApplier.php
+++ b/src/Symfony/Component/Tui/Render/ChromeApplier.php
@@ -90,8 +90,15 @@ final class ChromeApplier
         $contentWidth = max(1, $innerWidth - $paddingLeft - $paddingRight);
 
         $processedLines = [];
+        $processedWidths = [];
         foreach ($lines as $line) {
-            $processedLines[] = AnsiUtils::truncateToWidth($line, $contentWidth);
+            $lineWidth = AnsiUtils::visibleWidth($line);
+            if ($lineWidth > $contentWidth) {
+                $line = AnsiUtils::truncateToWidth($line, $contentWidth);
+                $lineWidth = AnsiUtils::visibleWidth($line);
+            }
+            $processedLines[] = $line;
+            $processedWidths[] = $lineWidth;
         }
 
         // If no content and no padding/border, return empty
@@ -110,10 +117,7 @@ final class ChromeApplier
         // multi-line content like FIGlet).
         $alignPadLeft = 0;
         if (TextAlign::Left !== $textAlign) {
-            $maxContentWidth = 0;
-            foreach ($processedLines as $line) {
-                $maxContentWidth = max($maxContentWidth, AnsiUtils::visibleWidth($line));
-            }
+            $maxContentWidth = $processedWidths ? max($processedWidths) : 0;
             $availableSpace = max(0, $contentWidth - $maxContentWidth);
             $alignPadLeft = match ($textAlign) {
                 TextAlign::Center => (int) floor($availableSpace / 2),
@@ -122,10 +126,11 @@ final class ChromeApplier
         }
 
         $contentLines = [];
-        foreach ($processedLines as $line) {
-            $lineWithPad = str_repeat(' ', $paddingLeft + $alignPadLeft).$line;
-            $visibleWidth = AnsiUtils::visibleWidth($lineWithPad);
-            $rightPad = str_repeat(' ', max(0, $innerWidth - $visibleWidth));
+        $padLen = $paddingLeft + $alignPadLeft;
+        $leftPad = str_repeat(' ', $padLen);
+        foreach ($processedLines as $i => $line) {
+            $lineWithPad = $leftPad.$line;
+            $rightPad = str_repeat(' ', max(0, $innerWidth - $padLen - $processedWidths[$i]));
             $contentLines[] = $style->apply($lineWithPad.$rightPad);
         }
 

--- a/src/Symfony/Component/Tui/Render/ChromeApplier.php
+++ b/src/Symfony/Component/Tui/Render/ChromeApplier.php
@@ -39,13 +39,13 @@ final class ChromeApplier
 
     /**
      * Apply chrome (padding, border, background) to rendered lines.
-     *
-     * @param string[] $lines
-     *
-     * @return string[]
      */
-    public function apply(array $lines, int $width, Style $style, AbstractWidget $widget): array
+    public function apply(LineBufferInterface $lines, int $width, Style $style, AbstractWidget $widget): LineBufferInterface
     {
+        if ($this->isIdentity($style)) {
+            return $lines;
+        }
+
         $border = $style->getBorder();
         $padding = $style->getPadding();
 
@@ -59,15 +59,9 @@ final class ChromeApplier
         $paddingBottom = $padding?->bottom ?? 0;
 
         $hasVerticalPadding = $paddingTop || $paddingBottom;
-        $hasHorizontalPadding = $paddingLeft || $paddingRight;
-        $hasBorder = $borderTop || $borderBottom || $borderLeft || $borderRight;
 
-        if (!$hasBorder && !$hasHorizontalPadding && !$hasVerticalPadding && $style->isPlain() && null === $style->getTextAlign()) {
-            return $lines;
-        }
-
-        if (!$lines && !$hasVerticalPadding && !$borderTop && !$borderBottom) {
-            return [];
+        if (0 === \count($lines) && !$hasVerticalPadding && !$borderTop && !$borderBottom) {
+            return new ArrayLineBuffer([]);
         }
 
         $outerStyle = $this->resolveOuterStyle($widget);
@@ -103,7 +97,7 @@ final class ChromeApplier
         // If no content and no padding/border, return empty
         if (!$processedLines && !$paddingTop && !$paddingBottom
             && !$borderTop && !$borderBottom) {
-            return [];
+            return new ArrayLineBuffer([]);
         }
 
         $styledEmptyLine = $style->apply(str_repeat(' ', $innerWidth));
@@ -137,12 +131,29 @@ final class ChromeApplier
 
         $innerLines = [...$topPadding, ...$contentLines, ...$bottomPadding];
 
-        return $border?->wrapLines(
+        return new ArrayLineBuffer($border?->wrapLines(
             $innerLines,
             $innerWidth,
             $style,
             $outerStyle,
-        ) ?? $innerLines;
+        ) ?? $innerLines);
+    }
+
+    private function isIdentity(Style $style): bool
+    {
+        $border = $style->getBorder();
+        $padding = $style->getPadding();
+
+        return !($border?->top ?? 0)
+            && !($border?->right ?? 0)
+            && !($border?->bottom ?? 0)
+            && !($border?->left ?? 0)
+            && !($padding?->top ?? 0)
+            && !($padding?->right ?? 0)
+            && !($padding?->bottom ?? 0)
+            && !($padding?->left ?? 0)
+            && null === $style->getTextAlign()
+            && $style->isPlain();
     }
 
     /**

--- a/src/Symfony/Component/Tui/Render/ConcatenatedLineBuffer.php
+++ b/src/Symfony/Component/Tui/Render/ConcatenatedLineBuffer.php
@@ -1,0 +1,127 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Render;
+
+use Symfony\Component\Tui\Exception\OutOfBoundsException;
+
+/**
+ * @experimental
+ *
+ * @internal
+ */
+final class ConcatenatedLineBuffer implements LineBufferInterface
+{
+    /** @var list<LineBufferInterface> */
+    private array $buffers;
+    private int $lineCount = 0;
+    private int $maxVisibleWidth = 0;
+
+    /**
+     * @param iterable<LineBufferInterface> $buffers
+     */
+    public function __construct(iterable $buffers)
+    {
+        $this->buffers = [];
+
+        foreach ($buffers as $buffer) {
+            if (0 === $bufferCount = \count($buffer)) {
+                continue;
+            }
+
+            $this->buffers[] = $buffer;
+            $this->lineCount += $bufferCount;
+            $this->maxVisibleWidth = max($this->maxVisibleWidth, $buffer->getMaxVisibleWidth());
+        }
+    }
+
+    public function count(): int
+    {
+        return $this->lineCount;
+    }
+
+    public function getLine(int $index): string
+    {
+        if ($index < 0 || $index >= $this->lineCount) {
+            throw new OutOfBoundsException(\sprintf('Line index %d is out of bounds.', $index));
+        }
+
+        foreach ($this->buffers as $buffer) {
+            $bufferCount = \count($buffer);
+            if ($index < $bufferCount) {
+                return $buffer->getLine($index);
+            }
+            $index -= $bufferCount;
+        }
+
+        throw new OutOfBoundsException('Line index is out of bounds.');
+    }
+
+    public function slice(int $offset, int $length): array
+    {
+        if ($offset < 0 || $length < 0) {
+            throw new OutOfBoundsException('Line slice offset and length must be non-negative.');
+        }
+        if (0 === $length || $offset >= $this->lineCount) {
+            return [];
+        }
+
+        $lines = [];
+        $remaining = min($length, $this->lineCount - $offset);
+
+        foreach ($this->buffers as $buffer) {
+            $bufferCount = \count($buffer);
+            if ($offset >= $bufferCount) {
+                $offset -= $bufferCount;
+                continue;
+            }
+
+            $bufferLines = $buffer->slice($offset, min($remaining, $bufferCount - $offset));
+            foreach ($bufferLines as $line) {
+                $lines[] = $line;
+            }
+            $remaining -= \count($bufferLines);
+            if (0 === $remaining) {
+                break;
+            }
+            $offset = 0;
+        }
+
+        return $lines;
+    }
+
+    public function toArray(): array
+    {
+        return $this->slice(0, $this->lineCount);
+    }
+
+    public function getMaxVisibleWidth(): int
+    {
+        return $this->maxVisibleWidth;
+    }
+
+    /**
+     * @return list<LineBufferInterface>
+     */
+    public function getBuffers(): array
+    {
+        return $this->buffers;
+    }
+
+    public function getIterator(): \Traversable
+    {
+        foreach ($this->buffers as $buffer) {
+            foreach ($buffer as $line) {
+                yield $line;
+            }
+        }
+    }
+}

--- a/src/Symfony/Component/Tui/Render/ConcatenatedLineBuffer.php
+++ b/src/Symfony/Component/Tui/Render/ConcatenatedLineBuffer.php
@@ -22,6 +22,11 @@ final class ConcatenatedLineBuffer implements LineBufferInterface
 {
     /** @var list<LineBufferInterface> */
     private array $buffers;
+    /** @var list<int> */
+    private array $offsets = [];
+    /** @var list<int> */
+    private array $counts = [];
+    private int $lastBuffer = 0;
     private int $lineCount = 0;
     private int $maxVisibleWidth = 0;
 
@@ -37,6 +42,8 @@ final class ConcatenatedLineBuffer implements LineBufferInterface
                 continue;
             }
 
+            $this->offsets[] = $this->lineCount;
+            $this->counts[] = $bufferCount;
             $this->buffers[] = $buffer;
             $this->lineCount += $bufferCount;
             $this->maxVisibleWidth = max($this->maxVisibleWidth, $buffer->getMaxVisibleWidth());
@@ -54,15 +61,22 @@ final class ConcatenatedLineBuffer implements LineBufferInterface
             throw new OutOfBoundsException(\sprintf('Line index %d is out of bounds.', $index));
         }
 
-        foreach ($this->buffers as $buffer) {
-            $bufferCount = \count($buffer);
-            if ($index < $bufferCount) {
-                return $buffer->getLine($index);
+        $i = $this->lastBuffer;
+        if ($index < $this->offsets[$i] || $index >= $this->offsets[$i] + $this->counts[$i]) {
+            $low = 0;
+            $high = \count($this->offsets) - 1;
+            while ($low < $high) {
+                $mid = intdiv($low + $high + 1, 2);
+                if ($this->offsets[$mid] <= $index) {
+                    $low = $mid;
+                } else {
+                    $high = $mid - 1;
+                }
             }
-            $index -= $bufferCount;
+            $i = $this->lastBuffer = $low;
         }
 
-        throw new OutOfBoundsException('Line index is out of bounds.');
+        return $this->buffers[$i]->getLine($index - $this->offsets[$i]);
     }
 
     public function slice(int $offset, int $length): array

--- a/src/Symfony/Component/Tui/Render/LayoutEngine.php
+++ b/src/Symfony/Component/Tui/Render/LayoutEngine.php
@@ -45,10 +45,8 @@ final class LayoutEngine
      * Layout children based on direction.
      *
      * @param AbstractWidget[] $children
-     *
-     * @return string[]
      */
-    public function layout(array $children, int $columns, int $rows, int $gap, Direction $direction, ?string $gapLine = null, ?VerticalAlign $verticalAlign = null): array
+    public function layout(array $children, int $columns, int $rows, int $gap, Direction $direction, ?string $gapLine = null, ?VerticalAlign $verticalAlign = null): LineBufferInterface
     {
         if (Direction::Horizontal === $direction) {
             return $this->layoutHorizontal($children, $columns, $rows, $gap, $verticalAlign);
@@ -59,21 +57,10 @@ final class LayoutEngine
 
     /**
      * Compute the horizontal offset needed to align content within the available width.
-     *
-     * @param string[] $lines
      */
-    public function computeAlignOffset(array $lines, int $columns, Align $align): int
+    public function computeAlignOffset(LineBufferInterface $lines, int $columns, Align $align): int
     {
-        if (!$lines) {
-            return 0;
-        }
-
-        $maxWidth = 0;
-        foreach ($lines as $line) {
-            $maxWidth = max($maxWidth, AnsiUtils::visibleWidth($line));
-        }
-
-        $availableSpace = max(0, $columns - $maxWidth);
+        $availableSpace = max(0, $columns - $lines->getMaxVisibleWidth());
 
         return match ($align) {
             Align::Center => $availableSpace >> 1,
@@ -98,12 +85,8 @@ final class LayoutEngine
 
     /**
      * Shift all lines by prepending spaces.
-     *
-     * @param string[] $lines
-     *
-     * @return string[]
      */
-    public function shiftLines(array $lines, int $offset): array
+    public function shiftLines(LineBufferInterface $lines, int $offset): LineBufferInterface
     {
         $prefix = str_repeat(' ', $offset);
         $result = [];
@@ -111,34 +94,29 @@ final class LayoutEngine
             $result[] = $prefix.$line;
         }
 
-        return $result;
+        return new ArrayLineBuffer($result);
     }
 
     /**
      * Layout children vertically with gap and fill support.
      *
      * @param AbstractWidget[] $children
-     *
-     * @return string[]
      */
-    private function layoutVertical(array $children, int $columns, int $rows, int $gap, ?string $gapLine = null): array
+    private function layoutVertical(array $children, int $columns, int $rows, int $gap, ?string $gapLine = null): LineBufferInterface
     {
         if (!$children) {
-            return [];
+            return new ArrayLineBuffer([]);
         }
 
-        $lines = [];
+        $segments = [];
+        $lineCount = 0;
         $gapLine ??= str_repeat(' ', max(1, $columns));
-        $gapLines = $gap > 0 ? array_fill(0, $gap, $gapLine) : [];
+        $gapLines = new ArrayLineBuffer($gap > 0 ? array_fill(0, $gap, $gapLine) : []);
         $first = true;
 
-        // Calculate total gap rows
         $totalGapRows = $gap * max(0, \count($children) - 1);
         $remainingRows = $rows - $totalGapRows;
 
-        // First pass: identify fill children and measure non-fill children.
-        // During this pass, suppress position tracking for descendants since
-        // we don't yet know each child's final absolute row offset.
         $fillChildren = [];
         $nonFillRenders = [];
         $nonFillCacheHits = [];
@@ -148,13 +126,10 @@ final class LayoutEngine
             if ($child instanceof VerticallyExpandableInterface && $child->isVerticallyExpanded()) {
                 $fillChildren[$index] = $child;
             } else {
-                // Suppress descendant position tracking during measurement.
-                // Uncached parent widgets are re-rendered later with their final
-                // absolute offset to populate descendant rects.
                 $context = new RenderContext($columns, $rows, null, $this->fontRegistry);
                 $revision = $child->getRenderRevision();
                 $hadCachedRender = null !== $child->getRenderCache($columns, $rows);
-                $childLines = $this->widgetRenderer->renderWidget($child, $context);
+                $childLines = $this->widgetRenderer->renderWidgetLines($child, $context);
                 $nonFillRenders[$index] = $childLines;
                 $nonFillCacheHits[$index] = $hadCachedRender && $revision === $child->getRenderRevision();
 
@@ -164,65 +139,61 @@ final class LayoutEngine
 
         $this->positionTracker->restoreStack($savedStack);
 
-        // Calculate rows for fill children
         $fillCount = \count($fillChildren);
         $baseFillRows = $fillCount > 0 ? max(1, intdiv(max(0, $remainingRows), $fillCount)) : 0;
         $extraRows = $fillCount > 0 ? max(0, $remainingRows) % $fillCount : 0;
 
-        // Second pass: render all children in order with correct position tracking.
-        // At this point we know the accumulated line count for each child's offset.
         $fillIndex = 0;
         $hasPositionStack = $this->positionTracker->isActive();
         foreach ($children as $index => $child) {
             $cacheHit = false;
             if (isset($fillChildren[$index])) {
-                // Fill child gets calculated rows, distributing remainder to first children
                 $childFillRows = $baseFillRows + ($fillIndex < $extraRows ? 1 : 0);
                 ++$fillIndex;
 
-                // Add gap before this child (so line count is correct for position)
-                if (!$first && $gapLines) {
-                    array_push($lines, ...$gapLines);
+                if (!$first && \count($gapLines) > 0) {
+                    $segments[] = $gapLines;
+                    $lineCount += \count($gapLines);
                 }
 
                 $context = new RenderContext($columns, $childFillRows, null, $this->fontRegistry);
                 $revision = $child->getRenderRevision();
                 $hadCachedRender = null !== $child->getRenderCache($columns, $childFillRows);
 
-                // Push correct absolute position so descendants get proper coordinates
                 if ($hasPositionStack) {
                     [$parentAbsRow, $parentAbsCol] = $this->positionTracker->currentOffset();
-                    $this->positionTracker->push($parentAbsRow + \count($lines), $parentAbsCol);
+                    $this->positionTracker->push($parentAbsRow + $lineCount, $parentAbsCol);
                 }
-                $childLines = $this->widgetRenderer->renderWidget($child, $context);
+                $childLines = $this->widgetRenderer->renderWidgetLines($child, $context);
                 $cacheHit = $hadCachedRender && $revision === $child->getRenderRevision();
                 if ($hasPositionStack) {
                     $this->positionTracker->pop();
                 }
 
-                // Pad fill children to their allocated rows so they actually fill the space
-                while (\count($childLines) < $childFillRows) {
-                    $childLines[] = '';
+                if (\count($childLines) < $childFillRows) {
+                    $childLines = new ConcatenatedLineBuffer([
+                        $childLines,
+                        new ArrayLineBuffer(array_fill(0, $childFillRows - \count($childLines), '')),
+                    ]);
                 }
             } else {
                 $context = new RenderContext($columns, $rows, null, $this->fontRegistry);
-                $childLines = $nonFillRenders[$index] ?? $this->widgetRenderer->renderWidget($child, $context);
+                $childLines = $nonFillRenders[$index] ?? $this->widgetRenderer->renderWidgetLines($child, $context);
                 $cacheHit = $nonFillCacheHits[$index] ?? false;
 
-                // Skip gap for children that render nothing
-                if (!$childLines) {
+                if (0 === \count($childLines)) {
                     continue;
                 }
 
-                if (!$first && $gapLines) {
-                    array_push($lines, ...$gapLines);
+                if (!$first && \count($gapLines) > 0) {
+                    $segments[] = $gapLines;
+                    $lineCount += \count($gapLines);
                 }
             }
 
-            // Track widget position
             if ($hasPositionStack) {
                 [$parentAbsRow, $parentAbsCol] = $this->positionTracker->currentOffset();
-                $childAbsRow = $parentAbsRow + \count($lines);
+                $childAbsRow = $parentAbsRow + $lineCount;
                 $childAbsCol = $parentAbsCol;
 
                 $rect = new WidgetRect(
@@ -239,21 +210,20 @@ final class LayoutEngine
                 $this->positionTracker->setWidgetRect($child, $rect);
 
                 if ($child instanceof ParentInterface && !$positionsTracked) {
-                    // Clear the render cache first so the re-render walks the
-                    // subtree and records descendant rects, instead of
-                    // returning the cached measurement output.
                     $child->clearRenderCache();
                     $this->positionTracker->push($childAbsRow, $childAbsCol);
-                    $this->widgetRenderer->renderWidget($child, $context);
+                    $childLines = $this->widgetRenderer->renderWidgetLines($child, $context);
                     $this->positionTracker->pop();
+                    $this->positionTracker->setWidgetRect($child, new WidgetRect($childAbsRow, $childAbsCol, $columns, \count($childLines)));
                 }
             }
 
-            array_push($lines, ...$childLines);
+            $segments[] = $childLines;
+            $lineCount += \count($childLines);
             $first = false;
         }
 
-        return $lines;
+        return new ConcatenatedLineBuffer($segments);
     }
 
     /**
@@ -265,13 +235,11 @@ final class LayoutEngine
      * - flex: N (N > 0): proportional weight (remaining space after fixed children is distributed by weight)
      *
      * @param AbstractWidget[] $children
-     *
-     * @return string[]
      */
-    private function layoutHorizontal(array $children, int $columns, int $rows, int $gap, ?VerticalAlign $verticalAlign = null): array
+    private function layoutHorizontal(array $children, int $columns, int $rows, int $gap, ?VerticalAlign $verticalAlign = null): LineBufferInterface
     {
         if (!$count = \count($children)) {
-            return [];
+            return new ArrayLineBuffer([]);
         }
 
         // When there are more children than available columns (accounting
@@ -330,7 +298,7 @@ final class LayoutEngine
             $context = new RenderContext($childColumns, $rows, null, $this->fontRegistry);
             $revision = $child->getRenderRevision();
             $hadCachedRender = null !== $child->getRenderCache($childColumns, $rows);
-            $childLines = $this->widgetRenderer->renderWidget($child, $context);
+            $childLines = $this->widgetRenderer->renderWidgetLines($child, $context);
             $cacheHits[$index] = $hadCachedRender && $revision === $child->getRenderRevision();
             $childContexts[$index] = $context;
             $childRenders[$index] = $childLines;
@@ -344,7 +312,7 @@ final class LayoutEngine
         }
 
         if (0 === $maxRows) {
-            return [];
+            return new ArrayLineBuffer([]);
         }
 
         // Compute per-child vertical offset for cross-axis alignment (align-items).
@@ -389,7 +357,7 @@ final class LayoutEngine
                     if (!$positionsTracked) {
                         $child->clearRenderCache();
                         $this->positionTracker->push($childAbsRow, $childAbsCol);
-                        $this->widgetRenderer->renderWidget($child, $childContexts[$index]);
+                        $this->widgetRenderer->renderWidgetLines($child, $childContexts[$index]);
                         $this->positionTracker->pop();
                     }
                 }
@@ -406,7 +374,7 @@ final class LayoutEngine
             $lineParts = [];
             foreach ($children as $index => $child) {
                 $childRow = $row - $childOffsets[$index];
-                $line = ($childRow >= 0 && isset($childRenders[$index][$childRow])) ? $childRenders[$index][$childRow] : '';
+                $line = ($childRow >= 0 && $childRow < \count($childRenders[$index])) ? $childRenders[$index]->getLine($childRow) : '';
                 $visibleLen = AnsiUtils::visibleWidth($line);
                 $cols = $childColumnCounts[$index];
 
@@ -422,7 +390,7 @@ final class LayoutEngine
             $lines[] = implode($gapSpaces, $lineParts);
         }
 
-        return $lines;
+        return new ArrayLineBuffer($lines);
     }
 
     /**
@@ -465,7 +433,7 @@ final class LayoutEngine
             if (0 === $flex = $flexValues[$index]) {
                 // Intrinsic width: measure the child's natural content width
                 // plus chrome (border/padding). This uses measureIntrinsicWidth()
-                // instead of renderWidget() because renderWidget() pads lines
+                // instead of renderWidgetLines() because renderWidgetLines() pads lines
                 // to the full allocated width via ChromeApplier.
                 $width = $this->widgetRenderer->measureIntrinsicWidth($child, $availableColumns, $rows);
                 $intrinsicWidths[$index] = $width;

--- a/src/Symfony/Component/Tui/Render/LineBufferDiffer.php
+++ b/src/Symfony/Component/Tui/Render/LineBufferDiffer.php
@@ -1,0 +1,127 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Render;
+
+/**
+ * @experimental
+ *
+ * @internal
+ */
+final class LineBufferDiffer
+{
+    /**
+     * @return array{first: int, last: int}|null
+     */
+    public function findChangedRange(LineBufferInterface $current, LineBufferInterface $previous): ?array
+    {
+        if ($current === $previous) {
+            return null;
+        }
+
+        $currentCount = \count($current);
+        $previousCount = \count($previous);
+        $commonPrefix = $this->commonPrefixLength($current, $previous, min($currentCount, $previousCount));
+
+        if ($currentCount === $previousCount) {
+            if ($commonPrefix === $currentCount) {
+                return null;
+            }
+
+            $commonSuffix = $this->commonSuffixLength($current, $previous, $currentCount - $commonPrefix);
+
+            return ['first' => $commonPrefix, 'last' => $currentCount - $commonSuffix - 1];
+        }
+
+        return ['first' => $commonPrefix, 'last' => max($currentCount, $previousCount) - 1];
+    }
+
+    private function commonPrefixLength(LineBufferInterface $current, LineBufferInterface $previous, int $limit): int
+    {
+        if (0 === $limit) {
+            return 0;
+        }
+        if ($current === $previous) {
+            return min($limit, \count($current));
+        }
+
+        if ($current instanceof ConcatenatedLineBuffer && $previous instanceof ConcatenatedLineBuffer) {
+            $currentBuffers = $current->getBuffers();
+            $previousBuffers = $previous->getBuffers();
+            $matched = 0;
+            $bufferCount = min(\count($currentBuffers), \count($previousBuffers));
+
+            for ($i = 0; $i < $bufferCount && $matched < $limit; ++$i) {
+                $currentBuffer = $currentBuffers[$i];
+                $previousBuffer = $previousBuffers[$i];
+                $bufferLimit = min($limit - $matched, \count($currentBuffer), \count($previousBuffer));
+                $bufferMatched = $this->commonPrefixLength($currentBuffer, $previousBuffer, $bufferLimit);
+                $matched += $bufferMatched;
+
+                if ($bufferMatched < $bufferLimit || \count($currentBuffer) !== \count($previousBuffer)) {
+                    return $matched;
+                }
+            }
+
+            return $matched;
+        }
+
+        for ($i = 0; $i < $limit; ++$i) {
+            if ($current->getLine($i) !== $previous->getLine($i)) {
+                return $i;
+            }
+        }
+
+        return $limit;
+    }
+
+    private function commonSuffixLength(LineBufferInterface $current, LineBufferInterface $previous, int $limit): int
+    {
+        if (0 === $limit) {
+            return 0;
+        }
+        if ($current === $previous) {
+            return min($limit, \count($current));
+        }
+
+        if ($current instanceof ConcatenatedLineBuffer && $previous instanceof ConcatenatedLineBuffer) {
+            $currentBuffers = $current->getBuffers();
+            $previousBuffers = $previous->getBuffers();
+            $matched = 0;
+            $currentIndex = \count($currentBuffers) - 1;
+            $previousIndex = \count($previousBuffers) - 1;
+
+            while ($currentIndex >= 0 && $previousIndex >= 0 && $matched < $limit) {
+                $currentBuffer = $currentBuffers[$currentIndex--];
+                $previousBuffer = $previousBuffers[$previousIndex--];
+                $bufferLimit = min($limit - $matched, \count($currentBuffer), \count($previousBuffer));
+                $bufferMatched = $this->commonSuffixLength($currentBuffer, $previousBuffer, $bufferLimit);
+                $matched += $bufferMatched;
+
+                if ($bufferMatched < $bufferLimit || \count($currentBuffer) !== \count($previousBuffer)) {
+                    return $matched;
+                }
+            }
+
+            return $matched;
+        }
+
+        $currentCount = \count($current);
+        $previousCount = \count($previous);
+        for ($i = 1; $i <= $limit; ++$i) {
+            if ($current->getLine($currentCount - $i) !== $previous->getLine($previousCount - $i)) {
+                return $i - 1;
+            }
+        }
+
+        return $limit;
+    }
+}

--- a/src/Symfony/Component/Tui/Render/LineBufferInterface.php
+++ b/src/Symfony/Component/Tui/Render/LineBufferInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Render;
+
+/**
+ * @extends \IteratorAggregate<int, string>
+ *
+ * @experimental
+ *
+ * @internal
+ */
+interface LineBufferInterface extends \Countable, \IteratorAggregate
+{
+    public function getLine(int $index): string;
+
+    /**
+     * @return list<string>
+     */
+    public function slice(int $offset, int $length): array;
+
+    /**
+     * @return list<string>
+     */
+    public function toArray(): array;
+
+    public function getMaxVisibleWidth(): int;
+}

--- a/src/Symfony/Component/Tui/Render/Renderer.php
+++ b/src/Symfony/Component/Tui/Render/Renderer.php
@@ -98,31 +98,24 @@ final class Renderer implements WidgetRendererInterface
 
     /**
      * Render the widget tree starting from root.
-     *
-     * @return string[] Array of rendered lines
      */
-    public function render(ContainerWidget $root, int $columns, int $rows): array
+    public function renderFrame(ContainerWidget $root, int $columns, int $rows): LineBufferInterface
     {
         $context = new RenderContext($columns, $rows, null, $this->fontRegistry, fillRows: true);
         $this->currentColumns = $columns;
         $this->positionTracker->reset();
 
-        $result = $this->renderWidget($root, $context);
+        $result = $this->renderWidgetLines($root, $context);
 
-        // Track root widget position
         $this->positionTracker->setWidgetRect($root, new WidgetRect(0, 0, $columns, \count($result)));
 
         return $result;
     }
 
-    public function renderWidget(AbstractWidget $widget, RenderContext $context): array
+    public function renderWidgetLines(AbstractWidget $widget, RenderContext $context): LineBufferInterface
     {
-        // Allow widget to sync state before rendering
         $widget->beforeRender();
 
-        // Check render cache: if the widget hasn't been invalidated and
-        // the available dimensions are unchanged, reuse the previous output.
-        // This skips style resolution, layout, chrome, and content rendering.
         $cacheColumns = $context->getColumns();
         $cacheRows = $context->getRows();
         $cached = $widget->getRenderCache($cacheColumns, $cacheRows);
@@ -130,53 +123,30 @@ final class Renderer implements WidgetRendererInterface
             return $cached;
         }
 
-        // 1. Resolve style by merging: global → FQCN → state → instance
         $resolvedStyle = $this->resolveStyle($widget);
 
-        // Hidden widgets produce no output and take no space
         if (true === $resolvedStyle->getHidden()) {
-            $widget->setRenderCache([], $cacheColumns, $cacheRows);
+            $lines = new ArrayLineBuffer([]);
+            $widget->setRenderCache($lines, $cacheColumns, $cacheRows);
 
-            return [];
+            return $lines;
         }
 
-        // 2. Apply maxColumns constraint if set
         $maxColumns = $resolvedStyle->getMaxColumns();
         if (null !== $maxColumns && $context->getColumns() > $maxColumns) {
             $context = $context->withColumns($maxColumns);
         }
 
-        // 3. Create enriched context with resolved style
         $styledContext = $context->withStyle($resolvedStyle);
 
-        // 4. For ContainerWidget, use the layout engine
         if ($widget instanceof ContainerWidget) {
             $lines = $this->renderContainer($widget, $styledContext, $resolvedStyle);
         } else {
-            // 5. For all other widgets (leaf widgets + ParentInterface),
-            // render content with inner dimensions, then apply chrome
             $innerContext = $this->chromeApplier->computeInnerContext($styledContext, $resolvedStyle);
-            $lines = $widget->render($innerContext);
-            $lines = $this->chromeApplier->apply($lines, $context->getColumns(), $resolvedStyle, $widget);
+            $lines = $this->chromeApplier->apply(new ArrayLineBuffer($widget->render($innerContext)), $context->getColumns(), $resolvedStyle, $widget);
         }
 
-        // Validate that no line exceeds the available width.
-        // This catches widget bugs early, at the source, rather than
-        // letting over-wide lines flow to ScreenWriter where the widget
-        // context is lost. Image lines (Kitty/iTerm2 protocol) are
-        // excluded because their visible width is not meaningful.
-        $availableColumns = $context->getColumns();
-        foreach ($lines as $i => $line) {
-            if ('' === $line || AnsiUtils::containsImage($line)) {
-                continue;
-            }
-
-            $lineWidth = AnsiUtils::visibleWidth($line);
-            if ($lineWidth > $availableColumns) {
-                throw new RenderException(\sprintf("Widget \"%s\" rendered line %d with width %d, exceeding the available %d columns.\nLine preview: \"%s\".", $widget::class, $i, $lineWidth, $availableColumns, mb_substr(AnsiUtils::stripAnsiCodes($line), 0, 100)), $i, $lineWidth, $availableColumns);
-            }
-        }
-
+        $this->validateLines($widget, $lines, $context->getColumns());
         $widget->setRenderCache($lines, $cacheColumns, $cacheRows);
 
         return $lines;
@@ -247,12 +217,9 @@ final class Renderer implements WidgetRendererInterface
 
     /**
      * Render a container widget with its children.
-     *
-     * @return string[]
      */
-    private function renderContainer(ContainerWidget $widget, RenderContext $context, Style $resolvedStyle): array
+    private function renderContainer(ContainerWidget $widget, RenderContext $context, Style $resolvedStyle): LineBufferInterface
     {
-        // Filter out hidden children so they don't take up layout space
         $children = array_values(array_filter(
             $widget->all(),
             fn (AbstractWidget $child) => true !== $this->resolveStyle($child)->getHidden(),
@@ -262,25 +229,20 @@ final class Renderer implements WidgetRendererInterface
         $rows = $context->getRows();
 
         if (!$children) {
-            return $this->chromeApplier->apply([], $columns, $resolvedStyle, $widget);
+            return $this->chromeApplier->apply(new ArrayLineBuffer([]), $columns, $resolvedStyle, $widget);
         }
 
-        // Calculate inner dimensions (content area after border/padding)
         [$innerColumns, $innerRows] = $this->chromeApplier->computeInnerDimensions($columns, $rows, $resolvedStyle);
 
-        // Get direction and gap from resolved style
         $direction = $resolvedStyle->getDirection() ?? Direction::Vertical;
         $gap = $resolvedStyle->getGap() ?? 0;
 
-        // Compute styled gap line matching what a child widget would render as blank
-        // This ensures gap lines inherit the container's resolved style (e.g. bold from * rule)
         $gapLine = null;
         if ($gap > 0) {
             $gapContent = str_repeat(' ', max(1, $innerColumns));
             $gapLine = $resolvedStyle->isPlain() ? $gapContent : $resolvedStyle->apply($gapContent);
         }
 
-        // Push the content area's absolute offset onto the position stack
         if ($this->positionTracker->isActive()) {
             [$parentRow, $parentCol] = $this->positionTracker->currentOffset();
             [$chromeTop, $chromeLeft] = $this->chromeApplier->computeChromeOffset($resolvedStyle);
@@ -292,9 +254,6 @@ final class Renderer implements WidgetRendererInterface
         $verticalAlign = $resolvedStyle->getVerticalAlign();
         $hasVerticalAlign = null !== $verticalAlign;
 
-        // Render children using layout engine.
-        // For horizontal containers, pass verticalAlign so layoutHorizontal can
-        // offset shorter children (align-items). For vertical containers it is unused.
         $childLines = $this->layoutEngine->layout(
             $children,
             $innerColumns,
@@ -305,44 +264,52 @@ final class Renderer implements WidgetRendererInterface
             Direction::Horizontal === $direction ? $verticalAlign : null,
         );
 
-        // Pop position stack
         $this->positionTracker->pop();
 
-        // Apply vertical alignment offset when VerticalAlign is set and the widget owns its rows.
         if ($hasVerticalAlign && \count($childLines) < $innerRows
             && ($context->shouldFillRows() || $widget->isVerticallyExpanded())
         ) {
             if (0 < $verticalOffset = $this->layoutEngine->computeVerticalAlignOffset(\count($childLines), $innerRows, $verticalAlign)) {
-                $topPad = array_fill(0, $verticalOffset, '');
-                array_unshift($childLines, ...$topPad);
+                $childLines = new ConcatenatedLineBuffer([
+                    new ArrayLineBuffer(array_fill(0, $verticalOffset, '')),
+                    $childLines,
+                ]);
                 $this->positionTracker->shiftContentPositions($children, 0, $verticalOffset);
             }
         }
 
-        // Pad to fill allocated rows so that chrome (e.g. background-color) covers the full height.
-        //
-        // A fill child is detected by isVerticallyExpanded()=true AND shouldFillRows()=false:
-        // layoutVertical creates a fresh RenderContext (fillRows=false) with exactly $childFillRows,
-        // so the child must fill those rows itself before chromeApplier runs — otherwise layoutVertical
-        // pads with bare empty strings that bypass chromeApplier and leave background incomplete.
-        //
-        // Root renders (shouldFillRows=true) pad only when VerticalAlign is explicitly set;
-        // without it the root returns its natural content height.
         $shouldPad = ($widget->isVerticallyExpanded() && !$context->shouldFillRows())
             || ($context->shouldFillRows() && $hasVerticalAlign);
         if ($shouldPad && \count($childLines) < $innerRows) {
-            while (\count($childLines) < $innerRows) {
-                $childLines[] = '';
-            }
+            $childLines = new ConcatenatedLineBuffer([
+                $childLines,
+                new ArrayLineBuffer(array_fill(0, $innerRows - \count($childLines), '')),
+            ]);
         }
 
-        // Apply horizontal alignment for child widgets and adjust tracked positions
         if ($hasAlign && 0 < $alignOffset = $this->layoutEngine->computeAlignOffset($childLines, $innerColumns, $align)) {
             $childLines = $this->layoutEngine->shiftLines($childLines, $alignOffset);
             $this->positionTracker->shiftContentPositions($children, $alignOffset);
         }
 
-        // Apply chrome (padding, border, background)
         return $this->chromeApplier->apply($childLines, $columns, $resolvedStyle, $widget);
+    }
+
+    private function validateLines(AbstractWidget $widget, LineBufferInterface $lines, int $availableColumns): void
+    {
+        if ($lines->getMaxVisibleWidth() <= $availableColumns) {
+            return;
+        }
+
+        foreach ($lines as $i => $line) {
+            if ('' === $line || AnsiUtils::containsImage($line)) {
+                continue;
+            }
+
+            $lineWidth = AnsiUtils::visibleWidth($line);
+            if ($lineWidth > $availableColumns) {
+                throw new RenderException(\sprintf("Widget \"%s\" rendered line %d with width %d, exceeding the available %d columns.\nLine preview: \"%s\".", $widget::class, $i, $lineWidth, $availableColumns, mb_substr(AnsiUtils::stripAnsiCodes($line), 0, 100)), $i, $lineWidth, $availableColumns);
+            }
+        }
     }
 }

--- a/src/Symfony/Component/Tui/Render/Renderer.php
+++ b/src/Symfony/Component/Tui/Render/Renderer.php
@@ -51,9 +51,18 @@ final class Renderer implements WidgetRendererInterface
     /** Current terminal columns, set during render() for breakpoint resolution */
     private ?int $currentColumns = null;
 
+    /**
+     * Resolved styles for the current frame, keyed on the widget's render
+     * revision so that a style changed from beforeRender() is picked up.
+     *
+     * @var \WeakMap<AbstractWidget, array{int, Style}>
+     */
+    private \WeakMap $styleCache;
+
     public function __construct(?StyleSheet $styleSheet = null, ?FontRegistry $fontRegistry = null)
     {
         $this->fontRegistry = $fontRegistry ?? new FontRegistry();
+        $this->styleCache = new \WeakMap();
         $this->positionTracker = new PositionTracker();
         $this->layoutEngine = new LayoutEngine($this, $this->positionTracker, $this->fontRegistry);
         $this->chromeApplier = new ChromeApplier($this);
@@ -103,6 +112,7 @@ final class Renderer implements WidgetRendererInterface
     {
         $context = new RenderContext($columns, $rows, null, $this->fontRegistry, fillRows: true);
         $this->currentColumns = $columns;
+        $this->styleCache = new \WeakMap();
         $this->positionTracker->reset();
 
         $result = $this->renderWidgetLines($root, $context);
@@ -154,7 +164,16 @@ final class Renderer implements WidgetRendererInterface
 
     public function resolveStyle(AbstractWidget $widget): Style
     {
-        return $this->styleSheet->resolve($widget, $this->currentColumns);
+        $revision = $widget->getRenderRevision();
+        $cached = $this->styleCache[$widget] ?? null;
+
+        if (null !== $cached && $cached[0] === $revision) {
+            return $cached[1];
+        }
+
+        $this->styleCache[$widget] = [$revision, $style = $this->styleSheet->resolve($widget, $this->currentColumns)];
+
+        return $style;
     }
 
     public function measureIntrinsicWidth(AbstractWidget $widget, int $maxColumns, int $rows): int

--- a/src/Symfony/Component/Tui/Render/ScreenWriter.php
+++ b/src/Symfony/Component/Tui/Render/ScreenWriter.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Tui\Render;
 
 use Symfony\Component\Tui\Ansi\AnsiUtils;
+use Symfony\Component\Tui\Exception\LogicException;
 use Symfony\Component\Tui\Exception\RenderException;
 use Symfony\Component\Tui\Terminal\TerminalInterface;
 
@@ -37,24 +38,22 @@ final class ScreenWriter
 {
     private const PRINTABLE_ASCII = ' !"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~';
 
-    /** @var string[] */
-    private array $previousLines = [];
+    private ?LineBufferInterface $previousLines = null;
     private int $previousWidth = 0;
-    private int $cursorRow = 0;
     private int $hardwareCursorRow = 0;
     private int $maxLinesRendered = 0;
     private bool $showHardwareCursor = true;
     private int $scrollOffset = 0;
 
-    /** @var string[] */
-    private array $previousRawLines = [];
-
     /** @var array{row: int, col: int, shape: int}|null */
     private ?array $previousCursorPos = null;
+    private readonly LineBufferDiffer $lineBufferDiffer;
 
     public function __construct(
         private readonly TerminalInterface $terminal,
+        ?LineBufferDiffer $lineBufferDiffer = null,
     ) {
+        $this->lineBufferDiffer = $lineBufferDiffer ?? new LineBufferDiffer();
     }
 
     public function setShowHardwareCursor(bool $enabled): void
@@ -93,15 +92,8 @@ final class ScreenWriter
         return $this->scrollOffset;
     }
 
-    /**
-     * Write ANSI lines to the terminal using differential rendering.
-     *
-     * @param string[] $lines The new content to display
-     */
-    public function writeLines(array $lines): void
+    public function writeFrame(LineBufferInterface $lines): void
     {
-        // Apply scroll offset: when content exceeds the viewport, slice to
-        // show a window shifted up from the bottom by scrollOffset lines.
         if ($this->scrollOffset > 0) {
             $totalLines = \count($lines);
             $rows = $this->terminal->getRows();
@@ -109,21 +101,28 @@ final class ScreenWriter
                 $maxOffset = $totalLines - $rows;
                 $effectiveOffset = min($this->scrollOffset, $maxOffset);
                 $startLine = $totalLines - $rows - $effectiveOffset;
-                $lines = \array_slice($lines, $startLine, $rows);
+                $lines = new ArrayLineBuffer($lines->slice($startLine, $rows));
             }
         }
 
-        if ($this->previousLines && $this->previousWidth === $this->terminal->getColumns() && $lines === $this->previousRawLines) {
-            $this->positionHardwareCursor($this->previousCursorPos, \count($this->previousLines));
+        $changedRange = null === $this->previousLines ? null : $this->lineBufferDiffer->findChangedRange($lines, $this->previousLines);
+        $cursorPos = match (true) {
+            null === $this->previousLines => $this->findCursorPosition($lines),
+            null === $changedRange => $this->previousCursorPos,
+            null === $this->previousCursorPos && \count($lines) === \count($this->previousLines) => $this->findCursorPosition($lines, $changedRange['first'], $changedRange['last']),
+            default => $this->findCursorPosition($lines),
+        };
+
+        if (null !== $this->previousLines && $this->previousWidth === $this->terminal->getColumns() && null === $changedRange) {
+            $this->positionHardwareCursor($cursorPos, \count($lines));
+            $this->previousLines = $lines;
+            $this->previousCursorPos = $cursorPos;
 
             return;
         }
 
-        $rawLines = $lines;
-        ['lines' => $lines, 'cursor_pos' => $cursorPos, 'first_changed' => $firstChanged, 'last_changed' => $lastChanged] = $this->prepareLines($lines);
-
-        $this->writeInternal($lines, $cursorPos, $firstChanged, $lastChanged);
-        $this->previousRawLines = $rawLines;
+        $this->writeInternal($lines, $cursorPos, $changedRange['first'] ?? 0, $changedRange['last'] ?? \count($lines) - 1);
+        $this->previousLines = $lines;
         $this->previousCursorPos = $cursorPos;
     }
 
@@ -135,11 +134,9 @@ final class ScreenWriter
      */
     public function reset(): void
     {
-        $this->previousLines = [];
-        $this->previousRawLines = [];
+        $this->previousLines = null;
         $this->previousCursorPos = null;
         $this->previousWidth = -1; // -1 triggers widthChanged
-        $this->cursorRow = 0;
         $this->hardwareCursorRow = 0;
         $this->maxLinesRendered = 0;
     }
@@ -152,7 +149,7 @@ final class ScreenWriter
     public function getState(): array
     {
         return [
-            'line_count' => \count($this->previousLines),
+            'line_count' => null === $this->previousLines ? 0 : \count($this->previousLines),
             'cursor_row' => $this->hardwareCursorRow,
         ];
     }
@@ -160,10 +157,9 @@ final class ScreenWriter
     /**
      * Internal write implementation.
      *
-     * @param string[]                                   $lines
      * @param array{row: int, col: int, shape: int}|null $cursorPos
      */
-    private function writeInternal(array $lines, ?array $cursorPos, int $firstChanged, int $lastChanged): void
+    private function writeInternal(LineBufferInterface $lines, ?array $cursorPos, int $firstChanged, int $lastChanged): void
     {
         $columns = $this->terminal->getColumns();
         $rows = $this->terminal->getRows();
@@ -172,21 +168,13 @@ final class ScreenWriter
         $widthChanged = 0 !== $this->previousWidth && $this->previousWidth !== $columns;
 
         // First render or width changed
-        if (!$this->previousLines || $widthChanged) {
+        if (null === $this->previousLines || $widthChanged) {
             $this->fullRender($lines, $cursorPos, $widthChanged);
 
             return;
         }
 
-        $lineCount = \count($lines);
-
-        if (-1 === $firstChanged) {
-            $this->positionHardwareCursor($cursorPos, $lineCount);
-
-            return;
-        }
-
-        if ($firstChanged >= $lineCount) {
+        if ($firstChanged >= \count($lines)) {
             $this->handleDeletedLines($lines, $cursorPos, $rows);
 
             return;
@@ -229,10 +217,9 @@ final class ScreenWriter
      *    erase exceeds the terminal height, clearing is more efficient than
      *    erasing them one by one.
      *
-     * @param string[]                                   $newLines
      * @param array{row: int, col: int, shape: int}|null $cursorPos
      */
-    private function fullRender(array $newLines, ?array $cursorPos, bool $clear): void
+    private function fullRender(LineBufferInterface $newLines, ?array $cursorPos, bool $clear): void
     {
         $buffer = "\x1b[?2026h"; // Begin synchronized output
 
@@ -240,15 +227,19 @@ final class ScreenWriter
             $buffer .= "\x1b[2J\x1b[3J\x1b[H"; // Clear screen, clear scrollback, and home
         }
 
-        if ($newLines) {
-            $buffer .= implode("\r\n", $newLines);
+        $first = true;
+        foreach ($newLines as $line) {
+            if (!$first) {
+                $buffer .= "\r\n";
+            }
+            $buffer .= $this->prepareLine($line);
+            $first = false;
         }
 
         $buffer .= "\x1b[?2026l"; // End synchronized output
 
         $this->terminal->write($buffer);
-        $this->cursorRow = max(0, \count($newLines) - 1);
-        $this->hardwareCursorRow = $this->cursorRow;
+        $this->hardwareCursorRow = max(0, \count($newLines) - 1);
 
         if ($clear) {
             $this->maxLinesRendered = \count($newLines);
@@ -257,26 +248,15 @@ final class ScreenWriter
         }
 
         $this->positionHardwareCursor($cursorPos, \count($newLines));
-        $this->previousLines = $newLines;
         $this->previousWidth = $this->terminal->getColumns();
     }
 
     /**
-     * @param string[]                                   $newLines
      * @param array{row: int, col: int, shape: int}|null $cursorPos
-     *
-     * @return bool True when a full render fallback was used
      */
-    private function handleDeletedLines(array $newLines, ?array $cursorPos, int $height): bool
+    private function handleDeletedLines(LineBufferInterface $newLines, ?array $cursorPos, int $height): void
     {
-        if (\count($this->previousLines) <= \count($newLines)) {
-            $this->positionHardwareCursor($cursorPos, \count($newLines));
-            $this->previousLines = $newLines;
-            $this->previousWidth = $this->terminal->getColumns();
-
-            return false;
-        }
-
+        $previousLineCount = \count($this->previousLines ?? throw new LogicException('Previous lines are not available.'));
         $buffer = "\x1b[?2026h";
 
         $targetRow = max(0, \count($newLines) - 1);
@@ -290,17 +270,17 @@ final class ScreenWriter
 
         $buffer .= "\r";
 
-        $extraLines = \count($this->previousLines) - \count($newLines);
+        $extraLines = $previousLineCount - \count($newLines);
 
         if ($extraLines > $height) {
             $this->fullRender($newLines, $cursorPos, true);
 
-            return true;
+            return;
         }
 
         $newLineCount = \count($newLines);
 
-        if ($extraLines > 0 && $newLineCount > 0) {
+        if ($newLineCount > 0) {
             $buffer .= "\x1b[1B";
         }
 
@@ -319,22 +299,18 @@ final class ScreenWriter
         $buffer .= "\x1b[?2026l";
 
         $this->terminal->write($buffer);
-        $this->cursorRow = $targetRow;
         $this->hardwareCursorRow = $targetRow;
 
         $this->positionHardwareCursor($cursorPos, \count($newLines));
-        $this->previousLines = $newLines;
         $this->previousWidth = $this->terminal->getColumns();
-
-        return false;
     }
 
     /**
-     * @param string[]                                   $newLines
      * @param array{row: int, col: int, shape: int}|null $cursorPos
      */
-    private function differentialRender(array $newLines, ?array $cursorPos, int $firstChanged, int $lastChanged, int $width): void
+    private function differentialRender(LineBufferInterface $newLines, ?array $cursorPos, int $firstChanged, int $lastChanged, int $width): void
     {
+        $previousLineCount = \count($this->previousLines ?? throw new LogicException('Previous lines are not available.'));
         $buffer = "\x1b[?2026h"; // Begin synchronized output
 
         // Move cursor to first changed line
@@ -356,7 +332,7 @@ final class ScreenWriter
             }
             $buffer .= "\x1b[2K";
 
-            $line = $newLines[$i];
+            $line = $this->prepareLine($newLines->getLine($i));
             $lineWidth = null;
             $lineLength = \strlen($line);
 
@@ -375,7 +351,7 @@ final class ScreenWriter
                 $this->hardwareCursorRow = $i;
                 // Force a full re-render with screen clear on next call
                 // since the screen is now in a partially updated state
-                $this->previousLines = [];
+                $this->previousLines = null;
                 $this->previousWidth = -1;
 
                 // Strip ANSI codes for readable debug output
@@ -390,109 +366,63 @@ final class ScreenWriter
 
         $finalCursorRow = $renderEnd;
 
-        // Handle content size changes
-        if (\count($this->previousLines) > \count($newLines)) {
-            // Content shrunk - clear extra lines
-            if ($renderEnd < \count($newLines) - 1) {
-                $moveDown = \count($newLines) - 1 - $renderEnd;
-                $buffer .= "\x1b[{$moveDown}B";
-                $finalCursorRow = \count($newLines) - 1;
-            }
-
-            $extraLines = \count($this->previousLines) - \count($newLines);
+        if ($previousLineCount > \count($newLines)) {
+            $extraLines = $previousLineCount - \count($newLines);
             $buffer .= str_repeat("\r\n\x1b[2K", $extraLines);
-
             $buffer .= "\x1b[{$extraLines}A";
-        } elseif (\count($newLines) > \count($this->previousLines) && $renderEnd < \count($newLines) - 1) {
-            // Content grew - output any additional lines not already rendered
-            // Only needed if renderEnd < newLines.length - 1 (i.e., we didn't render to the end)
-            for ($i = $renderEnd + 1; $i < \count($newLines); ++$i) {
-                $buffer .= "\r\n\x1b[2K";
-                $buffer .= $newLines[$i];
-                $finalCursorRow = $i;
-            }
         }
 
         $buffer .= "\x1b[?2026l"; // End synchronized output
 
         $this->terminal->write($buffer);
 
-        $this->cursorRow = max(0, \count($newLines) - 1);
         $this->hardwareCursorRow = $finalCursorRow;
         $this->maxLinesRendered = max($this->maxLinesRendered, \count($newLines));
 
         $this->positionHardwareCursor($cursorPos, \count($newLines));
-        $this->previousLines = $newLines;
         $this->previousWidth = $this->terminal->getColumns();
     }
 
     /**
-     * Strip cursor markers, apply line resets, and detect changed rows in one pass.
-     *
-     * @param string[] $lines
-     *
-     * @return array{lines: string[], cursor_pos: array{row: int, col: int, shape: int}|null, first_changed: int, last_changed: int}
+     * @return array{row: int, col: int, shape: int}|null
      */
-    private function prepareLines(array $lines): array
+    private function findCursorPosition(LineBufferInterface $lines, ?int $firstRow = null, ?int $lastRow = null): ?array
     {
-        $cursorPos = null;
-        $firstChanged = -1;
-        $lastChanged = -1;
-        $lineCount = \count($lines);
-        $previousLineCount = \count($this->previousLines);
+        $firstVisibleRow = max(0, \count($lines) - $this->terminal->getRows());
+        $firstRow = max($firstVisibleRow, $firstRow ?? $firstVisibleRow);
+        $lastRow = min(\count($lines) - 1, $lastRow ?? \count($lines) - 1);
 
-        foreach ($lines as $row => $line) {
-            if ($line === $oldLine = $row < $previousLineCount ? $this->previousLines[$row] : '') {
+        for ($row = $lastRow; $row >= $firstRow; --$row) {
+            $line = $lines->getLine($row);
+            $markerIndex = strpos($line, AnsiUtils::CURSOR_MARKER_PREFIX);
+            if (false === $markerIndex || false === $endIndex = strpos($line, "\x07", $markerIndex)) {
                 continue;
             }
 
-            if (str_contains($line, "\x1b")) {
-                if ($oldLine === $line."\x1b[0m" || $oldLine === $line.AnsiUtils::SEGMENT_RESET) {
-                    $lines[$row] = $oldLine;
-                    continue;
-                }
+            $shape = (int) substr($line, $markerIndex + \strlen(AnsiUtils::CURSOR_MARKER_PREFIX), $endIndex - $markerIndex - \strlen(AnsiUtils::CURSOR_MARKER_PREFIX));
 
-                if (null === $cursorPos) {
-                    $markerIndex = strpos($line, AnsiUtils::CURSOR_MARKER_PREFIX);
-                    if (false !== $markerIndex && false !== $endIndex = strpos($line, "\x07", $markerIndex)) {
-                        $markerLen = $endIndex - $markerIndex + 1;
-                        $shapeStr = substr($line, $markerIndex + \strlen(AnsiUtils::CURSOR_MARKER_PREFIX), $endIndex - $markerIndex - \strlen(AnsiUtils::CURSOR_MARKER_PREFIX));
-                        $beforeMarker = substr($line, 0, $markerIndex);
-                        $cursorPos = ['row' => $row, 'col' => AnsiUtils::visibleWidth($beforeMarker), 'shape' => (int) $shapeStr];
-                        $line = substr($line, 0, $markerIndex).substr($line, $markerIndex + $markerLen);
-                    }
-                }
-
-                if (str_contains($line, "\x1b") && !AnsiUtils::containsImage($line)) {
-                    $line = str_contains($line, "\x1b]8;")
-                        ? $line.AnsiUtils::SEGMENT_RESET
-                        : $line."\x1b[0m";
-                }
-            }
-
-            $lines[$row] = $line;
-
-            if ($oldLine !== $line) {
-                if (-1 === $firstChanged) {
-                    $firstChanged = $row;
-                }
-                $lastChanged = $row;
-            }
+            return ['row' => $row, 'col' => AnsiUtils::visibleWidth(substr($line, 0, $markerIndex)), 'shape' => $shape];
         }
 
-        if ($previousLineCount > $lineCount) {
-            if (-1 === $firstChanged) {
-                $firstChanged = $lineCount;
-            }
-            $lastChanged = $previousLineCount - 1;
+        return null;
+    }
+
+    private function prepareLine(string $line): string
+    {
+        if (!str_contains($line, "\x1b")) {
+            return $line;
         }
 
-        return [
-            'lines' => $lines,
-            'cursor_pos' => $cursorPos,
-            'first_changed' => $firstChanged,
-            'last_changed' => $lastChanged,
-        ];
+        $markerIndex = strpos($line, AnsiUtils::CURSOR_MARKER_PREFIX);
+        if (false !== $markerIndex && false !== $endIndex = strpos($line, "\x07", $markerIndex)) {
+            $line = substr($line, 0, $markerIndex).substr($line, $endIndex + 1);
+        }
+
+        if (!str_contains($line, "\x1b") || AnsiUtils::containsImage($line)) {
+            return $line;
+        }
+
+        return str_contains($line, "\x1b]8;") ? $line.AnsiUtils::SEGMENT_RESET : $line."\x1b[0m";
     }
 
     /**

--- a/src/Symfony/Component/Tui/Render/WidgetRendererInterface.php
+++ b/src/Symfony/Component/Tui/Render/WidgetRendererInterface.php
@@ -29,11 +29,9 @@ use Symfony\Component\Tui\Widget\AbstractWidget;
 interface WidgetRendererInterface
 {
     /**
-     * Render a single widget through the full pipeline.
-     *
-     * @return string[]
+     * Render a widget without flattening cached child buffers.
      */
-    public function renderWidget(AbstractWidget $widget, RenderContext $context): array;
+    public function renderWidgetLines(AbstractWidget $widget, RenderContext $context): LineBufferInterface;
 
     /**
      * Resolve the style for a widget by merging cascade layers.
@@ -43,7 +41,7 @@ interface WidgetRendererInterface
     /**
      * Measure the intrinsic width of a widget: content width + chrome (border/padding).
      *
-     * Unlike renderWidget(), this does not pad lines to the allocated width.
+     * Unlike renderWidgetLines(), this does not pad lines to the allocated width.
      * Used by the layout engine to measure flex: 0 children.
      */
     public function measureIntrinsicWidth(AbstractWidget $widget, int $maxColumns, int $rows): int;

--- a/src/Symfony/Component/Tui/Tests/Render/AlignTest.php
+++ b/src/Symfony/Component/Tui/Tests/Render/AlignTest.php
@@ -41,7 +41,7 @@ final class AlignTest extends TestCase
         $child->addStyleClass('child');
         $root->add($child);
 
-        $lines = $renderer->render($root, 30, 5);
+        $lines = $renderer->renderFrame($root, 30, 5)->toArray();
 
         $this->assertCount(1, $lines);
         $visible = AnsiUtils::stripAnsiCodes($lines[0]);
@@ -62,7 +62,7 @@ final class AlignTest extends TestCase
         $child->addStyleClass('child');
         $root->add($child);
 
-        $lines = $renderer->render($root, 30, 5);
+        $lines = $renderer->renderFrame($root, 30, 5)->toArray();
 
         $this->assertCount(1, $lines);
         $visible = AnsiUtils::stripAnsiCodes($lines[0]);
@@ -86,7 +86,7 @@ final class AlignTest extends TestCase
         $root->add($child1);
         $root->add($child2);
 
-        $lines = $renderer->render($root, 30, 5);
+        $lines = $renderer->renderFrame($root, 30, 5)->toArray();
 
         $this->assertCount(2, $lines);
         $line1 = AnsiUtils::stripAnsiCodes($lines[0]);
@@ -108,7 +108,7 @@ final class AlignTest extends TestCase
         // Text fills the full 10-column width
         $root->add(new TextWidget('0123456789'));
 
-        $lines = $renderer->render($root, 10, 5);
+        $lines = $renderer->renderFrame($root, 10, 5)->toArray();
 
         $this->assertCount(1, $lines);
         $visible = AnsiUtils::stripAnsiCodes($lines[0]);
@@ -136,7 +136,7 @@ final class AlignTest extends TestCase
         $child->setStyle(new Style(maxColumns: 10));
         $root->add($child);
 
-        $lines = $renderer->render($root, 30, 5);
+        $lines = $renderer->renderFrame($root, 30, 5)->toArray();
 
         $this->assertCount(1, $lines);
         $visible = AnsiUtils::stripAnsiCodes($lines[0]);
@@ -155,7 +155,7 @@ final class AlignTest extends TestCase
         $root->addStyleClass('parent');
         $root->add(new TextWidget('Hello'));
 
-        $lines = $renderer->render($root, 10, 10);
+        $lines = $renderer->renderFrame($root, 10, 10)->toArray();
 
         // 1 content line + centering: floor((10-1)/2) = 4 empty lines top, 5 bottom
         $this->assertCount(10, $lines);
@@ -178,7 +178,7 @@ final class AlignTest extends TestCase
         $root->addStyleClass('parent');
         $root->add(new TextWidget('Hello'));
 
-        $lines = $renderer->render($root, 10, 10);
+        $lines = $renderer->renderFrame($root, 10, 10)->toArray();
 
         // Content at top, all remaining rows are empty at bottom
         $this->assertCount(10, $lines);
@@ -196,7 +196,7 @@ final class AlignTest extends TestCase
         $root->addStyleClass('valign-center');
         $root->add(new TextWidget('Hi'));
 
-        $lines = $renderer->render($root, 10, 10);
+        $lines = $renderer->renderFrame($root, 10, 10)->toArray();
 
         // 1 content line centered in 10 rows: 4 empty top, content, 5 empty bottom
         $this->assertCount(10, $lines);
@@ -217,7 +217,7 @@ final class AlignTest extends TestCase
         $root->add(new TextWidget('Line1'));
         $root->add(new TextWidget('Line2'));
 
-        $lines = $renderer->render($root, 10, 10);
+        $lines = $renderer->renderFrame($root, 10, 10)->toArray();
 
         // 2 content lines centered in 10 rows: floor((10-2)/2) = 4 empty top
         $this->assertCount(10, $lines);
@@ -241,7 +241,7 @@ final class AlignTest extends TestCase
         $child->addStyleClass('child');
         $root->add($child);
 
-        $lines = $renderer->render($root, 30, 10);
+        $lines = $renderer->renderFrame($root, 30, 10)->toArray();
 
         // 1 content line centered both ways
         // Vertical: floor((10-1)/2) = 4 empty top
@@ -277,7 +277,7 @@ final class AlignTest extends TestCase
         $root->add($inner);
         $root->add(new TextWidget('After'));
 
-        $lines = $renderer->render($root, 10, 10);
+        $lines = $renderer->renderFrame($root, 10, 10)->toArray();
 
         // inner renders 2 lines (A + B), After renders 1 line — total 3 lines.
         // If inner incorrectly expands to 10 rows, After is pushed off and total is > 3.
@@ -313,7 +313,7 @@ final class AlignTest extends TestCase
         $row->add($short);
         $root->add($row);
 
-        $lines = $renderer->render($root, 30, 10);
+        $lines = $renderer->renderFrame($root, 30, 10)->toArray();
 
         // $row is a non-expanded nested container — it renders exactly 3 lines (tallest child height).
         // 'url' must appear on line 1 (center of 3), not line 0 (top).

--- a/src/Symfony/Component/Tui/Tests/Render/ArrayLineBufferTest.php
+++ b/src/Symfony/Component/Tui/Tests/Render/ArrayLineBufferTest.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Tests\Render;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Tui\Exception\OutOfBoundsException;
+use Symfony\Component\Tui\Render\ArrayLineBuffer;
+
+class ArrayLineBufferTest extends TestCase
+{
+    public function testGetLineThrowsOnOutOfBoundsIndex()
+    {
+        $this->expectException(OutOfBoundsException::class);
+
+        new ArrayLineBuffer(['A'])->getLine(1);
+    }
+
+    public function testSliceThrowsOnNegativeOffset()
+    {
+        $this->expectException(OutOfBoundsException::class);
+
+        new ArrayLineBuffer(['A'])->slice(-1, 1);
+    }
+}

--- a/src/Symfony/Component/Tui/Tests/Render/ChromeApplierTest.php
+++ b/src/Symfony/Component/Tui/Tests/Render/ChromeApplierTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Tui\Tests\Render;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Tui\Ansi\AnsiUtils;
+use Symfony\Component\Tui\Render\ArrayLineBuffer;
 use Symfony\Component\Tui\Render\ChromeApplier;
 use Symfony\Component\Tui\Render\RenderContext;
 use Symfony\Component\Tui\Render\WidgetRendererInterface;
@@ -128,7 +129,7 @@ final class ChromeApplierTest extends TestCase
     {
         $applier = $this->createApplier();
         $widget = new TextWidget('test');
-        $lines = ['Hello', 'World'];
+        $lines = new ArrayLineBuffer(['Hello', 'World']);
 
         $result = $applier->apply($lines, 20, new Style(), $widget);
 
@@ -140,7 +141,7 @@ final class ChromeApplierTest extends TestCase
         $applier = $this->createApplier();
         $widget = new TextWidget('test');
 
-        $result = $applier->apply([], 20, new Style(), $widget);
+        $result = $applier->apply(new ArrayLineBuffer([]), 20, new Style(), $widget)->toArray();
 
         $this->assertSame([], $result);
     }
@@ -155,7 +156,7 @@ final class ChromeApplierTest extends TestCase
         $widget = new TextWidget('test');
         $style = new Style(padding: new Padding(1, 0, 1, 0));
 
-        $result = $applier->apply(['Content'], 20, $style, $widget);
+        $result = $applier->apply(new ArrayLineBuffer(['Content']), 20, $style, $widget)->toArray();
 
         // 1 top padding + 1 content + 1 bottom padding = 3 lines
         $this->assertCount(3, $result);
@@ -172,7 +173,7 @@ final class ChromeApplierTest extends TestCase
         $widget = new TextWidget('test');
         $style = new Style(padding: new Padding(0, 3, 0, 5));
 
-        $result = $applier->apply(['Hi'], 20, $style, $widget);
+        $result = $applier->apply(new ArrayLineBuffer(['Hi']), 20, $style, $widget)->toArray();
 
         $this->assertCount(1, $result);
         // The content line should be padded to full width
@@ -188,7 +189,7 @@ final class ChromeApplierTest extends TestCase
         $widget = new TextWidget('test');
         $style = new Style(padding: new Padding(2, 0, 1, 0));
 
-        $result = $applier->apply([], 20, $style, $widget);
+        $result = $applier->apply(new ArrayLineBuffer([]), 20, $style, $widget)->toArray();
 
         // 2 top padding + 1 bottom padding = 3 lines (even with no content)
         $this->assertCount(3, $result);
@@ -204,7 +205,7 @@ final class ChromeApplierTest extends TestCase
         $widget = new TextWidget('test');
         $style = new Style(border: Border::all(1, 'none'));
 
-        $result = $applier->apply(['Hello'], 20, $style, $widget);
+        $result = $applier->apply(new ArrayLineBuffer(['Hello']), 20, $style, $widget)->toArray();
 
         // 1 border-top + 1 content + 1 border-bottom = 3 lines
         $this->assertCount(3, $result);
@@ -220,7 +221,7 @@ final class ChromeApplierTest extends TestCase
         $widget = new TextWidget('test');
         $style = new Style(border: Border::all(1, 'none'));
 
-        $result = $applier->apply([], 20, $style, $widget);
+        $result = $applier->apply(new ArrayLineBuffer([]), 20, $style, $widget)->toArray();
 
         // 1 border-top + 1 border-bottom = 2 lines
         $this->assertCount(2, $result);
@@ -232,7 +233,7 @@ final class ChromeApplierTest extends TestCase
         $applier = $this->createApplier();
         $widget = new TextWidget('test');
 
-        $result = $applier->apply(['Hello'], $width, $style, $widget);
+        $result = $applier->apply(new ArrayLineBuffer(['Hello']), $width, $style, $widget)->toArray();
 
         foreach ($result as $line) {
             $this->assertSame($width, AnsiUtils::visibleWidth($line));
@@ -260,7 +261,7 @@ final class ChromeApplierTest extends TestCase
         $widget = new TextWidget('test');
         $style = new Style(background: 'red');
 
-        $result = $applier->apply(['Hi'], 20, $style, $widget);
+        $result = $applier->apply(new ArrayLineBuffer(['Hi']), 20, $style, $widget)->toArray();
 
         $this->assertCount(1, $result);
         // Red background ANSI code should be present
@@ -278,7 +279,7 @@ final class ChromeApplierTest extends TestCase
         $widget = new TextWidget('test');
         $style = new Style(textAlign: TextAlign::Center);
 
-        $result = $applier->apply(['Hi'], 20, $style, $widget);
+        $result = $applier->apply(new ArrayLineBuffer(['Hi']), 20, $style, $widget)->toArray();
 
         // "Hi" is 2 chars wide, centered in 20 = 9 spaces + "Hi" + 9 spaces
         $plain = AnsiUtils::stripAnsiCodes($result[0]);
@@ -293,7 +294,7 @@ final class ChromeApplierTest extends TestCase
         $widget = new TextWidget('test');
         $style = new Style(textAlign: TextAlign::Right);
 
-        $result = $applier->apply(['Hi'], 20, $style, $widget);
+        $result = $applier->apply(new ArrayLineBuffer(['Hi']), 20, $style, $widget)->toArray();
 
         // "Hi" is 2 chars wide, right-aligned in 20 = 18 spaces + "Hi"
         $plain = AnsiUtils::stripAnsiCodes($result[0]);
@@ -310,7 +311,7 @@ final class ChromeApplierTest extends TestCase
 
         // Two lines of different length: both should shift by the same offset
         // (based on the widest line, not per-line)
-        $result = $applier->apply(['Long line', 'Hi'], 30, $style, $widget);
+        $result = $applier->apply(new ArrayLineBuffer(['Long line', 'Hi']), 30, $style, $widget)->toArray();
 
         $plain0 = AnsiUtils::stripAnsiCodes($result[0]);
         $plain1 = AnsiUtils::stripAnsiCodes($result[1]);
@@ -332,26 +333,10 @@ final class ChromeApplierTest extends TestCase
         $style = new Style(padding: new Padding(0, 5, 0, 5));
         $longLine = str_repeat('X', 30);
 
-        $result = $applier->apply([$longLine], 20, $style, $widget);
+        $result = $applier->apply(new ArrayLineBuffer([$longLine]), 20, $style, $widget)->toArray();
 
         $this->assertCount(1, $result);
         $this->assertSame(20, AnsiUtils::visibleWidth($result[0]));
-    }
-
-    // ---------------------------------------------------------------
-    // apply: caching
-    // ---------------------------------------------------------------
-
-    public function testApplyReturnsCachedResult()
-    {
-        $applier = $this->createApplier();
-        $widget = new TextWidget('test');
-        $style = new Style(padding: Padding::all(1));
-
-        $result1 = $applier->apply(['Hello'], 20, $style, $widget);
-        $result2 = $applier->apply(['Hello'], 20, $style, $widget);
-
-        $this->assertSame($result1, $result2);
     }
 
     // ---------------------------------------------------------------
@@ -364,7 +349,7 @@ final class ChromeApplierTest extends TestCase
         $widget = new TextWidget('test');
         $style = new Style(padding: Padding::all(1), border: Border::all(1, 'none'));
 
-        $result = $applier->apply(['Text'], 20, $style, $widget);
+        $result = $applier->apply(new ArrayLineBuffer(['Text']), 20, $style, $widget)->toArray();
 
         // 1 border-top + 1 padding-top + 1 content + 1 padding-bottom + 1 border-bottom = 5
         $this->assertCount(5, $result);

--- a/src/Symfony/Component/Tui/Tests/Render/ConcatenatedLineBufferTest.php
+++ b/src/Symfony/Component/Tui/Tests/Render/ConcatenatedLineBufferTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Tests\Render;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Tui\Exception\OutOfBoundsException;
+use Symfony\Component\Tui\Render\ArrayLineBuffer;
+use Symfony\Component\Tui\Render\ConcatenatedLineBuffer;
+
+class ConcatenatedLineBufferTest extends TestCase
+{
+    public function testGetLineThrowsOnOutOfBoundsIndex()
+    {
+        $this->expectException(OutOfBoundsException::class);
+
+        new ConcatenatedLineBuffer([new ArrayLineBuffer(['A'])])->getLine(1);
+    }
+
+    public function testSliceThrowsOnNegativeLength()
+    {
+        $this->expectException(OutOfBoundsException::class);
+
+        new ConcatenatedLineBuffer([new ArrayLineBuffer(['A'])])->slice(0, -1);
+    }
+}

--- a/src/Symfony/Component/Tui/Tests/Render/CountingLineBuffer.php
+++ b/src/Symfony/Component/Tui/Tests/Render/CountingLineBuffer.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Tests\Render;
+
+use Symfony\Component\Tui\Render\LineBufferInterface;
+
+/** @internal */
+final class CountingLineBuffer implements LineBufferInterface
+{
+    private int $readCount = 0;
+
+    public function __construct(private readonly int $lineCount)
+    {
+    }
+
+    public function count(): int
+    {
+        return $this->lineCount;
+    }
+
+    public function getLine(int $index): string
+    {
+        ++$this->readCount;
+
+        return 'transcript '.$index;
+    }
+
+    public function slice(int $offset, int $length): array
+    {
+        $lines = [];
+        for ($i = $offset; $i < min($offset + $length, $this->lineCount); ++$i) {
+            $lines[] = $this->getLine($i);
+        }
+
+        return $lines;
+    }
+
+    public function toArray(): array
+    {
+        return $this->slice(0, $this->lineCount);
+    }
+
+    public function getMaxVisibleWidth(): int
+    {
+        return 20;
+    }
+
+    public function getIterator(): \Traversable
+    {
+        for ($i = 0; $i < $this->lineCount; ++$i) {
+            yield $this->getLine($i);
+        }
+    }
+
+    public function resetReadCount(): void
+    {
+        $this->readCount = 0;
+    }
+
+    public function getReadCount(): int
+    {
+        return $this->readCount;
+    }
+}

--- a/src/Symfony/Component/Tui/Tests/Render/LayoutEngineTest.php
+++ b/src/Symfony/Component/Tui/Tests/Render/LayoutEngineTest.php
@@ -29,7 +29,7 @@ class LayoutEngineTest extends TestCase
         $root = new ContainerWidget();
         $root->add(new TextWidget('Hello'));
 
-        $result = $renderer->render($root, 80, 24);
+        $result = $renderer->renderFrame($root, 80, 24)->toArray();
 
         $this->assertCount(1, $result);
         $this->assertStringContainsString('Hello', $result[0]);
@@ -42,7 +42,7 @@ class LayoutEngineTest extends TestCase
         $root->add(new TextWidget('First'));
         $root->add(new TextWidget('Second'));
 
-        $result = $renderer->render($root, 80, 24);
+        $result = $renderer->renderFrame($root, 80, 24)->toArray();
 
         $this->assertCount(2, $result);
         $this->assertStringContainsString('First', $result[0]);
@@ -57,7 +57,7 @@ class LayoutEngineTest extends TestCase
         $root->add(new TextWidget('First'));
         $root->add(new TextWidget('Second'));
 
-        $result = $renderer->render($root, 80, 24);
+        $result = $renderer->renderFrame($root, 80, 24)->toArray();
 
         $this->assertCount(4, $result);
         $this->assertStringContainsString('First', $result[0]);
@@ -74,7 +74,7 @@ class LayoutEngineTest extends TestCase
         $root->add(new TextWidget('Left'));
         $root->add(new TextWidget('Right'));
 
-        $result = $renderer->render($root, 80, 24);
+        $result = $renderer->renderFrame($root, 80, 24)->toArray();
 
         $this->assertCount(1, $result);
         $this->assertStringContainsString('Left', $result[0]);
@@ -89,7 +89,7 @@ class LayoutEngineTest extends TestCase
         $root->add(new TextWidget('A'));
         $root->add(new TextWidget('B'));
 
-        $result = $renderer->render($root, 80, 24);
+        $result = $renderer->renderFrame($root, 80, 24)->toArray();
 
         $this->assertCount(1, $result);
         // Gap of 4 spaces between the two columns
@@ -116,17 +116,17 @@ class LayoutEngineTest extends TestCase
         $root->add($fill3);
 
         // With 10 rows: 1 for header, 9 remaining for 3 fill children (no remainder)
-        $result = $renderer->render($root, 20, 10);
+        $result = $renderer->renderFrame($root, 20, 10)->toArray();
         $this->assertCount(10, $result);
 
         // With 11 rows: 1 for header, 10 remaining for 3 fill children
         // base=3, extra=1 => first fill gets 4, others get 3 => 1+4+3+3 = 11
-        $result = $renderer->render($root, 20, 11);
+        $result = $renderer->renderFrame($root, 20, 11)->toArray();
         $this->assertCount(11, $result, 'Remainder rows should be distributed to fill children, not lost');
 
         // With 12 rows: 1 for header, 11 remaining for 3 fill children
         // base=3, extra=2 => first two fills get 4, last gets 3 => 1+4+4+3 = 12
-        $result = $renderer->render($root, 20, 12);
+        $result = $renderer->renderFrame($root, 20, 12)->toArray();
         $this->assertCount(12, $result, 'All remainder rows should be distributed across fill children');
     }
 
@@ -148,7 +148,7 @@ class LayoutEngineTest extends TestCase
         $root->add($center);
         $root->add($right);
 
-        $result = $renderer->render($root, 80, 24);
+        $result = $renderer->renderFrame($root, 80, 24)->toArray();
 
         $this->assertCount(1, $result);
         // L starts at position 0, C at position 20, R at position 60
@@ -173,7 +173,7 @@ class LayoutEngineTest extends TestCase
         $root->add($sidebar);
         $root->add($content);
 
-        $result = $renderer->render($root, 80, 24);
+        $result = $renderer->renderFrame($root, 80, 24)->toArray();
 
         $this->assertCount(1, $result);
         // "Menu" is 4 chars; sidebar gets intrinsic width (4)
@@ -198,7 +198,7 @@ class LayoutEngineTest extends TestCase
         $root->add($sidebar);
         $root->add($content);
 
-        $result = $renderer->render($root, 80, 24);
+        $result = $renderer->renderFrame($root, 80, 24)->toArray();
 
         // Text wraps within the 10-column constraint; content starts at column 10
         $this->assertSame('M', $result[0][10]);
@@ -219,7 +219,7 @@ class LayoutEngineTest extends TestCase
         $root->add($left);
         $root->add($right);
 
-        $result = $renderer->render($root, 80, 24);
+        $result = $renderer->renderFrame($root, 80, 24)->toArray();
 
         $this->assertCount(1, $result);
         // Both get equal space: 40 each
@@ -239,7 +239,7 @@ class LayoutEngineTest extends TestCase
         $root->add(new TextWidget('B'));
         $root->add(new TextWidget('C'));
 
-        $result = $renderer->render($root, 90, 24);
+        $result = $renderer->renderFrame($root, 90, 24)->toArray();
 
         $this->assertCount(1, $result);
         // 90 / 3 = 30 each
@@ -263,7 +263,7 @@ class LayoutEngineTest extends TestCase
         $root->add($left);
         $root->add($right);
 
-        $result = $renderer->render($root, 82, 24);
+        $result = $renderer->renderFrame($root, 82, 24)->toArray();
 
         $this->assertCount(1, $result);
         // Available = 82 - 2 gap = 80, each gets 40
@@ -288,7 +288,7 @@ class LayoutEngineTest extends TestCase
         $root->add($sidebar);
         $root->add($content);
 
-        $result = $renderer->render($root, 80, 24);
+        $result = $renderer->renderFrame($root, 80, 24)->toArray();
 
         $this->assertCount(1, $result);
         // "Hi" = 2 chars + 2 pad left + 2 pad right = 6 cols
@@ -310,7 +310,7 @@ class LayoutEngineTest extends TestCase
         $root->add($sidebar);
         $root->add($content);
 
-        $result = $renderer->render($root, 80, 24);
+        $result = $renderer->renderFrame($root, 80, 24)->toArray();
 
         // "Hi" = 2 chars + 1 border left + 1 border right = 4 cols
         // Border chars are multibyte; use mb_substr for character-level position
@@ -333,7 +333,7 @@ class LayoutEngineTest extends TestCase
         $root->add($sidebar);
         $root->add($content);
 
-        $result = $renderer->render($root, 80, 24);
+        $result = $renderer->renderFrame($root, 80, 24)->toArray();
 
         // "Hi" = 2 + 1 border-left + 1 pad-left + 1 pad-right + 1 border-right = 6
         $stripped = AnsiUtils::stripAnsiCodes($result[0]);
@@ -357,7 +357,7 @@ class LayoutEngineTest extends TestCase
         $root->add($main);
         $root->add($aside);
 
-        $result = $renderer->render($root, 80, 24);
+        $result = $renderer->renderFrame($root, 80, 24)->toArray();
 
         $this->assertCount(1, $result);
         // Gap total = 2 * 2 = 4, available = 80 - 4 = 76

--- a/src/Symfony/Component/Tui/Tests/Render/LineBufferDifferTest.php
+++ b/src/Symfony/Component/Tui/Tests/Render/LineBufferDifferTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Tests\Render;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Tui\Render\ArrayLineBuffer;
+use Symfony\Component\Tui\Render\ConcatenatedLineBuffer;
+use Symfony\Component\Tui\Render\LineBufferDiffer;
+
+class LineBufferDifferTest extends TestCase
+{
+    public function testSharedTranscriptIsNotReadWhenFooterChanges()
+    {
+        $transcript = new CountingLineBuffer(100_000);
+        $previous = new ConcatenatedLineBuffer([$transcript, new ArrayLineBuffer(['footer 1'])]);
+        $current = new ConcatenatedLineBuffer([$transcript, new ArrayLineBuffer(['footer 2'])]);
+
+        $this->assertSame(['first' => 100_000, 'last' => 100_000], new LineBufferDiffer()->findChangedRange($current, $previous));
+        $this->assertSame(0, $transcript->getReadCount());
+    }
+
+    /**
+     * @return iterable<string, array{list<string>, list<string>, array{first: int, last: int}|null}>
+     */
+    public static function changedRangeProvider(): iterable
+    {
+        yield 'identical content' => [['A', 'B'], ['A', 'B'], null];
+        yield 'middle lines' => [['A', 'X', 'C', 'Y', 'E'], ['A', 'B', 'C', 'D', 'E'], ['first' => 1, 'last' => 3]];
+        yield 'appended lines' => [['A', 'B', 'C', 'D'], ['A', 'B'], ['first' => 2, 'last' => 3]];
+        yield 'removed middle line' => [['A', 'C', 'D'], ['A', 'B', 'C', 'D'], ['first' => 1, 'last' => 3]];
+    }
+
+    /**
+     * @param list<string>                      $current
+     * @param list<string>                      $previous
+     * @param array{first: int, last: int}|null $expected
+     */
+    #[DataProvider('changedRangeProvider')]
+    public function testFindChangedRange(array $current, array $previous, ?array $expected)
+    {
+        $this->assertSame($expected, new LineBufferDiffer()->findChangedRange(new ArrayLineBuffer($current), new ArrayLineBuffer($previous)));
+    }
+}

--- a/src/Symfony/Component/Tui/Tests/Render/RendererTest.php
+++ b/src/Symfony/Component/Tui/Tests/Render/RendererTest.php
@@ -25,6 +25,7 @@ use Symfony\Component\Tui\Style\Direction;
 use Symfony\Component\Tui\Style\Padding;
 use Symfony\Component\Tui\Style\Style;
 use Symfony\Component\Tui\Style\StyleSheet;
+use Symfony\Component\Tui\Style\TextAlign;
 use Symfony\Component\Tui\Style\VerticalAlign;
 use Symfony\Component\Tui\Widget\AbstractWidget;
 use Symfony\Component\Tui\Widget\ContainerWidget;
@@ -1341,6 +1342,20 @@ class RendererTest extends TestCase
 
         return false;
     }
+
+    public function testStyleChangedDuringBeforeRenderIsApplied()
+    {
+        $styleSheet = new StyleSheet();
+        $styleSheet->addRule('.highlighted', new Style()->withTextAlign(TextAlign::Right));
+
+        $root = new ContainerWidget();
+        $root->add($widget = new RestylingWidget());
+
+        $lines = new Renderer($styleSheet)->renderFrame($root, 10, 3)->toArray();
+
+        $this->assertSame('        hi', $lines[0]);
+        $this->assertTrue($widget->beforeRenderRan);
+    }
 }
 
 /**
@@ -1372,6 +1387,27 @@ class CountingLeafWidget extends AbstractWidget
         ++$this->renderCount;
 
         return ['leaf'];
+    }
+}
+
+/**
+ * Adds a style class from beforeRender(), which the Renderer must observe even
+ * though the container already resolved this widget's style when filtering out
+ * hidden children.
+ */
+class RestylingWidget extends AbstractWidget
+{
+    public bool $beforeRenderRan = false;
+
+    public function beforeRender(): void
+    {
+        $this->beforeRenderRan = true;
+        $this->addStyleClass('highlighted');
+    }
+
+    public function render(RenderContext $context): array
+    {
+        return ['hi'];
     }
 }
 

--- a/src/Symfony/Component/Tui/Tests/Render/RendererTest.php
+++ b/src/Symfony/Component/Tui/Tests/Render/RendererTest.php
@@ -15,6 +15,8 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Tui\Ansi\AnsiUtils;
 use Symfony\Component\Tui\Exception\RenderException;
+use Symfony\Component\Tui\Render\ConcatenatedLineBuffer;
+use Symfony\Component\Tui\Render\LineBufferInterface;
 use Symfony\Component\Tui\Render\RenderContext;
 use Symfony\Component\Tui\Render\Renderer;
 use Symfony\Component\Tui\Style\Align;
@@ -42,9 +44,9 @@ class RendererTest extends TestCase
         $root = new ContainerWidget();
         $root->add($text);
 
-        $before = $renderer->render($root, 40, 10);
+        $before = $renderer->renderFrame($root, 40, 10)->toArray();
         $text->setText('After');
-        $after = $renderer->render($root, 40, 10);
+        $after = $renderer->renderFrame($root, 40, 10)->toArray();
 
         $this->assertNotSame($before, $after);
         $this->assertStringContainsString('Before', $before[0]);
@@ -61,8 +63,8 @@ class RendererTest extends TestCase
         $root = new ContainerWidget();
         $root->add($fill);
 
-        $small = $renderer->render($root, 40, 5);
-        $large = $renderer->render($root, 40, 10);
+        $small = $renderer->renderFrame($root, 40, 5)->toArray();
+        $large = $renderer->renderFrame($root, 40, 10)->toArray();
 
         // The fill child expands differently with different rows
         $this->assertNotSame($small, $large);
@@ -76,10 +78,10 @@ class RendererTest extends TestCase
         $root = new ContainerWidget();
         $root->add(new TextWidget('First'));
 
-        $oneChild = $renderer->render($root, 40, 10);
+        $oneChild = $renderer->renderFrame($root, 40, 10)->toArray();
 
         $root->add(new TextWidget('Second'));
-        $twoChildren = $renderer->render($root, 40, 10);
+        $twoChildren = $renderer->renderFrame($root, 40, 10)->toArray();
 
         $this->assertCount(1, $oneChild);
         $this->assertCount(2, $twoChildren);
@@ -94,10 +96,10 @@ class RendererTest extends TestCase
         $root->add($first);
         $root->add($second);
 
-        $before = $renderer->render($root, 40, 10);
+        $before = $renderer->renderFrame($root, 40, 10)->toArray();
 
         $root->remove($second);
-        $after = $renderer->render($root, 40, 10);
+        $after = $renderer->renderFrame($root, 40, 10)->toArray();
 
         $this->assertCount(2, $before);
         $this->assertCount(1, $after);
@@ -125,7 +127,7 @@ class RendererTest extends TestCase
         $root->add($fill2);
 
         // 10 rows / 2 fill children = 5 each
-        $result = $renderer->render($root, 20, 10);
+        $result = $renderer->renderFrame($root, 20, 10)->toArray();
         $this->assertCount(10, $result);
     }
 
@@ -147,7 +149,7 @@ class RendererTest extends TestCase
         $root->add($fill2);
 
         // 10 rows - 2 gap = 8 remaining, 8 / 2 = 4 each, total = 4 + 2 + 4 = 10
-        $result = $renderer->render($root, 20, 10);
+        $result = $renderer->renderFrame($root, 20, 10)->toArray();
         $this->assertCount(10, $result);
     }
 
@@ -168,7 +170,7 @@ class RendererTest extends TestCase
         $root->add($fill2);
 
         // 11 rows / 2 = 5 base + 1 extra => first gets 6, second gets 5 = 11
-        $result = $renderer->render($root, 20, 11);
+        $result = $renderer->renderFrame($root, 20, 11)->toArray();
         $this->assertCount(11, $result, 'Remainder rows should be distributed');
     }
 
@@ -194,7 +196,7 @@ class RendererTest extends TestCase
         $root->setStyle($style);
         $root->add(new TextWidget('Content'));
 
-        $result = $renderer->render($root, 40, 10);
+        $result = $renderer->renderFrame($root, 40, 10)->toArray();
 
         $this->assertCount($expectedLines, $result);
     }
@@ -206,7 +208,7 @@ class RendererTest extends TestCase
         $root->setStyle(new Style(background: 'red'));
         $root->add(new TextWidget('BG'));
 
-        $result = $renderer->render($root, 20, 10);
+        $result = $renderer->renderFrame($root, 20, 10)->toArray();
 
         // Red background ANSI code (\e[41m) should be in the output
         $this->assertStringContainsString("\x1b[41m", $result[0]);
@@ -221,7 +223,7 @@ class RendererTest extends TestCase
         // Text that would be wider than the inner area
         $root->add(new TextWidget('ABCDEFGHIJKLMNOPQRSTUVWXYZ'));
 
-        $result = $renderer->render($root, 20, 10);
+        $result = $renderer->renderFrame($root, 20, 10)->toArray();
 
         // Inner width = 20 - 10 = 10, text should wrap or be contained
         foreach ($result as $line) {
@@ -245,7 +247,7 @@ class RendererTest extends TestCase
 
         $root->add(new TextWidget('Also visible'));
 
-        $result = $renderer->render($root, 40, 10);
+        $result = $renderer->renderFrame($root, 40, 10)->toArray();
 
         // Only 2 visible children should produce lines
         $this->assertCount(2, $result);
@@ -269,7 +271,7 @@ class RendererTest extends TestCase
 
         $root->add(new TextWidget('Second'));
 
-        $result = $renderer->render($root, 40, 10);
+        $result = $renderer->renderFrame($root, 40, 10)->toArray();
 
         // Only 2 visible children + 1 gap = 3 lines
         $this->assertCount(3, $result);
@@ -282,7 +284,7 @@ class RendererTest extends TestCase
         $root->setStyle(new Style(hidden: true));
         $root->add(new TextWidget('Should not render'));
 
-        $result = $renderer->render($root, 40, 10);
+        $result = $renderer->renderFrame($root, 40, 10)->toArray();
         $this->assertSame([], $result);
     }
 
@@ -303,7 +305,7 @@ class RendererTest extends TestCase
         $child->add($innerText);
         $root->add($child);
 
-        $result = $renderer->render($root, 40, 10);
+        $result = $renderer->renderFrame($root, 40, 10)->toArray();
 
         // The root's blue background (ANSI code \e[44m) should appear in the
         // child's border rows since border segments reset to the outer background
@@ -331,7 +333,7 @@ class RendererTest extends TestCase
         $grandparent->add($parent);
         $parent->add($child);
 
-        $result = $renderer->render($grandparent, 40, 10);
+        $result = $renderer->renderFrame($grandparent, 40, 10)->toArray();
 
         // border-top + content + border-bottom = 3 lines
         $this->assertCount(3, $result);
@@ -363,7 +365,7 @@ class RendererTest extends TestCase
         $outer->add(new TextWidget('Top'));
         $outer->add($inner);
 
-        $result = $renderer->render($outer, 40, 10);
+        $result = $renderer->renderFrame($outer, 40, 10)->toArray();
 
         // Top is on first line, inner's two children on one line
         $this->assertCount(2, $result);
@@ -386,7 +388,7 @@ class RendererTest extends TestCase
 
         $outer->add($inner);
 
-        $result = $renderer->render($outer, 40, 10);
+        $result = $renderer->renderFrame($outer, 40, 10)->toArray();
 
         // Outer: 1 top + 1 bottom padding
         // Inner: 0 top + 0 bottom but 2 left/right padding
@@ -412,7 +414,7 @@ class RendererTest extends TestCase
 
         $outer->add($inner);
 
-        $result = $renderer->render($outer, 40, 10);
+        $result = $renderer->renderFrame($outer, 40, 10)->toArray();
 
         // Outer border top + inner border top + content + inner border bottom + outer border bottom = 5
         $this->assertCount(5, $result);
@@ -434,7 +436,7 @@ class RendererTest extends TestCase
         ));
         $root->add(new TextWidget('X'));
 
-        $result = $renderer->render($root, 10, 10);
+        $result = $renderer->renderFrame($root, 10, 10)->toArray();
 
         // Should render without error, content area is 1 column
         $this->assertStringContainsString('X', implode("\n", $result));
@@ -450,7 +452,7 @@ class RendererTest extends TestCase
         }
 
         // Only 10 rows available but 50 children
-        $result = $renderer->render($root, 40, 10);
+        $result = $renderer->renderFrame($root, 40, 10)->toArray();
 
         // All 50 children still produce lines (no truncation at container level)
         $this->assertCount(50, $result);
@@ -467,7 +469,7 @@ class RendererTest extends TestCase
             $root->add(new TextWidget((string) $i));
         }
 
-        $result = $renderer->render($root, 5, 10);
+        $result = $renderer->renderFrame($root, 5, 10)->toArray();
 
         // Only children 0–4 are rendered (one per column), each 1 column wide
         $visible = AnsiUtils::stripAnsiCodes($result[0]);
@@ -494,7 +496,7 @@ class RendererTest extends TestCase
         $root = new ContainerWidget();
         $root->setStyle($style);
 
-        $result = $renderer->render($root, 20, 10);
+        $result = $renderer->renderFrame($root, 20, 10)->toArray();
 
         $this->assertCount($expectedLines, $result);
     }
@@ -519,7 +521,7 @@ class RendererTest extends TestCase
         $root->add(new TextWidget('B'));
         $root->add(new TextWidget('C'));
 
-        $result = $renderer->render($root, $totalColumns, 10);
+        $result = $renderer->renderFrame($root, $totalColumns, 10)->toArray();
 
         $this->assertCount(1, $result);
         $this->assertSame($totalColumns, AnsiUtils::visibleWidth($result[0]));
@@ -538,7 +540,7 @@ class RendererTest extends TestCase
         $root->add($h1);
         $root->add($h2);
 
-        $result = $renderer->render($root, 40, 10);
+        $result = $renderer->renderFrame($root, 40, 10)->toArray();
         $this->assertSame([], $result);
     }
 
@@ -551,7 +553,7 @@ class RendererTest extends TestCase
         $root = new ContainerWidget();
         $root->add(new TextWidget('Bold text'));
 
-        $result = $renderer->render($root, 40, 10);
+        $result = $renderer->renderFrame($root, 40, 10)->toArray();
 
         // Bold ANSI code should be in the output
         $this->assertStringContainsString("\x1b[1m", $result[0]);
@@ -575,7 +577,7 @@ class RendererTest extends TestCase
         // 'X' * 34 fits exactly one content line
         $root->add(new TextWidget(str_repeat('X', 34)));
 
-        $result = $renderer->render($root, 40, 10);
+        $result = $renderer->renderFrame($root, 40, 10)->toArray();
 
         // Row count: border-top(1) + padding-top(2) + content(1) + padding-bottom(2) + border-bottom(1) = 7
         $this->assertCount(7, $result);
@@ -596,7 +598,7 @@ class RendererTest extends TestCase
 
         // Even with 10x5 viewport and padding=50 each side, padding is clamped
         // so inner content gets at least 1 column and lines don't exceed width
-        $result = $renderer->render($root, 10, 5);
+        $result = $renderer->renderFrame($root, 10, 5)->toArray();
 
         // Content is rendered and no line exceeds the container width
         $this->assertStringContainsString('X', implode('', $result));
@@ -615,7 +617,7 @@ class RendererTest extends TestCase
         $root = new ContainerWidget();
         $root->add(new TextWidget('Hello'));
 
-        $result = $renderer->render($root, 40, 10);
+        $result = $renderer->renderFrame($root, 40, 10)->toArray();
         $rect = $renderer->getWidgetRect($root);
 
         $this->assertSame(0, $rect->row);
@@ -635,7 +637,7 @@ class RendererTest extends TestCase
         $root->add($child2);
         $root->add($child3);
 
-        $renderer->render($root, 40, 10);
+        $renderer->renderFrame($root, 40, 10)->toArray();
 
         $rect1 = $renderer->getWidgetRect($child1);
         $rect2 = $renderer->getWidgetRect($child2);
@@ -662,7 +664,7 @@ class RendererTest extends TestCase
         $root->add($child1);
         $root->add($child2);
 
-        $renderer->render($root, 40, 20);
+        $renderer->renderFrame($root, 40, 20)->toArray();
 
         $rect1 = $renderer->getWidgetRect($child1);
         $rect2 = $renderer->getWidgetRect($child2);
@@ -683,7 +685,7 @@ class RendererTest extends TestCase
         $child = new TextWidget('Inside');
         $root->add($child);
 
-        $renderer->render($root, 40, 20);
+        $renderer->renderFrame($root, 40, 20)->toArray();
 
         $rect = $renderer->getWidgetRect($child);
 
@@ -703,7 +705,7 @@ class RendererTest extends TestCase
         $root->add($child1);
         $root->add($child2);
 
-        $renderer->render($root, 40, 10);
+        $renderer->renderFrame($root, 40, 10)->toArray();
 
         $rect1 = $renderer->getWidgetRect($child1);
         $rect2 = $renderer->getWidgetRect($child2);
@@ -733,7 +735,7 @@ class RendererTest extends TestCase
         $inner->add($leaf);
         $root->add($inner);
 
-        $renderer->render($root, 40, 20);
+        $renderer->renderFrame($root, 40, 20)->toArray();
 
         $innerRect = $renderer->getWidgetRect($inner);
         $leafRect = $renderer->getWidgetRect($leaf);
@@ -753,7 +755,7 @@ class RendererTest extends TestCase
         $root = new ContainerWidget();
         $root->add(new TextWidget('A'));
 
-        $renderer->render($root, 40, 10);
+        $renderer->renderFrame($root, 40, 10)->toArray();
 
         // A widget that was not part of the tree
         $orphan = new TextWidget('Orphan');
@@ -780,7 +782,7 @@ class RendererTest extends TestCase
         $root->add($fillChild);
         $root->add($footer);
 
-        $renderer->render($root, 40, 20);
+        $renderer->renderFrame($root, 40, 20)->toArray();
 
         $fillRect = $renderer->getWidgetRect($fillChild);
         $footerRect = $renderer->getWidgetRect($footer);
@@ -818,7 +820,7 @@ class RendererTest extends TestCase
         $root->add($leftPane);
         $root->add($rightPane);
 
-        $renderer->render($root, 40, 10);
+        $renderer->renderFrame($root, 40, 10)->toArray();
 
         $leftLeafRect = $renderer->getWidgetRect($leftLeaf);
         $rightLeafRect = $renderer->getWidgetRect($rightLeaf);
@@ -854,7 +856,7 @@ class RendererTest extends TestCase
         $root->add($prefix);
         $root->add($row);
 
-        $renderer->render($root, 40, 10);
+        $renderer->renderFrame($root, 40, 10)->toArray();
 
         $leftLeafRect = $renderer->getWidgetRect($leftLeaf);
         $this->assertNotNull($leftLeafRect);
@@ -868,7 +870,7 @@ class RendererTest extends TestCase
         // Shift the row down while the left pane stays cached
         $prefix->setText("First line\nSecond line");
         $rightLeaf->setText('Changed');
-        $renderer->render($root, 40, 10);
+        $renderer->renderFrame($root, 40, 10)->toArray();
 
         $this->assertSame(1, $leftCounter->renderCount);
         $this->assertSame(2, $renderer->getWidgetRect($leftLeaf)->row);
@@ -898,7 +900,7 @@ class RendererTest extends TestCase
         $row->add($shortPane);
         $root->add($row);
 
-        $renderer->render($root, 40, 10);
+        $renderer->renderFrame($root, 40, 10)->toArray();
 
         // shortPane is 1 line centered in 3: floor((3-1)/2) = 1, and its
         // descendant must carry the same cross-axis offset.
@@ -929,7 +931,7 @@ class RendererTest extends TestCase
         $row->add($short);
         $root->add($row);
 
-        $renderer->render($root, 40, 10);
+        $renderer->renderFrame($root, 40, 10)->toArray();
 
         $tallRect = $renderer->getWidgetRect($tall);
         $shortRect = $renderer->getWidgetRect($short);
@@ -959,7 +961,7 @@ class RendererTest extends TestCase
         $root->add($fill);
         $root->add($footer);
 
-        $lines = $renderer->render($root, 40, 10);
+        $lines = $renderer->renderFrame($root, 40, 10)->toArray();
 
         // fill gets 9 rows, footer gets 1 — total must be 10
         $this->assertCount(10, $lines);
@@ -977,7 +979,7 @@ class RendererTest extends TestCase
         $root->add($first);
         $root->add($second);
 
-        $renderer->render($root, 40, 10);
+        $renderer->renderFrame($root, 40, 10)->toArray();
 
         $this->assertSame(1, $first->renderCount);
         $this->assertSame(1, $second->renderCount);
@@ -994,12 +996,12 @@ class RendererTest extends TestCase
         $root->add($prefix);
         $root->add($childParent);
 
-        $renderer->render($root, 40, 10);
+        $renderer->renderFrame($root, 40, 10)->toArray();
         $this->assertSame(2, $childParent->renderCount);
         $this->assertSame(1, $renderer->getWidgetRect($childParent)->row);
 
         $prefix->setText("First line\nSecond line");
-        $renderer->render($root, 40, 10);
+        $renderer->renderFrame($root, 40, 10)->toArray();
 
         $this->assertSame(2, $childParent->renderCount);
         $this->assertSame(2, $renderer->getWidgetRect($childParent)->row);
@@ -1017,11 +1019,11 @@ class RendererTest extends TestCase
         $widget = new CountingLeafWidget();
         $root->add($widget);
 
-        $renderer->render($root, 40, 10);
+        $renderer->renderFrame($root, 40, 10)->toArray();
         $this->assertSame(1, $widget->renderCount);
 
         // Second render with no changes: cache hit, render() not called again
-        $renderer->render($root, 40, 10);
+        $renderer->renderFrame($root, 40, 10)->toArray();
         $this->assertSame(1, $widget->renderCount);
     }
 
@@ -1033,12 +1035,12 @@ class RendererTest extends TestCase
         $widget = new CountingLeafWidget();
         $root->add($widget);
 
-        $renderer->render($root, 40, 10);
+        $renderer->renderFrame($root, 40, 10)->toArray();
         $this->assertSame(1, $widget->renderCount);
 
         // Invalidate the widget: next render must call render() again
         $widget->invalidate();
-        $renderer->render($root, 40, 10);
+        $renderer->renderFrame($root, 40, 10)->toArray();
         $this->assertSame(2, $widget->renderCount);
     }
 
@@ -1050,11 +1052,11 @@ class RendererTest extends TestCase
         $widget = new CountingLeafWidget();
         $root->add($widget);
 
-        $renderer->render($root, 40, 10);
+        $renderer->renderFrame($root, 40, 10)->toArray();
         $this->assertSame(1, $widget->renderCount);
 
         // Different columns: cache miss, render() called again
-        $renderer->render($root, 60, 10);
+        $renderer->renderFrame($root, 60, 10)->toArray();
         $this->assertSame(2, $widget->renderCount);
     }
 
@@ -1068,15 +1070,36 @@ class RendererTest extends TestCase
         $root->add($stable);
         $root->add($changing);
 
-        $renderer->render($root, 40, 10);
+        $renderer->renderFrame($root, 40, 10)->toArray();
         $this->assertSame(1, $stable->renderCount);
         $this->assertSame(1, $changing->renderCount);
 
         // Only invalidate one child: the other should be cached
         $changing->invalidate();
-        $renderer->render($root, 40, 10);
+        $renderer->renderFrame($root, 40, 10)->toArray();
         $this->assertSame(1, $stable->renderCount);
         $this->assertSame(2, $changing->renderCount);
+    }
+
+    public function testVerticalLayoutPreservesUnchangedChildBuffer()
+    {
+        $renderer = new Renderer();
+        $root = new ContainerWidget();
+        $transcript = new ContainerWidget();
+        $transcript->add(new TextWidget("First\nSecond"));
+        $footer = new TextWidget('Footer 1');
+        $root->add($transcript);
+        $root->add($footer);
+
+        $firstFrame = $renderer->renderFrame($root, 40, 10);
+        $transcriptLines = $renderer->renderWidgetLines($transcript, new RenderContext(40, 10));
+
+        $this->assertTrue($this->containsBuffer($firstFrame, $transcriptLines));
+
+        $footer->setText('Footer 2');
+        $nextFrame = $renderer->renderFrame($root, 40, 10);
+
+        $this->assertTrue($this->containsBuffer($nextFrame, $transcriptLines));
     }
 
     public function testRenderCachePreservesCorrectOutput()
@@ -1087,8 +1110,8 @@ class RendererTest extends TestCase
         $widget = new TextWidget('Hello');
         $root->add($widget);
 
-        $first = $renderer->render($root, 40, 10);
-        $second = $renderer->render($root, 40, 10);
+        $first = $renderer->renderFrame($root, 40, 10)->toArray();
+        $second = $renderer->renderFrame($root, 40, 10)->toArray();
 
         $this->assertSame($first, $second);
     }
@@ -1105,14 +1128,14 @@ class RendererTest extends TestCase
         $root->add($inner);
 
         // First render populates positions
-        $renderer->render($root, 40, 20);
+        $renderer->renderFrame($root, 40, 20)->toArray();
         $leafRect = $renderer->getWidgetRect($leaf);
         $this->assertNotNull($leafRect);
         $this->assertSame(1, $leafRect->row);
         $this->assertSame(2, $leafRect->col);
 
         // Second render: inner + leaf unchanged, positions still tracked
-        $renderer->render($root, 40, 20);
+        $renderer->renderFrame($root, 40, 20)->toArray();
         $leafRect2 = $renderer->getWidgetRect($leaf);
         $this->assertNotNull($leafRect2);
         $this->assertSame(1, $leafRect2->row);
@@ -1131,13 +1154,13 @@ class RendererTest extends TestCase
         $root->add($prefix);
         $root->add($inner);
 
-        $renderer->render($root, 40, 20);
+        $renderer->renderFrame($root, 40, 20)->toArray();
         $leafRect = $renderer->getWidgetRect($leaf);
         $this->assertSame(2, $leafRect->row);
         $this->assertSame(2, $leafRect->col);
 
         $prefix->setText("First line\nSecond line");
-        $renderer->render($root, 40, 20);
+        $renderer->renderFrame($root, 40, 20)->toArray();
         $leafRect = $renderer->getWidgetRect($leaf);
         $this->assertSame(3, $leafRect->row);
         $this->assertSame(2, $leafRect->col);
@@ -1159,12 +1182,12 @@ class RendererTest extends TestCase
 
         // 8 remaining rows split 4/4; after the prefix grows, 7 rows split
         // 4/3, so the first fill child keeps its rows (cache hit) but shifts.
-        $renderer->render($root, 40, 9);
+        $renderer->renderFrame($root, 40, 9)->toArray();
         $this->assertSame(1, $leaf->renderCount);
         $this->assertSame(1, $renderer->getWidgetRect($leaf)->row);
 
         $prefix->setText("First line\nSecond line");
-        $renderer->render($root, 40, 9);
+        $renderer->renderFrame($root, 40, 9)->toArray();
 
         $this->assertSame(1, $leaf->renderCount);
         $this->assertSame(2, $renderer->getWidgetRect($leaf)->row);
@@ -1180,11 +1203,11 @@ class RendererTest extends TestCase
         $root->add($prefix);
         $root->add($leaf);
 
-        $renderer->render($root, 20, 5);
+        $renderer->renderFrame($root, 20, 5)->toArray();
         $this->assertSame(14, $renderer->getWidgetRect($leaf)->col);
 
         $prefix->setText('tick 1');
-        $renderer->render($root, 20, 5);
+        $renderer->renderFrame($root, 20, 5)->toArray();
 
         $this->assertSame(14, $renderer->getWidgetRect($leaf)->col);
     }
@@ -1202,16 +1225,33 @@ class RendererTest extends TestCase
         $root->add($inner);
 
         // The prefix fills the width, so nothing is shifted on the first frame.
-        $renderer->render($root, 20, 5);
+        $renderer->renderFrame($root, 20, 5)->toArray();
         $this->assertSame(0, $renderer->getWidgetRect($inner)->col);
         $this->assertSame(0, $renderer->getWidgetRect($leaf)->col);
 
         // Shrinking it introduces an offset while the inner container stays cached.
         $prefix->setText('x');
-        $renderer->render($root, 20, 5);
+        $renderer->renderFrame($root, 20, 5)->toArray();
 
         $this->assertSame(18, $renderer->getWidgetRect($inner)->col);
         $this->assertSame(18, $renderer->getWidgetRect($leaf)->col);
+    }
+
+    public function testAlignmentAccountsForTextAroundImageSequences()
+    {
+        $renderer = new Renderer();
+        $root = new ContainerWidget();
+        $root->setStyle(new Style(align: Align::Right));
+        $root->add(new class extends AbstractWidget {
+            public function render(RenderContext $context): array
+            {
+                return ["a\x1b_Gdata\x1b\\b"];
+            }
+        });
+
+        $lines = $renderer->renderFrame($root, 10, 5)->toArray();
+
+        $this->assertSame(10, AnsiUtils::visibleWidth($lines[0]));
     }
 
     // ---------------------------------------------------------------
@@ -1225,7 +1265,7 @@ class RendererTest extends TestCase
         $root->add(new OverwideWidget(50));
 
         try {
-            $renderer->render($root, 20, 10);
+            $renderer->renderFrame($root, 20, 10)->toArray();
             $this->fail('Expected RenderException');
         } catch (RenderException $e) {
             $this->assertStringContainsString('OverwideWidget', $e->getMessage());
@@ -1256,7 +1296,7 @@ class RendererTest extends TestCase
             $root->add(new TextWidget((string) $i));
         }
 
-        $result = $renderer->render($root, $columns, 10);
+        $result = $renderer->renderFrame($root, $columns, 10)->toArray();
         $this->assertSame($expectedWidth, AnsiUtils::visibleWidth($result[0]));
     }
 
@@ -1277,11 +1317,29 @@ class RendererTest extends TestCase
         }
         $root->add($row);
 
-        $result = $renderer->render($root, 40, 6);
+        $result = $renderer->renderFrame($root, 40, 6)->toArray();
 
         foreach ($result as $line) {
             $this->assertLessThanOrEqual(40, AnsiUtils::visibleWidth($line));
         }
+    }
+
+    private function containsBuffer(LineBufferInterface $buffer, LineBufferInterface $expected): bool
+    {
+        if ($buffer === $expected) {
+            return true;
+        }
+        if (!$buffer instanceof ConcatenatedLineBuffer) {
+            return false;
+        }
+
+        foreach ($buffer->getBuffers() as $child) {
+            if ($this->containsBuffer($child, $expected)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }
 

--- a/src/Symfony/Component/Tui/Tests/Render/ScreenWriterTest.php
+++ b/src/Symfony/Component/Tui/Tests/Render/ScreenWriterTest.php
@@ -15,6 +15,8 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Tui\Ansi\AnsiUtils;
 use Symfony\Component\Tui\Exception\RenderException;
+use Symfony\Component\Tui\Render\ArrayLineBuffer;
+use Symfony\Component\Tui\Render\ConcatenatedLineBuffer;
 use Symfony\Component\Tui\Render\ScreenWriter;
 use Symfony\Component\Tui\Terminal\VirtualTerminal;
 
@@ -34,7 +36,7 @@ class ScreenWriterTest extends TestCase
         $terminal = new VirtualTerminal(80, 24);
         $writer = new ScreenWriter($terminal);
 
-        $writer->writeLines(['Line 1', 'Line 2', 'Line 3']);
+        $writer->writeFrame(new ArrayLineBuffer(['Line 1', 'Line 2', 'Line 3']));
 
         $output = $terminal->getOutput();
 
@@ -59,7 +61,7 @@ class ScreenWriterTest extends TestCase
         $terminal = new VirtualTerminal(80, 24);
         $writer = new ScreenWriter($terminal);
 
-        $writer->writeLines([]);
+        $writer->writeFrame(new ArrayLineBuffer([]));
 
         $output = $terminal->getOutput();
 
@@ -75,12 +77,12 @@ class ScreenWriterTest extends TestCase
         $terminal = new VirtualTerminal(80, 24);
         $writer = new ScreenWriter($terminal);
 
-        $writer->writeLines(['Hello', 'World']);
+        $writer->writeFrame(new ArrayLineBuffer(['Hello', 'World']));
 
         $terminal->clearOutput();
 
         // Write the exact same lines again
-        $writer->writeLines(['Hello', 'World']);
+        $writer->writeFrame(new ArrayLineBuffer(['Hello', 'World']));
 
         $output = $terminal->getOutput();
 
@@ -92,17 +94,34 @@ class ScreenWriterTest extends TestCase
 
     // --- Differential render ---
 
+    public function testFrameDiffDoesNotReadAnUnchangedPrefix()
+    {
+        $terminal = new VirtualTerminal(80, 24);
+        $writer = new ScreenWriter($terminal);
+        $transcript = new CountingLineBuffer(100);
+
+        $writer->writeFrame(new ConcatenatedLineBuffer([$transcript, new ArrayLineBuffer(['footer 1'])]));
+        $transcript->resetReadCount();
+        $terminal->clearOutput();
+
+        $writer->writeFrame(new ConcatenatedLineBuffer([$transcript, new ArrayLineBuffer(['footer 2'])]));
+
+        $this->assertSame(0, $transcript->getReadCount());
+        $this->assertStringContainsString('footer 2', $terminal->getOutput());
+        $this->assertStringNotContainsString('transcript', $terminal->getOutput());
+    }
+
     public function testOnlyChangedLinesAreRewritten()
     {
         $terminal = new VirtualTerminal(80, 24);
         $writer = new ScreenWriter($terminal);
 
-        $writer->writeLines(['Line A', 'Line B', 'Line C']);
+        $writer->writeFrame(new ArrayLineBuffer(['Line A', 'Line B', 'Line C']));
 
         $terminal->clearOutput();
 
         // Change only the middle line
-        $writer->writeLines(['Line A', 'Line X', 'Line C']);
+        $writer->writeFrame(new ArrayLineBuffer(['Line A', 'Line X', 'Line C']));
 
         $output = $terminal->getOutput();
 
@@ -123,12 +142,12 @@ class ScreenWriterTest extends TestCase
         $terminal = new VirtualTerminal(80, 24);
         $writer = new ScreenWriter($terminal);
 
-        $writer->writeLines(['A', 'B', 'C', 'D', 'E']);
+        $writer->writeFrame(new ArrayLineBuffer(['A', 'B', 'C', 'D', 'E']));
 
         $terminal->clearOutput();
 
         // Change lines B and D
-        $writer->writeLines(['A', 'X', 'C', 'Y', 'E']);
+        $writer->writeFrame(new ArrayLineBuffer(['A', 'X', 'C', 'Y', 'E']));
 
         $output = $terminal->getOutput();
 
@@ -145,12 +164,12 @@ class ScreenWriterTest extends TestCase
         $terminal = new VirtualTerminal(80, 24);
         $writer = new ScreenWriter($terminal);
 
-        $writer->writeLines(['Line 1', 'Line 2', 'Line 3', 'Line 4']);
+        $writer->writeFrame(new ArrayLineBuffer(['Line 1', 'Line 2', 'Line 3', 'Line 4']));
 
         $terminal->clearOutput();
 
         // Shrink to 2 lines (same first 2 lines)
-        $writer->writeLines(['Line 1', 'Line 2']);
+        $writer->writeFrame(new ArrayLineBuffer(['Line 1', 'Line 2']));
 
         $output = $terminal->getOutput();
 
@@ -163,12 +182,12 @@ class ScreenWriterTest extends TestCase
         $terminal = new VirtualTerminal(80, 24);
         $writer = new ScreenWriter($terminal);
 
-        $writer->writeLines(['A', 'B', 'C', 'D']);
+        $writer->writeFrame(new ArrayLineBuffer(['A', 'B', 'C', 'D']));
 
         $terminal->clearOutput();
 
         // Change B and remove C,D
-        $writer->writeLines(['A', 'X']);
+        $writer->writeFrame(new ArrayLineBuffer(['A', 'X']));
 
         $output = $terminal->getOutput();
 
@@ -182,13 +201,13 @@ class ScreenWriterTest extends TestCase
         $terminal = new VirtualTerminal(80, 24);
         $writer = new ScreenWriter($terminal);
 
-        $writer->writeLines(['A', 'B', 'C', 'D']);
+        $writer->writeFrame(new ArrayLineBuffer(['A', 'B', 'C', 'D']));
 
         $terminal->clearOutput();
 
         // Removing a middle line shifts the remaining tail upward, so the
         // shifted trailing lines must still be rewritten.
-        $writer->writeLines(['A', 'C', 'D']);
+        $writer->writeFrame(new ArrayLineBuffer(['A', 'C', 'D']));
 
         $output = $terminal->getOutput();
 
@@ -202,12 +221,12 @@ class ScreenWriterTest extends TestCase
         $terminal = new VirtualTerminal(80, 24);
         $writer = new ScreenWriter($terminal);
 
-        $writer->writeLines(['A', 'B', 'C']);
+        $writer->writeFrame(new ArrayLineBuffer(['A', 'B', 'C']));
 
         $terminal->clearOutput();
 
         // Keep the same lines but remove last one
-        $writer->writeLines(['A', 'B']);
+        $writer->writeFrame(new ArrayLineBuffer(['A', 'B']));
 
         $output = $terminal->getOutput();
 
@@ -233,11 +252,11 @@ class ScreenWriterTest extends TestCase
         $terminal = new VirtualTerminal(80, 24);
         $writer = new ScreenWriter($terminal);
 
-        $writer->writeLines($initialLines);
+        $writer->writeFrame(new ArrayLineBuffer($initialLines));
 
         $terminal->clearOutput();
 
-        $writer->writeLines([]);
+        $writer->writeFrame(new ArrayLineBuffer([]));
 
         $output = $terminal->getOutput();
 
@@ -254,13 +273,13 @@ class ScreenWriterTest extends TestCase
         for ($i = 0; $i < 10; ++$i) {
             $lines[] = "Line $i";
         }
-        $writer->writeLines($lines);
+        $writer->writeFrame(new ArrayLineBuffer($lines));
 
         $terminal->clearOutput();
 
         // Shrink to just the first line (unchanged) - all changes are in deleted lines
         // Extra lines (9) exceed terminal height (5), triggering full render
-        $writer->writeLines(['Line 0']);
+        $writer->writeFrame(new ArrayLineBuffer(['Line 0']));
 
         $output = $terminal->getOutput();
 
@@ -275,12 +294,12 @@ class ScreenWriterTest extends TestCase
         $terminal = new VirtualTerminal(80, 24);
         $writer = new ScreenWriter($terminal);
 
-        $writer->writeLines(['A', 'B']);
+        $writer->writeFrame(new ArrayLineBuffer(['A', 'B']));
 
         $terminal->clearOutput();
 
         // Add more lines
-        $writer->writeLines(['A', 'B', 'C', 'D']);
+        $writer->writeFrame(new ArrayLineBuffer(['A', 'B', 'C', 'D']));
 
         $output = $terminal->getOutput();
 
@@ -296,13 +315,13 @@ class ScreenWriterTest extends TestCase
         $terminal = new VirtualTerminal(80, 24);
         $writer = new ScreenWriter($terminal);
 
-        $writer->writeLines(['Hello', 'World']);
+        $writer->writeFrame(new ArrayLineBuffer(['Hello', 'World']));
 
         // Simulate resize
         $terminal->simulateResize(100, 24);
         $terminal->clearOutput();
 
-        $writer->writeLines(['Hello', 'World']);
+        $writer->writeFrame(new ArrayLineBuffer(['Hello', 'World']));
 
         $output = $terminal->getOutput();
 
@@ -320,7 +339,7 @@ class ScreenWriterTest extends TestCase
         $writer = new ScreenWriter($terminal);
 
         $marker = AnsiUtils::cursorMarker();
-        $writer->writeLines(["Hello{$marker}World"]);
+        $writer->writeFrame(new ArrayLineBuffer(["Hello{$marker}World"]));
 
         $output = $terminal->getOutput();
 
@@ -339,7 +358,7 @@ class ScreenWriterTest extends TestCase
 
         $marker = AnsiUtils::cursorMarker();
         // Place cursor at beginning of second line (row 1, col 0)
-        $writer->writeLines(['First line', "{$marker}Second line"]);
+        $writer->writeFrame(new ArrayLineBuffer(['First line', "{$marker}Second line"]));
 
         $output = $terminal->getOutput();
 
@@ -351,6 +370,20 @@ class ScreenWriterTest extends TestCase
         $this->assertStringNotContainsString($marker, $output);
     }
 
+    public function testCursorIsShownWhenContentShrinkMakesItVisible()
+    {
+        $terminal = new VirtualTerminal(80, 2);
+        $writer = new ScreenWriter($terminal);
+        $marker = AnsiUtils::cursorMarker();
+
+        $writer->writeFrame(new ArrayLineBuffer(["{$marker}Cursor", 'Second', 'Third']));
+        $terminal->clearOutput();
+
+        $writer->writeFrame(new ArrayLineBuffer(["{$marker}Cursor", 'Second']));
+
+        $this->assertStringContainsString(self::SHOW_CURSOR, $terminal->getOutput());
+    }
+
     // --- Cursor positioning (hardware cursor moves to correct position) ---
 
     public function testHardwareCursorMovesToCursorPosition()
@@ -360,7 +393,7 @@ class ScreenWriterTest extends TestCase
 
         $marker = AnsiUtils::cursorMarker();
         // Place cursor in the middle of first line (col = 5)
-        $writer->writeLines(["Hello{$marker}World", 'Other']);
+        $writer->writeFrame(new ArrayLineBuffer(["Hello{$marker}World", 'Other']));
 
         $output = $terminal->getOutput();
 
@@ -375,7 +408,7 @@ class ScreenWriterTest extends TestCase
         $terminal = new VirtualTerminal(80, 24);
         $writer = new ScreenWriter($terminal);
 
-        $writer->writeLines(['No cursor here']);
+        $writer->writeFrame(new ArrayLineBuffer(['No cursor here']));
 
         $output = $terminal->getOutput();
 
@@ -406,7 +439,7 @@ class ScreenWriterTest extends TestCase
 
         $marker = AnsiUtils::cursorMarker();
         $line = $hasMarker ? "Hello{$marker}World" : 'No cursor here';
-        $writer->writeLines([$line]);
+        $writer->writeFrame(new ArrayLineBuffer([$line]));
 
         $output = $terminal->getOutput();
 
@@ -436,7 +469,7 @@ class ScreenWriterTest extends TestCase
         $terminal = new VirtualTerminal(80, 24);
         $writer = new ScreenWriter($terminal);
 
-        $writer->writeLines(['Plain text line']);
+        $writer->writeFrame(new ArrayLineBuffer(['Plain text line']));
 
         $output = $terminal->getOutput();
 
@@ -451,7 +484,7 @@ class ScreenWriterTest extends TestCase
         $terminal = new VirtualTerminal(80, 24);
         $writer = new ScreenWriter($terminal);
 
-        $writer->writeLines(["\x1b[31mRed text\x1b[0m"]);
+        $writer->writeFrame(new ArrayLineBuffer(["\x1b[31mRed text\x1b[0m"]));
 
         $output = $terminal->getOutput();
 
@@ -466,7 +499,7 @@ class ScreenWriterTest extends TestCase
         $terminal = new VirtualTerminal(80, 24);
         $writer = new ScreenWriter($terminal);
 
-        $writer->writeLines(["\x1b]8;;https://example.com\x07Link\x1b]8;;\x07"]);
+        $writer->writeFrame(new ArrayLineBuffer(["\x1b]8;;https://example.com\x07Link\x1b]8;;\x07"]));
 
         $output = $terminal->getOutput();
 
@@ -489,7 +522,7 @@ class ScreenWriterTest extends TestCase
         $terminal = new VirtualTerminal(80, 24);
         $writer = new ScreenWriter($terminal);
 
-        $writer->writeLines([$imageLine]);
+        $writer->writeFrame(new ArrayLineBuffer([$imageLine]));
 
         $output = $terminal->getOutput();
 
@@ -504,13 +537,13 @@ class ScreenWriterTest extends TestCase
         $terminal = new VirtualTerminal(80, 24);
         $writer = new ScreenWriter($terminal);
 
-        $writer->writeLines(['First', 'Second']);
+        $writer->writeFrame(new ArrayLineBuffer(['First', 'Second']));
 
         $writer->reset();
         $terminal->clearOutput();
 
         // After reset, even identical lines should trigger a full re-render
-        $writer->writeLines(['First', 'Second']);
+        $writer->writeFrame(new ArrayLineBuffer(['First', 'Second']));
 
         $output = $terminal->getOutput();
 
@@ -525,7 +558,7 @@ class ScreenWriterTest extends TestCase
         $terminal = new VirtualTerminal(80, 24);
         $writer = new ScreenWriter($terminal);
 
-        $writer->writeLines(['A', 'B', 'C']);
+        $writer->writeFrame(new ArrayLineBuffer(['A', 'B', 'C']));
 
         $state = $writer->getState();
         $this->assertSame(3, $state['line_count']);
@@ -545,13 +578,13 @@ class ScreenWriterTest extends TestCase
         $screenWriter = new ScreenWriter($terminal);
 
         // First render: short lines that fit
-        $screenWriter->writeLines(['Hello', 'World']);
+        $screenWriter->writeFrame(new ArrayLineBuffer(['Hello', 'World']));
 
         $terminal->clearOutput();
 
         // Second render triggers differential path with a line that exceeds width
         try {
-            $screenWriter->writeLines(['Hello', str_repeat('X', 30)]);
+            $screenWriter->writeFrame(new ArrayLineBuffer(['Hello', str_repeat('X', 30)]));
             $this->fail('Expected RenderException was not thrown');
         } catch (RenderException $e) {
             $this->assertSame(1, $e->getLineNumber());
@@ -574,11 +607,11 @@ class ScreenWriterTest extends TestCase
         $screenWriter = new ScreenWriter($terminal);
 
         // First render
-        $screenWriter->writeLines(['Hello', 'World']);
+        $screenWriter->writeFrame(new ArrayLineBuffer(['Hello', 'World']));
 
         // Trigger exception with oversized line
         try {
-            $screenWriter->writeLines(['Hello', str_repeat('X', 30)]);
+            $screenWriter->writeFrame(new ArrayLineBuffer(['Hello', str_repeat('X', 30)]));
         } catch (RenderException) {
             // expected
         }
@@ -586,7 +619,7 @@ class ScreenWriterTest extends TestCase
         $terminal->clearOutput();
 
         // ScreenWriter should recover with a full screen-clearing re-render
-        $screenWriter->writeLines(['Hello', 'Fixed']);
+        $screenWriter->writeFrame(new ArrayLineBuffer(['Hello', 'Fixed']));
 
         $output = $terminal->getOutput();
         $this->assertStringContainsString('Fixed', $output);
@@ -600,11 +633,11 @@ class ScreenWriterTest extends TestCase
         $screenWriter = new ScreenWriter($terminal);
 
         // First render
-        $screenWriter->writeLines(['Hello', 'World']);
+        $screenWriter->writeFrame(new ArrayLineBuffer(['Hello', 'World']));
 
         // The first changed line itself is oversized
         try {
-            $screenWriter->writeLines([str_repeat('X', 30), 'World']);
+            $screenWriter->writeFrame(new ArrayLineBuffer([str_repeat('X', 30), 'World']));
             $this->fail('Expected RenderException was not thrown');
         } catch (RenderException $e) {
             $this->assertSame(0, $e->getLineNumber());
@@ -613,7 +646,7 @@ class ScreenWriterTest extends TestCase
         $terminal->clearOutput();
 
         // ScreenWriter should recover with a full screen-clearing re-render
-        $screenWriter->writeLines(['Recovered', 'OK']);
+        $screenWriter->writeFrame(new ArrayLineBuffer(['Recovered', 'OK']));
 
         $output = $terminal->getOutput();
         $this->assertStringContainsString('Recovered', $output);

--- a/src/Symfony/Component/Tui/Tests/Render/TextAlignTest.php
+++ b/src/Symfony/Component/Tui/Tests/Render/TextAlignTest.php
@@ -34,7 +34,7 @@ final class TextAlignTest extends TestCase
         $text->addStyleClass($styleClass);
         $root->add($text);
 
-        $lines = $renderer->render($root, 10, 5);
+        $lines = $renderer->renderFrame($root, 10, 5)->toArray();
 
         $this->assertCount(1, $lines);
         $this->assertSame($expectedVisible, AnsiUtils::stripAnsiCodes($lines[0]));
@@ -61,7 +61,7 @@ final class TextAlignTest extends TestCase
         $text->addStyleClass('pr-1');
         $root->add($text);
 
-        $lines = $renderer->render($root, 10, 5);
+        $lines = $renderer->renderFrame($root, 10, 5)->toArray();
 
         $this->assertCount(1, $lines);
         $visible = AnsiUtils::stripAnsiCodes($lines[0]);
@@ -80,7 +80,7 @@ final class TextAlignTest extends TestCase
         $text->addStyleClass('text-center');
         $root->add($text);
 
-        $lines = $renderer->render($root, 10, 5);
+        $lines = $renderer->renderFrame($root, 10, 5)->toArray();
 
         $this->assertCount(2, $lines);
         $line1 = AnsiUtils::stripAnsiCodes($lines[0]);
@@ -103,7 +103,7 @@ final class TextAlignTest extends TestCase
         $text->addStyleClass('text-red-500');
         $root->add($text);
 
-        $lines = $renderer->render($root, 10, 5);
+        $lines = $renderer->renderFrame($root, 10, 5)->toArray();
 
         $this->assertCount(1, $lines);
         $visible = AnsiUtils::stripAnsiCodes($lines[0]);
@@ -124,7 +124,7 @@ final class TextAlignTest extends TestCase
         $text->addStyleClass('text-center');
         $root->add($text);
 
-        $lines = $renderer->render($root, 20, 5);
+        $lines = $renderer->renderFrame($root, 20, 5)->toArray();
 
         $this->assertCount(3, $lines);
 
@@ -153,7 +153,7 @@ final class TextAlignTest extends TestCase
         $text->addStyleClass('bg-blue-500');
         $root->add($text);
 
-        $lines = $renderer->render($root, 10, 5);
+        $lines = $renderer->renderFrame($root, 10, 5)->toArray();
 
         $this->assertCount(1, $lines);
         $visible = AnsiUtils::stripAnsiCodes($lines[0]);

--- a/src/Symfony/Component/Tui/Tests/TuiTest.php
+++ b/src/Symfony/Component/Tui/Tests/TuiTest.php
@@ -214,7 +214,7 @@ class TuiTest extends TestCase
         $root->add(new TextWidget('This is a longer text that should wrap properly.')->setStyle(Style::padding([0, 1])));
         $root->add(new TextWidget('End'));
 
-        $lines = $renderer->render($root, 40, 24);
+        $lines = $renderer->renderFrame($root, 40, 24)->toArray();
 
         foreach ($lines as $i => $line) {
             $width = AnsiUtils::visibleWidth($line);
@@ -604,7 +604,9 @@ class TuiTest extends TestCase
 
         $received = null;
         $listener = new class($received) {
-            public function __construct(private mixed &$received) {}
+            public function __construct(private mixed &$received)
+            {
+            }
 
             public function __invoke(InputEvent $event): void
             {

--- a/src/Symfony/Component/Tui/Tests/Widget/ContainerTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/ContainerTest.php
@@ -255,7 +255,7 @@ class ContainerTest extends TestCase
             '.spaced' => new Style(gap: 2),
         ]);
         $renderer = new Renderer($stylesheet);
-        $lines = $renderer->render($root, 40, 24);
+        $lines = $renderer->renderFrame($root, 40, 24)->toArray();
 
         // With gap=2: First, 2 empty lines, Second = 4 total
         $this->assertCount(4, $lines);
@@ -277,7 +277,7 @@ class ContainerTest extends TestCase
             '.horizontal' => new Style(direction: Direction::Horizontal),
         ]);
         $renderer = new Renderer($stylesheet);
-        $lines = $renderer->render($root, 40, 24);
+        $lines = $renderer->renderFrame($root, 40, 24)->toArray();
 
         $this->assertCount(1, $lines);
         $this->assertStringContainsString('Left', $lines[0]);
@@ -302,13 +302,13 @@ class ContainerTest extends TestCase
         $renderer = new Renderer($stylesheet);
 
         // Narrow terminal: vertical (2 lines)
-        $lines = $renderer->render($root, 60, 24);
+        $lines = $renderer->renderFrame($root, 60, 24)->toArray();
         $this->assertCount(2, $lines);
         $this->assertStringContainsString('A', $lines[0]);
         $this->assertStringContainsString('B', $lines[1]);
 
         // Wide terminal: horizontal (1 line)
-        $lines = $renderer->render($root, 120, 24);
+        $lines = $renderer->renderFrame($root, 120, 24)->toArray();
         $this->assertCount(1, $lines);
         $this->assertStringContainsString('A', $lines[0]);
         $this->assertStringContainsString('B', $lines[0]);
@@ -342,7 +342,7 @@ class ContainerTest extends TestCase
         $root->add($container);
 
         $renderer = new Renderer($stylesheet);
-        $lines = $renderer->render($root, 40, 24);
+        $lines = $renderer->renderFrame($root, 40, 24)->toArray();
 
         $text = implode("\n", array_map(static fn ($l) => AnsiUtils::stripAnsiCodes($l), $lines));
         $this->assertStringContainsString('Visible', $text);
@@ -362,7 +362,7 @@ class ContainerTest extends TestCase
         $root->add($container);
 
         $renderer = new Renderer();
-        $lines = $renderer->render($root, 40, 24);
+        $lines = $renderer->renderFrame($root, 40, 24)->toArray();
 
         // A + gap + C = 3 lines (no gap for the hidden widget)
         $this->assertCount(3, $lines);
@@ -382,7 +382,7 @@ class ContainerTest extends TestCase
         $root->add($container);
 
         $renderer = new Renderer();
-        $lines = $renderer->render($root, 40, 24);
+        $lines = $renderer->renderFrame($root, 40, 24)->toArray();
 
         // Hidden widget should not take column space: the visible widgets should share the full width
         $this->assertCount(1, $lines);
@@ -415,13 +415,13 @@ class ContainerTest extends TestCase
         $renderer = new Renderer($stylesheet);
 
         // Narrow: both visible
-        $lines = $renderer->render($root, 60, 24);
+        $lines = $renderer->renderFrame($root, 60, 24)->toArray();
         $text = implode("\n", array_map(static fn ($l) => AnsiUtils::stripAnsiCodes($l), $lines));
         $this->assertStringContainsString('Always', $text);
         $this->assertStringContainsString('Mobile Only', $text);
 
         // Wide: hint hidden
-        $lines = $renderer->render($root, 120, 24);
+        $lines = $renderer->renderFrame($root, 120, 24)->toArray();
         $text = implode("\n", array_map(static fn ($l) => AnsiUtils::stripAnsiCodes($l), $lines));
         $this->assertStringContainsString('Always', $text);
         $this->assertStringNotContainsString('Mobile Only', $text);
@@ -440,7 +440,7 @@ class ContainerTest extends TestCase
             '.item' => new Style(hidden: true),
         ]);
         $renderer = new Renderer($stylesheet);
-        $lines = $renderer->render($root, 40, 24);
+        $lines = $renderer->renderFrame($root, 40, 24)->toArray();
 
         $text = implode("\n", array_map(static fn ($l) => AnsiUtils::stripAnsiCodes($l), $lines));
         $this->assertStringContainsString('Visible', $text);
@@ -463,7 +463,7 @@ class ContainerTest extends TestCase
         $root->add($container);
 
         $renderer = new Renderer();
-        $lines = $renderer->render($root, 40, 24);
+        $lines = $renderer->renderFrame($root, 40, 24)->toArray();
 
         $text = implode("\n", array_map(static fn ($l) => AnsiUtils::stripAnsiCodes($l), $lines));
         $this->assertStringContainsString('Before', $text);
@@ -532,7 +532,7 @@ class ContainerTest extends TestCase
         $root->add($outer);
 
         $renderer = new Renderer();
-        $lines = $renderer->render($root, 30, 10);
+        $lines = $renderer->renderFrame($root, 30, 10)->toArray();
 
         $borderLine = $lines[0];
 
@@ -583,7 +583,7 @@ class ContainerTest extends TestCase
         $root->add($container);
         $renderer = new Renderer();
 
-        return $renderer->render($root, $columns, $rows);
+        return $renderer->renderFrame($root, $columns, $rows)->toArray();
     }
 }
 

--- a/src/Symfony/Component/Tui/Tests/Widget/EditorTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/EditorTest.php
@@ -1428,7 +1428,7 @@ class EditorTest extends TestCase
         $root = new ContainerWidget();
         $root->add($editor);
         $editor->invalidate();
-        $result = $renderer->render($root, 50, 15);
+        $result = $renderer->renderFrame($root, 50, 15)->toArray();
         $allContent = implode("\n", $result);
         $this->assertStringNotContainsString('Line 0:', $allContent, 'Scroll offset should advance when cursor moves past visible area with wrapping lines');
 

--- a/src/Symfony/Component/Tui/Tests/Widget/FigletTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/FigletTest.php
@@ -137,7 +137,7 @@ class FigletTest extends TestCase
         $widget = new TextWidget('Ok');
         $root->add($widget);
 
-        $lines = $renderer->render($root, 80, 24);
+        $lines = $renderer->renderFrame($root, 80, 24)->toArray();
 
         // Should render as FIGlet (multi-line), not normal text
         $this->assertCount(6, $lines);
@@ -155,7 +155,7 @@ class FigletTest extends TestCase
         $widget->addStyleClass('title');
         $root->add($widget);
 
-        $lines = $renderer->render($root, 80, 24);
+        $lines = $renderer->renderFrame($root, 80, 24)->toArray();
 
         // Should render as FIGlet
         $this->assertCount(4, $lines);
@@ -171,7 +171,7 @@ class FigletTest extends TestCase
         $widget->addStyleClass('font-small');
         $root->add($widget);
 
-        $lines = $renderer->render($root, 80, 24);
+        $lines = $renderer->renderFrame($root, 80, 24)->toArray();
 
         // Should render as FIGlet
         $this->assertCount(4, $lines);
@@ -190,7 +190,7 @@ class FigletTest extends TestCase
         $widget->setStyle(new Style(font: 'small'));
         $root->add($widget);
 
-        $lines = $renderer->render($root, 80, 24);
+        $lines = $renderer->renderFrame($root, 80, 24)->toArray();
 
         // Render with small font directly for comparison
         $renderer2 = new Renderer(new StyleSheet([
@@ -198,7 +198,7 @@ class FigletTest extends TestCase
         ]));
         $root2 = new ContainerWidget();
         $root2->add(new TextWidget('Hi'));
-        $linesSmall = $renderer2->render($root2, 80, 24);
+        $linesSmall = $renderer2->renderFrame($root2, 80, 24)->toArray();
 
         // Both should use 'small' font, so same line count
         $this->assertCount(\count($linesSmall), $lines);
@@ -216,7 +216,7 @@ class FigletTest extends TestCase
         $widget = new TextWidget('Hi');
         $root->add($widget);
 
-        $lines = $renderer->render($root, 80, 24);
+        $lines = $renderer->renderFrame($root, 80, 24)->toArray();
 
         // Normal text: single line
         $this->assertCount(1, $lines);
@@ -239,7 +239,7 @@ class FigletTest extends TestCase
         $widget->addStyleClass('banner');
         $root->add($widget);
 
-        $lines = $renderer->render($root, 80, 24);
+        $lines = $renderer->renderFrame($root, 80, 24)->toArray();
 
         // Should render as FIGlet using the registered custom font
         $this->assertCount(3, $lines);
@@ -260,7 +260,7 @@ class FigletTest extends TestCase
         $widget->addStyleClass('font-my-title');
         $root->add($widget);
 
-        $lines = $renderer->render($root, 80, 24);
+        $lines = $renderer->renderFrame($root, 80, 24)->toArray();
 
         // Should render as FIGlet
         $this->assertCount(5, $lines);
@@ -273,7 +273,7 @@ class FigletTest extends TestCase
     {
         $renderer = new Renderer();
 
-        return $renderer->renderWidget($widget, new RenderContext($columns, $rows));
+        return $renderer->renderWidgetLines($widget, new RenderContext($columns, $rows))->toArray();
     }
 
     /**
@@ -289,6 +289,6 @@ class FigletTest extends TestCase
         $root = new ContainerWidget();
         $root->add($widget);
 
-        return $renderer->render($root, $columns, $rows);
+        return $renderer->renderFrame($root, $columns, $rows)->toArray();
     }
 }

--- a/src/Symfony/Component/Tui/Tests/Widget/MarkdownTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/MarkdownTest.php
@@ -228,6 +228,6 @@ class MarkdownTest extends TestCase
     {
         $renderer = new Renderer();
 
-        return $renderer->renderWidget($widget, new RenderContext($columns, $rows));
+        return $renderer->renderWidgetLines($widget, new RenderContext($columns, $rows))->toArray();
     }
 }

--- a/src/Symfony/Component/Tui/Tests/Widget/SettingsListTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/SettingsListTest.php
@@ -146,7 +146,7 @@ class SettingsListTest extends TestCase
 
         // Render through the Renderer (which applies chrome)
         $renderer = new Renderer();
-        $lines = $renderer->renderWidget($widget, new RenderContext(60, 20));
+        $lines = $renderer->renderWidgetLines($widget, new RenderContext(60, 20))->toArray();
 
         // The submenu's padding should have been applied by the Renderer.
         // Without the fix, render() would call submenu->render() directly,

--- a/src/Symfony/Component/Tui/Tests/Widget/TextTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/TextTest.php
@@ -230,6 +230,6 @@ class TextTest extends TestCase
     {
         $renderer = new Renderer();
 
-        return $renderer->renderWidget($widget, new RenderContext($columns, $rows));
+        return $renderer->renderWidgetLines($widget, new RenderContext($columns, $rows))->toArray();
     }
 }

--- a/src/Symfony/Component/Tui/Tui.php
+++ b/src/Symfony/Component/Tui/Tui.php
@@ -473,7 +473,7 @@ class Tui implements RenderRequestorInterface, TickRuntimeInterface
             $this->renderRequested = false;
             $columns = $this->terminal->getColumns();
             $rows = $this->terminal->getRows();
-            $this->screenWriter->writeLines($this->renderer->render($this->root, $columns, $rows));
+            $this->screenWriter->writeFrame($this->renderer->renderFrame($this->root, $columns, $rows));
         }
     }
 

--- a/src/Symfony/Component/Tui/Widget/AbstractWidget.php
+++ b/src/Symfony/Component/Tui/Widget/AbstractWidget.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Tui\Widget;
 
 use Symfony\Component\Tui\Event\AbstractEvent;
 use Symfony\Component\Tui\Exception\RenderException;
+use Symfony\Component\Tui\Render\LineBufferInterface;
 use Symfony\Component\Tui\Render\RenderContext;
 use Symfony\Component\Tui\Style\DefaultStyleSheet;
 use Symfony\Component\Tui\Style\Style;
@@ -42,12 +43,11 @@ abstract class AbstractWidget
     /** @var array<class-string<AbstractEvent>, list<callable>> */
     private array $listeners = [];
 
-    // Render cache: stores the last output of Renderer::renderWidget()
+    // Render cache: stores the last output of Renderer::renderWidgetLines()
     // keyed on (renderRevision, columns, rows) so unchanged widgets
     // skip style resolution, layout, chrome, and content rendering.
 
-    /** @var string[]|null */
-    private ?array $renderCacheLines = null;
+    private ?LineBufferInterface $renderCacheLines = null;
     private int $renderCacheRevision = -1;
     private int $renderCacheColumns = -1;
     private int $renderCacheRows = -1;
@@ -310,9 +310,9 @@ abstract class AbstractWidget
      *
      * @internal Used by the Renderer
      *
-     * @return string[]|null Cached lines, or null on miss
+     * @return LineBufferInterface|null Cached lines, or null on miss
      */
-    final public function getRenderCache(int $columns, int $rows): ?array
+    final public function getRenderCache(int $columns, int $rows): ?LineBufferInterface
     {
         if ($this->renderCacheRevision === $this->getRenderRevision()
             && $this->renderCacheColumns === $columns
@@ -328,10 +328,8 @@ abstract class AbstractWidget
      * Store the render output for future cache lookups.
      *
      * @internal Used by the Renderer
-     *
-     * @param string[] $lines
      */
-    final public function setRenderCache(array $lines, int $columns, int $rows): void
+    final public function setRenderCache(LineBufferInterface $lines, int $columns, int $rows): void
     {
         $this->renderCacheLines = $lines;
         $this->renderCacheRevision = $this->getRenderRevision();

--- a/src/Symfony/Component/Tui/Widget/WidgetContext.php
+++ b/src/Symfony/Component/Tui/Widget/WidgetContext.php
@@ -101,7 +101,7 @@ final class WidgetContext
      */
     public function renderWidget(AbstractWidget $widget, RenderContext $context): array
     {
-        return $this->renderer->renderWidget($widget, $context);
+        return $this->renderer->renderWidgetLines($widget, $context)->toArray();
     }
 
     public function scheduleTick(callable $callback, float $intervalSeconds): string


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | not relevant <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | n/a
| License       | MIT

This GREATLY optimize the rendering when we have a large number of lines that don't change while just a few of them change.
