### PR TITLE
[DependencyInjection] Hoist repeated dirname() calls in dumped containers

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -1661,6 +1661,22 @@ class PhpDumper extends Dumper
         }
         $parameters = \sprintf("[\n%s\n%s]", implode("\n", $php), str_repeat(' ', 8));
 
+        $hoistedDirnames = '';
+        if (preg_match_all('/(?<!\\\\)\\\\dirname\(__DIR__, (\d+)\)/', $parameters, $matches)) {
+            $levels = array_count_values($matches[1]);
+            ksort($levels);
+            foreach ($levels as $level => $count) {
+                if (2 > $count) {
+                    continue;
+                }
+                $hoistedDirnames .= \sprintf("        \$dir%d = \\dirname(__DIR__, %d);\n", $level, $level);
+                $parameters = preg_replace(\sprintf('/(?<!\\\\)\\\\dirname\(__DIR__, %d\)/', $level), '\$dir'.$level, $parameters);
+            }
+            if ($hoistedDirnames) {
+                $hoistedDirnames .= "\n";
+            }
+        }
+
         $code = <<<'EOF'
 
                 public function getParameter(string $name): array|bool|string|int|float|\UnitEnum|null
@@ -1765,7 +1781,7 @@ class PhpDumper extends Dumper
 
                 protected function getDefaultParameters(): array
                 {
-                    return $parameters;
+            {$hoistedDirnames}        return $parameters;
                 }
 
             EOF;

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -155,6 +155,7 @@ class PhpDumperTest extends TestCase
         $container->setParameter('bar', __DIR__);
         $container->setParameter('baz', '%bar%/PhpDumperTest.php');
         $container->setParameter('buz', \dirname(__DIR__, 2));
+        $container->setParameter('bux', \dirname(__DIR__, 2).'/foo');
         $container->compile();
 
         $dumper = new PhpDumper($container);

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services12.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services12.php
@@ -94,11 +94,14 @@ class ProjectServiceContainer extends Container
 
     protected function getDefaultParameters(): array
     {
+        $dir2 = \dirname(__DIR__, 2);
+
         return [
             'foo' => ('file://'.\dirname(__DIR__, 1)),
             'bar' => __DIR__,
             'baz' => (__DIR__.'/PhpDumperTest.php'),
-            'buz' => \dirname(__DIR__, 2),
+            'buz' => $dir2,
+            'bux' => ($dir2.'/foo'),
         ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

When a container is dumped with the `file` option, every path-like parameter is exported as a `\dirname(__DIR__, N).'/...'` expression.

In a real-world app (symfony.com, 23 bundles, 98 top-level parameters), the generated `getDefaultParameters()` contains **30** such expressions (25 of level 4, 4 of level 3, 1 of level 6), and the whole container class contains ~272. Since `getDefaultParameters()` runs in the container constructor, those 30 `dirname()` calls execute **on every request**.

### OPcache does not optimize this

One could expect OPcache's SCCP pass to constant-fold `dirname(__DIR__, N)` (both arguments are compile-time constants). **It doesn't**: it resolves `__DIR__` but keeps the call:

```
$ php -d opcache.enable_cli=1 -d opcache.opt_debug_level=0x20000 var/cache/prod/Container*/App_KernelProdContainer.php 2>&1 | grep dirname | head -4

0029 T19 = FRAMELESS_ICALL_2(dirname) string("/path/to/app/var/cache/prod/ContainerXyV8Qew") int(4)
0032 T22 = FRAMELESS_ICALL_2(dirname) string("/path/to/app/var/cache/prod/ContainerXyV8Qew") int(4)
0035 T24 = FRAMELESS_ICALL_2(dirname) string("/path/to/app/var/cache/prod/ContainerXyV8Qew") int(4)
0039 T27 = FRAMELESS_ICALL_2(dirname) string("/path/to/app/var/cache/prod/ContainerXyV8Qew") int(4)
```

Note: `0x20000` dumps opcodes *after* the optimizer; every dirname expression survives as a `FRAMELESS_ICALL` executed at runtime, plus the subsequent string concatenation.

-----

This PR makes `PhpDumper` hoist each `\dirname(__DIR__, N)` expression that appears **2 or more times** in the parameters array into a local variable at the top of the generated method; single occurrences are left inline:

```diff
     protected function getDefaultParameters(): array
     {
+        $dir4 = \dirname(__DIR__, 4);
+
         return [
-            'kernel.project_dir' => \dirname(__DIR__, 4),
+            'kernel.project_dir' => $dir4,
             ...
-                    'path' => (\dirname(__DIR__, 4).'/vendor/doctrine/doctrine-bundle'),
+                    'path' => ($dir4.'/vendor/doctrine/doctrine-bundle'),
```

Note: only `getDefaultParameters()` is touched: it's the only dumped method that runs on every request. The ~240 remaining occurrences live in service factories (executed once per service, only if the service is instantiated, so it's not worth it).
