### PR TITLE
[Cache] Skip stampede protection when not in web mode

### DIFF
--- a/src/Symfony/Component/Cache/CHANGELOG.md
+++ b/src/Symfony/Component/Cache/CHANGELOG.md
@@ -5,6 +5,8 @@ CHANGELOG
 ---
 
  * Add `AbstractAdapter::createAdapter()` to create the adapter matching a connection
+ * Skip stampede protection when not running in web mode, as told by the `APP_RUNTIME_MODE` env var
+ * Add `LockRegistry::setEnabled()` and `LockRegistry::isEnabled()` to control stampede protection
 
 8.0
 ---

--- a/src/Symfony/Component/Cache/LockRegistry.php
+++ b/src/Symfony/Component/Cache/LockRegistry.php
@@ -28,6 +28,7 @@ final class LockRegistry
 {
     private static array $openedFiles = [];
     private static ?array $lockedFiles = null;
+    private static ?bool $enabled = null;
     private static \Exception $signalingException;
     private static \Closure $signalingCallback;
 
@@ -85,11 +86,55 @@ final class LockRegistry
     }
 
     /**
+     * Turns the stampede protection on or off.
+     *
+     * @param bool|null $enabled Null to restore the runtime-mode based behavior
+     *
+     * @return bool The previously effective state
+     */
+    public static function setEnabled(?bool $enabled): bool
+    {
+        $previousState = self::isEnabled();
+        self::$enabled = $enabled;
+
+        return $previousState;
+    }
+
+    /**
+     * Tells whether the stampede protection applies to the running process.
+     *
+     * Unless set explicitly, the protection applies in web mode only, as told by
+     * the "APP_RUNTIME_MODE" env var, defaulting to the current SAPI. Locking in
+     * CLI mode would let long-running commands hold slots of the shared pool and
+     * stall the web requests that hash to the same slots.
+     */
+    public static function isEnabled(): bool
+    {
+        if (null !== self::$enabled) {
+            return self::$enabled;
+        }
+
+        $runtimeMode = $_SERVER['APP_RUNTIME_MODE'] ?? $_ENV['APP_RUNTIME_MODE'] ?? getenv('APP_RUNTIME_MODE');
+
+        if (!\is_string($runtimeMode) || '' === $runtimeMode) {
+            return !\in_array(\PHP_SAPI, ['cli', 'phpdbg', 'embed'], true);
+        }
+
+        parse_str($runtimeMode, $mode);
+
+        return filter_var($mode['web'] ?? false, \FILTER_VALIDATE_BOOL);
+    }
+
+    /**
      * @param-immediately-invoked-callable $callback
      * @param-immediately-invoked-callable $setMetadata
      */
     public static function compute(callable $callback, ItemInterface $item, bool &$save, CacheInterface $pool, ?\Closure $setMetadata = null, ?LoggerInterface $logger = null, ?float $beta = null): mixed
     {
+        if (!self::isEnabled()) {
+            return $callback($item, $save);
+        }
+
         if ('\\' === \DIRECTORY_SEPARATOR && null === self::$lockedFiles) {
             // disable locking on Windows by default
             self::$files = self::$lockedFiles = [];

--- a/src/Symfony/Component/Cache/Tests/LockRegistryTest.php
+++ b/src/Symfony/Component/Cache/Tests/LockRegistryTest.php
@@ -12,10 +12,18 @@
 namespace Symfony\Component\Cache\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Psr\Log\AbstractLogger;
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Cache\LockRegistry;
 
 class LockRegistryTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        LockRegistry::setEnabled(null);
+        unset($_SERVER['APP_RUNTIME_MODE']);
+    }
+
     public function testFiles()
     {
         if ('\\' === \DIRECTORY_SEPARATOR) {
@@ -25,5 +33,72 @@ class LockRegistryTest extends TestCase
         LockRegistry::setFiles($lockFiles);
         $expected = array_map('realpath', glob(__DIR__.'/../Adapter/*.php'));
         $this->assertSame($expected, $lockFiles);
+    }
+
+    public function testDisabledInCliMode()
+    {
+        $this->assertFalse(LockRegistry::isEnabled());
+    }
+
+    public function testEnabledInWebMode()
+    {
+        $_SERVER['APP_RUNTIME_MODE'] = 'web=1&worker=1';
+
+        $this->assertTrue(LockRegistry::isEnabled());
+    }
+
+    public function testDisabledInCliRuntimeMode()
+    {
+        $_SERVER['APP_RUNTIME_MODE'] = 'web=0';
+
+        $this->assertFalse(LockRegistry::isEnabled());
+    }
+
+    public function testSetEnabledOverridesRuntimeMode()
+    {
+        $_SERVER['APP_RUNTIME_MODE'] = 'web=0';
+
+        $this->assertFalse(LockRegistry::setEnabled(true));
+        $this->assertTrue(LockRegistry::isEnabled());
+        $this->assertTrue(LockRegistry::setEnabled(null));
+        $this->assertFalse(LockRegistry::isEnabled());
+    }
+
+    public function testComputeIsNotLockedWhenDisabled()
+    {
+        [$pool, $logger] = $this->createPool();
+
+        $this->assertSame('bar', $pool->get('foo', static fn () => 'bar'));
+        $this->assertSame([], $logger->messages);
+    }
+
+    public function testComputeIsLockedWhenEnabled()
+    {
+        if ('\\' === \DIRECTORY_SEPARATOR) {
+            $this->markTestSkipped('LockRegistry is disabled on Windows');
+        }
+        LockRegistry::setEnabled(true);
+        [$pool, $logger] = $this->createPool();
+
+        $this->assertSame('bar', $pool->get('foo', static fn () => 'bar'));
+        $this->assertSame(['Lock acquired, now computing item "{key}"'], $logger->messages);
+    }
+
+    private function createPool(): array
+    {
+        $logger = new class extends AbstractLogger {
+            public array $messages = [];
+
+            public function log($level, $message, array $context = []): void
+            {
+                $this->messages[] = $message;
+            }
+        };
+
+        $pool = new FilesystemAdapter('lock-registry', 0, sys_get_temp_dir().'/symfony-cache-lock-registry');
+        $pool->clear();
+        $pool->setLogger($logger);
+
+        return [$pool, $logger];
     }
 }

--- a/src/Symfony/Component/Cache/Traits/ContractsTrait.php
+++ b/src/Symfony/Component/Cache/Traits/ContractsTrait.php
@@ -41,13 +41,7 @@ trait ContractsTrait
      */
     public function setCallbackWrapper(?callable $callbackWrapper): callable
     {
-        if (!isset($this->callbackWrapper)) {
-            $this->callbackWrapper = LockRegistry::compute(...);
-
-            if (\in_array(\PHP_SAPI, ['cli', 'phpdbg', 'embed'], true)) {
-                $this->setCallbackWrapper(null);
-            }
-        }
+        $this->callbackWrapper ??= LockRegistry::compute(...);
 
         if (null !== $callbackWrapper && !$callbackWrapper instanceof \Closure) {
             $callbackWrapper = $callbackWrapper(...);
@@ -93,10 +87,6 @@ trait ContractsTrait
 
             $this->computing[$key] = $key;
             $startTime = microtime(true);
-
-            if (!isset($this->callbackWrapper)) {
-                $this->setCallbackWrapper($this->setCallbackWrapper(null));
-            }
 
             try {
                 $value = ($this->callbackWrapper)($callback, $item, $save, $pool, static function (CacheItem $item) use ($setMetadata, $startTime, &$metadata) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

`LockRegistry` protects against cache stampede by serializing the computation of items over a pool of 24 lock files, picked with `crc32($key) % 24`. The pool is shared by every cache key, every pool and every process on the machine, so two unrelated keys can land on the same slot: a callback that takes seconds in one process makes any other process computing a colliding key wait behind it.

That trade is worth it between concurrent web requests, where the whole point is to compute once instead of N times. It is a bad deal for commands and workers: they hold slots for as long as their callbacks run, and the requests that pay for it are the web ones they collide with. [This article](https://jolicode.com/blog/quand-le-cache-de-symfony-ralentit-votre-application) walks through a production case where CLI workers doing DNS resolutions with a 120s TTL were adding seconds of latency to unrelated API endpoints.

So this PR ties the protection to the runtime mode: on in web mode, off otherwise.

The mode is read from `APP_RUNTIME_MODE`, the same env var behind the `kernel.runtime_mode.*` parameters, falling back to the SAPI name exactly like the `container.runtime_mode` parameter does. Reading the env var rather than the SAPI matters for the inverse case too: RoadRunner, Swoole and FrankenPHP workers run under the CLI SAPI while serving web traffic, and they keep the protection as long as their runtime declares `web=1`, which `FrankenPhpWorkerRunner` already does.

`LockRegistry::setEnabled()` overrides the mode either way, and `LockRegistry::isEnabled()` reports the effective state:

```php
LockRegistry::setEnabled(true);  // force the protection on, e.g. in a worker
LockRegistry::setEnabled(false); // force it off
LockRegistry::setEnabled(null);  // back to the runtime mode
```

Two processes computing colliding keys in separate pools, one of them a worker with a 3s callback:

```
before   worker 3.00s | web 2.74s
after    worker 3.00s | web 0.00s
```

CLI was already meant to be out: #44669 disabled the wrapper for the `cli` and `phpdbg` SAPIs back in 4.4, on the same reasoning. It has never taken effect on 6.x and above.

#42025 had landed on 6.0 five months earlier, turning `$callbackWrapper` into a lazily initialized typed property and adding `$this->callbackWrapper ??= ...` in both `setCallbackWrapper()` and `doGet()`. #44669 was written against 4.4, where `doGet()` had no such pre-init, and put its SAPI check in `setCallbackWrapper()` plus a matching lazy init in `doGet()`. The two met in `eb749ec88b7`, the 5.4 into 6.0 merge, the same evening #44669 was merged. They touch different regions of the file, so it auto-merged clean, and the result runs #42025's pre-init first, which leaves the `if (!isset($this->callbackWrapper))` block below unreachable. Since then the opt-out only runs for the callers that wire a wrapper by hand.

Grepping the tags for the two markers:

```
v4.4.49    pre-init no   opt-out yes   live
v5.3.14    pre-init no   opt-out yes   live
v5.4.50    pre-init no   opt-out yes   live
v6.0.19    pre-init yes  opt-out yes   dead
v6.1.0     pre-init yes  opt-out yes   dead
v6.4.0 / 6.4 / 7.4 / 8.1 / 8.2         dead
```

So the 5.x line kept it to end of life, and every 6.x and later release has been locking in CLI.

Doc-wise: the cache stampede page should say the protection applies in web mode only, name `APP_RUNTIME_MODE` as the switch, and mention `LockRegistry::setEnabled()` for the runtimes that serve HTTP from the CLI SAPI without declaring it.
