### PR TITLE
[Cache] Fix stampede protection not being disabled on CLI

### DIFF
--- a/src/Symfony/Component/Cache/Tests/LockRegistryTest.php
+++ b/src/Symfony/Component/Cache/Tests/LockRegistryTest.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\Cache\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Psr\Log\AbstractLogger;
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Cache\LockRegistry;
 
 class LockRegistryTest extends TestCase
@@ -25,5 +27,24 @@ class LockRegistryTest extends TestCase
         LockRegistry::setFiles($lockFiles);
         $expected = array_map('realpath', glob(__DIR__.'/../Adapter/*.php'));
         $this->assertSame($expected, $lockFiles);
+    }
+
+    public function testLockIsDisabledOnCli()
+    {
+        $logger = new class extends AbstractLogger {
+            public array $messages = [];
+
+            public function log($level, $message, array $context = []): void
+            {
+                $this->messages[] = $message;
+            }
+        };
+
+        $pool = new FilesystemAdapter('lock-registry', 0, sys_get_temp_dir().'/symfony-cache-lock-registry');
+        $pool->clear();
+        $pool->setLogger($logger);
+
+        $this->assertSame('bar', $pool->get('foo', static fn () => 'bar'));
+        $this->assertSame([], $logger->messages);
     }
 }

--- a/src/Symfony/Component/Cache/Traits/ContractsTrait.php
+++ b/src/Symfony/Component/Cache/Traits/ContractsTrait.php
@@ -80,8 +80,6 @@ trait ContractsTrait
             CacheItem::class
         );
 
-        $this->callbackWrapper ??= LockRegistry::compute(...);
-
         return $this->contractsGet($pool, $key, function (CacheItem $item, bool &$save) use ($pool, $callback, $setMetadata, &$metadata, $key, $beta) {
             // don't wrap nor save recursive calls
             if (isset($this->computing[$key])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

#44669 disabled the `LockRegistry` wrapper for the `cli` and `phpdbg` SAPIs, so that commands and workers stop holding slots of the 24-file lock pool and stalling the web requests whose keys hash to the same slot. That check has never run on 6.x and later.

#42025 had landed on 6.0 five months earlier, turning `$callbackWrapper` into a lazily initialized typed property and adding `$this->callbackWrapper ??= ...` in both `setCallbackWrapper()` and `doGet()`. #44669 was written against 4.4, where `doGet()` had no such pre-init, and put its SAPI check inside `setCallbackWrapper()` plus a matching lazy init in `doGet()`. The two met in `eb749ec88b7`, the 5.4 into 6.0 merge, the same evening #44669 was merged. They sit in different parts of the file, so it auto-merged clean, and the result runs #42025's pre-init first, which leaves the `if (!isset($this->callbackWrapper))` block below unreachable.

Grepping the tags for the two markers:

```
v4.4.49    pre-init no   opt-out yes   live
v5.3.14    pre-init no   opt-out yes   live
v5.4.50    pre-init no   opt-out yes   live
v6.0.19    pre-init yes  opt-out yes   dead
v6.1.0     pre-init yes  opt-out yes   dead
v6.4.0 / 6.4 / 7.4 / 8.1 / 8.2         dead
```

So the 5.x line kept the behavior to end of life, and every 6.x and later release has been taking the lock in CLI.

Dropping the pre-init line is enough: `doGet()` then initializes the wrapper through `setCallbackWrapper()`, which honors the SAPI check, exactly as #44669 intended. Nothing else reads the property, both entry points initialize it lazily, and `EarlyExpirationDispatcher` has its own.

The added test fails on 6.4 today with `Lock acquired, now computing item "{key}"` logged for a plain `->get()` under the CLI SAPI.
