### PR TITLE
[FrameworkBundle] Tolerate a newer DependencyInjection `InstanceofType` shape in the reference fixture

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/reference.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/reference.php
@@ -51,7 +51,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     shared?: bool,
  *     lazy?: bool|string,
  *     public?: bool,
- *     properties?: array<string, mixed>,
+ *%A   properties?: array<string, mixed>,
  *     configurator?: CallbackType,
  *     calls?: list<CallType>,
  *     tags?: TagsType,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`PhpConfigReferenceDumpPassTest` compares the generated reference against a fixture, but the FrameworkBundle low-deps and high-deps jobs install `symfony/dependency-injection` from packagist, so the file is generated from a released `AppReference` while the fixture is written against the local one. Any key added to a shape in the meantime turns those two jobs red on the PR that adds it.

`DefinitionType` already handles this: `decorates_tag` sits behind a `%A` since 892ae1de3cd. `InstanceofType` does not, and #60589 adds a `factory` key there. Same treatment, so the branch that adds the key does not have to carry the fixture workaround.
