### PR TITLE
[Serializer] Enforce the element type of scalar collections

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -579,11 +579,13 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                         $context['key_type'] = $collectionKeyType;
                         $context['value_type'] = $collectionValueType;
                     } elseif (\is_array($data) && $collectionValueBaseType instanceof BuiltinType && \in_array($collectionValueBaseType->getTypeIdentifier(), [TypeIdentifier::BOOL, TypeIdentifier::FLOAT, TypeIdentifier::INT, TypeIdentifier::STRING], true)) {
-                        // elements of a scalar collection are converted with the very same rules as any other value
+                        // elements of a scalar collection are converted and enforced with the very same rules as any other value
                         $result = [];
                         $childContext = null;
                         $valueTypeIdentifier = $collectionValueBaseType->getTypeIdentifier();
                         $valueIsNullable = $collectionValueType->isNullable();
+                        // a union that still has another viable member must fail over to it instead of reporting elements
+                        $collectElementErrors = isset($context['not_normalizable_value_exceptions']) && 1 === \count(array_filter($types, static fn (Type $t) => !$t->isIdentifiedBy(TypeIdentifier::NULL)));
 
                         foreach ($data as $key => $value) {
                             // values that already have the expected type are the common case, keep them as is
@@ -603,9 +605,13 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                             try {
                                 // the wrapped type is passed on so that a nullable element type keeps accepting null
                                 $result[$key] = $this->validateAndDenormalize($collectionValueType, $currentClass, $attribute, $value, $format, $childContext);
-                            } catch (NotNormalizableValueException) {
-                                // elements that cannot be converted are left untouched, as they have always been
-                                $result[$key] = $value;
+                            } catch (NotNormalizableValueException $exception) {
+                                if (!$collectElementErrors) {
+                                    throw $exception;
+                                }
+
+                                // report every offending element, the way nested objects already do
+                                $context['not_normalizable_value_exceptions'][] = $exception;
                             }
                         }
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
@@ -31,6 +31,7 @@ use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Exception\LogicException;
 use Symfony\Component\Serializer\Exception\MissingConstructorArgumentsException;
 use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
+use Symfony\Component\Serializer\Exception\PartialDenormalizationException;
 use Symfony\Component\Serializer\Mapping\ClassDiscriminatorFromClassMetadata;
 use Symfony\Component\Serializer\Mapping\ClassDiscriminatorMapping;
 use Symfony\Component\Serializer\Mapping\ClassDiscriminatorResolverInterface;
@@ -1463,13 +1464,52 @@ class AbstractObjectNormalizerTest extends TestCase
         $this->assertSame([1, 2], $dummy->ints);
     }
 
-    public function testDenormalizeLeavesUnconvertibleScalarCollectionElementsUntouched()
+    public function testDenormalizeEnforcesScalarCollectionElementType()
     {
         $normalizer = new AbstractObjectNormalizerWithMetadataAndPropertyTypeExtractors();
 
-        $dummy = $normalizer->denormalize(['ints' => [1, 'nope', ['a' => 1]]], ScalarCollectionsDummy::class, null, [AbstractObjectNormalizer::ENABLE_TYPE_CONVERSION => true]);
+        try {
+            $normalizer->denormalize(['ints' => [1, 'nope']], ScalarCollectionsDummy::class, null, [AbstractObjectNormalizer::ENABLE_TYPE_CONVERSION => true]);
+            $this->fail(\sprintf('A "%s" should have been thrown.', NotNormalizableValueException::class));
+        } catch (NotNormalizableValueException $e) {
+            $this->assertSame('The type of the "ints" attribute for class "'.ScalarCollectionsDummy::class.'" must be int ("nope" given).', $e->getMessage());
+            $this->assertSame('ints[1]', $e->getPath());
+        }
+    }
 
-        $this->assertSame([1, 'nope', ['a' => 1]], $dummy->ints);
+    public function testDenormalizeCollectsScalarCollectionElementErrors()
+    {
+        $serializer = new Serializer([new AbstractObjectNormalizerWithMetadataAndPropertyTypeExtractors()]);
+
+        try {
+            $serializer->denormalize(['ints' => ['nope', 2, ['a' => 1]]], ScalarCollectionsDummy::class, null, [
+                DenormalizerInterface::COLLECT_DENORMALIZATION_ERRORS => true,
+            ]);
+            $this->fail(\sprintf('A "%s" should have been thrown.', PartialDenormalizationException::class));
+        } catch (PartialDenormalizationException $e) {
+            $this->assertSame(['ints[0]', 'ints[2]'], array_map(static fn (NotNormalizableValueException $e) => $e->getPath(), $e->getNotNormalizableValueErrors()));
+            $this->assertSame([1 => 2], $e->getData()->ints);
+        }
+    }
+
+    public function testDenormalizeCollectingErrorsKeepsUnionCollectionFallback()
+    {
+        $serializer = new Serializer([new AbstractObjectNormalizerWithMetadataAndPropertyTypeExtractors()]);
+
+        $dummy = $serializer->denormalize(['intsOrStrings' => ['nope']], ScalarCollectionsDummy::class, null, [DenormalizerInterface::COLLECT_DENORMALIZATION_ERRORS => true]);
+
+        $this->assertSame(['nope'], $dummy->intsOrStrings);
+    }
+
+    public function testDenormalizeKeepsScalarCollectionElementsWhenTypeEnforcementIsDisabled()
+    {
+        $normalizer = new AbstractObjectNormalizerWithMetadataAndPropertyTypeExtractors();
+
+        $dummy = $normalizer->denormalize(['ints' => [1, 'nope']], ScalarCollectionsDummy::class, null, [
+            AbstractObjectNormalizer::DISABLE_TYPE_ENFORCEMENT => true,
+        ]);
+
+        $this->assertSame([1, 'nope'], $dummy->ints);
     }
 
     public function testDenormalizeCollectionOfUnionTypesPropertyWithPhpDocExtractor()
@@ -2247,6 +2287,9 @@ class ScalarCollectionsDummy
 
     /** @var array<string, bool> */
     public array $bools = [];
+
+    /** @var int[]|string[] */
+    public array $intsOrStrings = [];
 }
 
 class UnionCollectionDocBlockDummy


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65289, Fix #53490
| License       | MIT

Follow-up to #62352, which made the elements of a scalar collection go through `validateAndDenormalize()` so that they are converted, but swallowed the failures to keep the previous behaviour. This stops swallowing them.

Today a value that is rejected on a plain property is silently accepted inside a collection of the same type:

```php
class Dto {
    /** @var int[] */ public array $ids = [];
    public int $one = 0;
}

$serializer->denormalize(['one' => 'nope'], Dto::class);
// NotNormalizableValueException: the type of the "one" attribute must be one of "int" ("string" given)

$serializer->denormalize(['ids' => ['nope']], Dto::class);
// no error, $ids === ['nope']
```

This aligns scalar collections with plain scalar properties, which is the closest comparable. Note that object and union-typed collections do not enforce their element type either: `array<Inner>` turns both `'nope'` and `42` into an `Inner` with default values, and `array<int|string>` accepts `5.5` and `['a' => 1]`. Those are separate gaps, not precedents.

It also closes #53490 properly. That report deserializes `{"values":["1","2","3"]}` into `array<int>` over JSON and gets strings back. With #62352 alone it still gets strings, because JSON does not convert without `ENABLE_TYPE_CONVERSION`, exactly as a plain `int` property does not. With this PR it gets a `NotNormalizableValueException` naming the offending path instead of silently wrong data, which is the answer the component gives everywhere else.

Errors are collected per element rather than aborting at the first one, matching what nested objects already do:

```php
$serializer->denormalize(['ints' => ['nope', 2, ['a' => 1]]], Dto::class, null, [
    DenormalizerInterface::COLLECT_DENORMALIZATION_ERRORS => true,
]);

// ints[0]  must be one of "int" ("string" given)
// ints[2]  must be one of "int" ("array" given)
// getData()->ints === [1 => 2]
```

`DISABLE_TYPE_ENFORCEMENT` still keeps the values untouched, so applications that want the previous leniency have it, and a test pins that.

No deprecation. There is nothing to opt into: the remedy is to enable the conversion, fix the payload, or widen the declared type, all available today. See #65289 for the discussion.