### PR TITLE
[Mailer] Add `TrackingHeader` for per-message open/click tracking across bridges

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/AhaSend/Tests/Transport/AhaSendApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/AhaSend/Tests/Transport/AhaSendApiTransportTest.php
@@ -20,6 +20,7 @@ use Symfony\Component\Mailer\Bridge\AhaSend\Event\AhaSendDeliveryEvent;
 use Symfony\Component\Mailer\Bridge\AhaSend\Transport\AhaSendApiTransport;
 use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Header\TagHeader;
+use Symfony\Component\Mailer\Header\TrackingHeader;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
 use Symfony\Component\Mime\Part\DataPart;
@@ -301,5 +302,26 @@ class AhaSendApiTransportTest extends TestCase
         $this->assertArrayHasKey('base64', $payload['content']['attachments'][0]);
 
         $this->assertFalse($payload['content']['attachments'][0]['base64']);
+    }
+
+    public function testTrackingHeader()
+    {
+        $transport = new AhaSendApiTransport('ACCESS_KEY');
+        $method = new \ReflectionMethod(AhaSendApiTransport::class, 'getPayload');
+        $envelope = new Envelope(new Address('from@example.com'), [new Address('to@example.com')]);
+
+        $enabled = new Email();
+        $enabled->getHeaders()->add(new TrackingHeader(true));
+        $enabledPayload = $method->invoke($transport, $enabled, $envelope);
+        $this->assertTrue($enabledPayload['tracking']['open']);
+        $this->assertTrue($enabledPayload['tracking']['click']);
+        $this->assertArrayNotHasKey('headers', $enabledPayload['content']);
+
+        $disabled = new Email();
+        $disabled->getHeaders()->add(new TrackingHeader(false));
+        $disabledPayload = $method->invoke($transport, $disabled, $envelope);
+        $this->assertFalse($disabledPayload['tracking']['open']);
+        $this->assertFalse($disabledPayload['tracking']['click']);
+        $this->assertArrayNotHasKey('headers', $disabledPayload['content']);
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/AhaSend/Tests/Transport/AhaSendApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/AhaSend/Tests/Transport/AhaSendApiTransportTest.php
@@ -311,17 +311,31 @@ class AhaSendApiTransportTest extends TestCase
         $envelope = new Envelope(new Address('from@example.com'), [new Address('to@example.com')]);
 
         $enabled = new Email();
-        $enabled->getHeaders()->add(new TrackingHeader(true));
+        $enabled->getHeaders()->add(new TrackingHeader(opens: true, clicks: true));
         $enabledPayload = $method->invoke($transport, $enabled, $envelope);
         $this->assertTrue($enabledPayload['tracking']['open']);
         $this->assertTrue($enabledPayload['tracking']['click']);
         $this->assertArrayNotHasKey('headers', $enabledPayload['content']);
 
         $disabled = new Email();
-        $disabled->getHeaders()->add(new TrackingHeader(false));
+        $disabled->getHeaders()->add(new TrackingHeader(opens: false, clicks: false));
         $disabledPayload = $method->invoke($transport, $disabled, $envelope);
         $this->assertFalse($disabledPayload['tracking']['open']);
         $this->assertFalse($disabledPayload['tracking']['click']);
         $this->assertArrayNotHasKey('headers', $disabledPayload['content']);
+    }
+
+    public function testTrackingHeaderControlsOpensAndClicksIndependently()
+    {
+        $transport = new AhaSendApiTransport('ACCESS_KEY');
+        $method = new \ReflectionMethod(AhaSendApiTransport::class, 'getPayload');
+        $envelope = new Envelope(new Address('from@example.com'), [new Address('to@example.com')]);
+
+        $email = new Email();
+        $email->getHeaders()->add(new TrackingHeader(opens: false));
+        $payload = $method->invoke($transport, $email, $envelope);
+
+        $this->assertFalse($payload['tracking']['open']);
+        $this->assertArrayNotHasKey('click', $payload['tracking']);
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/AhaSend/Tests/Transport/AhaSendSmtpTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/AhaSend/Tests/Transport/AhaSendSmtpTransportTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Mailer\Bridge\AhaSend\Tests\Transport;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Mailer\Bridge\AhaSend\Transport\AhaSendSmtpTransport;
 use Symfony\Component\Mailer\Header\TagHeader;
+use Symfony\Component\Mailer\Header\TrackingHeader;
 use Symfony\Component\Mime\Email;
 
 class AhaSendSmtpTransportTest extends TestCase
@@ -43,5 +44,23 @@ class AhaSendSmtpTransportTest extends TestCase
         $method->invoke($transport, $email);
         $headers = $email->getHeaders();
         $this->assertSame('AhaSend-Tags: tag1,tag2', $email->getHeaders()->get('AhaSend-Tags')->toString());
+    }
+
+    public function testTrackingHeader()
+    {
+        $transport = new AhaSendSmtpTransport('USERNAME', 'PASSWORD');
+        $method = new \ReflectionMethod(AhaSendSmtpTransport::class, 'addAhaSendHeaders');
+
+        $enabled = new Email();
+        $enabled->getHeaders()->add(new TrackingHeader(true));
+        $method->invoke($transport, $enabled);
+        $this->assertSame('AhaSend-Track-Opens: true', $enabled->getHeaders()->get('AhaSend-Track-Opens')->toString());
+        $this->assertSame('AhaSend-Track-Clicks: true', $enabled->getHeaders()->get('AhaSend-Track-Clicks')->toString());
+
+        $disabled = new Email();
+        $disabled->getHeaders()->add(new TrackingHeader(false));
+        $method->invoke($transport, $disabled);
+        $this->assertSame('AhaSend-Track-Opens: false', $disabled->getHeaders()->get('AhaSend-Track-Opens')->toString());
+        $this->assertSame('AhaSend-Track-Clicks: false', $disabled->getHeaders()->get('AhaSend-Track-Clicks')->toString());
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/AhaSend/Tests/Transport/AhaSendSmtpTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/AhaSend/Tests/Transport/AhaSendSmtpTransportTest.php
@@ -52,15 +52,28 @@ class AhaSendSmtpTransportTest extends TestCase
         $method = new \ReflectionMethod(AhaSendSmtpTransport::class, 'addAhaSendHeaders');
 
         $enabled = new Email();
-        $enabled->getHeaders()->add(new TrackingHeader(true));
+        $enabled->getHeaders()->add(new TrackingHeader(opens: true, clicks: true));
         $method->invoke($transport, $enabled);
         $this->assertSame('AhaSend-Track-Opens: true', $enabled->getHeaders()->get('AhaSend-Track-Opens')->toString());
         $this->assertSame('AhaSend-Track-Clicks: true', $enabled->getHeaders()->get('AhaSend-Track-Clicks')->toString());
 
         $disabled = new Email();
-        $disabled->getHeaders()->add(new TrackingHeader(false));
+        $disabled->getHeaders()->add(new TrackingHeader(opens: false, clicks: false));
         $method->invoke($transport, $disabled);
         $this->assertSame('AhaSend-Track-Opens: false', $disabled->getHeaders()->get('AhaSend-Track-Opens')->toString());
         $this->assertSame('AhaSend-Track-Clicks: false', $disabled->getHeaders()->get('AhaSend-Track-Clicks')->toString());
+    }
+
+    public function testTrackingHeaderControlsOpensAndClicksIndependently()
+    {
+        $transport = new AhaSendSmtpTransport('USERNAME', 'PASSWORD');
+        $method = new \ReflectionMethod(AhaSendSmtpTransport::class, 'addAhaSendHeaders');
+
+        $email = new Email();
+        $email->getHeaders()->add(new TrackingHeader(clicks: false));
+        $method->invoke($transport, $email);
+
+        $this->assertNull($email->getHeaders()->get('AhaSend-Track-Opens'));
+        $this->assertSame('AhaSend-Track-Clicks: false', $email->getHeaders()->get('AhaSend-Track-Clicks')->toString());
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/AhaSend/Transport/AhaSendApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/AhaSend/Transport/AhaSendApiTransport.php
@@ -103,14 +103,14 @@ final class AhaSendApiTransport extends AbstractApiTransport
             ],
         ];
 
-        foreach ($email->getHeaders()->all() as $name => $header) {
+        foreach ($email->getHeaders()->all() as $header) {
             if ($header instanceof TrackingHeader) {
-                $track = 'true' === $header->getValue();
-
-                $payload['tracking'] = [
-                    'open' => $track,
-                    'click' => $track,
-                ];
+                if (null !== $header->getOpens()) {
+                    $payload['tracking']['open'] = $header->getOpens();
+                }
+                if (null !== $header->getClicks()) {
+                    $payload['tracking']['click'] = $header->getClicks();
+                }
             }
         }
 

--- a/src/Symfony/Component/Mailer/Bridge/AhaSend/Transport/AhaSendApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/AhaSend/Transport/AhaSendApiTransport.php
@@ -17,6 +17,7 @@ use Symfony\Component\Mailer\Bridge\AhaSend\Event\AhaSendDeliveryEvent;
 use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Exception\HttpTransportException;
 use Symfony\Component\Mailer\Header\TagHeader;
+use Symfony\Component\Mailer\Header\TrackingHeader;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\AbstractApiTransport;
 use Symfony\Component\Mime\Address;
@@ -102,6 +103,17 @@ final class AhaSendApiTransport extends AbstractApiTransport
             ],
         ];
 
+        foreach ($email->getHeaders()->all() as $name => $header) {
+            if ($header instanceof TrackingHeader) {
+                $track = 'true' === $header->getValue();
+
+                $payload['tracking'] = [
+                    'open' => $track,
+                    'click' => $track,
+                ];
+            }
+        }
+
         $text = $email->getTextBody();
         if (!empty($text)) {
             $payload['content']['text_body'] = $text;
@@ -142,6 +154,10 @@ final class AhaSendApiTransport extends AbstractApiTransport
 
             if ($header instanceof TagHeader) {
                 $tags[] = $header->getValue();
+                continue;
+            }
+
+            if ($header instanceof TrackingHeader) {
                 continue;
             }
 

--- a/src/Symfony/Component/Mailer/Bridge/AhaSend/Transport/AhaSendSmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/AhaSend/Transport/AhaSendSmtpTransport.php
@@ -15,6 +15,7 @@ use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Header\TagHeader;
+use Symfony\Component\Mailer\Header\TrackingHeader;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport;
 use Symfony\Component\Mime\Message;
@@ -50,6 +51,14 @@ class AhaSendSmtpTransport extends EsmtpTransport
         foreach ($headers->all() as $name => $header) {
             if ($header instanceof TagHeader) {
                 $tags[] = $header->getValue();
+                $headers->remove($name);
+            }
+
+            if ($header instanceof TrackingHeader) {
+                $track = 'true' === $header->getValue();
+
+                $headers->addTextHeader('AhaSend-Track-Opens', $track ? 'true' : 'false');
+                $headers->addTextHeader('AhaSend-Track-Clicks', $track ? 'true' : 'false');
                 $headers->remove($name);
             }
         }

--- a/src/Symfony/Component/Mailer/Bridge/AhaSend/Transport/AhaSendSmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/AhaSend/Transport/AhaSendSmtpTransport.php
@@ -55,10 +55,12 @@ class AhaSendSmtpTransport extends EsmtpTransport
             }
 
             if ($header instanceof TrackingHeader) {
-                $track = 'true' === $header->getValue();
-
-                $headers->addTextHeader('AhaSend-Track-Opens', $track ? 'true' : 'false');
-                $headers->addTextHeader('AhaSend-Track-Clicks', $track ? 'true' : 'false');
+                if (null !== $header->getOpens()) {
+                    $headers->addTextHeader('AhaSend-Track-Opens', $header->getOpens() ? 'true' : 'false');
+                }
+                if (null !== $header->getClicks()) {
+                    $headers->addTextHeader('AhaSend-Track-Clicks', $header->getClicks() ? 'true' : 'false');
+                }
                 $headers->remove($name);
             }
         }

--- a/src/Symfony/Component/Mailer/Bridge/AhaSend/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/AhaSend/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.4.1",
         "psr/event-dispatcher": "^1",
-        "symfony/mailer": "^7.4|^8.0"
+        "symfony/mailer": "^8.2"
     },
     "require-dev": {
         "symfony/http-client": "^7.4|^8.0",

--- a/src/Symfony/Component/Mailer/Bridge/Azure/Tests/Transport/AzureApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Azure/Tests/Transport/AzureApiTransportTest.php
@@ -170,15 +170,28 @@ class AzureApiTransportTest extends TestCase
         $envelope = new Envelope(new Address('alice@system.com'), [new Address('bob@system.com')]);
 
         $enabled = new Email();
-        $enabled->getHeaders()->add(new TrackingHeader(true));
+        $enabled->getHeaders()->add(new TrackingHeader(opens: true, clicks: true));
         $enabledPayload = $method->invoke($transport, $enabled, $envelope);
         $this->assertFalse($enabledPayload['userEngagementTrackingDisabled']);
         $this->assertNull($enabledPayload['headers']);
 
         $disabled = new Email();
-        $disabled->getHeaders()->add(new TrackingHeader(false));
+        $disabled->getHeaders()->add(new TrackingHeader(opens: false, clicks: false));
         $disabledPayload = $method->invoke($transport, $disabled, $envelope);
         $this->assertTrue($disabledPayload['userEngagementTrackingDisabled']);
         $this->assertNull($disabledPayload['headers']);
+    }
+
+    public function testTrackingHeaderDisablesCombinedFlagWhenEitherAspectIsFalse()
+    {
+        $transport = new AzureApiTransport('KEY', 'ACS_RESOURCE_NAME', false);
+        $method = new \ReflectionMethod(AzureApiTransport::class, 'getPayload');
+        $envelope = new Envelope(new Address('alice@system.com'), [new Address('bob@system.com')]);
+
+        $email = new Email();
+        $email->getHeaders()->add(new TrackingHeader(opens: true, clicks: false));
+        $payload = $method->invoke($transport, $email, $envelope);
+
+        $this->assertTrue($payload['userEngagementTrackingDisabled']);
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Azure/Tests/Transport/AzureApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Azure/Tests/Transport/AzureApiTransportTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\Mailer\Bridge\Azure\Transport\AzureApiTransport;
 use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Header\MetadataHeader;
 use Symfony\Component\Mailer\Header\TagHeader;
+use Symfony\Component\Mailer\Header\TrackingHeader;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
 use Symfony\Component\Mime\Part\DataPart;
@@ -160,5 +161,24 @@ class AzureApiTransportTest extends TestCase
         $this->expectExceptionMessage('Resource name must not end with a dot "."');
 
         new AzureApiTransport('KEY', 'ACS_RESOURCE_NAME.');
+    }
+
+    public function testTrackingHeaderOverridesDefaultTrackingAndIsNotForwarded()
+    {
+        $transport = new AzureApiTransport('KEY', 'ACS_RESOURCE_NAME', true);
+        $method = new \ReflectionMethod(AzureApiTransport::class, 'getPayload');
+        $envelope = new Envelope(new Address('alice@system.com'), [new Address('bob@system.com')]);
+
+        $enabled = new Email();
+        $enabled->getHeaders()->add(new TrackingHeader(true));
+        $enabledPayload = $method->invoke($transport, $enabled, $envelope);
+        $this->assertFalse($enabledPayload['userEngagementTrackingDisabled']);
+        $this->assertNull($enabledPayload['headers']);
+
+        $disabled = new Email();
+        $disabled->getHeaders()->add(new TrackingHeader(false));
+        $disabledPayload = $method->invoke($transport, $disabled, $envelope);
+        $this->assertTrue($disabledPayload['userEngagementTrackingDisabled']);
+        $this->assertNull($disabledPayload['headers']);
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Azure/Transport/AzureApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Azure/Transport/AzureApiTransport.php
@@ -15,6 +15,7 @@ use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Exception\HttpTransportException;
+use Symfony\Component\Mailer\Header\TrackingHeader;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\AbstractApiTransport;
 use Symfony\Component\Mime\Address;
@@ -114,7 +115,7 @@ final class AzureApiTransport extends AbstractApiTransport
             ],
             'senderAddress' => $envelope->getSender()->getAddress(),
             'attachments' => $this->getMessageAttachments($email),
-            'userEngagementTrackingDisabled' => $this->disableTracking,
+            'userEngagementTrackingDisabled' => null !== ($track = $this->getTracking($email)) ? !$track : $this->disableTracking,
             'headers' => ($headers = $this->getMessageCustomHeaders($email)) ? $headers : null,
             'importance' => $this->getPriorityLevel($email->getPriority()),
         ];
@@ -245,7 +246,7 @@ final class AzureApiTransport extends AbstractApiTransport
     {
         $headers = [];
 
-        $headersToBypass = ['x-ms-client-request-id', 'operation-id', 'authorization', 'x-ms-content-sha256', 'received', 'dkim-signature', 'content-transfer-encoding', 'from', 'to', 'cc', 'bcc', 'subject', 'content-type', 'reply-to'];
+        $headersToBypass = ['x-ms-client-request-id', 'operation-id', 'authorization', 'x-ms-content-sha256', 'received', 'dkim-signature', 'content-transfer-encoding', 'from', 'to', 'cc', 'bcc', 'subject', 'content-type', 'reply-to', 'x-track'];
 
         foreach ($email->getHeaders()->all() as $name => $header) {
             if (\in_array($name, $headersToBypass, true)) {
@@ -255,6 +256,17 @@ final class AzureApiTransport extends AbstractApiTransport
         }
 
         return $headers;
+    }
+
+    private function getTracking(Email $email): ?bool
+    {
+        foreach ($email->getHeaders()->all() as $header) {
+            if ($header instanceof TrackingHeader) {
+                return 'true' === $header->getValue();
+            }
+        }
+
+        return null;
     }
 
     private function getPriorityLevel(string $priority): ?string

--- a/src/Symfony/Component/Mailer/Bridge/Azure/Transport/AzureApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Azure/Transport/AzureApiTransport.php
@@ -258,12 +258,26 @@ final class AzureApiTransport extends AbstractApiTransport
         return $headers;
     }
 
+    /**
+     * Azure only exposes a single combined tracking toggle, so an explicit false on either
+     * flag disables it and an explicit true on either flag enables it.
+     */
     private function getTracking(Email $email): ?bool
     {
         foreach ($email->getHeaders()->all() as $header) {
-            if ($header instanceof TrackingHeader) {
-                return 'true' === $header->getValue();
+            if (!$header instanceof TrackingHeader) {
+                continue;
             }
+
+            if (false === $header->getOpens() || false === $header->getClicks()) {
+                return false;
+            }
+
+            if (true === $header->getOpens() || true === $header->getClicks()) {
+                return true;
+            }
+
+            return null;
         }
 
         return null;

--- a/src/Symfony/Component/Mailer/Bridge/Azure/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Azure/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=8.4.1",
-        "symfony/mailer": "^7.4|^8.0"
+        "symfony/mailer": "^8.2"
     },
     "require-dev": {
         "symfony/http-client": "^7.4|^8.0",

--- a/src/Symfony/Component/Mailer/Bridge/Brevo/Tests/Transport/BrevoApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Brevo/Tests/Transport/BrevoApiTransportTest.php
@@ -192,22 +192,35 @@ class BrevoApiTransportTest extends TestCase
         $enabled = new Email();
         $enabled->cc('cc@example.com');
         $enabled->bcc('bcc@example.com');
-        $enabled->getHeaders()->add(new TrackingHeader(true));
+        $enabled->getHeaders()->add(new TrackingHeader(opens: true, clicks: true));
         $enabledPayload = $method->invoke($transport, $enabled, $envelope);
         $this->assertTrue($enabledPayload['to'][0]['contactPixelTrackingConsent']);
         $this->assertTrue($enabledPayload['cc'][0]['contactPixelTrackingConsent']);
         $this->assertTrue($enabledPayload['bcc'][0]['contactPixelTrackingConsent']);
         $this->assertArrayNotHasKey('contactPixelTrackingConsent', $enabledPayload['sender']);
 
-        $disabled = new Email();
-        $disabled->cc('cc@example.com');
-        $disabled->bcc('bcc@example.com');
-        $disabled->getHeaders()->add(new TrackingHeader(false));
-        $disabledPayload = $method->invoke($transport, $disabled, $envelope);
-        $this->assertFalse($disabledPayload['to'][0]['contactPixelTrackingConsent']);
-        $this->assertFalse($disabledPayload['cc'][0]['contactPixelTrackingConsent']);
-        $this->assertFalse($disabledPayload['bcc'][0]['contactPixelTrackingConsent']);
-        $this->assertArrayNotHasKey('contactPixelTrackingConsent', $disabledPayload['sender']);
+        $anonymised = new Email();
+        $anonymised->cc('cc@example.com');
+        $anonymised->bcc('bcc@example.com');
+        $anonymised->getHeaders()->add(new TrackingHeader(opens: false, clicks: false));
+        $anonymisedPayload = $method->invoke($transport, $anonymised, $envelope);
+        $this->assertFalse($anonymisedPayload['to'][0]['contactPixelTrackingConsent']);
+        $this->assertFalse($anonymisedPayload['cc'][0]['contactPixelTrackingConsent']);
+        $this->assertFalse($anonymisedPayload['bcc'][0]['contactPixelTrackingConsent']);
+        $this->assertArrayNotHasKey('contactPixelTrackingConsent', $anonymisedPayload['sender']);
+    }
+
+    public function testTrackingHeaderAnonymisesWhenEitherAspectIsFalse()
+    {
+        $transport = new BrevoApiTransport('ACCESS_KEY');
+        $method = new \ReflectionMethod(BrevoApiTransport::class, 'getPayload');
+        $envelope = new Envelope(new Address('from@example.com'), [new Address('to@example.com')]);
+
+        $email = new Email();
+        $email->getHeaders()->add(new TrackingHeader(opens: true, clicks: false));
+
+        $payload = $method->invoke($transport, $email, $envelope);
+        $this->assertFalse($payload['to'][0]['contactPixelTrackingConsent']);
     }
 
     public function testTrackingHeaderIsNotForwardedAsCustomHeader()
@@ -217,7 +230,7 @@ class BrevoApiTransportTest extends TestCase
         $envelope = new Envelope(new Address('from@example.com'), [new Address('to@example.com')]);
 
         $email = new Email();
-        $email->getHeaders()->add(new TrackingHeader(true));
+        $email->getHeaders()->add(new TrackingHeader(opens: true, clicks: true));
 
         $payload = $method->invoke($transport, $email, $envelope);
         $this->assertArrayNotHasKey('headers', $payload);

--- a/src/Symfony/Component/Mailer/Bridge/Brevo/Tests/Transport/BrevoApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Brevo/Tests/Transport/BrevoApiTransportTest.php
@@ -21,6 +21,7 @@ use Symfony\Component\Mailer\Exception\HttpTransportException;
 use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
 use Symfony\Component\Mailer\Header\MetadataHeader;
 use Symfony\Component\Mailer\Header\TagHeader;
+use Symfony\Component\Mailer\Header\TrackingHeader;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
 use Symfony\Component\Mime\Part\DataPart;
@@ -180,5 +181,45 @@ class BrevoApiTransportTest extends TestCase
         $message = $transport->send($mail);
 
         $this->assertSame('foobar', $message->getMessageId());
+    }
+
+    public function testTrackingHeader()
+    {
+        $transport = new BrevoApiTransport('ACCESS_KEY');
+        $method = new \ReflectionMethod(BrevoApiTransport::class, 'getPayload');
+        $envelope = new Envelope(new Address('from@example.com'), [new Address('to@example.com'), new Address('cc@example.com'), new Address('bcc@example.com')]);
+
+        $enabled = new Email();
+        $enabled->cc('cc@example.com');
+        $enabled->bcc('bcc@example.com');
+        $enabled->getHeaders()->add(new TrackingHeader(true));
+        $enabledPayload = $method->invoke($transport, $enabled, $envelope);
+        $this->assertTrue($enabledPayload['to'][0]['contactPixelTrackingConsent']);
+        $this->assertTrue($enabledPayload['cc'][0]['contactPixelTrackingConsent']);
+        $this->assertTrue($enabledPayload['bcc'][0]['contactPixelTrackingConsent']);
+        $this->assertArrayNotHasKey('contactPixelTrackingConsent', $enabledPayload['sender']);
+
+        $disabled = new Email();
+        $disabled->cc('cc@example.com');
+        $disabled->bcc('bcc@example.com');
+        $disabled->getHeaders()->add(new TrackingHeader(false));
+        $disabledPayload = $method->invoke($transport, $disabled, $envelope);
+        $this->assertFalse($disabledPayload['to'][0]['contactPixelTrackingConsent']);
+        $this->assertFalse($disabledPayload['cc'][0]['contactPixelTrackingConsent']);
+        $this->assertFalse($disabledPayload['bcc'][0]['contactPixelTrackingConsent']);
+        $this->assertArrayNotHasKey('contactPixelTrackingConsent', $disabledPayload['sender']);
+    }
+
+    public function testTrackingHeaderIsNotForwardedAsCustomHeader()
+    {
+        $transport = new BrevoApiTransport('ACCESS_KEY');
+        $method = new \ReflectionMethod(BrevoApiTransport::class, 'getPayload');
+        $envelope = new Envelope(new Address('from@example.com'), [new Address('to@example.com')]);
+
+        $email = new Email();
+        $email->getHeaders()->add(new TrackingHeader(true));
+
+        $payload = $method->invoke($transport, $email, $envelope);
+        $this->assertArrayNotHasKey('headers', $payload);
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Brevo/Transport/BrevoApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Brevo/Transport/BrevoApiTransport.php
@@ -17,6 +17,7 @@ use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Exception\HttpTransportException;
 use Symfony\Component\Mailer\Header\MetadataHeader;
 use Symfony\Component\Mailer\Header\TagHeader;
+use Symfony\Component\Mailer\Header\TrackingHeader;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\AbstractApiTransport;
 use Symfony\Component\Mime\Address;
@@ -74,13 +75,13 @@ final class BrevoApiTransport extends AbstractApiTransport
     }
 
     /**
-     * @return list<array{email: string, name?: string}>
+     * @return list<array{email: string, name?: string, contactPixelTrackingConsent?: bool}>
      */
-    private function formatAddresses(array $addresses): array
+    private function formatAddresses(array $addresses, ?bool $tracking = null): array
     {
         $formattedAddresses = [];
         foreach ($addresses as $address) {
-            $formattedAddresses[] = $this->formatAddress($address);
+            $formattedAddresses[] = $this->formatAddress($address, $tracking);
         }
 
         return $formattedAddresses;
@@ -88,9 +89,11 @@ final class BrevoApiTransport extends AbstractApiTransport
 
     private function getPayload(Email $email, Envelope $envelope): array
     {
+        $tracking = $this->getTracking($email->getHeaders());
+
         $payload = [
             'sender' => $this->formatAddress($envelope->getSender()),
-            'to' => $this->formatAddresses($this->getRecipients($email, $envelope)),
+            'to' => $this->formatAddresses($this->getRecipients($email, $envelope), $tracking),
             'subject' => $email->getSubject(),
         ];
         if ($attachments = $this->prepareAttachments($email)) {
@@ -100,10 +103,10 @@ final class BrevoApiTransport extends AbstractApiTransport
             $payload['replyTo'] = current($this->formatAddresses($emails));
         }
         if ($emails = $email->getCc()) {
-            $payload['cc'] = $this->formatAddresses($emails);
+            $payload['cc'] = $this->formatAddresses($emails, $tracking);
         }
         if ($emails = $email->getBcc()) {
-            $payload['bcc'] = $this->formatAddresses($emails);
+            $payload['bcc'] = $this->formatAddresses($emails, $tracking);
         }
         if ($email->getTextBody()) {
             $payload['textContent'] = $email->getTextBody();
@@ -163,18 +166,38 @@ final class BrevoApiTransport extends AbstractApiTransport
 
                 continue;
             }
+
+            if ($header instanceof TrackingHeader) {
+                continue;
+            }
+
             $headersAndTags['headers'][$header->getName()] = $header->getBodyAsString();
         }
 
         return $headersAndTags;
     }
 
-    private function formatAddress(Address $address): array
+    private function getTracking(Headers $headers): ?bool
+    {
+        foreach ($headers->all() as $header) {
+            if ($header instanceof TrackingHeader) {
+                return 'true' === $header->getValue();
+            }
+        }
+
+        return null;
+    }
+
+    private function formatAddress(Address $address, ?bool $tracking = null): array
     {
         $formattedAddress = ['email' => $address->getEncodedAddress()];
 
         if ($address->getName()) {
             $formattedAddress['name'] = $address->getName();
+        }
+
+        if (null !== $tracking) {
+            $formattedAddress['contactPixelTrackingConsent'] = $tracking;
         }
 
         return $formattedAddress;

--- a/src/Symfony/Component/Mailer/Bridge/Brevo/Transport/BrevoApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Brevo/Transport/BrevoApiTransport.php
@@ -177,12 +177,27 @@ final class BrevoApiTransport extends AbstractApiTransport
         return $headersAndTags;
     }
 
+    /**
+     * Brevo only exposes a single combined "tracking consent" flag which anonymises the open/click
+     * events rather than disabling them, so an explicit false on either aspect anonymises both, and
+     * an explicit true on either aspect grants consent for both.
+     */
     private function getTracking(Headers $headers): ?bool
     {
         foreach ($headers->all() as $header) {
-            if ($header instanceof TrackingHeader) {
-                return 'true' === $header->getValue();
+            if (!$header instanceof TrackingHeader) {
+                continue;
             }
+
+            if (false === $header->getOpens() || false === $header->getClicks()) {
+                return false;
+            }
+
+            if (true === $header->getOpens() || true === $header->getClicks()) {
+                return true;
+            }
+
+            return null;
         }
 
         return null;

--- a/src/Symfony/Component/Mailer/Bridge/Brevo/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Brevo/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=8.4.1",
-        "symfony/mailer": "^7.4|^8.0"
+        "symfony/mailer": "^8.2"
     },
     "require-dev": {
         "symfony/http-client": "^7.4|^8.0",

--- a/src/Symfony/Component/Mailer/Bridge/Infobip/Tests/Transport/InfobipApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Infobip/Tests/Transport/InfobipApiTransportTest.php
@@ -518,7 +518,7 @@ class InfobipApiTransportTest extends TestCase
     public function testTrackingHeaderMapsToTrackOpensAndTrackClicks()
     {
         $enabled = $this->basicValidEmail();
-        $enabled->getHeaders()->add(new TrackingHeader(true));
+        $enabled->getHeaders()->add(new TrackingHeader(opens: true, clicks: true));
 
         $this->transport->send($enabled);
         $body = $this->response->getRequestOptions()['body'];
@@ -526,7 +526,7 @@ class InfobipApiTransportTest extends TestCase
         $this->assertMatchesRegularExpression('/name="trackClicks"\R\Rtrue\R/s', $body);
 
         $disabled = $this->basicValidEmail();
-        $disabled->getHeaders()->add(new TrackingHeader(false));
+        $disabled->getHeaders()->add(new TrackingHeader(opens: false, clicks: false));
 
         $this->transport->send($disabled);
         $body = $this->response->getRequestOptions()['body'];
@@ -534,16 +534,25 @@ class InfobipApiTransportTest extends TestCase
         $this->assertMatchesRegularExpression('/name="trackClicks"\R\Rfalse\R/s', $body);
     }
 
-    public function testExplicitInfobipTrackingHeadersOverrideGenericTrackingHeader()
+    public function testExplicitInfobipTrackingHeadersOverrideGenericTrackingHeaderRegardlessOfOrder()
     {
-        $email = $this->basicValidEmail();
-        $email->getHeaders()
-            ->add(new TrackingHeader(true))
+        $trackingHeaderFirst = $this->basicValidEmail();
+        $trackingHeaderFirst->getHeaders()
+            ->add(new TrackingHeader(opens: true, clicks: true))
             ->addTextHeader('X-Infobip-TrackClicks', 'false');
 
-        $this->transport->send($email);
+        $this->transport->send($trackingHeaderFirst);
         $body = $this->response->getRequestOptions()['body'];
+        $this->assertMatchesRegularExpression('/name="trackOpens"\R\Rtrue\R/s', $body);
+        $this->assertMatchesRegularExpression('/name="trackClicks"\R\Rfalse\R/s', $body);
 
+        $nativeHeaderFirst = $this->basicValidEmail();
+        $nativeHeaderFirst->getHeaders()
+            ->addTextHeader('X-Infobip-TrackClicks', 'false')
+            ->add(new TrackingHeader(opens: true, clicks: true));
+
+        $this->transport->send($nativeHeaderFirst);
+        $body = $this->response->getRequestOptions()['body'];
         $this->assertMatchesRegularExpression('/name="trackOpens"\R\Rtrue\R/s', $body);
         $this->assertMatchesRegularExpression('/name="trackClicks"\R\Rfalse\R/s', $body);
     }

--- a/src/Symfony/Component/Mailer/Bridge/Infobip/Tests/Transport/InfobipApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Infobip/Tests/Transport/InfobipApiTransportTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Mailer\Bridge\Infobip\Transport\InfobipApiTransport;
 use Symfony\Component\Mailer\Exception\HttpTransportException;
+use Symfony\Component\Mailer\Header\TrackingHeader;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
@@ -512,6 +513,39 @@ class InfobipApiTransportTest extends TestCase
         $this->expectException(HttpTransportException::class);
         $this->expectExceptionMessage('Could not reach the remote Infobip server.');
         $this->transport->send($email);
+    }
+
+    public function testTrackingHeaderMapsToTrackOpensAndTrackClicks()
+    {
+        $enabled = $this->basicValidEmail();
+        $enabled->getHeaders()->add(new TrackingHeader(true));
+
+        $this->transport->send($enabled);
+        $body = $this->response->getRequestOptions()['body'];
+        $this->assertMatchesRegularExpression('/name="trackOpens"\R\Rtrue\R/s', $body);
+        $this->assertMatchesRegularExpression('/name="trackClicks"\R\Rtrue\R/s', $body);
+
+        $disabled = $this->basicValidEmail();
+        $disabled->getHeaders()->add(new TrackingHeader(false));
+
+        $this->transport->send($disabled);
+        $body = $this->response->getRequestOptions()['body'];
+        $this->assertMatchesRegularExpression('/name="trackOpens"\R\Rfalse\R/s', $body);
+        $this->assertMatchesRegularExpression('/name="trackClicks"\R\Rfalse\R/s', $body);
+    }
+
+    public function testExplicitInfobipTrackingHeadersOverrideGenericTrackingHeader()
+    {
+        $email = $this->basicValidEmail();
+        $email->getHeaders()
+            ->add(new TrackingHeader(true))
+            ->addTextHeader('X-Infobip-TrackClicks', 'false');
+
+        $this->transport->send($email);
+        $body = $this->response->getRequestOptions()['body'];
+
+        $this->assertMatchesRegularExpression('/name="trackOpens"\R\Rtrue\R/s', $body);
+        $this->assertMatchesRegularExpression('/name="trackClicks"\R\Rfalse\R/s', $body);
     }
 
     private function basicValidEmail(): Email

--- a/src/Symfony/Component/Mailer/Bridge/Infobip/Transport/InfobipApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Infobip/Transport/InfobipApiTransport.php
@@ -15,6 +15,7 @@ use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Exception\HttpTransportException;
+use Symfony\Component\Mailer\Header\TrackingHeader;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\AbstractApiTransport;
 use Symfony\Component\Mime\Address;
@@ -138,6 +139,13 @@ final class InfobipApiTransport extends AbstractApiTransport
         foreach ($email->getHeaders()->all() as $header) {
             if ($convertConf = self::HEADER_TO_MESSAGE[$header->getName()] ?? false) {
                 $fields[$convertConf] = $header->getBodyAsString();
+            }
+
+            if ($header instanceof TrackingHeader) {
+                $track = 'true' === $header->getValue();
+
+                $fields['trackOpens'] = $track ? 'true' : 'false';
+                $fields['trackClicks'] = $track ? 'true' : 'false';
             }
         }
 

--- a/src/Symfony/Component/Mailer/Bridge/Infobip/Transport/InfobipApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Infobip/Transport/InfobipApiTransport.php
@@ -136,16 +136,21 @@ final class InfobipApiTransport extends AbstractApiTransport
 
         $this->attachmentsFormData($fields, $email);
 
+        // resolve the generic header first, so a native X-Infobip-Track* header always wins regardless of iteration order
+        foreach ($email->getHeaders()->all() as $header) {
+            if ($header instanceof TrackingHeader) {
+                if (null !== $header->getOpens()) {
+                    $fields['trackOpens'] = $header->getOpens() ? 'true' : 'false';
+                }
+                if (null !== $header->getClicks()) {
+                    $fields['trackClicks'] = $header->getClicks() ? 'true' : 'false';
+                }
+            }
+        }
+
         foreach ($email->getHeaders()->all() as $header) {
             if ($convertConf = self::HEADER_TO_MESSAGE[$header->getName()] ?? false) {
                 $fields[$convertConf] = $header->getBodyAsString();
-            }
-
-            if ($header instanceof TrackingHeader) {
-                $track = 'true' === $header->getValue();
-
-                $fields['trackOpens'] = $track ? 'true' : 'false';
-                $fields['trackClicks'] = $track ? 'true' : 'false';
             }
         }
 

--- a/src/Symfony/Component/Mailer/Bridge/Infobip/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Infobip/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": ">=8.4.1",
-        "symfony/mailer": "^7.4|^8.0",
+        "symfony/mailer": "^8.2",
         "symfony/mime": "^7.4|^8.0"
     },
     "require-dev": {

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Transport/MandrillApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Transport/MandrillApiTransportTest.php
@@ -243,15 +243,29 @@ class MandrillApiTransportTest extends TestCase
         $envelope = new Envelope(new Address('from@example.com'), [new Address('to@example.com')]);
 
         $enabled = new Email();
-        $enabled->getHeaders()->add(new TrackingHeader(true));
+        $enabled->getHeaders()->add(new TrackingHeader(opens: true, clicks: true));
         $enabledPayload = $method->invoke($transport, $enabled, $envelope);
         $this->assertTrue($enabledPayload['message']['track_opens']);
         $this->assertTrue($enabledPayload['message']['track_clicks']);
 
         $disabled = new Email();
-        $disabled->getHeaders()->add(new TrackingHeader(false));
+        $disabled->getHeaders()->add(new TrackingHeader(opens: false, clicks: false));
         $disabledPayload = $method->invoke($transport, $disabled, $envelope);
         $this->assertFalse($disabledPayload['message']['track_opens']);
         $this->assertFalse($disabledPayload['message']['track_clicks']);
+    }
+
+    public function testTrackingHeaderControlsOpensAndClicksIndependently()
+    {
+        $transport = new MandrillApiTransport('ACCESS_KEY');
+        $method = new \ReflectionMethod(MandrillApiTransport::class, 'getPayload');
+        $envelope = new Envelope(new Address('from@example.com'), [new Address('to@example.com')]);
+
+        $email = new Email();
+        $email->getHeaders()->add(new TrackingHeader(opens: true));
+        $payload = $method->invoke($transport, $email, $envelope);
+
+        $this->assertTrue($payload['message']['track_opens']);
+        $this->assertArrayNotHasKey('track_clicks', $payload['message']);
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Transport/MandrillApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Transport/MandrillApiTransportTest.php
@@ -20,6 +20,7 @@ use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Exception\HttpTransportException;
 use Symfony\Component\Mailer\Header\MetadataHeader;
 use Symfony\Component\Mailer\Header\TagHeader;
+use Symfony\Component\Mailer\Header\TrackingHeader;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
 use Symfony\Component\Mime\Part\DataPart;
@@ -233,5 +234,24 @@ class MandrillApiTransportTest extends TestCase
         // The HTML references "cid:logo.png" and no Content-ID was set, so the image
         // "name" must keep matching the filename rather than an auto-generated Content-ID.
         $this->assertSame('logo.png', $payload['message']['images'][0]['name']);
+    }
+
+    public function testTrackingHeader()
+    {
+        $transport = new MandrillApiTransport('ACCESS_KEY');
+        $method = new \ReflectionMethod(MandrillApiTransport::class, 'getPayload');
+        $envelope = new Envelope(new Address('from@example.com'), [new Address('to@example.com')]);
+
+        $enabled = new Email();
+        $enabled->getHeaders()->add(new TrackingHeader(true));
+        $enabledPayload = $method->invoke($transport, $enabled, $envelope);
+        $this->assertTrue($enabledPayload['message']['track_opens']);
+        $this->assertTrue($enabledPayload['message']['track_clicks']);
+
+        $disabled = new Email();
+        $disabled->getHeaders()->add(new TrackingHeader(false));
+        $disabledPayload = $method->invoke($transport, $disabled, $envelope);
+        $this->assertFalse($disabledPayload['message']['track_opens']);
+        $this->assertFalse($disabledPayload['message']['track_clicks']);
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Transport/MandrillSmtpTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Transport/MandrillSmtpTransportTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Mailer\Bridge\Mailchimp\Transport\MandrillSmtpTransport;
 use Symfony\Component\Mailer\Header\MetadataHeader;
 use Symfony\Component\Mailer\Header\TagHeader;
+use Symfony\Component\Mailer\Header\TrackingHeader;
 use Symfony\Component\Mime\Email;
 
 class MandrillSmtpTransportTest extends TestCase
@@ -36,5 +37,21 @@ class MandrillSmtpTransportTest extends TestCase
         $this->assertSame('foo: bar', $email->getHeaders()->get('FOO')->toString());
         $this->assertSame('X-MC-Tags: password-reset,user,another', $email->getHeaders()->get('X-MC-Tags')->toString());
         $this->assertSame('X-MC-Metadata: '.json_encode(['Color' => 'blue', 'Client-ID' => '12345']), $email->getHeaders()->get('X-MC-Metadata')->toString());
+    }
+
+    public function testTrackingHeader()
+    {
+        $transport = new MandrillSmtpTransport('user', 'password');
+        $method = new \ReflectionMethod(MandrillSmtpTransport::class, 'addMandrillHeaders');
+
+        $enabled = new Email();
+        $enabled->getHeaders()->add(new TrackingHeader(true));
+        $method->invoke($transport, $enabled);
+        $this->assertSame('X-MC-Track: opens,clicks', $enabled->getHeaders()->get('X-MC-Track')->toString());
+
+        $disabled = new Email();
+        $disabled->getHeaders()->add(new TrackingHeader(false));
+        $method->invoke($transport, $disabled);
+        $this->assertSame('X-MC-Track: none', $disabled->getHeaders()->get('X-MC-Track')->toString());
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Transport/MandrillSmtpTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Transport/MandrillSmtpTransportTest.php
@@ -45,13 +45,25 @@ class MandrillSmtpTransportTest extends TestCase
         $method = new \ReflectionMethod(MandrillSmtpTransport::class, 'addMandrillHeaders');
 
         $enabled = new Email();
-        $enabled->getHeaders()->add(new TrackingHeader(true));
+        $enabled->getHeaders()->add(new TrackingHeader(opens: true, clicks: true));
         $method->invoke($transport, $enabled);
         $this->assertSame('X-MC-Track: opens,clicks', $enabled->getHeaders()->get('X-MC-Track')->toString());
 
         $disabled = new Email();
-        $disabled->getHeaders()->add(new TrackingHeader(false));
+        $disabled->getHeaders()->add(new TrackingHeader(opens: false, clicks: false));
         $method->invoke($transport, $disabled);
         $this->assertSame('X-MC-Track: none', $disabled->getHeaders()->get('X-MC-Track')->toString());
+    }
+
+    public function testTrackingHeaderOnlyEnablesExplicitAspects()
+    {
+        $transport = new MandrillSmtpTransport('user', 'password');
+        $method = new \ReflectionMethod(MandrillSmtpTransport::class, 'addMandrillHeaders');
+
+        $email = new Email();
+        $email->getHeaders()->add(new TrackingHeader(opens: true));
+        $method->invoke($transport, $email);
+
+        $this->assertSame('X-MC-Track: opens', $email->getHeaders()->get('X-MC-Track')->toString());
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Transport/MandrillApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Transport/MandrillApiTransport.php
@@ -17,6 +17,7 @@ use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Exception\HttpTransportException;
 use Symfony\Component\Mailer\Header\MetadataHeader;
 use Symfony\Component\Mailer\Header\TagHeader;
+use Symfony\Component\Mailer\Header\TrackingHeader;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\AbstractApiTransport;
 use Symfony\Component\Mime\Email;
@@ -144,6 +145,15 @@ class MandrillApiTransport extends AbstractApiTransport
 
             if ($header instanceof MetadataHeader) {
                 $payload['message']['metadata'][$header->getKey()] = $header->getValue();
+
+                continue;
+            }
+
+            if ($header instanceof TrackingHeader) {
+                $track = 'true' === $header->getValue();
+
+                $payload['message']['track_opens'] = $track;
+                $payload['message']['track_clicks'] = $track;
 
                 continue;
             }

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Transport/MandrillApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Transport/MandrillApiTransport.php
@@ -150,10 +150,12 @@ class MandrillApiTransport extends AbstractApiTransport
             }
 
             if ($header instanceof TrackingHeader) {
-                $track = 'true' === $header->getValue();
-
-                $payload['message']['track_opens'] = $track;
-                $payload['message']['track_clicks'] = $track;
+                if (null !== $header->getOpens()) {
+                    $payload['message']['track_opens'] = $header->getOpens();
+                }
+                if (null !== $header->getClicks()) {
+                    $payload['message']['track_clicks'] = $header->getClicks();
+                }
 
                 continue;
             }

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Transport/MandrillHeadersTrait.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Transport/MandrillHeadersTrait.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Mailer\Bridge\Mailchimp\Transport;
 use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Header\MetadataHeader;
 use Symfony\Component\Mailer\Header\TagHeader;
+use Symfony\Component\Mailer\Header\TrackingHeader;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mime\Message;
 use Symfony\Component\Mime\RawMessage;
@@ -45,6 +46,11 @@ trait MandrillHeadersTrait
                 $headers->remove($name);
             } elseif ($header instanceof MetadataHeader) {
                 $metadata[$header->getKey()] = $header->getValue();
+                $headers->remove($name);
+            } elseif ($header instanceof TrackingHeader) {
+                $track = 'true' === $header->getValue();
+
+                $headers->addTextHeader('X-MC-Track', $track ? 'opens,clicks' : 'none');
                 $headers->remove($name);
             }
         }

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Transport/MandrillHeadersTrait.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Transport/MandrillHeadersTrait.php
@@ -48,9 +48,17 @@ trait MandrillHeadersTrait
                 $metadata[$header->getKey()] = $header->getValue();
                 $headers->remove($name);
             } elseif ($header instanceof TrackingHeader) {
-                $track = 'true' === $header->getValue();
+                $enabledAspects = [];
+                if (true === $header->getOpens()) {
+                    $enabledAspects[] = 'opens';
+                }
+                if (true === $header->getClicks()) {
+                    $enabledAspects[] = 'clicks';
+                }
 
-                $headers->addTextHeader('X-MC-Track', $track ? 'opens,clicks' : 'none');
+                // X-MC-Track only lists the aspects to enable; Mandrill disables tracking for any
+                // other value, so "none" is used deliberately when no aspect is explicitly enabled.
+                $headers->addTextHeader('X-MC-Track', $enabledAspects ? implode(',', $enabledAspects) : 'none');
                 $headers->remove($name);
             }
         }

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=8.4.1",
-        "symfony/mailer": "^7.4|^8.0"
+        "symfony/mailer": "^8.2"
     },
     "require-dev": {
         "symfony/http-client": "^7.4|^8.0",

--- a/src/Symfony/Component/Mailer/Bridge/MailerSend/Tests/Transport/MailerSendApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/MailerSend/Tests/Transport/MailerSendApiTransportTest.php
@@ -198,15 +198,29 @@ class MailerSendApiTransportTest extends TestCase
         $envelope = new \Symfony\Component\Mailer\Envelope(new Address('from@example.com'), [new Address('to@example.com')]);
 
         $enabledEmail = (new Email())->from('from@example.com')->to('to@example.com');
-        $enabledEmail->getHeaders()->add(new TrackingHeader(true));
+        $enabledEmail->getHeaders()->add(new TrackingHeader(opens: true, clicks: true));
         $enabledPayload = $method->invoke($transport, $enabledEmail, $envelope);
         $this->assertTrue($enabledPayload['settings']['track_opens']);
         $this->assertTrue($enabledPayload['settings']['track_clicks']);
 
         $disabledEmail = (new Email())->from('from@example.com')->to('to@example.com');
-        $disabledEmail->getHeaders()->add(new TrackingHeader(false));
+        $disabledEmail->getHeaders()->add(new TrackingHeader(opens: false, clicks: false));
         $disabledPayload = $method->invoke($transport, $disabledEmail, $envelope);
         $this->assertFalse($disabledPayload['settings']['track_opens']);
         $this->assertFalse($disabledPayload['settings']['track_clicks']);
+    }
+
+    public function testTrackingHeaderControlsOpensAndClicksIndependently()
+    {
+        $transport = new MailerSendApiTransport('ACCESS_KEY');
+        $method = new \ReflectionMethod(MailerSendApiTransport::class, 'getPayload');
+        $envelope = new \Symfony\Component\Mailer\Envelope(new Address('from@example.com'), [new Address('to@example.com')]);
+
+        $email = (new Email())->from('from@example.com')->to('to@example.com');
+        $email->getHeaders()->add(new TrackingHeader(clicks: false));
+        $payload = $method->invoke($transport, $email, $envelope);
+
+        $this->assertArrayNotHasKey('track_opens', $payload['settings']);
+        $this->assertFalse($payload['settings']['track_clicks']);
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/MailerSend/Tests/Transport/MailerSendApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/MailerSend/Tests/Transport/MailerSendApiTransportTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\HttpClient\Response\JsonMockResponse;
 use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Mailer\Bridge\MailerSend\Transport\MailerSendApiTransport;
 use Symfony\Component\Mailer\Exception\HttpTransportException;
+use Symfony\Component\Mailer\Header\TrackingHeader;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
 use Symfony\Component\Mime\Part\DataPart;
@@ -188,5 +189,24 @@ class MailerSendApiTransportTest extends TestCase
         $this->expectException(HttpTransportException::class);
         $this->expectExceptionMessage('Unable to send an email: "test" (code 202).');
         $transport->send($mail);
+    }
+
+    public function testTrackingHeader()
+    {
+        $transport = new MailerSendApiTransport('ACCESS_KEY');
+        $method = new \ReflectionMethod(MailerSendApiTransport::class, 'getPayload');
+        $envelope = new \Symfony\Component\Mailer\Envelope(new Address('from@example.com'), [new Address('to@example.com')]);
+
+        $enabledEmail = (new Email())->from('from@example.com')->to('to@example.com');
+        $enabledEmail->getHeaders()->add(new TrackingHeader(true));
+        $enabledPayload = $method->invoke($transport, $enabledEmail, $envelope);
+        $this->assertTrue($enabledPayload['settings']['track_opens']);
+        $this->assertTrue($enabledPayload['settings']['track_clicks']);
+
+        $disabledEmail = (new Email())->from('from@example.com')->to('to@example.com');
+        $disabledEmail->getHeaders()->add(new TrackingHeader(false));
+        $disabledPayload = $method->invoke($transport, $disabledEmail, $envelope);
+        $this->assertFalse($disabledPayload['settings']['track_opens']);
+        $this->assertFalse($disabledPayload['settings']['track_clicks']);
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/MailerSend/Transport/MailerSendApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/MailerSend/Transport/MailerSendApiTransport.php
@@ -16,6 +16,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpClient\Exception\JsonException;
 use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Exception\HttpTransportException;
+use Symfony\Component\Mailer\Header\TrackingHeader;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\AbstractApiTransport;
 use Symfony\Component\Mime\Address;
@@ -116,6 +117,17 @@ final class MailerSendApiTransport extends AbstractApiTransport
 
         if ($email->getHtmlBody()) {
             $payload['html'] = $email->getHtmlBody();
+        }
+
+        foreach ($email->getHeaders()->all() as $header) {
+            if ($header instanceof TrackingHeader) {
+                $track = 'true' === $header->getValue();
+
+                $payload['settings'] = [
+                    'track_opens' => $track,
+                    'track_clicks' => $track,
+                ];
+            }
         }
 
         return $payload;

--- a/src/Symfony/Component/Mailer/Bridge/MailerSend/Transport/MailerSendApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/MailerSend/Transport/MailerSendApiTransport.php
@@ -121,12 +121,12 @@ final class MailerSendApiTransport extends AbstractApiTransport
 
         foreach ($email->getHeaders()->all() as $header) {
             if ($header instanceof TrackingHeader) {
-                $track = 'true' === $header->getValue();
-
-                $payload['settings'] = [
-                    'track_opens' => $track,
-                    'track_clicks' => $track,
-                ];
+                if (null !== $header->getOpens()) {
+                    $payload['settings']['track_opens'] = $header->getOpens();
+                }
+                if (null !== $header->getClicks()) {
+                    $payload['settings']['track_clicks'] = $header->getClicks();
+                }
             }
         }
 

--- a/src/Symfony/Component/Mailer/Bridge/MailerSend/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/MailerSend/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": ">=8.4.1",
-        "symfony/mailer": "^7.4|^8.0"
+        "symfony/mailer": "^8.2"
     },
     "require-dev": {
         "symfony/http-client": "^7.4|^8.0",

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Transport/MailgunApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Transport/MailgunApiTransportTest.php
@@ -315,27 +315,52 @@ class MailgunApiTransportTest extends TestCase
         $envelope = new Envelope(new Address('from@example.com'), [new Address('to@example.com')]);
 
         $enabled = new Email();
-        $enabled->getHeaders()->add(new TrackingHeader(true));
+        $enabled->getHeaders()->add(new TrackingHeader(opens: true, clicks: true));
         $enabledPayload = $method->invoke($transport, $enabled, $envelope);
-        $this->assertSame('true', $enabledPayload['o:tracking']);
+        $this->assertSame('yes', $enabledPayload['o:tracking-opens']);
+        $this->assertSame('yes', $enabledPayload['o:tracking-clicks']);
 
         $disabled = new Email();
-        $disabled->getHeaders()->add(new TrackingHeader(false));
+        $disabled->getHeaders()->add(new TrackingHeader(opens: false, clicks: false));
         $disabledPayload = $method->invoke($transport, $disabled, $envelope);
-        $this->assertSame('false', $disabledPayload['o:tracking']);
+        $this->assertSame('no', $disabledPayload['o:tracking-opens']);
+        $this->assertSame('no', $disabledPayload['o:tracking-clicks']);
     }
 
-    public function testExplicitMailgunTrackingHeaderOverridesTrackingHeader()
+    public function testTrackingHeaderControlsOpensAndClicksIndependently()
     {
         $transport = new MailgunApiTransport('ACCESS_KEY', 'DOMAIN');
         $method = new \ReflectionMethod(MailgunApiTransport::class, 'getPayload');
         $envelope = new Envelope(new Address('from@example.com'), [new Address('to@example.com')]);
 
         $email = new Email();
-        $email->getHeaders()->add(new TrackingHeader(true));
-        $email->getHeaders()->addTextHeader('o:tracking', 'false');
-
+        $email->getHeaders()->add(new TrackingHeader(opens: false));
         $payload = $method->invoke($transport, $email, $envelope);
-        $this->assertSame('false', $payload['o:tracking']);
+
+        $this->assertSame('no', $payload['o:tracking-opens']);
+        $this->assertArrayNotHasKey('o:tracking-clicks', $payload);
+    }
+
+    public function testExplicitMailgunTrackingHeaderOverridesTrackingHeaderRegardlessOfOrder()
+    {
+        $transport = new MailgunApiTransport('ACCESS_KEY', 'DOMAIN');
+        $method = new \ReflectionMethod(MailgunApiTransport::class, 'getPayload');
+        $envelope = new Envelope(new Address('from@example.com'), [new Address('to@example.com')]);
+
+        $trackingHeaderFirst = new Email();
+        $trackingHeaderFirst->getHeaders()->add(new TrackingHeader(opens: true, clicks: true));
+        $trackingHeaderFirst->getHeaders()->addTextHeader('o:tracking-clicks', 'no');
+
+        $payload = $method->invoke($transport, $trackingHeaderFirst, $envelope);
+        $this->assertSame('yes', $payload['o:tracking-opens']);
+        $this->assertSame('no', $payload['o:tracking-clicks']);
+
+        $nativeHeaderFirst = new Email();
+        $nativeHeaderFirst->getHeaders()->addTextHeader('o:tracking-clicks', 'no');
+        $nativeHeaderFirst->getHeaders()->add(new TrackingHeader(opens: true, clicks: true));
+
+        $payload = $method->invoke($transport, $nativeHeaderFirst, $envelope);
+        $this->assertSame('yes', $payload['o:tracking-opens']);
+        $this->assertSame('no', $payload['o:tracking-clicks']);
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Transport/MailgunApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Transport/MailgunApiTransportTest.php
@@ -21,6 +21,7 @@ use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Exception\HttpTransportException;
 use Symfony\Component\Mailer\Header\MetadataHeader;
 use Symfony\Component\Mailer\Header\TagHeader;
+use Symfony\Component\Mailer\Header\TrackingHeader;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
 use Symfony\Component\Mime\Part\DataPart;
@@ -305,5 +306,36 @@ class MailgunApiTransportTest extends TestCase
 
         $this->assertArrayHasKey('h:Sender', $payload);
         $this->assertSame('=?utf-8?Q?=C5=BDlu=C5=A5ou=C4=8Dk=C3=BD_K=C5=AF=C5=88?= <alice@system.com>', $payload['h:Sender']);
+    }
+
+    public function testTrackingHeader()
+    {
+        $transport = new MailgunApiTransport('ACCESS_KEY', 'DOMAIN');
+        $method = new \ReflectionMethod(MailgunApiTransport::class, 'getPayload');
+        $envelope = new Envelope(new Address('from@example.com'), [new Address('to@example.com')]);
+
+        $enabled = new Email();
+        $enabled->getHeaders()->add(new TrackingHeader(true));
+        $enabledPayload = $method->invoke($transport, $enabled, $envelope);
+        $this->assertSame('true', $enabledPayload['o:tracking']);
+
+        $disabled = new Email();
+        $disabled->getHeaders()->add(new TrackingHeader(false));
+        $disabledPayload = $method->invoke($transport, $disabled, $envelope);
+        $this->assertSame('false', $disabledPayload['o:tracking']);
+    }
+
+    public function testExplicitMailgunTrackingHeaderOverridesTrackingHeader()
+    {
+        $transport = new MailgunApiTransport('ACCESS_KEY', 'DOMAIN');
+        $method = new \ReflectionMethod(MailgunApiTransport::class, 'getPayload');
+        $envelope = new Envelope(new Address('from@example.com'), [new Address('to@example.com')]);
+
+        $email = new Email();
+        $email->getHeaders()->add(new TrackingHeader(true));
+        $email->getHeaders()->addTextHeader('o:tracking', 'false');
+
+        $payload = $method->invoke($transport, $email, $envelope);
+        $this->assertSame('false', $payload['o:tracking']);
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Transport/MailgunSmtpTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Transport/MailgunSmtpTransportTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Mailer\Bridge\Mailgun\Transport\MailgunSmtpTransport;
 use Symfony\Component\Mailer\Header\MetadataHeader;
 use Symfony\Component\Mailer\Header\TagHeader;
+use Symfony\Component\Mailer\Header\TrackingHeader;
 use Symfony\Component\Mime\Email;
 
 /**
@@ -38,5 +39,21 @@ class MailgunSmtpTransportTest extends TestCase
         $this->assertSame('foo: bar', $email->getHeaders()->get('foo')->toString());
         $this->assertSame('X-Mailgun-Tag: password-reset', $email->getHeaders()->get('X-Mailgun-Tag')->toString());
         $this->assertSame('X-Mailgun-Variables: '.json_encode(['Color' => 'blue', 'Client-ID' => '12345']), $email->getHeaders()->get('X-Mailgun-Variables')->toString());
+    }
+
+    public function testTrackingHeader()
+    {
+        $transport = new MailgunSmtpTransport('user', 'password');
+        $method = new \ReflectionMethod(MailgunSmtpTransport::class, 'addMailgunHeaders');
+
+        $enabled = new Email();
+        $enabled->getHeaders()->add(new TrackingHeader(true));
+        $method->invoke($transport, $enabled);
+        $this->assertSame('X-Mailgun-Track: yes', $enabled->getHeaders()->get('X-Mailgun-Track')->toString());
+
+        $disabled = new Email();
+        $disabled->getHeaders()->add(new TrackingHeader(false));
+        $method->invoke($transport, $disabled);
+        $this->assertSame('X-Mailgun-Track: no', $disabled->getHeaders()->get('X-Mailgun-Track')->toString());
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Transport/MailgunSmtpTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Transport/MailgunSmtpTransportTest.php
@@ -47,13 +47,28 @@ class MailgunSmtpTransportTest extends TestCase
         $method = new \ReflectionMethod(MailgunSmtpTransport::class, 'addMailgunHeaders');
 
         $enabled = new Email();
-        $enabled->getHeaders()->add(new TrackingHeader(true));
+        $enabled->getHeaders()->add(new TrackingHeader(opens: true, clicks: true));
         $method->invoke($transport, $enabled);
-        $this->assertSame('X-Mailgun-Track: yes', $enabled->getHeaders()->get('X-Mailgun-Track')->toString());
+        $this->assertSame('X-Mailgun-Track-Opens: yes', $enabled->getHeaders()->get('X-Mailgun-Track-Opens')->toString());
+        $this->assertSame('X-Mailgun-Track-Clicks: yes', $enabled->getHeaders()->get('X-Mailgun-Track-Clicks')->toString());
 
         $disabled = new Email();
-        $disabled->getHeaders()->add(new TrackingHeader(false));
+        $disabled->getHeaders()->add(new TrackingHeader(opens: false, clicks: false));
         $method->invoke($transport, $disabled);
-        $this->assertSame('X-Mailgun-Track: no', $disabled->getHeaders()->get('X-Mailgun-Track')->toString());
+        $this->assertSame('X-Mailgun-Track-Opens: no', $disabled->getHeaders()->get('X-Mailgun-Track-Opens')->toString());
+        $this->assertSame('X-Mailgun-Track-Clicks: no', $disabled->getHeaders()->get('X-Mailgun-Track-Clicks')->toString());
+    }
+
+    public function testTrackingHeaderControlsOpensAndClicksIndependently()
+    {
+        $transport = new MailgunSmtpTransport('user', 'password');
+        $method = new \ReflectionMethod(MailgunSmtpTransport::class, 'addMailgunHeaders');
+
+        $email = new Email();
+        $email->getHeaders()->add(new TrackingHeader(clicks: false));
+        $method->invoke($transport, $email);
+
+        $this->assertNull($email->getHeaders()->get('X-Mailgun-Track-Opens'));
+        $this->assertSame('X-Mailgun-Track-Clicks: no', $email->getHeaders()->get('X-Mailgun-Track-Clicks')->toString());
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunApiTransport.php
@@ -17,6 +17,7 @@ use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Exception\HttpTransportException;
 use Symfony\Component\Mailer\Header\MetadataHeader;
 use Symfony\Component\Mailer\Header\TagHeader;
+use Symfony\Component\Mailer\Header\TrackingHeader;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\AbstractApiTransport;
 use Symfony\Component\Mime\Email;
@@ -129,6 +130,14 @@ class MailgunApiTransport extends AbstractApiTransport
 
             if ($header instanceof MetadataHeader) {
                 $payload['v:'.$header->getKey()] = $header->getValue();
+
+                continue;
+            }
+
+            if ($header instanceof TrackingHeader) {
+                $track = 'true' === $header->getValue();
+
+                $payload['o:tracking'] = $track ? 'true' : 'false';
 
                 continue;
             }

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunApiTransport.php
@@ -117,8 +117,20 @@ class MailgunApiTransport extends AbstractApiTransport
             $payload['html'] = $html;
         }
 
+        // resolve the generic header first, so a native o:/h:/t:/v: header always wins regardless of iteration order
+        foreach ($headers->all() as $header) {
+            if ($header instanceof TrackingHeader) {
+                if (null !== $header->getOpens()) {
+                    $payload['o:tracking-opens'] = $header->getOpens() ? 'yes' : 'no';
+                }
+                if (null !== $header->getClicks()) {
+                    $payload['o:tracking-clicks'] = $header->getClicks() ? 'yes' : 'no';
+                }
+            }
+        }
+
         foreach ($headers->all() as $name => $header) {
-            if (\in_array($name, ['from', 'to', 'cc', 'bcc', 'subject', 'content-type'], true)) {
+            if (\in_array($name, ['from', 'to', 'cc', 'bcc', 'subject', 'content-type', 'x-track'], true)) {
                 continue;
             }
 
@@ -130,14 +142,6 @@ class MailgunApiTransport extends AbstractApiTransport
 
             if ($header instanceof MetadataHeader) {
                 $payload['v:'.$header->getKey()] = $header->getValue();
-
-                continue;
-            }
-
-            if ($header instanceof TrackingHeader) {
-                $track = 'true' === $header->getValue();
-
-                $payload['o:tracking'] = $track ? 'true' : 'false';
 
                 continue;
             }

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunHeadersTrait.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunHeadersTrait.php
@@ -47,9 +47,12 @@ trait MailgunHeadersTrait
                 $metadata[$header->getKey()] = $header->getValue();
                 $headers->remove($name);
             } elseif ($header instanceof TrackingHeader) {
-                $track = 'true' === $header->getValue();
-
-                $headers->addTextHeader('X-Mailgun-Track', $track ? 'yes' : 'no');
+                if (null !== $header->getOpens()) {
+                    $headers->addTextHeader('X-Mailgun-Track-Opens', $header->getOpens() ? 'yes' : 'no');
+                }
+                if (null !== $header->getClicks()) {
+                    $headers->addTextHeader('X-Mailgun-Track-Clicks', $header->getClicks() ? 'yes' : 'no');
+                }
                 $headers->remove($name);
             }
         }

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunHeadersTrait.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunHeadersTrait.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Mailer\Bridge\Mailgun\Transport;
 use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Header\MetadataHeader;
 use Symfony\Component\Mailer\Header\TagHeader;
+use Symfony\Component\Mailer\Header\TrackingHeader;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mime\Message;
 use Symfony\Component\Mime\RawMessage;
@@ -44,6 +45,11 @@ trait MailgunHeadersTrait
                 $headers->remove($name);
             } elseif ($header instanceof MetadataHeader) {
                 $metadata[$header->getKey()] = $header->getValue();
+                $headers->remove($name);
+            } elseif ($header instanceof TrackingHeader) {
+                $track = 'true' === $header->getValue();
+
+                $headers->addTextHeader('X-Mailgun-Track', $track ? 'yes' : 'no');
                 $headers->remove($name);
             }
         }

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=8.4.1",
-        "symfony/mailer": "^7.4|^8.0"
+        "symfony/mailer": "^8.2"
     },
     "require-dev": {
         "symfony/http-client": "^7.4|^8.0",

--- a/src/Symfony/Component/Mailer/Bridge/Mailjet/Tests/Transport/MailjetApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailjet/Tests/Transport/MailjetApiTransportTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Mailer\Bridge\Mailjet\Transport\MailjetApiTransport;
 use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Exception\HttpTransportException;
+use Symfony\Component\Mailer\Header\TrackingHeader;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
@@ -514,5 +515,39 @@ class MailjetApiTransportTest extends TestCase
         $this->assertSame('text.txt', $contentId ?? null);
         $this->assertCount(1, $payload['Messages']);
         $this->assertCount(1, $payload['Messages'][0]['InlinedAttachments']);
+    }
+
+    public function testTrackingHeader()
+    {
+        $transport = new MailjetApiTransport(self::USER, self::PASSWORD);
+        $method = new \ReflectionMethod(MailjetApiTransport::class, 'getPayload');
+        $envelope = new Envelope(new Address('from@example.com'), [new Address('to@example.com')]);
+
+        $enabled = new Email();
+        $enabled->getHeaders()->add(new TrackingHeader(true));
+        $enabledPayload = $method->invoke($transport, $enabled, $envelope);
+        $this->assertSame('enabled', $enabledPayload['Messages'][0]['TrackClicks']);
+        $this->assertSame('enabled', $enabledPayload['Messages'][0]['TrackOpens']);
+
+        $disabled = new Email();
+        $disabled->getHeaders()->add(new TrackingHeader(false));
+        $disabledPayload = $method->invoke($transport, $disabled, $envelope);
+        $this->assertSame('disabled', $disabledPayload['Messages'][0]['TrackClicks']);
+        $this->assertSame('disabled', $disabledPayload['Messages'][0]['TrackOpens']);
+    }
+
+    public function testExplicitMailjetTrackingHeadersOverrideTrackingHeader()
+    {
+        $transport = new MailjetApiTransport(self::USER, self::PASSWORD);
+        $method = new \ReflectionMethod(MailjetApiTransport::class, 'getPayload');
+        $envelope = new Envelope(new Address('from@example.com'), [new Address('to@example.com')]);
+
+        $email = new Email();
+        $email->getHeaders()->add(new TrackingHeader(false));
+        $email->getHeaders()->addTextHeader('X-Mailjet-TrackClick', 'account_default');
+
+        $payload = $method->invoke($transport, $email, $envelope);
+        $this->assertSame('account_default', $payload['Messages'][0]['TrackClicks']);
+        $this->assertSame('disabled', $payload['Messages'][0]['TrackOpens']);
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Mailjet/Tests/Transport/MailjetApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailjet/Tests/Transport/MailjetApiTransportTest.php
@@ -524,29 +524,51 @@ class MailjetApiTransportTest extends TestCase
         $envelope = new Envelope(new Address('from@example.com'), [new Address('to@example.com')]);
 
         $enabled = new Email();
-        $enabled->getHeaders()->add(new TrackingHeader(true));
+        $enabled->getHeaders()->add(new TrackingHeader(opens: true, clicks: true));
         $enabledPayload = $method->invoke($transport, $enabled, $envelope);
         $this->assertSame('enabled', $enabledPayload['Messages'][0]['TrackClicks']);
         $this->assertSame('enabled', $enabledPayload['Messages'][0]['TrackOpens']);
 
         $disabled = new Email();
-        $disabled->getHeaders()->add(new TrackingHeader(false));
+        $disabled->getHeaders()->add(new TrackingHeader(opens: false, clicks: false));
         $disabledPayload = $method->invoke($transport, $disabled, $envelope);
         $this->assertSame('disabled', $disabledPayload['Messages'][0]['TrackClicks']);
         $this->assertSame('disabled', $disabledPayload['Messages'][0]['TrackOpens']);
     }
 
-    public function testExplicitMailjetTrackingHeadersOverrideTrackingHeader()
+    public function testTrackingHeaderControlsOpensAndClicksIndependently()
     {
         $transport = new MailjetApiTransport(self::USER, self::PASSWORD);
         $method = new \ReflectionMethod(MailjetApiTransport::class, 'getPayload');
         $envelope = new Envelope(new Address('from@example.com'), [new Address('to@example.com')]);
 
         $email = new Email();
-        $email->getHeaders()->add(new TrackingHeader(false));
-        $email->getHeaders()->addTextHeader('X-Mailjet-TrackClick', 'account_default');
-
+        $email->getHeaders()->add(new TrackingHeader(opens: false));
         $payload = $method->invoke($transport, $email, $envelope);
+
+        $this->assertSame('disabled', $payload['Messages'][0]['TrackOpens']);
+        $this->assertArrayNotHasKey('TrackClicks', $payload['Messages'][0]);
+    }
+
+    public function testExplicitMailjetTrackingHeadersOverrideTrackingHeaderRegardlessOfOrder()
+    {
+        $transport = new MailjetApiTransport(self::USER, self::PASSWORD);
+        $method = new \ReflectionMethod(MailjetApiTransport::class, 'getPayload');
+        $envelope = new Envelope(new Address('from@example.com'), [new Address('to@example.com')]);
+
+        $trackingHeaderFirst = new Email();
+        $trackingHeaderFirst->getHeaders()->add(new TrackingHeader(opens: false, clicks: false));
+        $trackingHeaderFirst->getHeaders()->addTextHeader('X-Mailjet-TrackClick', 'account_default');
+
+        $payload = $method->invoke($transport, $trackingHeaderFirst, $envelope);
+        $this->assertSame('account_default', $payload['Messages'][0]['TrackClicks']);
+        $this->assertSame('disabled', $payload['Messages'][0]['TrackOpens']);
+
+        $nativeHeaderFirst = new Email();
+        $nativeHeaderFirst->getHeaders()->addTextHeader('X-Mailjet-TrackClick', 'account_default');
+        $nativeHeaderFirst->getHeaders()->add(new TrackingHeader(opens: false, clicks: false));
+
+        $payload = $method->invoke($transport, $nativeHeaderFirst, $envelope);
         $this->assertSame('account_default', $payload['Messages'][0]['TrackClicks']);
         $this->assertSame('disabled', $payload['Messages'][0]['TrackOpens']);
     }

--- a/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetApiTransport.php
@@ -140,6 +140,18 @@ class MailjetApiTransport extends AbstractApiTransport
             $message['HTMLPart'] = $html;
         }
 
+        // resolve the generic header first, so a native x-mailjet-track* header always wins regardless of iteration order
+        foreach ($email->getHeaders()->all() as $header) {
+            if ($header instanceof TrackingHeader) {
+                if (null !== $header->getOpens()) {
+                    $message['TrackOpens'] = $header->getOpens() ? 'enabled' : 'disabled';
+                }
+                if (null !== $header->getClicks()) {
+                    $message['TrackClicks'] = $header->getClicks() ? 'enabled' : 'disabled';
+                }
+            }
+        }
+
         foreach ($email->getHeaders()->all() as $headerName => $header) {
             if ($convertConf = self::HEADER_TO_MESSAGE[$headerName] ?? false) {
                 $message[$convertConf[0]] = $this->castCustomHeader($header->getBodyAsString(), $convertConf[1]);
@@ -147,11 +159,6 @@ class MailjetApiTransport extends AbstractApiTransport
             }
 
             if ($header instanceof TrackingHeader) {
-                $track = 'true' === $header->getValue();
-
-                $message['TrackClicks'] = $track ? 'enabled' : 'disabled';
-                $message['TrackOpens'] = $track ? 'enabled' : 'disabled';
-
                 continue;
             }
 

--- a/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetApiTransport.php
@@ -16,6 +16,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Exception\HttpTransportException;
 use Symfony\Component\Mailer\Exception\TransportException;
+use Symfony\Component\Mailer\Header\TrackingHeader;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\AbstractApiTransport;
 use Symfony\Component\Mime\Address;
@@ -142,6 +143,15 @@ class MailjetApiTransport extends AbstractApiTransport
         foreach ($email->getHeaders()->all() as $headerName => $header) {
             if ($convertConf = self::HEADER_TO_MESSAGE[$headerName] ?? false) {
                 $message[$convertConf[0]] = $this->castCustomHeader($header->getBodyAsString(), $convertConf[1]);
+                continue;
+            }
+
+            if ($header instanceof TrackingHeader) {
+                $track = 'true' === $header->getValue();
+
+                $message['TrackClicks'] = $track ? 'enabled' : 'disabled';
+                $message['TrackOpens'] = $track ? 'enabled' : 'disabled';
+
                 continue;
             }
 

--- a/src/Symfony/Component/Mailer/Bridge/Mailjet/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Mailjet/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=8.4.1",
-        "symfony/mailer": "^7.4|^8.0"
+        "symfony/mailer": "^8.2"
     },
     "require-dev": {
         "symfony/http-client": "^7.4|^8.0",

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/Tests/Transport/PostmarkApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/Tests/Transport/PostmarkApiTransportTest.php
@@ -250,15 +250,29 @@ class PostmarkApiTransportTest extends TestCase
         $envelope = new Envelope(new Address('alice@system.com'), [new Address('bob@system.com')]);
 
         $enabled = new Email();
-        $enabled->getHeaders()->add(new TrackingHeader(true));
+        $enabled->getHeaders()->add(new TrackingHeader(opens: true, clicks: true));
         $enabledPayload = $method->invoke($transport, $enabled, $envelope);
         $this->assertTrue($enabledPayload['TrackOpens']);
         $this->assertSame('HtmlAndText', $enabledPayload['TrackLinks']);
 
         $disabled = new Email();
-        $disabled->getHeaders()->add(new TrackingHeader(false));
+        $disabled->getHeaders()->add(new TrackingHeader(opens: false, clicks: false));
         $disabledPayload = $method->invoke($transport, $disabled, $envelope);
         $this->assertFalse($disabledPayload['TrackOpens']);
         $this->assertSame('None', $disabledPayload['TrackLinks']);
+    }
+
+    public function testTrackingHeaderControlsOpensAndClicksIndependently()
+    {
+        $transport = new PostmarkApiTransport('ACCESS_KEY');
+        $method = new \ReflectionMethod(PostmarkApiTransport::class, 'getPayload');
+        $envelope = new Envelope(new Address('alice@system.com'), [new Address('bob@system.com')]);
+
+        $email = new Email();
+        $email->getHeaders()->add(new TrackingHeader(opens: false));
+        $payload = $method->invoke($transport, $email, $envelope);
+
+        $this->assertFalse($payload['TrackOpens']);
+        $this->assertArrayNotHasKey('TrackLinks', $payload);
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/Tests/Transport/PostmarkApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/Tests/Transport/PostmarkApiTransportTest.php
@@ -24,6 +24,7 @@ use Symfony\Component\Mailer\Exception\HttpTransportException;
 use Symfony\Component\Mailer\Exception\TransportException;
 use Symfony\Component\Mailer\Header\MetadataHeader;
 use Symfony\Component\Mailer\Header\TagHeader;
+use Symfony\Component\Mailer\Header\TrackingHeader;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
 use Symfony\Contracts\HttpClient\ResponseInterface;
@@ -240,5 +241,24 @@ class PostmarkApiTransportTest extends TestCase
         $this->expectException(TransportException::class);
 
         $method->invoke($transport, $email, $envelope);
+    }
+
+    public function testTrackingHeader()
+    {
+        $transport = new PostmarkApiTransport('ACCESS_KEY');
+        $method = new \ReflectionMethod(PostmarkApiTransport::class, 'getPayload');
+        $envelope = new Envelope(new Address('alice@system.com'), [new Address('bob@system.com')]);
+
+        $enabled = new Email();
+        $enabled->getHeaders()->add(new TrackingHeader(true));
+        $enabledPayload = $method->invoke($transport, $enabled, $envelope);
+        $this->assertTrue($enabledPayload['TrackOpens']);
+        $this->assertSame('HtmlAndText', $enabledPayload['TrackLinks']);
+
+        $disabled = new Email();
+        $disabled->getHeaders()->add(new TrackingHeader(false));
+        $disabledPayload = $method->invoke($transport, $disabled, $envelope);
+        $this->assertFalse($disabledPayload['TrackOpens']);
+        $this->assertSame('None', $disabledPayload['TrackLinks']);
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/Tests/Transport/PostmarkSmtpTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/Tests/Transport/PostmarkSmtpTransportTest.php
@@ -78,15 +78,28 @@ class PostmarkSmtpTransportTest extends TestCase
         $method = new \ReflectionMethod(PostmarkSmtpTransport::class, 'addPostmarkHeaders');
 
         $enabled = new Email();
-        $enabled->getHeaders()->add(new TrackingHeader(true));
+        $enabled->getHeaders()->add(new TrackingHeader(opens: true, clicks: true));
         $method->invoke($transport, $enabled);
         $this->assertSame('X-PM-TrackOpens: true', $enabled->getHeaders()->get('X-PM-TrackOpens')->toString());
         $this->assertSame('X-PM-TrackLinks: HtmlAndText', $enabled->getHeaders()->get('X-PM-TrackLinks')->toString());
 
         $disabled = new Email();
-        $disabled->getHeaders()->add(new TrackingHeader(false));
+        $disabled->getHeaders()->add(new TrackingHeader(opens: false, clicks: false));
         $method->invoke($transport, $disabled);
         $this->assertSame('X-PM-TrackOpens: false', $disabled->getHeaders()->get('X-PM-TrackOpens')->toString());
         $this->assertSame('X-PM-TrackLinks: None', $disabled->getHeaders()->get('X-PM-TrackLinks')->toString());
+    }
+
+    public function testTrackingHeaderControlsOpensAndClicksIndependently()
+    {
+        $transport = new PostmarkSmtpTransport('ACCESS_KEY');
+        $method = new \ReflectionMethod(PostmarkSmtpTransport::class, 'addPostmarkHeaders');
+
+        $email = new Email();
+        $email->getHeaders()->add(new TrackingHeader(opens: false));
+        $method->invoke($transport, $email);
+
+        $this->assertSame('X-PM-TrackOpens: false', $email->getHeaders()->get('X-PM-TrackOpens')->toString());
+        $this->assertNull($email->getHeaders()->get('X-PM-TrackLinks'));
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/Tests/Transport/PostmarkSmtpTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/Tests/Transport/PostmarkSmtpTransportTest.php
@@ -17,6 +17,7 @@ use Symfony\Component\Mailer\Bridge\Postmark\Transport\PostmarkSmtpTransport;
 use Symfony\Component\Mailer\Exception\TransportException;
 use Symfony\Component\Mailer\Header\MetadataHeader;
 use Symfony\Component\Mailer\Header\TagHeader;
+use Symfony\Component\Mailer\Header\TrackingHeader;
 use Symfony\Component\Mime\Email;
 
 class PostmarkSmtpTransportTest extends TestCase
@@ -69,5 +70,23 @@ class PostmarkSmtpTransportTest extends TestCase
         $this->expectException(TransportException::class);
 
         $method->invoke($transport, $email);
+    }
+
+    public function testTrackingHeader()
+    {
+        $transport = new PostmarkSmtpTransport('ACCESS_KEY');
+        $method = new \ReflectionMethod(PostmarkSmtpTransport::class, 'addPostmarkHeaders');
+
+        $enabled = new Email();
+        $enabled->getHeaders()->add(new TrackingHeader(true));
+        $method->invoke($transport, $enabled);
+        $this->assertSame('X-PM-TrackOpens: true', $enabled->getHeaders()->get('X-PM-TrackOpens')->toString());
+        $this->assertSame('X-PM-TrackLinks: HtmlAndText', $enabled->getHeaders()->get('X-PM-TrackLinks')->toString());
+
+        $disabled = new Email();
+        $disabled->getHeaders()->add(new TrackingHeader(false));
+        $method->invoke($transport, $disabled);
+        $this->assertSame('X-PM-TrackOpens: false', $disabled->getHeaders()->get('X-PM-TrackOpens')->toString());
+        $this->assertSame('X-PM-TrackLinks: None', $disabled->getHeaders()->get('X-PM-TrackLinks')->toString());
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/Transport/PostmarkApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/Transport/PostmarkApiTransport.php
@@ -19,6 +19,7 @@ use Symfony\Component\Mailer\Exception\HttpTransportException;
 use Symfony\Component\Mailer\Exception\TransportException;
 use Symfony\Component\Mailer\Header\MetadataHeader;
 use Symfony\Component\Mailer\Header\TagHeader;
+use Symfony\Component\Mailer\Header\TrackingHeader;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\AbstractApiTransport;
 use Symfony\Component\Mime\Email;
@@ -115,6 +116,15 @@ class PostmarkApiTransport extends AbstractApiTransport
 
         foreach ($email->getHeaders()->all() as $name => $header) {
             if (\in_array($name, ['from', 'to', 'cc', 'bcc', 'subject', 'content-type', 'sender', 'reply-to', 'date'], true)) {
+                continue;
+            }
+
+            if ($header instanceof TrackingHeader) {
+                $track = 'true' === $header->getValue();
+
+                $payload['TrackOpens'] = $track;
+                $payload['TrackLinks'] = $track ? 'HtmlAndText' : 'None';
+
                 continue;
             }
 

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/Transport/PostmarkApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/Transport/PostmarkApiTransport.php
@@ -120,10 +120,12 @@ class PostmarkApiTransport extends AbstractApiTransport
             }
 
             if ($header instanceof TrackingHeader) {
-                $track = 'true' === $header->getValue();
-
-                $payload['TrackOpens'] = $track;
-                $payload['TrackLinks'] = $track ? 'HtmlAndText' : 'None';
+                if (null !== $header->getOpens()) {
+                    $payload['TrackOpens'] = $header->getOpens();
+                }
+                if (null !== $header->getClicks()) {
+                    $payload['TrackLinks'] = $header->getClicks() ? 'HtmlAndText' : 'None';
+                }
 
                 continue;
             }

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/Transport/PostmarkSmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/Transport/PostmarkSmtpTransport.php
@@ -70,10 +70,12 @@ class PostmarkSmtpTransport extends EsmtpTransport
             }
 
             if ($header instanceof TrackingHeader) {
-                $track = 'true' === $header->getValue();
-
-                $headers->addTextHeader('X-PM-TrackOpens', $track ? 'true' : 'false');
-                $headers->addTextHeader('X-PM-TrackLinks', $track ? 'HtmlAndText' : 'None');
+                if (null !== $header->getOpens()) {
+                    $headers->addTextHeader('X-PM-TrackOpens', $header->getOpens() ? 'true' : 'false');
+                }
+                if (null !== $header->getClicks()) {
+                    $headers->addTextHeader('X-PM-TrackLinks', $header->getClicks() ? 'HtmlAndText' : 'None');
+                }
                 $headers->remove($name);
             }
         }

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/Transport/PostmarkSmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/Transport/PostmarkSmtpTransport.php
@@ -17,6 +17,7 @@ use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Exception\TransportException;
 use Symfony\Component\Mailer\Header\MetadataHeader;
 use Symfony\Component\Mailer\Header\TagHeader;
+use Symfony\Component\Mailer\Header\TrackingHeader;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport;
 use Symfony\Component\Mime\Message;
@@ -65,6 +66,14 @@ class PostmarkSmtpTransport extends EsmtpTransport
 
             if ($header instanceof MetadataHeader) {
                 $headers->addTextHeader('X-PM-Metadata-'.$header->getKey(), $header->getValue());
+                $headers->remove($name);
+            }
+
+            if ($header instanceof TrackingHeader) {
+                $track = 'true' === $header->getValue();
+
+                $headers->addTextHeader('X-PM-TrackOpens', $track ? 'true' : 'false');
+                $headers->addTextHeader('X-PM-TrackLinks', $track ? 'HtmlAndText' : 'None');
                 $headers->remove($name);
             }
         }

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.4.1",
         "psr/event-dispatcher": "^1",
-        "symfony/mailer": "^7.4|^8.0"
+        "symfony/mailer": "^8.2"
     },
     "require-dev": {
         "symfony/http-client": "^7.4|^8.0",

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Transport/SendgridApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Transport/SendgridApiTransportTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\Mailer\Bridge\Sendgrid\Transport\SendgridApiTransport;
 use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Header\MetadataHeader;
 use Symfony\Component\Mailer\Header\TagHeader;
+use Symfony\Component\Mailer\Header\TrackingHeader;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
 use Symfony\Component\Mime\Part\DataPart;
@@ -327,5 +328,39 @@ class SendgridApiTransportTest extends TestCase
         $this->assertArrayHasKey('send_at', $payload);
         $this->assertSame(1746626400, $payload['send_at']);
         $this->assertTrue($email->getHeaders()->has('Send-At'));
+    }
+
+    public function testTrackingHeader()
+    {
+        $transport = new SendgridApiTransport('ACCESS_KEY');
+        $method = new \ReflectionMethod(SendgridApiTransport::class, 'getPayload');
+        $envelope = new Envelope(new Address('from@example.com'), [new Address('to@example.com')]);
+
+        $enabled = new Email();
+        $enabled->getHeaders()->add(new TrackingHeader(true));
+        $enabledPayload = $method->invoke($transport, $enabled, $envelope);
+        $this->assertTrue($enabledPayload['tracking_settings']['open_tracking']['enable']);
+        $this->assertTrue($enabledPayload['tracking_settings']['click_tracking']['enable']);
+        $this->assertTrue($enabledPayload['tracking_settings']['click_tracking']['enable_text']);
+
+        $disabled = new Email();
+        $disabled->getHeaders()->add(new TrackingHeader(false));
+        $disabledPayload = $method->invoke($transport, $disabled, $envelope);
+        $this->assertFalse($disabledPayload['tracking_settings']['open_tracking']['enable']);
+        $this->assertFalse($disabledPayload['tracking_settings']['click_tracking']['enable']);
+        $this->assertFalse($disabledPayload['tracking_settings']['click_tracking']['enable_text']);
+    }
+
+    public function testTrackingHeaderIsNotForwardedAsCustomHeader()
+    {
+        $transport = new SendgridApiTransport('ACCESS_KEY');
+        $method = new \ReflectionMethod(SendgridApiTransport::class, 'getPayload');
+        $envelope = new Envelope(new Address('from@example.com'), [new Address('to@example.com')]);
+
+        $email = new Email();
+        $email->getHeaders()->add(new TrackingHeader(true));
+
+        $payload = $method->invoke($transport, $email, $envelope);
+        $this->assertArrayNotHasKey('headers', $payload);
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Transport/SendgridApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Transport/SendgridApiTransportTest.php
@@ -337,18 +337,32 @@ class SendgridApiTransportTest extends TestCase
         $envelope = new Envelope(new Address('from@example.com'), [new Address('to@example.com')]);
 
         $enabled = new Email();
-        $enabled->getHeaders()->add(new TrackingHeader(true));
+        $enabled->getHeaders()->add(new TrackingHeader(opens: true, clicks: true));
         $enabledPayload = $method->invoke($transport, $enabled, $envelope);
         $this->assertTrue($enabledPayload['tracking_settings']['open_tracking']['enable']);
         $this->assertTrue($enabledPayload['tracking_settings']['click_tracking']['enable']);
         $this->assertTrue($enabledPayload['tracking_settings']['click_tracking']['enable_text']);
 
         $disabled = new Email();
-        $disabled->getHeaders()->add(new TrackingHeader(false));
+        $disabled->getHeaders()->add(new TrackingHeader(opens: false, clicks: false));
         $disabledPayload = $method->invoke($transport, $disabled, $envelope);
         $this->assertFalse($disabledPayload['tracking_settings']['open_tracking']['enable']);
         $this->assertFalse($disabledPayload['tracking_settings']['click_tracking']['enable']);
         $this->assertFalse($disabledPayload['tracking_settings']['click_tracking']['enable_text']);
+    }
+
+    public function testTrackingHeaderControlsOpensAndClicksIndependently()
+    {
+        $transport = new SendgridApiTransport('ACCESS_KEY');
+        $method = new \ReflectionMethod(SendgridApiTransport::class, 'getPayload');
+        $envelope = new Envelope(new Address('from@example.com'), [new Address('to@example.com')]);
+
+        $email = new Email();
+        $email->getHeaders()->add(new TrackingHeader(opens: false));
+        $payload = $method->invoke($transport, $email, $envelope);
+
+        $this->assertFalse($payload['tracking_settings']['open_tracking']['enable']);
+        $this->assertArrayNotHasKey('click_tracking', $payload['tracking_settings']);
     }
 
     public function testTrackingHeaderIsNotForwardedAsCustomHeader()
@@ -358,7 +372,7 @@ class SendgridApiTransportTest extends TestCase
         $envelope = new Envelope(new Address('from@example.com'), [new Address('to@example.com')]);
 
         $email = new Email();
-        $email->getHeaders()->add(new TrackingHeader(true));
+        $email->getHeaders()->add(new TrackingHeader(opens: true, clicks: true));
 
         $payload = $method->invoke($transport, $email, $envelope);
         $this->assertArrayNotHasKey('headers', $payload);

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Transport/SendgridApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Transport/SendgridApiTransport.php
@@ -148,12 +148,12 @@ class SendgridApiTransport extends AbstractApiTransport
                     $payload['asm']['groups_to_display'] = $groupsToDisplay;
                 }
             } elseif ($header instanceof TrackingHeader) {
-                $track = 'true' === $header->getValue();
-
-                $payload['tracking_settings'] = [
-                    'open_tracking' => ['enable' => $track],
-                    'click_tracking' => ['enable' => $track, 'enable_text' => $track],
-                ];
+                if (null !== $header->getOpens()) {
+                    $payload['tracking_settings']['open_tracking'] = ['enable' => $header->getOpens()];
+                }
+                if (null !== $header->getClicks()) {
+                    $payload['tracking_settings']['click_tracking'] = ['enable' => $header->getClicks(), 'enable_text' => $header->getClicks()];
+                }
 
                 continue;
             } else {

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Transport/SendgridApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Transport/SendgridApiTransport.php
@@ -19,6 +19,7 @@ use Symfony\Component\Mailer\Exception\HttpTransportException;
 use Symfony\Component\Mailer\Exception\TransportException;
 use Symfony\Component\Mailer\Header\MetadataHeader;
 use Symfony\Component\Mailer\Header\TagHeader;
+use Symfony\Component\Mailer\Header\TrackingHeader;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\AbstractApiTransport;
 use Symfony\Component\Mime\Address;
@@ -146,6 +147,15 @@ class SendgridApiTransport extends AbstractApiTransport
                 if ($groupsToDisplay = $header->getGroupsToDisplay()) {
                     $payload['asm']['groups_to_display'] = $groupsToDisplay;
                 }
+            } elseif ($header instanceof TrackingHeader) {
+                $track = 'true' === $header->getValue();
+
+                $payload['tracking_settings'] = [
+                    'open_tracking' => ['enable' => $track],
+                    'click_tracking' => ['enable' => $track, 'enable_text' => $track],
+                ];
+
+                continue;
             } else {
                 $payload['headers'][$header->getName()] = $header->getBodyAsString();
             }

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=8.4.1",
-        "symfony/mailer": "^7.4|^8.0"
+        "symfony/mailer": "^8.2"
     },
     "require-dev": {
         "symfony/http-client": "^7.4|^8.0",

--- a/src/Symfony/Component/Mailer/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add a `rate_limiter` option to mailer transports
  * Reorder EsmtpTransport authenticators to prefer PLAIN over obsolete LOGIN
+ * Add `TrackingHeader` for per-message open/click tracking across bridges and map it to provider-specific settings in Brevo, MailerSend, Postmark, AhaSend, Mandrill/Mailchimp, Azure, Infobip, Mailgun, Mailjet and Sendgrid transports
 
 8.0
 ---

--- a/src/Symfony/Component/Mailer/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/CHANGELOG.md
@@ -6,7 +6,7 @@ CHANGELOG
 
  * Add a `rate_limiter` option to mailer transports
  * Reorder EsmtpTransport authenticators to prefer PLAIN over obsolete LOGIN
- * Add `TrackingHeader` for per-message open/click tracking across bridges and map it to provider-specific settings in Brevo, MailerSend, Postmark, AhaSend, Mandrill/Mailchimp, Azure, Infobip, Mailgun, Mailjet and Sendgrid transports
+ * Add `TrackingHeader` for per-message open/click tracking and map it to provider-specific settings in the AhaSend, Azure, Brevo, Infobip, Mailchimp/Mandrill, MailerSend, Mailgun, Mailjet, Postmark and Sendgrid transports
 
 8.0
 ---

--- a/src/Symfony/Component/Mailer/Header/TrackingHeader.php
+++ b/src/Symfony/Component/Mailer/Header/TrackingHeader.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Header;
+
+use Symfony\Component\Mime\Header\UnstructuredHeader;
+
+/**
+ * Boolean header that enables/disables both open and click tracking.
+ */
+final class TrackingHeader extends UnstructuredHeader
+{
+    public function __construct(bool $enabled)
+    {
+        parent::__construct('X-Track', $enabled ? 'true' : 'false');
+    }
+}

--- a/src/Symfony/Component/Mailer/Header/TrackingHeader.php
+++ b/src/Symfony/Component/Mailer/Header/TrackingHeader.php
@@ -14,12 +14,45 @@ namespace Symfony\Component\Mailer\Header;
 use Symfony\Component\Mime\Header\UnstructuredHeader;
 
 /**
- * Boolean header that enables/disables both open and click tracking.
+ * Controls per-message open and click tracking; a null flag keeps the provider/transport default.
+ *
+ * Supported by the Brevo, AhaSend, Azure, Infobip, Mailchimp (Mandrill), MailerSend, Mailgun,
+ * Mailjet, Postmark and Sendgrid bridges. Azure and Brevo only expose a single combined toggle, so
+ * tracking is disabled (anonymised, for Brevo) as soon as either flag is explicitly false, and
+ * enabled as soon as either is explicitly true. Note that Brevo's toggle anonymises the open/click
+ * events rather than disabling them outright. On transports that don't support this header (plain
+ * SMTP, SES, Resend, ...), it is sent as a literal `X-Track` header and has no effect.
  */
 final class TrackingHeader extends UnstructuredHeader
 {
-    public function __construct(bool $enabled)
+    public function __construct(
+        private readonly ?bool $opens = null,
+        private readonly ?bool $clicks = null,
+    ) {
+        parent::__construct('X-Track', self::formatValue($opens, $clicks));
+    }
+
+    public function getOpens(): ?bool
     {
-        parent::__construct('X-Track', $enabled ? 'true' : 'false');
+        return $this->opens;
+    }
+
+    public function getClicks(): ?bool
+    {
+        return $this->clicks;
+    }
+
+    private static function formatValue(?bool $opens, ?bool $clicks): string
+    {
+        return \sprintf('opens=%s; clicks=%s', self::formatFlag($opens), self::formatFlag($clicks));
+    }
+
+    private static function formatFlag(?bool $flag): string
+    {
+        return match ($flag) {
+            null => 'default',
+            true => 'true',
+            false => 'false',
+        };
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | N/A
| License       | MIT

# Summary
This PR introduces a standardized way to control open and click tracking on a per-message basis across multiple Mailer providers. The goal is to make compliance-oriented behavior practical by default, while preserving backward compatibility with each provider’s existing transport options.

# Why
Recent regulatory interpretation in France (CNIL) reinforces that users must be able to refuse email tracking, including open and link tracking. In practice, teams need to enforce this at per-recipient level, not only as a global provider setting.

I initially considered implementing this only for Postmark, but that would leave users with provider-specific behavior and inconsistent compliance controls in multi-provider setups. Standardizing this in the Mailer layer is the safest path for application developers who need predictable, provider-agnostic controls for GDPR compliance workflows.

# What this PR does

- Adds a common per-message tracking control in Mailer.
- Maps that control to each provider’s native API/SMTP tracking fields.
- Keeps provider-specific headers/options functional and authoritative where already supported.
- Enables per-message consent-aware behavior without forcing global provider-level toggles.

# Why this matters for users

- Teams can now enforce consent decisions at send time per recipient/message.
- Applications do not need custom logic per provider for a basic compliance requirement.
- Migration cost is low because existing integrations continue to work.

# Testing and risk

- Added/updated focused transport tests for the affected bridges in the Symfony test suite.
- This was not validated end-to-end against every live provider API/SMTP service.
- Risk is low because the feature is opt-in: existing behavior is unchanged unless the tracking header is explicitly used.

# Example
```php
<?php
use Symfony\Component\Mailer\Header\TrackingHeader;
use Symfony\Component\Mime\Email;

$email = (new Email())
    ->from('noreply@example.com')
    ->to('user@example.com')
    ->subject('Your account update')
    ->text('Hello!');

// Per-user consent: disable open/click tracking for this message
$email->getHeaders()->add(new TrackingHeader(opens: false, clicks: false));

// If you want the opposite case:
$email->getHeaders()->add(new TrackingHeader(opens: true, clicks: true));

// Send with your configured Mailer transport
$mailer->send($email);
```

# Supported transports

| Bridge | API | SMTP | Notes |
| --- | --- | --- | --- |
| AhaSend | yes (v1 and v2) | yes | v1 maps to `content.headers`, v2 to the `tracking` object |
| Azure | yes | n/a | single combined toggle: false on either flag disables |
| Brevo | yes | no | per-recipient consent flag; anonymises instead of disabling |
| Infobip | yes | yes | |
| Mailchimp (Mandrill) | yes | yes | SMTP header lists aspects to enable; a null aspect is disabled when the other is set |
| MailerSend | yes | no | |
| Mailgun | yes | yes | |
| Mailjet | yes | yes | |
| Postmark | yes | yes | clicks map to `TrackLinks: HtmlAndText`/`None` |
| Sendgrid | yes | yes | SMTP goes through the `X-SMTPAPI` filters |

An explicit provider-specific header or setting always wins over the generic one. On every other transport the header is sent as a literal `X-Track` and has no effect; notably Resend and Mailtrap only expose domain-level toggles, and SES selects tracking through configuration sets (`X-SES-CONFIGURATION-SET`).
