### PR TITLE
[ObjectMapper] Fix reusing an already mapped object for a different target

### DIFF
--- a/src/Symfony/Component/ObjectMapper/ObjectMapper.php
+++ b/src/Symfony/Component/ObjectMapper/ObjectMapper.php
@@ -349,9 +349,10 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
         ) {
             $value = $this->applyTransforms($mapTo, $value, $source, $target);
 
-            if ($value === $source) {
+            // an already mapped source is reusable only when it matches the target resolved for this property
+            if ($value === $source && $target instanceof $mapTo->target) {
                 $value = $target;
-            } elseif ($objectMap->offsetExists($value)) {
+            } elseif ($objectMap->offsetExists($value) && $objectMap[$value] instanceof $mapTo->target) {
                 $value = $objectMap[$value];
             } else {
                 if ($mapTo->transform) {

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/RecursionCacheMultiTarget/ChildSource.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/RecursionCacheMultiTarget/ChildSource.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\RecursionCacheMultiTarget;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(target: ChildTarget::class)]
+class ChildSource
+{
+    public string $label = '';
+    public ItemSource $item;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/RecursionCacheMultiTarget/ChildTarget.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/RecursionCacheMultiTarget/ChildTarget.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\RecursionCacheMultiTarget;
+
+class ChildTarget
+{
+    public string $label = '';
+    public ?ItemTarget $item = null;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/RecursionCacheMultiTarget/ItemSource.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/RecursionCacheMultiTarget/ItemSource.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\RecursionCacheMultiTarget;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+use Symfony\Component\ObjectMapper\Transform\MapCollection;
+
+#[Map(target: ItemTarget::class)]
+class ItemSource
+{
+    public int $id = 1;
+
+    /** @var ChildSource[] */
+    #[Map(transform: new MapCollection(targetClass: ChildTarget::class))]
+    public array $children = [];
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/RecursionCacheMultiTarget/ItemSummaryTarget.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/RecursionCacheMultiTarget/ItemSummaryTarget.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\RecursionCacheMultiTarget;
+
+class ItemSummaryTarget
+{
+    public int $id = 0;
+    public array $children = [];
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/RecursionCacheMultiTarget/ItemTarget.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/RecursionCacheMultiTarget/ItemTarget.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\RecursionCacheMultiTarget;
+
+class ItemTarget
+{
+    public int $id = 0;
+    public array $children = [];
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/RecursionCacheMultiTarget/SelfSource.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/RecursionCacheMultiTarget/SelfSource.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\RecursionCacheMultiTarget;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(target: SelfTarget::class)]
+#[Map(target: SelfSummaryTarget::class)]
+class SelfSource
+{
+    public int $id = 1;
+    public ?self $self = null;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/RecursionCacheMultiTarget/SelfSummaryTarget.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/RecursionCacheMultiTarget/SelfSummaryTarget.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\RecursionCacheMultiTarget;
+
+class SelfSummaryTarget
+{
+    public int $id = 0;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/RecursionCacheMultiTarget/SelfTarget.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/RecursionCacheMultiTarget/SelfTarget.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\RecursionCacheMultiTarget;
+
+class SelfTarget
+{
+    public int $id = 0;
+    public ?SelfSummaryTarget $self = null;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
@@ -27,12 +27,6 @@ use Symfony\Component\ObjectMapper\Metadata\ReflectionObjectMapperMetadataFactor
 use Symfony\Component\ObjectMapper\Metadata\ReverseClassObjectMapperMetadataFactory;
 use Symfony\Component\ObjectMapper\ObjectMapper;
 use Symfony\Component\ObjectMapper\ObjectMapperInterface;
-use Symfony\Component\ObjectMapper\Tests\Fixtures\SourceCarriesMetadata\Lead as SourceCarriesMetadataLead;
-use Symfony\Component\ObjectMapper\Tests\Fixtures\SourceCarriesMetadata\LeadDto as SourceCarriesMetadataLeadDto;
-use Symfony\Component\ObjectMapper\Tests\Fixtures\SourceCarriesMetadata\TypeDto as SourceCarriesMetadataTypeDto;
-use Symfony\Component\ObjectMapper\Tests\Fixtures\TargetInClassMap\OtherView as TargetInClassMapOtherView;
-use Symfony\Component\ObjectMapper\Tests\Fixtures\TargetInClassMap\Source as TargetInClassMapSource;
-use Symfony\Component\ObjectMapper\Tests\Fixtures\TargetInClassMap\Target as TargetInClassMapTarget;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\A;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\B;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\C;
@@ -184,6 +178,13 @@ use Symfony\Component\ObjectMapper\Tests\Fixtures\ReadOnlyPromotedProperty\ReadO
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ReadOnlyPromotedProperty\ReadOnlyPromotedPropertyBMapped;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\Recursion\AB;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\Recursion\Dto;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\RecursionCacheMultiTarget\ChildSource as RecursionCacheChildSource;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\RecursionCacheMultiTarget\ItemSource as RecursionCacheItemSource;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\RecursionCacheMultiTarget\ItemSummaryTarget as RecursionCacheItemSummaryTarget;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\RecursionCacheMultiTarget\ItemTarget as RecursionCacheItemTarget;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\RecursionCacheMultiTarget\SelfSource as RecursionCacheSelfSource;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\RecursionCacheMultiTarget\SelfSummaryTarget as RecursionCacheSelfSummaryTarget;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\RecursionCacheMultiTarget\SelfTarget as RecursionCacheSelfTarget;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\SelfReferencing\Category;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\SelfReferencing\CategoryDto;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ServiceLoadedValue\LoadedValueService;
@@ -194,9 +195,15 @@ use Symfony\Component\ObjectMapper\Tests\Fixtures\ServiceLocator\A as ServiceLoc
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ServiceLocator\B as ServiceLocatorB;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ServiceLocator\ConditionCallable;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ServiceLocator\TransformCallable;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\SourceCarriesMetadata\Lead as SourceCarriesMetadataLead;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\SourceCarriesMetadata\LeadDto as SourceCarriesMetadataLeadDto;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\SourceCarriesMetadata\TypeDto as SourceCarriesMetadataTypeDto;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\SubclassTargetWithTransform\ChildTarget as SubclassTargetWithTransformChildTarget;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\SubclassTargetWithTransform\ParentTarget as SubclassTargetWithTransformParentTarget;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\SubclassTargetWithTransform\Source as SubclassTargetWithTransformSource;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\TargetInClassMap\OtherView as TargetInClassMapOtherView;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\TargetInClassMap\Source as TargetInClassMapSource;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\TargetInClassMap\Target as TargetInClassMapTarget;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\TargetTransform\SourceEntity;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\TargetTransform\TargetDto as TargetTransformTargetDto;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\Transform\TransformToStdClass;
@@ -1695,5 +1702,31 @@ final class ObjectMapperTest extends TestCase
         ));
 
         $this->assertSame('lower', $mapper->map(new TargetInClassMapSource(), TargetInClassMapTarget::class)->label);
+    }
+
+    public function testRecursionCacheIsNotReusedForADifferentTarget()
+    {
+        // mapping to ItemSummaryTarget caches it for $item, while the back-reference
+        // ChildTarget::$item resolves to the other target ItemSource declares
+        $item = new RecursionCacheItemSource();
+        $child = new RecursionCacheChildSource();
+        $child->label = 'child';
+        $child->item = $item;
+        $item->children = [$child];
+
+        $mapped = (new ObjectMapper())->map($item, RecursionCacheItemSummaryTarget::class);
+
+        $this->assertInstanceOf(RecursionCacheItemTarget::class, $mapped->children[0]->item);
+    }
+
+    public function testSelfReferenceIsNotReusedForADifferentTarget()
+    {
+        $source = new RecursionCacheSelfSource();
+        $source->self = $source;
+
+        $mapped = (new ObjectMapper())->map($source, RecursionCacheSelfTarget::class);
+
+        $this->assertInstanceOf(RecursionCacheSelfSummaryTarget::class, $mapped->self);
+        $this->assertSame(1, $mapped->self->id);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65293
| License       | MIT

`ObjectMapper` keeps a `WeakMap` of the objects it already mapped, so that cycles in the source graph resolve to a single target instance instead of recursing forever. That map is keyed on the source object alone, while the target a nested object maps to is resolved per property: `filterMetadataByPropertyType()` narrows the source's `#[Map]` candidates using the declared type of the destination property.

The two disagree when a source class declares several targets, typically a full representation and a lighter projection. A source already mapped to one of them earlier in the graph was handed back for a property expecting the other, and the mismatch surfaced as a native `TypeError` several layers below the actual cause:

```
Cannot assign ItemSummaryTarget to property ChildTarget::$item of type ?ItemTarget
```

Both reuse paths in `getSourceValue()` now check the object against the target resolved for the property before returning it, mirroring the `is_a()` guard `doMap()` already applies to freshly mapped objects: the recursion cache entry, and the short-circuit that hands back the target being built for a direct self-reference. When the object does not match, the property is mapped again to the target its declared type asks for.

Object identity is unchanged whenever the source and the resolved target agree, so existing cyclic graphs still collapse to a single instance per source. A cycle whose targets alternate now maps lazily, one level per dereference.
