### PR TITLE
[DoctrineBridge] Fix removing lazy listeners by object

### DIFF
--- a/src/Symfony/Bridge/Doctrine/ContainerAwareEventManager.php
+++ b/src/Symfony/Bridge/Doctrine/ContainerAwareEventManager.php
@@ -136,6 +136,10 @@ class ContainerAwareEventManager extends EventManager
         $hash = $this->getHash($listener);
 
         foreach ((array) $events as $event) {
+            if (\is_object($listener) && isset($this->listeners[$event]) && !isset($this->listeners[$event][$hash]) && !isset($this->initialized[$event])) {
+                $this->initializeListeners($event);
+            }
+
             if (isset($this->initializedHashMapping[$event][$hash])) {
                 $hash = $this->initializedHashMapping[$event][$hash];
                 unset($this->initializedHashMapping[$event][$hash]);

--- a/src/Symfony/Bridge/Doctrine/Tests/ContainerAwareEventManagerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/ContainerAwareEventManagerTest.php
@@ -281,6 +281,16 @@ class ContainerAwareEventManagerTest extends TestCase
         $this->assertSame([], $this->evm->getListeners('foo'));
     }
 
+    public function testRemoveLazyEventListenerByObject()
+    {
+        $this->container->set('lazy', $listener = new MyListener());
+        $this->evm->addEventListener('foo', 'lazy');
+
+        $this->evm->removeEventListener('foo', $listener);
+
+        $this->assertSame([], $this->evm->getListeners('foo'));
+    }
+
     public function testRemoveAllEventListener()
     {
         $this->container->set('lazy', new MyListener());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #52322
| License       | MIT

`ContainerAwareEventManager` keeps service-backed event listeners lazy and stores them under a hash derived from their service ID until the event is initialized.

When the listener object is injected elsewhere and passed to `removeEventListener()` (or indirectly through Doctrine's `removeEventSubscriber()`), removal happens by object hash. Before the event has been initialized, that hash cannot match the service-ID hash and the listener remains registered.

When removal is requested by an object that is not already registered under its object hash, the affected event's lazy listeners are now initialized first. This reuses the existing object-hash representation and lets the normal removal path remove the listener. Already registered object listeners do not trigger lazy initialization, and removal by service ID remains unchanged.

The regression test covers removing a service-backed listener by object before the event has been dispatched or its listeners inspected.

## Validation

- Focused lazy-listener removal scenarios were verified locally, including that removing an already registered object listener does not initialize lazy listeners.
- The full Symfony test suite could not be run in the execution environment because the repository dependencies cannot be cloned there; CI should provide the authoritative result.