### PR TITLE
[DoctrineBridge] Fix removing lazy listeners by object

### DIFF
--- a/src/Symfony/Bridge/Doctrine/ContainerAwareEventManager.php
+++ b/src/Symfony/Bridge/Doctrine/ContainerAwareEventManager.php
@@ -136,19 +136,20 @@ class ContainerAwareEventManager extends EventManager
         $hash = $this->getHash($listener);
 
         foreach ((array) $events as $event) {
-            if (isset($this->initializedHashMapping[$event][$hash])) {
-                $hash = $this->initializedHashMapping[$event][$hash];
-                unset($this->initializedHashMapping[$event][$hash]);
+            $eventHash = $hash;
+
+            // The listener might be registered as a service that is not initialized yet,
+            // in which case it is stored under the hash of its service id
+            if (\is_object($listener) && isset($this->listeners[$event]) && !isset($this->listeners[$event][$eventHash]) && !isset($this->initialized[$event])) {
+                $this->initializeListeners($event);
             }
 
-            // Check if we actually have this listener associated
-            if (isset($this->listeners[$event][$hash])) {
-                unset($this->listeners[$event][$hash]);
+            if (null !== $initializedHash = $this->initializedHashMapping[$event][$eventHash] ?? null) {
+                unset($this->initializedHashMapping[$event][$eventHash]);
+                $eventHash = $initializedHash;
             }
 
-            if (isset($this->methods[$event][$hash])) {
-                unset($this->methods[$event][$hash]);
-            }
+            unset($this->listeners[$event][$eventHash], $this->methods[$event][$eventHash]);
         }
     }
 

--- a/src/Symfony/Bridge/Doctrine/Tests/ContainerAwareEventManagerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/ContainerAwareEventManagerTest.php
@@ -281,6 +281,42 @@ class ContainerAwareEventManagerTest extends TestCase
         $this->assertSame([], $this->evm->getListeners('foo'));
     }
 
+    public function testRemoveLazyEventListenerByObject()
+    {
+        $this->container->set('lazy1', $listener1 = new MyListener());
+        $this->container->set('lazy2', $listener2 = new MyListener());
+        $this->evm->addEventListener('foo', 'lazy1');
+        $this->evm->addEventListener('foo', 'lazy2');
+
+        $this->evm->removeEventListener('foo', $listener1);
+        $this->assertSame([$listener2], array_values($this->evm->getListeners('foo')));
+
+        $this->evm->removeEventListener('foo', $listener2);
+        $this->assertSame([], $this->evm->getListeners('foo'));
+    }
+
+    public function testRemoveLazyEventSubscriberByObject()
+    {
+        $this->container->set('lazy', $subscriber = new MySubscriber(['foo']));
+        $this->evm->addEventListener('foo', 'lazy');
+
+        $this->evm->removeEventSubscriber($subscriber);
+
+        $this->assertSame([], $this->evm->getListeners('foo'));
+    }
+
+    public function testRemoveEventListenerOnSeveralEvents()
+    {
+        $this->container->set('lazy', new MyListener());
+        $this->evm->addEventListener(['foo', 'bar'], 'lazy');
+
+        $this->evm->getListeners('foo');
+        $this->evm->removeEventListener(['foo', 'bar'], 'lazy');
+
+        $this->assertSame([], $this->evm->getListeners('foo'));
+        $this->assertSame([], $this->evm->getListeners('bar'));
+    }
+
     public function testRemoveAllEventListener()
     {
         $this->container->set('lazy', new MyListener());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #52322
| License       | MIT

`ContainerAwareEventManager` keeps listener services lazy: until the event is initialized, such a listener is stored under a hash derived from its service id, and only then replaced by the hash of the instance the container returns.

Removing it by object, which is what Doctrine's `removeEventSubscriber()` does under the hood, computes the hash of the instance. Before initialization that hash matches nothing, so the listener stays registered and keeps being called. This is the case reported in #52322: injecting a listener service somewhere and passing it to `removeEventSubscriber()` silently does nothing.

Removal by object now initializes the listeners of the affected event first, so that the instance can be found under its own hash and removed by the regular path. Listeners already registered as objects are removed without triggering any initialization, and removal by service id is unchanged. This mirrors what `EventDispatcher::removeListener()` does with its own lazy listeners.

While at it, the hash was leaking from one iteration to the next when several events were passed at once, so `removeEventListener(['foo', 'bar'], 'lazy')` removed nothing from `bar` unless both events happened to be initialized. The mapping entry was also being unset under the wrong key. Both are fixed by keeping the hash local to each event.
