### PR TITLE
[DependencyInjection] Speed up ResolveInstanceofConditionalsPass

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveInstanceofConditionalsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveInstanceofConditionalsPass.php
@@ -25,22 +25,47 @@ use Symfony\Component\VarExporter\DeepCloner;
  */
 class ResolveInstanceofConditionalsPass implements CompilerPassInterface
 {
+    /**
+     * @var array<string, list<string>> lowercased canonical type name => rule keys as registered
+     */
+    private array $loadedRuleTypes = [];
+
+    /**
+     * @var array<string, true> rule keys whose type was not loaded when the pass started
+     */
+    private array $unresolvedRuleTypes = [];
+
+    /**
+     * @var array<string, array<string, ChildDefinition>> resolved class name => rules that can match it
+     */
+    private array $matchingRules = [];
+
     public function process(ContainerBuilder $container): void
     {
-        foreach ($container->getAutoconfiguredInstanceof() as $interface => $definition) {
-            if ($definition->getArguments()) {
-                throw new InvalidArgumentException(\sprintf('Autoconfigured instanceof for type "%s" defines arguments but these are not supported and should be removed.', $interface));
+        try {
+            foreach ($container->getAutoconfiguredInstanceof() as $interface => $definition) {
+                if ($definition->getArguments()) {
+                    throw new InvalidArgumentException(\sprintf('Autoconfigured instanceof for type "%s" defines arguments but these are not supported and should be removed.', $interface));
+                }
+
+                if (class_exists($interface, false) || interface_exists($interface, false)) {
+                    $this->loadedRuleTypes[strtolower((new \ReflectionClass($interface))->name)][] = $interface;
+                } else {
+                    $this->unresolvedRuleTypes[$interface] = true;
+                }
             }
-        }
 
-        $tagsToKeep = [];
+            $tagsToKeep = [];
 
-        if ($container->hasParameter('container.behavior_describing_tags')) {
-            $tagsToKeep = $container->getParameter('container.behavior_describing_tags');
-        }
+            if ($container->hasParameter('container.behavior_describing_tags')) {
+                $tagsToKeep = $container->getParameter('container.behavior_describing_tags');
+            }
 
-        foreach ($container->getDefinitions() as $id => $definition) {
-            $container->setDefinition($id, $this->processDefinition($container, $id, $definition, $tagsToKeep));
+            foreach ($container->getDefinitions() as $id => $definition) {
+                $container->setDefinition($id, $this->processDefinition($container, $id, $definition, $tagsToKeep));
+            }
+        } finally {
+            $this->loadedRuleTypes = $this->unresolvedRuleTypes = $this->matchingRules = [];
         }
 
         if ($container->hasParameter('container.behavior_describing_tags')) {
@@ -60,6 +85,7 @@ class ResolveInstanceofConditionalsPass implements CompilerPassInterface
             return $definition;
         }
 
+        $autoconfiguredInstanceof = $this->filterAutoconfigured($container, $class, $autoconfiguredInstanceof);
         $conditionals = $this->mergeConditionals($autoconfiguredInstanceof, $instanceofConditionals, $container);
 
         $definition->setInstanceofConditionals([]);
@@ -188,6 +214,45 @@ class ResolveInstanceofConditionalsPass implements CompilerPassInterface
     }
 
     /**
+     * Narrows the autoconfiguration rules to those that can match the class; rules whose
+     * type is not loaded yet are always kept so that the caller's is_subclass_of() check
+     * decides them (e.g. nonexistent types, late-defined class aliases).
+     */
+    private function filterAutoconfigured(ContainerBuilder $container, string $class, array $autoconfiguredInstanceof): array
+    {
+        if (!$autoconfiguredInstanceof || !$this->loadedRuleTypes) {
+            return $autoconfiguredInstanceof;
+        }
+
+        if (null !== $rules = $this->matchingRules[$class] ?? null) {
+            return $rules;
+        }
+
+        $candidates = $this->unresolvedRuleTypes;
+
+        // a rule keyed by the exact class name applies even when the class doesn't exist
+        if (isset($autoconfiguredInstanceof[$class])) {
+            $candidates[$class] = true;
+        }
+
+        if ($container->getReflectionClass($class, false)) {
+            foreach (class_implements($class) ?: [] as $type) {
+                foreach ($this->loadedRuleTypes[strtolower($type)] ?? [] as $ruleKey) {
+                    $candidates[$ruleKey] = true;
+                }
+            }
+            foreach (class_parents($class) ?: [] as $type) {
+                foreach ($this->loadedRuleTypes[strtolower($type)] ?? [] as $ruleKey) {
+                    $candidates[$ruleKey] = true;
+                }
+            }
+        }
+
+        // array_intersect_key() preserves the registration order of the rules
+        return $this->matchingRules[$class] = array_intersect_key($autoconfiguredInstanceof, $candidates);
+    }
+
+    /**
      * Whether a tag attribute-set is a lazily-computed one to be resolved per concrete class: either a
      * [\Closure] (a closure wrapped in an array so it survives addTag()) or a [class-string, method] callable.
      */
@@ -228,7 +293,7 @@ class ResolveInstanceofConditionalsPass implements CompilerPassInterface
         }
 
         if (!\is_array($resolved)) {
-            throw new InvalidArgumentException(\sprintf('%s must return an array of attributes, "%s" returned.', $source, get_debug_type($resolved)));
+            throw new InvalidArgumentException($source.\sprintf(' must return an array of attributes, "%s" returned.', get_debug_type($resolved)));
         }
 
         return $resolved;

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveInstanceofConditionalsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveInstanceofConditionalsPassTest.php
@@ -22,6 +22,10 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\Bar;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\BarInterface;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\InstanceofLateAlias\LateAliasedInterface;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\InstanceofLateAlias\LateAliasedService;
 use Symfony\Component\DependencyInjection\TypedReference;
 use Symfony\Contracts\Service\ResetInterface;
 use Symfony\Contracts\Service\ServiceSubscriberInterface;
@@ -402,6 +406,116 @@ class ResolveInstanceofConditionalsPassTest extends TestCase
             ],
         ], $container->getDefinition('decorator')->getTags());
         $this->assertFalse($container->hasParameter('container.behavior_describing_tags'));
+    }
+
+    public function testAutoconfiguredCaseInsensitiveTypeIsApplied()
+    {
+        $container = new ContainerBuilder();
+        $container->register('foo', Bar::class)->setAutoconfigured(true);
+        $container->registerForAutoconfiguration(strtolower(BarInterface::class))->addTag('some_tag');
+
+        (new ResolveInstanceofConditionalsPass())->process($container);
+
+        $def = $container->getDefinition('foo');
+        $this->assertInstanceOf(ChildDefinition::class, $def);
+        $this->assertSame('.instanceof.'.strtolower(BarInterface::class).'.0.foo', $def->getParent());
+        $this->assertSame(['some_tag' => [[]]], $def->getTags());
+    }
+
+    public function testAutoconfiguredCaseInsensitiveTypeOfTheClassItselfIsNotApplied()
+    {
+        $container = new ContainerBuilder();
+        $container->register('foo', Bar::class)->setAutoconfigured(true);
+        $container->registerForAutoconfiguration(strtolower(Bar::class))->addTag('some_tag');
+
+        (new ResolveInstanceofConditionalsPass())->process($container);
+
+        $def = $container->getDefinition('foo');
+        $this->assertNotInstanceOf(ChildDefinition::class, $def);
+        $this->assertSame([], $def->getTags());
+    }
+
+    public function testAutoconfiguredTypeMatchingANonExistentClassExactlyIsApplied()
+    {
+        $container = new ContainerBuilder();
+        $container->register('foo', 'App\Nope')->setAutoconfigured(true);
+        $container->registerForAutoconfiguration('App\Nope')->addTag('some_tag');
+
+        (new ResolveInstanceofConditionalsPass())->process($container);
+
+        $def = $container->getDefinition('foo');
+        $this->assertInstanceOf(ChildDefinition::class, $def);
+        $this->assertSame('.instanceof.App\Nope.0.foo', $def->getParent());
+        $this->assertSame(['some_tag' => [[]]], $def->getTags());
+    }
+
+    public function testAutoconfiguredAliasDefinedBeforeThePassIsApplied()
+    {
+        $alias = 'Symfony\Component\DependencyInjection\Tests\Compiler\PreloadedBarInterfaceAlias';
+        if (!interface_exists($alias, false)) {
+            class_alias(BarInterface::class, $alias);
+        }
+
+        $container = new ContainerBuilder();
+        $container->register('foo', Bar::class)->setAutoconfigured(true);
+        $container->registerForAutoconfiguration($alias)->addTag('some_tag');
+
+        (new ResolveInstanceofConditionalsPass())->process($container);
+
+        $this->assertSame(['some_tag' => [[]]], $container->getDefinition('foo')->getTags());
+    }
+
+    public function testAutoconfiguredAliasDefinedWhileAutoloadingTheServiceClassIsApplied()
+    {
+        $this->assertFalse(class_exists(LateAliasedService::class, false));
+
+        $container = new ContainerBuilder();
+        $container->register('foo', LateAliasedService::class)->setAutoconfigured(true);
+        $container->register('bar', LateAliasedService::class)->setAutoconfigured(true);
+        $container->registerForAutoconfiguration(\ArrayAccess::class)->addTag('unrelated_tag');
+        $container->registerForAutoconfiguration(LateAliasedInterface::class)->addTag('late_tag');
+
+        (new ResolveInstanceofConditionalsPass())->process($container);
+
+        $this->assertSame(['late_tag' => [[]]], $container->getDefinition('foo')->getTags());
+        $this->assertSame(['late_tag' => [[]]], $container->getDefinition('bar')->getTags());
+    }
+
+    public function testDuplicateCaseInsensitiveAutoconfiguredTypesAreAllApplied()
+    {
+        $container = new ContainerBuilder();
+        $container->register('foo', Bar::class)->setAutoconfigured(true);
+        $container->registerForAutoconfiguration(BarInterface::class)->addTag('tag_from_canonical');
+        $container->registerForAutoconfiguration(strtolower(BarInterface::class))->addTag('tag_from_lowercase');
+
+        (new ResolveInstanceofConditionalsPass())->process($container);
+
+        $def = $container->getDefinition('foo');
+        $this->assertTrue($container->hasDefinition('.instanceof.'.BarInterface::class.'.0.foo'));
+        $this->assertTrue($container->hasDefinition('.instanceof.'.strtolower(BarInterface::class).'.0.foo'));
+        $this->assertSame('.instanceof.'.strtolower(BarInterface::class).'.0.foo', $def->getParent());
+        $this->assertSame(['tag_from_lowercase' => [[]], 'tag_from_canonical' => [[]]], $def->getTags());
+    }
+
+    public function testProcessCanBeCalledSeveralTimes()
+    {
+        $pass = new ResolveInstanceofConditionalsPass();
+
+        $container = new ContainerBuilder();
+        $container->register('foo', Bar::class)->setAutoconfigured(true);
+        $container->registerForAutoconfiguration(BarInterface::class)->addTag('first_tag');
+
+        $pass->process($container);
+
+        $this->assertSame(['first_tag' => [[]]], $container->findDefinition('foo')->getTags());
+
+        $container = new ContainerBuilder();
+        $container->register('foo', Bar::class)->setAutoconfigured(true);
+        $container->registerForAutoconfiguration(Bar::class)->addTag('second_tag');
+
+        $pass->process($container);
+
+        $this->assertSame(['second_tag' => [[]]], $container->findDefinition('foo')->getTags());
     }
 
     public function testSyntheticService()

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/InstanceofLateAlias/LateAliasedService.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/InstanceofLateAlias/LateAliasedService.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\InstanceofLateAlias;
+
+interface RealInterface
+{
+}
+
+class LateAliasedService implements RealInterface
+{
+}
+
+// "LateAliasedInterface" has no file of its own: it only becomes defined when
+// this file is autoloaded, which lets tests exercise autoconfiguration rules
+// registered for a type that is unloadable when the pass starts.
+class_alias(RealInterface::class, __NAMESPACE__.'\LateAliasedInterface');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`ResolveInstanceofConditionalsPass` tests every registered autoconfiguration rule against every autoconfigured service with `is_subclass_of()`, and rebuilds the wrapped rule array for each service along the way. With `S` autoconfigured services and `C` global rules, the pass is **O(S × C)**, plus one array allocation per rule per service.

`C` is not small in practice: a standard app gets 60+ rules just from FrameworkBundle, Twig, Messenger, Console, etc. (one per extension point: `kernel.event_subscriber`, `console.command`, `twig.extension`, ...). For example, symfony.com has 66 rules for 292 autoconfigured services, and live.symfony.com has 68 rules for 396 services. On those real apps, this change makes the pass **16–18% faster** (e.g. 11.2 ms --> 9.2 ms on live.symfony.com).

**What changed?** While iterating the rules for validation, the pass now also indexes the rules whose type is already loaded by their lowercased canonical name. For each service class, the matching rules are then looked up from its own hierarchy (`class_implements()` + `class_parents()`) instead of scanning all rules again.

Rules whose type is not loaded yet are always kept as candidates so that the existing `is_subclass_of()` check keeps deciding them, which preserves the current behavior for nonexistent types, late-defined class aliases, exact-name matches, case-insensitivity and registration order.

A synthetic benchmark with 1,000 autoconfigured services:

| Rules | Before   | After    | Change |
| ----- | -------- | -------- | ------ |
| 50    | 9.87 ms  | 5.35 ms  | −46%   |
| 100   | 17.05 ms | 6.35 ms  | −63%   |
| 250   | 40.59 ms | 9.95 ms  | −75%   |
| 500   | 80.41 ms | 15.52 ms | −81%   |

This improvement is visible for all app sizes, but it gets better as the app complexity increases.


**How far this goes.** The index only helps for rules whose type is already loaded when the pass runs; the others stay candidates for every service and keep being decided by `is_subclass_of()`. On a cold container build a good share of them are still unloaded (23 of 46 rules on a FrameworkBundle test app), which is why real apps land at 16-18% rather than at the synthetic figures above. The pass also stays O(S × C), since `array_intersect_key()` still scans every rule per service; what collapses is the constant, and the measured time is nearly flat from 50 to 500 rules.
