### PR TITLE
[EventDispatcher] Do not initialize lazy listeners when they cannot match

### DIFF
--- a/src/Symfony/Component/EventDispatcher/EventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/EventDispatcher.php
@@ -95,7 +95,8 @@ class EventDispatcher implements EventDispatcherInterface
 
         foreach ($this->listeners[$eventName] as $priority => &$listeners) {
             foreach ($listeners as &$v) {
-                if ($v !== $listener && \is_array($v) && isset($v[0]) && $v[0] instanceof \Closure && 2 >= \count($v)) {
+                // Lazy listeners are arrays, they can never match a non-array listener
+                if (\is_array($listener) && $v !== $listener && \is_array($v) && isset($v[0]) && $v[0] instanceof \Closure && 2 >= \count($v)) {
                     $v[0] = $v[0]();
                     $v[1] ??= '__invoke';
                 }
@@ -142,7 +143,8 @@ class EventDispatcher implements EventDispatcherInterface
 
         foreach ($this->listeners[$eventName] as $priority => &$listeners) {
             foreach ($listeners as $k => &$v) {
-                if ($v !== $listener && \is_array($v) && isset($v[0]) && $v[0] instanceof \Closure && 2 >= \count($v)) {
+                // Lazy listeners are arrays, they can never match a non-array listener
+                if (\is_array($listener) && $v !== $listener && \is_array($v) && isset($v[0]) && $v[0] instanceof \Closure && 2 >= \count($v)) {
                     $v[0] = $v[0]();
                     $v[1] ??= '__invoke';
                 }

--- a/src/Symfony/Component/EventDispatcher/Tests/EventDispatcherTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/EventDispatcherTest.php
@@ -350,6 +350,40 @@ class EventDispatcherTest extends TestCase
         $this->assertFalse($this->dispatcher->hasListeners('foo'));
     }
 
+    public function testRemoveKeepsLazyListenersLazy()
+    {
+        $called = 0;
+        $factory = static function () use (&$called) {
+            ++$called;
+
+            return new TestWithDispatcher();
+        };
+
+        $this->dispatcher->addListener('foo', [$factory, 'foo']);
+        $this->dispatcher->addListener('foo', $listener = static function () {});
+
+        $this->dispatcher->removeListener('foo', $listener);
+
+        $this->assertSame(0, $called);
+        $this->assertTrue($this->dispatcher->hasListeners('foo'));
+    }
+
+    public function testPriorityKeepsLazyListenersLazy()
+    {
+        $called = 0;
+        $factory = static function () use (&$called) {
+            ++$called;
+
+            return new TestWithDispatcher();
+        };
+
+        $this->dispatcher->addListener('foo', [$factory, 'foo'], 3);
+        $this->dispatcher->addListener('foo', $listener = static function () {}, 5);
+
+        $this->assertSame(5, $this->dispatcher->getListenerPriority('foo', $listener));
+        $this->assertSame(0, $called);
+    }
+
     public function testPriorityFindsLazyListeners()
     {
         $test = new TestWithDispatcher();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`removeListener()` and `getListenerPriority()` have to compare the given listener with the registered ones. A lazy listener is registered as a `[closure, method]` array, so they initialize it first, replacing the closure by the service it returns.

That initialization is useless when the given listener is not an array itself: a closure, a string or an invokable object can never be identical to an array, before or after initialization. Comparing them is enough, so this skips initializing lazy listeners in that case.

This is not a corner case: `ContextListener::onKernelResponse()` removes a first-class callable from `kernel.response` while that event is being dispatched, on every request that runs a stateful firewall. Each listener service of that event that had not been reached yet was instantiated right there. `ExceptionListener` does the same on `kernel.exception`.

Removing a listener given as a `[object, method]` array still initializes lazy listeners, since those can match.
