### PR TITLE
[DoctrineBridge][EventDispatcher] Defer removing lazy listeners instead of initializing them

### DIFF
--- a/src/Symfony/Bridge/Doctrine/ContainerAwareEventManager.php
+++ b/src/Symfony/Bridge/Doctrine/ContainerAwareEventManager.php
@@ -26,6 +26,8 @@ class ContainerAwareEventManager extends EventManager
     private array $initialized = [];
     private bool $initializedSubscribers = false;
     private array $initializedHashMapping = [];
+    /** @var array<string, \WeakMap<object, true>> */
+    private array $removedListeners = [];
     private array $methods = [];
 
     /**
@@ -126,15 +128,15 @@ class ContainerAwareEventManager extends EventManager
         foreach ((array) $events as $event) {
             $eventHash = $hash;
 
-            // The listener might be registered as a service that is not initialized yet,
-            // in which case it is stored under the hash of its service id
-            if (\is_object($listener) && isset($this->listeners[$event]) && !isset($this->listeners[$event][$eventHash]) && !isset($this->initialized[$event])) {
-                $this->initializeListeners($event);
-            }
-
             if (null !== $initializedHash = $this->initializedHashMapping[$event][$eventHash] ?? null) {
                 unset($this->initializedHashMapping[$event][$eventHash]);
                 $eventHash = $initializedHash;
+            } elseif (\is_object($listener) && isset($this->listeners[$event]) && !isset($this->listeners[$event][$eventHash]) && !isset($this->initialized[$event])) {
+                // The listener might be one of the services that are not initialized yet,
+                // which are stored under the hash of their service id. Defer the removal
+                // to the moment they are instantiated anyway.
+                $this->removedListeners[$event] ??= new \WeakMap();
+                $this->removedListeners[$event][$listener] = true;
             }
 
             unset($this->listeners[$event][$eventHash], $this->methods[$event][$eventHash]);
@@ -162,12 +164,19 @@ class ContainerAwareEventManager extends EventManager
     private function initializeListeners(string $eventName): void
     {
         $this->initialized[$eventName] = true;
+        $removedListeners = $this->removedListeners[$eventName] ?? null;
+        unset($this->removedListeners[$eventName]);
 
         // We'll refill the whole array in order to keep the same order
         $listeners = [];
         foreach ($this->listeners[$eventName] as $hash => $listener) {
             if (\is_string($listener)) {
                 $listener = $this->container->get($listener);
+
+                if (isset($removedListeners[$listener])) {
+                    continue;
+                }
+
                 $newHash = $this->getHash($listener);
 
                 $this->initializedHashMapping[$eventName][$hash] = $newHash;

--- a/src/Symfony/Bridge/Doctrine/Tests/ContainerAwareEventManagerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/ContainerAwareEventManagerTest.php
@@ -15,6 +15,7 @@ use Doctrine\Common\EventSubscriber;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Doctrine\ContainerAwareEventManager;
 use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\ServiceLocator;
 
 class ContainerAwareEventManagerTest extends TestCase
 {
@@ -167,6 +168,42 @@ class ContainerAwareEventManagerTest extends TestCase
 
         $this->evm->removeEventListener('foo', $listener2);
         $this->assertSame([], $this->evm->getListeners('foo'));
+    }
+
+    public function testRemoveLazyEventListenerByObjectKeepsListenersLazy()
+    {
+        $called = 0;
+        $listener = new MyListener();
+        $evm = new ContainerAwareEventManager(new ServiceLocator([
+            'lazy1' => static function () use (&$called, $listener) {
+                ++$called;
+
+                return $listener;
+            },
+            'lazy2' => static function () use (&$called) {
+                ++$called;
+
+                return new MyListener();
+            },
+        ]));
+        $evm->addEventListener('foo', 'lazy1');
+        $evm->addEventListener('foo', 'lazy2');
+
+        $evm->removeEventListener('foo', $listener);
+        $this->assertSame(0, $called);
+
+        $this->assertCount(1, $evm->getListeners('foo'));
+    }
+
+    public function testDispatchEventAfterRemovingLazyEventListenerByObject()
+    {
+        $this->container->set('lazy', $listener = new MyListener());
+        $this->evm->addEventListener('foo', 'lazy');
+
+        $this->evm->removeEventListener('foo', $listener);
+        $this->evm->dispatchEvent('foo');
+
+        $this->assertSame(0, $listener->calledByEventNameCount);
     }
 
     public function testRemoveLazyEventSubscriberByObject()

--- a/src/Symfony/Component/EventDispatcher/EventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/EventDispatcher.php
@@ -34,6 +34,8 @@ class EventDispatcher implements EventDispatcherInterface
     private array $listeners = [];
     private array $sorted = [];
     private array $optimized;
+    /** @var array<string, \WeakMap<object, array<string, bool>>> */
+    private array $removedListeners = [];
 
     public function __construct()
     {
@@ -88,6 +90,10 @@ class EventDispatcher implements EventDispatcherInterface
             return null;
         }
 
+        if (isset($this->removedListeners[$eventName])) {
+            $this->sortListeners($eventName);
+        }
+
         if (\is_array($listener) && isset($listener[0]) && $listener[0] instanceof \Closure && 2 >= \count($listener)) {
             $listener[0] = $listener[0]();
             $listener[1] ??= '__invoke';
@@ -112,11 +118,19 @@ class EventDispatcher implements EventDispatcherInterface
     public function hasListeners(?string $eventName = null): bool
     {
         if (null !== $eventName) {
+            if (empty($this->listeners[$eventName])) {
+                return false;
+            }
+
+            if (isset($this->removedListeners[$eventName])) {
+                $this->sortListeners($eventName);
+            }
+
             return !empty($this->listeners[$eventName]);
         }
 
-        foreach ($this->listeners as $eventListeners) {
-            if ($eventListeners) {
+        foreach (array_keys($this->listeners) as $eventName) {
+            if ($this->hasListeners($eventName)) {
                 return true;
             }
         }
@@ -136,17 +150,19 @@ class EventDispatcher implements EventDispatcherInterface
             return;
         }
 
-        if (\is_array($listener) && isset($listener[0]) && $listener[0] instanceof \Closure && 2 >= \count($listener)) {
+        if (($isArray = \is_array($listener) && isset($listener[0]) && 2 >= \count($listener)) && $listener[0] instanceof \Closure) {
             $listener[0] = $listener[0]();
             $listener[1] ??= '__invoke';
         }
 
+        $lazy = false;
+
         foreach ($this->listeners[$eventName] as $priority => &$listeners) {
             foreach ($listeners as $k => &$v) {
-                // Lazy listeners are arrays, they can never match a non-array listener
-                if (\is_array($listener) && $v !== $listener && \is_array($v) && isset($v[0]) && $v[0] instanceof \Closure && 2 >= \count($v)) {
-                    $v[0] = $v[0]();
-                    $v[1] ??= '__invoke';
+                if (\is_array($v) && isset($v[0]) && $v[0] instanceof \Closure && 2 >= \count($v)) {
+                    // Comparing would require initializing the listener, defer instead
+                    $lazy = true;
+                    continue;
                 }
                 if ($v === $listener || ($listener instanceof \Closure && $v == $listener)) {
                     unset($listeners[$k], $this->sorted[$eventName], $this->optimized[$eventName]);
@@ -156,6 +172,15 @@ class EventDispatcher implements EventDispatcherInterface
             if (!$listeners) {
                 unset($this->listeners[$eventName][$priority]);
             }
+        }
+
+        if ($lazy && $isArray && \is_object($listener[0])) {
+            // The listener might be one of the services that are not initialized yet.
+            // Defer the removal to the moment they are instantiated anyway.
+            $removedListeners = $this->removedListeners[$eventName] ??= new \WeakMap();
+            $methods = $removedListeners[$listener[0]] ?? [];
+            $methods[\is_string($listener[1] ?? null) ? $listener[1] : '__invoke'] = true;
+            $removedListeners[$listener[0]] = $methods;
         }
     }
 
@@ -216,14 +241,25 @@ class EventDispatcher implements EventDispatcherInterface
     {
         krsort($this->listeners[$eventName]);
         $this->sorted[$eventName] = [];
+        $removedListeners = $this->removedListeners[$eventName] ?? null;
+        unset($this->removedListeners[$eventName]);
 
-        foreach ($this->listeners[$eventName] as &$listeners) {
-            foreach ($listeners as &$listener) {
+        foreach ($this->listeners[$eventName] as $priority => &$listeners) {
+            foreach ($listeners as $k => &$listener) {
                 if (\is_array($listener) && isset($listener[0]) && $listener[0] instanceof \Closure && 2 >= \count($listener)) {
                     $listener[0] = $listener[0]();
                     $listener[1] ??= '__invoke';
+
+                    if (isset($removedListeners[$listener[0]][$listener[1]])) {
+                        unset($listeners[$k]);
+                        continue;
+                    }
                 }
                 $this->sorted[$eventName][] = $listener;
+            }
+
+            if (!$listeners) {
+                unset($this->listeners[$eventName][$priority]);
             }
         }
     }
@@ -233,6 +269,10 @@ class EventDispatcher implements EventDispatcherInterface
      */
     private function optimizeListeners(string $eventName): array
     {
+        if (isset($this->removedListeners[$eventName])) {
+            $this->sortListeners($eventName);
+        }
+
         krsort($this->listeners[$eventName]);
         $this->optimized[$eventName] = [];
 

--- a/src/Symfony/Component/EventDispatcher/Tests/EventDispatcherTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/EventDispatcherTest.php
@@ -368,6 +368,73 @@ class EventDispatcherTest extends TestCase
         $this->assertTrue($this->dispatcher->hasListeners('foo'));
     }
 
+    public function testRemoveByObjectKeepsLazyListenersLazy()
+    {
+        $called = 0;
+        $test = new TestWithDispatcher();
+        $factory = static function () use (&$called, $test) {
+            ++$called;
+
+            return $test;
+        };
+
+        $this->dispatcher->addListener('foo', [$factory, 'foo']);
+        $this->dispatcher->addListener('foo', [static function () use (&$called) {
+            ++$called;
+
+            return new TestWithDispatcher();
+        }, 'foo']);
+
+        $this->dispatcher->removeListener('foo', [$test, 'foo']);
+        $this->assertSame(0, $called);
+
+        $this->assertCount(1, $this->dispatcher->getListeners('foo'));
+    }
+
+    public function testDispatchSkipsLazyListenerRemovedByObject()
+    {
+        $test = new TestWithDispatcher();
+        $factory = static fn () => $test;
+
+        $this->dispatcher->addListener('foo', [$factory, 'foo']);
+        $this->dispatcher->removeListener('foo', [$test, 'foo']);
+        $this->dispatcher->dispatch(new Event(), 'foo');
+
+        $this->assertNull($test->name);
+        $this->assertFalse($this->dispatcher->hasListeners('foo'));
+    }
+
+    public function testPriorityKeepsPendingRemovals()
+    {
+        $test = new TestWithDispatcher();
+        $factory = static fn () => $test;
+        $other = static function () {};
+
+        $this->dispatcher->addListener('foo', [$factory, 'foo'], 3);
+        $this->dispatcher->addListener('foo', $other, 5);
+        $this->dispatcher->removeListener('foo', [$test, 'foo']);
+
+        $this->assertSame(5, $this->dispatcher->getListenerPriority('foo', $other));
+        $this->assertSame([$other], $this->dispatcher->getListeners('foo'));
+    }
+
+    public function testRemoveSubscriberKeepsLazyListenersLazy()
+    {
+        $called = 0;
+        $subscriber = new TestEventSubscriber();
+        $factory = static function () use (&$called, $subscriber) {
+            ++$called;
+
+            return $subscriber;
+        };
+
+        $this->dispatcher->addListener('pre.foo', [$factory, 'preFoo']);
+        $this->dispatcher->removeSubscriber($subscriber);
+        $this->assertSame(0, $called);
+
+        $this->assertFalse($this->dispatcher->hasListeners('pre.foo'));
+    }
+
     public function testPriorityKeepsLazyListenersLazy()
     {
         $called = 0;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Removing a listener by object is the one operation that cannot be answered without knowing which service a lazy listener resolves to. Both dispatchers therefore initialize the listeners of the event to find the one to remove: `EventDispatcher::removeListener()` has always done so, and `ContainerAwareEventManager::removeEventListener()` since #65296.

Those services are instantiated when the event is used anyway, so the comparison can wait for that moment. The removal is now recorded and applied when the listeners are initialized, so nothing is instantiated on behalf of a removal any more, and nothing at all when the event never fires.

Pending removals are held in a `\WeakMap` keyed by the listener instance. Matching by identity instead of by `spl_object_hash()` rules out a recycled hash, and the entry disappears on its own when the instance dies before the event is initialized. That is the right outcome: a shared service is kept alive by the container, so a real removal always survives, while an instance nobody holds could never have been the one a lazy listener resolves to.

Two consequences worth knowing about:

 * When a removal is pending on an event, its listeners are initialized by the next call that has to know about them, which is `hasListeners()`, `getListenerPriority()` or the next dispatch. This is never more work than before, which did it in `removeListener()` itself, and it is skipped entirely while no removal is pending. Applying pending removals there rather than inside the closures built by `optimizeListeners()` also keeps those closures `static`, so the dispatcher stays out of their reference cycle.
 * Removing a lazy listener by object and registering the same service again for the same event, both before the event is initialized, leaves it removed. Clearing the pending removals on `addListener()` would resurrect the unrelated ones, which is the worse of the two behaviours.
