### PR TITLE
[DoctrineBridge] Deprecate `DoctrineCloseConnectionMiddleware` in favor of the new `DoctrineDbalCloseConnectionMiddleware`

### DIFF
--- a/UPGRADE-8.2.md
+++ b/UPGRADE-8.2.md
@@ -24,6 +24,11 @@ DoctrineBridge
  * `UniqueEntity` now throws a `ConstraintDefinitionException` when a checked field holds an array or is a to-many
    association and the default `findBy` repository method is used. Such fields were silently validated against a
    query that could not match. Use the `repositoryMethod` option to provide a method that can query them
+ * Deprecate `DoctrineCloseConnectionMiddleware` in favor of the new `DoctrineDbalCloseConnectionMiddleware`,
+   which targets DBAL connections instead of entity managers. Its first argument is a `ConnectionRegistry` instead
+   of a `ManagerRegistry`, and its second one takes connection names, either one or a list, instead of an entity
+   manager name. Passing no name now closes every DBAL connection, where the deprecated middleware closed the
+   connection of the default entity manager
 
 Form
 ----

--- a/src/Symfony/Bridge/Doctrine/CHANGELOG.md
+++ b/src/Symfony/Bridge/Doctrine/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Add IterableToArrayCollectionTransformer for ObjectMapper
  * Throw a `ConstraintDefinitionException` from `UniqueEntity` when a checked field holds an array or is a to-many association, instead of building a query that cannot match
  * Allow using closures with the `#[MapEntity]` attribute
+ * Deprecate `DoctrineCloseConnectionMiddleware` in favor of the new `DoctrineDbalCloseConnectionMiddleware`
 
 8.1
 ---

--- a/src/Symfony/Bridge/Doctrine/Messenger/AbstractDoctrineDbalMiddleware.php
+++ b/src/Symfony/Bridge/Doctrine/Messenger/AbstractDoctrineDbalMiddleware.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Messenger;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\Persistence\ConnectionRegistry;
+use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
+use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
+
+/**
+ * @internal
+ */
+abstract class AbstractDoctrineDbalMiddleware implements MiddlewareInterface
+{
+    public function __construct(
+        protected ConnectionRegistry $connectionRegistry,
+    ) {
+    }
+
+    final protected function getConnection(?string $name = null): Connection
+    {
+        try {
+            if (!($connection = $this->connectionRegistry->getConnection($name)) instanceof Connection) {
+                throw new UnrecoverableMessageHandlingException(\sprintf('Expected "%s" to be a DBAL connection, but got a "%s".', $name ?? $this->connectionRegistry->getDefaultConnectionName(), $connection::class));
+            }
+        } catch (\InvalidArgumentException $e) {
+            throw new UnrecoverableMessageHandlingException($e->getMessage(), 0, $e);
+        }
+
+        return $connection;
+    }
+
+    /**
+     * @param list<string> $names or none to get every DBAL connection
+     *
+     * @return array<string, Connection> indexed by their name
+     */
+    final protected function getConnections(array $names = []): array
+    {
+        $connections = [];
+
+        try {
+            foreach ($names ?: array_keys($this->connectionRegistry->getConnectionNames()) as $name) {
+                if (($connection = $this->connectionRegistry->getConnection($name)) instanceof Connection) {
+                    $connections[$name] = $connection;
+                } elseif ([] !== $names) {
+                    throw new UnrecoverableMessageHandlingException(\sprintf('Expected "%s" to be a DBAL connection, but got a "%s".', $name, $connection::class));
+                }
+            }
+        } catch (\InvalidArgumentException $e) {
+            throw new UnrecoverableMessageHandlingException($e->getMessage(), 0, $e);
+        }
+
+        return $connections;
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Messenger/DoctrineCloseConnectionMiddleware.php
+++ b/src/Symfony/Bridge/Doctrine/Messenger/DoctrineCloseConnectionMiddleware.php
@@ -16,10 +16,14 @@ use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Middleware\StackInterface;
 use Symfony\Component\Messenger\Stamp\ConsumedByWorkerStamp;
 
+trigger_deprecation('symfony/doctrine-bridge', '8.2', 'The "%s" class is deprecated, use "%s" instead.', DoctrineCloseConnectionMiddleware::class, DoctrineDbalCloseConnectionMiddleware::class);
+
 /**
  * Closes connection and therefore saves number of connections.
  *
  * @author Fuong <insidestyles@gmail.com>
+ *
+ * @deprecated since Symfony 8.2, use DoctrineDbalCloseConnectionMiddleware instead
  */
 class DoctrineCloseConnectionMiddleware extends AbstractDoctrineMiddleware
 {

--- a/src/Symfony/Bridge/Doctrine/Messenger/DoctrineDbalCloseConnectionMiddleware.php
+++ b/src/Symfony/Bridge/Doctrine/Messenger/DoctrineDbalCloseConnectionMiddleware.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Messenger;
+
+use Doctrine\Persistence\ConnectionRegistry;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Middleware\StackInterface;
+use Symfony\Component\Messenger\Stamp\ConsumedByWorkerStamp;
+
+/**
+ * Closes connections and therefore saves number of connections.
+ *
+ * @author Fuong <insidestyles@gmail.com>
+ */
+class DoctrineDbalCloseConnectionMiddleware extends AbstractDoctrineDbalMiddleware
+{
+    /** @var list<string> */
+    private array $connectionNames;
+
+    /**
+     * @param list<string>|string $connectionNames or none to close them all
+     */
+    public function __construct(ConnectionRegistry $connectionRegistry, array|string $connectionNames = [])
+    {
+        parent::__construct($connectionRegistry);
+
+        $this->connectionNames = (array) $connectionNames;
+    }
+
+    public function handle(Envelope $envelope, StackInterface $stack): Envelope
+    {
+        $connections = $this->getConnections($this->connectionNames);
+
+        try {
+            return $stack->next()->handle($envelope, $stack);
+        } finally {
+            if ($envelope->last(ConsumedByWorkerStamp::class)) {
+                foreach ($connections as $connection) {
+                    $connection->close();
+                }
+            }
+        }
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Messenger/AbstractDoctrineDbalMiddlewareTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Messenger/AbstractDoctrineDbalMiddlewareTest.php
@@ -1,0 +1,173 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Messenger;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\Persistence\ConnectionRegistry;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\Doctrine\Messenger\AbstractDoctrineDbalMiddleware;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
+use Symfony\Component\Messenger\Middleware\StackInterface;
+
+class AbstractDoctrineDbalMiddlewareTest extends TestCase
+{
+    public function testGetDefaultConnection()
+    {
+        $defaultConnection = $this->createStub(Connection::class);
+
+        $connectionRegistry = $this->createMock(ConnectionRegistry::class);
+        $connectionRegistry
+            ->expects($this->once())
+            ->method('getConnection')
+            ->with(null)
+            ->willReturn($defaultConnection)
+        ;
+
+        $this->assertSame($defaultConnection, new DummyDbalMiddleware($connectionRegistry)->connection());
+    }
+
+    public function testGetNamedConnection()
+    {
+        $fooConnection = $this->createStub(Connection::class);
+
+        $connectionRegistry = $this->createMock(ConnectionRegistry::class);
+        $connectionRegistry
+            ->expects($this->once())
+            ->method('getConnection')
+            ->with('foo')
+            ->willReturn($fooConnection)
+        ;
+
+        $this->assertSame($fooConnection, new DummyDbalMiddleware($connectionRegistry)->connection('foo'));
+    }
+
+    public function testGetMissingConnection()
+    {
+        $connectionRegistry = $this->createStub(ConnectionRegistry::class);
+        $connectionRegistry
+            ->method('getConnection')
+            ->willThrowException(new \InvalidArgumentException('Doctrine default Connection named "foo" does not exist.'))
+        ;
+
+        $this->expectException(UnrecoverableMessageHandlingException::class);
+        $this->expectExceptionMessage('Doctrine default Connection named "foo" does not exist.');
+
+        new DummyDbalMiddleware($connectionRegistry)->connection('foo');
+    }
+
+    public function testGetInvalidConnection()
+    {
+        $connectionRegistry = $this->createStub(ConnectionRegistry::class);
+        $connectionRegistry->method('getConnection')->willReturn(new \stdClass());
+
+        $this->expectException(UnrecoverableMessageHandlingException::class);
+        $this->expectExceptionMessage('Expected "foo" to be a DBAL connection, but got a "stdClass".');
+
+        new DummyDbalMiddleware($connectionRegistry)->connection('foo');
+    }
+
+    public function testGetInvalidDefaultConnection()
+    {
+        $connectionRegistry = $this->createStub(ConnectionRegistry::class);
+        $connectionRegistry->method('getDefaultConnectionName')->willReturn('default');
+        $connectionRegistry->method('getConnection')->willReturn(new \stdClass());
+
+        $this->expectException(UnrecoverableMessageHandlingException::class);
+        $this->expectExceptionMessage('Expected "default" to be a DBAL connection, but got a "stdClass".');
+
+        new DummyDbalMiddleware($connectionRegistry)->connection();
+    }
+
+    public function testGetAllConnectionsSkipsNonDbalOnes()
+    {
+        $fooConnection = $this->createStub(Connection::class);
+        $barConnection = $this->createStub(Connection::class);
+
+        $connectionRegistry = $this->createStub(ConnectionRegistry::class);
+        $connectionRegistry
+            ->method('getConnectionNames')
+            ->willReturn([
+                'foo' => 'doctrine.dbal.foo_connection',
+                'bar' => 'doctrine.dbal.bar_connection',
+                'baz' => 'doctrine.dbal.baz_connection',
+            ]);
+        $connectionRegistry
+            ->method('getConnection')
+            ->willReturnMap([
+                ['foo', $fooConnection],
+                ['bar', $barConnection],
+                ['baz', new \stdClass()],
+            ])
+        ;
+
+        $this->assertSame(['foo' => $fooConnection, 'bar' => $barConnection], new DummyDbalMiddleware($connectionRegistry)->connections());
+    }
+
+    public function testGetNamedConnections()
+    {
+        $fooConnection = $this->createStub(Connection::class);
+
+        $connectionRegistry = $this->createStub(ConnectionRegistry::class);
+        $connectionRegistry->method('getConnection')->willReturn($fooConnection);
+
+        $this->assertSame(['foo' => $fooConnection], new DummyDbalMiddleware($connectionRegistry)->connections(['foo']));
+    }
+
+    public function testGetMissingNamedConnection()
+    {
+        $connectionRegistry = $this->createStub(ConnectionRegistry::class);
+        $connectionRegistry
+            ->method('getConnection')
+            ->willThrowException(new \InvalidArgumentException('Doctrine default Connection named "foo" does not exist.'))
+        ;
+
+        $this->expectException(UnrecoverableMessageHandlingException::class);
+        $this->expectExceptionMessage('Doctrine default Connection named "foo" does not exist.');
+
+        new DummyDbalMiddleware($connectionRegistry)->connections(['foo']);
+    }
+
+    public function testGetInvalidNamedConnection()
+    {
+        $connectionRegistry = $this->createStub(ConnectionRegistry::class);
+        $connectionRegistry->method('getConnection')->willReturn(new \stdClass());
+
+        $this->expectException(UnrecoverableMessageHandlingException::class);
+        $this->expectExceptionMessage('Expected "foo" to be a DBAL connection, but got a "stdClass".');
+
+        new DummyDbalMiddleware($connectionRegistry)->connections(['foo']);
+    }
+}
+
+class DummyDbalMiddleware extends AbstractDoctrineDbalMiddleware
+{
+    public function handle(Envelope $envelope, StackInterface $stack): Envelope
+    {
+        return $stack->next()->handle($envelope, $stack);
+    }
+
+    public function connection(?string $name = null): Connection
+    {
+        return $this->getConnection($name);
+    }
+
+    /**
+     * @param list<string> $names
+     *
+     * @return array<string, Connection>
+     */
+    public function connections(array $names = []): array
+    {
+        return $this->getConnections($names);
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrineCloseConnectionMiddlewareTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrineCloseConnectionMiddlewareTest.php
@@ -14,6 +14,8 @@ namespace Symfony\Bridge\Doctrine\Tests\Messenger;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ManagerRegistry;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Bridge\Doctrine\Messenger\DoctrineCloseConnectionMiddleware;
 use Symfony\Component\Messenger\Envelope;
@@ -21,6 +23,8 @@ use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 use Symfony\Component\Messenger\Stamp\ConsumedByWorkerStamp;
 use Symfony\Component\Messenger\Test\Middleware\MiddlewareTestCase;
 
+#[Group('legacy')]
+#[IgnoreDeprecations]
 class DoctrineCloseConnectionMiddlewareTest extends MiddlewareTestCase
 {
     private MockObject&Connection $connection;

--- a/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrineDbalCloseConnectionMiddlewareTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrineDbalCloseConnectionMiddlewareTest.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Messenger;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\Persistence\ConnectionRegistry;
+use PHPUnit\Framework\Attributes\TestWith;
+use Symfony\Bridge\Doctrine\Messenger\DoctrineDbalCloseConnectionMiddleware;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBus;
+use Symfony\Component\Messenger\Middleware\AddBusNameStampMiddleware;
+use Symfony\Component\Messenger\Stamp\ConsumedByWorkerStamp;
+use Symfony\Component\Messenger\Test\Middleware\MiddlewareTestCase;
+
+class DoctrineDbalCloseConnectionMiddlewareTest extends MiddlewareTestCase
+{
+    public function testMiddlewareClosesConnections()
+    {
+        $fooConnection = $this->createMock(Connection::class);
+        $fooConnection->expects($this->once())->method('close');
+
+        $barConnection = $this->createMock(Connection::class);
+        $barConnection->expects($this->once())->method('close');
+
+        $connectionRegistry = $this->createStub(ConnectionRegistry::class);
+        $connectionRegistry->method('getConnection')->willReturn($fooConnection, $barConnection);
+
+        new DoctrineDbalCloseConnectionMiddleware($connectionRegistry, ['foo', 'bar'])->handle(
+            new Envelope(new \stdClass(), [new ConsumedByWorkerStamp()]),
+            $this->getStackMock(),
+        );
+    }
+
+    #[TestWith(['foo'])]
+    #[TestWith([['foo']])]
+    public function testMiddlewareDoesntCloseConnectionsInNonWorkerContext(array|string $connectionNames)
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->never())->method('close');
+
+        $connectionRegistry = $this->createStub(ConnectionRegistry::class);
+        $connectionRegistry->method('getConnection')->willReturn($connection);
+
+        new DoctrineDbalCloseConnectionMiddleware($connectionRegistry, $connectionNames)->handle(
+            new Envelope(new \stdClass()),
+            $this->getStackMock(),
+        );
+    }
+
+    public function testMiddlewareClosesAllConnectionsWhenUsedInABus()
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->once())->method('close');
+
+        $connectionRegistry = $this->createStub(ConnectionRegistry::class);
+        $connectionRegistry->method('getConnectionNames')->willReturn(['default' => 'doctrine.dbal.default_connection']);
+        $connectionRegistry->method('getConnection')->willReturn($connection);
+
+        $bus = new MessageBus([
+            new AddBusNameStampMiddleware('bus'),
+            new DoctrineDbalCloseConnectionMiddleware($connectionRegistry),
+        ]);
+
+        $bus->dispatch(new Envelope(new \stdClass(), [new ConsumedByWorkerStamp()]));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Issues        | Part of #38988
| License       | MIT

`DoctrineCloseConnectionMiddleware` goes through the ORM to close a connection: it takes a `ManagerRegistry` and an entity manager name, so it cannot target DBAL-only connections and always resolves the connection via an entity manager.

This PR deprecates it in favor of a new `DoctrineDbalCloseConnectionMiddleware` which targets DBAL connections directly:

- it takes a `ConnectionRegistry` instead of a `ManagerRegistry`;
- its second argument accepts connection name(s), either one or a list, instead of an entity manager name;
- when no name is passed, it closes every DBAL connection, where the deprecated middleware closed the connection of the default entity manager.

The connection lookup lives in a new internal `AbstractDoctrineDbalMiddleware` base class, which exposes `getConnection(?string $name)` and `getConnections(array $names)` helpers (both wrapping lookup failures in `UnrecoverableMessageHandlingException`) so each middleware declares its own constructor and arity. It is meant to be reused by DBAL ports of the ping/transaction middlewares.

For symfony-docs: the messenger documentation should mention the new middleware, its constructor signature, and that passing no connection name closes all DBAL connections.
