### PR TITLE
[FrameworkBundle] Do not leak the response body from `assertResponseRedirects()` when not verbose

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/BrowserKitAssertionsTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/BrowserKitAssertionsTrait.php
@@ -55,21 +55,29 @@ trait BrowserKitAssertionsTrait
 
     public static function assertResponseRedirects(?string $expectedLocation = null, ?int $expectedCode = null, string $message = '', ?bool $verbose = null): void
     {
-        $constraint = new ResponseConstraint\ResponseIsRedirected($verbose ?? self::$defaultVerboseMode);
+        $verbose ??= self::$defaultVerboseMode;
+
+        $constraints = [new ResponseConstraint\ResponseIsRedirected($verbose)];
         if ($expectedLocation) {
             if (class_exists(ResponseConstraint\ResponseHeaderLocationSame::class)) {
-                $locationConstraint = new ResponseConstraint\ResponseHeaderLocationSame(self::getRequest(), $expectedLocation);
+                $constraints[] = new ResponseConstraint\ResponseHeaderLocationSame(self::getRequest(), $expectedLocation);
             } else {
-                $locationConstraint = new ResponseConstraint\ResponseHeaderSame('Location', $expectedLocation);
+                $constraints[] = new ResponseConstraint\ResponseHeaderSame('Location', $expectedLocation);
             }
-
-            $constraint = LogicalAnd::fromConstraints($constraint, $locationConstraint);
         }
         if ($expectedCode) {
-            $constraint = LogicalAnd::fromConstraints($constraint, new ResponseConstraint\ResponseStatusCodeSame($expectedCode));
+            $constraints[] = new ResponseConstraint\ResponseStatusCodeSame($expectedCode, $verbose);
         }
 
-        self::assertThatForResponse($constraint, $message);
+        // LogicalAnd describes its failure by exporting the whole response, body included, so it
+        // cannot be used when $verbose asked for the body to be omitted; assert one by one instead
+        if ($verbose && 1 < \count($constraints)) {
+            $constraints = [LogicalAnd::fromConstraints(...$constraints)];
+        }
+
+        foreach ($constraints as $constraint) {
+            self::assertThatForResponse($constraint, $message);
+        }
     }
 
     public static function assertResponseHasHeader(string $headerName, string $message = ''): void

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Test/WebTestCaseTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Test/WebTestCaseTest.php
@@ -62,6 +62,32 @@ class WebTestCaseTest extends TestCase
         $this->getResponseTester(new Response('', 301))->assertResponseRedirects('https://example.com/');
     }
 
+    public function testAssertResponseRedirectsWithLocationOmitsBodyWhenNotVerbose()
+    {
+        $error = null;
+
+        try {
+            $this->getResponseTester(new Response('the response body', 301))->assertResponseRedirects('https://example.com/', verbose: false);
+        } catch (AssertionFailedError $error) {
+        }
+
+        $this->assertNotNull($error, 'The assertion is expected to fail.');
+        $this->assertStringNotContainsString('the response body', $error->getMessage());
+    }
+
+    public function testAssertResponseRedirectsWithStatusCodeOmitsBodyWhenNotVerbose()
+    {
+        $error = null;
+
+        try {
+            $this->getResponseTester(new Response('the response body', 302))->assertResponseRedirects(null, 301, verbose: false);
+        } catch (AssertionFailedError $error) {
+        }
+
+        $this->assertNotNull($error, 'The assertion is expected to fail.');
+        $this->assertStringNotContainsString('the response body', $error->getMessage());
+    }
+
     public function testAssertResponseRedirectsWithLocationWithoutHost()
     {
         $this->getResponseTester(new Response('', 301, ['Location' => 'https://example.com/']))->assertResponseRedirects('/');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`assertResponseRedirects()` accepts `verbose: false` to keep the response body out of the failure message, but it prints the body anyway as soon as an expected location or status code is given. Two causes:

 * with more than one expectation the constraints are wrapped in `LogicalAnd`, which does not override `failureDescription()`, so PHPUnit's default runs and exports the whole `Response`, body included, regardless of what the wrapped constraints do;
 * `ResponseStatusCodeSame` takes a `$verbose` argument, but `assertResponseRedirects()` never passes it.

Before, with `verbose: false` and a 302 body of `the response body`:

```
Failed asserting that Symfony\Component\HttpFoundation\Response Object (
    'headers' => ...
    'content' => 'the response body',
    'statusCode' => 302,
    ...
) is redirected and status code is 301.
```

After:

```
Failed asserting that the Response status code is 301.
HTTP/1.0 302 Found
Cache-Control: no-cache, private
```

The fix keeps `LogicalAnd` when verbose, so the combined `is redirected and has header "Location" ...` message and every existing test are unchanged, and asserts one constraint at a time only when the body was asked to be omitted.
