### PR TITLE
[Console] Revert "Add a `listedAt` option to list a command only from a given verbosity"

### DIFF
--- a/src/Symfony/Component/Console/Attribute/AsCommand.php
+++ b/src/Symfony/Component/Console/Attribute/AsCommand.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Component\Console\Attribute;
 
-use Symfony\Component\Console\Output\OutputInterface;
-
 /**
  * Service tag to autoconfigure commands.
  */
@@ -23,13 +21,12 @@ final class AsCommand
     public ?string $help;
 
     /**
-     * @param string                            $name        The name of the command, used when calling it (i.e. "cache:clear")
-     * @param string|(callable():string)|null   $description The description of the command, displayed with the help page
-     * @param string[]                          $aliases     The list of aliases of the command. The command will be executed when using one of them (i.e. "cache:clean")
-     * @param bool                              $hidden      If true, the command won't be shown when listing all the available commands, but it can still be run as any other command
-     * @param string|(callable():string)|null   $help        The help content of the command, displayed with the help page
-     * @param string[]                          $usages      The list of usage examples, displayed with the help page
-     * @param OutputInterface::VERBOSITY_*|null $listedAt    The verbosity from which the command is listed, null to always list it. It can still be run as any other command
+     * @param string                          $name        The name of the command, used when calling it (i.e. "cache:clear")
+     * @param string|(callable():string)|null $description The description of the command, displayed with the help page
+     * @param string[]                        $aliases     The list of aliases of the command. The command will be executed when using one of them (i.e. "cache:clean")
+     * @param bool                            $hidden      If true, the command won't be shown when listing all the available commands, but it can still be run as any other command
+     * @param string|(callable():string)|null $help        The help content of the command, displayed with the help page
+     * @param string[]                        $usages      The list of usage examples, displayed with the help page
      */
     public function __construct(
         public string $name,
@@ -38,7 +35,6 @@ final class AsCommand
         bool $hidden = false,
         string|callable|null $help = null,
         public array $usages = [],
-        public ?int $listedAt = null,
     ) {
         $this->description = null === $description || \is_string($description) ? $description : $description();
         $this->help = null === $help || \is_string($help) ? $help : $help();

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -5,7 +5,6 @@ CHANGELOG
 ---
 
  * Add `InputOption::HIDDEN` and `InputOption::DEPRECATED` modes
- * Add the `listedAt` option to `#[AsCommand]` and the `listed_at` attribute to the `console.command` tag, to list a command only from the given verbosity
  * Allow a callable for the `description` and `help` options of `#[AsCommand]`, and for the `description` option of `#[Argument]` and `#[Option]`
 
 8.1

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -47,8 +47,6 @@ class Command implements SignalableCommandInterface
     private array $aliases = [];
     private InputDefinition $definition;
     private bool $hidden = false;
-    /** @var OutputInterface::VERBOSITY_*|null */
-    private ?int $listedAt = null;
     private string $help = '';
     private string $description = '';
     private ?InputDefinition $fullDefinition = null;
@@ -512,30 +510,6 @@ class Command implements SignalableCommandInterface
     public function isHidden(): bool
     {
         return $this->hidden;
-    }
-
-    /**
-     * Sets the verbosity from which "list" shows the command.
-     *
-     * @param OutputInterface::VERBOSITY_*|null $listedAt Null to always show it
-     *
-     * @return $this
-     */
-    public function setListedAt(?int $listedAt): static
-    {
-        $this->listedAt = $listedAt;
-
-        return $this;
-    }
-
-    /**
-     * Returns the verbosity from which "list" shows the command, null when it is always shown.
-     *
-     * @return OutputInterface::VERBOSITY_*|null
-     */
-    public function getListedAt(): ?int
-    {
-        return $this->listedAt;
     }
 
     /**

--- a/src/Symfony/Component/Console/Command/LazyCommand.php
+++ b/src/Symfony/Component/Console/Command/LazyCommand.php
@@ -28,9 +28,6 @@ final class LazyCommand extends Command
 {
     private \Closure|Command $command;
 
-    /**
-     * @param OutputInterface::VERBOSITY_*|null $listedAt
-     */
     public function __construct(
         string $name,
         array $aliases,
@@ -38,12 +35,10 @@ final class LazyCommand extends Command
         bool $isHidden,
         \Closure $commandFactory,
         private ?bool $isEnabled = true,
-        ?int $listedAt = null,
     ) {
         $this->setName($name)
             ->setAliases($aliases)
             ->setHidden($isHidden)
-            ->setListedAt($listedAt)
             ->setDescription($description);
 
         $this->command = $commandFactory;
@@ -201,7 +196,6 @@ final class LazyCommand extends Command
         $command->setName($this->getName())
             ->setAliases($this->getAliases())
             ->setHidden($this->isHidden())
-            ->setListedAt($this->getListedAt())
             ->setDescription($this->getDescription());
 
         // Will throw if the command is not correctly initialized.

--- a/src/Symfony/Component/Console/DependencyInjection/AddConsoleCommandPass.php
+++ b/src/Symfony/Component/Console/DependencyInjection/AddConsoleCommandPass.php
@@ -126,7 +126,6 @@ class AddConsoleCommandPass implements CompilerPassInterface
         $description = $tags[0]['description'] ?? null;
         $help = $tags[0]['help'] ?? null;
         $usages = $tags[0]['usages'] ?? null;
-        $listedAt = $tags[0]['listed_at'] ?? $attribute?->listedAt;
 
         unset($tags[0]);
         $lazyCommandMap[$commandName] = $id;
@@ -157,10 +156,6 @@ class AddConsoleCommandPass implements CompilerPassInterface
             $definition->addMethodCall('setHidden', [true]);
         }
 
-        if (null !== $listedAt) {
-            $definition->addMethodCall('setListedAt', [$listedAt]);
-        }
-
         if ($help ??= $attribute?->help) {
             $definition->addMethodCall('setHelp', [str_replace('%', '%%', $help)]);
         }
@@ -176,7 +171,7 @@ class AddConsoleCommandPass implements CompilerPassInterface
             $definition->addMethodCall('setDescription', [$escapedDescription]);
 
             $container->register('.'.$id.'.lazy', LazyCommand::class)
-                ->setArguments([$commandName, $aliases, $escapedDescription, $isHidden, new ServiceClosureArgument($lazyCommandRefs[$id]), true, $listedAt]);
+                ->setArguments([$commandName, $aliases, $escapedDescription, $isHidden, new ServiceClosureArgument($lazyCommandRefs[$id])]);
 
             $lazyCommandRefs[$id] = new Reference('.'.$id.'.lazy');
         }

--- a/src/Symfony/Component/Console/Descriptor/ApplicationDescription.php
+++ b/src/Symfony/Component/Console/Descriptor/ApplicationDescription.php
@@ -14,7 +14,6 @@ namespace Symfony\Component\Console\Descriptor;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Exception\CommandNotFoundException;
-use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>
@@ -37,16 +36,10 @@ class ApplicationDescription
      */
     private array $aliases = [];
 
-    private ?int $nextVerbosity = null;
-
-    /**
-     * @param OutputInterface::VERBOSITY_* $verbosity
-     */
     public function __construct(
         private Application $application,
         private ?string $namespace = null,
         private bool $showHidden = false,
-        private int $verbosity = OutputInterface::VERBOSITY_NORMAL,
     ) {
     }
 
@@ -83,18 +76,6 @@ class ApplicationDescription
         return $this->commands[$name] ?? $this->aliases[$name];
     }
 
-    /**
-     * Returns the lowest verbosity that would list more commands, or null when none is left out.
-     */
-    public function getNextVerbosity(): ?int
-    {
-        if (!isset($this->commands)) {
-            $this->inspectApplication();
-        }
-
-        return $this->nextVerbosity;
-    }
-
     private function inspectApplication(): void
     {
         $this->commands = [];
@@ -105,17 +86,7 @@ class ApplicationDescription
             $names = [];
 
             foreach ($commands as $name => $command) {
-                if (!$command->getName()) {
-                    continue;
-                }
-
-                if (!$this->showHidden && $command->isHidden()) {
-                    continue;
-                }
-
-                if (!$this->showHidden && $command->getListedAt() > $this->verbosity) {
-                    $this->nextVerbosity = min($this->nextVerbosity ?? \PHP_INT_MAX, $command->getListedAt());
-
+                if (!$command->getName() || (!$this->showHidden && $command->isHidden())) {
                     continue;
                 }
 

--- a/src/Symfony/Component/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/TextDescriptor.php
@@ -18,7 +18,6 @@ use Symfony\Component\Console\Helper\Helper;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Text descriptor.
@@ -167,7 +166,7 @@ class TextDescriptor extends Descriptor
     protected function describeApplication(Application $application, array $options = []): void
     {
         $describedNamespace = $options['namespace'] ?? null;
-        $description = new ApplicationDescription($application, $describedNamespace, false, $this->output->getVerbosity());
+        $description = new ApplicationDescription($application, $describedNamespace);
 
         if (isset($options['raw_text']) && $options['raw_text']) {
             $width = $this->getColumnWidth($description->getCommands());
@@ -230,18 +229,6 @@ class TextDescriptor extends Descriptor
             }
 
             $this->writeText("\n");
-
-            if (null !== $nextVerbosity = $description->getNextVerbosity()) {
-                $option = match (true) {
-                    $nextVerbosity >= OutputInterface::VERBOSITY_DEBUG => '-vvv',
-                    $nextVerbosity >= OutputInterface::VERBOSITY_VERY_VERBOSE => '-vv',
-                    default => '-v',
-                };
-
-                $this->writeText("\n");
-                $this->writeText(\sprintf(' <comment>Run with "%s" to list more commands.</comment>', $option), $options);
-                $this->writeText("\n");
-            }
         }
     }
 

--- a/src/Symfony/Component/Console/Tests/Command/ListCommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/ListCommandTest.php
@@ -14,8 +14,6 @@ namespace Symfony\Component\Console\Tests\Command;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
-use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Tester\CommandCompletionTester;
 use Symfony\Component\Console\Tester\CommandTester;
 
@@ -28,21 +26,6 @@ class ListCommandTest extends TestCase
         $commandTester->execute(['command' => $command->getName()], ['decorated' => false]);
 
         $this->assertMatchesRegularExpression('/help\s{2,}Display help for a command/', $commandTester->getDisplay(), '->execute() returns a list of available commands');
-    }
-
-    public function testExecuteHintsAtCommandsListedAtAHigherVerbosity()
-    {
-        $application = new Application();
-        $application->addCommand((new Command('app:verbose'))->setCode(static fn () => 0)->setListedAt(OutputInterface::VERBOSITY_VERY_VERBOSE));
-        $commandTester = new CommandTester($command = $application->get('list'));
-
-        $commandTester->execute(['command' => $command->getName()], ['decorated' => false]);
-        $this->assertStringNotContainsString('app:verbose', $commandTester->getDisplay());
-        $this->assertStringContainsString('Run with "-vv" to list more commands.', $commandTester->getDisplay());
-
-        $commandTester->execute(['command' => $command->getName()], ['decorated' => false, 'verbosity' => OutputInterface::VERBOSITY_VERY_VERBOSE]);
-        $this->assertStringContainsString('app:verbose', $commandTester->getDisplay());
-        $this->assertStringNotContainsString('to list more commands', $commandTester->getDisplay());
     }
 
     public function testExecuteListsCommandsWithXmlOption()

--- a/src/Symfony/Component/Console/Tests/DependencyInjection/AddConsoleCommandPassTest.php
+++ b/src/Symfony/Component/Console/Tests/DependencyInjection/AddConsoleCommandPassTest.php
@@ -402,21 +402,6 @@ class AddConsoleCommandPassTest extends TestCase
         self::assertSame('The command description', $command->getDescription());
         self::assertSame('The %command.name% command help content.', $command->getHelp());
     }
-
-    public function testListedAtFromTagAndAttribute()
-    {
-        $container = new ContainerBuilder();
-        $container->setParameter('my-command.class', 'Symfony\\Component\\Console\\Tests\\DependencyInjection\\MyCommand');
-        $definition = new Definition('%my-command.class%');
-        $definition->addTag('console.command', ['command' => 'my:command', 'listed_at' => 64]);
-        $container->setDefinition('my-command', $definition);
-        $container->addCompilerPass(new AddConsoleCommandPass(), PassConfig::TYPE_BEFORE_REMOVING);
-        $container->compile();
-
-        $calls = $container->getDefinition('my-command')->getMethodCalls();
-        $this->assertContains(['setListedAt', [64]], $calls);
-    }
-
 }
 
 class MyCommand extends Command

--- a/src/Symfony/Component/Console/Tests/Descriptor/ApplicationDescriptionTest.php
+++ b/src/Symfony/Component/Console/Tests/Descriptor/ApplicationDescriptionTest.php
@@ -16,7 +16,6 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Descriptor\ApplicationDescription;
-use Symfony\Component\Console\Output\OutputInterface;
 
 final class ApplicationDescriptionTest extends TestCase
 {
@@ -38,22 +37,6 @@ final class ApplicationDescriptionTest extends TestCase
             [['a', 'b'], ['b:foo', 'a:foo', 'b:bar']],
             [['_global', 22, 33, 'b', 'z'], ['z:foo', '1', '33:foo', 'b:foo', '22:foo:bar']],
         ];
-    }
-
-    public function testCommandsAreFilteredByListedAt()
-    {
-        $application = new Application();
-        $always = (new Command('app:always'))->setCode(static fn () => 0);
-        $verbose = (new Command('app:verbose'))->setCode(static fn () => 0)->setListedAt(OutputInterface::VERBOSITY_VERBOSE);
-        $application->addCommand($always);
-        $application->addCommand($verbose);
-        $normal = new ApplicationDescription($application);
-        $this->assertArrayHasKey('app:always', $normal->getCommands());
-        $this->assertArrayNotHasKey('app:verbose', $normal->getCommands());
-        $this->assertSame(OutputInterface::VERBOSITY_VERBOSE, $normal->getNextVerbosity());
-        $raised = new ApplicationDescription($application, null, false, OutputInterface::VERBOSITY_VERBOSE);
-        $this->assertArrayHasKey('app:verbose', $raised->getCommands());
-        $this->assertNull($raised->getNextVerbosity());
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

#64142 requested a way for a developer to hide commands from their `console list` output, but proposed a solution imposing said developers’ choices to every CLI user, which is not desirable since their needs may vary.

As such this PR reverts #64723 which implemented the solution.

If an output must only be changed on a developer machine, a good solution would only impact said developer. This PR doesn’t suggest anything, but tools like `grep` could serve such purpose.