### PR TITLE
[Messenger] Handle synchronous batch nack

### DIFF
--- a/src/Symfony/Component/Messenger/Handler/BatchHandlerTrait.php
+++ b/src/Symfony/Component/Messenger/Handler/BatchHandlerTrait.php
@@ -40,6 +40,10 @@ trait BatchHandlerTrait
             $this->jobs[] = [$message, $ack];
             $this->flush(true);
 
+            if ($error = $ack->getError()) {
+                throw $error;
+            }
+
             return $ack->getResult();
         }
 

--- a/src/Symfony/Component/Messenger/Tests/Handler/BatchHandlerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Handler/BatchHandlerTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Handler;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Handler\Acknowledger;
+use Symfony\Component\Messenger\Handler\BatchHandlerInterface;
+use Symfony\Component\Messenger\Handler\BatchHandlerTrait;
+
+class BatchHandlerTest extends TestCase
+{
+    public function testSynchronousAckReturnsTheResult()
+    {
+        $handler = new BatchHandlerTestHandler();
+
+        $this->assertSame('the result', $handler(new \stdClass()));
+    }
+
+    public function testSynchronousNackRethrowsTheError()
+    {
+        $handler = new BatchHandlerTestHandler(new \RuntimeException('handler failed'));
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('handler failed');
+
+        $handler(new \stdClass());
+    }
+}
+
+class BatchHandlerTestHandler implements BatchHandlerInterface
+{
+    use BatchHandlerTrait;
+
+    public function __construct(
+        private ?\Throwable $error = null,
+    ) {
+    }
+
+    public function __invoke(object $message, ?Acknowledger $ack = null): mixed
+    {
+        return $this->handle($message, $ack);
+    }
+
+    private function process(array $jobs): void
+    {
+        foreach ($jobs as [, $ack]) {
+            if ($this->error) {
+                $ack->nack($this->error);
+            } else {
+                $ack->ack('the result');
+            }
+        }
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #49654
| License       | MIT

When a batch handler is invoked with a `null` acknowledger, `BatchHandlerTrait::handle()` creates one itself, flushes the batch and returns `$ack->getResult()`. An error passed to `nack()` from `process()` is stored on that acknowledger and then dropped, so the handler returns `null` and the message is reported as successfully handled.

This concerns every dispatch that does not come from a consuming worker, since `AckStamp` is only added by `Worker`: direct `$bus->dispatch()` calls, messages routed to the `sync` transport, and any other invocation outside `messenger:consume`.

The synchronous path now rethrows the acknowledger error before returning the result, which is what `HandleMessageMiddleware` already does when a batch is acknowledged during a worker run. Batch handling through a worker is unchanged.
