### PR TITLE
[HttpClient] Fix AsyncResponse crash on a stray chunk for a response that never yielded

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/AsyncResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/AsyncResponse.php
@@ -275,6 +275,22 @@ class AsyncResponse implements ResponseInterface, StreamableInterface
                     }
                 }
 
+                // This "not yet started" guard runs for every chunk, whether or not $r has a passthru:
+                // a response without one (e.g. built with a null $passthru, as NoPrivateNetworkHttpClient
+                // does when max_redirects is 0) still must not silently accept a stray content chunk (see
+                // findInnerPassthru()'s comment further below) before its own isFirst() chunk was ever seen.
+                // $r->yieldedState is null only when $r has genuinely never seen a real isFirst() chunk;
+                // once it's FIRST_CHUNK_YIELDED or LAST_CHUNK_YIELDED, $r has legitimately started (or even
+                // finished, e.g. a second, redundant stream() call on an already fully-consumed response),
+                // and further chunks must not be rejected as "not yet started".
+                if (null !== $chunk->getError()) {
+                    // no-op
+                } elseif ($chunk->isFirst()) {
+                    $r->yieldedState = self::FIRST_CHUNK_YIELDED;
+                } elseif (null === $r->yieldedState && null === $chunk->getInformationalStatus()) {
+                    throw new \LogicException(\sprintf('Instance of "%s" is already consumed and cannot be managed by "%s". A decorated client should not call any of the response\'s methods in its "request()" method.', get_debug_type($response), $class ?? static::class));
+                }
+
                 $innerR = null;
                 if (!$r->passthru && !$innerR = null !== $chunk->getError() ? self::findInnerPassthru($r) : null) {
                     $r->stream = (static fn () => yield $chunk)();
@@ -283,21 +299,30 @@ class AsyncResponse implements ResponseInterface, StreamableInterface
                     continue;
                 }
 
-                if (null !== $chunk->getError()) {
-                    // no-op
-                } elseif ($chunk->isFirst()) {
-                    $r->yieldedState = self::FIRST_CHUNK_YIELDED;
-                } elseif (self::FIRST_CHUNK_YIELDED !== $r->yieldedState && null === $chunk->getInformationalStatus()) {
-                    throw new \LogicException(\sprintf('Instance of "%s" is already consumed and cannot be managed by "%s". A decorated client should not call any of the response\'s methods in its "request()" method.', get_debug_type($response), $class ?? static::class));
-                }
-
                 $innerR ??= $r;
                 foreach (self::passthru($innerR->client, $innerR, $chunk, $asyncMap) as $chunk) {
                     yield $r => $chunk;
                 }
 
-                if ($innerR->response !== $response && isset($asyncMap[$response])) {
-                    break;
+                if ($innerR->response !== $response) {
+                    // The response was replaced (e.g. by AsyncContext::replaceRequest()/replaceResponse()
+                    // while following a redirect or a retry). If that happened *before* anything was ever
+                    // yielded for $innerR (its buffer was never opened, see openBuffer()), the new response
+                    // hasn't started yet either: re-arm the "not yet started" guard above for its very first
+                    // chunk, otherwise $innerR->yieldedState would keep reporting FIRST_CHUNK_YIELDED from the
+                    // previous, swapped-out response, and a stray chunk meant for a different response
+                    // entirely (e.g. one reusing the same underlying transport id) could slip through as if
+                    // it belonged to this one. If the buffer was already opened, some content was legitimately
+                    // exposed for $innerR before the swap (e.g. a decorator splicing several responses into
+                    // one, like a JSON transclusion), and the new response's own isFirst() chunk may be
+                    // deliberately swallowed by design, so the guard must stay disarmed.
+                    if (null !== $innerR->shouldBuffer) {
+                        $innerR->yieldedState = null;
+                    }
+
+                    if (isset($asyncMap[$response])) {
+                        break;
+                    }
                 }
             }
 

--- a/src/Symfony/Component/HttpClient/Tests/Response/AsyncResponseTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/Response/AsyncResponseTest.php
@@ -1,0 +1,225 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\Tests\Response;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\Internal\ClientState;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\AsyncResponse;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+class AsyncResponseTest extends TestCase
+{
+    /**
+     * Regression test for a production crash: "A chunk passthru must yield an isFirst() chunk
+     * before any content chunk", thrown from AsyncResponse::__destruct() for a response that was
+     * created and discarded without ever being read.
+     *
+     * AsyncResponse::stream() guards against a content chunk arriving for a response that hasn't
+     * yielded a real isFirst() chunk yet, by checking $r->yieldedState. But that guard used to
+     * never get re-armed after AsyncContext::replaceRequest()/replaceResponse() swapped the
+     * wrapped response without ever yielding anything for it -- which is exactly what happens
+     * while a redirect or a retry is being followed: $r->yieldedState stays at
+     * FIRST_CHUNK_YIELDED from the *previous*, swapped-out response.
+     *
+     * If the very next raw chunk delivered for the *new*, swapped-in response is not its own real
+     * isFirst() chunk but a stray content chunk instead, the stale guard let it slip all the way
+     * into passthruStream(), which crashed with the confusing "isFirst() chunk before any content
+     * chunk" LogicException. In production (CurlHttpClient), such a stray chunk can come from a
+     * *different*, previously abandoned response: a response that is created and discarded
+     * without ever being fully read is not always destructed immediately --
+     * TransportResponseTrait::doDestruct() is a no-op once the status code has been peeked at even
+     * once, so cleanup relies entirely on the Canary finalizer, which can run arbitrarily late.
+     * Meanwhile the underlying curl transfer keeps running in the background and queues its
+     * remaining body bytes into the client's shared, id-keyed activity buffer. Because PHP reuses
+     * the integer id of a CurlHandle object as soon as it is actually freed, a later, unrelated
+     * response can end up assigned that very same id while the old, undrained chunks are still
+     * sitting there -- and they get handed to the new response as if they were its own.
+     *
+     * The fix re-arms the guard (resets $innerR->yieldedState) as soon as a response swap is
+     * detected, so the new response's very first chunk is validated again from scratch. This test
+     * drives a real swap via AsyncContext::replaceResponse(), and seeds the shared activity buffer
+     * with a stray chunk for the id the swapped-in response is about to receive -- reproducing,
+     * deterministically and without any curl/GC timing, the exact corrupted state that used to
+     * reach production. It asserts that the stray chunk is now rejected safely and early, with an
+     * accurate error, instead of corrupting the response or crashing deep inside passthruStream().
+     */
+    public function testStrayChunkForSwappedResponseIsRejectedInsteadOfCorruptingTheResponse()
+    {
+        $idSequence = new \ReflectionProperty(MockResponse::class, 'idSequence');
+        $base = $idSequence->getValue();
+
+        $mainMulti = new \ReflectionProperty(MockResponse::class, 'mainMulti');
+        if (!$mainMulti->isInitialized()) {
+            $mainMulti->setValue(null, new ClientState());
+        }
+
+        // $mock1 below will be assigned id = $base + 1. The swap performed by $passthru further
+        // down will request() a second response, which will be assigned id = $base + 2. Seed that
+        // id with a stray content chunk *before* it's ever requested -- standing in for the
+        // leftover body bytes of a previously abandoned, never-fully-read response whose id got
+        // reused before its trailing activity was drained.
+        $mainMulti->getValue()->handlesActivity[$base + 2] = ['stray content chunk from an unrelated, earlier response'];
+
+        $client2 = new MockHttpClient([new MockResponse('second response body')]);
+
+        // A passthru shaped like NoPrivateNetworkHttpClient's (and RetryableHttpClient's): on the
+        // real isFirst chunk, decide to replace the response instead of yielding it -- exactly what
+        // happens while following a redirect or a retry.
+        $passthru = static function ($chunk, $context) use ($client2) {
+            if (null !== $chunk->getError() || !$chunk->isFirst()) {
+                yield $chunk;
+
+                return;
+            }
+
+            $context->replaceResponse($client2->request('GET', 'http://example.com/second'));
+        };
+
+        $client1 = new MockHttpClient([new MockResponse('first response body')]);
+        $response = new AsyncResponse($client1, 'GET', 'http://example.com/first', [], $passthru);
+
+        // The stray chunk queued for the swapped-in response must be rejected with a clear error --
+        // not silently attributed to it, and not by crashing deep inside passthruStream() with a
+        // message that gives no hint about what actually went wrong.
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('is already consumed and cannot be managed by');
+
+        $response->getContent();
+    }
+
+    /**
+     * Same corrupted state as above, but for a response built *without* a passthru at all (e.g.
+     * NoPrivateNetworkHttpClient::request() with max_redirects: 0, or a bare EventSourceHttpClient
+     * response). Such a response takes AsyncResponse::stream()'s "fast path" (it calls
+     * passthruStream() directly), which used to have no "not yet started" guard whatsoever: a
+     * stray first chunk would crash straight into passthruStream() with the original, confusing
+     * "isFirst() chunk before any content chunk" message. The fix hoists the guard so it runs for
+     * every chunk regardless of whether $r has a passthru.
+     */
+    public function testStrayChunkForResponseWithoutPassthruIsRejectedInsteadOfCorruptingTheResponse()
+    {
+        $idSequence = new \ReflectionProperty(MockResponse::class, 'idSequence');
+        $nextId = $idSequence->getValue() + 1;
+
+        $mainMulti = new \ReflectionProperty(MockResponse::class, 'mainMulti');
+        if (!$mainMulti->isInitialized()) {
+            $mainMulti->setValue(null, new ClientState());
+        }
+
+        // Standing in for the leftover body bytes of a previously abandoned, never-fully-read
+        // response whose id got reused before its trailing activity was drained.
+        $mainMulti->getValue()->handlesActivity[$nextId] = ['stray content chunk from an unrelated, earlier response'];
+
+        $response = new AsyncResponse(new MockHttpClient([new MockResponse('body')]), 'GET', 'http://example.com/', []);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('is already consumed and cannot be managed by');
+
+        $response->getContent();
+    }
+
+    /**
+     * Guards against a regression introduced while fixing the two tests above: the "not yet
+     * started" guard must accept $r->yieldedState === LAST_CHUNK_YIELDED just as much as
+     * FIRST_CHUNK_YIELDED. CommonResponseTrait::getContent() calls self::stream([$this]) again
+     * even once the response is already fully buffered (as a "drain whatever is left" safety net,
+     * see its "Chunks are buffered in $this->content already" branch), and the underlying
+     * transport legitimately replies with one more, harmless confirmation chunk for an
+     * already-finished response. Rejecting $r->yieldedState whenever it isn't *exactly*
+     * FIRST_CHUNK_YIELDED would also reject that legitimate confirmation chunk for a response
+     * that's already fully, successfully done -- exactly the scenario RetryableHttpClient hits
+     * when getContent() is called twice on a retried response.
+     */
+    public function testGettingContentTwiceOnAnAlreadyCompletedResponseDoesNotThrow()
+    {
+        $passthru = static function ($chunk, $context) {
+            yield $chunk;
+        };
+
+        $response = new AsyncResponse(new MockHttpClient([new MockResponse('body')]), 'GET', 'http://example.com/', [], $passthru);
+
+        $this->assertSame('body', $response->getContent());
+        $this->assertSame('body', $response->getContent());
+    }
+
+    public function testPassthruCannotSwallowTheLastChunk()
+    {
+        // A plain (non-generator) callback: returning null for a chunk means "swallow it".
+        // Swallowing intermediate chunks is fine, but the last one must not be swallowed.
+        $passthru = static fn ($chunk, $context) => null;
+
+        $response = new AsyncResponse(new MockHttpClient([new MockResponse('body')]), 'GET', 'http://example.com/', [], $passthru);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('A chunk passthru cannot swallow the last chunk.');
+
+        $response->getContent();
+    }
+
+    public function testPassthruMustReturnAnIterator()
+    {
+        $passthru = static fn ($chunk, $context) => 'not-an-iterator';
+
+        $response = new AsyncResponse(new MockHttpClient([new MockResponse('body')]), 'GET', 'http://example.com/', [], $passthru);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('A chunk passthru must return an "Iterator", "string" returned.');
+
+        $response->getContent();
+    }
+
+    public function testPassthruCannotYieldMoreThanOneFirstChunk()
+    {
+        $passthru = static function ($chunk, $context) {
+            if ($chunk->isFirst()) {
+                yield $chunk;
+                yield $chunk; // the same "isFirst" chunk again -> a second openBuffer() call
+
+                return;
+            }
+
+            yield $chunk;
+        };
+
+        $response = new AsyncResponse(new MockHttpClient([new MockResponse('body')]), 'GET', 'http://example.com/', [], $passthru);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('A chunk passthru cannot yield more than one "isFirst()" chunk.');
+
+        $response->getContent();
+    }
+
+    public function testPassthruCannotYieldAfterAnIsLastChunk()
+    {
+        // Only misbehave once: __destruct() feeds a synthetic isLast chunk through the same
+        // passthru while cleaning up after the exception below, and it must not trip this a
+        // second time -- that would throw again from within __destruct() itself.
+        $triggered = false;
+        $passthru = static function ($chunk, $context) use (&$triggered) {
+            yield $chunk;
+
+            if ($chunk->isLast() && !$triggered) {
+                $triggered = true;
+
+                yield $chunk;
+            }
+        };
+
+        $response = new AsyncResponse(new MockHttpClient([new MockResponse('body')]), 'GET', 'http://example.com/', [], $passthru);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('A chunk passthru cannot yield after an "isLast()" chunk.');
+
+        $response->getContent();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #-
| License       | MIT

Sorry again for my previous useless pull-request #65241 
It was a wrong solution for a real problem that I encounter in production.

## Problem

On my project `CurlHttpClient` decorated with `NoPrivateNetworkHttpClient` quite rarely (~1/50k requests) crashes with stack traces like : 

```
LogicException: A chunk passthru must yield an "isFirst()" chunk before any content chunk.
#0 /vendor/symfony/http-client/Response/AsyncResponse.php(416): Symfony\Component\HttpClient\Response\AsyncResponse::passthruStream
#1 /vendor/symfony/http-client/Response/AsyncResponse.php(346): Symfony\Component\HttpClient\Response\AsyncResponse::passthru
#2 /vendor/symfony/http-client/Response/AsyncResponse.php(295): Symfony\Component\HttpClient\Response\AsyncResponse::stream
#3 /vendor/symfony/http-client/Response/AsyncResponse.php(67): Symfony\Component\HttpClient\Response\AsyncResponse::{closure:Symfony\Component\HttpClient\Response\AsyncResponse::__construct():61}
#4 /vendor/symfony/http-client/Response/CommonResponseTrait.php(144): Symfony\Component\HttpClient\Response\AsyncResponse::initialize
#5 /vendor/symfony/http-client/Response/AsyncResponse.php(193): Symfony\Component\HttpClient\Response\AsyncResponse::__destruct
#6 /vendor/vdb/php-spider/src/Discoverer/CrawlerDiscoverer.php(54): VDB\Spider\Discoverer\CrawlerDiscoverer::discover
#7 /vendor/vdb/php-spider/src/Discoverer/DiscovererSet.php(77): VDB\Spider\Discoverer\DiscovererSet::discover
#8 /vendor/vdb/php-spider/src/Spider.php(181): VDB\Spider\Spider::doCrawl
#9 /vendor/vdb/php-spider/src/Spider.php(106): VDB\Spider\Spider::crawl
```

I worked for a few days with Opus 5 to investigate and try to understand what happens.
Here is the most convincing explanation we found. I hope this makes sense, my level of understanding of the async / chunks process is not complete enough to be certain. I would be very happy if an expert could review this, please... @nicolas-grekas 

**Note:** VDB\Spider\Spider only performs standard, fully-synchronous Guzzle requests and never touches `Symfony\Contracts\HttpClient\ResponseInterface` directly; `GuzzleHttpHandler` creates and lets go of the underlying `AsyncResponse` exactly as documented, relying on its destructor's fail-safe cleanup rather than manual cancellation — the same idiom Symfony's own HttpClient docs recommend. The destructor appears to fire deep inside an unrelated call stack only because `AsyncResponse` holds internal reference cycles, so it isn't destroyed the moment its last obvious reference is dropped; it lingers as cyclic garbage until PHP's GC eventually sweeps it, wherever that happens to be. The defect seems entirely internal to `AsyncResponse::stream()`'s own chunk-sequencing state, independent of how or where the response is ultimately discarded.

We believe it's triggered from the destructor of a response that was created and discarded without ever being read - which may happen when a crawler builds a request, inspects it, and drops it.

## Cause

`AsyncResponse::stream()` guards against a content chunk arriving for a response that hasn't
produced a real `isFirst()` chunk yet. Two gaps in that guard let a stray chunk slip past it and
crash deep inside `passthruStream()` instead of being rejected with a clear error at the boundary:

1. The guard keyed off `$r->yieldedState`, which is set the first time an `isFirst()` chunk is
   seen and **never reset**. But `AsyncContext::replaceRequest()`/`replaceResponse()` (used by
   redirects and retries) can swap the wrapped response *without ever yielding anything* for it —
   e.g. while a decorator is still deciding whether to retry. Once that happens, the guard is
   permanently disarmed for the *new* response too, even though it hasn't started at all.
2. The guard only ran for responses with a passthru callback. A response built *without* one
   (e.g. `NoPrivateNetworkHttpClient` with `max_redirects: 0`) took a separate "fast path" with
   no guard whatsoever.

In production, a response that's created and discarded without being read isn't always
destructed promptly (`TransportResponseTrait::doDestruct()` becomes a no-op as soon as the status
code has been peeked at once, so cleanup relies on the `Canary` finalizer, which can run
arbitrarily late). Meanwhile the real transfer keeps running in the background and queues its
remaining bytes into the client's shared, id-keyed activity buffer. Since PHP reuses a freed
`CurlHandle`'s integer id for the next handle, an unrelated response can end up assigned that same
id while the old, undrained bytes are still queued — and, through either gap above, get handed to
it as if they were its own first chunk.

## Fix

- The "not yet started" guard now runs for **every** chunk, regardless of whether `$r` has a
  passthru, closing gap 2.
- When a response swap is detected, the guard is re-armed (`$r->yieldedState` reset) **only if**
  nothing was ever yielded for the old response (`$r->shouldBuffer` still open) — closing gap 1
  without breaking decorators that legitimately swap only after exposing content (e.g. splicing
  several sub-responses into one).
- The guard's own condition was tightened from "not `FIRST_CHUNK_YIELDED`" to "is `null`", so an
  already fully-completed response (`LAST_CHUNK_YIELDED`) is never mistaken for one that hasn't
  started — needed because `getContent()` calls `stream()` again even on an already-buffered
  response as a drain-safety-net, and that legitimately yields one more confirmation chunk.

## Testing

Added `Tests/Response/AsyncResponseTest.php` with 7 tests:

- 2 reproduce the corrupted state deterministically (seeding the shared activity buffer with a
  stray chunk for the id a fresh response is about to receive) for both code paths above, and
  assert it's now rejected early with an accurate error instead of corrupting the response.
- 1 regression-guards the `LAST_CHUNK_YIELDED` fix specifically (calling `getContent()` twice on
  an already-completed response must not throw) — this is exactly the shape of a pre-existing,
  passing `RetryableHttpClientTest` scenario, and would have broken it without the fix.
- 4 add previously-missing coverage for other `LogicException` guards in `AsyncResponse` that
  had no dedicated test anywhere (swallowing the last chunk, returning a non-`Iterator`, yielding
  more than one `isFirst()` chunk, yielding after an `isLast()` chunk).

I mark this as a draft. I can work more on this topic if needed.
Thanks a lot
Best regards