### PR TITLE
[Yaml] Guard the `gitlab` lint format behind the Console class it needs

### DIFF
--- a/src/Symfony/Component/Yaml/Command/LintCommand.php
+++ b/src/Symfony/Component/Yaml/Command/LintCommand.php
@@ -155,7 +155,9 @@ class LintCommand extends Command
             'txt' => $this->displayTxt($io, $files),
             'json' => $this->displayJson($io, $files),
             'github' => $this->displayTxt($io, $files, true),
-            'gitlab' => $this->displayGitlab($io, $files),
+            'gitlab' => class_exists(GitlabCiReporter::class)
+                ? $this->displayGitlab($io, $files)
+                : throw new InvalidArgumentException('The "gitlab" format requires symfony/console 8.2 or higher.'),
             default => throw new InvalidArgumentException(\sprintf('Supported formats are "%s".', implode('", "', $this->getAvailableFormatOptions()))),
         };
     }
@@ -294,6 +296,12 @@ class LintCommand extends Command
     /** @return string[] */
     private function getAvailableFormatOptions(): array
     {
-        return ['txt', 'json', 'github', 'gitlab'];
+        $formats = ['txt', 'json', 'github'];
+
+        if (class_exists(GitlabCiReporter::class)) {
+            $formats[] = 'gitlab';
+        }
+
+        return $formats;
     }
 }

--- a/src/Symfony/Component/Yaml/Tests/Command/LintCommandTest.php
+++ b/src/Symfony/Component/Yaml/Tests/Command/LintCommandTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Yaml\Tests\Command;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
+use Symfony\Component\Console\CI\GitlabCiReporter;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Tester\CommandCompletionTester;
@@ -83,6 +84,10 @@ bar';
 
     public function testLintIncorrectFileWithGitlabFormat()
     {
+        if (!class_exists(GitlabCiReporter::class)) {
+            $this->markTestSkipped('The "gitlab" format requires symfony/console 8.2 or higher.');
+        }
+
         $incorrectContent = <<<YAML
             foo:
             bar
@@ -107,6 +112,10 @@ bar';
 
     public function testLintCorrectFileWithGitlabFormat()
     {
+        if (!class_exists(GitlabCiReporter::class)) {
+            $this->markTestSkipped('The "gitlab" format requires symfony/console 8.2 or higher.');
+        }
+
         $tester = $this->createCommandTester();
         $filename = $this->createFile('foo: bar');
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Fixes the `low-deps` job, red on 8.2 since #64117.

`lint:yaml --format=gitlab` instantiates `Symfony\Component\Console\CI\GitlabCiReporter`, which #64117 added to Console 8.2. Yaml requires `symfony/console: ^7.4|^8.0` in `require-dev`, so the low-deps job installs Console 7.4 and both gitlab tests fatal with `Class "Symfony\Component\Console\CI\GitlabCiReporter" not found`. The same applies at runtime to anyone on Yaml 8.2 with an older Console.

The `github` format already guards its reporter with `class_exists()`; this does the same for `gitlab`: the format is only advertised in `--format`'s help and completion when the class is available, and asking for it without the class gives a clear message instead of a fatal error. The two tests skip in that case.
