### PR TITLE
[VarExporter] Split Exporter::export() so it stops crashing the PHP 8.5 JIT compiler

### DIFF
--- a/src/Symfony/Component/VarExporter/Internal/Exporter.php
+++ b/src/Symfony/Component/VarExporter/Internal/Exporter.php
@@ -89,26 +89,37 @@ class Exporter
 
         // Single-line: content fits within the 20-items budget
         if ($size <= 20) {
-            $j = -1;
-            $code = '[';
-            foreach ($value as $k => $v) {
-                if ('[' !== $code) {
-                    $code .= ', ';
-                }
-                if (!\is_int($k) || 1 !== $k - $j) {
-                    $code .= self::export($k, $indent).' => ';
-                }
-                if (\is_int($k) && $k > $j) {
-                    $j = $k;
-                }
-                $code .= self::export($v, $indent);
-            }
-
-            return $code.']';
+            return self::exportSingleLine($value, $indent);
         }
 
-        // Multi-line wrapped: pack values onto each line; before appending the next
-        // value, check that the line would still hold <= 20 items.
+        return self::exportWrapped($value, $indent);
+    }
+
+    private static function exportSingleLine(array $value, string $indent): string
+    {
+        $j = -1;
+        $code = '[';
+        foreach ($value as $k => $v) {
+            if ('[' !== $code) {
+                $code .= ', ';
+            }
+            if (!\is_int($k) || 1 !== $k - $j) {
+                $code .= self::export($k, $indent).' => ';
+            }
+            if (\is_int($k) && $k > $j) {
+                $j = $k;
+            }
+            $code .= self::export($v, $indent);
+        }
+
+        return $code.']';
+    }
+
+    private static function exportWrapped(array $value, string $indent): string
+    {
+        // Pack values onto each line; before appending the next value,
+        // check that the line would still hold <= 20 items.
+        $subIndent = $indent.'    ';
         $j = -1;
         $code = '';
         $line = '';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | no Symfony issue — this works around https://github.com/php/php-src/issues/22558 and https://github.com/php/php-src/issues/22084
| License       | MIT

On PHP 8.5.5 – 8.5.9 with function JIT at optimization level ≥ 4 (`opcache.jit=1204`,
`1205`, `1235`), **compiling** `Exporter::export()` kills the process — SIGSEGV, or an
infinite loop inside the JIT compiler. The method is never called; loading the file is
enough:

```bash
composer create-project symfony/symfony-demo:v3.1.0 demo

php -d opcache.enable=1 -d opcache.enable_cli=1 \
    -d opcache.jit=1205 -d opcache.jit_buffer_size=256M \
    -r 'require "demo/vendor/symfony/var-exporter/Internal/Exporter.php"; echo "OK\n";'
```

In production behind nginx → php-fpm this shows up as workers dying on the first request
to any not-yet-compiled code path — `Exporter::export()` runs during container cache
warmup, so it is the first request after a cold cache. nginx retries, the second worker
dies too, the client gets a 502.

**This is a PHP bug, not a Symfony one** — the current code is valid PHP and a compiler
must not crash on it. It is reported upstream with a full analysis. But 8.1 is currently
unusable for anyone on PHP 8.5.5+ with function JIT unless they lower `opcache.jit`
across the whole pool, and this side is a cheap place to unblock them.

## Why this method, and why now

The crash appeared with the 8.1 rewrite of `export()`. Same PHP, same JIT settings, only
the file version differs:

| `Internal/Exporter.php` | result |
|---|---|
| v8.0.0 (434 lines) | clean, 0/5 |
| v8.1.0 – v8.1.4 (143 lines, identical) | **fails 5/5** |

Note the 8.0 file is the *larger* one — this is not about file size. Reducing the method
shows there is no single culprit construct: removing the `switch (true)`, or the
recursive `self::export()` calls, or any one of the three `foreach` loops makes the crash
disappear. It behaves like a threshold on the size of the SSA graph, and the rewritten
`export()` (227 opcodes, 273 SSA vars, three loops, recursion) crosses it.

## What this PR does

Moves the last two `foreach` loops into private methods, `exportSingleLine()` and
`exportWrapped()`. No logic is changed — only method boundaries, so each compiled unit
stays below the threshold.

Verified three ways on PHP 8.5.9, `opcache.jit=1205`, `opcache.jit_buffer_size=256M`
(the failure is ASLR-sensitive on the CLI, so every check is a series, not one run):

| check | before | after |
|---|---|---|
| compiling the file alone | 5/5 fail | **0/5 fail** |
| `Exporter::export()` output over 24 inputs (both loop paths, nesting, control chars, arrays above and below the 20-item budget) | — | **byte-identical** |
| symfony-demo `/` under php-fpm, cold OPcache, fresh container per run | 10/10 SIGSEGV | **5/5 OK** |

No new tests: behaviour is unchanged and the existing `VarExporterTest` /
`ExporterTest` cases already cover both the single-line and the wrapped branch. The
output-equivalence check above is what verifies the refactor itself.

## Honest limitations

This shifts the method below a threshold; it does not fix the compiler. A future edit to
`export()` — or to any comparably sized method elsewhere — can cross the same line again.
If you would rather not carry a workaround for a PHP bug, the alternative that actually
guards against it is **a CI job running the test suite with `opcache.jit=1205` on PHP
8.5**: it would have caught this before 8.1.0, and it will catch the next one. Happy to
open that separately if there is interest.

Upstream references: php/php-src#22558, php/php-src#22084 (same faulting instruction,
same 8.5.4 → 8.5.5 regression window).
