### PR TITLE
[HttpClient] Remove unused code in `AsyncResponse::__destruct()`

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/AsyncResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/AsyncResponse.php
@@ -190,7 +190,7 @@ class AsyncResponse implements ResponseInterface, StreamableInterface
 
         if ($this->initializer && null === $this->getInfo('error') && !$this->hasThrown) {
             try {
-                self::initialize($this, -0.0);
+                self::initialize($this);
                 $this->getHeaders(true);
             } catch (HttpExceptionInterface $httpException) {
                 // no-op


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Backport of #64838 to 6.4.

The `-0.0` argument has been ignored since 8f3bdeb359c (5.4): `initialize()` lost its `$timeout` parameter there and hard-codes `-0.0` internally, but this call site kept passing it. Keeping the argument on the LTS wrongly suggests the destructor opts into special timeout semantics at this call site, which can mislead debugging sessions.