### PR TITLE
[HttpClient] Fix mis-armed consumption guard in AsyncResponse::stream()

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/AsyncResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/AsyncResponse.php
@@ -275,6 +275,14 @@ class AsyncResponse implements ResponseInterface, StreamableInterface
                     }
                 }
 
+                if (null !== $chunk->getError()) {
+                    // no-op
+                } elseif ($chunk->isFirst()) {
+                    $r->yieldedState = self::FIRST_CHUNK_YIELDED;
+                } elseif (null === $r->yieldedState && null === $chunk->getInformationalStatus()) {
+                    throw new \LogicException(\sprintf('Instance of "%s" is already consumed and cannot be managed by "%s". A decorated client should not call any of the response\'s methods in its "request()" method.', get_debug_type($response), $class ?? static::class));
+                }
+
                 $innerR = null;
                 if (!$r->passthru && !$innerR = null !== $chunk->getError() ? self::findInnerPassthru($r) : null) {
                     $r->stream = (static fn () => yield $chunk)();
@@ -283,21 +291,20 @@ class AsyncResponse implements ResponseInterface, StreamableInterface
                     continue;
                 }
 
-                if (null !== $chunk->getError()) {
-                    // no-op
-                } elseif ($chunk->isFirst()) {
-                    $r->yieldedState = self::FIRST_CHUNK_YIELDED;
-                } elseif (self::FIRST_CHUNK_YIELDED !== $r->yieldedState && null === $chunk->getInformationalStatus()) {
-                    throw new \LogicException(\sprintf('Instance of "%s" is already consumed and cannot be managed by "%s". A decorated client should not call any of the response\'s methods in its "request()" method.', get_debug_type($response), $class ?? static::class));
-                }
-
                 $innerR ??= $r;
                 foreach (self::passthru($innerR->client, $innerR, $chunk, $asyncMap) as $chunk) {
                     yield $r => $chunk;
                 }
 
-                if ($innerR->response !== $response && isset($asyncMap[$response])) {
-                    break;
+                if ($innerR->response !== $response) {
+                    if (null !== $innerR->shouldBuffer) {
+                        // nothing was ever yielded for the previous response: the new one didn't start yet
+                        $innerR->yieldedState = null;
+                    }
+
+                    if (isset($asyncMap[$response])) {
+                        break;
+                    }
                 }
             }
 

--- a/src/Symfony/Component/HttpClient/Tests/Response/AsyncResponseTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/Response/AsyncResponseTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\Tests\Response;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\DecoratorTrait;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\AsyncResponse;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Contracts\HttpClient\ChunkInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+class AsyncResponseTest extends TestCase
+{
+    public function testReplacingTheResponseByAConsumedOneRearmsTheConsumptionGuard()
+    {
+        $client2 = new MockHttpClient([new MockResponse('second body')]);
+
+        $passthru = static function (ChunkInterface $chunk, $context) use ($client2): \Generator {
+            if (null !== $chunk->getError() || !$chunk->isFirst()) {
+                yield $chunk;
+
+                return;
+            }
+
+            $response = $client2->request('GET', 'http://example.com/second');
+            $response->getStatusCode();
+            $context->replaceResponse($response);
+        };
+
+        $response = new AsyncResponse(new MockHttpClient([new MockResponse('first body')]), 'GET', 'http://example.com/', [], $passthru);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('is already consumed and cannot be managed by');
+
+        $response->getContent();
+    }
+
+    public function testStreamingAConsumedResponseWithoutPassthruHitsTheConsumptionGuard()
+    {
+        $decorated = new class(new MockHttpClient([new MockResponse('body')])) implements HttpClientInterface {
+            use DecoratorTrait;
+
+            public function request(string $method, string $url, array $options = []): ResponseInterface
+            {
+                $response = $this->client->request($method, $url, $options);
+                $response->getStatusCode();
+
+                return $response;
+            }
+        };
+
+        $response = new AsyncResponse($decorated, 'GET', 'http://example.com/', []);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('is already consumed and cannot be managed by');
+
+        $response->getContent();
+    }
+
+    public function testGettingTheContentTwiceIsNotMistakenForOutOfBandConsumption()
+    {
+        $passthru = static function (ChunkInterface $chunk, $context): \Generator {
+            yield $chunk;
+        };
+
+        $response = new AsyncResponse(new MockHttpClient([new MockResponse('body')]), 'GET', 'http://example.com/', [], $passthru);
+
+        $this->assertSame('body', $response->getContent());
+        $this->assertSame('body', $response->getContent());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues       | -
| License       | MIT

Supersedes #65306.

`AsyncResponse::stream()` guards against streaming a response that was consumed out-of-band (e.g. a decorated client calling one of the response's methods in its `request()` method) by throwing "Instance of X is already consumed and cannot be managed". That guard has two arming gaps:

1. It never runs for responses built without a passthru: those take a fast path that skips the check entirely.
2. `$r->yieldedState` is not reset when `AsyncContext::replaceRequest()`/`replaceResponse()` swaps the wrapped response before anything was yielded for it, e.g. while following a redirect. The guard then stays disarmed for the new response even though it has not started yet.

Through either gap, a content chunk arriving for a not-yet-started response slips past the guard and crashes deep inside `passthruStream()` with "A chunk passthru must yield an isFirst() chunk before any content chunk", wrongly blaming the passthru. This is the crash reported in #65306, seen in production from `AsyncResponse::__destruct()` behind `NoPrivateNetworkHttpClient`.

With this change, the guard runs for every chunk and is re-armed when the response is swapped before anything was yielded for it. Decorators that legitimately swap after exposing content (e.g. response splicing) keep the guard disarmed, and an already-completed response is accepted since `getContent()` streams one more time as a drain when called again on a buffered response.

Out-of-band consumption now fails at the boundary with the accurate exception. Credit to @peter17 for identifying both gaps in #65306.

