### PR TITLE
[WebProfilerBundle] Fix missing `has_dump` variable

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/results.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/results.html.twig
@@ -120,6 +120,7 @@
                         {% set css_class = result.status_code|default(0) > 399 ? 'status-error' : result.status_code|default(0) > 299 ? 'status-warning' : 'status-success' %}
                         {% set has_errors = result.has_errors|default(false) and result.status_code < 400 %}
                     {% endif %}
+                    {% set has_dump = result.has_dump|default(false) %}
 
                     <tr>
                         <td class="text-center">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Add `has_dump` variable to check for dump presence. Without this variable it causes the following error: `Variable "has_dump" does not exist in @WebProfiler/Profiler/results.html.twig at line 138.`

The variable is read at line 138 but never assigned, while `has_errors` right above it is. `FileProfilerStorage::find()` does return `has_dump` for each row, so the fix is the missing `{% set %}`.

It only surfaces with `strict_variables`, which is on in any application running in debug mode, and never in the test suite, since `WebProfilerBundleKernel` runs with debug disabled.

See #64210
