### PR TITLE
[HttpClient] Cancel the previous hop's response when following a redirect

### DIFF
--- a/src/Symfony/Component/HttpClient/Internal/FollowRedirectsTrait.php
+++ b/src/Symfony/Component/HttpClient/Internal/FollowRedirectsTrait.php
@@ -87,6 +87,7 @@ trait FollowRedirectsTrait
             static $redirectCount = 0;
             $context->setInfo('redirect_count', ++$redirectCount);
 
+            $context->getResponse()->cancel();
             $context->replaceRequest($method, $url, $options);
 
             if ($redirectCount >= $maxRedirects) {

--- a/src/Symfony/Component/HttpClient/Tests/NoPrivateNetworkHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/NoPrivateNetworkHttpClientTest.php
@@ -246,6 +246,66 @@ class NoPrivateNetworkHttpClientTest extends TestCase
         $this->assertEquals($content, $response->getContent());
     }
 
+    /**
+     * The redirect response is abandoned in favor of the target response as soon as it's
+     * followed. If it isn't explicitly canceled at that point, its underlying transport is left
+     * running unsupervised in the background, and its own destructor can later throw uncaught,
+     * independently of the response actually being used, whenever it eventually gets
+     * garbage-collected on its own.
+     */
+    public function testRedirectResponseIsCanceledAfterBeingFollowed()
+    {
+        $redirectResponse = new MockResponse('', ['http_code' => 302, 'redirect_url' => 'http://104.26.14.7']);
+        $client = new NoPrivateNetworkHttpClient(new MockHttpClient([$redirectResponse, new MockResponse('final body')]));
+
+        $response = $client->request('GET', 'http://104.26.14.6/');
+
+        // MockHttpClient::request() wraps $redirectResponse into a fresh MockResponse instance
+        // (see MockResponse::fromRequest()) -- that's the one AsyncResponse actually holds and
+        // the one that must end up canceled, not the request template itself.
+        $wrapped = new \ReflectionProperty($response, 'response');
+        $firstHop = $wrapped->getValue($response);
+
+        $this->assertSame('final body', $response->getContent());
+        $this->assertTrue($firstHop->getInfo('canceled'));
+    }
+
+    /**
+     * Demonstrates the actual consequence of not canceling the abandoned redirect response: its
+     * own destructor throws uncaught. In production, this happens because the response's
+     * underlying transport is left running unsupervised in the background and can complete (or
+     * time out) entirely independently of AsyncResponse's own bookkeeping -- e.g. curl finishing
+     * headers for an abandoned handle before any PHP-level code ever calls getStatusCode() on it.
+     * That exact curl/GC timing can't be forced in a fast, deterministic test, but the state it
+     * leaves behind can be recreated directly: a response whose status was genuinely never
+     * checked by anything. Without the fix, destructing such a response crashes; with it, the
+     * explicit cancel() call already short-circuits that destructor check beforehand.
+     */
+    public function testUnfollowedRedirectResponseDoesNotThrowFromDestructWhenLeftUnchecked()
+    {
+        $redirectResponse = new MockResponse('', ['http_code' => 302, 'redirect_url' => 'http://104.26.14.7']);
+        $client = new NoPrivateNetworkHttpClient(new MockHttpClient([$redirectResponse, new MockResponse('final body')]));
+
+        $response = $client->request('GET', 'http://104.26.14.6/');
+
+        $wrapped = new \ReflectionProperty($response, 'response');
+        $firstHop = $wrapped->getValue($response);
+
+        $this->assertSame('final body', $response->getContent());
+
+        // Simulate curl completing this abandoned hop's headers on its own, as if
+        // getStatusCode() had never been called on it by anything.
+        (new \ReflectionProperty($firstHop, 'initializer'))->setValue($firstHop, static fn () => false);
+
+        try {
+            unset($firstHop);
+        } catch (\Throwable $e) {
+            $this->fail(\sprintf('Destructing the abandoned redirect response threw: %s(%s)', $e::class, $e->getMessage()));
+        }
+
+        $this->addToAssertionCount(1);
+    }
+
     private function getMockHttpClient(string $ipAddr, string $content)
     {
         return new MockHttpClient(new MockResponse($content, ['primary_ip' => $ipAddr]));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #-
| License       | MIT

@nicolas-grekas this is another finding by Opus 5 when investigating different stack traces coming from `__destruct()`:
it seems that FollowRedirectsTrait is missing a `$context->getResponse()->cancel();` before `$context->replaceRequest()`.

This PR fixes the issue in `Internal\FollowRedirectsTrait` for Symfony >= 8.1, but the problem existed earlier in `NoPrivateNetworkHttpClient` before the trait was created. I can create another PR for Symfony >= 6.4 and < 8.1 if needed.

Best regards

## Problem

In production, responses going through `NoPrivateNetworkHttpClient` occasionally crash with an
uncaught exception thrown from a destructor, for a URL that was never explicitly read by
application code:

```
Symfony\Component\HttpClient\Exception\RedirectionException: HTTP/1.1 301 Moved Permanently
returned for "...".
#0 CommonResponseTrait.php: CurlResponse::checkStatusCode
#1 TransportResponseTrait.php: CurlResponse::doDestruct
#2 CurlResponse.php: CurlResponse::__destruct
```

and, separately:

```
Symfony\Component\HttpClient\Exception\TransportException: Operation timed out after ...
milliseconds with 0 bytes received for "...".
#0 ErrorChunk.php: ErrorChunk::isFirst
#1 CommonResponseTrait.php: CurlResponse::initialize
#2 TransportResponseTrait.php: CurlResponse::doDestruct
#3 CurlResponse.php: CurlResponse::__destruct
```

## Cause

`TransportResponseTrait::doDestruct()` is a fail-safe: if a response's status was never checked
by anything, it throws on destruction rather than silently letting an error go unnoticed. That's
intentional and documented for a response the application actually holds.

But `Internal\FollowRedirectsTrait::followRedirects()` (used by `NoPrivateNetworkHttpClient` and
`DnsResolvingHttpClient` to follow redirects transparently) swaps in the next hop's response via
`AsyncContext::replaceRequest()` without ever telling the *previous* hop's response to stop. Its
underlying transport is left running unsupervised in the background and can complete (or time
out) entirely independently of `AsyncResponse`'s own bookkeeping. Whenever that abandoned
response eventually gets garbage-collected on its own, its unprotected destructor fires based on
whatever it happens to have accumulated by then -- an idle timeout, or a status nobody ever
checked -- and throws uncaught.

`RetryableHttpClient` already avoids this: it calls `$context->getResponse()->cancel();` a few lines
before its own `replaceRequest()` call when giving up on a response to retry. Comparing the two
is what pinpointed this as a missing line rather than a deeper design problem.

## Fix

Add the same explicit `$context->getResponse()->cancel();` call in
`FollowRedirectsTrait::followRedirects()`, right before `replaceRequest()`. Since the trait is
shared, this also fixes the identical, previously unnoticed issue in `DnsResolvingHttpClient`.

## Testing

Added two tests to `NoPrivateNetworkHttpClientTest`:

- `testRedirectResponseIsCanceledAfterBeingFollowed` checks the mechanism: the abandoned hop's
  `canceled` info is `true` once the redirect is followed.
- `testUnfollowedRedirectResponseDoesNotThrowFromDestructWhenLeftUnchecked` demonstrates the
  actual consequence: it recreates the state a genuinely orphaned response would be in (the exact
  curl/GC timing can't be forced deterministically, but the state it leaves behind can), then
  destructs it and asserts nothing escapes. Confirmed this fails with the original
  `RedirectionException` without the fix, and passes with it.
