### PR TITLE
[HttpClient] Fix abandoned wrapped response throwing on destruct

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/AsyncResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/AsyncResponse.php
@@ -188,12 +188,17 @@ class AsyncResponse implements ResponseInterface, StreamableInterface
     {
         $httpException = null;
 
-        if ($this->initializer && null === $this->getInfo('error') && !$this->hasThrown) {
-            try {
-                self::initialize($this);
-                $this->getHeaders(true);
-            } catch (HttpExceptionInterface $httpException) {
-                // no-op
+        if ($this->initializer && null === $this->getInfo('error')) {
+            if (!$this->hasThrown) {
+                try {
+                    self::initialize($this);
+                    $this->getHeaders(true);
+                } catch (HttpExceptionInterface $httpException) {
+                    // no-op
+                }
+            } else {
+                // Ensure the wrapped response cannot throw on destruct either: an error was already thrown
+                $this->response->cancel();
             }
         }
 

--- a/src/Symfony/Component/HttpClient/Tests/Response/AsyncResponseTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/Response/AsyncResponseTest.php
@@ -12,8 +12,11 @@
 namespace Symfony\Component\HttpClient\Tests\Response;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\AsyncDecoratorTrait;
+use Symfony\Component\HttpClient\Chunk\ErrorChunk;
 use Symfony\Component\HttpClient\DecoratorTrait;
 use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\AsyncContext;
 use Symfony\Component\HttpClient\Response\AsyncResponse;
 use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Contracts\HttpClient\ChunkInterface;
@@ -78,5 +81,44 @@ class AsyncResponseTest extends TestCase
 
         $this->assertSame('body', $response->getContent());
         $this->assertSame('body', $response->getContent());
+    }
+
+    /**
+     * When an error chunk has been yielded and the response is then dropped while a replacement
+     * request is in flight, the replacement is abandoned before anything could check its status:
+     * destructing it must not throw, the app already got the error.
+     */
+    public function testAbandonedReplacementResponseDoesNotThrowOnDestruct()
+    {
+        $client = new class(new MockHttpClient([new MockResponse('', ['http_code' => 302, 'redirect_url' => 'http://example.com/redirected']), new MockResponse('', ['http_code' => 301])])) implements HttpClientInterface {
+            use AsyncDecoratorTrait;
+
+            public function request(string $method, string $url, array $options = []): ResponseInterface
+            {
+                return new AsyncResponse($this->client, $method, $url, $options, static function (ChunkInterface $chunk, AsyncContext $context): \Generator {
+                    if (null !== $chunk->getError() || !$chunk->isFirst()) {
+                        yield $chunk;
+
+                        return;
+                    }
+
+                    $context->replaceRequest('GET', $context->getInfo('redirect_url'), []);
+
+                    yield new ErrorChunk($chunk->getOffset(), 'Simulated timeout');
+                });
+            }
+        };
+
+        $response = $client->request('GET', 'http://example.com/');
+
+        foreach ($client->stream($response) as $chunk) {
+            if ($chunk->isTimeout()) {
+                break;
+            }
+        }
+
+        unset($response);
+
+        $this->addToAssertionCount(1);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

When `AsyncResponse::__destruct()` skips initialization because an error chunk was already yielded to the app (the `hasThrown` flag introduced by affbb0edc5f, shipped in 6.4.34), it leaves the wrapped response untouched. If that wrapped response was swapped in by `AsyncContext::replaceRequest()` and never entered any `stream()` call, it is then garbage-collected with its initializer still armed and no error recorded. Its own destructor then initializes it and throws uncaught: a 3xx that arrived in the meantime gives a `RedirectionException`, a transport timeout a `TransportException`, both with stack traces starting at `CurlResponse::__destruct()`.

The state is reachable when streaming: an error chunk is yielded (a timeout for instance), the app keeps streaming, a passthru replaces the request (`NoPrivateNetworkHttpClient` following a redirect for instance), and the app then stops consuming before the replacement delivers its first chunk, which can happen when multiplexing several responses. This matches the production traces reported by @peter17 in #65313, whose investigation this PR builds on.

The fix cancels the wrapped response when skipping initialization: the app already got the error, so nothing should throw from the abandoned replacement's destructor. All other abandon paths are already guarded: idle timeouts flag the streamed response with `didTimeout`, transport errors record `info['error']`, and a failed synchronous initialization cancels the wrapped response via `close()`.
