### PR TITLE
[Translation] Do not extract messages from classes merely named TranslatableMessage

### DIFF
--- a/src/Symfony/Component/Translation/Extractor/Visitor/TranslatableMessageVisitor.php
+++ b/src/Symfony/Component/Translation/Extractor/Visitor/TranslatableMessageVisitor.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Translation\Extractor\Visitor;
 
 use PhpParser\Node;
 use PhpParser\NodeVisitor;
+use Symfony\Component\Translation\TranslatableMessage;
 
 /**
  * @author Mathieu Santostefano <msantostefano@protonmail.com>
@@ -39,7 +40,9 @@ final class TranslatableMessageVisitor extends AbstractVisitor implements NodeVi
             return null;
         }
 
-        if (!\in_array('TranslatableMessage', $className->getParts(), true)) {
+        // the name resolver gives a fully qualified name; templates without a "use"
+        // statement resolve to the global namespace, which is accepted as well
+        if (!\in_array($className->name, [TranslatableMessage::class, 'TranslatableMessage'], true)) {
             return null;
         }
 

--- a/src/Symfony/Component/Translation/Tests/Extractor/PhpAstExtractorTest.php
+++ b/src/Symfony/Component/Translation/Tests/Extractor/PhpAstExtractorTest.php
@@ -146,12 +146,12 @@ final class PhpAstExtractorTest extends TestCase
             ],
             'validators' => [
                 'message-in-constraint-attribute' => 'prefixmessage-in-constraint-attribute',
-//                'custom Isbn message from attribute' => 'prefixcustom Isbn message from attribute',
+                // 'custom Isbn message from attribute' => 'prefixcustom Isbn message from attribute',
                 'custom Isbn message from attribute with options as array' => 'prefixcustom Isbn message from attribute with options as array',
                 'custom Length exact message from attribute from named argument' => 'prefixcustom Length exact message from attribute from named argument',
                 'custom Length exact message from attribute from named argument 1/2' => 'prefixcustom Length exact message from attribute from named argument 1/2',
                 'custom Length min message from attribute from named argument 2/2' => 'prefixcustom Length min message from attribute from named argument 2/2',
-//                'custom Isbn message' => 'prefixcustom Isbn message',
+                // 'custom Isbn message' => 'prefixcustom Isbn message',
                 'custom Isbn message with options as array' => 'prefixcustom Isbn message with options as array',
                 'custom Isbn message from named argument' => 'prefixcustom Isbn message from named argument',
                 'custom Length exact message from named argument' => 'prefixcustom Length exact message from named argument',
@@ -208,6 +208,16 @@ final class PhpAstExtractorTest extends TestCase
         ];
 
         $this->assertEquals($expectedCatalogue, $catalogue->all());
+    }
+
+    public function testExtractionSkipsClassesNamedTranslatableMessageInOtherNamespaces()
+    {
+        $extractor = new PhpAstExtractor([new TranslatableMessageVisitor()]);
+        $catalogue = new MessageCatalogue('en');
+
+        $extractor->extract(__DIR__.'/../Fixtures/extractor-ast-other-namespace/', $catalogue);
+
+        $this->assertSame(['message from the Symfony class' => 'message from the Symfony class'], $catalogue->all('messages'));
     }
 
     public static function resourcesProvider(): array

--- a/src/Symfony/Component/Translation/Tests/Fixtures/extractor-ast-other-namespace/translatable-other-namespace.html.php
+++ b/src/Symfony/Component/Translation/Tests/Fixtures/extractor-ast-other-namespace/translatable-other-namespace.html.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Component\Translation\TranslatableMessage;
+
+new App\Model\TranslatableMessage('message from an unrelated class');
+new \TranslatableMessage\Message('message from an unrelated namespace');
+new TranslatableMessage('message from the Symfony class');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`TranslatableMessageVisitor` matches on any name *segment*:

```php
if (!\in_array('TranslatableMessage', $className->getParts(), true)) {
```

so every class whose name contains a `TranslatableMessage` part is extracted as if it were Symfony's. On 6.4 today:

```php
new \App\Model\TranslatableMessage('message from an unrelated class');   // extracted
new \TranslatableMessage\Message('message from an unrelated namespace'); // extracted
```

Both end up in the catalogue, so unrelated strings land in translation files.

`PhpAstExtractor` registers a `NameResolver`, so the visitor sees resolved names and can compare them. The check now accepts the Symfony class, plus a bare `TranslatableMessage` for templates that have no namespace and no `use` statement, which is what the existing fixtures use and what the resolver reports as a global-namespace name.

Spotted while reviewing #60854, which carries a stricter variant of this check. That one drops the global-namespace case and makes the current fixtures fail, which is how the two cases turned up.
