### PR TITLE
[FrameworkBundle][Messenger] Fix two low-deps failures

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Test/WebTestCaseTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Test/WebTestCaseTest.php
@@ -124,7 +124,8 @@ class WebTestCaseTest extends TestCase
     {
         $this->getResponseTester(new Response())->assertResponseHeaderSame('Cache-Control', 'no-cache, private');
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('Failed asserting that the Response has header "Cache-Control" with value "public", value of header "Cache-Control" is "no-cache, private".');
+        // the ", value of header ... is ..." suffix requires symfony/http-foundation >= 8.2
+        $this->expectExceptionMessage('Failed asserting that the Response has header "Cache-Control" with value "public"');
         $this->getResponseTester(new Response())->assertResponseHeaderSame('Cache-Control', 'public');
     }
 

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/AmazonSqsSenderTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/AmazonSqsSenderTest.php
@@ -14,7 +14,6 @@ namespace Symfony\Component\Messenger\Bridge\AmazonSqs\Tests\Transport;
 use AsyncAws\Core\Exception\Http\NetworkException;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
-use Psr\Log\LoggerTrait;
 use Symfony\Component\Messenger\Bridge\AmazonSqs\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Messenger\Bridge\AmazonSqs\Transport\AmazonSqsFairQueueStamp;
 use Symfony\Component\Messenger\Bridge\AmazonSqs\Transport\AmazonSqsFifoStamp;
@@ -126,23 +125,13 @@ class AmazonSqsSenderTest extends TestCase
         $serializer = $this->createMock(SerializerInterface::class);
         $serializer->method('encode')->with($envelope)->willReturn($encoded);
 
-        $logger = new class implements LoggerInterface {
-            use LoggerTrait;
-
-            public array $records = [];
-
-            public function log($level, string|\Stringable $message, array $context = []): void
-            {
-                $this->records[] = [$level, (string) $message, $context];
-            }
-        };
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
+            ->method('debug')
+            ->with($this->stringContains('takes precedence'), $this->anything());
 
         $sender = new AmazonSqsSender($connection, $serializer, $logger);
         $sender->send($envelope);
-
-        $this->assertCount(1, $logger->records);
-        $this->assertSame('debug', $logger->records[0][0]);
-        $this->assertStringContainsString('takes precedence', $logger->records[0][1]);
     }
 
     public function testItConvertsNetworkExceptionDuringSendIntoTransportException()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`low-deps` and `high-deps` are red on 8.2 for two unrelated reasons, both of the same kind: a test asserting behaviour of a sibling component that the job installs from packagist at an older version.

**FrameworkBundle**, from 71cc1be5beb. `ResponseHeaderSame` gained a `, value of header "X" is "Y"` suffix in 8.2, and `WebTestCaseTest::testAssertResponseHeaderSame` asserts the full message, but FrameworkBundle requires `symfony/http-foundation: ^7.4|^8.0`, so the job installs a version without it. The assertion now checks the version-independent prefix.

**Messenger AmazonSqs**, from #62080, my own. The test used an anonymous class with `LoggerTrait` and a typed `log(string|\Stringable $message)` override; `psr/log` is allowed at `^1|^2|^3` and the trait is untyped in 1.x and 2.x, so the job fatals with `Declaration of ... must be compatible with Psr\Log\LoggerTrait::log($level, $message, array $context = [])`. Replaced with a plain `LoggerInterface` mock, which tests the same thing.
