### PR TITLE
[Messenger] Cache the message type hierarchy

### DIFF
--- a/src/Symfony/Component/Messenger/Handler/HandlersLocator.php
+++ b/src/Symfony/Component/Messenger/Handler/HandlersLocator.php
@@ -22,6 +22,8 @@ use Symfony\Component\Messenger\Stamp\ReceivedStamp;
  */
 class HandlersLocator implements HandlersLocatorInterface
 {
+    private static array $typeCache = [];
+
     /**
      * @param HandlerDescriptor[][]|callable[][] $handlers
      */
@@ -63,7 +65,7 @@ class HandlersLocator implements HandlersLocatorInterface
     {
         $class = $envelope->getMessage()::class;
 
-        return [$class => $class]
+        return self::$typeCache[$class] ??= [$class => $class]
             + class_parents($class)
             + class_implements($class)
             + self::listWildcards($class)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`HandlersLocator::listTypes()` recomputes the full list of types for a message (its class + parents + interfaces + namespace wildcards + `'*'`) on every call, even though the result only depends on the message class, whose hierarchy is immutable once loaded. Also, `class_parents()` and `class_implements()` rebuild their arrays on each call, and `listWildcards()` runs a `strrpos()`/`substr_replace()` loop each time.

This method is called for every handled message via `HandlersLocator::getHandlers()` and for every sent message via `SendersLocator::getSenders()`, so a synchronous message currently computes the same hierarchy twice per dispatch.

This PR caches the computed list in a private static cache, using the same pattern already applied in `ControllerAttributesListener` to cache class hierarchies.

### Benchmarks

Measured using Messenger's own `DummyMessage` fixture, which produces 8 types (500K–1M iterations per measurement):

| Measurement                           | Improvement
| ------------------------------------- | -----------
| `listTypes()` in isolation            | -90%
| `getHandlers()` + iterate (1 handler) | −60%
| Minimal `MessageBus::dispatch()`      | −31%

The cache costs ~588 bytes per distinct message class, which shouldn't be a problem because the number of different message classes is limited in the app.