### PR TITLE
[HttpClient] Skip the transient-on-windows group on Windows

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -117,7 +117,7 @@ jobs:
           mv src\Symfony\Component\HttpClient\phpunit.xml.dist src\Symfony\Component\HttpClient\phpunit.xml
           php phpunit src\Symfony --exclude-group tty,benchmark,intl-data,network,transient-on-windows || ($x = 1)
           # HttpClient tests need to run separately, they block when run with other components' tests concurrently
-          php phpunit src\Symfony\Component\HttpClient || ($x = 1)
+          php phpunit src\Symfony\Component\HttpClient --exclude-group tty,benchmark,intl-data,network,transient-on-windows || ($x = 1)
 
           exit $x
 
@@ -131,6 +131,6 @@ jobs:
           Copy c:\php\php.ini-max c:\php\php.ini
           php phpunit src\Symfony --exclude-group tty,benchmark,intl-data,network,transient-on-windows || ($x = 1)
           # HttpClient tests need to run separately, they block when run with other components' tests concurrently
-          php phpunit src\Symfony\Component\HttpClient || ($x = 1)
+          php phpunit src\Symfony\Component\HttpClient --exclude-group tty,benchmark,intl-data,network,transient-on-windows || ($x = 1)
 
           exit $x


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The Windows workflow runs HttpClient in its own invocation because those tests block when run alongside the other components. That invocation carries no `--exclude-group` flags, unlike the main one right above it, so the groups the job means to skip run anyway:

```
php phpunit src\Symfony --exclude-group tty,benchmark,intl-data,network,transient-on-windows || ($x = 1)
# HttpClient tests need to run separately, they block when run with other components' tests concurrently
php phpunit src\Symfony\Component\HttpClient || ($x = 1)
```

On 6.4 that leaves `AmpHttpClientTest::testResolve` (`@group transient-on-windows`) and `HttpClientTraitTest` (`@group network`) running in both Windows jobs. This gives the HttpClient invocation the same exclusion list as the one above it.

Note for the merge up: on 7.4 and up, `testResolve` still carries its group as a doc-comment, which PHPUnit 13 ignores, so it needs converting to `#[Group(...)]` there for this to take effect.