### PR TITLE
 Record recent merge-up lessons in the skill

### DIFF
--- a/.agents/skills/symfony-merge-up/SKILL.md
+++ b/.agents/skills/symfony-merge-up/SKILL.md
@@ -104,7 +104,9 @@ git commit --no-edit
 | `.github/workflows/*.yml`, CI config | Keep the TARGET value for branch-specific pins. A new job merged from SOURCE may carry SOURCE's `php-version` (its branch minimum); bump it to the TARGET's minimum (see `min_php_requirements` in releases.json) |
 | Idiom the TARGET replaced (e.g. `unserialize(serialize())` - a deep-clone helper, logic extracted to a trait, a method/class removed) | Take the TARGET version; the SOURCE change is superseded. `git checkout --ours <file>` then re-apply any security option (e.g. `allowed_classes`) the TARGET's version happens to drop |
 | File the TARGET deleted (modify/delete conflict) | Keep it deleted if the TARGET removed the feature (confirm with `git log <TARGET> -- <file>`); the SOURCE edit is moot. `git rm <file>` |
-| Test using docblock metadata (`@dataProvider`, `@group legacy`) | Convert to attributes (`#[DataProvider(...)]`, `#[Group(...)]`) when the TARGET runs PHPUnit 10+ (7.4/8.x here); docblock providers are ignored and the test errors with "too few arguments" |
+| Test using docblock metadata (`@dataProvider`, `@testWith`, `@group legacy`) | Convert to attributes (`#[DataProvider(...)]`, `#[TestWith([...])]`, `#[Group(...)]`) when the TARGET runs PHPUnit 10+ (7.4/8.x here); PHPUnit ignores *all* metadata in doc-comments, so the data sets are never passed and the test errors with "too few arguments" |
+| Compat guard added by SOURCE (`class_exists()` / `method_exists()` fallback for a symbol that may be missing from an older sibling package) | Check whether the TARGET dropped it on purpose: `git log <TARGET> -S'<guard text>' -- <file>`. Symfony removes these in "Remove legacy code paths that rely on feature checks" style commits, so take SOURCE's new structure but leave the guard out |
+| Both sides added a member at the same spot (no overlapping content, git just collapsed them onto a shared closing) | Keep both. Give each its own terminator: two `elseif` branches each need their own `return`/closing brace, and two methods each need their own `}`. Private methods go last, after all public ones |
 | Code files | Merge logically based on context; when unsure, ask the user |
 
 #### Structural divergence across major versions
@@ -126,6 +128,28 @@ shared logic into a trait or a new utility class. When merging across such a bou
 - Prefer the TARGET branch's approach for any refactored idiom.
 - Fastest sanity check: look at how the *downstream* branch (one already past this
   divergence, e.g. 8.2 while resolving on 8.0) resolved the same files, and match it.
+
+#### Divergence a clean merge hides
+
+Most of these produce no conflict at all: the merge succeeds and the tests fail.
+All three show up as a merged test that is fine on SOURCE and wrong on TARGET.
+
+- **A config key the TARGET removed or deprecated.** A merged test builds a config
+  array (`'annotations' => false`, `'profiler' => ['collect_serializer_data' => true]`)
+  that the TARGET no longer accepts. The symptom is `Unrecognized option "x" under
+  "framework"` with the valid list attached, or a deprecation the run reports as an
+  issue. Drop the key: these are boilerplate, not what the test is about. Grep the
+  whole merge diff for the key, since several merged tests usually carry it.
+- **Registration the TARGET gates.** The TARGET may drop a service unless something
+  consumes it (profiler or test mode, for instance), so a merged test asserting on it
+  fails with "You have requested a non-existent service". Do not assert on a stripped
+  container: rebuild it the way the TARGET's own sibling tests do, keeping the
+  assertion intact.
+- **A default the TARGET flipped.** SOURCE adds a code path behind a flag whose
+  default the TARGET changed, so the new path becomes the TARGET's default and changes
+  observable output. Both sides merge cleanly and the assertions SOURCE wrote for the
+  old path now fail. Confirm with `git log <TARGET> -S'<flag> = <value>'`, then adapt
+  the expectations, capturing the real output from a run rather than guessing at it.
 
 After resolving, show `git diff HEAD~1` (first parent of the merge commit, i.e.
 the previous TARGET state) and wait for the user to confirm the resolution looks
@@ -157,15 +181,49 @@ For files under `src/Symfony/Contracts/`, run the single shared test suite:
 Ignore files outside these directories (root configs, `.github/`, etc.): they
 don't have component-level test suites.
 
+Read the whole summary line, not just the exit status: a suite can end with
+`Tests: N, Failures: 1` or abort on a `Fatal error` well before any `FAILURES!`
+banner, and ANSI colour codes sit in front of those words, so a check anchored to
+the start of a line reports a red run as green.
+
 If tests fail or report PHPUnit deprecations (the PHPUnit version may differ
-between branches), first check whether the failure is pre-existing: run the same
-test on the TARGET branch before the merge (`git stash && git checkout HEAD~1`
-or check CI). Only fix failures introduced by the merge:
+between branches), first check whether the failure is pre-existing. Cheapest test
+first: if the merge did not touch the failing area, it did not cause the failure.
+
+```bash
+git diff --name-only HEAD~1..HEAD -- <path of the failing test or the code it covers>
+```
+
+Only when that is inconclusive, run the test on the TARGET before the merge
+(`git checkout HEAD~1`, run, `git checkout <TARGET>`). Beware a CI baseline as
+evidence: a branch tip that has not been pushed in a while keeps an old green run,
+and CI installs dependencies fresh on every run, so a release made in between can
+turn a suite red with no commit to blame.
+
+Only fix failures introduced by the merge:
 1. Analyze and fix the code, including any PHPUnit deprecation notices.
 2. Commit the fix: `[<ComponentName>] Fix merge conflict resolution`.
 3. Re-run failing tests until green and deprecation-free.
 
 Report any pre-existing failures to the user without attempting to fix them.
+
+#### Failures a local run cannot show
+
+Locally, every sibling `symfony/*` package resolves to the branch you are on, so
+cross-component drift is invisible. CI's `high-deps` job installs the newest dev of
+the other components and `low-deps` the oldest each `composer.json` allows, which is
+where merged tests break even though the merge itself is sound:
+
+- **An assertion pinned to another component's message.** A newer sibling appends to
+  an exception message and an expectation that ended at the old last word stops
+  matching. Assert the part that identifies the failure and leave the tail free
+  (drop a trailing `.`, or use `expectExceptionMessageMatches()`), and fix it on the
+  oldest branch that has the test so the cascade carries it up.
+- **A test in the wrong component.** A test exercising code that lives in component B
+  but sitting in component A passes everywhere except `low-deps`, where A's
+  `composer.json` pulls a B too old to have the feature. Move the test to B rather
+  than raising A's constraint or skipping the case; `low-deps` is what proves A's
+  declared constraints are honest.
 
 ### 2c-bis. Run the repo's static-analysis / hardening checks
 
@@ -240,11 +298,42 @@ All merges complete:
   and CI version pins can each be wrong even when git reports no conflict.
 - Some components have slow test suites. Only run tests for components with
   changed files, not the entire project.
+- When the user states a constraint about the merge as a whole ("8.x stays on
+  ext-redis 6"), it applies to the entire merge diff, not only to the files git
+  flagged as conflicting. Grep the whole diff for the concept and check every hit,
+  including root `composer.json`, static-analysis baselines, and other components'
+  bridges. Auto-merged hunks are where a constraint like that gets lost silently.
+- Resolving only the conflicted hunk of a file leaves the rest of it auto-merged.
+  When the two sides restructured the same file, read the resolved file end to end
+  before staging it, otherwise it can end up declaring the same thing twice or
+  dropping a `return`.
+
+## Recurring CI failures that are not yours
+
+These recur across runs and are unrelated to any merge. Re-run the job to confirm
+rather than investigating the component:
+
+- Windows: `AmpHttpClientTest` idle timeouts on `localhost:8057`, and
+  `RedisException: Redis server went away` in the Redis Messenger integration tests.
+- Any job: composer aborting with `curl error 60 ... SSL certificate problem`, and
+  PHPUnit dying in `RecursiveDirectoryIterator` on a `vendor/composer/<hash>` temp
+  directory that vanished while it was walking the tree.
+- Timing assertions that compare an elapsed duration against a bound
+  (`Failed asserting that 0.0 is greater than 0`).
+
+Before writing one off, check that the group meant to exclude it is actually
+excluded: a marker only takes effect if the job passes the matching
+`--exclude-group`, and if the TARGET runs PHPUnit 10+, only if the marker is an
+attribute rather than a doc-comment.
 
 ## Error handling
 
 - **Never** force-push or rewrite history.
 - **Never** use `--no-verify` on commits.
+- **Never** `git add -A` (or `git add .`) while resolving: it sweeps the user's
+  untracked working files into the merge commit. Stage the files you resolved, by name.
+- **Never** `git reset` in the middle of a merge: it deletes `.git/MERGE_HEAD`, and the
+  commit that follows records a single parent, silently turning the merge into a squash.
 - **Never** auto-recover from a failed `git push` or `git pull`. Stop and hand
   control back to the user.
 - **Never** parallelize the cascade or run branches concurrently (e.g. via subagents): each


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The last cascades kept hitting the same shapes, none of which the skill covered.

**Divergence that produces no conflict at all**, so the merge succeeds and the tests fail. Three variants, each with its symptom and the `git log -S` check that confirms it: a config key the target removed or deprecated, registration the target gates, and a default the target flipped so the source's new code path becomes the target's default and changes observable output.

**Failures no local run can show.** Locally every sibling `symfony/*` resolves to the branch you are on, so cross-component drift is invisible; `high-deps` installs the newest dev of the others and `low-deps` the oldest each `composer.json` allows. Hence: do not pin an assertion to the tail of another component's message, and a test failing only in `low-deps` usually belongs in the other component.

**Reading a test run.** A suite can abort on a fatal error long before any `FAILURES!` banner, and ANSI codes sit in front of those words, so a check anchored to the start of a line reports a red run as green.

**Triage.** How to tell a pre-existing failure from one the merge caused without an expensive checkout, and why a green CI baseline on a tip that has not moved is not evidence.

**Conflict table**, three new rows: `@testWith` alongside `@dataProvider` (PHPUnit ignores all doc-comment metadata, not just providers), compat guards the target removed on purpose, and both sides adding a member at the same spot where git collapses them onto a shared closing.

**Error handling.** `git add -A` while resolving sweeps untracked working files into the merge commit, and `git reset` mid-merge deletes `MERGE_HEAD` so the next commit records a single parent and silently turns the merge into a squash.