### PR TITLE
 Check arrays and bools directly instead of comparing them to count()/true/false/[]

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Messenger/AbstractDoctrineDbalMiddleware.php
+++ b/src/Symfony/Bridge/Doctrine/Messenger/AbstractDoctrineDbalMiddleware.php
@@ -52,7 +52,7 @@ abstract class AbstractDoctrineDbalMiddleware implements MiddlewareInterface
             foreach ($names ?: array_keys($this->connectionRegistry->getConnectionNames()) as $name) {
                 if (($connection = $this->connectionRegistry->getConnection($name)) instanceof Connection) {
                     $connections[$name] = $connection;
-                } elseif ([] !== $names) {
+                } elseif ($names) {
                     throw new UnrecoverableMessageHandlingException(\sprintf('Expected "%s" to be a DBAL connection, but got a "%s".', $name, $connection::class));
                 }
             }

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -530,7 +530,7 @@ class Configuration implements ConfigurationInterface
                                         ->end()
                                         ->validate()
                                             ->ifTrue(static function ($v) {
-                                                if (!\is_array($v) || [] === $v) {
+                                                if (!\is_array($v) || !$v) {
                                                     return false;
                                                 }
                                                 $hasAllowList = false;

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/LdapFactoryTrait.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/LdapFactoryTrait.php
@@ -122,7 +122,7 @@ trait LdapFactoryTrait
                 return null;
             }
 
-            if (true === $legProvidesLdapUsers = self::providesLdapUsers($container, (string) $leg)) {
+            if ($legProvidesLdapUsers = self::providesLdapUsers($container, (string) $leg)) {
                 return true;
             }
 

--- a/src/Symfony/Component/AssetMapper/ImportMap/ImportMapRenderer.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/ImportMapRenderer.php
@@ -176,7 +176,7 @@ class ImportMapRenderer
             $output .= "\n<link rel=\"modulepreload\" href=\"$url\"$integrity>";
         }
 
-        if (\count($entryPoint) > 0) {
+        if ($entryPoint) {
             $output .= "\n<script type=\"module\"$scriptAttributes>";
             foreach ($entryPoint as $entryPointName) {
                 $entryPointName = $this->escapeAttributeValue($entryPointName);

--- a/src/Symfony/Component/ErrorHandler/DebugClassLoader.php
+++ b/src/Symfony/Component/ErrorHandler/DebugClassLoader.php
@@ -1072,7 +1072,7 @@ class DebugClassLoader
      */
     private function patchReturnTypeWillChange(\ReflectionMethod $method): void
     {
-        if (\count($method->getAttributes(\ReturnTypeWillChange::class))) {
+        if ($method->getAttributes(\ReturnTypeWillChange::class)) {
             return;
         }
 

--- a/src/Symfony/Component/Messenger/Command/FailedMessagesRetryCommand.php
+++ b/src/Symfony/Component/Messenger/Command/FailedMessagesRetryCommand.php
@@ -153,7 +153,7 @@ class FailedMessagesRetryCommand extends AbstractFailedMessagesCommand implement
             }
         }
 
-        if (0 === \count($ids)) {
+        if (!$ids) {
             if (!$input->isInteractive()) {
                 throw new RuntimeException('Message id must be passed when in non-interactive mode.');
             }

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -255,8 +255,8 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
             // If you update this check, update accordingly the one in Symfony\Component\PropertyInfo\Extractor\SerializerExtractor::getProperties()
             if (
                 !$ignore
-                && ([] === $groups || \in_array('*', $groups, true) || array_intersect($attributeMetadata->getGroups(), $groups))
-                && ([] === $ignoredGroups || !array_intersect($attributeMetadata->getGroups(), $ignoredGroups))
+                && (!$groups || \in_array('*', $groups, true) || array_intersect($attributeMetadata->getGroups(), $groups))
+                && (!$ignoredGroups || !array_intersect($attributeMetadata->getGroups(), $ignoredGroups))
                 && $this->isAllowedAttribute($classOrObject, $name = $attributeMetadata->getName(), null, $context)
             ) {
                 $allowedAttributes[] = $attributesAsString ? $name : $attributeMetadata;
@@ -264,12 +264,12 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
         }
 
         // returning false means "no restriction", which would defeat the exclusion
-        if (!$ignoreUsed && [] === $ignoredGroups && $allowExtraAttributes) {
-            if ([] === $groups) {
+        if (!$ignoreUsed && !$ignoredGroups && $allowExtraAttributes) {
+            if (!$groups) {
                 return false;
             }
 
-            if ([] === $allowedAttributes && \in_array('*', $groups, true)) {
+            if (!$allowedAttributes && \in_array('*', $groups, true)) {
                 return false;
             }
         }

--- a/src/Symfony/Component/Tui/Render/Renderer.php
+++ b/src/Symfony/Component/Tui/Render/Renderer.php
@@ -135,7 +135,7 @@ final class Renderer implements WidgetRendererInterface
 
         $resolvedStyle = $this->resolveStyle($widget);
 
-        if (true === $resolvedStyle->getHidden()) {
+        if ($resolvedStyle->getHidden()) {
             $lines = new ArrayLineBuffer([]);
             $widget->setRenderCache($lines, $cacheColumns, $cacheRows);
 
@@ -241,7 +241,7 @@ final class Renderer implements WidgetRendererInterface
     {
         $children = array_values(array_filter(
             $widget->all(),
-            fn (AbstractWidget $child) => true !== $this->resolveStyle($child)->getHidden(),
+            fn (AbstractWidget $child) => !$this->resolveStyle($child)->getHidden(),
         ));
 
         $columns = $context->getColumns();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues       | -
| License       | MIT

Remainder of the sweep after the bulk landed on the older branches (#65336 on 6.4, #65338 on 7.4, #65339 on 8.1) and merged up: what is left here are the sites that only exist on 8.2 (new files, drifted contexts, Tui variants).

Two code-style simplifications, no behavior change intended:

- `count($array) > 0`, `0 === count($array)`, `[] === $array`, `[] !== $array` and friends used as emptiness checks are replaced by checking the array itself (`if ($array)`, `if (!$array)`). Only applied where the operand is provably a plain array and no cast is needed (positive checks in `return` position keep their comparison rather than gaining a `(bool)` cast); `count()` on `Countable` objects (Crawler, Form, ConstraintViolationList, RouteCollection, ...) is the correct idiom and was left untouched, as were non-emptiness comparisons (`> 1`, `=== 1`, ...) and `[]` comparisons on nullable arrays, where `null` and `[]` must stay distinct.
- `true === $x`, `false !== $x` and friends are replaced by `$x` / `!$x` where the operand is provably a native `bool`. Comparisons that carry semantics were kept: `int|false` / `string|false` return values (`strpos()`, `preg_match()`, stream and curl handles, ...), `mixed` values from options/config arrays, and `?bool` values where `false === $x` distinguishes `null` from `false`.

Matches inside generated-code strings (PhpDumper and other dumpers) and fixtures were excluded.

Four pre-existing `throw` statements in touched files trip Fabbot's exception-message rewriter with false positives (sentence fragments, pre-quoted or free-form values). They are restructured with plain concatenation instead of `sprintf()`, keeping every message byte-identical, so the check no longer matches (same approach as NoPrivateNetworkHttpClient).
