### PR TITLE
[Tui] Add gradient backgrounds (linear, color stops)

### DIFF
--- a/src/Symfony/Component/Tui/Ansi/AnsiUtils.php
+++ b/src/Symfony/Component/Tui/Ansi/AnsiUtils.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Tui\Ansi;
 
 use Symfony\Component\String\UnicodeString;
+use Symfony\Component\Tui\Style\Color;
 use Symfony\Component\Tui\Style\CursorShape;
 
 /**
@@ -686,6 +687,74 @@ final class AnsiUtils
     public static function isPunctuation(string $char): bool
     {
         return preg_match('/[(){}[\]<>.,;:\'"!?+\-=*\/\\\\|&%^$#@~`]/', $char);
+    }
+
+    /**
+     * Paint a per-column background layer under a rendered line.
+     *
+     * Walks the line with walkCells(), injecting a background code before a
+     * visible cell only when no explicit background is active at that point:
+     * a background an inner widget set on its own cells wins over the layer,
+     * the way a child background wins over a parent one in CSS. Adjacent
+     * cells sharing a color state the code once.
+     *
+     * The line is painted over its full $width. Columns before $offsetX and
+     * past the last color clamp to the nearest edge of the layer, so a layer
+     * resolved for a content area extends under the border cells around it.
+     *
+     * @param array<int, Color> $colors Layer colors indexed by column
+     */
+    public static function paintBackground(string $line, array $colors, int $width, int $offsetX = 0): string
+    {
+        if (!$colors) {
+            return $line;
+        }
+
+        // Convert once so the walk below reads plain strings; the codes are
+        // memoized on the Color instances, which a gradient reuses across frames
+        $lastCol = \count($colors) - 1;
+        $codes = [];
+        for ($col = 0; $col < $width; ++$col) {
+            $codes[$col] = $colors[max(0, min($col - $offsetX, $lastCol))]->toBackgroundCode();
+        }
+
+        $result = '';
+        $col = 0;
+        // Last layer code written to the line. Reset whenever a sequence of the
+        // line goes through, since it may change the background behind our back.
+        $lastCode = null;
+
+        foreach (self::walkCells($line) as $token) {
+            // Zero-width tokens (SGR, cursor moves, OSC hyperlinks, APC
+            // markers) pass through untouched, wherever they sit on the line
+            if (0 === $token['width']) {
+                $result .= $token['text'];
+                $lastCode = null;
+                continue;
+            }
+
+            // Drop visible cells past the painted width
+            if ($token['col'] >= $width) {
+                continue;
+            }
+
+            if (!$token['bg'] && $codes[$token['col']] !== $lastCode) {
+                $result .= $lastCode = $codes[$token['col']];
+            }
+            $result .= $token['text'];
+            $col = $token['col'] + $token['width'];
+        }
+
+        // Fill the remaining width with layer-colored spaces
+        while ($col < $width) {
+            if ($codes[$col] !== $lastCode) {
+                $result .= $lastCode = $codes[$col];
+            }
+            $result .= ' ';
+            ++$col;
+        }
+
+        return $result."\x1b[49m";
     }
 
     /**

--- a/src/Symfony/Component/Tui/CHANGELOG.md
+++ b/src/Symfony/Component/Tui/CHANGELOG.md
@@ -12,6 +12,7 @@ CHANGELOG
  * Add `AbstractWidget::attachChild()` and `AbstractWidget::detachChild()` to wire child widgets
  * Add multi-select support to `SelectListWidget`
  * [BC BREAK] Add `$multiselect` as the third argument of `SelectListWidget::__construct()`, moving `$keybindings` to fourth position
+ * Add `Style::withLinearGradient()`, `LinearGradient`, `ColorStop`, `GradientDirection` and `Angle` to paint gradient backgrounds
 
 8.1
 ---

--- a/src/Symfony/Component/Tui/Render/ChromeApplier.php
+++ b/src/Symfony/Component/Tui/Render/ChromeApplier.php
@@ -136,12 +136,22 @@ final class ChromeApplier
 
         $innerLines = [...$topPadding, ...$contentLines, ...$bottomPadding];
 
-        return new ArrayLineBuffer($border?->wrapLines(
-            $innerLines,
-            $innerWidth,
-            $style,
-            $outerStyle,
-        ) ?? $innerLines);
+        $lines = $border?->wrapLines($innerLines, $innerWidth, $style, $outerStyle) ?? $innerLines;
+
+        // A gradient paints as a background layer under the finished box, borders
+        // included: the box renders with no background at all, then one compositing
+        // pass injects a background code wherever no child background is active.
+        // The gradient spans the inner area; border cells around it clamp to the
+        // nearest edge color, and border rows count toward its height.
+        if (null !== $gradient = $style->getGradient()) {
+            $colors = $gradient->resolve($innerWidth, \count($lines));
+            $width = $borderLeft + $innerWidth + $borderRight;
+            foreach ($lines as $i => $line) {
+                $lines[$i] = AnsiUtils::paintBackground($line, $colors[$i], $width, $borderLeft);
+            }
+        }
+
+        return new ArrayLineBuffer($lines);
     }
 
     private function isIdentity(Style $style): bool

--- a/src/Symfony/Component/Tui/Style/Angle.php
+++ b/src/Symfony/Component/Tui/Style/Angle.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Style;
+
+use Symfony\Component\Tui\Exception\InvalidArgumentException;
+
+/**
+ * An angle value, expressible in degrees or radians.
+ *
+ * Used to specify the direction of a linear gradient.
+ * Convention: 0° points right, 90° points down (screen coordinates).
+ *
+ * @experimental
+ */
+final class Angle
+{
+    private function __construct(private readonly float $radians)
+    {
+    }
+
+    public static function degrees(float $degrees): self
+    {
+        if (!is_finite($degrees)) {
+            throw new InvalidArgumentException(\sprintf('An angle must be a finite number of degrees, got "%s".', var_export($degrees, true)));
+        }
+
+        return new self($degrees * \M_PI / 180.0);
+    }
+
+    public static function radians(float $radians): self
+    {
+        if (!is_finite($radians)) {
+            throw new InvalidArgumentException(\sprintf('An angle must be a finite number of radians, got "%s".', var_export($radians, true)));
+        }
+
+        return new self($radians);
+    }
+
+    public function toRadians(): float
+    {
+        return $this->radians;
+    }
+
+    public function toDegrees(): float
+    {
+        return $this->radians * 180.0 / \M_PI;
+    }
+}

--- a/src/Symfony/Component/Tui/Style/Color.php
+++ b/src/Symfony/Component/Tui/Style/Color.php
@@ -74,6 +74,8 @@ final class Color
         'grey' => [127, 127, 127],
     ];
 
+    private ?string $bgCode = null;
+
     /**
      * Create a color from a named ANSI color.
      */
@@ -295,7 +297,8 @@ final class Color
      */
     public function toBackgroundCode(): string
     {
-        return match ($this->type) {
+        // Memoized: a gradient paints the same Color instances frame after frame
+        return $this->bgCode ??= match ($this->type) {
             ColorType::Named => \sprintf("\x1b[%dm", self::BASIC_COLORS[(string) $this->value] + 10),
             ColorType::Palette => \sprintf("\x1b[48;5;%dm", (int) $this->value),
             ColorType::Hex => \sprintf(

--- a/src/Symfony/Component/Tui/Style/ColorStop.php
+++ b/src/Symfony/Component/Tui/Style/ColorStop.php
@@ -1,0 +1,120 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Style;
+
+use Symfony\Component\Tui\Exception\InvalidArgumentException;
+
+/**
+ * A color stop: a color with an explicit position (0-100) along a gradient.
+ *
+ * When passed to a gradient, stops with no explicit position are automatically
+ * distributed between their neighbours (CSS-compatible algorithm):
+ *   - first stop without position → 0
+ *   - last stop without position → 100
+ *   - intermediate stops without position → evenly interpolated between neighbours
+ *
+ * Stops are never reordered: a position lower than the one before it is clamped up
+ * to it, which makes the two colors meet at a hard stop, as CSS does.
+ *
+ * @experimental
+ */
+final class ColorStop
+{
+    public readonly Color $color;
+
+    private function __construct(Color $color, public readonly int $position)
+    {
+        $this->color = $color;
+    }
+
+    public static function at(Color|string|int $color, int $position): self
+    {
+        if ($position < 0 || $position > 100) {
+            throw new InvalidArgumentException(\sprintf('Color stop position must be between 0 and 100, got %d.', $position));
+        }
+
+        return new self(Color::from($color), $position);
+    }
+
+    /**
+     * Normalizes a mixed array of plain colors and ColorStops into an array of
+     * [color => Color, offset => float] entries where offset ∈ [0.0, 1.0].
+     *
+     * Plain colors (Color|string|int) without an explicit position receive one
+     * automatically using the CSS interpolation algorithm.
+     *
+     * @param array<Color|string|int|ColorStop> $input
+     *
+     * @return array<array{color: Color, offset: float}>
+     *
+     * @internal plumbing for the gradient implementations
+     */
+    public static function normalize(array $input): array
+    {
+        // Convert to [color, pos: float|null] pairs preserving order
+        /** @var array<array{color: Color, pos: float|null}> $pairs */
+        $pairs = [];
+        foreach ($input as $item) {
+            if ($item instanceof self) {
+                $pairs[] = ['color' => $item->color, 'pos' => (float) $item->position];
+            } else {
+                $pairs[] = ['color' => Color::from($item), 'pos' => null];
+            }
+        }
+
+        $n = \count($pairs);
+
+        if ($n < 2) {
+            throw new InvalidArgumentException('A gradient requires at least 2 colors.');
+        }
+
+        // First and last plain stops default to 0 and 100
+        if (null === $pairs[0]['pos']) {
+            $pairs[0]['pos'] = 0.0;
+        }
+        if (null === $pairs[$n - 1]['pos']) {
+            $pairs[$n - 1]['pos'] = 100.0;
+        }
+
+        // Fill each run of un-positioned stops by linear interpolation between neighbours
+        $i = 0;
+        while ($i < $n) {
+            if (null !== $pairs[$i]['pos']) {
+                ++$i;
+                continue;
+            }
+            $prev = $i - 1;
+            $j = $i;
+            while ($j < $n && null === $pairs[$j]['pos']) {
+                ++$j;
+            }
+            $intervals = $j - $prev;
+            for ($k = $i; $k < $j; ++$k) {
+                $pairs[$k]['pos'] = $pairs[$prev]['pos']
+                    + ($pairs[$j]['pos'] - $pairs[$prev]['pos']) * ($k - $prev) / $intervals;
+            }
+            $i = $j;
+        }
+
+        // Clamp each position up to the highest one seen so far. A stop that goes
+        // backwards becomes a hard stop instead of being moved earlier in the
+        // gradient, which is what CSS does.
+        $stops = [];
+        $highest = 0.0;
+        foreach ($pairs as $pair) {
+            $highest = max($highest, $pair['pos']);
+            $stops[] = ['color' => $pair['color'], 'offset' => $highest / 100.0];
+        }
+
+        return $stops;
+    }
+}

--- a/src/Symfony/Component/Tui/Style/GradientDirection.php
+++ b/src/Symfony/Component/Tui/Style/GradientDirection.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Style;
+
+/**
+ * @experimental
+ */
+enum GradientDirection
+{
+    case LeftToRight;
+    case RightToLeft;
+    case TopToBottom;
+    case BottomToTop;
+
+    public function toAngle(): Angle
+    {
+        return match ($this) {
+            self::LeftToRight => Angle::degrees(0),
+            self::TopToBottom => Angle::degrees(90),
+            self::RightToLeft => Angle::degrees(180),
+            self::BottomToTop => Angle::degrees(270),
+        };
+    }
+}

--- a/src/Symfony/Component/Tui/Style/GradientInterface.php
+++ b/src/Symfony/Component/Tui/Style/GradientInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Style;
+
+/**
+ * Contract shared by the gradient backgrounds a Style can carry.
+ *
+ * This is not a third-party extension point: Style::withLinearGradient() is
+ * typed against the concrete class, and the interface stays internal. It is
+ * what lets Style hold any gradient implementation without knowing its
+ * geometry, a radial gradient being the natural second one.
+ *
+ * @experimental
+ *
+ * @internal
+ */
+interface GradientInterface
+{
+    /**
+     * Resolve the background of every cell of a $width x $height area.
+     *
+     * @return array<int, array<int, Color>> colors indexed by row, then by column
+     */
+    public function resolve(int $width, int $height): array;
+}

--- a/src/Symfony/Component/Tui/Style/LinearGradient.php
+++ b/src/Symfony/Component/Tui/Style/LinearGradient.php
@@ -1,0 +1,178 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Style;
+
+/**
+ * Linear gradient background: colors distributed along a directional axis.
+ *
+ * Requires a truecolor terminal. Interpolating between two stops yields an
+ * arbitrary RGB color, including for the cells sitting exactly on a named or
+ * palette stop. The component detects no capability, so on a 256-color
+ * terminal the area shows no background at all, where Style::withBackground()
+ * would still render.
+ *
+ * @experimental
+ */
+final class LinearGradient implements GradientInterface
+{
+    /** @var array<array{color: Color, offset: float}> Normalized stops, in declaration order */
+    private readonly array $stops;
+
+    /**
+     * Colors of the last resolved size only. An app renders one size at a time, and
+     * keeping every size ever asked for made these otherwise immutable value objects
+     * grow without bound: 300 widths at height 24 cost around 91 MB.
+     *
+     * @var array<int, array<int, Color>>|null
+     */
+    private ?array $cache = null;
+
+    private string $cacheKey = '';
+
+    /**
+     * @param array<array{color: Color, offset: float}> $stops
+     */
+    private function __construct(array $stops, private readonly Angle $angle)
+    {
+        $this->stops = $stops;
+    }
+
+    /**
+     * Create a LinearGradient from colors, or derive one from an existing gradient.
+     *
+     * @param self|array<Color|string|int|ColorStop> $colors    Gradient specification:
+     *                                                          - LinearGradient instance: returned as-is, or re-angled when $direction is given
+     *                                                          - array: at least 2 colors, color stops, or a mix of both
+     * @param GradientDirection|Angle|null           $direction Gradient axis. Null keeps the direction of an existing
+     *                                                          gradient, and defaults to left-to-right for an array.
+     */
+    public static function from(self|array $colors, GradientDirection|Angle|null $direction = null): self
+    {
+        if (!$colors instanceof self) {
+            // ColorStop::normalize() rejects a list of fewer than 2 colors
+            return new self(ColorStop::normalize($colors), self::toAngle($direction ?? GradientDirection::LeftToRight));
+        }
+
+        if (null === $direction) {
+            return $colors;
+        }
+
+        return new self($colors->stops, self::toAngle($direction));
+    }
+
+    private static function toAngle(GradientDirection|Angle $direction): Angle
+    {
+        return $direction instanceof Angle ? $direction : $direction->toAngle();
+    }
+
+    /**
+     * @return array<int, array<int, Color>>
+     */
+    public function resolve(int $width, int $height): array
+    {
+        $key = $width.':'.$height;
+        if ($key === $this->cacheKey && null !== $this->cache) {
+            return $this->cache;
+        }
+
+        $this->cacheKey = $key;
+
+        return $this->cache = $this->compute($width, $height);
+    }
+
+    /**
+     * @return array<int, array<int, Color>>
+     */
+    private function compute(int $width, int $height): array
+    {
+        $angleRad = $this->angle->toRadians();
+        $dx = cos($angleRad);
+        $dy = sin($angleRad);
+
+        $xHalf = $width > 1 ? 0.5 : 0.0;
+        $yHalf = $height > 1 ? 0.5 : 0.0;
+
+        $pxMin = $dx >= 0 ? -$xHalf * $dx : $xHalf * $dx;
+        $pxMax = $dx >= 0 ? $xHalf * $dx : -$xHalf * $dx;
+        $pyMin = $dy >= 0 ? -$yHalf * $dy : $yHalf * $dy;
+        $pyMax = $dy >= 0 ? $yHalf * $dy : -$yHalf * $dy;
+
+        $minProj = $pxMin + $pyMin;
+        $range = ($pxMax + $pyMax) - $minProj;
+
+        $colors = [];
+        for ($row = 0; $row < $height; ++$row) {
+            $yNorm = $height > 1 ? $row / ($height - 1) - 0.5 : 0.0;
+            $pyContrib = $yNorm * $dy;
+
+            $rowColors = [];
+            for ($col = 0; $col < $width; ++$col) {
+                $xNorm = $width > 1 ? $col / ($width - 1) - 0.5 : 0.0;
+                $proj = $xNorm * $dx + $pyContrib;
+                $offset = $range > 1e-10 ? ($proj - $minProj) / $range : 0.0;
+                $offset = max(0.0, min(1.0, $offset));
+
+                $rowColors[$col] = $this->interpolate($offset);
+            }
+            $colors[$row] = $rowColors;
+        }
+
+        return $colors;
+    }
+
+    private function interpolate(float $offset): Color
+    {
+        $stops = $this->stops;
+        $n = \count($stops);
+
+        if ($offset <= $stops[0]['offset']) {
+            return self::mix($stops[0]['color'], $stops[0]['color'], 0.0);
+        }
+        if ($offset >= $stops[$n - 1]['offset']) {
+            return self::mix($stops[$n - 1]['color'], $stops[$n - 1]['color'], 0.0);
+        }
+
+        for ($i = 0; $i < $n - 1; ++$i) {
+            if ($offset >= $stops[$i]['offset'] && $offset <= $stops[$i + 1]['offset']) {
+                $segmentRange = $stops[$i + 1]['offset'] - $stops[$i]['offset'];
+                $localOffset = $segmentRange > 1e-10 ? ($offset - $stops[$i]['offset']) / $segmentRange : 0.0;
+
+                return self::mix($stops[$i]['color'], $stops[$i + 1]['color'], $localOffset);
+            }
+        }
+
+        return self::mix($stops[$n - 1]['color'], $stops[$n - 1]['color'], 0.0);
+    }
+
+    /**
+     * Mix two stop colors channel by channel.
+     *
+     * Color::mix() rounds the ratio to an integer percentage, which caps a
+     * segment at 101 distinct colors: a two-stop gradient bands from about 100
+     * columns on. Keeping the ratio in float removes that ceiling.
+     *
+     * Both endpoints go through the same path, so a named or palette color
+     * resolves to an RGB color there too, instead of showing as a band of its
+     * own SGR code next to the interpolated cells.
+     */
+    private static function mix(Color $from, Color $to, float $ratio): Color
+    {
+        $a = $from->toRgb();
+        $b = $to->toRgb();
+
+        return Color::rgb(
+            (int) round($a['r'] + ($b['r'] - $a['r']) * $ratio),
+            (int) round($a['g'] + ($b['g'] - $a['g']) * $ratio),
+            (int) round($a['b'] + ($b['b'] - $a['b']) * $ratio),
+        );
+    }
+}

--- a/src/Symfony/Component/Tui/Style/Style.php
+++ b/src/Symfony/Component/Tui/Style/Style.php
@@ -64,6 +64,7 @@ final class Style
     private ?string $ansiPrefix = null;
     private ?string $ansiSuffix = null;
     private ?string $bgCode = null;
+    private ?GradientInterface $gradient = null;
 
     /**
      * @param Padding|null          $padding       Padding specification (null = not set, see Padding::from())
@@ -122,153 +123,104 @@ final class Style
         $this->bgCode = null;
     }
 
-    /**
-     * Get the background color.
-     */
     public function getBackground(): ?Color
     {
         return $this->backgroundColor;
     }
 
     /**
-     * Get the foreground color.
+     * @internal the renderer's accessor; its return type is not part of the public API
      */
+    public function getGradient(): ?GradientInterface
+    {
+        return $this->gradient;
+    }
+
     public function getColor(): ?Color
     {
         return $this->foregroundColor;
     }
 
-    /**
-     * Get the padding.
-     */
     public function getPadding(): ?Padding
     {
         return $this->padding;
     }
 
-    /**
-     * Get the border.
-     */
     public function getBorder(): ?Border
     {
         return $this->border;
     }
 
-    /**
-     * Get the bold flag.
-     */
     public function getBold(): ?bool
     {
         return $this->bold;
     }
 
-    /**
-     * Get the dim flag.
-     */
     public function getDim(): ?bool
     {
         return $this->dim;
     }
 
-    /**
-     * Get the italic flag.
-     */
     public function getItalic(): ?bool
     {
         return $this->italic;
     }
 
-    /**
-     * Get the strikethrough flag.
-     */
     public function getStrikethrough(): ?bool
     {
         return $this->strikethrough;
     }
 
-    /**
-     * Get the underline flag.
-     */
     public function getUnderline(): ?bool
     {
         return $this->underline;
     }
 
-    /**
-     * Get the reverse flag.
-     */
     public function getReverse(): ?bool
     {
         return $this->reverse;
     }
 
-    /**
-     * Get the layout direction.
-     */
     public function getDirection(): ?Direction
     {
         return $this->direction;
     }
 
-    /**
-     * Get the gap between children.
-     */
     public function getGap(): ?int
     {
         return $this->gap;
     }
 
-    /**
-     * Get the hidden flag.
-     */
     public function getHidden(): ?bool
     {
         return $this->hidden;
     }
 
-    /**
-     * Get the cursor shape.
-     */
     public function getCursorShape(): ?CursorShape
     {
         return $this->cursorShape;
     }
 
-    /**
-     * Get the text alignment.
-     */
     public function getTextAlign(): ?TextAlign
     {
         return $this->textAlign;
     }
 
-    /**
-     * Get the FIGlet font name or path.
-     */
     public function getFont(): ?string
     {
         return $this->font;
     }
 
-    /**
-     * Get the maximum width in columns.
-     */
     public function getMaxColumns(): ?int
     {
         return $this->maxColumns;
     }
 
-    /**
-     * Get the horizontal alignment of child widgets.
-     */
     public function getAlign(): ?Align
     {
         return $this->align;
     }
 
-    /**
-     * Get the vertical alignment of child widgets.
-     */
     public function getVerticalAlign(): ?VerticalAlign
     {
         return $this->verticalAlign;
@@ -300,11 +252,12 @@ final class Style
             && null === $this->italic
             && null === $this->strikethrough
             && null === $this->underline
-            && null === $this->reverse;
+            && null === $this->reverse
+            && null === $this->gradient;
     }
 
     /**
-     * Create a style with padding only.
+     * Creates a style with padding only.
      *
      * @param Padding|array<int> $padding Padding specification (see Padding::from())
      */
@@ -314,7 +267,7 @@ final class Style
     }
 
     /**
-     * Create a style with border only.
+     * Creates a style with border only.
      *
      * @param Border|array<int>         $border  Border specification (see Border::from())
      * @param BorderPattern|string|null $pattern Border pattern (see BorderPattern::fromName())
@@ -355,11 +308,11 @@ final class Style
         $align = null;
         $verticalAlign = null;
         $flex = null;
+        $gradient = null;
 
         foreach ($styles as $style) {
             $padding = $style->padding ?? $padding;
             $border = $style->border ?? $border;
-            $background = $style->backgroundColor ?? $background;
             $color = $style->foregroundColor ?? $color;
             $bold = $style->bold ?? $bold;
             $dim = $style->dim ?? $dim;
@@ -377,9 +330,19 @@ final class Style
             $align = $style->align ?? $align;
             $verticalAlign = $style->verticalAlign ?? $verticalAlign;
             $flex = $style->flex ?? $flex;
+            // Background and gradient share a single slot: they are mutually
+            // exclusive on a Style (see withBackground()/withLinearGradient()),
+            // so the last style setting either one wins over the other.
+            if (null !== $style->gradient) {
+                $gradient = $style->gradient;
+                $background = null;
+            } elseif (null !== $style->backgroundColor) {
+                $background = $style->backgroundColor;
+                $gradient = null;
+            }
         }
 
-        return new self(
+        $result = new self(
             $padding,
             $border,
             $background,
@@ -401,10 +364,13 @@ final class Style
             $verticalAlign,
             $flex,
         );
+        $result->gradient = $gradient;
+
+        return $result;
     }
 
     /**
-     * Create new style with different padding.
+     * Creates new style with different padding.
      *
      * @param Padding|array<int> $padding Padding specification (see Padding::from())
      */
@@ -417,7 +383,7 @@ final class Style
     }
 
     /**
-     * Create new style with different border.
+     * Creates new style with different border.
      *
      * @param Border|array<int>         $border  Border specification (see Border::from())
      * @param BorderPattern|string|null $pattern Border pattern (see BorderPattern::fromName())
@@ -432,7 +398,7 @@ final class Style
     }
 
     /**
-     * Create new style with a different border pattern.
+     * Creates new style with a different border pattern.
      */
     public function withBorderPattern(BorderPattern|string|null $pattern): self
     {
@@ -442,7 +408,7 @@ final class Style
     }
 
     /**
-     * Create new style with a different border color.
+     * Creates new style with a different border color.
      */
     public function withBorderColor(Color|string|int|null $color): self
     {
@@ -452,7 +418,7 @@ final class Style
     }
 
     /**
-     * Create new style with background color.
+     * Creates new style with background color.
      *
      * @param Color|string|int|null $background Color specification:
      *                                          - Color instance
@@ -464,13 +430,33 @@ final class Style
     public function withBackground(Color|string|int|null $background): self
     {
         $clone = clone $this;
+        $clone->gradient = null;
         $clone->backgroundColor = null !== $background ? Color::from($background) : null;
 
         return $clone;
     }
 
     /**
-     * Create new style with foreground color.
+     * Creates new style with a linear gradient.
+     *
+     * Clears any background color: the two are mutually exclusive. Requires a
+     * truecolor terminal, see LinearGradient.
+     *
+     * @param LinearGradient|array<Color|string|int> $gradient  Colors array or pre-built gradient object (see LinearGradient::from())
+     * @param GradientDirection|Angle|null           $direction Gradient axis. Null keeps the direction of a pre-built
+     *                                                          gradient, and defaults to left-to-right for an array.
+     */
+    public function withLinearGradient(LinearGradient|array $gradient, GradientDirection|Angle|null $direction = null): self
+    {
+        $clone = clone $this;
+        $clone->gradient = LinearGradient::from($gradient, $direction);
+        $clone->backgroundColor = null;
+
+        return $clone;
+    }
+
+    /**
+     * Creates new style with foreground color.
      *
      * @param Color|string|int|null $color Color specification:
      *                                     - Color instance
@@ -488,7 +474,7 @@ final class Style
     }
 
     /**
-     * Create new style with bold enabled.
+     * Creates new style with bold enabled.
      */
     public function withBold(bool $bold = true): self
     {
@@ -499,7 +485,7 @@ final class Style
     }
 
     /**
-     * Create new style with dim/faint enabled.
+     * Creates new style with dim/faint enabled.
      */
     public function withDim(bool $dim = true): self
     {
@@ -510,7 +496,7 @@ final class Style
     }
 
     /**
-     * Create new style with italic enabled.
+     * Creates new style with italic enabled.
      */
     public function withItalic(bool $italic = true): self
     {
@@ -521,7 +507,7 @@ final class Style
     }
 
     /**
-     * Create new style with strikethrough enabled.
+     * Creates new style with strikethrough enabled.
      */
     public function withStrikethrough(bool $strikethrough = true): self
     {
@@ -532,7 +518,7 @@ final class Style
     }
 
     /**
-     * Create new style with underline enabled.
+     * Creates new style with underline enabled.
      */
     public function withUnderline(bool $underline = true): self
     {
@@ -543,7 +529,7 @@ final class Style
     }
 
     /**
-     * Create new style with reverse video enabled.
+     * Creates new style with reverse video enabled.
      */
     public function withReverse(bool $reverse = true): self
     {
@@ -554,7 +540,7 @@ final class Style
     }
 
     /**
-     * Create new style with layout direction.
+     * Creates new style with layout direction.
      */
     public function withDirection(Direction $direction): self
     {
@@ -565,7 +551,7 @@ final class Style
     }
 
     /**
-     * Create new style with gap between children.
+     * Creates new style with gap between children.
      */
     public function withGap(int $gap): self
     {
@@ -576,7 +562,7 @@ final class Style
     }
 
     /**
-     * Create new style with hidden flag.
+     * Creates new style with hidden flag.
      *
      * Hidden widgets are skipped during rendering; they produce no output
      * and take no space, similar to CSS `display: none`.
@@ -590,7 +576,7 @@ final class Style
     }
 
     /**
-     * Create new style with a cursor shape.
+     * Creates new style with a cursor shape.
      */
     public function withCursorShape(CursorShape $cursorShape): self
     {
@@ -601,7 +587,7 @@ final class Style
     }
 
     /**
-     * Create new style with text alignment.
+     * Creates new style with text alignment.
      */
     public function withTextAlign(TextAlign $textAlign): self
     {
@@ -612,7 +598,7 @@ final class Style
     }
 
     /**
-     * Create new style with a FIGlet font.
+     * Creates new style with a FIGlet font.
      *
      * @param string|null $font Bundled font name (big, small, slant, standard, mini) or path to a .flf file, or null to clear
      */
@@ -625,7 +611,7 @@ final class Style
     }
 
     /**
-     * Create new style with a maximum column width.
+     * Creates new style with a maximum column width.
      *
      * @param int|null $maxColumns Maximum width in columns, or null to clear
      */
@@ -638,7 +624,7 @@ final class Style
     }
 
     /**
-     * Create new style with horizontal alignment for child widgets.
+     * Creates new style with horizontal alignment for child widgets.
      */
     public function withAlign(Align $align): self
     {
@@ -649,7 +635,7 @@ final class Style
     }
 
     /**
-     * Create new style with vertical alignment for child widgets.
+     * Creates new style with vertical alignment for child widgets.
      */
     public function withVerticalAlign(VerticalAlign $verticalAlign): self
     {
@@ -660,7 +646,7 @@ final class Style
     }
 
     /**
-     * Create new style with a flex grow weight for horizontal layouts.
+     * Creates new style with a flex grow weight for horizontal layouts.
      *
      * @param int|null $flex 0 = intrinsic width, 1+ = proportional weight, null = clear
      */
@@ -673,7 +659,7 @@ final class Style
     }
 
     /**
-     * Create a copy with only visual formatting and content properties.
+     * Creates a copy with only visual formatting and content properties.
      *
      * Strips layout properties that the Renderer owns: padding, border,
      * gap, direction, hidden, cursorShape, textAlign, maxColumns, align,

--- a/src/Symfony/Component/Tui/Tests/Render/ChromeApplierTest.php
+++ b/src/Symfony/Component/Tui/Tests/Render/ChromeApplierTest.php
@@ -19,9 +19,12 @@ use Symfony\Component\Tui\Render\ChromeApplier;
 use Symfony\Component\Tui\Render\RenderContext;
 use Symfony\Component\Tui\Render\WidgetRendererInterface;
 use Symfony\Component\Tui\Style\Border;
+use Symfony\Component\Tui\Style\Color;
+use Symfony\Component\Tui\Style\GradientDirection;
 use Symfony\Component\Tui\Style\Padding;
 use Symfony\Component\Tui\Style\Style;
 use Symfony\Component\Tui\Style\TextAlign;
+use Symfony\Component\Tui\Widget\ContainerWidget;
 use Symfony\Component\Tui\Widget\TextWidget;
 
 /**
@@ -361,8 +364,463 @@ final class ChromeApplierTest extends TestCase
     }
 
     // ---------------------------------------------------------------
+    // apply: gradient
+    // ---------------------------------------------------------------
+
+    public function testGradientAppliedColumnByColumnOnPaddingLine()
+    {
+        $applier = $this->createApplier();
+        $widget = new TextWidget('test');
+        $style = (new Style())
+            ->withLinearGradient(['#000000', '#ffffff'], GradientDirection::LeftToRight)
+            ->withPadding(new Padding(1, 0, 0, 0));
+
+        $lines = $applier->apply(new ArrayLineBuffer([]), 4, $style, $widget)->toArray();
+
+        // First line is top-padding: 4 spaces each with different gradient bg code
+        $this->assertCount(1, $lines);
+
+        $black = Color::from('#000000')->toBackgroundCode();
+        $white = Color::from('#ffffff')->toBackgroundCode();
+
+        $this->assertStringContainsString($black, $lines[0]);
+        $this->assertStringContainsString($white, $lines[0]);
+    }
+
+    public function testGradientContentLineHasPerColumnCodes()
+    {
+        $applier = $this->createApplier();
+        $widget = new TextWidget('test');
+        $style = (new Style())
+            ->withLinearGradient(['#000000', '#ffffff'], GradientDirection::LeftToRight);
+
+        $lines = $applier->apply(new ArrayLineBuffer(['ab']), 2, $style, $widget)->toArray();
+
+        $this->assertCount(1, $lines);
+        $black = Color::from('#000000')->toBackgroundCode();
+        $white = Color::from('#ffffff')->toBackgroundCode();
+
+        $this->assertStringContainsString($black, $lines[0]);
+        $this->assertStringContainsString($white, $lines[0]);
+    }
+
+    public function testGradientVerticalDifferentRowsHaveDifferentCodes()
+    {
+        $applier = $this->createApplier();
+        $widget = new TextWidget('test');
+        $style = (new Style())
+            ->withLinearGradient(['#000000', '#ffffff'], GradientDirection::TopToBottom);
+
+        // Both rows hold the same character, so any difference between them can only
+        // come from the gradient.
+        $lines = $applier->apply(new ArrayLineBuffer(['a', 'a']), 1, $style, $widget)->toArray();
+
+        $this->assertCount(2, $lines);
+        $this->assertSame(Color::from('#000000')->toBackgroundCode(), self::backgroundAtColumn($lines[0], 0), 'row 0 is the first stop');
+        $this->assertSame(Color::from('#ffffff')->toBackgroundCode(), self::backgroundAtColumn($lines[1], 0), 'row 1 is the last stop');
+    }
+
+    public function testGradientVerticalContentUsesOffsetWhenBorderPresent()
+    {
+        // Top+bottom borders only (no left/right sides, to isolate content bg from │ segments).
+        // fullHeight = 3: 1(top) + 1(content) + 1(bottom).
+        // TopToBottom gradient [black→white] over fullHeight=3:
+        //   row 0 (top border): offset=0   → black
+        //   row 1 (content):    offset=0.5 → 50% gray  ← 'a' character must use this, not pure black
+        //   row 2 (bot border): offset=1   → white
+        $applier = $this->createApplier();
+        $widget = new TextWidget('a');
+        $style = (new Style())
+            ->withLinearGradient(['#000000', '#ffffff'], GradientDirection::TopToBottom)
+            ->withBorder(Border::xy(0, 1)); // top=1, right=0, bottom=1, left=0
+
+        // lines[0]=top border, lines[1]=content row (no │ side segs), lines[2]=bottom border
+        $lines = $applier->apply(new ArrayLineBuffer(['a']), 1, $style, $widget)->toArray();
+
+        $gray = Color::from('#000000')->mix(Color::from('#ffffff'), 50)->toBackgroundCode();
+
+        $this->assertStringContainsString($gray, $lines[1], 'content char should use offset=0.5 (row 1 of fullHeight=3), not pure black');
+    }
+
+    public function testGradientContentStartsAtGradientOriginWhenBorderPresent()
+    {
+        // width=5: 1(left border) + 3(inner) + 1(right border)
+        // Gradient spans innerWidth=3 only:
+        //   content[0]: offset=0   → pure black  ← first content char (same as left border)
+        //   content[1]: offset=0.5 → mix 50%
+        //   content[2]: offset=1   → pure white  ← last content char (same as right border)
+        // The 25%-interpolated color (from old totalWidth=5 offset) must NOT appear.
+        $applier = $this->createApplier();
+        $widget = new TextWidget('abc');
+        $style = (new Style())
+            ->withLinearGradient(['#000000', '#ffffff'], GradientDirection::LeftToRight)
+            ->withBorder(Border::all(1));
+
+        // lines[0]=top border, lines[1]=content row, lines[2]=bottom border
+        $lines = $applier->apply(new ArrayLineBuffer(['abc']), 5, $style, $widget)->toArray();
+
+        $black = Color::from('#000000')->toBackgroundCode();
+        $gray = Color::from('#000000')->mix(Color::from('#ffffff'), 50)->toBackgroundCode();
+        $white = Color::from('#ffffff')->toBackgroundCode();
+        $quarter = Color::from('#000000')->mix(Color::from('#ffffff'), 25)->toBackgroundCode();
+
+        // The 5 columns are: left border, 3 content cells, right border. The strip
+        // spans the 3 inner columns, and the borders echo its endpoints.
+        $this->assertSame($black, self::backgroundAtColumn($lines[1], 0), 'left border');
+        $this->assertSame($black, self::backgroundAtColumn($lines[1], 1), 'first content cell is offset=0');
+        $this->assertSame($gray, self::backgroundAtColumn($lines[1], 2), 'middle content cell is offset=0.5');
+        $this->assertSame($white, self::backgroundAtColumn($lines[1], 3), 'last content cell is offset=1');
+        $this->assertSame($white, self::backgroundAtColumn($lines[1], 4), 'right border');
+
+        // Spanning totalWidth instead of innerWidth would put 25% gray on a cell.
+        $this->assertStringNotContainsString($quarter, $lines[1], 'the strip must span innerWidth, not totalWidth');
+    }
+
+    public function testGradientRightBorderHasEndpointColor()
+    {
+        // width=29: 1(left border) + 27(inner) + 1(right border)
+        $applier = $this->createApplier();
+        $widget = new TextWidget(str_repeat('a', 27));
+        // The child paints its own background, so no content cell carries a gradient
+        // code: the endpoint color can then only come from the border itself.
+        $style = (new Style())
+            ->withLinearGradient(['#000000', '#ffffff'], GradientDirection::LeftToRight)
+            ->withBorder(Border::all(1));
+
+        $lines = $applier->apply(new ArrayLineBuffer(["\x1b[48;2;255;0;0m".str_repeat('a', 27)."\x1b[49m"]), 29, $style, $widget)->toArray();
+
+        $white = Color::from('#ffffff')->toBackgroundCode();
+        $black = Color::from('#000000')->toBackgroundCode();
+        $childBg = "\x1b[48;2;255;0;0m";
+
+        $this->assertSame($black, self::backgroundAtColumn($lines[1], 0), 'left border takes the first stop');
+        $this->assertSame($childBg, self::backgroundAtColumn($lines[1], 14), 'content keeps its own background');
+        $this->assertSame($white, self::backgroundAtColumn($lines[1], 28), 'right border takes the last stop');
+    }
+
+    public function testGradientDoesNotOverrideChildBgWithZeroBlueComponent()
+    {
+        // ESC[48;2;255;0;0m sets red background (R=255, G=0, B=0). The blue component
+        // "0" must NOT be misread as SGR 0 (full reset) while tracking the bg state, which
+        // would let the parent gradient overwrite the child's red background.
+        $applier = $this->createApplier();
+        $widget = new TextWidget('X');
+        $style = (new Style())
+            ->withLinearGradient(['#0000ff', '#ffffff'], GradientDirection::LeftToRight);
+
+        // Content with red background active: gradient must not be injected before 'X'
+        $redBg = "\x1b[48;2;255;0;0m";
+        $lines = $applier->apply(new ArrayLineBuffer([$redBg.'X']), 2, $style, $widget)->toArray();
+
+        // 'X' must be directly after the red bg code: no parent gradient injected between them
+        $this->assertStringContainsString($redBg.'X', $lines[0],
+            'the red bg (48;2;255;0;0) must be seen as active, not mistake blue=0 for SGR 0');
+    }
+
+    /**
+     * A foreground (38) or underline (58) color never changes the background state,
+     * but its payload has to be skipped: a zero channel would otherwise be read as
+     * SGR 0 and let the parent gradient paint over the child's background.
+     */
+    #[DataProvider('zeroComponentForegroundSequenceProvider')]
+    public function testGradientDoesNotOverrideChildBgOnForegroundWithZeroComponent(string $foregroundSequence)
+    {
+        $applier = $this->createApplier();
+        $widget = new TextWidget('X');
+        $style = (new Style())
+            ->withLinearGradient(['#0000ff', '#ffffff'], GradientDirection::LeftToRight);
+
+        $redBg = "\x1b[48;2;255;0;0m";
+        $lines = $applier->apply(new ArrayLineBuffer([$redBg.$foregroundSequence.'X']), 2, $style, $widget)->toArray();
+
+        $this->assertStringContainsString($redBg.$foregroundSequence.'X', $lines[0],
+            'the child background must survive a foreground color holding a zero component');
+    }
+
+    public static function zeroComponentForegroundSequenceProvider(): iterable
+    {
+        yield 'rgb foreground, zero red' => ["\x1b[38;2;0;255;255m"];
+        yield 'rgb foreground, zero green' => ["\x1b[38;2;255;0;255m"];
+        yield 'rgb foreground, zero blue' => ["\x1b[38;2;255;255;0m"];
+        yield 'palette foreground, index 0' => ["\x1b[38;5;0m"];
+        yield 'rgb underline, zero red' => ["\x1b[58;2;0;255;0m"];
+        yield 'palette underline, index 0' => ["\x1b[58;5;0m"];
+        // 49 as an RGB channel is the bg-default code; it must not be read as one
+        yield 'rgb foreground, channel 49' => ["\x1b[38;2;49;49;49m"];
+    }
+
+    public function testGradientStillYieldsToBackgroundResetAfterAForegroundColor()
+    {
+        // The payload skipping must not swallow a genuine SGR 49 that follows.
+        $applier = $this->createApplier();
+        $widget = new TextWidget('X');
+        $style = (new Style())
+            ->withLinearGradient(['#0000ff', '#ffffff'], GradientDirection::LeftToRight);
+
+        $lines = $applier->apply(new ArrayLineBuffer(["\x1b[48;2;255;0;0m\x1b[38;2;0;255;0m\x1b[49mX"]), 2, $style, $widget)->toArray();
+
+        $blue = Color::from('#0000ff')->toBackgroundCode();
+        $this->assertStringContainsString($blue.'X', $lines[0],
+            'once the child resets its background, the gradient must paint again');
+    }
+
+    public function testGradientLineKeepsTheTrailingResetsOfTheChild()
+    {
+        $applier = $this->createApplier();
+        $widget = new TextWidget('AB');
+        $style = (new Style())
+            ->withLinearGradient(['#ff0000', '#0000ff'], GradientDirection::LeftToRight);
+
+        // 'AB' fills the two columns exactly, so the resets of the child sit past
+        // the last visible cell and used to be dropped along with the rest.
+        $lines = $applier->apply(new ArrayLineBuffer(["\x1b[1m\x1b[38;2;0;255;0mAB\x1b[22m\x1b[39m"]), 2, $style, $widget)->toArray();
+
+        $this->assertStringContainsString("\x1b[22m", $lines[0], 'the bold reset of the child must survive');
+        $this->assertStringContainsString("\x1b[39m", $lines[0], 'the foreground reset of the child must survive');
+        $this->assertStringEndsWith("\x1b[22m\x1b[39m\x1b[49m", $lines[0]);
+    }
+
+    public function testGradientLineDoesNotLeakChildStyleOntoTheNextRow()
+    {
+        $applier = $this->createApplier();
+        $widget = new TextWidget('ABCD');
+        $style = (new Style())
+            ->withLinearGradient(['#ff0000', '#0000ff'], GradientDirection::LeftToRight);
+
+        // Both rows fill the four columns exactly; only the first one is styled.
+        $lines = $applier->apply(new ArrayLineBuffer(["\x1b[38;2;0;255;0m\x1b[1mABCD\x1b[22m\x1b[39m", 'efgh']), 4, $style, $widget)->toArray();
+
+        $this->assertStringEndsWith("\x1b[22m\x1b[39m\x1b[49m", $lines[0],
+            'row 0 must close the bold and the foreground it opened');
+        $this->assertStringNotContainsString("\x1b[1m", $lines[1],
+            'row 1 carries no style of its own and must not re-open one');
+    }
+
+    public function testGradientLineStatesARepeatedBackgroundOnlyOnce()
+    {
+        $applier = $this->createApplier();
+        $widget = new TextWidget('aaaa');
+        $style = (new Style())
+            ->withLinearGradient(['#000000', '#ffffff'], GradientDirection::TopToBottom);
+
+        // A vertical gradient gives every cell of a row the same color.
+        $lines = $applier->apply(new ArrayLineBuffer(['aaaa']), 4, $style, $widget)->toArray();
+
+        $this->assertSame(1, substr_count($lines[0], "\x1b[48;2;"), 'a row of one color states it once');
+    }
+
+    public function testGradientLineRestatesTheBackgroundAfterAChildSequence()
+    {
+        $applier = $this->createApplier();
+        $widget = new TextWidget('abcd');
+        $style = (new Style())
+            ->withLinearGradient(['#000000', '#ffffff'], GradientDirection::TopToBottom);
+
+        // The child sets then drops its own background in the middle of the row: the
+        // gradient has to be restated afterwards even though its color has not changed.
+        $lines = $applier->apply(new ArrayLineBuffer(["ab\x1b[48;2;255;0;0mc\x1b[49md"]), 4, $style, $widget)->toArray();
+
+        $gradientCode = $style->getGradient()->resolve(4, 1)[0][0]->toBackgroundCode();
+        $this->assertSame(2, substr_count($lines[0], $gradientCode),
+            'the gradient is stated once before the child, then once after it');
+        $this->assertStringContainsString("\x1b[48;2;255;0;0mc", $lines[0], "the child's own background survives");
+    }
+
+    public function testGradientPaintsTopAndBottomBorderRows()
+    {
+        $applier = $this->createApplier();
+        $widget = new TextWidget('abc');
+        $style = (new Style())
+            ->withLinearGradient(['#000000', '#ffffff'], GradientDirection::LeftToRight)
+            ->withBorder(Border::all(1));
+
+        $lines = $applier->apply(new ArrayLineBuffer(['abc']), 5, $style, $widget)->toArray();
+
+        $black = Color::from('#000000')->toBackgroundCode();
+        $gray = Color::from('#000000')->mix(Color::from('#ffffff'), 50)->toBackgroundCode();
+        $white = Color::from('#ffffff')->toBackgroundCode();
+        $quarter = Color::from('#000000')->mix(Color::from('#ffffff'), 25)->toBackgroundCode();
+
+        // Border rows are painted like any other row of the box: the corners echo
+        // the endpoints of the strip, and the strip spans the 3 inner columns.
+        foreach ([0, 2] as $row) {
+            $this->assertSame($black, self::backgroundAtColumn($lines[$row], 0), "row $row: left corner takes the first gradient color");
+            $this->assertSame($black, self::backgroundAtColumn($lines[$row], 1), "row $row: fill[0] is offset=0");
+            $this->assertSame($gray, self::backgroundAtColumn($lines[$row], 2), "row $row: fill[1] is offset=0.5");
+            $this->assertSame($white, self::backgroundAtColumn($lines[$row], 3), "row $row: fill[2] is offset=1");
+            $this->assertSame($white, self::backgroundAtColumn($lines[$row], 4), "row $row: right corner takes the last gradient color");
+
+            // Spanning totalWidth=5 instead of innerWidth=3 would put 25% gray on a cell.
+            $this->assertStringNotContainsString($quarter, $lines[$row], "row $row: the strip must span innerWidth");
+        }
+    }
+
+    public function testGradientBorderRowOfOneColorDoesNotStateItPerCell()
+    {
+        // A vertical gradient gives every cell of a row the same color. The border
+        // draws in three segments whose own resets break the run, so the code may
+        // be restated once per segment, but never per cell.
+        $applier = $this->createApplier();
+        $widget = new TextWidget('abc');
+        $style = (new Style())
+            ->withLinearGradient(['#000000', '#ffffff'], GradientDirection::TopToBottom)
+            ->withBorder(Border::all(1));
+
+        $lines = $applier->apply(new ArrayLineBuffer(['abc']), 5, $style, $widget)->toArray();
+
+        $black = Color::from('#000000')->toBackgroundCode();
+        foreach (range(0, 4) as $col) {
+            $this->assertSame($black, self::backgroundAtColumn($lines[0], $col), "top border, column $col");
+        }
+        $this->assertLessThan(5, substr_count($lines[0], "\x1b[48;2;"), 'a run of cells sharing a color must not restate it per cell');
+    }
+
+    public function testGradientOfTheWidgetWinsOverOuterStyle()
+    {
+        // Border cells and content cells must always show the widget's own gradient,
+        // whether the parent carries a gradient, a solid background, or nothing.
+        $child = new TextWidget('abc');
+        $style = (new Style())
+            ->withLinearGradient(['#000000', '#ffffff'], GradientDirection::LeftToRight)
+            ->withBorder(Border::all(1));
+
+        $black = Color::from('#000000')->toBackgroundCode();
+        $gray = Color::from('#000000')->mix(Color::from('#ffffff'), 50)->toBackgroundCode();
+
+        foreach ([
+            'no outer' => new Style(),
+            'outer gradient' => (new Style())->withLinearGradient(['#ff0000', '#0000ff'], GradientDirection::TopToBottom),
+            'outer solid bg' => (new Style())->withBackground('#ff0000'),
+        ] as $label => $outerStyle) {
+            $parent = new ContainerWidget();
+            $parent->add($child);
+
+            $renderer = $this->createStub(WidgetRendererInterface::class);
+            $renderer->method('resolveStyle')->willReturnCallback(
+                static fn ($widget) => $widget === $parent ? $outerStyle : new Style()
+            );
+
+            $lines = (new ChromeApplier($renderer))->apply(new ArrayLineBuffer(['abc']), 5, $style, $child)->toArray();
+
+            $this->assertSame($black, self::backgroundAtColumn($lines[1], 0), "$label: the left border cell shows the widget's gradient");
+            $this->assertSame($gray, self::backgroundAtColumn($lines[0], 2), "$label: the top border fill shows the widget's gradient");
+            $this->assertSame($gray, self::backgroundAtColumn($lines[2], 2), "$label: the bottom border fill shows the widget's gradient");
+        }
+    }
+
+    public function testGradientKeepsAnOscHyperlinkIntact()
+    {
+        $applier = $this->createApplier();
+        $widget = new TextWidget('ab');
+        $style = (new Style())
+            ->withLinearGradient(['#000000', '#ffffff'], GradientDirection::LeftToRight);
+
+        $open = "\x1b]8;;https://example.com\x1b\\";
+        $close = "\x1b]8;;\x1b\\";
+        $lines = $applier->apply(new ArrayLineBuffer([$open.'ab'.$close]), 2, $style, $widget)->toArray();
+
+        $this->assertStringContainsString($open, $lines[0], 'the hyperlink opener must pass through as a sequence, not as visible cells');
+        $this->assertStringContainsString($close, $lines[0], 'the hyperlink closer must pass through too');
+        $this->assertStringContainsString(Color::from('#000000')->toBackgroundCode().'a', $lines[0], 'the gradient still paints under the link text');
+    }
+
+    public function testGradientKeepsAnApcMarkerIntact()
+    {
+        $applier = $this->createApplier();
+        $widget = new TextWidget('ab');
+        $style = (new Style())
+            ->withLinearGradient(['#000000', '#ffffff'], GradientDirection::LeftToRight);
+
+        $marker = "\x1b_marker\x1b\\";
+        $lines = $applier->apply(new ArrayLineBuffer([$marker.'ab']), 2, $style, $widget)->toArray();
+
+        $this->assertStringContainsString($marker, $lines[0], 'the APC marker must pass through as a sequence, not as visible cells');
+    }
+
+    public function testGradientPaintsBehindACombiningCharacterAsOneCell()
+    {
+        $applier = $this->createApplier();
+        $widget = new TextWidget('e');
+        $style = (new Style())
+            ->withLinearGradient(['#000000', '#ffffff'], GradientDirection::LeftToRight);
+
+        // "e" + combining acute is one grapheme of one column: the layer code
+        // must land before the cluster, never between the base and the mark
+        $lines = $applier->apply(new ArrayLineBuffer(["e\u{0301}b"]), 2, $style, $widget)->toArray();
+
+        $black = Color::from('#000000')->toBackgroundCode();
+        $white = Color::from('#ffffff')->toBackgroundCode();
+        $this->assertStringContainsString($black."e\u{0301}", $lines[0], 'the cluster stays contiguous behind its layer code');
+        $this->assertStringContainsString($white.'b', $lines[0], 'the cluster counts one column, so "b" sits on the second one');
+    }
+
+    public function testGradientKeepsATabAndItsColumns()
+    {
+        $applier = $this->createApplier();
+        $widget = new TextWidget('a');
+        $style = (new Style())
+            ->withLinearGradient(['#000000', '#ffffff'], GradientDirection::LeftToRight);
+
+        // "a" + tab (TAB_WIDTH = 3 columns) + "b" spans 5 columns
+        $lines = $applier->apply(new ArrayLineBuffer(["a\tb"]), 5, $style, $widget)->toArray();
+
+        $white = Color::from('#ffffff')->toBackgroundCode();
+        $this->assertStringContainsString("\t", $lines[0], 'the tab must survive the compositing pass');
+        $this->assertStringContainsString($white.'b', $lines[0], 'the tab counts its columns, so "b" sits on the last one');
+    }
+
+    public function testGradientChildBackgroundSurvivesANonSgrCsiSequence()
+    {
+        $applier = $this->createApplier();
+        $widget = new TextWidget('XY');
+        $style = (new Style())
+            ->withLinearGradient(['#0000ff', '#ffffff'], GradientDirection::LeftToRight);
+
+        // ESC[0K erases to end of line; its "0" parameter is not SGR 0, so the
+        // red background is still active when "Y" prints
+        $redBg = "\x1b[48;2;255;0;0m";
+        $lines = $applier->apply(new ArrayLineBuffer([$redBg."X\x1b[0KY"]), 2, $style, $widget)->toArray();
+
+        $this->assertStringContainsString("X\x1b[0KY", $lines[0], 'a non-SGR CSI sequence must not clear the child background state');
+    }
+
+    // ---------------------------------------------------------------
     // helpers
     // ---------------------------------------------------------------
+
+    /**
+     * Return the background code in effect at a given visible column of a line.
+     *
+     * Asserting on the state of a column rather than on the presence of a code
+     * somewhere in the line keeps the test honest: a color that repeats is not
+     * restated, and the same code may legitimately appear at another column.
+     */
+    private static function backgroundAtColumn(string $line, int $column): string
+    {
+        $background = '';
+        $col = 0;
+
+        foreach (preg_split('/(\x1b\[[0-9;]*[a-zA-Z])/', $line, -1, \PREG_SPLIT_DELIM_CAPTURE | \PREG_SPLIT_NO_EMPTY) as $part) {
+            if (str_starts_with($part, "\x1b[")) {
+                if (preg_match('/^\x1b\[(?:4[0-7]|10[0-7]|48;[25];[0-9;]+)m$/', $part)) {
+                    $background = $part;
+                } elseif ("\x1b[49m" === $part || "\x1b[0m" === $part) {
+                    $background = '';
+                }
+
+                continue;
+            }
+
+            foreach (preg_split('//u', $part, -1, \PREG_SPLIT_NO_EMPTY) as $ignored) {
+                if ($col === $column) {
+                    return $background;
+                }
+                ++$col;
+            }
+        }
+
+        return $background;
+    }
 
     private function createApplier(): ChromeApplier
     {

--- a/src/Symfony/Component/Tui/Tests/Style/AngleTest.php
+++ b/src/Symfony/Component/Tui/Tests/Style/AngleTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Tests\Style;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Tui\Exception\InvalidArgumentException;
+use Symfony\Component\Tui\Style\Angle;
+
+final class AngleTest extends TestCase
+{
+    public function testDegrees()
+    {
+        $this->assertEqualsWithDelta(0.0, Angle::degrees(0)->toRadians(), 1e-10);
+        $this->assertEqualsWithDelta(\M_PI / 2, Angle::degrees(90)->toRadians(), 1e-10);
+        $this->assertEqualsWithDelta(\M_PI, Angle::degrees(180)->toRadians(), 1e-10);
+        $this->assertEqualsWithDelta(3 * \M_PI / 2, Angle::degrees(270)->toRadians(), 1e-10);
+    }
+
+    public function testRadians()
+    {
+        $this->assertEqualsWithDelta(0.0, Angle::radians(0.0)->toDegrees(), 1e-10);
+        $this->assertEqualsWithDelta(90.0, Angle::radians(\M_PI / 2)->toDegrees(), 1e-10);
+        $this->assertEqualsWithDelta(180.0, Angle::radians(\M_PI)->toDegrees(), 1e-10);
+        $this->assertEqualsWithDelta(45.0, Angle::radians(\M_PI / 4)->toDegrees(), 1e-10);
+    }
+
+    public function testDegreesAndRadiansAreEquivalent()
+    {
+        $this->assertEqualsWithDelta(
+            Angle::degrees(45)->toRadians(),
+            Angle::radians(\M_PI / 4)->toRadians(),
+            1e-10
+        );
+    }
+
+    #[DataProvider('nonFiniteProvider')]
+    public function testDegreesRejectsNonFiniteValues(float $value)
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('An angle must be a finite number of degrees');
+
+        Angle::degrees($value);
+    }
+
+    #[DataProvider('nonFiniteProvider')]
+    public function testRadiansRejectsNonFiniteValues(float $value)
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('An angle must be a finite number of radians');
+
+        Angle::radians($value);
+    }
+
+    public static function nonFiniteProvider(): iterable
+    {
+        yield 'NAN' => [\NAN];
+        yield 'INF' => [\INF];
+        yield '-INF' => [-\INF];
+    }
+}

--- a/src/Symfony/Component/Tui/Tests/Style/BorderTest.php
+++ b/src/Symfony/Component/Tui/Tests/Style/BorderTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Tui\Tests\Style;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Tui\Ansi\AnsiUtils;
 use Symfony\Component\Tui\Exception\InvalidArgumentException;
 use Symfony\Component\Tui\Style\Border;
 use Symfony\Component\Tui\Style\BorderPattern;
@@ -298,5 +299,22 @@ class BorderTest extends TestCase
 
         $this->assertSame(BorderPattern::rounded()->getChars(), $border->pattern->getChars());
         $this->assertSame(Color::from('#ff0000')->toRgb(), $border->color->toRgb());
+    }
+
+    public function testWrapLinesKeepsReverseVideoBalancedOnPatternsUsingIt()
+    {
+        // tall-medium drives its top fill with strategy 3, which is reverse video.
+        $border = Border::all(1, 'tall-medium');
+        $style = new Style();
+
+        $lines = $border->wrapLines(['abc'], 3, $style);
+
+        $this->assertStringContainsString("\e[7m", $lines[0]);
+        $this->assertSame(
+            substr_count($lines[0], "\e[7m"),
+            substr_count($lines[0], "\e[27m"),
+            'reverse video must be closed as many times as it is opened'
+        );
+        $this->assertSame('▌▆▆▆▌', AnsiUtils::stripAnsiCodes($lines[0]));
     }
 }

--- a/src/Symfony/Component/Tui/Tests/Style/ColorStopTest.php
+++ b/src/Symfony/Component/Tui/Tests/Style/ColorStopTest.php
@@ -1,0 +1,154 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Tests\Style;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Tui\Style\Color;
+use Symfony\Component\Tui\Style\ColorStop;
+
+final class ColorStopTest extends TestCase
+{
+    public function testAtAcceptsString()
+    {
+        $stop = ColorStop::at('red', 30);
+        $this->assertSame(Color::named('red')->toBackgroundCode(), $stop->color->toBackgroundCode());
+        $this->assertSame(30, $stop->position);
+    }
+
+    public function testAtAcceptsColorObject()
+    {
+        $color = Color::rgb(255, 128, 0);
+        $stop = ColorStop::at($color, 50);
+        $this->assertSame($color->toBackgroundCode(), $stop->color->toBackgroundCode());
+    }
+
+    public function testAtAcceptsPaletteInt()
+    {
+        $stop = ColorStop::at(196, 100);
+        $this->assertSame(Color::palette(196)->toBackgroundCode(), $stop->color->toBackgroundCode());
+    }
+
+    public function testAtRejectsPositionBelow0()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        ColorStop::at('red', -1);
+    }
+
+    public function testAtRejectsPositionAbove100()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        ColorStop::at('red', 101);
+    }
+
+    public function testNormalizeAllExplicit()
+    {
+        $stops = ColorStop::normalize([
+            ColorStop::at('#ff0000', 0),
+            ColorStop::at('#00ff00', 30),
+            ColorStop::at('#0000ff', 100),
+        ]);
+
+        $this->assertCount(3, $stops);
+        $this->assertEqualsWithDelta(0.0, $stops[0]['offset'], 1e-9);
+        $this->assertEqualsWithDelta(0.3, $stops[1]['offset'], 1e-9);
+        $this->assertEqualsWithDelta(1.0, $stops[2]['offset'], 1e-9);
+    }
+
+    public function testNormalizePlainColorsDistributedUniformly()
+    {
+        // No positions: first=0, last=1, middle=0.5
+        $stops = ColorStop::normalize(['#ff0000', '#00ff00', '#0000ff']);
+
+        $this->assertEqualsWithDelta(0.0, $stops[0]['offset'], 1e-9);
+        $this->assertEqualsWithDelta(0.5, $stops[1]['offset'], 1e-9);
+        $this->assertEqualsWithDelta(1.0, $stops[2]['offset'], 1e-9);
+    }
+
+    public function testNormalizeMixedImplicitPositionsInterpolated()
+    {
+        // Only the middle stop has an explicit position
+        $stops = ColorStop::normalize([
+            '#ff0000',                     // → 0
+            ColorStop::at('#00ff00', 30),  // → 0.3
+            '#0000ff',                     // → 1.0
+        ]);
+
+        $this->assertEqualsWithDelta(0.0, $stops[0]['offset'], 1e-9);
+        $this->assertEqualsWithDelta(0.3, $stops[1]['offset'], 1e-9);
+        $this->assertEqualsWithDelta(1.0, $stops[2]['offset'], 1e-9);
+    }
+
+    public function testNormalizeRunOfImplicitsBetweenTwoPositioned()
+    {
+        // Two plain colors between 0 and 60 → 20 and 40
+        $stops = ColorStop::normalize([
+            ColorStop::at('#ff0000', 0),
+            '#aaaaaa',   // → 20
+            '#bbbbbb',   // → 40
+            ColorStop::at('#0000ff', 60),
+            '#ffffff',   // → 100 (last)
+        ]);
+
+        $this->assertEqualsWithDelta(0.0, $stops[0]['offset'], 1e-9);
+        $this->assertEqualsWithDelta(0.2, $stops[1]['offset'], 1e-9);
+        $this->assertEqualsWithDelta(0.4, $stops[2]['offset'], 1e-9);
+        $this->assertEqualsWithDelta(0.6, $stops[3]['offset'], 1e-9);
+        $this->assertEqualsWithDelta(1.0, $stops[4]['offset'], 1e-9);
+    }
+
+    public function testNormalizeClampsOutOfOrderStopsInsteadOfSortingThem()
+    {
+        $stops = ColorStop::normalize([
+            ColorStop::at('#0000ff', 100),
+            ColorStop::at('#00ff00', 50),
+            ColorStop::at('#ff0000', 0),
+        ]);
+
+        // The declaration order is kept: blue stays first, and the two positions
+        // that go backwards are both clamped up to 100.
+        $this->assertSame(Color::from('#0000ff')->toBackgroundCode(), $stops[0]['color']->toBackgroundCode());
+        $this->assertSame(Color::from('#00ff00')->toBackgroundCode(), $stops[1]['color']->toBackgroundCode());
+        $this->assertSame(Color::from('#ff0000')->toBackgroundCode(), $stops[2]['color']->toBackgroundCode());
+
+        $this->assertEqualsWithDelta(1.0, $stops[0]['offset'], 1e-9);
+        $this->assertEqualsWithDelta(1.0, $stops[1]['offset'], 1e-9);
+        $this->assertEqualsWithDelta(1.0, $stops[2]['offset'], 1e-9);
+    }
+
+    public function testNormalizeClampsASingleBackwardsStopToAHardStop()
+    {
+        // CSS: blue runs from 0 to 80%, then red takes over at a hard stop.
+        $stops = ColorStop::normalize([
+            ColorStop::at('#0000ff', 80),
+            ColorStop::at('#ff0000', 20),
+        ]);
+
+        $this->assertSame(Color::from('#0000ff')->toBackgroundCode(), $stops[0]['color']->toBackgroundCode());
+        $this->assertEqualsWithDelta(0.8, $stops[0]['offset'], 1e-9);
+
+        $this->assertSame(Color::from('#ff0000')->toBackgroundCode(), $stops[1]['color']->toBackgroundCode());
+        $this->assertEqualsWithDelta(0.8, $stops[1]['offset'], 1e-9);
+    }
+
+    public function testNormalizeKeepsAlreadyOrderedStopsUntouched()
+    {
+        $stops = ColorStop::normalize([
+            ColorStop::at('#ff0000', 0),
+            ColorStop::at('#00ff00', 50),
+            ColorStop::at('#0000ff', 100),
+        ]);
+
+        $this->assertEqualsWithDelta(0.0, $stops[0]['offset'], 1e-9);
+        $this->assertEqualsWithDelta(0.5, $stops[1]['offset'], 1e-9);
+        $this->assertEqualsWithDelta(1.0, $stops[2]['offset'], 1e-9);
+    }
+}

--- a/src/Symfony/Component/Tui/Tests/Style/LinearGradientTest.php
+++ b/src/Symfony/Component/Tui/Tests/Style/LinearGradientTest.php
@@ -1,0 +1,399 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Tests\Style;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Tui\Style\Angle;
+use Symfony\Component\Tui\Style\Color;
+use Symfony\Component\Tui\Style\ColorStop;
+use Symfony\Component\Tui\Style\GradientDirection;
+use Symfony\Component\Tui\Style\LinearGradient;
+
+final class LinearGradientTest extends TestCase
+{
+    public function testResolveTwoColorsHorizontal()
+    {
+        $g = LinearGradient::from(['#000000', '#ffffff'], GradientDirection::LeftToRight);
+        $codes = self::codes($g->resolve(3, 1));
+
+        // col 0 = black, col 2 = white, col 1 = mid-grey
+        $this->assertSame(Color::from('#000000')->toBackgroundCode(), $codes[0][0]);
+        $this->assertSame(Color::from('#ffffff')->toBackgroundCode(), $codes[0][2]);
+
+        // Mid color is grey (128,128,128)
+        $mid = Color::rgb(128, 128, 128)->toBackgroundCode();
+        $this->assertSame($mid, $codes[0][1]);
+    }
+
+    public function testResolveAllRowsIdenticalForHorizontal()
+    {
+        $g = LinearGradient::from(['#ff0000', '#0000ff'], GradientDirection::LeftToRight);
+        $codes = self::codes($g->resolve(4, 3));
+
+        $this->assertSame($codes[0], $codes[1]);
+        $this->assertSame($codes[0], $codes[2]);
+    }
+
+    public function testResolveAllColsIdenticalForVertical()
+    {
+        $g = LinearGradient::from(['#ff0000', '#0000ff'], GradientDirection::TopToBottom);
+        $codes = self::codes($g->resolve(4, 3));
+
+        $this->assertSame($codes[0][0], $codes[0][1]);
+        $this->assertSame($codes[0][0], $codes[0][2]);
+        $this->assertSame($codes[0][0], $codes[0][3]);
+
+        // Vertical: different rows must have different codes
+        $this->assertNotSame($codes[0][0], $codes[1][0]);
+        $this->assertNotSame($codes[1][0], $codes[2][0]);
+    }
+
+    public function testResolveRightToLeftIsReversedLeftToRight()
+    {
+        $g1 = LinearGradient::from(['#000000', '#ffffff'], GradientDirection::LeftToRight);
+        $g2 = LinearGradient::from(['#000000', '#ffffff'], GradientDirection::RightToLeft);
+
+        $c1 = self::codes($g1->resolve(4, 1));
+        $c2 = self::codes($g2->resolve(4, 1));
+
+        $this->assertSame($c1[0][0], $c2[0][3]);
+        $this->assertSame($c1[0][3], $c2[0][0]);
+
+        $this->assertSame($c1[0][1], $c2[0][2]);
+        $this->assertSame($c1[0][2], $c2[0][1]);
+    }
+
+    public function testResolveThreeColorsEvenlyDistributed()
+    {
+        $g = LinearGradient::from(['#000000', '#ffffff', '#000000'], GradientDirection::LeftToRight);
+        $codes = self::codes($g->resolve(5, 1));
+
+        // col 0 = black, col 2 = white, col 4 = black
+        $this->assertSame(Color::from('#000000')->toBackgroundCode(), $codes[0][0]);
+        $this->assertSame(Color::from('#ffffff')->toBackgroundCode(), $codes[0][2]);
+        $this->assertSame(Color::from('#000000')->toBackgroundCode(), $codes[0][4]);
+    }
+
+    public function testResolveIsStableForAGivenSize()
+    {
+        // PHP arrays compare by value, so this asserts the result is stable, not that
+        // the cache was hit. testResolveKeepsOnlyTheLastSize covers the cache itself.
+        $g = LinearGradient::from(['#ff0000', '#0000ff'], GradientDirection::LeftToRight);
+
+        $a = self::codes($g->resolve(10, 5));
+        $b = self::codes($g->resolve(10, 5));
+
+        $this->assertSame($a, $b);
+    }
+
+    public function testResolveKeepsOnlyTheLastSize()
+    {
+        $g = LinearGradient::from(['#000000', '#ffffff']);
+        $g->resolve(1, 24);
+
+        $before = memory_get_usage();
+        for ($width = 2; $width <= 300; ++$width) {
+            $g->resolve($width, 24);
+        }
+        $retained = memory_get_usage() - $before;
+
+        // Keeping every size cost around 91 MB here; one strip is well under 5.
+        $this->assertLessThan(5 * 1024 * 1024, $retained,
+            \sprintf('the cache must not grow with every size, %.1f MB retained', $retained / 1048576));
+    }
+
+    public function testResolveRecomputesASizeItHasEvicted()
+    {
+        $g = LinearGradient::from(['#000000', '#ffffff']);
+
+        $first = self::codes($g->resolve(10, 5));
+        $g->resolve(20, 5);
+
+        $this->assertSame($first, self::codes($g->resolve(10, 5)), 'an evicted size must be recomputed identically');
+    }
+
+    public function testFromAcceptsColorObjects()
+    {
+        $g = LinearGradient::from([Color::named('red'), Color::named('blue')], GradientDirection::LeftToRight);
+        $codes = self::codes($g->resolve(2, 1));
+
+        // Named colors are normalized to RGB so all gradient steps produce consistent \x1b[48;2;...] codes
+        $this->assertSame(Color::named('red')->mix(Color::named('blue'), 0)->toBackgroundCode(), $codes[0][0]);
+        $this->assertSame(Color::named('red')->mix(Color::named('blue'), 100)->toBackgroundCode(), $codes[0][1]);
+    }
+
+    public function testFromAcceptsMixedInput()
+    {
+        // string, Color object, palette int: all accepted as gradient stops
+        $g = LinearGradient::from(['red', Color::named('blue'), 196], GradientDirection::LeftToRight);
+        $codes = self::codes($g->resolve(3, 1));
+
+        // All codes must be RGB format: named/palette stops are normalized via mix()
+        foreach ($codes[0] as $col => $code) {
+            $this->assertStringStartsWith("\x1b[48;2;", $code,
+                "Column $col must produce an RGB bg code");
+        }
+    }
+
+    public function testEveryDirectionMapsToItsAxis()
+    {
+        $lr = LinearGradient::from(['red', 'blue'], GradientDirection::LeftToRight);
+        $rl = LinearGradient::from(['red', 'blue'], GradientDirection::RightToLeft);
+        $tb = LinearGradient::from(['red', 'blue'], GradientDirection::TopToBottom);
+        $bt = LinearGradient::from(['red', 'blue'], GradientDirection::BottomToTop);
+
+        $codesLr = self::codes($lr->resolve(3, 1));
+        $codesRl = self::codes($rl->resolve(3, 1));
+        $codesTb = self::codes($tb->resolve(1, 3));
+        $codesBt = self::codes($bt->resolve(1, 3));
+
+        $this->assertSame($codesLr[0][0], $codesRl[0][2]);
+        $this->assertSame($codesTb[0][0], $codesBt[2][0]);
+    }
+
+    public function testFromAcceptsAngleDegrees()
+    {
+        // Angle::degrees(0) = left-to-right: first column gets first color, last column gets last color
+        $g = LinearGradient::from(['#ff0000', '#0000ff'], Angle::degrees(0));
+        $ref = LinearGradient::from(['#ff0000', '#0000ff']);
+        $this->assertSame(self::codes($ref->resolve(5, 1))[0][0], self::codes($g->resolve(5, 1))[0][0]);
+        $this->assertSame(self::codes($ref->resolve(5, 1))[0][4], self::codes($g->resolve(5, 1))[0][4]);
+
+        // Angle::degrees(90) = top-to-bottom
+        $g90 = LinearGradient::from(['#ff0000', '#0000ff'], Angle::degrees(90));
+        $ref90 = LinearGradient::from(['#ff0000', '#0000ff'], GradientDirection::TopToBottom);
+        $this->assertSame(self::codes($ref90->resolve(1, 5))[0][0], self::codes($g90->resolve(1, 5))[0][0]);
+        $this->assertSame(self::codes($ref90->resolve(1, 5))[4][0], self::codes($g90->resolve(1, 5))[4][0]);
+    }
+
+    public function testFromAcceptsAngleRadians()
+    {
+        // radians(π/2) == degrees(90) == top-to-bottom
+        $gDeg = LinearGradient::from(['#ff0000', '#0000ff'], Angle::degrees(90));
+        $gRad = LinearGradient::from(['#ff0000', '#0000ff'], Angle::radians(\M_PI / 2));
+        $this->assertSame(self::codes($gDeg->resolve(3, 4)), self::codes($gRad->resolve(3, 4)));
+    }
+
+    public function testAngle45ProducesDiagonalGradient()
+    {
+        // At 45°, the gradient runs diagonally: top-left = first color, bottom-right = last color
+        $g = LinearGradient::from(['#ff0000', '#0000ff'], Angle::degrees(45));
+        $codes = self::codes($g->resolve(3, 3));
+
+        $firstColor = Color::from('#ff0000')->mix(Color::from('#0000ff'), 0)->toBackgroundCode();
+        $lastColor = Color::from('#ff0000')->mix(Color::from('#0000ff'), 100)->toBackgroundCode();
+
+        $this->assertSame($firstColor, $codes[0][0], 'top-left must be first color at 45°');
+        $this->assertSame($lastColor, $codes[2][2], 'bottom-right must be last color at 45°');
+
+        // Corners orthogonal to the gradient axis must share the midpoint color
+        $this->assertSame($codes[0][2], $codes[2][0], 'anti-diagonal corners must be equal at 45°');
+    }
+
+    public function testAngle135ProducesMirroredDiagonal()
+    {
+        // At 135° the gradient runs top-right to bottom-left (opposite diagonal)
+        $g = LinearGradient::from(['#ff0000', '#0000ff'], Angle::degrees(135));
+        $codes = self::codes($g->resolve(3, 3));
+
+        $firstColor = Color::from('#ff0000')->mix(Color::from('#0000ff'), 0)->toBackgroundCode();
+        $lastColor = Color::from('#ff0000')->mix(Color::from('#0000ff'), 100)->toBackgroundCode();
+
+        $this->assertSame($firstColor, $codes[0][2], 'top-right must be first color at 135°');
+        $this->assertSame($lastColor, $codes[2][0], 'bottom-left must be last color at 135°');
+    }
+
+    public function testNamedColorEndpointProducesConsistentRgbCode()
+    {
+        // At a gradient endpoint with a named color stop, the resolved code
+        // must be an RGB code (\x1b[48;2;...]) matching the format produced
+        // by intermediate rows via mix(). Without this, named colors produce
+        // ANSI codes (\x1b[41m] for red) that terminals render differently
+        // from the adjacent RGB-mixed rows, creating a visible lighter band.
+        $g = LinearGradient::from(['#0000ff', 'red'], GradientDirection::TopToBottom);
+        $codes = self::codes($g->resolve(1, 3)); // 3 rows: blue at top, mix in middle, red at bottom
+
+        foreach ($codes as $row => $rowCodes) {
+            $this->assertStringStartsWith("\x1b[48;2;", $rowCodes[0],
+                "Row $row must produce an RGB bg code for visual consistency across all gradient steps");
+        }
+    }
+
+    public function testColorStopShiftsTransitionPoint()
+    {
+        // Without stop: red→blue uniform over 5 cols, midpoint at col 2
+        // With stop at 20%: green is at col 1 (offset=0.25 for width=5 → position=25 > stop=20)
+        // Key property: with green at 20%, col 0 (offset=0) = red, col 1 (offset=0.25) is past the stop → in green→blue segment
+        $g = LinearGradient::from([
+            ColorStop::at('#ff0000', 0),
+            ColorStop::at('#00ff00', 20),
+            ColorStop::at('#0000ff', 100),
+        ]);
+        $codes = self::codes($g->resolve(5, 1));
+
+        // col 0 → offset=0 → red (mix red→green at 0%)
+        $this->assertSame(
+            Color::from('#ff0000')->mix(Color::from('#00ff00'), 0)->toBackgroundCode(),
+            $codes[0][0]
+        );
+        // col 4 → offset=1 → blue (mix green→blue at 100%)
+        $this->assertSame(
+            Color::from('#00ff00')->mix(Color::from('#0000ff'), 100)->toBackgroundCode(),
+            $codes[0][4]
+        );
+        // col 1 → offset=0.25 → past green stop (20%) → in green→blue segment at localOffset=(25-20)/80=6.25%
+        // The ratio stays in float, so this is 6.25% of the way, not a rounded 6%.
+        $this->assertSame(
+            Color::rgb(0, (int) round(255 * (1 - 0.0625)), (int) round(255 * 0.0625))->toBackgroundCode(),
+            $codes[0][1]
+        );
+    }
+
+    public function testInterpolationIsNotCappedAtOneHundredAndOneColors()
+    {
+        // Color::mix() takes an integer percentage, which capped a two-stop
+        // gradient at 101 distinct colors per segment and made wide gradients band.
+        $codes = self::codes(LinearGradient::from(['#000000', '#ffffff'])->resolve(240, 1));
+
+        $this->assertGreaterThan(101, \count(array_unique($codes[0])));
+    }
+
+    public function testEveryStripIsMonotonicAcrossItsWidth()
+    {
+        // A greyscale ramp must never step backwards from one column to the next.
+        $codes = self::codes(LinearGradient::from(['#000000', '#ffffff'])->resolve(200, 1));
+
+        $previous = -1;
+        foreach ($codes[0] as $col => $code) {
+            $this->assertSame(1, preg_match('/48;2;(\d+);/', $code, $m), "column $col must emit a truecolor bg code");
+            $this->assertGreaterThanOrEqual($previous, (int) $m[1], "column $col must not step back");
+            $previous = (int) $m[1];
+        }
+
+        $this->assertSame(255, $previous, 'the last column must reach the end color');
+    }
+
+    public function testHardStopProducesSharpChange()
+    {
+        // Two stops at the same position → sharp color change, no blend
+        $g = LinearGradient::from([
+            ColorStop::at('#ff0000', 0),
+            ColorStop::at('#ff0000', 50),
+            ColorStop::at('#0000ff', 50),
+            ColorStop::at('#0000ff', 100),
+        ]);
+        $codes = self::codes($g->resolve(5, 1));
+
+        $red = Color::from('#ff0000')->mix(Color::from('#ff0000'), 0)->toBackgroundCode();
+        $blue = Color::from('#0000ff')->mix(Color::from('#0000ff'), 0)->toBackgroundCode();
+
+        // cols 0-1 (offset=0,0.25) → red side
+        $this->assertSame($red, $codes[0][0]);
+        $this->assertSame($red, $codes[0][1]);
+        // cols 3-4 (offset=0.75,1) → blue side
+        $this->assertSame($blue, $codes[0][3]);
+        $this->assertSame($blue, $codes[0][4]);
+    }
+
+    public function testMixedPlainAndColorStopBackwardCompat()
+    {
+        // Plain colors still work (uniform distribution)
+        $g1 = LinearGradient::from(['#ff0000', '#0000ff']);
+        $g2 = LinearGradient::from([
+            ColorStop::at('#ff0000', 0),
+            ColorStop::at('#0000ff', 100),
+        ]);
+        $this->assertSame(self::codes($g1->resolve(4, 1)), self::codes($g2->resolve(4, 1)));
+    }
+
+    public function testFromRequiresAtLeastTwoColors()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        LinearGradient::from(['red'], GradientDirection::LeftToRight);
+    }
+
+    public function testResolveWithSingleCellReturnsFirstColor()
+    {
+        $g = LinearGradient::from(['#ff0000', '#0000ff'], GradientDirection::LeftToRight);
+        $codes = self::codes($g->resolve(1, 1));
+
+        $this->assertSame(Color::from('#ff0000')->toBackgroundCode(), $codes[0][0]);
+    }
+
+    public function testFromExistingGradientWithoutDirectionReturnsSameInstance()
+    {
+        $g = LinearGradient::from(['#000000', '#ffffff'], GradientDirection::TopToBottom);
+
+        $this->assertSame($g, LinearGradient::from($g));
+    }
+
+    public function testFromExistingGradientOverridesDirection()
+    {
+        $g = LinearGradient::from(['#000000', '#ffffff']);
+        $rotated = LinearGradient::from($g, GradientDirection::TopToBottom);
+
+        $this->assertNotSame($g, $rotated);
+        $this->assertSame(
+            self::codes(LinearGradient::from(['#000000', '#ffffff'], GradientDirection::TopToBottom)->resolve(4, 3)),
+            self::codes($rotated->resolve(4, 3)),
+            'stops must be preserved and the new direction applied'
+        );
+    }
+
+    public function testFromExistingGradientAcceptsAngle()
+    {
+        $g = LinearGradient::from(['#000000', '#ffffff']);
+        $rotated = LinearGradient::from($g, Angle::degrees(90));
+
+        $this->assertSame(
+            self::codes(LinearGradient::from(['#000000', '#ffffff'], Angle::degrees(90))->resolve(4, 3)),
+            self::codes($rotated->resolve(4, 3))
+        );
+    }
+
+    public function testFromExistingGradientLeavesTheSourceUntouched()
+    {
+        $g = LinearGradient::from(['#000000', '#ffffff']);
+        $before = self::codes($g->resolve(4, 3));
+
+        LinearGradient::from($g, GradientDirection::TopToBottom);
+
+        $this->assertSame($before, self::codes($g->resolve(4, 3)));
+    }
+
+    public function testFromExistingGradientPreservesColorStopOffsets()
+    {
+        $stops = [ColorStop::at('#000000', 0), ColorStop::at('#ffffff', 25)];
+        $rotated = LinearGradient::from(LinearGradient::from($stops, GradientDirection::LeftToRight), GradientDirection::TopToBottom);
+
+        $this->assertSame(
+            self::codes(LinearGradient::from($stops, GradientDirection::TopToBottom)->resolve(5, 5)),
+            self::codes($rotated->resolve(5, 5))
+        );
+    }
+
+    public function testFromArrayWithoutDirectionDefaultsToLeftToRight()
+    {
+        $this->assertSame(
+            self::codes(LinearGradient::from(['#000000', '#ffffff'], GradientDirection::LeftToRight)->resolve(4, 3)),
+            self::codes(LinearGradient::from(['#000000', '#ffffff'])->resolve(4, 3))
+        );
+    }
+
+    /**
+     * @return array<int, array<int, string>>
+     */
+    private static function codes(array $colors): array
+    {
+        return array_map(static fn (array $row) => array_map(static fn (Color $c) => $c->toBackgroundCode(), $row), $colors);
+    }
+}

--- a/src/Symfony/Component/Tui/Tests/Style/StyleTest.php
+++ b/src/Symfony/Component/Tui/Tests/Style/StyleTest.php
@@ -19,6 +19,8 @@ use Symfony\Component\Tui\Style\BorderPattern;
 use Symfony\Component\Tui\Style\Color;
 use Symfony\Component\Tui\Style\CursorShape;
 use Symfony\Component\Tui\Style\Direction;
+use Symfony\Component\Tui\Style\GradientDirection;
+use Symfony\Component\Tui\Style\LinearGradient;
 use Symfony\Component\Tui\Style\Padding;
 use Symfony\Component\Tui\Style\Style;
 use Symfony\Component\Tui\Style\TextAlign;
@@ -420,5 +422,112 @@ class StyleTest extends TestCase
         $this->assertSame(Align::Right, $result->getAlign());
         $this->assertSame(VerticalAlign::Center, $result->getVerticalAlign());
         $this->assertSame(2, $result->getFlex());
+    }
+
+    public function testMergeAllGradientOverridesEarlierBackground()
+    {
+        $result = Style::mergeAll([
+            new Style(background: '#00ff00'),
+            (new Style())->withLinearGradient(['red', 'blue']),
+        ]);
+
+        $this->assertInstanceOf(LinearGradient::class, $result->getGradient());
+        $this->assertNull($result->getBackground());
+    }
+
+    public function testMergeAllBackgroundOverridesEarlierGradient()
+    {
+        $result = Style::mergeAll([
+            (new Style())->withLinearGradient(['red', 'blue']),
+            new Style(background: '#00ff00'),
+        ]);
+
+        $this->assertNull($result->getGradient());
+        $this->assertSame('#00ff00', $result->getBackground()->toHex());
+    }
+
+    public function testMergeAllKeepsGradientWhenLaterStylesSetNoBackground()
+    {
+        $result = Style::mergeAll([
+            (new Style())->withLinearGradient(['red', 'blue']),
+            new Style(bold: true),
+        ]);
+
+        $this->assertInstanceOf(LinearGradient::class, $result->getGradient());
+        $this->assertNull($result->getBackground());
+    }
+
+    public function testMergeAllKeepsBackgroundWhenLaterStylesSetNoGradient()
+    {
+        $result = Style::mergeAll([
+            new Style(background: '#00ff00'),
+            new Style(bold: true),
+        ]);
+
+        $this->assertNull($result->getGradient());
+        $this->assertSame('#00ff00', $result->getBackground()->toHex());
+    }
+
+    public function testWithLinearGradientFromArray()
+    {
+        $style = (new Style())->withLinearGradient(['red', 'blue']);
+        $gradient = $style->getGradient();
+
+        $this->assertInstanceOf(LinearGradient::class, $gradient);
+        $this->assertNull($style->getBackground()); // gradient clears background
+    }
+
+    public function testWithLinearGradientFromObject()
+    {
+        $g = LinearGradient::from(['red', 'blue']);
+        $style = (new Style())->withLinearGradient($g);
+
+        $this->assertSame($g, $style->getGradient());
+    }
+
+    public function testWithLinearGradientWithDirection()
+    {
+        $style = (new Style())->withLinearGradient(['red', 'blue'], GradientDirection::TopToBottom);
+        $codes = array_map(static fn ($row) => array_map(static fn ($c) => $c->toBackgroundCode(), $row), $style->getGradient()->resolve(2, 2));
+
+        // Vertical: col 0 and col 1 in same row are identical
+        $this->assertSame($codes[0][0], $codes[0][1]);
+        // Vertical: row 0 and row 1 differ
+        $this->assertNotSame($codes[0][0], $codes[1][0]);
+    }
+
+    public function testWithBackgroundClearsGradient()
+    {
+        $style = (new Style())->withLinearGradient(['red', 'blue'])->withBackground('green');
+
+        $this->assertNull($style->getGradient());
+        $this->assertNotNull($style->getBackground());
+    }
+
+    public function testWithLinearGradientClearsBackground()
+    {
+        $style = (new Style())->withBackground('green')->withLinearGradient(['red', 'blue']);
+
+        $this->assertNull($style->getBackground());
+        $this->assertNotNull($style->getGradient());
+    }
+
+    public function testIsPlainFalseWhenGradientSet()
+    {
+        $style = (new Style())->withLinearGradient(['red', 'blue']);
+
+        $this->assertFalse($style->isPlain());
+    }
+
+    public function testWithLinearGradientObjectAndDirectionOverridesDirection()
+    {
+        $g = LinearGradient::from(['#000000', '#ffffff']);
+        $style = (new Style())->withLinearGradient($g, GradientDirection::TopToBottom);
+
+        $this->assertNotSame($g, $style->getGradient());
+
+        $codes = array_map(static fn ($row) => array_map(static fn ($c) => $c->toBackgroundCode(), $row), $style->getGradient()->resolve(2, 2));
+        $this->assertSame($codes[0][0], $codes[0][1], 'vertical gradient: columns of a row are identical');
+        $this->assertNotSame($codes[0][0], $codes[1][0], 'vertical gradient: rows differ');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Supersedes #64415, keeping its feature with a simpler design.

`Style::withLinearGradient()` paints the whole widget box, chrome included, with a color transition:

```php
$style->withLinearGradient(['#e74c3c', '#3498db']);  // left to right (default)
$style->withLinearGradient(['red', 'blue'], GradientDirection::TopToBottom);
$style->withLinearGradient(['#00e5ff', '#ff00e5'], Angle::degrees(45));
```

<img width="1098" height="413" alt="directions" src="https://github.com/user-attachments/assets/024d8f60-2939-4519-9273-1f25cd10dc70" />

Plain colors are distributed evenly. `ColorStop::at($color, $position)` places a stop explicitly, positions clamp the way CSS clamps them, and two stops sharing a position make a hard edge:

```php
$style->withLinearGradient([
    ColorStop::at('blue',  33),
    ColorStop::at('white', 33),
    ColorStop::at('white', 66),
    ColorStop::at('red',   66),
]);
```

<img width="1093" height="399" alt="stops" src="https://github.com/user-attachments/assets/040deb6f-52fe-422b-90e1-04b2cd4f4c98" />

For dynamic gradients, set a new style from `scheduleInterval()`:

<img width="1046" height="170" alt="animated" src="https://github.com/user-attachments/assets/cb98afd9-c2b8-421a-bf85-25091841358a" />

## Design

The gradient is composited as a background layer under the finished box. The box renders exactly as it would with no background, then a single pass (`AnsiUtils::paintBackground()`) walks each line and injects a per-cell background code wherever no child widget has set its own background. As a result:

- the border drawing and the content path know nothing about gradients: `Border` and `BorderPattern` are untouched, and `ChromeApplier` carries a 16-line hook;
- the one hard piece, the SGR-state parser that lets a child background win over the gradient, exists in a single place;
- border cells pick up the gradient behind their foreground for free, clamping to the edge colors of the strip, which spans the inner area.

Compared to #64415: `RadialGradient` is dropped to keep the surface small; nicolas-grekas/symfony#48 rebuilds it as a pure layer on top of this PR, which is what the internal `GradientInterface` is for. Gradients resolve to `Color` objects instead of ANSI strings, so 256-color degradation stays possible without breaking anything.

## Notes

- A truecolor terminal is required. Every painted cell is a `48;2;R;G;B` sequence; on a 256-color terminal the area shows no background at all.
- A gradient and `withBackground()` are mutually exclusive: the setters clear one another, and the last one set wins through `Style::mergeAll()`.
- Cost on an 80x24 framed box: a vertical gradient is about 4.6 KB per frame, close to a plain background at 4.3 KB; a horizontal one needs a distinct code per column, 34 KB. The compositing pass takes about 1 ms per full-screen frame.

## For the documentation

- `Style::withLinearGradient(array|LinearGradient $gradient, GradientDirection|Angle|null $direction = null)`.
- The four `GradientDirection` cases, and `Angle::degrees()` / `Angle::radians()` for an arbitrary angle.
- `ColorStop::at($color, $position)` with `$position` between 0 and 100, and the hard-stop trick of giving two stops the same position.
- The truecolor requirement, and the mutual exclusion with `withBackground()`.


