### PR TITLE
[DoctrineBridge] Deprecate `DoctrineOpenTransactionLoggerMiddleware` in favor of the new `DoctrineDbalOpenTransactionLoggerMiddleware`

### DIFF
--- a/UPGRADE-8.2.md
+++ b/UPGRADE-8.2.md
@@ -24,11 +24,14 @@ DoctrineBridge
  * `UniqueEntity` now throws a `ConstraintDefinitionException` when a checked field holds an array or is a to-many
    association and the default `findBy` repository method is used. Such fields were silently validated against a
    query that could not match. Use the `repositoryMethod` option to provide a method that can query them
- * Deprecate `DoctrineCloseConnectionMiddleware` in favor of the new `DoctrineDbalCloseConnectionMiddleware`,
-   which targets DBAL connections instead of entity managers. Its first argument is a `ConnectionRegistry` instead
-   of a `ManagerRegistry`, and its second one takes connection names, either one or a list, instead of an entity
-   manager name. Passing no name now closes every DBAL connection, where the deprecated middleware closed the
-   connection of the default entity manager
+ * Deprecate `DoctrineCloseConnectionMiddleware` in favor of `DoctrineDbalCloseConnectionMiddleware`,
+   and `DoctrineOpenTransactionLoggerMiddleware` in favor of `DoctrineDbalOpenTransactionLoggerMiddleware`.
+   Those new middlewares target DBAL connections instead of entity managers. They are instantiated with a
+   `ConnectionRegistry` instead of a `ManagerRegistry`, and connection names (either one or a list) instead
+   of an entity manager name. Passing no name now targets every DBAL connection, where the deprecated middlewares
+   targeted the connection of the default entity manager. Beware that `DoctrineDbalOpenTransactionLoggerMiddleware`
+   takes its logger as second argument and its connection names as third, where
+   `DoctrineOpenTransactionLoggerMiddleware` took the entity manager name as second argument and its logger as third
 
 Form
 ----

--- a/src/Symfony/Bridge/Doctrine/CHANGELOG.md
+++ b/src/Symfony/Bridge/Doctrine/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Throw a `ConstraintDefinitionException` from `UniqueEntity` when a checked field holds an array or is a to-many association, instead of building a query that cannot match
  * Allow using closures with the `#[MapEntity]` attribute
  * Deprecate `DoctrineCloseConnectionMiddleware` in favor of the new `DoctrineDbalCloseConnectionMiddleware`
+ * Deprecate `DoctrineOpenTransactionLoggerMiddleware` in favor of the new `DoctrineDbalOpenTransactionLoggerMiddleware`
 
 8.1
 ---

--- a/src/Symfony/Bridge/Doctrine/Messenger/DoctrineDbalOpenTransactionLoggerMiddleware.php
+++ b/src/Symfony/Bridge/Doctrine/Messenger/DoctrineDbalOpenTransactionLoggerMiddleware.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Messenger;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\Persistence\ConnectionRegistry;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Middleware\StackInterface;
+
+/**
+ * Middleware to log when transaction has been left open.
+ *
+ * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ */
+class DoctrineDbalOpenTransactionLoggerMiddleware extends AbstractDoctrineDbalMiddleware
+{
+    /** @var list<string> */
+    private array $connectionNames;
+
+    private bool $isHandling = false;
+
+    /**
+     * @param list<string>|string $connectionNames or none to check them all
+     */
+    public function __construct(
+        ConnectionRegistry $connectionRegistry,
+        private readonly ?LoggerInterface $logger = null,
+        array|string $connectionNames = [],
+    ) {
+        parent::__construct($connectionRegistry);
+
+        $this->connectionNames = (array) $connectionNames;
+    }
+
+    public function handle(Envelope $envelope, StackInterface $stack): Envelope
+    {
+        if ($this->isHandling) {
+            return $stack->next()->handle($envelope, $stack);
+        }
+
+        $connections = $this->getConnections($this->connectionNames);
+        $initialTransactionLevels = array_map(
+            static fn (Connection $connection) => $connection->getTransactionNestingLevel(),
+            $connections,
+        );
+
+        $this->isHandling = true;
+
+        try {
+            return $stack->next()->handle($envelope, $stack);
+        } finally {
+            $connectionsWithUnclosedTransactions = array_filter(
+                $connections,
+                static fn (Connection $connection, string $name) => $connection->getTransactionNestingLevel() > $initialTransactionLevels[$name],
+                \ARRAY_FILTER_USE_BOTH,
+            );
+            if ($connectionsWithUnclosedTransactions) {
+                $this->logger?->error('A handler opened a transaction but did not close it.', [
+                    'connections' => array_keys($connectionsWithUnclosedTransactions),
+                    'message' => $envelope->getMessage(),
+                ]);
+            }
+            $this->isHandling = false;
+        }
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Messenger/DoctrineOpenTransactionLoggerMiddleware.php
+++ b/src/Symfony/Bridge/Doctrine/Messenger/DoctrineOpenTransactionLoggerMiddleware.php
@@ -17,10 +17,14 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Middleware\StackInterface;
 
+trigger_deprecation('symfony/doctrine-bridge', '8.2', 'The "%s" class is deprecated, use "%s" instead.', DoctrineOpenTransactionLoggerMiddleware::class, DoctrineDbalOpenTransactionLoggerMiddleware::class);
+
 /**
  * Middleware to log when transaction has been left open.
  *
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ *
+ * @deprecated since Symfony 8.2, use DoctrineDbalOpenTransactionLoggerMiddleware instead
  */
 class DoctrineOpenTransactionLoggerMiddleware extends AbstractDoctrineMiddleware
 {

--- a/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrineDbalOpenTransactionLoggerMiddlewareTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrineDbalOpenTransactionLoggerMiddlewareTest.php
@@ -1,0 +1,140 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Messenger;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\Persistence\ConnectionRegistry;
+use Psr\Log\AbstractLogger;
+use Symfony\Bridge\Doctrine\Messenger\DoctrineDbalOpenTransactionLoggerMiddleware;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
+use Symfony\Component\Messenger\Middleware\StackInterface;
+use Symfony\Component\Messenger\Middleware\StackMiddleware;
+use Symfony\Component\Messenger\Test\Middleware\MiddlewareTestCase;
+
+class DoctrineDbalOpenTransactionLoggerMiddlewareTest extends MiddlewareTestCase
+{
+    private AbstractLogger $logger;
+
+    protected function setUp(): void
+    {
+        $this->logger = new class extends AbstractLogger {
+            public array $logs = [];
+
+            public function log($level, $message, $context = []): void
+            {
+                $this->logs[] = [
+                    'level' => $level,
+                    'message' => $message,
+                    'context' => $context,
+                ];
+            }
+        };
+    }
+
+    public function testMiddlewareLogsUnclosedTransactions()
+    {
+        $fooConnection = $this->createStub(Connection::class);
+        $fooConnection->method('getTransactionNestingLevel')->willReturn(0, 1);
+
+        $barConnection = $this->createStub(Connection::class);
+        $barConnection->method('getTransactionNestingLevel')->willReturn(0, 2);
+
+        $bazConnection = $this->createStub(Connection::class);
+        $bazConnection->method('getTransactionNestingLevel')->willReturn(0, 0);
+
+        $connectionRegistry = $this->createStub(ConnectionRegistry::class);
+        $connectionRegistry->method('getConnection')->willReturnMap([
+            ['foo', $fooConnection],
+            ['bar', $barConnection],
+            ['baz', $bazConnection],
+        ]);
+
+        $message = new \stdClass();
+
+        $middleware = new DoctrineDbalOpenTransactionLoggerMiddleware(
+            $connectionRegistry,
+            $this->logger,
+            ['foo', 'bar', 'baz'],
+        );
+
+        $middleware->handle(new Envelope($message), $this->getStackMock());
+
+        $this->assertSame(
+            [[
+                'level' => 'error',
+                'message' => 'A handler opened a transaction but did not close it.',
+                'context' => ['connections' => ['foo', 'bar'], 'message' => $message],
+            ]],
+            $this->logger->logs,
+        );
+    }
+
+    public function testMiddlewareChecksEveryConnectionWhenPassedNoName()
+    {
+        $fooConnection = $this->createMock(Connection::class);
+        $fooConnection->expects($this->exactly(2))->method('getTransactionNestingLevel')->willReturn(0, 0);
+
+        $barConnection = $this->createMock(Connection::class);
+        $barConnection->expects($this->exactly(2))->method('getTransactionNestingLevel')->willReturn(0, 0);
+
+        $connectionRegistry = $this->createStub(ConnectionRegistry::class);
+        $connectionRegistry->method('getConnectionNames')->willReturn([
+            'foo' => 'doctrine.dbal.foo_connection',
+            'bar' => 'doctrine.dbal.bar_connection',
+        ]);
+        $connectionRegistry->method('getConnection')->willReturnMap([
+            ['foo', $fooConnection],
+            ['bar', $barConnection],
+        ]);
+
+        $middleware = new DoctrineDbalOpenTransactionLoggerMiddleware($connectionRegistry, $this->logger);
+
+        $middleware->handle(new Envelope(new \stdClass()), $this->getStackMock());
+    }
+
+    public function testMiddlewareLogsNothingIfNoTransactionIsLeftOpen()
+    {
+        $connection = $this->createStub(Connection::class);
+        $connection->method('getTransactionNestingLevel')->willReturn(0, 0);
+
+        $connectionRegistry = $this->createStub(ConnectionRegistry::class);
+        $connectionRegistry->method('getConnection')->willReturn($connection);
+
+        $middleware = new DoctrineDbalOpenTransactionLoggerMiddleware($connectionRegistry, $this->logger, 'default');
+
+        $middleware->handle(new Envelope(new \stdClass()), $this->getStackMock());
+
+        $this->assertSame([], $this->logger->logs);
+    }
+
+    public function testMiddlewareLogsOnceWhenAMessageIsDispatchedFromAHandler()
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->exactly(2))->method('getTransactionNestingLevel')->willReturn(0, 1);
+
+        $connectionRegistry = $this->createStub(ConnectionRegistry::class);
+        $connectionRegistry->method('getConnection')->willReturn($connection);
+
+        $middleware = new DoctrineDbalOpenTransactionLoggerMiddleware($connectionRegistry, $this->logger, 'default');
+
+        $handler = $this->createMock(MiddlewareInterface::class);
+        $handler->expects($this->once())
+            ->method('handle')
+            ->willReturnCallback(static fn (Envelope $envelope, StackInterface $stack): Envelope => $middleware->handle($envelope, new StackMiddleware()))
+        ;
+
+        $middleware->handle(new Envelope(new \stdClass()), new StackMiddleware($handler));
+
+        $this->assertCount(1, $this->logger->logs);
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrineOpenTransactionLoggerMiddlewareTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrineOpenTransactionLoggerMiddlewareTest.php
@@ -14,12 +14,16 @@ namespace Symfony\Bridge\Doctrine\Tests\Messenger;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ManagerRegistry;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\AbstractLogger;
 use Symfony\Bridge\Doctrine\Messenger\DoctrineOpenTransactionLoggerMiddleware;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Test\Middleware\MiddlewareTestCase;
 
+#[Group('legacy')]
+#[IgnoreDeprecations]
 class DoctrineOpenTransactionLoggerMiddlewareTest extends MiddlewareTestCase
 {
     private AbstractLogger $logger;
@@ -49,7 +53,7 @@ class DoctrineOpenTransactionLoggerMiddlewareTest extends MiddlewareTestCase
         $this->middleware = new DoctrineOpenTransactionLoggerMiddleware($managerRegistry, null, $this->logger);
     }
 
-    public function testMiddlewareWrapsInTransactionAndFlushes()
+    public function testMiddlewareLogsUnclosedTransaction()
     {
         $this->connection->expects($this->exactly(2))
             ->method('getTransactionNestingLevel')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Issues        | N/A
| License       | MIT

Same changes as #65302 but targeting the `DoctrineOpenTransactionLoggerMiddleware`: its replacement works on many connections instead of a single entity manager.

Note that the logger is passed as second argument to avoid recreating #64194.

Tried to factorize changes in `UPGRADE-8.2.md` but not sure this is the best way.