### PR TITLE
[Tui] Stop a column slice at a wide character instead of taking later columns

### DIFF
--- a/src/Symfony/Component/Tui/Ansi/AnsiUtils.php
+++ b/src/Symfony/Component/Tui/Ansi/AnsiUtils.php
@@ -640,7 +640,9 @@ final class AnsiUtils
                     foreach ($graphemes as $grapheme) {
                         $w = "\t" === $grapheme ? self::TAB_WIDTH : self::graphemeWidth($grapheme);
                         if ($currentCol + $w > $length) {
-                            break;
+                            // Breaking would leave the outer scan running and let a later
+                            // segment contribute columns the prefix never reached.
+                            return $result;
                         }
                         $result .= $grapheme;
                         $currentCol += $w;

--- a/src/Symfony/Component/Tui/Tests/Ansi/AnsiUtilsTest.php
+++ b/src/Symfony/Component/Tui/Tests/Ansi/AnsiUtilsTest.php
@@ -566,4 +566,26 @@ class AnsiUtilsTest extends TestCase
         // A tab is never split, so the result stops below the limit here.
         $this->assertSame(4, AnsiUtils::visibleWidth(AnsiUtils::truncateToWidth("\tx\t\t", 6, '')));
     }
+
+    public function testSliceByColumnStopsAtAWideCharacterInsteadOfTakingLaterColumns()
+    {
+        // "東" occupies columns 1-2, "京" columns 3-4, the space column 5.
+        // Neither wide character can be split, so the slice stops before it
+        // instead of skipping it and pulling in a character further right.
+        $line = "\x1b[31m東京\x1b[0m OK";
+
+        $this->assertSame("\x1b[31m", AnsiUtils::sliceByColumn($line, 0, 1));
+        $this->assertSame("\x1b[31m東", AnsiUtils::sliceByColumn($line, 0, 2));
+        $this->assertSame("\x1b[31m東", AnsiUtils::sliceByColumn($line, 0, 3));
+        $this->assertSame("\x1b[31m東京", AnsiUtils::sliceByColumn($line, 0, 4));
+        $this->assertSame("\x1b[31m東京\x1b[0m ", AnsiUtils::sliceByColumn($line, 0, 5));
+        $this->assertSame("\x1b[31m東京\x1b[0m O", AnsiUtils::sliceByColumn($line, 0, 6));
+    }
+
+    public function testTruncateToWidthDoesNotPullInCharactersPastAWideCharacter()
+    {
+        // Truncating "東京 OK" to 4 columns keeps "東" and drops the rest;
+        // the space at column 5 must not surface where "京" was dropped.
+        $this->assertSame("\x1b[31m東\x1b[0m…", AnsiUtils::truncateToWidth("\x1b[31m東京\x1b[0m OK", 4, '…'));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`AnsiUtils::sliceByColumn()` routes `startCol === 0` to the `slicePrefix()`
specialization. When a grapheme is too wide to fit in the remaining columns,
that method breaks out of the per-grapheme loop but leaves the outer segment
scan running, so the following segment keeps appending. Characters from further
right end up standing in for the columns the slice never reached.

A segment boundary is what exposes it, so any style change after the wide
character triggers it, which is the normal shape of rendered widget output.

With `"\e[31m東京\e[0m OK"` (`東` on columns 1-2, `京` on 3-4, the space on 5):

| call | before | after |
| --- | --- | --- |
| `sliceByColumn($line, 0, 1)` | `\e[31m` + the space from column 5 | `\e[31m` |
| `sliceByColumn($line, 0, 3)` | `\e[31m東` + the space from column 5 | `\e[31m東` |
| `truncateToWidth($line, 4, '…')` | `東 …` | `東…` |

`京` is dropped and the space from column 5 is drawn in its place.

Returning the prefix built so far stops the scan. That keeps the existing
"never overflow a wide character" behaviour already pinned by
`testSliceByColumnGivesTabsTheSameWidthAsVisibleWidth()`, and makes the
wide-character boundary agree with `sliceWithWidth()` in strict mode.

Dropping the source's trailing reset at the cut point is not new: the same
already happens at an exact-width boundary, where `sliceByColumn("\e[31mab\e[0m", 0, 2)`
returns `\e[31mab`. `truncateToWidth()`, the only caller in the component,
re-terminates the style itself.
