### PR TITLE
[Tui] Match ctrl+alt+<letter> in its CSI u encoding too

### DIFF
--- a/src/Symfony/Component/Tui/Input/KeyParser.php
+++ b/src/Symfony/Component/Tui/Input/KeyParser.php
@@ -815,8 +815,8 @@ final class KeyParser
             $codepoint = \ord($key);
             $rawCtrl = $this->rawCtrlChar($key);
 
-            if ($ctrl && $alt && !$shift && !$this->kittyProtocolActive && null !== $rawCtrl) {
-                return "\x1b".$rawCtrl === $data;
+            if ($ctrl && $alt && !$shift && !$this->kittyProtocolActive && null !== $rawCtrl && "\x1b".$rawCtrl === $data) {
+                return true;
             }
 
             if ($alt && !$ctrl && !$shift && !$this->kittyProtocolActive && (($key >= 'a' && $key <= 'z') || $isDigit)) {

--- a/src/Symfony/Component/Tui/Tests/Input/KeyParserTest.php
+++ b/src/Symfony/Component/Tui/Tests/Input/KeyParserTest.php
@@ -290,4 +290,16 @@ class KeyParserTest extends TestCase
         $this->assertFalse($this->parser->matches("\x1b[43;5u", 'ctrl+a'));
         $this->assertFalse($this->parser->matches("\x1b[97;5u", 'ctrl++'));
     }
+
+    public function testCtrlAltLetterMatchesBothEncodingsWithoutTheKittyFlag()
+    {
+        // A CSI u sequence is parsed whether or not the flag is set, so both
+        // encodings have to match, as they do for alt and ctrl on their own.
+        $this->assertSame('ctrl+alt+a', $this->parser->parse("\x1b[97;7u")['key']);
+
+        $this->assertTrue($this->parser->matches("\x1b\x01", 'ctrl+alt+a'));
+        $this->assertTrue($this->parser->matches("\x1b[97;7u", 'ctrl+alt+a'));
+        $this->assertFalse($this->parser->matches("\x1b[98;7u", 'ctrl+alt+a'));
+        $this->assertFalse($this->parser->matches("\x1b[97;5u", 'ctrl+alt+a'));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`KeyParser::parseKey()` routes any `ESC [ ... u` sequence to the Kitty parser
whether or not `kittyProtocolActive` is set, so a key can reach `matches()` in
either encoding. Every modifier combination accepts both, except ctrl+alt:

```php
if ($ctrl && $alt && !$shift && !$this->kittyProtocolActive && null !== $rawCtrl) {
    return "\x1b".$rawCtrl === $data;
}
```

It returns the legacy comparison directly, so the later
`matchesKittySequence()` check is unreachable for that combination. The
alt-only branch immediately below has the same shape but returns only on a
match, and so still falls through.

With the flag unset:

| | `parse()` | `matches(.., 'ctrl+alt+a')` |
| --- | --- | --- |
| `"\e\x01"` (legacy) | `ctrl+alt+a` | true |
| `"\e[97;7u"` (CSI u) | `ctrl+alt+a` | **false** |

For comparison, `alt+a` and `ctrl+a` both match their legacy byte *and* their
CSI u form. So a `ctrl+alt+...` binding silently never fires for input the
parser itself reports as that key.

Fixed by folding the byte comparison into the condition, so anything else falls
through to the CSI u check below.
