### PR TITLE
 Check arrays and bools directly instead of comparing them to count()/true/false/[]

### DIFF
--- a/src/Symfony/Bridge/Doctrine/CacheWarmer/ProxyCacheWarmer.php
+++ b/src/Symfony/Bridge/Doctrine/CacheWarmer/ProxyCacheWarmer.php
@@ -43,7 +43,7 @@ class ProxyCacheWarmer implements CacheWarmerInterface
         foreach ($this->registry->getManagers() as $em) {
             // we need the directory no matter the proxy cache generation strategy
             if (!is_dir($proxyCacheDir = $em->getConfiguration()->getProxyDir())) {
-                if (false === @mkdir($proxyCacheDir, 0o777, true) && !is_dir($proxyCacheDir)) {
+                if (!@mkdir($proxyCacheDir, 0o777, true) && !is_dir($proxyCacheDir)) {
                     throw new \RuntimeException(\sprintf('Unable to create the Doctrine Proxy directory "%s".', $proxyCacheDir));
                 }
             } elseif (!is_writable($proxyCacheDir)) {

--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterMappingsPass.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterMappingsPass.php
@@ -136,7 +136,7 @@ abstract class RegisterMappingsPass implements CompilerPassInterface
             $chainDriverDef->addMethodCall('addDriver', [$mappingDriverDef, $namespace]);
         }
 
-        if (!\count($this->aliasMap)) {
+        if (!$this->aliasMap) {
             return;
         }
 

--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
@@ -56,7 +56,7 @@ class UniqueEntityValidator extends ConstraintValidator
 
         $fields = (array) $constraint->fields;
 
-        if (0 === \count($fields)) {
+        if (!$fields) {
             throw new ConstraintDefinitionException('At least one field has to be specified.');
         }
 

--- a/src/Symfony/Bridge/Monolog/Processor/DebugProcessor.php
+++ b/src/Symfony/Bridge/Monolog/Processor/DebugProcessor.php
@@ -74,7 +74,7 @@ class DebugProcessor implements DebugLoggerInterface, ResetInterface
             return $this->records[spl_object_id($request)] ?? [];
         }
 
-        if (0 === \count($this->records)) {
+        if (!$this->records) {
             return [];
         }
 

--- a/src/Symfony/Bridge/Twig/Command/DebugCommand.php
+++ b/src/Symfony/Bridge/Twig/Command/DebugCommand.php
@@ -100,7 +100,7 @@ class DebugCommand extends Command
         $name = $input->getArgument('name');
         $filter = $input->getOption('filter');
 
-        if (null !== $name && [] === $this->getFilesystemLoaders()) {
+        if (null !== $name && !$this->getFilesystemLoaders()) {
             throw new InvalidArgumentException(\sprintf('Argument "name" not supported, it requires the Twig loader "%s".', FilesystemLoader::class));
         }
 

--- a/src/Symfony/Bridge/Twig/Tests/Translation/TwigExtractorTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Translation/TwigExtractorTest.php
@@ -43,7 +43,7 @@ class TwigExtractorTest extends TestCase
         $m = new \ReflectionMethod($extractor, 'extractTemplate');
         $m->invoke($extractor, $template, $catalogue);
 
-        if (0 === \count($messages)) {
+        if (!$messages) {
             $this->assertSame($catalogue->all(), $messages);
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Command/CachePoolClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CachePoolClearCommand.php
@@ -119,7 +119,7 @@ final class CachePoolClearCommand extends Command
                     $failure = true;
                 }
             } else {
-                if (false === $this->poolClearer->clearPool($id)) {
+                if (!$this->poolClearer->clearPool($id)) {
                     $io->warning(\sprintf('Cache pool "%s" could not be cleared.', $pool));
                     $failure = true;
                 }

--- a/src/Symfony/Bundle/FrameworkBundle/Command/EventDispatcherDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/EventDispatcherDebugCommand.php
@@ -91,7 +91,7 @@ class EventDispatcherDebugCommand extends Command
             } else {
                 // if there is no direct match, try find partial matches
                 $events = $this->searchForEvent($dispatcher, $event);
-                if (0 === \count($events)) {
+                if (!$events) {
                     $io->getErrorStyle()->warning(\sprintf('The event "%s" does not have any registered listeners.', $event));
 
                     return 0;

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
@@ -291,7 +291,7 @@ class JsonDescriptor extends Descriptor
         }
 
         $calls = $definition->getMethodCalls();
-        if (\count($calls) > 0) {
+        if ($calls) {
             $data['calls'] = [];
             foreach ($calls as $callData) {
                 $data['calls'][] = $callData[0];

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
@@ -318,7 +318,7 @@ class TextDescriptor extends Descriptor
         $tableRows[] = ['Tags', $tagInformation];
 
         $calls = $definition->getMethodCalls();
-        if (\count($calls) > 0) {
+        if ($calls) {
             $callInformation = [];
             foreach ($calls as $call) {
                 $callInformation[] = $call[0];

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
@@ -367,7 +367,7 @@ class XmlDescriptor extends Descriptor
         $serviceXML->setAttribute('file', $definition->getFile() ?? '');
 
         $calls = $definition->getMethodCalls();
-        if (\count($calls) > 0) {
+        if ($calls) {
             $serviceXML->appendChild($callsXML = $dom->createElement('calls'));
             foreach ($calls as $callData) {
                 $callsXML->appendChild($callXML = $dom->createElement('call'));

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -2394,7 +2394,7 @@ class FrameworkExtension extends Extension
                 ->replaceArgument(0, $transportRateLimiterReferences);
         }
 
-        if (\count($failureTransports) > 0) {
+        if ($failureTransports) {
             if ($this->hasConsole()) {
                 $container->getDefinition('console.command.messenger_failed_messages_retry')
                     ->replaceArgument(0, $config['failure_transport']);
@@ -2672,7 +2672,7 @@ class FrameworkExtension extends Extension
 
         $loader->load('mailer.php');
         $loader->load('mailer_transports.php');
-        if (!\count($config['transports']) && null === $config['dsn']) {
+        if (!$config['transports'] && null === $config['dsn']) {
             $config['dsn'] = 'smtp://null';
         }
         $transports = $config['dsn'] ? ['main' => $config['dsn']] : $config['transports'];

--- a/src/Symfony/Bundle/SecurityBundle/Command/DebugFirewallCommand.php
+++ b/src/Symfony/Bundle/SecurityBundle/Command/DebugFirewallCommand.php
@@ -207,7 +207,7 @@ final class DebugFirewallCommand extends Command
 
         $authenticators = $this->authenticators[$name] ?? [];
 
-        if (0 === \count($authenticators)) {
+        if (!$authenticators) {
             $io->text('No authenticators have been registered for this firewall.');
 
             return;

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
@@ -339,7 +339,7 @@ class MainConfiguration implements ConfigurationInterface
         $firewallNodeBuilder
             ->end()
             ->validate()
-                ->ifTrue(static fn ($v) => true === $v['security'] && isset($v['pattern']) && !isset($v['request_matcher']))
+                ->ifTrue(static fn ($v) => $v['security'] && isset($v['pattern']) && !isset($v['request_matcher']))
                 ->then(static function ($firewall) use ($abstractFactoryKeys) {
                     foreach ($abstractFactoryKeys as $k) {
                         if (!isset($firewall[$k]['check_path'])) {
@@ -410,7 +410,7 @@ class MainConfiguration implements ConfigurationInterface
                 ->thenInvalid('You cannot set multiple provider types for the same provider')
             ->end()
             ->validate()
-                ->ifTrue(static fn ($v) => 0 === \count($v))
+                ->ifTrue(static fn ($v) => !$v)
                 ->thenInvalid('You must set a provider definition for the provider.')
             ->end()
         ;

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -214,7 +214,7 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
 
     private function createRoleHierarchy(array $config, ContainerBuilder $container): void
     {
-        if (!isset($config['role_hierarchy']) || 0 === \count($config['role_hierarchy'])) {
+        if (!isset($config['role_hierarchy']) || !$config['role_hierarchy']) {
             $container->removeDefinition('security.access.role_hierarchy_voter');
 
             return;
@@ -269,7 +269,7 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
         }
 
         // allow cache warm-up for expressions
-        if (\count($this->expressions)) {
+        if ($this->expressions) {
             $container->getDefinition('security.cache_warmer.expression')
                 ->replaceArgument(0, new IteratorArgument(array_values($this->expressions)));
         } else {
@@ -387,7 +387,7 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
         $config->replaceArgument(3, $firewall['security']);
 
         // Security disabled?
-        if (false === $firewall['security']) {
+        if (!$firewall['security']) {
             return [$matcher, [], null, null, []];
         }
 
@@ -436,7 +436,7 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
 
         $contextKey = null;
         // Context serializer listener
-        if (false === $firewall['stateless']) {
+        if (!$firewall['stateless']) {
             $contextKey = $firewall['context'] ?? $id;
             $listeners[] = new Reference($this->createContextListener($container, $contextKey, $firewallEventDispatcherId));
             $sessionStrategyId = 'security.authentication.session_strategy';
@@ -473,13 +473,13 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
             }
 
             // add session logout listener
-            if (true === $firewall['logout']['invalidate_session'] && false === $firewall['stateless']) {
+            if ($firewall['logout']['invalidate_session'] && !$firewall['stateless']) {
                 $container->setDefinition('security.logout.listener.session.'.$id, new ChildDefinition('security.logout.listener.session'))
                     ->addTag('kernel.event_subscriber', ['dispatcher' => $firewallEventDispatcherId]);
             }
 
             // add cookie logout listener
-            if (\count($firewall['logout']['delete_cookies']) > 0) {
+            if ($firewall['logout']['delete_cookies']) {
                 $container->setDefinition('security.logout.listener.cookie_clearing.'.$id, new ChildDefinition('security.logout.listener.cookie_clearing'))
                     ->addArgument($firewall['logout']['delete_cookies'])
                     ->addTag('kernel.event_subscriber', ['dispatcher' => $firewallEventDispatcherId]);
@@ -501,7 +501,7 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
                     $firewall['logout']['csrf_token_id'],
                     $firewall['logout']['csrf_parameter'],
                     isset($firewall['logout']['csrf_token_manager']) ? new Reference($firewall['logout']['csrf_token_manager']) : null,
-                    false === $firewall['stateless'] && isset($firewall['context']) ? $firewall['context'] : null,
+                    !$firewall['stateless'] && isset($firewall['context']) ? $firewall['context'] : null,
                 ])
             ;
 

--- a/src/Symfony/Component/Asset/VersionStrategy/JsonManifestVersionStrategy.php
+++ b/src/Symfony/Component/Asset/VersionStrategy/JsonManifestVersionStrategy.php
@@ -105,7 +105,7 @@ class JsonManifestVersionStrategy implements VersionStrategyInterface
         if ($this->strictMode) {
             $message = \sprintf('Asset "%s" not found in manifest "%s".', $path, $this->manifestPath);
             $alternatives = $this->findAlternatives($path, $this->manifestData);
-            if (\count($alternatives) > 0) {
+            if ($alternatives) {
                 $message .= \sprintf(' Did you mean one of these? "%s".', implode('", "', $alternatives));
             }
 

--- a/src/Symfony/Component/AssetMapper/Command/ImportMapAuditCommand.php
+++ b/src/Symfony/Component/AssetMapper/Command/ImportMapAuditCommand.php
@@ -127,7 +127,7 @@ class ImportMapAuditCommand extends Command
             ));
         }
 
-        if ([] !== $rows) {
+        if ($rows) {
             $vulnerabilityCount = 0;
             $vulnerabilitySummary = [];
             foreach ($vulnerabilitiesCount as $severity => $count) {

--- a/src/Symfony/Component/AssetMapper/ImportMap/Resolver/JsDelivrEsmResolver.php
+++ b/src/Symfony/Component/AssetMapper/ImportMap/Resolver/JsDelivrEsmResolver.php
@@ -204,7 +204,7 @@ final class JsDelivrEsmResolver implements PackageResolverInterface
                 'extraFiles' => [],
             ];
 
-            if (0 !== \count($extraFiles)) {
+            if ($extraFiles) {
                 $extraFileResponses[$package] = [];
                 foreach ($extraFiles as $extraFile) {
                     $extraFileResponses[$package][] = [$this->httpClient->request('GET', \sprintf(self::URL_PATTERN_DIST_CSS, $entry->getPackageName(), $entry->version, $extraFile)), $extraFile, $entry->getPackageName(), $entry->version];
@@ -244,7 +244,7 @@ final class JsDelivrEsmResolver implements PackageResolverInterface
                 }
                 $contents[$package]['extraFiles'][$extraFile] = $content;
 
-                if (0 !== \count($extraFiles)) {
+                if ($extraFiles) {
                     $extraFileResponses[$package] = [];
                     foreach ($extraFiles as $newExtraFile) {
                         $extraFileResponses[$package][] = [$this->httpClient->request('GET', \sprintf(self::URL_PATTERN_DIST_CSS, $packageName, $version, $newExtraFile)), $newExtraFile, $packageName, $version];

--- a/src/Symfony/Component/BrowserKit/AbstractBrowser.php
+++ b/src/Symfony/Component/BrowserKit/AbstractBrowser.php
@@ -375,7 +375,7 @@ abstract class AbstractBrowser
 
         $this->request = $this->filterRequest($this->internalRequest);
 
-        if (true === $changeHistory) {
+        if ($changeHistory) {
             $this->history->add($this->internalRequest);
         }
 
@@ -444,7 +444,7 @@ abstract class AbstractBrowser
         }
 
         if (!$process->isSuccessful() || !preg_match('/^O\:\d+\:/', $process->getOutput())) {
-            throw new RuntimeException(\sprintf('OUTPUT: %s ERROR OUTPUT: %s.', $process->getOutput(), $process->getErrorOutput()));
+            throw new RuntimeException('OUTPUT: '.$process->getOutput().' ERROR OUTPUT: '.$process->getErrorOutput().'.');
         }
 
         return unserialize($process->getOutput(), ['allowed_classes' => true]);

--- a/src/Symfony/Component/BrowserKit/History.php
+++ b/src/Symfony/Component/BrowserKit/History.php
@@ -51,7 +51,7 @@ class History
      */
     public function isEmpty(): bool
     {
-        return 0 === \count($this->stack);
+        return !$this->stack;
     }
 
     /**

--- a/src/Symfony/Component/BrowserKit/Response.php
+++ b/src/Symfony/Component/BrowserKit/Response.php
@@ -81,7 +81,7 @@ final class Response
         foreach ($this->headers as $key => $value) {
             if (str_replace('-', '_', strtolower($key)) === $normalizedHeader) {
                 if ($first) {
-                    return \is_array($value) ? (\count($value) ? $value[0] : '') : $value;
+                    return \is_array($value) ? ($value ? $value[0] : '') : $value;
                 }
 
                 return \is_array($value) ? $value : [$value];

--- a/src/Symfony/Component/Cache/Adapter/CouchbaseCollectionAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/CouchbaseCollectionAdapter.php
@@ -173,7 +173,7 @@ class CouchbaseCollectionAdapter extends AbstractAdapter
             }
         }
 
-        return 0 === \count($idsErrors);
+        return !$idsErrors;
     }
 
     protected function doSave(array $values, $lifetime): array|bool
@@ -194,6 +194,6 @@ class CouchbaseCollectionAdapter extends AbstractAdapter
             }
         }
 
-        return [] === $ko ? true : $ko;
+        return !$ko ? true : $ko;
     }
 }

--- a/src/Symfony/Component/Cache/Marshaller/TagAwareMarshaller.php
+++ b/src/Symfony/Component/Cache/Marshaller/TagAwareMarshaller.php
@@ -40,7 +40,7 @@ class TagAwareMarshaller implements MarshallerInterface
                     $f = [];
                     $failed[] = $id;
                 } else {
-                    if ([] === $value['tags']) {
+                    if (!$value['tags']) {
                         $v['tags'] = '';
                     }
 

--- a/src/Symfony/Component/Config/Definition/ArrayNode.php
+++ b/src/Symfony/Component/Config/Definition/ArrayNode.php
@@ -218,7 +218,7 @@ class ArrayNode extends BaseNode implements PrototypeNodeInterface
     protected function finalizeValue(mixed $value): mixed
     {
         if (false === $value) {
-            throw new UnsetKeyException(\sprintf('Unsetting key for path "%s", value: %s.', $this->getPath(), json_encode($value)));
+            throw new UnsetKeyException(\sprintf('Unsetting key for path "%s", value: ', $this->getPath()).json_encode($value).'.');
         }
 
         foreach ($this->children as $name => $child) {
@@ -299,7 +299,7 @@ class ArrayNode extends BaseNode implements PrototypeNodeInterface
         }
 
         // if extra fields are present, throw exception
-        if (\count($value) && !$this->ignoreExtraKeys) {
+        if ($value && !$this->ignoreExtraKeys) {
             $proposals = array_keys($this->children);
             sort($proposals);
             $guesses = [];
@@ -317,7 +317,7 @@ class ArrayNode extends BaseNode implements PrototypeNodeInterface
 
             $msg = \sprintf('Unrecognized option%s "%s" under "%s"', 1 === \count($value) ? '' : 's', implode(', ', array_keys($value)), $this->getPath());
 
-            if (\count($guesses)) {
+            if ($guesses) {
                 asort($guesses);
                 $msg .= \sprintf('. Did you mean "%s"?', implode('", "', array_keys($guesses)));
             } else {

--- a/src/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.php
@@ -368,13 +368,13 @@ class ArrayNodeDefinition extends NodeDefinition implements ParentNodeDefinition
                 $node->setKeyAttribute($this->key, $this->removeKeyItem);
             }
 
-            if (true === $this->atLeastOne || false === $this->allowEmptyValue) {
+            if ($this->atLeastOne || !$this->allowEmptyValue) {
                 $node->setMinNumberOfElements(1);
             }
 
             if ($this->default) {
                 if (!\is_array($this->defaultValue)) {
-                    throw new \InvalidArgumentException(\sprintf('%s: the default value of an array node has to be an array.', $node->getPath()));
+                    throw new \InvalidArgumentException($node->getPath().': the default value of an array node has to be an array.');
                 }
 
                 $node->setDefaultValue($this->defaultValue);
@@ -437,11 +437,11 @@ class ArrayNodeDefinition extends NodeDefinition implements ParentNodeDefinition
             throw new InvalidDefinitionException(\sprintf('->useAttributeAsKey() is not applicable to concrete nodes at path "%s".', $path));
         }
 
-        if (false === $this->allowEmptyValue) {
+        if (!$this->allowEmptyValue) {
             throw new InvalidDefinitionException(\sprintf('->cannotBeEmpty() is not applicable to concrete nodes at path "%s".', $path));
         }
 
-        if (true === $this->atLeastOne) {
+        if ($this->atLeastOne) {
             throw new InvalidDefinitionException(\sprintf('->requiresAtLeastOneElement() is not applicable to concrete nodes at path "%s".', $path));
         }
 

--- a/src/Symfony/Component/Config/Definition/Builder/VariableNodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/VariableNodeDefinition.php
@@ -41,7 +41,7 @@ class VariableNodeDefinition extends NodeDefinition
             $node->setAllowOverwrite($this->merge->allowOverwrite);
         }
 
-        if (true === $this->default) {
+        if ($this->default) {
             $node->setDefaultValue($this->defaultValue);
         }
 

--- a/src/Symfony/Component/Config/Definition/Dumper/XmlReferenceDumper.php
+++ b/src/Symfony/Component/Config/Definition/Dumper/XmlReferenceDumper.php
@@ -61,7 +61,7 @@ class XmlReferenceDumper
         if ($node->getParent()) {
             $remapping = array_filter($node->getParent()->getXmlRemappings(), static fn (array $mapping) => $rootName === $mapping[1]);
 
-            if (\count($remapping)) {
+            if ($remapping) {
                 [$singular] = current($remapping);
                 $rootName = $singular;
             }
@@ -158,7 +158,7 @@ class XmlReferenceDumper
                     $comments[] = 'One of '.$child->getPermissibleValues('; ');
                 }
 
-                if (\count($comments)) {
+                if ($comments) {
                     $rootAttributeComments[$name] = implode(";\n", $comments);
                 }
 
@@ -175,14 +175,14 @@ class XmlReferenceDumper
         // render comments
 
         // root node comment
-        if (\count($rootComments)) {
+        if ($rootComments) {
             foreach ($rootComments as $comment) {
                 $this->writeLine('<!-- '.$comment.' -->', $depth);
             }
         }
 
         // attribute comments
-        if (\count($rootAttributeComments)) {
+        if ($rootAttributeComments) {
             foreach ($rootAttributeComments as $attrName => $comment) {
                 $commentDepth = $depth + 4 + \strlen($attrName) + 2;
                 $commentLines = explode("\n", $comment);
@@ -201,7 +201,7 @@ class XmlReferenceDumper
 
         // render start tag + attributes
         $rootIsVariablePrototype = isset($prototypeValue);
-        $rootIsEmptyTag = (0 === \count($rootChildren) && !$rootIsVariablePrototype);
+        $rootIsEmptyTag = (!$rootChildren && !$rootIsVariablePrototype);
         $rootOpenTag = '<'.$rootName;
         if (1 >= ($attributesCount = \count($rootAttributes))) {
             if (1 === $attributesCount) {

--- a/src/Symfony/Component/Config/FileLocator.php
+++ b/src/Symfony/Component/Config/FileLocator.php
@@ -60,7 +60,7 @@ class FileLocator implements FileLocatorInterface
 
         foreach ($paths as $path) {
             if (@file_exists($file = $path.\DIRECTORY_SEPARATOR.$name)) {
-                if (true === $first) {
+                if ($first) {
                     return $file;
                 }
                 $filepaths[] = $file;

--- a/src/Symfony/Component/Config/Util/XmlUtils.php
+++ b/src/Symfony/Component/Config/Util/XmlUtils.php
@@ -194,7 +194,7 @@ class XmlUtils
 
         if (false !== $nodeValue) {
             $value = static::phpize($nodeValue);
-            if (\count($config)) {
+            if ($config) {
                 $config['value'] = $value;
             } else {
                 $config = $value;

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -240,7 +240,7 @@ class Application implements ResetInterface
         }
 
         $name = $this->getCommandName($input);
-        if (true === $input->hasParameterOption(['--help', '-h'], true)) {
+        if ($input->hasParameterOption(['--help', '-h'], true)) {
             if (!$name) {
                 $name = 'help';
                 $input = new ArrayInput(['command_name' => $this->defaultCommand]);
@@ -1334,7 +1334,7 @@ class Application implements ResetInterface
         $namespaces = [];
 
         foreach ($parts as $part) {
-            if (\count($namespaces)) {
+            if ($namespaces) {
                 $namespaces[] = end($namespaces).':'.$part;
             } else {
                 $namespaces[] = $part;

--- a/src/Symfony/Component/Console/Color.php
+++ b/src/Symfony/Component/Console/Color.php
@@ -84,7 +84,7 @@ final class Color
         foreach ($this->options as $option) {
             $setCodes[] = $option['set'];
         }
-        if (0 === \count($setCodes)) {
+        if (!$setCodes) {
             return '';
         }
 
@@ -103,7 +103,7 @@ final class Color
         foreach ($this->options as $option) {
             $unsetCodes[] = $option['unset'];
         }
-        if (0 === \count($unsetCodes)) {
+        if (!$unsetCodes) {
             return '';
         }
 

--- a/src/Symfony/Component/Console/Descriptor/MarkdownDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/MarkdownDescriptor.php
@@ -77,7 +77,7 @@ class MarkdownDescriptor extends Descriptor
 
     protected function describeInputDefinition(InputDefinition $definition, array $options = []): void
     {
-        if ($showArguments = \count($definition->getArguments()) > 0) {
+        if ($showArguments = $definition->getArguments()) {
             $this->write('### Arguments');
             foreach ($definition->getArguments() as $argument) {
                 $this->write("\n\n");

--- a/src/Symfony/Component/Console/Input/ArgvInput.php
+++ b/src/Symfony/Component/Console/Input/ArgvInput.php
@@ -180,7 +180,7 @@ class ArgvInput extends Input
                 unset($all[$key]);
             }
 
-            if (\count($all)) {
+            if ($all) {
                 if ($symfonyCommandName) {
                     $message = \sprintf('Too many arguments to "%s" command, expected arguments "%s".', $symfonyCommandName, implode('" "', array_keys($all)));
                 } else {
@@ -237,7 +237,7 @@ class ArgvInput extends Input
             throw new RuntimeException(\sprintf('The "--%s" option does not accept a value.', $name));
         }
 
-        if (\in_array($value, ['', null], true) && $option->acceptValue() && \count($this->parsed)) {
+        if (\in_array($value, ['', null], true) && $option->acceptValue() && $this->parsed) {
             // if option accepts an optional or mandatory argument
             // let's see if there is one provided
             $next = array_shift($this->parsed);
@@ -324,7 +324,7 @@ class ArgvInput extends Input
         $values = (array) $values;
         $tokens = $this->tokens;
 
-        while (0 < \count($tokens)) {
+        while ($tokens) {
             $token = array_shift($tokens);
             if ($onlyParams && '--' === $token) {
                 return $default;

--- a/src/Symfony/Component/Console/Input/Input.php
+++ b/src/Symfony/Component/Console/Input/Input.php
@@ -73,7 +73,7 @@ abstract class Input implements InputInterface, StreamableInputInterface
 
         $missingArguments = array_filter(array_keys($definition->getArguments()), static fn ($argument) => !\array_key_exists($argument, $givenArguments) && $definition->getArgument($argument)->isRequired());
 
-        if (\count($missingArguments) > 0) {
+        if ($missingArguments) {
             throw new RuntimeException(\sprintf('Not enough arguments (missing: "%s").', implode(', ', $missingArguments)));
         }
     }

--- a/src/Symfony/Component/Console/Input/InputDefinition.php
+++ b/src/Symfony/Component/Console/Input/InputDefinition.php
@@ -392,7 +392,7 @@ class InputDefinition
             }
         }
 
-        if (\count($elements) && $this->getArguments()) {
+        if ($elements && $this->getArguments()) {
             $elements[] = '[--]';
         }
 

--- a/src/Symfony/Component/Console/Output/ConsoleOutput.php
+++ b/src/Symfony/Component/Console/Output/ConsoleOutput.php
@@ -100,7 +100,7 @@ class ConsoleOutput extends StreamOutput implements ConsoleOutputInterface
      */
     protected function hasStdoutSupport(): bool
     {
-        return false === $this->isRunningOS400();
+        return !$this->isRunningOS400();
     }
 
     /**
@@ -109,7 +109,7 @@ class ConsoleOutput extends StreamOutput implements ConsoleOutputInterface
      */
     protected function hasStderrSupport(): bool
     {
-        return false === $this->isRunningOS400();
+        return !$this->isRunningOS400();
     }
 
     /**

--- a/src/Symfony/Component/Console/Tests/Helper/ProcessHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProcessHelperTest.php
@@ -76,7 +76,7 @@ class ProcessHelperTest extends TestCase
             }
         }
 
-        if ([] !== $expectedOutputLines) {
+        if ($expectedOutputLines) {
             sort($expectedOutputLines);
             sort($output);
 

--- a/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
@@ -277,7 +277,7 @@ class PassConfig
      */
     private function sortPasses(array $passes): array
     {
-        if (0 === \count($passes)) {
+        if (!$passes) {
             return [];
         }
 

--- a/src/Symfony/Component/DependencyInjection/Compiler/RegisterServiceSubscribersPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/RegisterServiceSubscribersPass.php
@@ -49,7 +49,7 @@ class RegisterServiceSubscribersPass extends AbstractRecursivePass
                 continue;
             }
             ksort($attributes);
-            if ([] !== array_diff(array_keys($attributes), ['id', 'key'])) {
+            if (array_diff(array_keys($attributes), ['id', 'key'])) {
                 throw new InvalidArgumentException(\sprintf('The "container.service_subscriber" tag accepts only the "key" and "id" attributes, "%s" given for service "%s".', implode('", "', array_keys($attributes)), $this->currentId));
             }
             if (!\array_key_exists('id', $attributes)) {
@@ -133,7 +133,7 @@ class RegisterServiceSubscribersPass extends AbstractRecursivePass
 
         if ($serviceMap = array_keys($serviceMap)) {
             $message = \sprintf(1 < \count($serviceMap) ? 'keys "%s" do' : 'key "%s" does', str_replace('%', '%%', implode('", "', $serviceMap)));
-            throw new InvalidArgumentException(\sprintf('Service %s not exist in the map returned by "%s::getSubscribedServices()" for service "%s".', $message, $class, $this->currentId));
+            throw new InvalidArgumentException('Service '.$message.\sprintf(' not exist in the map returned by "%s::getSubscribedServices()" for service "%s".', $class, $this->currentId));
         }
 
         $locatorRef = ServiceLocatorTagPass::register($this->container, $subscriberMap, $this->currentId);

--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -251,7 +251,7 @@ class Definition
      */
     public function replaceArgument(int|string $index, mixed $argument): static
     {
-        if (0 === \count($this->arguments)) {
+        if (!$this->arguments) {
             throw new OutOfBoundsException(\sprintf('Cannot replace arguments for class "%s" if none have been configured yet.', $this->class));
         }
 

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -2000,7 +2000,7 @@ class PhpDumper extends Dumper
             return $this->getExpressionLanguage()->compile((string) $value, ['container' => 'container']);
         } elseif ($value instanceof Parameter) {
             return $this->dumpParameter($value);
-        } elseif (true === $interpolate && \is_string($value)) {
+        } elseif ($interpolate && \is_string($value)) {
             if (preg_match('/^%([^%]+)%$/', $value, $match)) {
                 // we do this to deal with non string values (Boolean, integer, ...)
                 // the preg_replace_callback converts them to strings

--- a/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
@@ -77,10 +77,10 @@ class ParameterBag implements ParameterBagInterface
             }
 
             $nonNestedAlternative = null;
-            if (!\count($alternatives) && str_contains($name, '.')) {
+            if (!$alternatives && str_contains($name, '.')) {
                 $namePartsLength = array_map('strlen', explode('.', $name));
                 $key = substr($name, 0, -1 * (1 + array_pop($namePartsLength)));
-                while (\count($namePartsLength)) {
+                while ($namePartsLength) {
                     if ($this->has($key)) {
                         if (\is_array($this->get($key))) {
                             $nonNestedAlternative = $key;

--- a/src/Symfony/Component/ExpressionLanguage/Node/Node.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/Node.php
@@ -42,7 +42,7 @@ class Node
 
         $repr = [str_replace('Symfony\Component\ExpressionLanguage\Node\\', '', static::class).'('.implode(', ', $attributes)];
 
-        if (\count($this->nodes)) {
+        if ($this->nodes) {
             foreach ($this->nodes as $node) {
                 foreach (explode("\n", (string) $node) as $line) {
                     $repr[] = '    '.$line;
@@ -67,9 +67,6 @@ class Node
         }
     }
 
-    /**
-     * @return mixed
-     */
     public function evaluate(array $functions, array $values)
     {
         $results = [];

--- a/src/Symfony/Component/Filesystem/Path.php
+++ b/src/Symfony/Component/Filesystem/Path.php
@@ -746,7 +746,7 @@ final class Path
 
             // Collapse ".." with the previous part, if one exists
             // Don't collapse ".." if the previous part is also ".."
-            if ('..' === $part && \count($canonicalParts) > 0 && '..' !== $canonicalParts[\count($canonicalParts) - 1]) {
+            if ('..' === $part && $canonicalParts && '..' !== $canonicalParts[\count($canonicalParts) - 1]) {
                 array_pop($canonicalParts);
 
                 continue;

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTestCase.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTestCase.php
@@ -31,7 +31,7 @@ class FilesystemTestCase extends TestCase
             self::$linkOnWindows = true;
             $originFile = tempnam(sys_get_temp_dir(), 'li');
             $targetFile = tempnam(sys_get_temp_dir(), 'li');
-            if (true !== @link($originFile, $targetFile)) {
+            if (!@link($originFile, $targetFile)) {
                 $report = error_get_last();
                 if (\is_array($report) && str_contains($report['message'], 'error code(1314)')) {
                     self::$linkOnWindows = false;
@@ -43,7 +43,7 @@ class FilesystemTestCase extends TestCase
             self::$symlinkOnWindows = true;
             $originDir = tempnam(sys_get_temp_dir(), 'sl');
             $targetDir = tempnam(sys_get_temp_dir(), 'sl');
-            if (true !== @symlink($originDir, $targetDir)) {
+            if (!@symlink($originDir, $targetDir)) {
                 $report = error_get_last();
                 if (\is_array($report) && str_contains($report['message'], 'error code(1314)')) {
                     self::$symlinkOnWindows = false;
@@ -103,7 +103,7 @@ class FilesystemTestCase extends TestCase
     {
         $this->markAsSkippedIfPosixIsMissing();
 
-        return ($datas = posix_getpwuid($this->getFileOwnerId($filepath))) ? $datas['name'] : null;
+        return ($data = posix_getpwuid($this->getFileOwnerId($filepath))) ? $data['name'] : null;
     }
 
     protected function getFileGroupId($filepath)
@@ -119,8 +119,8 @@ class FilesystemTestCase extends TestCase
     {
         $this->markAsSkippedIfPosixIsMissing();
 
-        if ($datas = posix_getgrgid($this->getFileGroupId($filepath))) {
-            return $datas['name'];
+        if ($data = posix_getgrgid($this->getFileGroupId($filepath))) {
+            return $data['name'];
         }
 
         $this->markTestSkipped('Unable to retrieve file group name');

--- a/src/Symfony/Component/Form/AbstractExtension.php
+++ b/src/Symfony/Component/Form/AbstractExtension.php
@@ -81,7 +81,7 @@ abstract class AbstractExtension implements FormExtensionInterface
             $this->initTypeExtensions();
         }
 
-        return isset($this->typeExtensions[$name]) && \count($this->typeExtensions[$name]) > 0;
+        return isset($this->typeExtensions[$name]) && $this->typeExtensions[$name];
     }
 
     public function getTypeGuesser(): ?FormTypeGuesserInterface

--- a/src/Symfony/Component/Form/ButtonBuilder.php
+++ b/src/Symfony/Component/Form/ButtonBuilder.php
@@ -418,7 +418,7 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
      */
     public function setAutoInitialize(bool $initialize): static
     {
-        if (true === $initialize) {
+        if ($initialize) {
             throw new BadMethodCallException('Buttons do not support automatic initialization.');
         }
 

--- a/src/Symfony/Component/Form/ChoiceList/Factory/DefaultChoiceListFactory.php
+++ b/src/Symfony/Component/Form/ChoiceList/Factory/DefaultChoiceListFactory.php
@@ -104,13 +104,13 @@ class DefaultChoiceListFactory implements ChoiceListFactoryInterface
             // Remove empty group views that may have been created by
             // addChoiceViewsGroupedByCallable()
             foreach ($preferredViews as $key => $view) {
-                if ($view instanceof ChoiceGroupView && 0 === \count($view->choices)) {
+                if ($view instanceof ChoiceGroupView && !$view->choices) {
                     unset($preferredViews[$key]);
                 }
             }
 
             foreach ($otherViews as $key => $view) {
-                if ($view instanceof ChoiceGroupView && 0 === \count($view->choices)) {
+                if ($view instanceof ChoiceGroupView && !$view->choices) {
                     unset($otherViews[$key]);
                 }
             }
@@ -222,11 +222,11 @@ class DefaultChoiceListFactory implements ChoiceListFactoryInterface
                     $duplicatePreferredChoices,
                 );
 
-                if (\count($preferredViewsForGroup) > 0) {
+                if ($preferredViewsForGroup) {
                     $preferredViews[$key] = new ChoiceGroupView($key, $preferredViewsForGroup);
                 }
 
-                if (\count($otherViewsForGroup) > 0) {
+                if ($otherViewsForGroup) {
                     $otherViews[$key] = new ChoiceGroupView($key, $otherViewsForGroup);
                 }
 

--- a/src/Symfony/Component/Form/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Component/Form/Console/Descriptor/TextDescriptor.php
@@ -166,7 +166,7 @@ class TextDescriptor extends Descriptor
                     unset($options[$group][$class]);
                 }
 
-                if (!\is_array($opt) || 0 === \count($opt)) {
+                if (!\is_array($opt) || !$opt) {
                     continue;
                 }
 

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/ArrayToPartsTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/ArrayToPartsTransformer.php
@@ -68,7 +68,7 @@ class ArrayToPartsTransformer implements DataTransformerInterface
             }
         }
 
-        if (\count($emptyKeys) > 0) {
+        if ($emptyKeys) {
             if (\count($emptyKeys) === \count($this->partMapping)) {
                 // All parts empty
                 return null;

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateIntervalToArrayTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateIntervalToArrayTransformer.php
@@ -123,7 +123,7 @@ class DateIntervalToArrayTransformer implements DataTransformerInterface
                 $emptyFields[] = $field;
             }
         }
-        if (\count($emptyFields) > 0) {
+        if ($emptyFields) {
             throw new TransformationFailedException(\sprintf('The fields "%s" should not be empty.', implode('", "', $emptyFields)));
         }
         if (isset($value['invert']) && !\is_bool($value['invert'])) {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToArrayTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToArrayTransformer.php
@@ -122,7 +122,7 @@ class DateTimeToArrayTransformer extends BaseDateTimeTransformer
             }
         }
 
-        if (\count($emptyFields) > 0) {
+        if ($emptyFields) {
             throw new TransformationFailedException(\sprintf('The fields "%s" should not be empty.', implode('", "', $emptyFields)));
         }
 
@@ -138,7 +138,7 @@ class DateTimeToArrayTransformer extends BaseDateTimeTransformer
             throw new TransformationFailedException('This year is invalid.');
         }
 
-        if (!empty($value['month']) && !empty($value['day']) && !empty($value['year']) && false === checkdate($value['month'], $value['day'], $value['year'])) {
+        if (!empty($value['month']) && !empty($value['day']) && !empty($value['year']) && !checkdate($value['month'], $value['day'], $value['year'])) {
             throw new TransformationFailedException('This is an invalid date.');
         }
 

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/ValueToDuplicatesTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/ValueToDuplicatesTransformer.php
@@ -67,7 +67,7 @@ class ValueToDuplicatesTransformer implements DataTransformerInterface
             }
         }
 
-        if (\count($emptyKeys) > 0) {
+        if ($emptyKeys) {
             if (\count($emptyKeys) == \count($this->keys)) {
                 // All keys empty
                 return null;

--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -87,7 +87,7 @@ class ChoiceType extends AbstractType
 
             // Check if the choices already contain the empty value
             // Only add the placeholder option if this is not the case
-            if (null !== $options['placeholder'] && 0 === \count($choiceList->getChoicesForValues(['']))) {
+            if (null !== $options['placeholder'] && !$choiceList->getChoicesForValues([''])) {
                 $placeholderView = new ChoiceView(null, '', $options['placeholder'], $options['placeholder_attr']);
 
                 // "placeholder" is a reserved name
@@ -159,7 +159,7 @@ class ChoiceType extends AbstractType
                 unset($unknownValues['']);
 
                 // Throw exception if unknown values were submitted (multiple choices will be handled in a different event listener below)
-                if (\count($unknownValues) > 0 && !$options['multiple']) {
+                if ($unknownValues && !$options['multiple']) {
                     throw new TransformationFailedException(\sprintf('The choices "%s" do not exist in the choice list.', implode('", "', array_keys($unknownValues))));
                 }
 
@@ -173,7 +173,7 @@ class ChoiceType extends AbstractType
 
             $builder->addEventListener(FormEvents::POST_SUBMIT, static function (FormEvent $event) use (&$unknownValues, $messageTemplate, $translator) {
                 // Throw exception if unknown values were submitted
-                if (\count($unknownValues) > 0) {
+                if ($unknownValues) {
                     $form = $event->getForm();
 
                     $clientDataAsString = \is_scalar($form->getViewData()) ? (string) $form->getViewData() : (\is_array($form->getViewData()) ? implode('", "', array_keys($unknownValues)) : \gettype($form->getViewData()));

--- a/src/Symfony/Component/Form/Extension/Core/Type/FileType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FileType.php
@@ -73,7 +73,7 @@ class FileType extends AbstractType
 
                 // Since the array is never considered empty in the view data format
                 // on submission, we need to evaluate the configured empty data here
-                if ([] === $data) {
+                if (!$data) {
                     $emptyData = $form->getConfig()->getEmptyData();
                     $data = $emptyData instanceof \Closure ? $emptyData($form, $data) : $emptyData;
                 }

--- a/src/Symfony/Component/Form/Extension/HttpFoundation/HttpFoundationRequestHandler.php
+++ b/src/Symfony/Component/Form/Extension/HttpFoundation/HttpFoundationRequestHandler.php
@@ -103,7 +103,7 @@ class HttpFoundationRequestHandler implements RequestHandlerInterface
         }
 
         // Don't auto-submit the form unless at least one field is present.
-        if ('' === $name && \count(array_intersect_key($data, $form->all())) <= 0) {
+        if ('' === $name && !array_intersect_key($data, $form->all())) {
             return;
         }
 

--- a/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
@@ -192,7 +192,7 @@ class FormValidator extends ConstraintValidator
         }
 
         // Mark the form with an error if it contains extra fields
-        if (!$config->getOption('allow_extra_fields') && \count($form->getExtraData()) > 0) {
+        if (!$config->getOption('allow_extra_fields') && $form->getExtraData()) {
             $this->context->setConstraint($formConstraint);
             $this->context->buildViolation($config->getOption('extra_fields_message', ''))
                 ->setParameter('{{ extra_fields }}', '"'.implode('", "', array_keys($form->getExtraData())).'"')

--- a/src/Symfony/Component/Form/FormFactoryBuilder.php
+++ b/src/Symfony/Component/Form/FormFactoryBuilder.php
@@ -137,7 +137,7 @@ class FormFactoryBuilder implements FormFactoryBuilderInterface
             }
         }
 
-        if (\count($this->types) > 0 || \count($this->typeExtensions) > 0 || \count($this->typeGuessers) > 0) {
+        if ($this->types || $this->typeExtensions || $this->typeGuessers) {
             if (\count($this->typeGuessers) > 1) {
                 $typeGuesser = new FormTypeGuesserChain($this->typeGuessers);
             } else {

--- a/src/Symfony/Component/Form/FormView.php
+++ b/src/Symfony/Component/Form/FormView.php
@@ -62,7 +62,7 @@ class FormView implements \ArrayAccess, \IteratorAggregate, \Countable
      */
     public function isRendered(): bool
     {
-        if (true === $this->rendered || 0 === \count($this->children)) {
+        if ($this->rendered || !$this->children) {
             return $this->rendered;
         }
 

--- a/src/Symfony/Component/Form/NativeRequestHandler.php
+++ b/src/Symfony/Component/Form/NativeRequestHandler.php
@@ -114,7 +114,7 @@ class NativeRequestHandler implements RequestHandlerInterface
         }
 
         // Don't auto-submit the form unless at least one field is present.
-        if ('' === $name && \count(array_intersect_key($data, $form->all())) <= 0) {
+        if ('' === $name && !array_intersect_key($data, $form->all())) {
             return;
         }
 

--- a/src/Symfony/Component/HttpFoundation/AcceptHeaderItem.php
+++ b/src/Symfony/Component/HttpFoundation/AcceptHeaderItem.php
@@ -50,7 +50,7 @@ class AcceptHeaderItem
     public function __toString(): string
     {
         $string = $this->value.($this->quality < 1 ? ';q='.$this->quality : '');
-        if (\count($this->attributes) > 0) {
+        if ($this->attributes) {
             $string .= '; '.HeaderUtils::toString($this->attributes, ';');
         }
 

--- a/src/Symfony/Component/HttpFoundation/HeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/HeaderBag.php
@@ -140,13 +140,13 @@ class HeaderBag implements \IteratorAggregate, \Countable, \Stringable
         if (\is_array($values)) {
             $values = array_values($values);
 
-            if (true === $replace || !isset($this->headers[$key])) {
+            if ($replace || !isset($this->headers[$key])) {
                 $this->headers[$key] = $values;
             } else {
                 $this->headers[$key] = array_merge($this->headers[$key], $values);
             }
         } else {
-            if (true === $replace || !isset($this->headers[$key])) {
+            if ($replace || !isset($this->headers[$key])) {
                 $this->headers[$key] = [$values];
             } else {
                 $this->headers[$key][] = $values;

--- a/src/Symfony/Component/HttpFoundation/RateLimiter/AbstractRequestRateLimiter.php
+++ b/src/Symfony/Component/HttpFoundation/RateLimiter/AbstractRequestRateLimiter.php
@@ -37,7 +37,7 @@ abstract class AbstractRequestRateLimiter implements PeekableRequestRateLimiterI
     private function doConsume(Request $request, int $tokens): RateLimit
     {
         $limiters = $this->getLimiters($request);
-        if (0 === \count($limiters)) {
+        if (!$limiters) {
             $limiters = [new NoLimiter()];
         }
 

--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -991,7 +991,7 @@ class Response
                 $etag = '"'.$etag.'"';
             }
 
-            $this->headers->set('ETag', (true === $weak ? 'W/' : '').$etag);
+            $this->headers->set('ETag', ($weak ? 'W/' : '').$etag);
         }
 
         return $this;
@@ -1344,7 +1344,7 @@ class Response
      */
     protected function ensureIEOverSSLCompatibility(Request $request): void
     {
-        if (false !== stripos($this->headers->get('Content-Disposition') ?? '', 'attachment') && 1 == preg_match('/MSIE (.*?);/i', $request->server->get('HTTP_USER_AGENT') ?? '', $match) && true === $request->isSecure()) {
+        if (false !== stripos($this->headers->get('Content-Disposition') ?? '', 'attachment') && 1 == preg_match('/MSIE (.*?);/i', $request->server->get('HTTP_USER_AGENT') ?? '', $match) && $request->isSecure()) {
             if ((int) preg_replace('/(MSIE )(.*?);/', '$2', $match[0]) < 9) {
                 $this->headers->remove('Cache-Control');
             }

--- a/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
@@ -206,7 +206,7 @@ class ControllerResolver implements ControllerResolverInterface
 
         $message = \sprintf('Expected method "%s" on class "%s"', $method, $className);
 
-        if (\count($alternatives) > 0) {
+        if ($alternatives) {
             $message .= \sprintf(', did you mean "%s"?', implode('", "', $alternatives));
         } else {
             $message .= \sprintf('. Available methods: "%s".', implode('", "', $collection));

--- a/src/Symfony/Component/HttpKernel/Fragment/HIncludeFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/HIncludeFragmentRenderer.php
@@ -76,7 +76,7 @@ class HIncludeFragmentRenderer extends RoutableFragmentRenderer
             $attributes['id'] = $options['id'];
         }
         $renderedAttributes = '';
-        if (\count($attributes) > 0) {
+        if ($attributes) {
             $flags = \ENT_QUOTES | \ENT_SUBSTITUTE;
             foreach ($attributes as $attribute => $value) {
                 $renderedAttributes .= \sprintf(

--- a/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
@@ -705,7 +705,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
             $key = strtolower(str_replace('HTTP_', '', $key));
 
             if ('cookie' === $key) {
-                if (\count($request->cookies->all())) {
+                if ($request->cookies->all()) {
                     return true;
                 }
             } elseif ($request->headers->has($key)) {

--- a/src/Symfony/Component/HttpKernel/HttpCache/Store.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/Store.php
@@ -80,7 +80,7 @@ class Store implements StoreInterface
 
         if (!isset($this->locks[$key])) {
             $path = $this->getPath($key);
-            if (!is_dir(\dirname($path)) && false === @mkdir(\dirname($path), 0o777, true) && !is_dir(\dirname($path))) {
+            if (!is_dir(\dirname($path)) && !@mkdir(\dirname($path), 0o777, true) && !is_dir(\dirname($path))) {
                 return $path;
             }
             $h = fopen($path, 'c');
@@ -382,7 +382,7 @@ class Store implements StoreInterface
                 return false;
             }
         } else {
-            if (!is_dir(\dirname($path)) && false === @mkdir(\dirname($path), 0o777, true) && !is_dir(\dirname($path))) {
+            if (!is_dir(\dirname($path)) && !@mkdir(\dirname($path), 0o777, true) && !is_dir(\dirname($path))) {
                 return false;
             }
 
@@ -401,7 +401,7 @@ class Store implements StoreInterface
                 return false;
             }
 
-            if (false === @rename($tmpFile, $path)) {
+            if (!@rename($tmpFile, $path)) {
                 @unlink($tmpFile);
 
                 return false;

--- a/src/Symfony/Component/HttpKernel/Profiler/FileProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/FileProfilerStorage.php
@@ -37,7 +37,7 @@ class FileProfilerStorage implements ProfilerStorageInterface
         }
         $this->folder = substr($dsn, 5);
 
-        if (!is_dir($this->folder) && false === @mkdir($this->folder, 0o777, true) && !is_dir($this->folder)) {
+        if (!is_dir($this->folder) && !@mkdir($this->folder, 0o777, true) && !is_dir($this->folder)) {
             throw new \RuntimeException(\sprintf('Unable to create the storage directory (%s).', $this->folder));
         }
     }
@@ -143,7 +143,7 @@ class FileProfilerStorage implements ProfilerStorageInterface
         if (!$profileIndexed) {
             // Create directory
             $dir = \dirname($file);
-            if (!is_dir($dir) && false === @mkdir($dir, 0o777, true) && !is_dir($dir)) {
+            if (!is_dir($dir) && !@mkdir($dir, 0o777, true) && !is_dir($dir)) {
                 throw new \RuntimeException(\sprintf('Unable to create the storage directory (%s).', $dir));
             }
         }

--- a/src/Symfony/Component/HttpKernel/Profiler/Profiler.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/Profiler.php
@@ -140,7 +140,7 @@ class Profiler implements ResetInterface
      */
     public function collect(Request $request, Response $response, ?\Throwable $exception = null): ?Profile
     {
-        if (false === $this->enabled) {
+        if (!$this->enabled) {
             return null;
         }
 

--- a/src/Symfony/Component/Intl/Resources/bin/common.php
+++ b/src/Symfony/Component/Intl/Resources/bin/common.php
@@ -46,7 +46,7 @@ function centered(string $text)
 
 function cd(string $dir): void
 {
-    if (false === chdir($dir)) {
+    if (!chdir($dir)) {
         bailout("Could not switch to directory $dir.");
     }
 }

--- a/src/Symfony/Component/Ldap/Adapter/ExtLdap/Connection.php
+++ b/src/Symfony/Component/Ldap/Adapter/ExtLdap/Connection.php
@@ -168,7 +168,7 @@ class Connection extends AbstractConnection
             }
         }
 
-        if ('tls' === $this->config['encryption'] && false === @ldap_start_tls($this->connection)) {
+        if ('tls' === $this->config['encryption'] && !@ldap_start_tls($this->connection)) {
             throw new LdapException('Could not initiate TLS connection: '.ldap_error($this->connection));
         }
     }

--- a/src/Symfony/Component/Lock/Store/FlockStore.php
+++ b/src/Symfony/Component/Lock/Store/FlockStore.php
@@ -40,7 +40,7 @@ class FlockStore implements BlockingStoreInterface, SharedLockStoreInterface
     public function __construct(?string $lockPath = null)
     {
         if (!is_dir($lockPath ??= sys_get_temp_dir())) {
-            if (false === @mkdir($lockPath, 0o777, true) && !is_dir($lockPath)) {
+            if (!@mkdir($lockPath, 0o777, true) && !is_dir($lockPath)) {
                 throw new InvalidArgumentException(\sprintf('The FlockStore directory "%s" does not exists and cannot be created.', $lockPath));
             }
         } elseif (!is_writable($lockPath)) {

--- a/src/Symfony/Component/Lock/Store/InMemoryStore.php
+++ b/src/Symfony/Component/Lock/Store/InMemoryStore.php
@@ -50,7 +50,7 @@ class InMemoryStore implements SharedLockStoreInterface
             return;
         }
 
-        if (\count($this->readLocks[$hashKey] ?? []) > 0) {
+        if ($this->readLocks[$hashKey] ?? []) {
             throw new LockConflictedException();
         }
 

--- a/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetApiTransport.php
@@ -95,7 +95,7 @@ class MailjetApiTransport extends AbstractApiTransport
         }
 
         // The response needs to contains a 'Messages' key that is an array
-        if (!\array_key_exists('Messages', $result) || !\is_array($result['Messages']) || 0 === \count($result['Messages'])) {
+        if (!\array_key_exists('Messages', $result) || !\is_array($result['Messages']) || !$result['Messages']) {
             throw new HttpTransportException(\sprintf('Unable to send an email: "%s" malformed api response.', $response->getContent(false)), $response);
         }
 

--- a/src/Symfony/Component/Mailer/Transport/AbstractApiTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/AbstractApiTransport.php
@@ -48,6 +48,6 @@ abstract class AbstractApiTransport extends AbstractHttpTransport
      */
     protected function getRecipients(Email $email, Envelope $envelope): array
     {
-        return array_filter($envelope->getRecipients(), static fn (Address $address) => false === \in_array($address, array_merge($email->getCc(), $email->getBcc()), true));
+        return array_filter($envelope->getRecipients(), static fn (Address $address) => !\in_array($address, array_merge($email->getCc(), $email->getBcc()), true));
     }
 }

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
@@ -117,13 +117,13 @@ class Connection
 
         // check for extra keys in options
         $optionsExtraKeys = array_diff(array_keys($options), array_keys(self::DEFAULT_OPTIONS));
-        if (0 < \count($optionsExtraKeys)) {
+        if ($optionsExtraKeys) {
             throw new InvalidArgumentException(\sprintf('Unknown option found: [%s]. Allowed options are [%s].', implode(', ', $optionsExtraKeys), implode(', ', array_keys(self::DEFAULT_OPTIONS))));
         }
 
         // check for extra keys in options
         $queryExtraKeys = array_diff(array_keys($query), array_keys(self::DEFAULT_OPTIONS));
-        if (0 < \count($queryExtraKeys)) {
+        if ($queryExtraKeys) {
             throw new InvalidArgumentException(\sprintf('Unknown option found in DSN: [%s]. Allowed options are [%s].', implode(', ', $queryExtraKeys), implode(', ', array_keys(self::DEFAULT_OPTIONS))));
         }
 

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpExtIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpExtIntegrationTest.php
@@ -116,7 +116,7 @@ class AmqpExtIntegrationTest extends TestCase
 
         // this should be the custom routing key message first
         $this->assertCount(1, $envelopes);
-        /** @var Envelope $envelope */
+        /* @var Envelope $envelope */
         $receiver->ack($envelopes[0]);
         $this->assertEquals($customRoutingKeyMessage, $envelopes[0]->getMessage());
 
@@ -125,7 +125,7 @@ class AmqpExtIntegrationTest extends TestCase
         // duration should be about 2 seconds
         $this->assertApproximateDuration($startTime, 2);
 
-        /** @var RedeliveryStamp|null $retryStamp */
+        /* @var RedeliveryStamp|null $retryStamp */
         // verify the stamp still exists from the last send
         $this->assertCount(1, $envelopes);
         $retryStamp = $envelopes[0]->last(RedeliveryStamp::class);
@@ -285,7 +285,7 @@ class AmqpExtIntegrationTest extends TestCase
     {
         $envelopes = [];
         $startTime = microtime(true);
-        while (0 === \count($envelopes) && $startTime + $timeout > time()) {
+        while (!$envelopes && $startTime + $timeout > time()) {
             $envelopes = iterator_to_array($receiver->get());
         }
 

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
@@ -247,7 +247,7 @@ class Connection
 
     private static function validateOptions(array $options): void
     {
-        if (0 < \count($invalidOptions = array_diff(array_keys($options), self::AVAILABLE_OPTIONS))) {
+        if ($invalidOptions = array_diff(array_keys($options), self::AVAILABLE_OPTIONS)) {
             throw new LogicException(\sprintf('Invalid option(s) "%s" passed to the AMQP Messenger transport.', implode('", "', $invalidOptions)));
         }
 
@@ -257,14 +257,14 @@ class Connection
                     continue;
                 }
 
-                if (0 < \count($invalidQueueOptions = array_diff(array_keys($queue), self::AVAILABLE_QUEUE_OPTIONS))) {
+                if ($invalidQueueOptions = array_diff(array_keys($queue), self::AVAILABLE_QUEUE_OPTIONS)) {
                     throw new LogicException(\sprintf('Invalid queue option(s) "%s" passed to the AMQP Messenger transport.', implode('", "', $invalidQueueOptions)));
                 }
             }
         }
 
         if (\is_array($options['exchange'] ?? false)
-            && 0 < \count($invalidExchangeOptions = array_diff(array_keys($options['exchange']), self::AVAILABLE_EXCHANGE_OPTIONS))) {
+            && ($invalidExchangeOptions = array_diff(array_keys($options['exchange']), self::AVAILABLE_EXCHANGE_OPTIONS))) {
             throw new LogicException(\sprintf('Invalid exchange option(s) "%s" passed to the AMQP Messenger transport.', implode('", "', $invalidExchangeOptions)));
         }
     }

--- a/src/Symfony/Component/Messenger/Bridge/Beanstalkd/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Beanstalkd/Transport/Connection.php
@@ -77,13 +77,13 @@ class Connection
 
         // check for extra keys in options
         $optionsExtraKeys = array_diff(array_keys($options), array_keys(self::DEFAULT_OPTIONS));
-        if (0 < \count($optionsExtraKeys)) {
+        if ($optionsExtraKeys) {
             throw new InvalidArgumentException(\sprintf('Unknown option found : [%s]. Allowed options are [%s].', implode(', ', $optionsExtraKeys), implode(', ', array_keys(self::DEFAULT_OPTIONS))));
         }
 
         // check for extra keys in options
         $queryExtraKeys = array_diff(array_keys($query), array_keys(self::DEFAULT_OPTIONS));
-        if (0 < \count($queryExtraKeys)) {
+        if ($queryExtraKeys) {
             throw new InvalidArgumentException(\sprintf('Unknown option found in DSN: [%s]. Allowed options are [%s].', implode(', ', $queryExtraKeys), implode(', ', array_keys(self::DEFAULT_OPTIONS))));
         }
 

--- a/src/Symfony/Component/Messenger/Command/FailedMessagesRetryCommand.php
+++ b/src/Symfony/Component/Messenger/Command/FailedMessagesRetryCommand.php
@@ -174,7 +174,7 @@ class FailedMessagesRetryCommand extends AbstractFailedMessagesCommand implement
                 }
 
                 // break the loop if all messages are consumed
-                if (0 === \count($envelopes)) {
+                if (!$envelopes) {
                     break;
                 }
 

--- a/src/Symfony/Component/Messenger/Command/FailedMessagesShowCommand.php
+++ b/src/Symfony/Component/Messenger/Command/FailedMessagesShowCommand.php
@@ -164,7 +164,7 @@ class FailedMessagesShowCommand extends AbstractFailedMessagesCommand
             $this->phpSerializer?->rejectPhpIncompleteClass();
         }
 
-        if (0 === \count($countPerClass)) {
+        if (!$countPerClass) {
             $io->success('No failed messages were found.');
 
             return;

--- a/src/Symfony/Component/Messenger/Middleware/DispatchAfterCurrentBusMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/DispatchAfterCurrentBusMiddleware.php
@@ -96,7 +96,7 @@ class DispatchAfterCurrentBusMiddleware implements MiddlewareInterface
         }
 
         $this->isRootDispatchCallRunning = false;
-        if (\count($exceptions) > 0) {
+        if ($exceptions) {
             throw new DelayedMessageHandlingException($exceptions, $returnedEnvelope);
         }
 

--- a/src/Symfony/Component/Messenger/Middleware/HandleMessageMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/HandleMessageMiddleware.php
@@ -120,7 +120,7 @@ class HandleMessageMiddleware implements MiddlewareInterface
             $this->logger?->info('No handler for message {class}', $context);
         }
 
-        if (\count($exceptions)) {
+        if ($exceptions) {
             throw new HandlerFailedException($envelope, $exceptions);
         }
 

--- a/src/Symfony/Component/Mime/Header/Headers.php
+++ b/src/Symfony/Component/Mime/Header/Headers.php
@@ -169,7 +169,7 @@ final class Headers
         $header->setMaxLineLength($this->lineLength);
         $name = strtolower($header->getName());
 
-        if (\in_array($name, self::UNIQUE_HEADERS, true) && isset($this->headers[$name]) && \count($this->headers[$name]) > 0) {
+        if (\in_array($name, self::UNIQUE_HEADERS, true) && isset($this->headers[$name]) && $this->headers[$name]) {
             throw new LogicException(\sprintf('Impossible to set header "%s" as it\'s already defined and must be unique.', $header->getName()));
         }
 

--- a/src/Symfony/Component/Notifier/Bridge/AllMySms/AllMySmsTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/AllMySms/AllMySmsTransport.php
@@ -82,7 +82,7 @@ final class AllMySmsTransport extends AbstractTransport
 
         $success = $response->toArray(false);
 
-        if (false === isset($success['smsId'])) {
+        if (!isset($success['smsId'])) {
             throw new TransportException(\sprintf('Unable to send the SMS: "%s" (%s).', $success['description'], $success['code']), $response);
         }
 

--- a/src/Symfony/Component/OptionsResolver/OptionsResolver.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolver.php
@@ -869,7 +869,7 @@ class OptionsResolver implements Options
         // Make sure that no unknown options are passed
         $diff = $this->ignoreUndefined ? [] : array_diff_key($options, $clone->defined);
 
-        if (\count($diff) > 0) {
+        if ($diff) {
             ksort($clone->defined);
             ksort($diff);
 
@@ -890,7 +890,7 @@ class OptionsResolver implements Options
         // Check whether any required option is missing
         $diff = array_diff_key($clone->required, $clone->defaults);
 
-        if (\count($diff) > 0) {
+        if ($diff) {
             ksort($diff);
 
             throw new MissingOptionsException(\sprintf(\count($diff) > 1 ? 'The required options "%s" are missing.' : 'The required option "%s" is missing.', $this->formatOptions(array_keys($diff))));
@@ -955,7 +955,7 @@ class OptionsResolver implements Options
             }
 
             if (!\is_array($value)) {
-                throw new InvalidOptionsException(\sprintf('The nested option "%s" with value %s is expected to be of type array, but is of type "%s".', $this->formatOptions([$option]), $this->formatValue($value), get_debug_type($value)));
+                throw new InvalidOptionsException(\sprintf('The nested option "%s" with value ', $this->formatOptions([$option])).$this->formatValue($value).\sprintf(' is expected to be of type array, but is of type "%s".', get_debug_type($value)));
             }
 
             // The following section must be protected from cyclic calls.
@@ -1032,13 +1032,13 @@ class OptionsResolver implements Options
                 $fmtActualValue = $this->formatValue($value);
                 $fmtAllowedTypes = implode('" or "', $this->allowedTypes[$option]);
                 $fmtProvidedTypes = implode('|', array_keys($invalidTypes));
-                $allowedContainsArrayType = \count(array_filter($this->allowedTypes[$option], static fn ($item) => str_ends_with($item, '[]'))) > 0;
+                $allowedContainsArrayType = array_filter($this->allowedTypes[$option], static fn ($item) => str_ends_with($item, '[]'));
 
                 if (\is_array($value) && $allowedContainsArrayType) {
-                    throw new InvalidOptionsException(\sprintf('The option "%s" with value %s is expected to be of type "%s", but one of the elements is of type "%s".', $this->formatOptions([$option]), $fmtActualValue, $fmtAllowedTypes, $fmtProvidedTypes));
+                    throw new InvalidOptionsException(\sprintf('The option "%s" with value ', $this->formatOptions([$option])).$fmtActualValue.\sprintf(' is expected to be of type "%s", but one of the elements is of type "%s".', $fmtAllowedTypes, $fmtProvidedTypes));
                 }
 
-                throw new InvalidOptionsException(\sprintf('The option "%s" with value %s is expected to be of type "%s", but is of type "%s".', $this->formatOptions([$option]), $fmtActualValue, $fmtAllowedTypes, $fmtProvidedTypes));
+                throw new InvalidOptionsException(\sprintf('The option "%s" with value ', $this->formatOptions([$option])).$fmtActualValue.\sprintf(' is expected to be of type "%s", but is of type "%s".', $fmtAllowedTypes, $fmtProvidedTypes));
             }
         }
 
@@ -1073,7 +1073,7 @@ class OptionsResolver implements Options
                     $this->formatValue($value)
                 );
 
-                if (\count($printableAllowedValues) > 0) {
+                if ($printableAllowedValues) {
                     $message .= \sprintf(
                         ' Accepted values are: %s.',
                         $this->formatValues($printableAllowedValues)

--- a/src/Symfony/Component/Routing/Loader/AttributeFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AttributeFileLoader.php
@@ -95,7 +95,7 @@ class AttributeFileLoader extends FileLoader
                 continue;
             }
 
-            if (true === $class && \T_STRING === $token[0]) {
+            if ($class && \T_STRING === $token[0]) {
                 return $namespace.'\\'.$token[1];
             }
 

--- a/src/Symfony/Component/Routing/RouteCompiler.php
+++ b/src/Symfony/Component/Routing/RouteCompiler.php
@@ -252,7 +252,7 @@ class RouteCompiler implements RouteCompilerInterface
 
         $prefix = $tokens[0][1];
 
-        if (isset($tokens[1][1]) && '/' !== $tokens[1][1] && false === $route->hasDefault($tokens[1][3])) {
+        if (isset($tokens[1][1]) && '/' !== $tokens[1][1] && !$route->hasDefault($tokens[1][3])) {
             $prefix .= $tokens[1][1];
         }
 

--- a/src/Symfony/Component/Security/Http/EventListener/CsrfProtectionListener.php
+++ b/src/Symfony/Component/Security/Http/EventListener/CsrfProtectionListener.php
@@ -47,7 +47,7 @@ class CsrfProtectionListener implements EventSubscriberInterface
 
         $csrfToken = new CsrfToken($badge->getCsrfTokenId(), $badge->getCsrfToken());
 
-        if (false === $this->csrfTokenManager->isTokenValid($csrfToken)) {
+        if (!$this->csrfTokenManager->isTokenValid($csrfToken)) {
             throw new InvalidCsrfTokenException('Invalid CSRF token.');
         }
 

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/CheckCredentialsListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/CheckCredentialsListenerTest.php
@@ -47,7 +47,7 @@ class CheckCredentialsListenerTest extends TestCase
             InMemoryUser::class => $hasher,
         ]);
 
-        if (false === $result) {
+        if (!$result) {
             $this->expectException(BadCredentialsException::class);
             $this->expectExceptionMessage('The presented password is invalid.');
         }
@@ -55,7 +55,7 @@ class CheckCredentialsListenerTest extends TestCase
         $credentials = new PasswordCredentials($password);
         (new CheckCredentialsListener($hasherFactory))->checkPassport($this->createEvent(new Passport(new UserBadge('wouter', fn () => $this->user), $credentials)));
 
-        if (true === $result) {
+        if ($result) {
             $this->assertTrue($credentials->isResolved());
         }
     }
@@ -86,14 +86,14 @@ class CheckCredentialsListenerTest extends TestCase
         $hasherFactory = $this->createMock(PasswordHasherFactory::class);
         $hasherFactory->expects($this->never())->method('getPasswordHasher');
 
-        if (false === $result) {
+        if (!$result) {
             $this->expectException(BadCredentialsException::class);
         }
 
         $credentials = new CustomCredentials(static fn () => $result, ['password' => 'foo']);
         (new CheckCredentialsListener($hasherFactory))->checkPassport($this->createEvent(new Passport(new UserBadge('wouter', fn () => $this->user), $credentials)));
 
-        if (true === $result) {
+        if ($result) {
             $this->assertTrue($credentials->isResolved());
         }
     }

--- a/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
@@ -231,7 +231,7 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
 
         $value = $this->parseXmlValue($node, $context);
 
-        if (!\count($data)) {
+        if (!$data) {
             return $value;
         }
 
@@ -410,7 +410,7 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
             return $this->appendNode($parentNode, $data, $format, $context, 'data');
         }
 
-        throw new NotEncodableValueException('An unexpected value could not be serialized: '.(!\is_resource($data) ? var_export($data, true) : \sprintf('%s resource', get_resource_type($data))));
+        throw new NotEncodableValueException('An unexpected value could not be serialized: '.(!\is_resource($data) ? var_export($data, true) : get_resource_type($data).' resource'));
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -338,7 +338,7 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
 
         $constructor = $this->getConstructor($data, $class, $context, $reflectionClass, $allowedAttributes);
         if ($constructor) {
-            if (true !== $constructor->isPublic()) {
+            if (!$constructor->isPublic()) {
                 return $reflectionClass->newInstanceWithoutConstructor();
             }
 

--- a/src/Symfony/Component/Serializer/Normalizer/ConstraintViolationListNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ConstraintViolationListNormalizer.php
@@ -55,7 +55,7 @@ class ConstraintViolationListNormalizer implements NormalizerInterface, Cacheabl
             $payloadFieldsToSerialize = [];
         }
 
-        if (\is_array($payloadFieldsToSerialize) && [] !== $payloadFieldsToSerialize) {
+        if (\is_array($payloadFieldsToSerialize) && $payloadFieldsToSerialize) {
             $payloadFieldsToSerialize = array_flip($payloadFieldsToSerialize);
         }
 

--- a/src/Symfony/Component/Stopwatch/StopwatchEvent.php
+++ b/src/Symfony/Component/Stopwatch/StopwatchEvent.php
@@ -85,7 +85,7 @@ class StopwatchEvent
      */
     public function stop(): static
     {
-        if (!\count($this->started)) {
+        if (!$this->started) {
             throw new \LogicException('stop() called but start() has not been called before.');
         }
 

--- a/src/Symfony/Component/Translation/Bridge/Phrase/PhraseProvider.php
+++ b/src/Symfony/Component/Translation/Bridge/Phrase/PhraseProvider.php
@@ -56,7 +56,7 @@ class PhraseProvider implements ProviderInterface
 
         foreach ($translatorBag->getCatalogues() as $catalogue) {
             foreach ($catalogue->getDomains() as $domain) {
-                if (!\count($catalogue->all($domain))) {
+                if (!$catalogue->all($domain)) {
                     continue;
                 }
 

--- a/src/Symfony/Component/Translation/Command/XliffLintCommand.php
+++ b/src/Symfony/Component/Translation/Command/XliffLintCommand.php
@@ -151,7 +151,7 @@ class XliffLintCommand extends Command
         libxml_clear_errors();
         libxml_use_internal_errors($internal);
 
-        return ['file' => $file, 'valid' => 0 === \count($errors), 'messages' => $errors];
+        return ['file' => $file, 'valid' => !$errors, 'messages' => $errors];
     }
 
     private function display(SymfonyStyle $io, array $files): int

--- a/src/Symfony/Component/Translation/Dumper/PoFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/PoFileDumper.php
@@ -53,7 +53,7 @@ class PoFileDumper extends FileDumper
             // in an ICU domain the pipe is an ordinary character, pluralization is expressed by the message itself
             $sourceRules = $isIntlDomain ? [] : $this->getStandardRules($source);
             $targetRules = $isIntlDomain ? [] : $this->getStandardRules($target);
-            if (2 == \count($sourceRules) && [] !== $targetRules) {
+            if (2 == \count($sourceRules) && $targetRules) {
                 $output .= \sprintf('msgid "%s"'."\n", $this->escape($sourceRules[0]));
                 $output .= \sprintf('msgid_plural "%s"'."\n", $this->escape($sourceRules[1]));
                 foreach ($targetRules as $i => $targetRule) {

--- a/src/Symfony/Component/Translation/Resources/bin/translation-status.php
+++ b/src/Symfony/Component/Translation/Resources/bin/translation-status.php
@@ -218,7 +218,7 @@ function printTable($translations, $verboseOutput, bool $includeCompletedLanguag
 
         if ($translation['translated'] > $translation['total']) {
             textColorRed();
-        } elseif (count($translation['mismatches']) > 0) {
+        } elseif ($translation['mismatches']) {
             textColorRed();
         } elseif ($translation['is_completed']) {
             textColorGreen();
@@ -235,7 +235,7 @@ function printTable($translations, $verboseOutput, bool $includeCompletedLanguag
         textColorNormal();
 
         $shouldBeClosed = false;
-        if (true === $verboseOutput && count($translation['missingKeys']) > 0) {
+        if ($verboseOutput && $translation['missingKeys']) {
             echo '|    Missing Translations:'.\PHP_EOL;
 
             foreach ($translation['missingKeys'] as $id => $content) {
@@ -243,7 +243,7 @@ function printTable($translations, $verboseOutput, bool $includeCompletedLanguag
             }
             $shouldBeClosed = true;
         }
-        if (true === $verboseOutput && count($translation['mismatches']) > 0) {
+        if ($verboseOutput && $translation['mismatches']) {
             echo '|    Mismatches between trans-unit id and source:'.\PHP_EOL;
 
             foreach ($translation['mismatches'] as $id => $content) {

--- a/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php
+++ b/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php
@@ -500,7 +500,7 @@ class RecursiveContextualValidator implements ContextualValidatorInterface
 
         // If no more groups should be validated for the property nodes,
         // we can safely quit
-        if (0 === \count($groups)) {
+        if (!$groups) {
             return;
         }
 
@@ -610,7 +610,7 @@ class RecursiveContextualValidator implements ContextualValidatorInterface
             $this->validateInGroup($value, $cacheKey, $metadata, $group, $context);
         }
 
-        if (0 === \count($groups)) {
+        if (!$groups) {
             return;
         }
 
@@ -634,7 +634,7 @@ class RecursiveContextualValidator implements ContextualValidatorInterface
         // The $cascadedGroups property is set, if the "Default" group is
         // overridden by a group sequence
         // See validateClassNode()
-        $cascadedGroups = null !== $cascadedGroups && \count($cascadedGroups) > 0 ? $cascadedGroups : $groups;
+        $cascadedGroups = $cascadedGroups ?: $groups;
 
         if ($value instanceof LazyProperty) {
             $value = $value->getPropertyValue();

--- a/src/Symfony/Component/WebLink/HttpHeaderSerializer.php
+++ b/src/Symfony/Component/WebLink/HttpHeaderSerializer.php
@@ -51,7 +51,7 @@ final class HttpHeaderSerializer
                     continue;
                 }
 
-                if (true === $value) {
+                if ($value) {
                     $attributesParts[] = $key;
                 }
             }

--- a/src/Symfony/Component/Workflow/Definition.php
+++ b/src/Symfony/Component/Workflow/Definition.php
@@ -98,7 +98,7 @@ final class Definition
 
     private function addPlace(string $place): void
     {
-        if (!\count($this->places)) {
+        if (!$this->places) {
             $this->initialPlaces = [$place];
         }
 

--- a/src/Symfony/Component/Workflow/Dumper/MermaidDumper.php
+++ b/src/Symfony/Component/Workflow/Dumper/MermaidDumper.php
@@ -164,7 +164,7 @@ class MermaidDumper implements DumperInterface
             $nodeStyles[] = 'stroke-width:4px';
         }
 
-        if (0 === \count($nodeStyles)) {
+        if (!$nodeStyles) {
             return '';
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues       | -
| License       | MIT

Subset of #65327 that applies to 6.4: emptiness checks written as `count($array) > 0`, `0 === count($array)`, `[] === $array` and friends are replaced by checking the array itself, and strict `true`/`false` comparisons on native `bool` operands are replaced by `$x` / `!$x`. Same rules as on 8.2: only provably plain arrays and native bools qualify, `count()` on `Countable` objects, `int|false` / `string|false` sentinels, `mixed` values, `?bool` false-forms and nullable arrays are all left untouched, and no `(bool)` casts are introduced.

Every ported hunk was re-verified against the 6.4 declarations rather than assumed safe because it applied cleanly; hunks whose operand types are wider on 6.4 were dropped.

Fabbot's exception-message rewriter false-positives on several pre-existing `throw` statements in touched files (a few more than on 8.2, since 6.4 carries older messages); they are restructured with concatenation, keeping every message byte-identical. Its codespell step also forces a `$datas` -> `$data` local-variable rename in a Filesystem test helper.

Merging 6.4 up will resolve cleanly against #65327: the overlapping hunks are content-identical.
