### PR TITLE
[Yaml] Narrow the by-ref type of $isQuotedString in evaluateScalar()

### DIFF
--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -655,7 +655,7 @@ class Inline
      *
      * @throws ParseException when object parsing support was disabled and the parser detected a PHP object or when a reference could not be resolved
      */
-    private static function evaluateScalar(ParserState $state, string $scalar, int $flags, array &$references = [], ?bool &$isQuotedString = null): mixed
+    private static function evaluateScalar(ParserState $state, string $scalar, int $flags, array &$references = [], bool &$isQuotedString = false): mixed
     {
         $isQuotedString = false;
         $scalar = trim($scalar);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

PHPStan fails on every pull request opened since #65243 with:

> Method `Symfony\Component\Yaml\Inline::evaluateScalar()` never assigns null to `&$isQuotedString` so it can be removed from the by-ref type.

It is right. Inside the method the only assignment is `$isQuotedString = false`, and the one caller that passes the argument reaches it through the branch where `$isQuoted` has already been set to `false`. `parseQuotedScalar()` assigns `false` or `true` on every path, so null never reaches it either.

The method is private, so narrowing the type is not a BC concern. The public `parseScalar()` keeps its `?bool &$isQuoted` since it is called with null.

Yaml is green at 1328 tests, and so are the two loader suites that go through this code, DependencyInjection at 298 and Routing at 179. Parsing 20 scalar shapes, quoted, plain, tagged, anchors and aliases, raises no `TypeError`.
