### PR TITLE
 Check arrays and bools directly instead of comparing them to count()/true/false/[]

### DIFF
--- a/src/Symfony/Bridge/Monolog/Handler/ServerLogHandler.php
+++ b/src/Symfony/Bridge/Monolog/Handler/ServerLogHandler.php
@@ -58,7 +58,7 @@ final class ServerLogHandler extends AbstractProcessingHandler
 
         try {
             if (!$this->socket = $this->socket ?: $this->createSocket()) {
-                return false === $this->bubble;
+                return !$this->bubble;
             }
         } finally {
             restore_error_handler();

--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationExtractCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationExtractCommand.php
@@ -199,7 +199,7 @@ class TranslationExtractCommand extends Command
             : new MergeOperation($currentCatalogue, $extractedCatalogue);
 
         // Exit if no messages found.
-        if (!\count($operation->getDomains())) {
+        if (!$operation->getDomains()) {
             $errorIo->warning('No translation messages were found.');
 
             return 0;

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
@@ -617,7 +617,7 @@ class TextDescriptor extends Descriptor
      */
     private function formatMethods(array $methods): string
     {
-        if ([] === $methods) {
+        if (!$methods) {
             $methods = ['ANY'];
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/ProfilerPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/ProfilerPass.php
@@ -26,7 +26,7 @@ class ProfilerPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {
-        if (false === $container->hasDefinition('profiler')) {
+        if (!$container->hasDefinition('profiler')) {
             return;
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -2330,7 +2330,7 @@ class Configuration implements ConfigurationInterface
                     ->info('Mailer configuration')
                     ->{$enableIfStandalone('symfony/mailer', Mailer::class)}()
                     ->validate()
-                        ->ifTrue(static fn ($v) => isset($v['dsn']) && \count($v['transports']))
+                        ->ifTrue(static fn ($v) => isset($v['dsn']) && $v['transports'])
                         ->thenInvalid('"dsn" and "transports" cannot be used together.')
                     ->end()
                     ->children()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -2353,7 +2353,7 @@ class FrameworkExtension extends Extension
         }
 
         foreach ($config['resources'] as $resourceName => $resourceStores) {
-            if (0 === \count($resourceStores)) {
+            if (!$resourceStores) {
                 continue;
             }
 

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/TwigEnvironmentPass.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/TwigEnvironmentPass.php
@@ -26,7 +26,7 @@ class TwigEnvironmentPass implements CompilerPassInterface
 
     public function process(ContainerBuilder $container): void
     {
-        if (false === $container->hasDefinition('twig')) {
+        if (!$container->hasDefinition('twig')) {
             return;
         }
 

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/TwigLoaderPass.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/TwigLoaderPass.php
@@ -25,7 +25,7 @@ class TwigLoaderPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {
-        if (false === $container->hasDefinition('twig')) {
+        if (!$container->hasDefinition('twig')) {
             return;
         }
 

--- a/src/Symfony/Component/AssetMapper/Command/ImportMapOutdatedCommand.php
+++ b/src/Symfony/Component/AssetMapper/Command/ImportMapOutdatedCommand.php
@@ -76,7 +76,7 @@ final class ImportMapOutdatedCommand extends Command
         $packages = $input->getArgument('packages');
         $packagesUpdateInfos = $this->updateChecker->getAvailableUpdates($packages);
         $packagesUpdateInfos = array_filter($packagesUpdateInfos, static fn ($packageUpdateInfo) => $packageUpdateInfo->hasUpdate());
-        if (0 === \count($packagesUpdateInfos)) {
+        if (!$packagesUpdateInfos) {
             if ('json' === $input->getOption('format')) {
                 $io->writeln('[]');
             } else {

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -258,7 +258,7 @@ class Application implements ResetInterface
      */
     public function doRun(InputInterface $input, OutputInterface $output): int
     {
-        if (true === $input->hasParameterOption(['--version', '-V'], true)) {
+        if ($input->hasParameterOption(['--version', '-V'], true)) {
             $output->writeln($this->getLongVersion());
 
             return 0;

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -180,7 +180,7 @@ class Crawler implements \Countable, \IteratorAggregate
         $base = $this->filterRelativeXPath('descendant-or-self::base')->extract(['href']);
 
         $baseHref = current($base);
-        if (\count($base) && $baseHref) {
+        if ($base && $baseHref) {
             if ($this->baseHref) {
                 $linkNode = $dom->createElement('a');
                 $linkNode->setAttribute('href', $baseHref);

--- a/src/Symfony/Component/ExpressionLanguage/Parser.php
+++ b/src/Symfony/Component/ExpressionLanguage/Parser.php
@@ -242,7 +242,7 @@ class Parser
 
                     default:
                         if ('(' === $this->stream->current->value) {
-                            if (!($this->flags & self::IGNORE_UNKNOWN_FUNCTIONS) && false === isset($this->functions[$token->value])) {
+                            if (!($this->flags & self::IGNORE_UNKNOWN_FUNCTIONS) && !isset($this->functions[$token->value])) {
                                 throw new SyntaxError(\sprintf('The function "%s" does not exist.', $token->value), $token->cursor, $this->stream->getExpression(), $token->value, array_keys($this->functions));
                             }
 

--- a/src/Symfony/Component/HttpFoundation/RequestMatcher/QueryParameterRequestMatcher.php
+++ b/src/Symfony/Component/HttpFoundation/RequestMatcher/QueryParameterRequestMatcher.php
@@ -41,6 +41,6 @@ class QueryParameterRequestMatcher implements RequestMatcherInterface
             return true;
         }
 
-        return 0 === \count(array_diff_assoc($this->parameters, $request->query->keys()));
+        return !array_diff_assoc($this->parameters, $request->query->keys());
     }
 }

--- a/src/Symfony/Component/Ldap/Adapter/ExtLdap/Connection.php
+++ b/src/Symfony/Component/Ldap/Adapter/ExtLdap/Connection.php
@@ -69,7 +69,7 @@ class Connection extends AbstractConnection
             $this->connect();
         }
 
-        if (false === @ldap_bind($this->connection, $dn, $password)) {
+        if (!@ldap_bind($this->connection, $dn, $password)) {
             $error = ldap_error($this->connection);
             ldap_get_option($this->connection, \LDAP_OPT_DIAGNOSTIC_MESSAGE, $diagnostic);
 
@@ -97,7 +97,7 @@ class Connection extends AbstractConnection
             $this->connect();
         }
 
-        if (false === @ldap_sasl_bind($this->connection, $dn, $password, $mech, $realm, $authcId, $authzId, $props)) {
+        if (!@ldap_sasl_bind($this->connection, $dn, $password, $mech, $realm, $authcId, $authzId, $props)) {
             $error = ldap_error($this->connection);
             ldap_get_option($this->connection, \LDAP_OPT_DIAGNOSTIC_MESSAGE, $diagnostic);
 

--- a/src/Symfony/Component/Ldap/Security/LdapUserProvider.php
+++ b/src/Symfony/Component/Ldap/Security/LdapUserProvider.php
@@ -68,7 +68,7 @@ class LdapUserProvider implements UserProviderInterface, PasswordUpgraderInterfa
 
         $identifier = $this->ldap->escape($identifier, '', LdapInterface::ESCAPE_FILTER);
         $query = str_replace('{user_identifier}', $identifier, $this->defaultSearch);
-        $search = $this->ldap->query($this->baseDn, $query, ['filter' => 0 == \count($this->extraFields) ? '*' : $this->extraFields]);
+        $search = $this->ldap->query($this->baseDn, $query, ['filter' => !$this->extraFields ? '*' : $this->extraFields]);
 
         $entries = $search->execute();
         $count = \count($entries);

--- a/src/Symfony/Component/Lock/Bridge/DynamoDb/Store/DynamoDbStore.php
+++ b/src/Symfony/Component/Lock/Bridge/DynamoDb/Store/DynamoDbStore.php
@@ -81,13 +81,13 @@ class DynamoDbStore implements PersistingStoreInterface
 
             // check for extra keys in options
             $optionsExtraKeys = array_diff_key($options, self::DEFAULT_OPTIONS);
-            if (0 < \count($optionsExtraKeys)) {
+            if ($optionsExtraKeys) {
                 throw new InvalidArgumentException(\sprintf('Unknown option found: [%s]. Allowed options are [%s].', implode(', ', $optionsExtraKeys), implode(', ', array_keys(self::DEFAULT_OPTIONS))));
             }
 
             // check for extra keys in query
             $queryExtraKeys = array_diff_key($query, self::DEFAULT_OPTIONS);
-            if (0 < \count($queryExtraKeys)) {
+            if ($queryExtraKeys) {
                 throw new InvalidArgumentException(\sprintf('Unknown option found in DSN: [%s]. Allowed options are [%s].', implode(', ', $queryExtraKeys), implode(', ', array_keys(self::DEFAULT_OPTIONS))));
             }
 

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Webhook/MailchimpRequestParser.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Webhook/MailchimpRequestParser.php
@@ -67,7 +67,7 @@ final class MailchimpRequestParser extends AbstractRequestParser
      */
     private function validateSignature(array $content, string $secret, string $webhookUrl, ?string $mandrillHeaderSignature): void
     {
-        if (null === $mandrillHeaderSignature || false === isset($content['mandrill_events'])) {
+        if (null === $mandrillHeaderSignature || !isset($content['mandrill_events'])) {
             throw new RejectWebhookException(400, 'Signature is wrong.');
         }
         // First add url to signedData.

--- a/src/Symfony/Component/Mailer/EventListener/SmimeEncryptedMessageListener.php
+++ b/src/Symfony/Component/Mailer/EventListener/SmimeEncryptedMessageListener.php
@@ -47,7 +47,7 @@ final class SmimeEncryptedMessageListener implements EventSubscriberInterface
             }
             $certificatePaths[] = $certificatePath;
         }
-        if (0 === \count($certificatePaths)) {
+        if (!$certificatePaths) {
             return;
         }
         $encrypter = new SMimeEncrypter($certificatePaths, $this->cipher);

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/AmazonSqsTransport.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/AmazonSqsTransport.php
@@ -73,7 +73,7 @@ class AmazonSqsTransport implements TransportInterface, KeepaliveReceiverInterfa
 
     public function send(Envelope $envelope): Envelope
     {
-        if (false === $this->handleRetries && $this->isRedelivered($envelope)) {
+        if (!$this->handleRetries && $this->isRedelivered($envelope)) {
             return $envelope;
         }
 

--- a/src/Symfony/Component/Notifier/Bridge/Bluesky/BlueskyTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Bluesky/BlueskyTransport.php
@@ -65,7 +65,7 @@ final class BlueskyTransport extends AbstractTransport
             throw new UnsupportedMessageTypeException(__CLASS__, ChatMessage::class, $message);
         }
 
-        if ([] === $this->authSession) {
+        if (!$this->authSession) {
             $this->authenticate();
         }
 
@@ -74,7 +74,7 @@ final class BlueskyTransport extends AbstractTransport
             'text' => $message->getSubject(),
             'createdAt' => $this->clock->now()->format('Y-m-d\\TH:i:s.u\\Z'),
         ];
-        if ([] !== $facets = $this->parseFacets($post['text'])) {
+        if ($facets = $this->parseFacets($post['text'])) {
             $post['facets'] = $facets;
         }
 

--- a/src/Symfony/Component/Notifier/Bridge/JoliNotif/JoliNotifTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/JoliNotif/JoliNotifTransport.php
@@ -56,7 +56,7 @@ final class JoliNotifTransport extends AbstractTransport
 
         $joliNotification = $this->buildJoliNotificationObject($message, $options);
 
-        if (false === $this->joliNotifier->send($joliNotification)) {
+        if (!$this->joliNotifier->send($joliNotification)) {
             throw new RuntimeException(\sprintf('An error occurred while sending a notification via the "%s" transport.', __CLASS__));
         }
 

--- a/src/Symfony/Component/Notifier/Bridge/Matrix/MatrixTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Matrix/MatrixTransport.php
@@ -132,7 +132,7 @@ final class MatrixTransport extends AbstractTransport
     private function updateAccountData(string $userId, string $type, array $data): void
     {
         $response = $this->request('PUT', \sprintf('/_matrix/client/v3/user/%s/account_data/%s', urlencode($userId), $type), ['json' => $data]);
-        if ([] !== $response->toArray()) {
+        if ($response->toArray()) {
             throw new TransportException('Unable to update account data.', $response);
         }
     }

--- a/src/Symfony/Component/Notifier/Bridge/Sevenio/SevenIoTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sevenio/SevenIoTransport.php
@@ -81,7 +81,7 @@ final class SevenIoTransport extends AbstractTransport
 
         $success = $response->toArray(false);
 
-        if (false === \in_array((int) $success['success'], [100, 101], true)) {
+        if (!\in_array((int) $success['success'], [100, 101], true)) {
             throw new TransportException(\sprintf('Unable to send the SMS: "%s".', $success['success']), $response);
         }
 

--- a/src/Symfony/Component/Routing/DependencyInjection/RoutingResolverPass.php
+++ b/src/Symfony/Component/Routing/DependencyInjection/RoutingResolverPass.php
@@ -27,7 +27,7 @@ class RoutingResolverPass implements CompilerPassInterface
 
     public function process(ContainerBuilder $container): void
     {
-        if (false === $container->hasDefinition('routing.resolver')) {
+        if (!$container->hasDefinition('routing.resolver')) {
             return;
         }
 

--- a/src/Symfony/Component/Security/Http/AccessToken/Oidc/OidcTokenHandler.php
+++ b/src/Symfony/Component/Security/Http/AccessToken/Oidc/OidcTokenHandler.php
@@ -274,7 +274,7 @@ final class OidcTokenHandler implements AccessTokenHandlerInterface
             $jwe = $serializerManager->unserialize($accessToken);
             $jweHeaderChecker->check($jwe, 0);
             $result = $jweDecrypter->decryptUsingKeySet($jwe, $this->decryptionKeyset, 0);
-            if (false === $result) {
+            if (!$result) {
                 throw new \RuntimeException('The JWE could not be decrypted.');
             }
 

--- a/src/Symfony/Component/Security/Http/Command/OidcTokenGenerateCommand.php
+++ b/src/Symfony/Component/Security/Http/Command/OidcTokenGenerateCommand.php
@@ -79,7 +79,7 @@ final class OidcTokenGenerateCommand extends Command
 
     private function getGenerator(?string $firewall): OidcTokenGenerator
     {
-        if (0 === \count($this->generators)) {
+        if (!$this->generators) {
             throw new \InvalidArgumentException('No OIDC token generator configured.');
         }
 

--- a/src/Symfony/Component/Security/Http/Firewall/AccessListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AccessListener.php
@@ -37,7 +37,7 @@ class AccessListener extends AbstractListener
         private AccessMapInterface $map,
         bool $exceptionOnNoToken = false,
     ) {
-        if (false !== $exceptionOnNoToken) {
+        if ($exceptionOnNoToken) {
             throw new \LogicException(\sprintf('Argument $exceptionOnNoToken of "%s()" must be set to "false".', __METHOD__));
         }
     }

--- a/src/Symfony/Component/Security/Http/Firewall/LogoutListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/LogoutListener.php
@@ -71,7 +71,7 @@ class LogoutListener extends AbstractListener
         if (null !== $this->csrfTokenManager) {
             $csrfToken = ParameterBagUtils::getRequestParameterValue($request, $this->options['csrf_parameter'], $request->request->all());
 
-            if (!\is_string($csrfToken) || false === $this->csrfTokenManager->isTokenValid(new CsrfToken($this->options['csrf_token_id'], $csrfToken))) {
+            if (!\is_string($csrfToken) || !$this->csrfTokenManager->isTokenValid(new CsrfToken($this->options['csrf_token_id'], $csrfToken))) {
                 throw new LogoutException('Invalid CSRF token.');
             }
         }

--- a/src/Symfony/Component/Serializer/Normalizer/FormErrorNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/FormErrorNormalizer.php
@@ -31,7 +31,7 @@ final class FormErrorNormalizer implements NormalizerInterface
             'errors' => $this->convertFormErrorsToArray($data),
         ];
 
-        if (0 !== \count($data->all())) {
+        if ($data->all()) {
             $error['children'] = $this->convertFormChildrenToArray($data);
         }
 

--- a/src/Symfony/Component/Stopwatch/StopwatchEvent.php
+++ b/src/Symfony/Component/Stopwatch/StopwatchEvent.php
@@ -119,7 +119,7 @@ class StopwatchEvent
      */
     public function ensureStopped(): void
     {
-        while (\count($this->started)) {
+        while ($this->started) {
             $this->stop();
         }
     }
@@ -139,7 +139,7 @@ class StopwatchEvent
      */
     public function getLastPeriod(): ?StopwatchPeriod
     {
-        if ([] === $this->periods) {
+        if (!$this->periods) {
             return null;
         }
 

--- a/src/Symfony/Component/TypeInfo/TypeFactoryTrait.php
+++ b/src/Symfony/Component/TypeInfo/TypeFactoryTrait.php
@@ -439,7 +439,7 @@ trait TypeFactoryTrait
 
             $valueType = $valueTypes ? CollectionType::mergeCollectionValueTypes($valueTypes) : Type::mixed();
 
-            return self::collection($type, $valueType, $keyType, \is_array($value) && [] !== $value && array_is_list($value));
+            return self::collection($type, $valueType, $keyType, \is_array($value) && $value && array_is_list($value));
         }
 
         if ($value instanceof \ArrayAccess) {

--- a/src/Symfony/Component/Validator/Constraints/ChoiceValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ChoiceValidator.php
@@ -60,7 +60,7 @@ class ChoiceValidator extends ConstraintValidator
             $choices = $constraint->choices;
         }
 
-        if (true !== $constraint->strict) {
+        if (!$constraint->strict) {
             throw new RuntimeException('The "strict" option of the Choice constraint should not be used.');
         }
 

--- a/src/Symfony/Component/Validator/Constraints/Composite.php
+++ b/src/Symfony/Component/Validator/Constraints/Composite.php
@@ -103,7 +103,7 @@ abstract class Composite extends Constraint
                 if (isset(((array) $constraint)['groups'])) {
                     $excessGroups = array_diff($constraint->groups, $this->groups);
 
-                    if (\count($excessGroups) > 0) {
+                    if ($excessGroups) {
                         throw new ConstraintDefinitionException(\sprintf('The group(s) "%s" passed to the constraint "%s" should also be passed to its containing constraint "%s".', implode('", "', $excessGroups), get_debug_type($constraint), get_debug_type($this)));
                     }
                 } else {

--- a/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
@@ -416,7 +416,7 @@ class ClassMetadata extends GenericMetadata implements ClassMetadataInterface
 
     public function hasGroupSequence(): bool
     {
-        return isset($this->groupSequence) && \count($this->groupSequence->groups) > 0;
+        return isset($this->groupSequence) && $this->groupSequence->groups;
     }
 
     public function getGroupSequence(): ?GroupSequence


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues       | -
| License       | MIT

The part of #65327 that applies to 7.4 but was not covered by the #65336 merge-up: emptiness checks written as `count($array) > 0`, `0 === count($array)`, `[] === $array` and friends are replaced by checking the array itself, and strict `true`/`false` comparisons on native `bool` operands are replaced by `$x` / `!$x`. Same rules as before: only provably plain arrays and native bools qualify, and no `(bool)` casts are introduced.

Every hunk was re-verified against the 7.4 declarations, including the lowest allowed versions of third-party dependencies (monolog 3, jolinotif 2.7, web-token 3.3 - all natively typed where it matters). This includes three sites that were skipped on 6.4 because their types were wider there (`ServerLogHandler::$bubble` under monolog 1, untyped `Choice::$strict` and `GroupSequence::$groups`); on 7.4 they are all natively typed.
