### PR TITLE
 Check arrays and bools directly instead of comparing them to count()/true/false/[]

### DIFF
--- a/src/Symfony/Component/Console/Input/File/InputFile.php
+++ b/src/Symfony/Component/Console/Input/File/InputFile.php
@@ -178,7 +178,7 @@ final class InputFile extends \SplFileInfo
         $target = rtrim($directory, '/\\').\DIRECTORY_SEPARATOR.$name;
 
         if (!is_dir($directory)) {
-            if (false === @mkdir($directory, 0o777, true) && !is_dir($directory)) {
+            if (!@mkdir($directory, 0o777, true) && !is_dir($directory)) {
                 throw new InvalidFileException(\sprintf('Unable to create the "%s" directory.', $directory));
             }
         } elseif (!is_writable($directory)) {

--- a/src/Symfony/Component/DependencyInjection/Compiler/MergeExtensionConfigurationPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/MergeExtensionConfigurationPass.php
@@ -44,7 +44,7 @@ class MergeExtensionConfigurationPass implements CompilerPassInterface
     public function process(ContainerBuilder $container): void
     {
         foreach ($this->extensions as $extension) {
-            if (!\count($container->getExtensionConfig($extension))) {
+            if (!$container->getExtensionConfig($extension)) {
                 $container->loadFromExtension($extension, []);
             }
         }

--- a/src/Symfony/Component/HttpKernel/HttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernel.php
@@ -85,7 +85,7 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
             if ($e instanceof RequestExceptionInterface) {
                 $e = new BadRequestHttpException($e->getMessage(), $e);
             }
-            if (false === $catch) {
+            if (!$catch) {
                 $this->finishRequest($request, $type, $controllerMetadata);
 
                 throw $e;

--- a/src/Symfony/Component/Translation/Resources/bin/translation-status.php
+++ b/src/Symfony/Component/Translation/Resources/bin/translation-status.php
@@ -142,7 +142,7 @@ function calculateTranslationStatus($originalFilePath, $translationFilePaths): a
 
 function isTranslationCompleted(array $translationStatus): bool
 {
-    return $translationStatus['total'] === $translationStatus['translated'] && 0 === count($translationStatus['mismatches']);
+    return $translationStatus['total'] === $translationStatus['translated'] && !$translationStatus['mismatches'];
 }
 
 function printTranslationStatus($originalFilePath, $translationStatus, $verboseOutput, $includeCompletedLanguages): void
@@ -204,7 +204,7 @@ function printTitle($title): void
 
 function printTable($translations, $verboseOutput, bool $includeCompletedLanguages): void
 {
-    if (0 === count($translations)) {
+    if (!$translations) {
         echo 'No translations found';
 
         return;

--- a/src/Symfony/Component/Tui/Render/Renderer.php
+++ b/src/Symfony/Component/Tui/Render/Renderer.php
@@ -204,7 +204,7 @@ final class Renderer implements WidgetRendererInterface
             // For containers, render children within inner dimensions and measure
             $children = array_values(array_filter(
                 $widget->all(),
-                fn (AbstractWidget $child) => true !== $this->resolveStyle($child)->getHidden(),
+                fn (AbstractWidget $child) => !$this->resolveStyle($child)->getHidden(),
             ));
 
             $direction = $resolvedStyle->getDirection() ?? Direction::Vertical;

--- a/src/Symfony/Component/Validator/Constraints/CssColor.php
+++ b/src/Symfony/Component/Validator/Constraints/CssColor.php
@@ -72,7 +72,7 @@ class CssColor extends Constraint
         if (!$formats) {
             $formats = self::$validationModes;
         } elseif (\is_array($formats)) {
-            if ([] === array_intersect(self::$validationModes, $formats)) {
+            if (!array_intersect(self::$validationModes, $formats)) {
                 throw new InvalidArgumentException(\sprintf('The "formats" parameter value is not valid. It must contain one or more of the following values: "%s".', $validationModesAsString));
             }
         } elseif (\is_string($formats)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues       | -
| License       | MIT

The part of #65327 that applies to 8.1 but was not covered by the #65336/#65338 merge-ups: emptiness checks written with `count()` or `[]` comparisons are replaced by checking the array itself, and strict `true`/`false` comparisons on native `bool` operands are replaced by `$x` / `!$x`. Same rules as before; every hunk re-verified against the 8.1 declarations (`getHidden(): ?bool` only gets the null-safe true-form rewrite).
