### PR TITLE
[Serializer] Restore the quotes around the resource type in the XmlEncoder exception message

### DIFF
--- a/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
@@ -429,7 +429,7 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
             return $this->appendNode($parentNode, $data, $format, $context, 'data');
         }
 
-        throw new NotEncodableValueException('An unexpected value could not be serialized: '.(!\is_resource($data) ? var_export($data, true) : get_resource_type($data).' resource'));
+        throw new NotEncodableValueException('An unexpected value could not be serialized: '.(!\is_resource($data) ? var_export($data, true) : '"'.get_resource_type($data).'" resource'));
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues       | -
| License       | MIT

The 6.4 variant of this message (restructured for Fabbot in #65336, byte-identical there) won over the 8.2 variant during the merge-up, dropping the quotes that 23c4f488112 added on 8.2 together with `XmlEncoderTest::testNotEncodableValueExceptionMessageForAResource`. This restores the quoted 8.2 message, keeping the concatenated form. Unbreaks the currently red 8.2 test suite; 6.4/7.4/8.1 assert the unquoted message and are consistent as they are.
