### PR TITLE
[Tui] Enforce the paste cap when the end marker is split across reads

### DIFF
--- a/src/Symfony/Component/Tui/Input/StdinBuffer.php
+++ b/src/Symfony/Component/Tui/Input/StdinBuffer.php
@@ -113,18 +113,18 @@ final class StdinBuffer
                     if (0 < $hold) {
                         $this->pasteBuffer .= substr($this->buffer, 0, -$hold);
                         $this->buffer = substr($this->buffer, -$hold);
-
-                        break;
+                    } else {
+                        $this->pasteBuffer .= $this->buffer;
+                        $this->buffer = '';
                     }
-
-                    $this->pasteBuffer .= $this->buffer;
-                    $this->buffer = '';
 
                     // Cap reached without an end marker: discard the partial
                     // paste and emit a visible overflow notice through the
                     // paste callback so the user can see why their paste did
                     // not land. Defense against unbounded buffering from a
-                    // missing/spoofed end marker.
+                    // missing/spoofed end marker. This has to run on the held
+                    // path too: a writer that ends every chunk with a byte of
+                    // the end marker would otherwise never reach the check.
                     if (\strlen($this->pasteBuffer) > self::MAX_PASTE_BYTES) {
                         $this->pasteBuffer = '';
                         $this->inPaste = false;
@@ -132,6 +132,14 @@ final class StdinBuffer
                         if (null !== $this->onPaste) {
                             ($this->onPaste)(self::PASTE_OVERFLOW_MESSAGE);
                         }
+
+                        // The paste is over, so the held bytes are no longer a
+                        // partial end marker: parse them as normal input.
+                        continue;
+                    }
+
+                    if (0 < $hold) {
+                        break;
                     }
                 }
                 continue;

--- a/src/Symfony/Component/Tui/Tests/Input/StdinBufferTest.php
+++ b/src/Symfony/Component/Tui/Tests/Input/StdinBufferTest.php
@@ -436,6 +436,27 @@ class StdinBufferTest extends TestCase
         $this->assertSame(['B'], $sequences, 'Buffer should accept new input after abort');
     }
 
+    public function testUnterminatedPasteAbortsAtCapWhenEveryWriteEndsWithAPartialEndMarker()
+    {
+        $buffer = new StdinBuffer();
+        $pastes = [];
+
+        $buffer->onData(static function (string $data) {});
+        $buffer->onPaste(static function (string $data) use (&$pastes) { $pastes[] = $data; });
+
+        $buffer->process("\x1b[200~");
+
+        // A lone ESC is a one-byte prefix of "\x1b[201~", so it gets held back
+        // for the next read instead of being appended to the content. The cap
+        // has to be enforced on that path too, or a writer that ends every
+        // chunk this way never reaches it and the buffer grows unbounded.
+        for ($i = 0; $i < 24 && !$pastes; ++$i) {
+            $buffer->process(str_repeat('A', 1024 * 1024)."\x1b");
+        }
+
+        $this->assertSame(['[paste exceeded 16 MiB limit]'], $pastes);
+    }
+
     public function testUnterminatedOscAbortsAtCap()
     {
         $buffer = new StdinBuffer();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

While a bracketed paste is open, `StdinBuffer::process()` holds back a trailing
partial `"\e[201~"` so that a read splitting the end marker cannot bury it in
the paste content. That branch returned early, before the `MAX_PASTE_BYTES`
check:

```php
if (0 < $hold) {
    $this->pasteBuffer .= substr($this->buffer, 0, -$hold);
    $this->buffer = substr($this->buffer, -$hold);

    break;
}
```

A lone `ESC` is a one-byte prefix of the end marker, so any writer that ends
every chunk with one keeps `$hold` at 1 and the cap is never evaluated.

Feeding 25 MiB as 1 MiB writes each ending with `ESC`, against the 16 MiB cap:

| | before | after |
| --- | --- | --- |
| overflow notice | none | `[paste exceeded 16 MiB limit]` |
| MiB buffered before the cap fired | 25 and counting | 16 |
| paste delivered on the end marker | 26 214 425 bytes | — (aborted) |

So the documented bound did not apply and `pasteBuffer` grew unbounded.

The fix runs the check on both paths and keeps holding the partial marker only
while the paste is still open, so an aborted paste leaves the held bytes to be
parsed normally. `testUnterminatedPasteAbortsAtCap()`, which covers the
non-held path and the resume-after-abort behaviour, is unaffected.
