### PR TITLE
[Messenger] Add --redispatch to messenger:failed:retry

### DIFF
--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Add `--failed-after` and `--failed-before` options to the `messenger:failed:retry`, `messenger:failed:remove` and `messenger:failed:show` commands, and a `--class-filter` option to `messenger:failed:retry`
  * `RedispatchMessage` now dispatches to the senders configured for the message (routing config or `#[AsMessage]`) when `$transportNames` is empty, instead of sending to no sender at all
  * Add a `--concurrency` option to the `messenger:consume` command to process messages in parallel
+ * Add a `--redispatch` option to the `messenger:failed:retry` command to send messages back to their transport instead of handling them in the command
 
 8.1
 ---

--- a/src/Symfony/Component/Messenger/Command/FailedMessagesRetryCommand.php
+++ b/src/Symfony/Component/Messenger/Command/FailedMessagesRetryCommand.php
@@ -25,7 +25,9 @@ use Symfony\Component\Messenger\Event\WorkerMessageReceivedEvent;
 use Symfony\Component\Messenger\Event\WorkerMessageSkipEvent;
 use Symfony\Component\Messenger\EventListener\StopWorkerOnMessageLimitListener;
 use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\NonSendableStampInterface;
 use Symfony\Component\Messenger\Stamp\SentToFailureTransportStamp;
+use Symfony\Component\Messenger\Stamp\TransportMessageIdStamp;
 use Symfony\Component\Messenger\Transport\Receiver\ListableReceiverInterface;
 use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
 use Symfony\Component\Messenger\Transport\Receiver\SingleMessageReceiver;
@@ -43,6 +45,7 @@ class FailedMessagesRetryCommand extends AbstractFailedMessagesCommand implement
 
     private bool $shouldStop = false;
     private bool $forceExit = false;
+    private bool $redispatchFailed = false;
     private ?Worker $worker = null;
 
     public function __construct(
@@ -63,6 +66,7 @@ class FailedMessagesRetryCommand extends AbstractFailedMessagesCommand implement
             ->setDefinition([
                 new InputArgument('id', InputArgument::IS_ARRAY, 'Specific message id(s) to retry'),
                 new InputOption('force', null, InputOption::VALUE_NONE, 'Force action without confirmation'),
+                new InputOption('redispatch', null, InputOption::VALUE_NONE, 'Redispatch messages to their configured transport instead of handling them synchronously'),
                 new InputOption('transport', null, InputOption::VALUE_REQUIRED, 'Use a specific failure transport', self::DEFAULT_TRANSPORT_OPTION),
                 new InputOption('keepalive', null, InputOption::VALUE_REQUIRED, 'Whether to use the transport\'s keepalive mechanism if implemented', self::DEFAULT_KEEPALIVE_INTERVAL),
                 new InputOption('class-filter', null, InputOption::VALUE_REQUIRED, 'Filter by a specific class name'),
@@ -85,6 +89,11 @@ class FailedMessagesRetryCommand extends AbstractFailedMessagesCommand implement
                 Or pass multiple ids at once to process multiple messages:
 
                 <info>php %command.full_name% {id1} {id2} {id3}</info>
+
+                Add "--redispatch" to send selected messages through the bus again, allowing
+                their configured transport to process them instead of this command:
+
+                    <info>php %command.full_name% {id1} {id2} --force --redispatch</info>
 
                 Instead of ids, messages can be selected by class name, by failure time, or by both:
 
@@ -140,6 +149,7 @@ class FailedMessagesRetryCommand extends AbstractFailedMessagesCommand implement
         $io->writeln(\sprintf('To retry all the messages, run <comment>messenger:consume %s</comment>', $failureTransportName));
 
         $shouldForce = $input->getOption('force');
+        $shouldRedispatch = $input->getOption('redispatch');
 
         if (null !== $classFilter || null !== $failedAfter || null !== $failedBefore) {
             if (!$receiver instanceof ListableReceiverInterface) {
@@ -158,14 +168,14 @@ class FailedMessagesRetryCommand extends AbstractFailedMessagesCommand implement
                 throw new RuntimeException('Message id must be passed when in non-interactive mode.');
             }
 
-            $this->runInteractive($failureTransportName, $io, $errorIo, $shouldForce);
+            $this->runInteractive($failureTransportName, $io, $errorIo, $shouldForce, $shouldRedispatch);
 
             return 0;
         }
 
-        $this->retrySpecificIds($failureTransportName, $ids, $io, $errorIo, $shouldForce);
+        $this->retrySpecificIds($failureTransportName, $ids, $io, $errorIo, $shouldForce, $shouldRedispatch);
 
-        if (!$this->shouldStop) {
+        if (!$this->shouldStop && !$this->redispatchFailed) {
             $io->success('All done!');
         }
 
@@ -199,7 +209,7 @@ class FailedMessagesRetryCommand extends AbstractFailedMessagesCommand implement
         return $this->forceExit ? 0 : false;
     }
 
-    private function runInteractive(string $failureTransportName, SymfonyStyle $io, SymfonyStyle $errorIo, bool $shouldForce): void
+    private function runInteractive(string $failureTransportName, SymfonyStyle $io, SymfonyStyle $errorIo, bool $shouldForce, bool $shouldRedispatch): void
     {
         $receiver = $this->failureTransports->get($failureTransportName);
         $count = 0;
@@ -226,23 +236,23 @@ class FailedMessagesRetryCommand extends AbstractFailedMessagesCommand implement
                     break;
                 }
 
-                $this->retrySpecificEnvelopes($envelopes, $failureTransportName, $io, $errorIo, $shouldForce);
+                $this->retrySpecificEnvelopes($envelopes, $failureTransportName, $io, $errorIo, $shouldForce, $shouldRedispatch);
             }
         } else {
             // get() and ask messages one-by-one
-            $count = $this->runWorker($failureTransportName, $receiver, $io, $errorIo, $shouldForce);
+            $count = $this->runWorker($failureTransportName, $receiver, $io, $errorIo, $shouldForce, $shouldRedispatch);
         }
 
         // avoid success message if nothing was processed
-        if (1 <= $count && !$this->shouldStop) {
+        if (1 <= $count && !$this->shouldStop && !$this->redispatchFailed) {
             $io->success('All failed messages have been handled or removed!');
         }
     }
 
-    private function runWorker(string $failureTransportName, ReceiverInterface $receiver, SymfonyStyle $io, SymfonyStyle $errorIo, bool $shouldForce): int
+    private function runWorker(string $failureTransportName, ReceiverInterface $receiver, SymfonyStyle $io, SymfonyStyle $errorIo, bool $shouldForce, bool $shouldRedispatch): int
     {
         $count = 0;
-        $listener = function (WorkerMessageReceivedEvent $messageReceivedEvent) use ($io, $errorIo, $receiver, $shouldForce, &$count) {
+        $listener = function (WorkerMessageReceivedEvent $messageReceivedEvent) use ($io, $errorIo, $receiver, $shouldForce, $shouldRedispatch, &$count) {
             ++$count;
             $envelope = $messageReceivedEvent->getEnvelope();
 
@@ -257,6 +267,29 @@ class FailedMessagesRetryCommand extends AbstractFailedMessagesCommand implement
             }
 
             if ($shouldHandle) {
+                if ($shouldRedispatch) {
+                    $messageReceivedEvent->shouldHandle(false);
+
+                    try {
+                        $this->messageBus->dispatch($envelope
+                            ->withoutStampsOfType(NonSendableStampInterface::class)
+                            ->withoutAll(SentToFailureTransportStamp::class)
+                            ->withoutAll(TransportMessageIdStamp::class)
+                        );
+                    } catch (\Throwable $e) {
+                        // the message is left on the failure transport so that
+                        // it can be redispatched once the cause is fixed
+                        $this->redispatchFailed = true;
+                        $errorIo->error(\sprintf('The message could not be redispatched and was kept in the failure transport: %s', $e->getMessage()));
+
+                        return;
+                    }
+
+                    // ack the original envelope: the failure transport needs the
+                    // stamps that were stripped from the redispatched one
+                    $receiver->ack($envelope);
+                }
+
                 return;
             }
 
@@ -286,7 +319,7 @@ class FailedMessagesRetryCommand extends AbstractFailedMessagesCommand implement
         return $count;
     }
 
-    private function retrySpecificIds(string $failureTransportName, array $ids, SymfonyStyle $io, SymfonyStyle $errorIo, bool $shouldForce): void
+    private function retrySpecificIds(string $failureTransportName, array $ids, SymfonyStyle $io, SymfonyStyle $errorIo, bool $shouldForce, bool $shouldRedispatch): void
     {
         $receiver = $this->getReceiver($failureTransportName);
 
@@ -306,7 +339,7 @@ class FailedMessagesRetryCommand extends AbstractFailedMessagesCommand implement
             }
 
             $singleReceiver = new SingleMessageReceiver($receiver, $envelope);
-            $this->runWorker($failureTransportName, $singleReceiver, $io, $errorIo, $shouldForce);
+            $this->runWorker($failureTransportName, $singleReceiver, $io, $errorIo, $shouldForce, $shouldRedispatch);
 
             if ($this->shouldStop) {
                 break;
@@ -314,13 +347,13 @@ class FailedMessagesRetryCommand extends AbstractFailedMessagesCommand implement
         }
     }
 
-    private function retrySpecificEnvelopes(array $envelopes, string $failureTransportName, SymfonyStyle $io, SymfonyStyle $errorIo, bool $shouldForce): void
+    private function retrySpecificEnvelopes(array $envelopes, string $failureTransportName, SymfonyStyle $io, SymfonyStyle $errorIo, bool $shouldForce, bool $shouldRedispatch): void
     {
         $receiver = $this->getReceiver($failureTransportName);
 
         foreach ($envelopes as $envelope) {
             $singleReceiver = new SingleMessageReceiver($receiver, $envelope);
-            $this->runWorker($failureTransportName, $singleReceiver, $io, $errorIo, $shouldForce);
+            $this->runWorker($failureTransportName, $singleReceiver, $io, $errorIo, $shouldForce, $shouldRedispatch);
 
             if ($this->shouldStop) {
                 break;

--- a/src/Symfony/Component/Messenger/Tests/Command/FailedMessagesRetryCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/FailedMessagesRetryCommandTest.php
@@ -22,6 +22,8 @@ use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\InvalidArgumentException;
 use Symfony\Component\Messenger\MessageBus;
 use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\ConsumedByWorkerStamp;
+use Symfony\Component\Messenger\Stamp\ReceivedStamp;
 use Symfony\Component\Messenger\Stamp\RedeliveryStamp;
 use Symfony\Component\Messenger\Stamp\SentToFailureTransportStamp;
 use Symfony\Component\Messenger\Stamp\TransportMessageIdStamp;
@@ -337,6 +339,82 @@ class FailedMessagesRetryCommandTest extends TestCase
 
         $tester->execute(['id' => ['10']]);
         $this->assertStringContainsString('[OK]', $tester->getDisplay());
+    }
+
+    public function testRedispatchRunWithServiceLocator()
+    {
+        $message = new \stdClass();
+        $redeliveryStamp = new RedeliveryStamp(2);
+        $envelope = new Envelope($message, [
+            new ReceivedStamp('async'),
+            new ConsumedByWorkerStamp(),
+            new SentToFailureTransportStamp('async'),
+            new TransportMessageIdStamp('failed-id'),
+            $redeliveryStamp,
+        ]);
+
+        $receiver = $this->createMock(ListableReceiverInterface::class);
+        $receiver->expects($this->once())->method('find')->with('failed-id')->willReturn($envelope);
+        $receiver->expects($this->once())->method('ack')->with($envelope);
+        $receiver->expects($this->never())->method('reject');
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects($this->once())->method('dispatch')
+            ->with($this->callback(function (Envelope $dispatchedEnvelope) use ($message, $redeliveryStamp) {
+                $this->assertSame($message, $dispatchedEnvelope->getMessage());
+                $this->assertNull($dispatchedEnvelope->last(ReceivedStamp::class));
+                $this->assertNull($dispatchedEnvelope->last(ConsumedByWorkerStamp::class));
+                $this->assertNull($dispatchedEnvelope->last(SentToFailureTransportStamp::class));
+                $this->assertNull($dispatchedEnvelope->last(TransportMessageIdStamp::class));
+                $this->assertSame($redeliveryStamp, $dispatchedEnvelope->last(RedeliveryStamp::class));
+
+                return true;
+            }))
+            ->willReturnCallback(static fn (Envelope $dispatchedEnvelope) => $dispatchedEnvelope);
+
+        $failureTransportName = 'failure_receiver';
+        $command = new FailedMessagesRetryCommand(
+            $failureTransportName,
+            new ServiceLocator([$failureTransportName => static fn () => $receiver]),
+            $bus,
+            new EventDispatcher(),
+        );
+
+        $tester = new CommandTester($command);
+        $tester->execute(['id' => ['failed-id'], '--force' => true, '--redispatch' => true]);
+
+        $this->assertStringContainsString('[OK]', $tester->getDisplay());
+    }
+
+    public function testRedispatchKeepsTheMessageWhenTheBusThrows()
+    {
+        $envelope = new Envelope(new \stdClass(), [
+            new SentToFailureTransportStamp('async'),
+            new TransportMessageIdStamp('failed-id'),
+        ]);
+
+        $receiver = $this->createMock(ListableReceiverInterface::class);
+        $receiver->expects($this->exactly(2))->method('find')->willReturn($envelope);
+        $receiver->expects($this->never())->method('ack');
+        $receiver->expects($this->never())->method('reject');
+
+        $bus = $this->createStub(MessageBusInterface::class);
+        $bus->method('dispatch')->willThrowException(new \RuntimeException('Transport is down'));
+
+        $failureTransportName = 'failure_receiver';
+        $command = new FailedMessagesRetryCommand(
+            $failureTransportName,
+            new ServiceLocator([$failureTransportName => static fn () => $receiver]),
+            $bus,
+            new EventDispatcher(),
+        );
+
+        $tester = new CommandTester($command);
+        $tester->execute(['id' => ['failed-id', 'other-id'], '--force' => true, '--redispatch' => true]);
+
+        // every id is still attempted, and the run does not report success
+        $this->assertStringContainsString('Transport is down', $tester->getDisplay());
+        $this->assertStringNotContainsString('[OK] All done!', $tester->getDisplay());
     }
 
     public function testRetryMessagesFilteredByClass()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #54186
| License       | MIT

`messenger:failed:retry` processes retried messages synchronously inside the
command, one at a time. Recovering a large failure queue is slow even when the
application has a fleet of workers sitting idle on the transports the messages
came from.

This adds a `--redispatch` option that sends the selected failed messages back
through the message bus instead, so the regular workers process them. The name
follows `RedispatchMessage`, the component's existing vocabulary for this
operation.

```
php bin/console messenger:failed:retry --force --redispatch
php bin/console messenger:failed:retry {id1} {id2} --force --redispatch
php bin/console messenger:failed:retry --class-filter='App\Message\SendEmail' --force --redispatch
```

How it behaves:

- The envelope is dispatched through the routable bus after the transport
  context of the failed run is removed: non-sendable stamps,
  `SentToFailureTransportStamp` and the failure transport's
  `TransportMessageIdStamp`. Removing `SentToFailureTransportStamp` is what
  lets a message that fails again return to the failure transport; keeping it
  would make the failure listener skip the message and lose it after its last
  retry.
- All other sendable stamps are kept: `BusNameStamp` keeps the message on its
  original bus, routing (configuration or `#[AsMessage]`) applies again, and
  the retry/error history keeps accumulating across redrives.
- The message is acknowledged on the failure transport only after the dispatch
  succeeded. If the bus throws, the error is printed, the message stays in the
  failure queue, the run continues with the remaining ids, and no success
  message is shown.
- Works with message ids, `--class-filter`, `--failed-after`/`--failed-before`,
  interactive selection and `--force`.

Points the symfony-docs PR should carry (`messenger.rst`, "Retrying Failed
Messages", `versionadded: 8.2`):

- When to reach for it: a large failure queue and running workers; the plain
  command remains the right tool to watch a handful of messages succeed
  synchronously.
- Success means re-queued, not handled. The outcome shows up in the workers,
  and a message that fails again goes through its transport's normal retry
  strategy before returning to the failure transport with a fresh error.
- The redispatch and the acknowledgement are two operations on two transports.
  A crash between them can leave the message on both, so a re-run may process
  it twice: the usual at-least-once semantics, handlers should be idempotent.
- Draining with `--force --redispatch` while workers consume fast can pick a
  message up again if it fails quickly and returns to the failure queue during
  the run.
