### PR TITLE
[Tui] Keep horizontal layout inside the available columns

### DIFF
--- a/src/Symfony/Component/Tui/Render/LayoutEngine.php
+++ b/src/Symfony/Component/Tui/Render/LayoutEngine.php
@@ -482,6 +482,16 @@ final class LayoutEngine
 
         $this->positionTracker->restoreStack($savedStack);
 
+        // Each intrinsic child is measured on its own against the full width, so
+        // several of them can add up to more than the row. Every flex sibling
+        // still ends up with at least one column, so clamp the intrinsic widths
+        // to what is left, or the row overflows and the renderer rejects it.
+        $intrinsicBudget = $availableColumns - \count($flexWeights);
+        if ($intrinsicWidths && array_sum($intrinsicWidths) > $intrinsicBudget) {
+            $intrinsicWidths = self::shrinkToFit($intrinsicWidths, $intrinsicBudget);
+            $usedColumns = array_sum($intrinsicWidths);
+        }
+
         // Second pass: distribute remaining space among flex children
         $remainingColumns = max(0, $availableColumns - $usedColumns);
         $result = [];
@@ -500,6 +510,10 @@ final class LayoutEngine
                         $allocated = $remainingColumns - $flexColumnsUsed;
                     } else {
                         $allocated = (int) floor($remainingColumns * $flexWeights[$index] / $totalFlexWeight);
+                        // Each flex child still to come keeps at least one
+                        // column, so a heavier weight cannot spend their share:
+                        // they are floored to 1 below and the row would overflow.
+                        $allocated = min($allocated, $remainingColumns - $flexColumnsUsed - ($flexCount - $flexAllocated));
                     }
                 } else {
                     $allocated = 0;
@@ -510,5 +524,51 @@ final class LayoutEngine
         }
 
         return $result;
+    }
+
+    /**
+     * Reduce widths so they sum to at most the budget, keeping one column each.
+     *
+     * Scales proportionally first, then trims the widest entries to absorb the
+     * rounding, so the narrow children keep their content.
+     *
+     * @param array<int, int> $widths
+     *
+     * @return array<int, int>
+     */
+    private static function shrinkToFit(array $widths, int $budget): array
+    {
+        $total = array_sum($widths);
+        // layoutHorizontal() caps the child count at the column count, so every
+        // child is guaranteed at least one column here.
+        $budget = max(\count($widths), $budget);
+
+        // Carry the fraction each child loses over to the next one, so the
+        // scaled widths add up to the budget instead of leaving columns unused.
+        $used = 0;
+        $carry = 0;
+        foreach ($widths as $index => $width) {
+            $carry += $width * $budget;
+            $share = intdiv($carry, $total);
+            $carry -= $share * $total;
+            $used += $widths[$index] = max(1, $share);
+        }
+
+        // The carry only overshoots by the number of entries raised to 1.
+        while ($used > $budget) {
+            $widest = null;
+            foreach ($widths as $index => $width) {
+                if ($width > 1 && (null === $widest || $width > $widths[$widest])) {
+                    $widest = $index;
+                }
+            }
+            if (null === $widest) {
+                break;
+            }
+            --$widths[$widest];
+            --$used;
+        }
+
+        return $widths;
     }
 }

--- a/src/Symfony/Component/Tui/Tests/Render/LayoutEngineTest.php
+++ b/src/Symfony/Component/Tui/Tests/Render/LayoutEngineTest.php
@@ -368,4 +368,67 @@ class LayoutEngineTest extends TestCase
         $this->assertSame('M', $line[4]);
         $this->assertSame('X', $line[43]);
     }
+
+    public function testIntrinsicChildrenAreClampedToTheAvailableColumns()
+    {
+        // Each flex: 0 child is measured on its own against the full width, so
+        // their natural widths can add up to more columns than the row has.
+        $renderer = new Renderer();
+        $root = new ContainerWidget();
+        $root->setStyle(new Style(direction: Direction::Horizontal));
+
+        foreach (['abcdefgh', 'ijklmnop'] as $text) {
+            $child = new TextWidget($text);
+            $child->setStyle(new Style(flex: 0));
+            $root->add($child);
+        }
+
+        $result = $renderer->render($root, 10, 1);
+
+        $this->assertSame(10, AnsiUtils::visibleWidth($result[0]));
+        foreach ($result as $line) {
+            $this->assertLessThanOrEqual(10, AnsiUtils::visibleWidth($line));
+        }
+    }
+
+    public function testClampedIntrinsicChildrenStillFillTheRow()
+    {
+        // Scaling the natural widths down leaves a remainder, and dropping it
+        // would cost a child a column the row has room for.
+        $renderer = new Renderer();
+        $root = new ContainerWidget();
+        $root->setStyle(new Style(direction: Direction::Horizontal));
+
+        foreach (['aaaa', 'bbbbbb', 'cc'] as $text) {
+            $child = new TextWidget($text);
+            $child->setStyle(new Style(flex: 0));
+            $root->add($child);
+        }
+
+        $result = $renderer->render($root, 10, 1);
+
+        $this->assertSame('aaabbbbbcc', AnsiUtils::stripAnsiCodes($result[0]));
+    }
+
+    public function testFlexChildrenLeaveAColumnForEachRemainingSibling()
+    {
+        // A heavier weight must not spend the columns its later siblings need:
+        // they are floored to one column each, which overflowed the row.
+        $renderer = new Renderer();
+        $root = new ContainerWidget();
+        $root->setStyle(new Style(direction: Direction::Horizontal));
+
+        foreach ([null, 3, 1, null, null] as $flex) {
+            $child = new TextWidget('Hello');
+            $child->setStyle(new Style(flex: $flex));
+            $root->add($child);
+        }
+
+        $result = $renderer->render($root, 5, 1);
+
+        $this->assertSame(5, AnsiUtils::visibleWidth($result[0]));
+        foreach ($result as $line) {
+            $this->assertLessThanOrEqual(5, AnsiUtils::visibleWidth($line));
+        }
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

A horizontal row could be allocated more columns than it has, and the renderer's
own width contract then rejected the frame:

> Widget "Symfony\Component\Tui\Widget\ContainerWidget" rendered line 0 with
> width 16, exceeding the available 10 columns.

That guard is there for misbehaving widget authors (its own test uses a custom
`OverwideWidget`), so a built-in `ContainerWidget` tripping it means an app
crashes once the terminal is narrower than its content instead of degrading.

Two independent causes, both in `computeFlexColumnWidths()`.

**Intrinsic widths were never capped as a group.** Each `flex: 0` child is
measured on its own against the full row, so two of them can each report 8
columns in a 10 column row:

```php
$root->setStyle(new Style(direction: Direction::Horizontal));
foreach (['abcdefgh', 'ijklmnop'] as $text) {
    $child = new TextWidget($text);
    $child->setStyle(new Style(flex: 0));
    $root->add($child);
}
$renderer->render($root, 10, 1);   // width 16, available 10
```

**Flex shares did not reserve room for later siblings.** Every flex child is
floored to one column, but a heavier weight could spend the columns those
children still needed. With `[null, 3, 1, null, null]` in 5 columns the
allocations were `1, 2, 1, 1` and the last child was still floored to `1`:

```php
foreach ([null, 3, 1, null, null] as $flex) {
    $child = new TextWidget('Hello');
    $child->setStyle(new Style(flex: $flex));
    $root->add($child);
}
$renderer->render($root, 5, 1);    // width 6, available 5
```

The fix reserves one column per flex sibling before distributing intrinsic
widths, shrinks the intrinsic ones proportionally into what is left, and caps
each flex share so the children after it keep their minimum. The proportional
shrink carries the fraction each child loses over to the next one, so the row
ends up exactly filled rather than one column short of it.

Fuzzing 48000 random frames (nested containers, gaps, borders, padding, tabs,
CJK, emoji, flex weights up to 8): thousands of frames violated the contract
before, **0 after**, with no change to the existing suite.
