### PR TITLE
[SecurityBundle] Add a debug:roles command to inspect the role hierarchy

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.2
 ---
 
+ * Add the `debug:roles` command to inspect the role hierarchy
  * Add `allowed_time_drift` option to the OIDC token handler configuration
  * Allow disabling the redirection on successful logout by passing `null` to the `target` option
  * Deprecate the `remember_me` option of the `form_login`, `json_login`, `login_link`, and `access_token` authenticators, as it has no effect

--- a/src/Symfony/Bundle/SecurityBundle/Command/DebugRolesCommand.php
+++ b/src/Symfony/Bundle/SecurityBundle/Command/DebugRolesCommand.php
@@ -1,0 +1,207 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Command;
+
+use Symfony\Bundle\SecurityBundle\Debug\DebugRoleHierarchy;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Security\Core\Role\RoleHierarchyInterface;
+
+#[AsCommand(name: 'debug:roles', description: 'Debug the role hierarchy configuration.')]
+final class DebugRolesCommand extends Command
+{
+    public function __construct(private readonly RoleHierarchyInterface $roleHierarchy)
+    {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->setHelp(<<<EOF
+            This <info>%command.name%</info> command display the current role hierarchy:
+
+                <info>php %command.full_name%</info>
+
+            You can pass one or multiple role names to display the effective roles:
+
+                <info>php %command.full_name% ROLE_USER</info>
+
+            To get a tree view of the inheritance, use the <info>tree</info> option:
+
+                <info>php %command.full_name% --tree</info>
+                <info>php %command.full_name% ROLE_USER --tree</info>
+
+            <comment>Note:</comment> With a custom implementation for <info>security.role_hierarchy</info>, the <info>--tree</info> option is ignored and the <info>roles</info> argument is required.
+
+            EOF
+        )
+            ->setDefinition([
+                new InputArgument('roles', ($this->isBuiltInRoleHierarchy() ? InputArgument::OPTIONAL : InputArgument::REQUIRED) | InputArgument::IS_ARRAY, 'The role(s) to resolve'),
+                new InputOption('tree', 't', InputOption::VALUE_NONE, 'Show the hierarchy in a tree view'),
+            ]);
+    }
+
+    protected function initialize(InputInterface $input, OutputInterface $output): void
+    {
+        if (!$this->isBuiltInRoleHierarchy()) {
+            $io = new SymfonyStyle($input, $output);
+
+            if ($input->getOption('tree')) {
+                $io->warning('Ignoring option "--tree" because of a custom role hierarchy implementation.');
+                $input->setOption('tree', null);
+            }
+        }
+    }
+
+    protected function interact(InputInterface $input, OutputInterface $output): void
+    {
+        if (!$this->isBuiltInRoleHierarchy() && empty($input->getArgument('roles'))) {
+            $io = new SymfonyStyle($input, $output);
+
+            $roles[] = $io->ask('Enter a role to debug', validator: static function (?string $role) {
+                $role = trim($role);
+                if (empty($role)) {
+                    throw new \RuntimeException('You must enter a non empty role name.');
+                }
+
+                return $role;
+            });
+            while ($role = trim($io->ask('Add another role? (press enter to skip)') ?? '')) {
+                $roles[] = $role;
+            }
+
+            $input->setArgument('roles', $roles);
+        }
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $roles = $input->getArgument('roles');
+
+        if (empty($roles)) {
+            // Full configuration output
+            $io->title('Current role hierarchy configuration:');
+
+            if ($input->getOption('tree')) {
+                $this->outputTree($io, $this->getBuiltInDebugHierarchy()->getHierarchy());
+            } else {
+                $this->outputMap($io, $this->getBuiltInDebugHierarchy()->getMap());
+            }
+
+            $io->comment('To show reachable roles for a given role, re-run this command with role names. (e.g. <comment>debug:roles ROLE_USER</comment>)');
+
+            return self::SUCCESS;
+        }
+
+        // Matching roles output
+        $io->title(\sprintf('Effective roles for %s:', implode(', ', array_map(static fn ($v) => \sprintf('<info>%s</info>', $v), $roles))));
+
+        if ($input->getOption('tree')) {
+            $this->outputTree($io, $this->getBuiltInDebugHierarchy()->getHierarchy($roles));
+        } else {
+            $io->listing($this->roleHierarchy->getReachableRoleNames($roles));
+        }
+
+        return self::SUCCESS;
+    }
+
+    private function outputMap(OutputInterface $output, array $map): void
+    {
+        foreach ($map as $main => $roles) {
+            if ($this->getBuiltInDebugHierarchy()->isPlaceholder($main)) {
+                $main = $this->stylePlaceholder($main);
+            }
+
+            $output->writeln(\sprintf('%s:', $main));
+            foreach ($roles as $r) {
+                $output->writeln(\sprintf('  - %s', $r));
+            }
+            $output->writeln('');
+        }
+    }
+
+    private function outputTree(OutputInterface $output, array $tree): void
+    {
+        foreach ($tree as $role => $hierarchy) {
+            $output->writeln($this->generateTree($role, $hierarchy));
+            $output->writeln('');
+        }
+    }
+
+    /**
+     * Generates a tree representation, line by line, in the tree unix style.
+     *
+     * Example output:
+     *
+     *     ROLE_A
+     *     └── ROLE_B
+     *
+     *     ROLE_C
+     *     ├── ROLE_A
+     *     │   └── ROLE_B
+     *     └── ROLE_D
+     */
+    private function generateTree(string $name, array $tree, string $indent = '', bool $last = true, bool $root = true): \Generator
+    {
+        if ($this->getBuiltInDebugHierarchy()->isPlaceholder($name)) {
+            $name = $this->stylePlaceholder($name);
+        }
+
+        if ($root) {
+            // Yield root node as it is
+            yield $name;
+        } else {
+            // Generate line in the tree:
+            // Line: [indent]├── [name]
+            // Last line: [indent]└── [name]
+            yield \sprintf('%s%s%s %s', $indent, $last ? "\u{2514}" : "\u{251c}", str_repeat("\u{2500}", 2), $name);
+
+            // Update indent for next nested:
+            // Append "|   " for a nested tree
+            // Append "    " for last nested tree
+            $indent .= ($last ? ' ' : "\u{2502}").str_repeat(' ', 3);
+        }
+
+        $i = 0;
+        $count = \count($tree);
+        foreach ($tree as $key => $value) {
+            yield from $this->generateTree($key, $value, $indent, $i === $count - 1, false);
+            ++$i;
+        }
+    }
+
+    private function stylePlaceholder(string $role): string
+    {
+        return \sprintf('<info>%s</info>', $role);
+    }
+
+    private function isBuiltInRoleHierarchy(): bool
+    {
+        return $this->roleHierarchy instanceof DebugRoleHierarchy;
+    }
+
+    private function getBuiltInDebugHierarchy(): DebugRoleHierarchy
+    {
+        if (!$this->roleHierarchy instanceof DebugRoleHierarchy) {
+            throw new \LogicException('Cannot use the built-in debug hierarchy with a custom implementation.');
+        }
+
+        return $this->roleHierarchy;
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Debug/DebugRoleHierarchy.php
+++ b/src/Symfony/Bundle/SecurityBundle/Debug/DebugRoleHierarchy.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Debug;
+
+use Symfony\Component\Security\Core\Role\RoleHierarchy;
+
+/**
+ * Extended Role Hierarchy to access inner configuration data.
+ *
+ * @author Nicolas Rigaud <squrious@protonmail.com>
+ *
+ * @internal
+ */
+final class DebugRoleHierarchy extends RoleHierarchy
+{
+    private readonly array $debugHierarchy;
+
+    public function __construct(array $hierarchy)
+    {
+        $this->debugHierarchy = $hierarchy;
+
+        parent::__construct($hierarchy);
+    }
+
+    /**
+     * Get the hierarchy tree.
+     *
+     * Example output:
+     *
+     *     [
+     *       'ROLE_A' => [
+     *          'ROLE_B' => [],
+     *          'ROLE_C' => [
+     *             'ROLE_D' => []
+     *          ]
+     *       ],
+     *       'ROLE_C' => [
+     *          'ROLE_D' => []
+     *       ]
+     *     ]
+     *
+     * @param string[] $roles Optionally restrict the tree to these roles
+     *
+     * @return array<string,array<string,array>>
+     */
+    public function getHierarchy(array $roles = []): array
+    {
+        $hierarchy = [];
+
+        foreach ($roles ?: array_keys($this->debugHierarchy) as $role) {
+            $hierarchy += $this->buildHierarchy([$role]);
+        }
+
+        return $hierarchy;
+    }
+
+    /**
+     * Get the computed role map.
+     *
+     * @return array<string,string[]>
+     */
+    public function getMap(): array
+    {
+        return $this->map;
+    }
+
+    /**
+     * Return whether a given role is processed as a placeholder.
+     */
+    public function isPlaceholder(string $role): bool
+    {
+        return \in_array($role, array_keys($this->rolePlaceholdersPatterns));
+    }
+
+    private function buildHierarchy(array $roles, array &$visited = []): array
+    {
+        $tree = [];
+        foreach ($roles as $role) {
+            $visited[] = $role;
+
+            $tree[$role] = [];
+
+            // Get placeholders matches
+            $placeholders = array_diff($this->getMatchingPlaceholders([$role]), $visited) ?? [];
+            array_push($visited, ...$placeholders);
+            $tree[$role] += $this->buildHierarchy($placeholders, $visited);
+
+            // Get regular inherited roles
+            $inherited = array_diff($this->debugHierarchy[$role] ?? [], $visited);
+            array_push($visited, ...$inherited);
+            $tree[$role] += $this->buildHierarchy($inherited, $visited);
+        }
+
+        return $tree;
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/RegisterDebugRoleHierarchyPass.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/RegisterDebugRoleHierarchyPass.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler;
+
+use Symfony\Bundle\SecurityBundle\Debug\DebugRoleHierarchy;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\Security\Core\Role\RoleHierarchy;
+
+class RegisterDebugRoleHierarchyPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->hasDefinition('security.role_hierarchy')) {
+            $container->removeDefinition('security.command.debug_role_hierarchy');
+
+            return;
+        }
+
+        $definition = $container->findDefinition('security.role_hierarchy');
+
+        if (RoleHierarchy::class === $definition->getClass()) {
+            $hierarchy = $definition->getArgument(0);
+            $definition = new Definition(DebugRoleHierarchy::class, [$hierarchy]);
+        }
+        $container->setDefinition('debug.security.role_hierarchy', $definition);
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/debug_console.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/debug_console.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Symfony\Bundle\SecurityBundle\Command\DebugFirewallCommand;
+use Symfony\Bundle\SecurityBundle\Command\DebugRolesCommand;
 
 return static function (ContainerConfigurator $container) {
     $container->services()
@@ -24,5 +25,11 @@ return static function (ContainerConfigurator $container) {
                 false,
             ])
             ->tag('console.command', ['command' => 'debug:firewall'])
+
+        ->set('security.command.debug_role_hierarchy', DebugRolesCommand::class)
+            ->args([
+                service('debug.security.role_hierarchy'),
+            ])
+            ->tag('console.command', ['command' => 'debug:roles'])
     ;
 };

--- a/src/Symfony/Bundle/SecurityBundle/SecurityBundle.php
+++ b/src/Symfony/Bundle/SecurityBundle/SecurityBundle.php
@@ -17,6 +17,7 @@ use Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler\AddSessionDomainC
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler\CleanRememberMeVerifierPass;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler\MakeFirewallsEventDispatcherTraceablePass;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler\RegisterCsrfFeaturesPass;
+use Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler\RegisterDebugRoleHierarchyPass;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler\RegisterEntryPointPass;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler\RegisterGlobalSecurityEventListenersPass;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler\RegisterLdapLocatorPass;
@@ -101,6 +102,7 @@ class SecurityBundle extends Bundle
         // execute after ResolveChildDefinitionsPass optimization pass, to ensure class names are set
         $container->addCompilerPass(new SortFirewallListenersPass(), PassConfig::TYPE_BEFORE_REMOVING);
         $container->addCompilerPass(new ReplaceDecoratedRememberMeHandlerPass(), PassConfig::TYPE_OPTIMIZE);
+        $container->addCompilerPass(new RegisterDebugRoleHierarchyPass(), PassConfig::TYPE_OPTIMIZE);
 
         $container->addCompilerPass(new AddEventAliasesPass(array_merge(
             AuthenticationEvents::ALIASES,

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Command/DebugRolesCommandTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Command/DebugRolesCommandTest.php
@@ -1,0 +1,151 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\Command;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\SecurityBundle\Command\DebugRolesCommand;
+use Symfony\Bundle\SecurityBundle\Debug\DebugRoleHierarchy;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Exception\RuntimeException;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Security\Core\Role\RoleHierarchyInterface;
+
+class DebugRolesCommandTest extends TestCase
+{
+    public function testDebugBuiltInRoleHierarchy()
+    {
+        $roleHierarchy = new DebugRoleHierarchy([
+            'ROLE_FOO' => ['ROLE_BAR'],
+            'ROLE_BAR' => ['ROLE_BAZ'],
+        ]);
+
+        $tester = $this->createCommandTester($roleHierarchy);
+
+        $tester->execute([]);
+
+        $tester->assertCommandIsSuccessful();
+        $expected = <<<EOF
+            ROLE_FOO:
+              - ROLE_BAR
+              - ROLE_BAZ
+
+            ROLE_BAR:
+              - ROLE_BAZ
+
+            EOF;
+        $this->assertStringContainsString($expected, $tester->getDisplay());
+    }
+
+    public function testDebugBuiltInHierarchyWithTreeOption()
+    {
+        $roleHierarchy = new DebugRoleHierarchy([
+            'ROLE_FOO' => ['ROLE_BAR'],
+            'ROLE_BAR' => ['ROLE_BAZ'],
+        ]);
+
+        $tester = $this->createCommandTester($roleHierarchy);
+
+        $tester->execute(['--tree' => true]);
+
+        $tester->assertCommandIsSuccessful();
+        $expected = <<<EOF
+            ROLE_FOO
+            └── ROLE_BAR
+                └── ROLE_BAZ
+
+            ROLE_BAR
+            └── ROLE_BAZ
+
+            EOF;
+        $this->assertStringContainsString($expected, $tester->getDisplay());
+    }
+
+    public function testDebugCustomRoleHierarchy()
+    {
+        $roleHierarchy = $this->createMock(RoleHierarchyInterface::class);
+        $roleHierarchy
+            ->expects($this->once())
+            ->method('getReachableRoleNames')
+            ->with(['ROLE_FOO'])
+            ->willReturn([
+                'ROLE_FOO',
+                'ROLE_BAR',
+            ]);
+        $tester = $this->createCommandTester($roleHierarchy);
+
+        $tester->execute(['roles' => ['ROLE_FOO']]);
+
+        $tester->assertCommandIsSuccessful();
+        $expected = <<<EOF
+             * ROLE_FOO
+             * ROLE_BAR
+            EOF;
+        $this->assertStringContainsString($expected, $tester->getDisplay());
+    }
+
+    public function testDebugCustomRoleHierarchyWithNoArgumentsAsksInteractively()
+    {
+        $roleHierarchy = $this->createMock(RoleHierarchyInterface::class);
+        $roleHierarchy
+            ->expects($this->once())
+            ->method('getReachableRoleNames')
+            ->with(['ROLE_FOO'])
+            ->willReturnArgument(0);
+        $tester = $this->createCommandTester($roleHierarchy);
+
+        $tester->setInputs(['ROLE_FOO', '']);
+        $tester->execute([], ['interactive' => true]);
+
+        $tester->assertCommandIsSuccessful();
+        $this->assertStringContainsString('Enter a role to debug', $tester->getDisplay());
+        $this->assertEquals(['ROLE_FOO'], $tester->getInput()->getArgument('roles'));
+    }
+
+    public function testDebugCustomRoleHierarchyRequiresRoleArgument()
+    {
+        $roleHierarchy = $this->createStub(RoleHierarchyInterface::class);
+
+        $tester = $this->createCommandTester($roleHierarchy);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Not enough arguments (missing: "roles").');
+
+        $tester->execute([], ['interactive' => false]);
+    }
+
+    public function testDebugCustomRoleHierarchyIgnoresTreeOption()
+    {
+        $roleHierarchy = $this->createMock(RoleHierarchyInterface::class);
+        $roleHierarchy
+            ->expects($this->once())
+            ->method('getReachableRoleNames')
+            ->with(['ROLE_FOO'])
+            ->willReturnArgument(0);
+
+        $tester = $this->createCommandTester($roleHierarchy);
+
+        $tester->execute(['roles' => ['ROLE_FOO'], '--tree' => true]);
+
+        $tester->assertCommandIsSuccessful();
+        $this->assertNull($tester->getInput()->getOption('tree'));
+        $this->assertStringContainsString('Ignoring option "--tree"', $tester->getDisplay());
+    }
+
+    private function createCommandTester(RoleHierarchyInterface $roleHierarchy): CommandTester
+    {
+        $application = new Application();
+        $command = new DebugRolesCommand($roleHierarchy);
+        $application->addCommand($command);
+
+        return new CommandTester($command);
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Debug/DebugRoleHierarchyTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Debug/DebugRoleHierarchyTest.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\Debug;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\SecurityBundle\Debug\DebugRoleHierarchy;
+
+class DebugRoleHierarchyTest extends TestCase
+{
+    public function testBuildHierarchy()
+    {
+        $hierarchy = [
+            'ROLE_FOO' => ['ROLE_BAR'],
+            'ROLE_FOO_BAR' => ['ROLE_BAZ'],
+        ];
+
+        $debugRoleHierarchy = new DebugRoleHierarchy($hierarchy);
+
+        $this->assertNotEmpty($debugRoleHierarchy->getMap());
+        $this->assertEquals([
+            'ROLE_FOO' => [
+                'ROLE_BAR' => [],
+            ],
+            'ROLE_FOO_BAR' => [
+                'ROLE_BAZ' => [],
+            ],
+        ], $debugRoleHierarchy->getHierarchy());
+    }
+
+    public function testBuildHierarchyWithPlaceholders()
+    {
+        $debugRoleHierarchy = new DebugRoleHierarchy([
+            'ROLE_FOOBAR' => ['ROLE_QUX'],
+            'ROLE_FOO_*' => ['ROLE_FOOBAR'],
+            'ROLE_BAR_*' => ['ROLE_BAR_FOO'],
+            'ROLE_BAZ_*' => ['ROLE_FOO_BAR'],
+        ]);
+
+        foreach (['ROLE_FOO_*', 'ROLE_BAR_*', 'ROLE_BAZ_*'] as $placeholder) {
+            $this->assertTrue($debugRoleHierarchy->isPlaceholder($placeholder));
+        }
+        $this->assertFalse($debugRoleHierarchy->isPlaceholder('ROLE_FOOBAR'));
+
+        // Test full hierarchy tree
+        $this->assertEquals([
+            'ROLE_FOOBAR' => [
+                'ROLE_QUX' => [],
+            ],
+            'ROLE_FOO_*' => [
+                'ROLE_FOOBAR' => [
+                    'ROLE_QUX' => [],
+                ],
+            ],
+            'ROLE_BAR_*' => [
+                'ROLE_BAR_FOO' => [],
+            ],
+            'ROLE_BAZ_*' => [
+                'ROLE_FOO_BAR' => [
+                    'ROLE_FOO_*' => [
+                        'ROLE_FOOBAR' => [
+                            'ROLE_QUX' => [],
+                        ],
+                    ],
+                ],
+            ],
+        ], $debugRoleHierarchy->getHierarchy());
+
+        // Test hierarchy tree for given roles
+        $this->assertEquals([
+            'ROLE_BAZ_A' => [
+                'ROLE_BAZ_*' => [
+                    'ROLE_FOO_BAR' => [
+                        'ROLE_FOO_*' => [
+                            'ROLE_FOOBAR' => [
+                                'ROLE_QUX' => [],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'ROLE_FOO_A' => [
+                'ROLE_FOO_*' => [
+                    'ROLE_FOOBAR' => [
+                        'ROLE_QUX' => [],
+                    ],
+                ],
+            ],
+        ], $debugRoleHierarchy->getHierarchy(['ROLE_BAZ_A', 'ROLE_FOO_A']));
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -27,7 +27,7 @@
         "symfony/http-kernel": "^7.4|^8.0",
         "symfony/http-foundation": "^7.4|^8.0",
         "symfony/password-hasher": "^7.4|^8.0",
-        "symfony/security-core": "^7.4|^8.0",
+        "symfony/security-core": "^8.2",
         "symfony/security-csrf": "^8.2",
         "symfony/security-http": "^8.2",
         "symfony/service-contracts": "^2.5|^3"

--- a/src/Symfony/Component/Security/Core/Role/RoleHierarchy.php
+++ b/src/Symfony/Component/Security/Core/Role/RoleHierarchy.php
@@ -24,7 +24,7 @@ class RoleHierarchy implements RoleHierarchyInterface
      *
      * @var array<string, string>
      */
-    private array $rolePlaceholdersPatterns = [];
+    protected private(set) array $rolePlaceholdersPatterns = [];
 
     /**
      * @param array<string, list<string>> $hierarchy
@@ -126,7 +126,7 @@ class RoleHierarchy implements RoleHierarchyInterface
      *
      * @return list<string>
      */
-    private function getMatchingPlaceholders(array $roles): array
+    protected function getMatchingPlaceholders(array $roles): array
     {
         $matching = [];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

Split out of #52099, which mixed two features. This is the second half, and it builds on the first: it needs the placeholder support that #52099 adds, so it should be merged after it.

Adds `debug:roles`, which answers "what does this role actually grant" without reading the configuration by hand.

```
php bin/console debug:roles
php bin/console debug:roles ROLE_USER
php bin/console debug:roles ROLE_USER --tree
```

Without arguments it lists the whole hierarchy. With roles, it resolves what they reach. With `--tree` it shows the inheritance path that leads there rather than a flat list.

When `security.role_hierarchy` is a custom `RoleHierarchyInterface` implementation, it is used as is: the command can then only report reachable role names, so `--tree` is ignored and the `roles` argument becomes required. A `RegisterDebugRoleHierarchyPass` registers the debug wrapper only when the built-in `RoleHierarchy` is in use.

`DebugRoleHierarchy` extends `RoleHierarchy` to read the placeholder patterns it needs for the tree view, so this PR widens `RoleHierarchy::$rolePlaceholdersPatterns` and `RoleHierarchy::getMatchingPlaceholders()` from private to protected. #52099 keeps them private, so that no API is exposed unless this command is taken.

Documentation should cover: the three invocations, the `--tree` option, and the reduced output on a custom role hierarchy.

Original work by @squrious.

