### PR TITLE
[DoctrineBridge] Deprecate `DoctrinePingConnectionMiddleware` in favor of the new `DoctrineDbalPingConnectionMiddleware`, add `DoctrineDbalTransactionMiddleware`

### DIFF
--- a/UPGRADE-8.2.md
+++ b/UPGRADE-8.2.md
@@ -25,13 +25,17 @@ DoctrineBridge
    association and the default `findBy` repository method is used. Such fields were silently validated against a
    query that could not match. Use the `repositoryMethod` option to provide a method that can query them
  * Deprecate `DoctrineCloseConnectionMiddleware` in favor of `DoctrineDbalCloseConnectionMiddleware`,
-   and `DoctrineOpenTransactionLoggerMiddleware` in favor of `DoctrineDbalOpenTransactionLoggerMiddleware`.
+   `DoctrineOpenTransactionLoggerMiddleware` in favor of `DoctrineDbalOpenTransactionLoggerMiddleware`,
+   and `DoctrinePingConnectionMiddleware` in favor of `DoctrineDbalPingConnectionMiddleware`.
    Those new middlewares target DBAL connections instead of entity managers. They are instantiated with a
    `ConnectionRegistry` instead of a `ManagerRegistry`, and connection names (either one or a list) instead
-   of an entity manager name. Passing no name now targets every DBAL connection, where the deprecated middlewares
-   targeted the connection of the default entity manager. Beware that `DoctrineDbalOpenTransactionLoggerMiddleware`
+   of an entity manager name. Passing no name now targets every DBAL connection, where the deprecated close and
+   logger middlewares targeted the connection of the default entity manager, and the deprecated ping middleware
+   targeted the connections of every entity manager. Beware that `DoctrineDbalOpenTransactionLoggerMiddleware`
    takes its logger as second argument and its connection names as third, where
-   `DoctrineOpenTransactionLoggerMiddleware` took the entity manager name as second argument and its logger as third
+   `DoctrineOpenTransactionLoggerMiddleware` took the entity manager name as second argument and its logger as third.
+   Also note that `DoctrineDbalPingConnectionMiddleware` does not reset closed entity managers as its deprecated
+   counterpart did: workers already reset them between messages
 
 Form
 ----

--- a/src/Symfony/Bridge/Doctrine/CHANGELOG.md
+++ b/src/Symfony/Bridge/Doctrine/CHANGELOG.md
@@ -9,6 +9,8 @@ CHANGELOG
  * Allow using closures with the `#[MapEntity]` attribute
  * Deprecate `DoctrineCloseConnectionMiddleware` in favor of the new `DoctrineDbalCloseConnectionMiddleware`
  * Deprecate `DoctrineOpenTransactionLoggerMiddleware` in favor of the new `DoctrineDbalOpenTransactionLoggerMiddleware`
+ * Deprecate `DoctrinePingConnectionMiddleware` in favor of the new `DoctrineDbalPingConnectionMiddleware`
+ * Add `DoctrineDbalTransactionMiddleware` to wrap all handlers in a single DBAL transaction without requiring the ORM
 
 8.1
 ---

--- a/src/Symfony/Bridge/Doctrine/Messenger/DoctrineDbalPingConnectionMiddleware.php
+++ b/src/Symfony/Bridge/Doctrine/Messenger/DoctrineDbalPingConnectionMiddleware.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Messenger;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception as DBALException;
+use Doctrine\Persistence\ConnectionRegistry;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Middleware\StackInterface;
+use Symfony\Component\Messenger\Stamp\ConsumedByWorkerStamp;
+
+/**
+ * Checks whether connections are still open and reconnects them otherwise.
+ *
+ * @author Fuong <insidestyles@gmail.com>
+ */
+class DoctrineDbalPingConnectionMiddleware extends AbstractDoctrineDbalMiddleware
+{
+    /** @var list<string> */
+    private array $connectionNames;
+
+    /**
+     * @param list<string>|string $connectionNames or none to ping them all
+     */
+    public function __construct(ConnectionRegistry $connectionRegistry, array|string $connectionNames = [])
+    {
+        parent::__construct($connectionRegistry);
+
+        $this->connectionNames = (array) $connectionNames;
+    }
+
+    public function handle(Envelope $envelope, StackInterface $stack): Envelope
+    {
+        if (null !== $envelope->last(ConsumedByWorkerStamp::class)) {
+            // Ping every connection and let healthy ones proceed even if another one failed.
+            // The first failure is rethrown at the end.
+            $firstFailure = null;
+            foreach ($this->getConnections($this->connectionNames) as $connection) {
+                try {
+                    $this->pingConnection($connection);
+                } catch (DBALException $e) {
+                    $firstFailure ??= $e;
+                }
+            }
+
+            if (null !== $firstFailure) {
+                throw $firstFailure;
+            }
+        }
+
+        return $stack->next()->handle($envelope, $stack);
+    }
+
+    private function pingConnection(Connection $connection): void
+    {
+        if (!$connection->isConnected()) {
+            return;
+        }
+
+        try {
+            $this->executeDummySql($connection);
+        } catch (DBALException) {
+            $connection->close();
+            // Attempt to reestablish the lazy connection by sending another query.
+            $this->executeDummySql($connection);
+        }
+    }
+
+    /**
+     * @throws DBALException
+     */
+    private function executeDummySql(Connection $connection): void
+    {
+        $connection->executeQuery($connection->getDatabasePlatform()->getDummySelectSQL());
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Messenger/DoctrineDbalTransactionMiddleware.php
+++ b/src/Symfony/Bridge/Doctrine/Messenger/DoctrineDbalTransactionMiddleware.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Messenger;
+
+use Doctrine\Persistence\ConnectionRegistry;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\HandlerFailedException;
+use Symfony\Component\Messenger\Middleware\StackInterface;
+use Symfony\Component\Messenger\Stamp\HandledStamp;
+
+/**
+ * Wraps all handlers in a single DBAL transaction.
+ *
+ * Unlike DoctrineTransactionMiddleware, this middleware does not flush any
+ * entity manager before committing: flushing is up to the handlers.
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class DoctrineDbalTransactionMiddleware extends AbstractDoctrineDbalMiddleware
+{
+    public function __construct(
+        ConnectionRegistry $connectionRegistry,
+        private readonly ?string $connectionName = null,
+    ) {
+        parent::__construct($connectionRegistry);
+    }
+
+    public function handle(Envelope $envelope, StackInterface $stack): Envelope
+    {
+        $connection = $this->getConnection($this->connectionName);
+
+        $connection->beginTransaction();
+
+        $success = false;
+        try {
+            $envelope = $stack->next()->handle($envelope, $stack);
+            $connection->commit();
+
+            $success = true;
+
+            return $envelope;
+        } catch (\Throwable $exception) {
+            if ($exception instanceof HandlerFailedException) {
+                // Remove all HandledStamp from the envelope so the retry will execute all handlers again.
+                // When a handler fails, the queries of allegedly successful previous handlers just got rolled back.
+                throw new HandlerFailedException($exception->getEnvelope()->withoutAll(HandledStamp::class), $exception->getWrappedExceptions());
+            }
+
+            throw $exception;
+        } finally {
+            if (!$success && $connection->isTransactionActive()) {
+                $connection->rollBack();
+            }
+        }
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Messenger/DoctrinePingConnectionMiddleware.php
+++ b/src/Symfony/Bridge/Doctrine/Messenger/DoctrinePingConnectionMiddleware.php
@@ -18,10 +18,14 @@ use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Middleware\StackInterface;
 use Symfony\Component\Messenger\Stamp\ConsumedByWorkerStamp;
 
+trigger_deprecation('symfony/doctrine-bridge', '8.2', 'The "%s" class is deprecated, use "%s" instead.', DoctrinePingConnectionMiddleware::class, DoctrineDbalPingConnectionMiddleware::class);
+
 /**
  * Checks whether the connection is still open or reconnects otherwise.
  *
  * @author Fuong <insidestyles@gmail.com>
+ *
+ * @deprecated since Symfony 8.2, use DoctrineDbalPingConnectionMiddleware instead
  */
 class DoctrinePingConnectionMiddleware extends AbstractDoctrineMiddleware
 {

--- a/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrineDbalPingConnectionMiddlewareTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrineDbalPingConnectionMiddlewareTest.php
@@ -1,0 +1,177 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Messenger;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception as DBALException;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Result;
+use Doctrine\Persistence\ConnectionRegistry;
+use Symfony\Bridge\Doctrine\Messenger\DoctrineDbalPingConnectionMiddleware;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
+use Symfony\Component\Messenger\Stamp\ConsumedByWorkerStamp;
+use Symfony\Component\Messenger\Test\Middleware\MiddlewareTestCase;
+
+class DoctrineDbalPingConnectionMiddlewareTest extends MiddlewareTestCase
+{
+    public function testMiddlewareReconnectsWhenPingFails()
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->method('isConnected')->willReturn(true);
+        $connection->method('getDatabasePlatform')->willReturn($this->mockPlatform());
+        $connection->expects($this->exactly(2))
+            ->method('executeQuery')
+            ->willReturnCallback(function () {
+                static $counter = 0;
+
+                if (1 === ++$counter) {
+                    throw $this->createStub(DBALException::class);
+                }
+
+                return $this->createStub(Result::class);
+            });
+        $connection->expects($this->once())->method('close');
+
+        $connectionRegistry = $this->createStub(ConnectionRegistry::class);
+        $connectionRegistry->method('getConnection')->willReturn($connection);
+
+        $middleware = new DoctrineDbalPingConnectionMiddleware($connectionRegistry, 'default');
+
+        $envelope = new Envelope(new \stdClass(), [
+            new ConsumedByWorkerStamp(),
+        ]);
+        $middleware->handle($envelope, $this->getStackMock());
+    }
+
+    public function testMiddlewarePingsEveryConnectionWhenPassedNoName()
+    {
+        $fooConnection = $this->connectionExpectingOnePing();
+        $barConnection = $this->connectionExpectingOnePing();
+
+        $connectionRegistry = $this->createStub(ConnectionRegistry::class);
+        $connectionRegistry->method('getConnectionNames')->willReturn([
+            'foo' => 'doctrine.dbal.foo_connection',
+            'bar' => 'doctrine.dbal.bar_connection',
+        ]);
+        $connectionRegistry->method('getConnection')->willReturnMap([
+            ['foo', $fooConnection],
+            ['bar', $barConnection],
+        ]);
+
+        $middleware = new DoctrineDbalPingConnectionMiddleware($connectionRegistry);
+
+        $envelope = new Envelope(new \stdClass(), [
+            new ConsumedByWorkerStamp(),
+        ]);
+        $middleware->handle($envelope, $this->getStackMock());
+    }
+
+    public function testMiddlewarePingsHealthyConnectionsWhenAnotherOneFails()
+    {
+        $failing = $this->createMock(Connection::class);
+        $failing->method('isConnected')->willReturn(true);
+        $failing->method('getDatabasePlatform')->willReturn($this->mockPlatform());
+        $failing->expects($this->exactly(2))
+            ->method('executeQuery')
+            ->willThrowException($this->createStub(DBALException::class));
+        $failing->expects($this->once())->method('close');
+
+        $healthy = $this->connectionExpectingOnePing();
+
+        $connectionRegistry = $this->createStub(ConnectionRegistry::class);
+        $connectionRegistry->method('getConnection')->willReturnMap([
+            ['broken', $failing],
+            ['healthy', $healthy],
+        ]);
+
+        $middleware = new DoctrineDbalPingConnectionMiddleware($connectionRegistry, ['broken', 'healthy']);
+
+        $envelope = new Envelope(new \stdClass(), [
+            new ConsumedByWorkerStamp(),
+        ]);
+
+        $this->expectException(DBALException::class);
+
+        $middleware->handle($envelope, $this->getStackMock(false));
+    }
+
+    public function testMiddlewareSkipsPingWhenConnectionIsNotConnected()
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->method('isConnected')->willReturn(false);
+        $connection->expects($this->never())->method('executeQuery');
+        $connection->expects($this->never())->method('close');
+
+        $connectionRegistry = $this->createStub(ConnectionRegistry::class);
+        $connectionRegistry->method('getConnection')->willReturn($connection);
+
+        $middleware = new DoctrineDbalPingConnectionMiddleware($connectionRegistry, 'default');
+
+        $envelope = new Envelope(new \stdClass(), [
+            new ConsumedByWorkerStamp(),
+        ]);
+        $middleware->handle($envelope, $this->getStackMock());
+    }
+
+    public function testMiddlewareDoesntPingInNonWorkerContext()
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->expects($this->never())->method('executeQuery');
+        $connection->expects($this->never())->method('close');
+
+        $connectionRegistry = $this->createStub(ConnectionRegistry::class);
+        $connectionRegistry->method('getConnection')->willReturn($connection);
+
+        $middleware = new DoctrineDbalPingConnectionMiddleware($connectionRegistry, 'default');
+
+        $middleware->handle(new Envelope(new \stdClass()), $this->getStackMock());
+    }
+
+    public function testUnknownConnectionThrowsUnrecoverableException()
+    {
+        $connectionRegistry = $this->createMock(ConnectionRegistry::class);
+        $connectionRegistry
+            ->expects($this->once())
+            ->method('getConnection')
+            ->with('unknown_connection')
+            ->willThrowException(new \InvalidArgumentException());
+
+        $middleware = new DoctrineDbalPingConnectionMiddleware($connectionRegistry, 'unknown_connection');
+
+        $envelope = new Envelope(new \stdClass(), [
+            new ConsumedByWorkerStamp(),
+        ]);
+
+        $this->expectException(UnrecoverableMessageHandlingException::class);
+
+        $middleware->handle($envelope, $this->getStackMock(false));
+    }
+
+    private function mockPlatform(): AbstractPlatform
+    {
+        $platform = $this->createStub(AbstractPlatform::class);
+        $platform->method('getDummySelectSQL')->willReturn('SELECT 1');
+
+        return $platform;
+    }
+
+    private function connectionExpectingOnePing(): Connection
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->method('isConnected')->willReturn(true);
+        $connection->method('getDatabasePlatform')->willReturn($this->mockPlatform());
+        $connection->expects($this->once())->method('executeQuery');
+
+        return $connection;
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrineDbalTransactionMiddlewareTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrineDbalTransactionMiddlewareTest.php
@@ -1,0 +1,115 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Messenger;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\Persistence\ConnectionRegistry;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Bridge\Doctrine\Messenger\DoctrineDbalTransactionMiddleware;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\HandlerFailedException;
+use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
+use Symfony\Component\Messenger\Stamp\HandledStamp;
+use Symfony\Component\Messenger\Test\Middleware\MiddlewareTestCase;
+
+class DoctrineDbalTransactionMiddlewareTest extends MiddlewareTestCase
+{
+    private MockObject&Connection $connection;
+    private DoctrineDbalTransactionMiddleware $middleware;
+
+    protected function setUp(): void
+    {
+        $this->connection = $this->createMock(Connection::class);
+
+        $connectionRegistry = $this->createStub(ConnectionRegistry::class);
+        $connectionRegistry->method('getConnection')->willReturn($this->connection);
+
+        $this->middleware = new DoctrineDbalTransactionMiddleware($connectionRegistry);
+    }
+
+    public function testMiddlewareWrapsInTransaction()
+    {
+        $this->connection->expects($this->once())->method('beginTransaction');
+        $this->connection->expects($this->once())->method('commit');
+
+        $this->middleware->handle(new Envelope(new \stdClass()), $this->getStackMock());
+    }
+
+    public function testTransactionIsRolledBackOnException()
+    {
+        $this->connection->expects($this->once())->method('beginTransaction');
+        $this->connection->expects($this->once())->method('isTransactionActive')->willReturn(true);
+        $this->connection->expects($this->once())->method('rollBack');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Thrown from next middleware.');
+
+        $this->middleware->handle(new Envelope(new \stdClass()), $this->getThrowingStackMock());
+    }
+
+    public function testExceptionInRollBackDoesNotHidePreviousException()
+    {
+        $this->connection->expects($this->once())->method('beginTransaction');
+        $this->connection->expects($this->once())->method('isTransactionActive')->willReturn(true);
+        $this->connection->expects($this->once())->method('rollBack')->willThrowException(new \RuntimeException('Thrown from rollBack.'));
+
+        try {
+            $this->middleware->handle(new Envelope(new \stdClass()), $this->getThrowingStackMock());
+        } catch (\Throwable $exception) {
+        }
+
+        self::assertNotNull($exception);
+        self::assertInstanceOf(\RuntimeException::class, $exception);
+        self::assertSame('Thrown from rollBack.', $exception->getMessage());
+
+        $previous = $exception->getPrevious();
+        self::assertNotNull($previous);
+        self::assertInstanceOf(\RuntimeException::class, $previous);
+        self::assertSame('Thrown from next middleware.', $previous->getMessage());
+    }
+
+    public function testHandledStampsAreRemovedOnHandlerFailure()
+    {
+        $this->connection->expects($this->once())->method('beginTransaction');
+        $this->connection->expects($this->once())->method('isTransactionActive')->willReturn(true);
+        $this->connection->expects($this->once())->method('rollBack');
+
+        $envelope = new Envelope(new \stdClass(), [new HandledStamp('done', 'first_handler')]);
+        $wrappedException = new \RuntimeException('Thrown from a handler.');
+
+        try {
+            $this->middleware->handle($envelope, $this->getThrowingStackMock(new HandlerFailedException($envelope, ['second_handler' => $wrappedException])));
+
+            $this->fail('HandlerFailedException was not thrown.');
+        } catch (HandlerFailedException $exception) {
+            self::assertSame([], $exception->getEnvelope()->all(HandledStamp::class));
+            self::assertSame(['second_handler' => $wrappedException], $exception->getWrappedExceptions());
+        }
+    }
+
+    public function testUnknownConnectionThrowsUnrecoverableException()
+    {
+        $this->connection->expects($this->never())->method('beginTransaction');
+        $connectionRegistry = $this->createMock(ConnectionRegistry::class);
+        $connectionRegistry
+            ->expects($this->once())
+            ->method('getConnection')
+            ->with('unknown_connection')
+            ->willThrowException(new \InvalidArgumentException());
+
+        $middleware = new DoctrineDbalTransactionMiddleware($connectionRegistry, 'unknown_connection');
+
+        $this->expectException(UnrecoverableMessageHandlingException::class);
+
+        $middleware->handle(new Envelope(new \stdClass()), $this->getStackMock(false));
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrinePingConnectionMiddlewareTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrinePingConnectionMiddlewareTest.php
@@ -17,12 +17,16 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Result;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ManagerRegistry;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use Symfony\Bridge\Doctrine\Messenger\DoctrinePingConnectionMiddleware;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException;
 use Symfony\Component\Messenger\Stamp\ConsumedByWorkerStamp;
 use Symfony\Component\Messenger\Test\Middleware\MiddlewareTestCase;
 
+#[Group('legacy')]
+#[IgnoreDeprecations]
 class DoctrinePingConnectionMiddlewareTest extends MiddlewareTestCase
 {
     private string $entityManagerName = 'default';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Issues        | Fix #38988
| License       | MIT

Follow-up to #65302 and #65329, porting the two remaining Messenger middlewares to DBAL:

- `DoctrineDbalPingConnectionMiddleware` takes a `ConnectionRegistry` and connection name(s), or none to ping every DBAL connection. It keeps the "ping every connection, let healthy ones proceed, rethrow the first failure" semantics, but drops the entity-manager reset: workers already reset closed managers between messages, see the discussion in #38988. `DoctrinePingConnectionMiddleware` is deprecated in its favor.
- `DoctrineDbalTransactionMiddleware` takes a `ConnectionRegistry` and a single optional connection name, since `beginTransaction`/`commit` over many connections would not be a transaction. It keeps the `HandledStamp`-stripping on `HandlerFailedException` so retries re-run all handlers.

`DoctrineTransactionMiddleware` is *not* deprecated: it flushes the entity manager before committing, which has no DBAL equivalent, so it remains as the ORM flavor next to the new DBAL one.

For symfony-docs: the messenger documentation should mention both new middlewares, their constructor signatures, that passing no name to the ping middleware targets every DBAL connection, and that the DBAL transaction middleware does not flush.
