### PR TITLE
[Tui] Ignore arbitrary hex lengths Color cannot use

### DIFF
--- a/src/Symfony/Component/Tui/Style/TailwindStylesheet.php
+++ b/src/Symfony/Component/Tui/Style/TailwindStylesheet.php
@@ -392,8 +392,11 @@ class TailwindStylesheet extends StyleSheet
      */
     private function parseColorValue(string $value): Color|string|int|null
     {
-        // Bracket syntax for arbitrary hex: [#ff5500]
-        if (preg_match('/^\[#([0-9a-fA-F]{3,6})]$/', $value, $m)) {
+        // Bracket syntax for arbitrary hex: [#ff5500], [#f50].
+        // Only the two lengths Color::hex() accepts: matching 4 or 5 digits here
+        // hands it a value it rejects, turning a typo into an exception while
+        // every other unparsable value is ignored.
+        if (preg_match('/^\[#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})]$/', $value, $m)) {
             return '#'.$m[1];
         }
 

--- a/src/Symfony/Component/Tui/Tests/Style/TailwindStylesheetTest.php
+++ b/src/Symfony/Component/Tui/Tests/Style/TailwindStylesheetTest.php
@@ -1096,4 +1096,38 @@ class TailwindStylesheetTest extends TestCase
         $this->assertSame(Color::hex('#06b6d4')->toRgb(), $resolved->getColor()->toRgb());
         $this->assertSame(1, $resolved->getPadding()->top);
     }
+
+    public function testArbitraryHexLengthsColorCannotUseAreIgnoredNotFatal()
+    {
+        // The bracket syntax only has meaning for the lengths Color::hex()
+        // accepts. Every other unparsable value is ignored, so a 4 or 5 digit
+        // typo must be ignored too rather than escaping as an exception.
+        $stylesheet = new TailwindStylesheet();
+
+        foreach (['bg', 'text', 'border'] as $prefix) {
+            foreach (['[#abcd]', '[#abcde]'] as $value) {
+                $widget = new TextWidget('Hello');
+                $widget->addStyleClass($prefix.'-'.$value);
+
+                $resolved = $stylesheet->resolve($widget);
+
+                $this->assertNull($resolved->getBackground());
+                $this->assertNull($resolved->getColor());
+            }
+        }
+    }
+
+    public function testArbitraryHexStillAcceptsTheSupportedLengths()
+    {
+        $stylesheet = new TailwindStylesheet();
+
+        foreach (['[#f50]' => '#f50', '[#ff5500]' => '#ff5500'] as $value => $hex) {
+            $widget = new TextWidget('Hello');
+            $widget->addStyleClass('bg-'.$value);
+
+            $resolved = $stylesheet->resolve($widget);
+
+            $this->assertSame(Color::hex($hex)->toRgb(), $resolved->getBackground()->toRgb());
+        }
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`TailwindStylesheet::parseColorValue()` matches the bracket syntax with
`[0-9a-fA-F]{3,6}` and hands the digits straight to `Color::hex()`, which
accepts only 3 or 6. A 4 or 5 digit value escapes as an exception from inside
style resolution:

```php
$widget->addStyleClass('bg-[#abcd]');
$stylesheet->resolve($widget);
// InvalidArgumentException: Invalid hex color: "abcd".
```

Every other unparseable value is ignored rather than fatal, and the method is
typed `Color|string|int|null` for exactly that reason:

| class | before | after |
| --- | --- | --- |
| `bg-[#f50]` | `#ff5500` | `#ff5500` |
| `bg-[#ff5500]` | `#ff5500` | `#ff5500` |
| `bg-[#ab]` | ignored | ignored |
| `bg-[#zzz]` | ignored | ignored |
| `bg-[#abcd]` | **throws** | ignored |
| `bg-[#abcde]` | **throws** | ignored |

So a mistyped hex of the wrong length takes down the render while a mistyped
hex of any other length is silently dropped. It affects all three color slots:
`bg-`, `text-` and `border-`.

Matching only the two lengths `Color::hex()` accepts makes the wrong-length
case behave like every other unparseable value. Sweeping 814 generated utility
classes across every prefix: 7 threw before, 0 after, with the supported
lengths unchanged.
