### PR TITLE
[Tui] Keep horizontal layout inside the available columns

### DIFF
--- a/src/Symfony/Component/Tui/Render/LayoutEngine.php
+++ b/src/Symfony/Component/Tui/Render/LayoutEngine.php
@@ -450,6 +450,16 @@ final class LayoutEngine
 
         $this->positionTracker->restoreStack($savedStack);
 
+        // Each intrinsic child is measured on its own against the full width, so
+        // several of them can add up to more than the row. Every flex sibling
+        // still ends up with at least one column, so clamp the intrinsic widths
+        // to what is left, or the row overflows and the renderer rejects it.
+        $intrinsicBudget = $availableColumns - \count($flexWeights);
+        if ($intrinsicWidths && array_sum($intrinsicWidths) > $intrinsicBudget) {
+            $intrinsicWidths = self::shrinkToFit($intrinsicWidths, $intrinsicBudget);
+            $usedColumns = array_sum($intrinsicWidths);
+        }
+
         // Second pass: distribute remaining space among flex children
         $remainingColumns = max(0, $availableColumns - $usedColumns);
         $result = [];
@@ -468,6 +478,10 @@ final class LayoutEngine
                         $allocated = $remainingColumns - $flexColumnsUsed;
                     } else {
                         $allocated = (int) floor($remainingColumns * $flexWeights[$index] / $totalFlexWeight);
+                        // Each flex child still to come keeps at least one
+                        // column, so a heavier weight cannot spend their share:
+                        // they are floored to 1 below and the row would overflow.
+                        $allocated = min($allocated, $remainingColumns - $flexColumnsUsed - ($flexCount - $flexAllocated));
                     }
                 } else {
                     $allocated = 0;
@@ -478,5 +492,45 @@ final class LayoutEngine
         }
 
         return $result;
+    }
+
+    /**
+     * Reduce widths so they sum to at most the budget, keeping one column each.
+     *
+     * Scales proportionally first, then trims the widest entries to absorb the
+     * rounding, so the narrow children keep their content.
+     *
+     * @param array<int, int> $widths
+     *
+     * @return array<int, int>
+     */
+    private static function shrinkToFit(array $widths, int $budget): array
+    {
+        $total = array_sum($widths);
+        // layoutHorizontal() caps the child count at the column count, so every
+        // child is guaranteed at least one column here.
+        $budget = max(\count($widths), $budget);
+
+        $used = 0;
+        foreach ($widths as $index => $width) {
+            $used += $widths[$index] = max(1, intdiv($width * $budget, $total));
+        }
+
+        // Flooring can only overshoot by the number of entries raised to 1.
+        while ($used > $budget) {
+            $widest = null;
+            foreach ($widths as $index => $width) {
+                if ($width > 1 && (null === $widest || $width > $widths[$widest])) {
+                    $widest = $index;
+                }
+            }
+            if (null === $widest) {
+                break;
+            }
+            --$widths[$widest];
+            --$used;
+        }
+
+        return $widths;
     }
 }

--- a/src/Symfony/Component/Tui/Tests/Render/LayoutEngineTest.php
+++ b/src/Symfony/Component/Tui/Tests/Render/LayoutEngineTest.php
@@ -368,4 +368,48 @@ class LayoutEngineTest extends TestCase
         $this->assertSame('M', $line[4]);
         $this->assertSame('X', $line[43]);
     }
+
+    public function testIntrinsicChildrenAreClampedToTheAvailableColumns()
+    {
+        // Each flex: 0 child is measured on its own against the full width, so
+        // their natural widths can add up to more columns than the row has.
+        $renderer = new Renderer();
+        $root = new ContainerWidget();
+        $root->setStyle(new Style(direction: Direction::Horizontal));
+
+        foreach (['abcdefgh', 'ijklmnop'] as $text) {
+            $child = new TextWidget($text);
+            $child->setStyle(new Style(flex: 0));
+            $root->add($child);
+        }
+
+        $result = $renderer->renderFrame($root, 10, 1)->toArray();
+
+        $this->assertSame(10, AnsiUtils::visibleWidth($result[0]));
+        foreach ($result as $line) {
+            $this->assertLessThanOrEqual(10, AnsiUtils::visibleWidth($line));
+        }
+    }
+
+    public function testFlexChildrenLeaveAColumnForEachRemainingSibling()
+    {
+        // A heavier weight must not spend the columns its later siblings need:
+        // they are floored to one column each, which overflowed the row.
+        $renderer = new Renderer();
+        $root = new ContainerWidget();
+        $root->setStyle(new Style(direction: Direction::Horizontal));
+
+        foreach ([null, 3, 1, null, null] as $flex) {
+            $child = new TextWidget('Hello');
+            $child->setStyle(new Style(flex: $flex));
+            $root->add($child);
+        }
+
+        $result = $renderer->renderFrame($root, 5, 1)->toArray();
+
+        $this->assertSame(5, AnsiUtils::visibleWidth($result[0]));
+        foreach ($result as $line) {
+            $this->assertLessThanOrEqual(5, AnsiUtils::visibleWidth($line));
+        }
+    }
 }


### PR DESCRIPTION
A horizontal row could be allocated more columns than it has, and the renderer's own width contract then rejected the frame with a RenderException. That guard exists for misbehaving widget authors — its own test uses a custom OverwideWidget — so a built-in ContainerWidget tripping it means an app crashes once the terminal is narrower than its content, instead of degrading.

Two independent causes, both in computeFlexColumnWidths():

Intrinsic widths were never capped as a group. Each `flex: 0` child is measured on its own against the full row, so two of them can each report 8 columns in a 10 column row:

    foreach (['abcdefgh', 'ijklmnop'] as $text) {
        $child = new TextWidget($text);
        $child->setStyle(new Style(flex: 0));
        $root->add($child);
    }
    $renderer->renderFrame($root, 10, 1);   // width 16, available 10

Flex shares did not reserve room for later siblings. Every flex child is floored to one column, but a heavier weight could take the columns those children still needed — with widths [null, 3, 1, null, null] in 5 columns the allocations were 1, 2, 1, 1 and the last child was still floored to 1, totalling 6:

    foreach ([null, 3, 1, null, null] as $flex) { ... }
    $renderer->renderFrame($root, 5, 1);    // width 6, available 5

Reserve one column per flex sibling before distributing intrinsic widths, shrink the intrinsic ones proportionally into what is left, and cap each flex share so the children after it keep their minimum.

Fuzzing 12000 random frames (nested containers, gaps, borders, padding, tabs, CJK, emoji, flex weights to 8): 2665 frames violated the contract before, 0 after.

| Q             | A
| ------------- | ---
| Branch?       | 8.2 for features / 6.4, 7.4, 8.1 for bug fixes
| Bug fix?      | yes/no
| New feature?  | yes/no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | yes/no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

<!--
🛠️ Replace this text with a concise explanation of your change:
- What it does and why it's needed
- A simple example of how it works (include PHP, YAML, etc.)
- If it modifies existing behavior, include a before/after comparison

Contributor guidelines:
- ✅ Add tests and ensure they pass
- 🐞 Bug fixes must target the **lowest maintained** branch where they apply
  https://symfony.com/releases#maintained-symfony-branches
- ✨ New features and deprecations must target the **feature** branch
  and must add an entry to the changelog file of the patched component:
  https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
- 🔒 Do not break backward compatibility:
  https://symfony.com/bc
-->
