### PR TITLE
 Remove six unused codeOWNERS rules for removed templating files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,12 +15,6 @@
 /src/Symfony/Bridge/Twig/Tests/Node/FormThemeTest.php @xabbuh
 /src/Symfony/Bridge/Twig/Tests/TokenParser/FormThemeTokenParserTest.php @xabbuh
 /src/Symfony/Bridge/Twig/TokenParser/FormThemeTokenParser.php @xabbuh
-/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/FormPass.php @xabbuh
-/src/Symfony/Bundle/FrameworkBundle/Resources/views/ @xabbuh
-/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/FormHelper.php @xabbuh
-/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/FormPassTest.php @xabbuh
-/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/FormHelperTableLayoutTest.php @xabbuh
-/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/FormHelperDivLayoutTest.php @xabbuh
 /src/Symfony/Component/Form/ @xabbuh @yceruto
 # HttpKernel
 /src/Symfony/Component/HttpKernel/Log/Logger.php @dunglas


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | none
| License       | MIT

## Summary
Resolves six stale references in CODEOWNERS. The lines themselves were left unchanged while the paths they referenced disappeared from the tree.

Remove CODEOWNERS lines 18-23

## Test

    # the stale lines
    sed -n '18,23p' .github/CODEOWNERS

    # tracked files under the referenced paths, 0 before this PR
    git ls-files -- 'src/Symfony/Bundle/FrameworkBundle/Templating/' 'src/Symfony/Bundle/FrameworkBundle/Resources/views/' | wc -l

## Additional information
I found this mismatch in your repo while analyzing public data with my tool: https://github.com/DanielSwift1992/gate. If you need more details, happy to share.