### PR TITLE
[DependencyInjection] Allow ignoring classes when preloading

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Add support for injecting a service as a lazy proxy on a per-argument basis, using the `!lazy_proxy` YAML tag, the `@~` reference prefix or the `lazy_proxy()` function in the PHP-DSL
  * Write a `CACHEDIR.TAG` file in the cache and build directories so backup tools can skip them
  * Add a `factory` argument to the `#[Autoconfigure]` attribute, and support the `factory` key under `_instanceof`
+ * Add `Preloader::ignore()` to exclude classes or namespace prefixes from preloading
 
 8.1
 ---

--- a/src/Symfony/Component/DependencyInjection/Dumper/Preloader.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/Preloader.php
@@ -16,6 +16,16 @@ namespace Symfony\Component\DependencyInjection\Dumper;
  */
 final class Preloader
 {
+    private static array $ignoredClasses = [];
+
+    /**
+     * Excludes a class from preloading; a name ending with a backslash excludes a whole namespace instead.
+     */
+    public static function ignore(string $class): void
+    {
+        self::$ignoredClasses[] = ltrim($class, '\\');
+    }
+
     public static function append(string $file, array $list): void
     {
         if (!file_exists($file)) {
@@ -75,6 +85,12 @@ final class Preloader
         }
 
         $preloaded[$class] = true;
+
+        foreach (self::$ignoredClasses as $ignoredClass) {
+            if ($class === $ignoredClass || (str_ends_with($ignoredClass, '\\') && str_starts_with($class, $ignoredClass))) {
+                return;
+            }
+        }
 
         try {
             if (!class_exists($class) && !interface_exists($class, false) && !trait_exists($class, false)) {

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PreloaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PreloaderTest.php
@@ -22,6 +22,7 @@ use Symfony\Component\DependencyInjection\Tests\Fixtures\Preload\DummyWithInterf
 use Symfony\Component\DependencyInjection\Tests\Fixtures\Preload\E;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\Preload\F;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\Preload\G;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\Preload\Ignored\SomeClass;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\Preload\IntersectionDummy;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\Preload\UnionDummy;
 
@@ -76,4 +77,68 @@ class PreloaderTest extends TestCase
         self::assertTrue(class_exists(F::class, false));
         self::assertTrue(class_exists(G::class, false));
     }
+
+    public function testPreloadIgnoresExactClass()
+    {
+        $r = new \ReflectionMethod(Preloader::class, 'doPreload');
+
+        $preloaded = [];
+        $ignoredClass = 'Vendor\\Package\\SomeClass';
+        $prefixedClass = $ignoredClass.'WithSuffix';
+        $autoloaded = [];
+        $loader = static function (string $class) use (&$autoloaded) {
+            $autoloaded[] = $class;
+        };
+
+        spl_autoload_register($loader, true, true);
+
+        try {
+            Preloader::ignore($ignoredClass);
+            $r->invokeArgs(null, [$ignoredClass, &$preloaded]);
+            $r->invokeArgs(null, [$prefixedClass, &$preloaded]);
+        } finally {
+            spl_autoload_unregister($loader);
+            (new \ReflectionProperty(Preloader::class, 'ignoredClasses'))->setValue(null, []);
+        }
+
+        self::assertSame([$prefixedClass], $autoloaded);
+    }
+
+    public function testPreloadIgnoresNamespacePrefix()
+    {
+        $r = new \ReflectionMethod(Preloader::class, 'doPreload');
+
+        $preloaded = [];
+        $ignoredClass = SomeClass::class;
+        self::assertFalse(class_exists($ignoredClass, false));
+
+        $autoloaded = false;
+        $loader = static function (string $class) use ($ignoredClass, &$autoloaded) {
+            if ($ignoredClass === $class) {
+                $autoloaded = true;
+            }
+        };
+
+        spl_autoload_register($loader, true, true);
+
+        try {
+            Preloader::ignore('\\Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\Preload\\Ignored\\');
+            $r->invokeArgs(null, [PreloaderTestWithIgnoredType::class, &$preloaded]);
+        } finally {
+            spl_autoload_unregister($loader);
+            (new \ReflectionProperty(Preloader::class, 'ignoredClasses'))->setValue(null, []);
+        }
+
+        self::assertFalse($autoloaded);
+        self::assertFalse(class_exists($ignoredClass, false));
+        self::assertSame([
+            PreloaderTestWithIgnoredType::class => true,
+            $ignoredClass => true,
+        ], $preloaded);
+    }
+}
+
+class PreloaderTestWithIgnoredType
+{
+    public SomeClass $ignored;
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Preload/Ignored/SomeClass.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Preload/Ignored/SomeClass.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\Preload\Ignored;
+
+final class SomeClass
+{
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #65322
| License       | MIT

`Preloader` recursively follows public property, method argument and return types. This means that referencing a large SDK from a service can cause thousands of classes to be autoloaded and preloaded, even when the application does not benefit from preloading them.

This adds `Preloader::ignore()` to exclude classes by prefix before including the generated preload file:

```php
use Symfony\Component\DependencyInjection\Dumper\Preloader;

Preloader::ignore('Microsoft\\Graph\\');

require '/path/to/var/cache/prod/App_KernelProdContainer.preload.php';