### PR TITLE
[Cache][FrameworkBundle] Wire PdoTagAwareAdapter as cache.adapter.pdo_tag_aware

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.2
 ---
 
+ * Add the `cache.adapter.pdo_tag_aware` cache pool adapter
  * Add `framework.asset_mapper.importmap_integrity_algorithms` option to add integrity metadata to importmaps
  * Add `framework.cache.default_provider` to configure `cache.app` with a DSN
  * Add `framework.messenger.reject_redelivered_messages` to allow disabling the `RejectRedeliveredMessageMiddleware`

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -2743,7 +2743,7 @@ class FrameworkExtension extends Extension
                 'tags' => false,
             ];
         }
-        $redisTagAwareAdapters = [['cache.adapter.redis_tag_aware'], ['cache.adapter.valkey_tag_aware']];
+        $nativeTagAwareAdapters = [['cache.adapter.redis_tag_aware'], ['cache.adapter.valkey_tag_aware'], ['cache.adapter.pdo_tag_aware']];
         foreach ($config['pools'] as $name => $pool) {
             if (null === ($pool['provider'] ??= null)) {
                 unset($pool['provider']);
@@ -2752,10 +2752,10 @@ class FrameworkExtension extends Extension
             $isDsnPool = !$pool['adapters'] && isset($pool['provider']);
             $pool['adapters'] = $pool['adapters'] ?: ['cache.app'];
 
-            $isRedisTagAware = \in_array($pool['adapters'], $redisTagAwareAdapters, true);
+            $isNativeTagAware = \in_array($pool['adapters'], $nativeTagAwareAdapters, true);
             foreach ($pool['adapters'] as $provider => $adapter) {
-                if (\in_array($config['pools'][$adapter]['adapters'] ?? null, $redisTagAwareAdapters, true)) {
-                    $isRedisTagAware = true;
+                if (\in_array($config['pools'][$adapter]['adapters'] ?? null, $nativeTagAwareAdapters, true)) {
+                    $isNativeTagAware = true;
                 } elseif ($config['pools'][$adapter]['tags'] ?? false) {
                     $pool['adapters'][$provider] = $adapter = '.'.$adapter.'.inner';
                 }
@@ -2780,10 +2780,10 @@ class FrameworkExtension extends Extension
                 $pool['reset'] = 'reset';
             }
 
-            if ($isRedisTagAware && 'cache.app' === $name) {
+            if ($isNativeTagAware && 'cache.app' === $name) {
                 $container->setAlias('cache.app.taggable', $name);
                 $definition->addTag('cache.taggable', ['pool' => $name]);
-            } elseif ($isRedisTagAware) {
+            } elseif ($isNativeTagAware) {
                 $tagAwareId = $name;
                 $container->setAlias('.'.$name.'.inner', $name);
                 $definition->addTag('cache.taggable', ['pool' => $name]);

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/cache.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/cache.php
@@ -20,6 +20,7 @@ use Symfony\Component\Cache\Adapter\DoctrineDbalAdapter;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Cache\Adapter\MemcachedAdapter;
 use Symfony\Component\Cache\Adapter\PdoAdapter;
+use Symfony\Component\Cache\Adapter\PdoTagAwareAdapter;
 use Symfony\Component\Cache\Adapter\ProxyAdapter;
 use Symfony\Component\Cache\Adapter\RedisAdapter;
 use Symfony\Component\Cache\Adapter\RedisTagAwareAdapter;
@@ -213,6 +214,23 @@ return static function (ContainerConfigurator $container) {
             ->tag('monolog.logger', ['channel' => 'cache'])
 
         ->set('cache.adapter.pdo', PdoAdapter::class)
+            ->abstract()
+            ->args([
+                abstract_arg('PDO connection service'),
+                '', // namespace
+                0, // default lifetime
+                [], // table options
+                service('cache.default_marshaller')->ignoreOnInvalid(),
+            ])
+            ->call('setLogger', [service('logger')->ignoreOnInvalid()])
+            ->tag('cache.pool', [
+                'provider' => 'cache.default_pdo_provider',
+                'clearer' => 'cache.default_clearer',
+                'reset' => 'reset',
+            ])
+            ->tag('monolog.logger', ['channel' => 'cache'])
+
+        ->set('cache.adapter.pdo_tag_aware', PdoTagAwareAdapter::class)
             ->abstract()
             ->args([
                 abstract_arg('PDO connection service'),

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/cache_pdo_tag_aware.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/cache_pdo_tag_aware.php
@@ -1,0 +1,29 @@
+<?php
+
+$container->loadFromExtension('framework', [
+    'cache' => [
+        'pools' => [
+            'cache.pdo_tag_aware.foo' => [
+                'adapter' => 'cache.adapter.pdo_tag_aware',
+            ],
+            'cache.pdo_tag_aware.foo2' => [
+                'tags' => true,
+                'adapter' => 'cache.adapter.pdo_tag_aware',
+            ],
+            'cache.pdo_tag_aware.bar' => [
+                'adapter' => 'cache.pdo_tag_aware.foo',
+            ],
+            'cache.pdo_tag_aware.bar2' => [
+                'tags' => true,
+                'adapter' => 'cache.pdo_tag_aware.foo',
+            ],
+            'cache.pdo_tag_aware.baz' => [
+                'adapter' => 'cache.pdo_tag_aware.foo2',
+            ],
+            'cache.pdo_tag_aware.baz2' => [
+                'tags' => true,
+                'adapter' => 'cache.pdo_tag_aware.foo2',
+            ],
+        ],
+    ],
+]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/cache_pdo_tag_aware.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/cache_pdo_tag_aware.yml
@@ -1,0 +1,18 @@
+framework:
+    cache:
+        pools:
+            cache.pdo_tag_aware.foo:
+                adapter: cache.adapter.pdo_tag_aware
+            cache.pdo_tag_aware.foo2:
+                tags: true
+                adapter: cache.adapter.pdo_tag_aware
+            cache.pdo_tag_aware.bar:
+                adapter: cache.pdo_tag_aware.foo
+            cache.pdo_tag_aware.bar2:
+                tags: true
+                adapter: cache.pdo_tag_aware.foo
+            cache.pdo_tag_aware.baz:
+                adapter: cache.pdo_tag_aware.foo2
+            cache.pdo_tag_aware.baz2:
+                tags: true
+                adapter: cache.pdo_tag_aware.foo2

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -31,6 +31,7 @@ use Symfony\Component\Cache\Adapter\ApcuAdapter;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\ChainAdapter;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+use Symfony\Component\Cache\Adapter\PdoTagAwareAdapter;
 use Symfony\Component\Cache\Adapter\ProxyAdapter;
 use Symfony\Component\Cache\Adapter\RedisAdapter;
 use Symfony\Component\Cache\Adapter\RedisTagAwareAdapter;
@@ -2348,6 +2349,37 @@ abstract class FrameworkExtensionTestCase extends TestCase
             }
 
             $this->assertSame(RedisTagAwareAdapter::class, $defParent->getClass(), \sprintf("'%s' is not %s", $aliasForArgumentStr, RedisTagAwareAdapter::class));
+        }
+    }
+
+    public function testPdoTagAwareAdapter()
+    {
+        $container = $this->createContainerFromFile('cache_pdo_tag_aware', [], true);
+
+        $argNames = [
+            'cachePdoTagAwareFoo',
+            'cachePdoTagAwareFoo2',
+            'cachePdoTagAwareBar',
+            'cachePdoTagAwareBar2',
+            'cachePdoTagAwareBaz',
+            'cachePdoTagAwareBaz2',
+        ];
+        foreach ($argNames as $argumentName) {
+            foreach ([TagAwareCacheInterface::class, CacheInterface::class, CacheItemPoolInterface::class] as $alias) {
+                $aliasForArgumentStr = \sprintf('%s $%s', $alias, $argumentName);
+                $aliasForArgument = $container->getAlias($aliasForArgumentStr);
+                $this->assertNotNull($aliasForArgument, \sprintf("No alias found for '%s'", $aliasForArgumentStr));
+
+                $def = $container->getDefinition((string) $aliasForArgument);
+                $this->assertInstanceOf(ChildDefinition::class, $def, \sprintf("No definition found for '%s'", $aliasForArgumentStr));
+
+                $defParent = $container->getDefinition($def->getParent());
+                if ($defParent instanceof ChildDefinition) {
+                    $defParent = $container->getDefinition($defParent->getParent());
+                }
+
+                $this->assertSame(PdoTagAwareAdapter::class, $defParent->getClass(), \sprintf("'%s' is not %s", $aliasForArgumentStr, PdoTagAwareAdapter::class));
+            }
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | 
| License       | MIT

Follow-up to #58296.

Wires `PdoTagAwareAdapter` into FrameworkBundle as `cache.adapter.pdo_tag_aware`, the way `cache.adapter.redis_tag_aware` is wired:

```yaml
framework:
    cache:
        default_pdo_provider: 'sqlite:///%kernel.project_dir%/var/cache.db'
        pools:
            my.pool:
                adapter: cache.adapter.pdo_tag_aware
```

The abstract service mirrors `cache.adapter.pdo` (same arguments, same `cache.default_pdo_provider`), and the adapter joins the natively tag-aware list in `FrameworkExtension`, so a pool using it, directly or through a parent pool, is tagged `cache.taggable` itself instead of being wrapped in `TagAwareAdapter`. Without that second half, `tags: true` on a PDO pool would put `TagAwareAdapter` around the native adapter and reintroduce the double bookkeeping #58296 removes. The `$redisTagAwareAdapters` local is renamed `$nativeTagAwareAdapters`, since the list already carried Valkey and now carries PDO.

The test mirrors `testRedisTagAwareAdapter` across the same six pool shapes: direct, `tags: true`, and pools chained through both, in the php and yaml configuration formats. Reverting only the `FrameworkExtension` list entry fails the `tags: true` cases with the pool resolving to `TagAwareAdapter`, so the wrapping-skip is what the test pins.

Documentation should cover: the `cache.adapter.pdo_tag_aware` service name, `default_pdo_provider` as its connection source, and when to pick it over `tags: true` on `cache.adapter.pdo`.

