### PR TITLE
[Mailer] Reconnect after a timeout to avoid SMTP response desync

### DIFF
--- a/src/Symfony/Component/Mailer/Tests/Transport/Smtp/SmtpTransportTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/Smtp/SmtpTransportTest.php
@@ -42,6 +42,38 @@ class SmtpTransportTest extends TestCase
         $this->assertEquals('smtp://127.0.0.1:2525', (string) $t);
     }
 
+    public function testConnectionIsResetAfterTimeoutToPreventResponseDesync()
+    {
+        $stream = new TimeoutBufferStream();
+        $envelope = new Envelope(new Address('sender@example.org'), [new Address('recipient@example.org')]);
+
+        $transport = new SmtpTransport($stream);
+        // A failed send resets lastMessageTime to 0; keep the ping path out of the way.
+        $transport->setPingThreshold(\PHP_INT_MAX);
+
+        // The read of the first message's end-of-DATA reply times out.
+        try {
+            $transport->send(new RawMessage('Message 1'), $envelope);
+            $this->fail('The first message is expected to time out.');
+        } catch (TransportException $e) {
+            $this->assertStringContainsString('timed out', $e->getMessage());
+        }
+
+        // Before the fix, the timed-out reply stayed buffered and RSET consumed it, so
+        // every following command read one response too early: DATA got "250" instead of
+        // "354" ("Expected response code 354 but got code 250"). The connection must be
+        // closed and re-opened instead, so the next message goes through cleanly.
+        $transport->send(new RawMessage('Message 2'), $envelope);
+
+        $heloCommands = 0;
+        foreach ($stream->getCommands() as $command) {
+            if (str_starts_with($command, 'HELO')) {
+                ++$heloCommands;
+            }
+        }
+        $this->assertSame(2, $heloCommands, 'The transport must reconnect after a read timeout.');
+    }
+
     public function testSendDoesNotPingBelowThreshold()
     {
         $stream = new DummyStream();

--- a/src/Symfony/Component/Mailer/Tests/Transport/Smtp/TimeoutBufferStream.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/Smtp/TimeoutBufferStream.php
@@ -1,0 +1,109 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Tests\Transport\Smtp;
+
+use Symfony\Component\Mailer\Exception\TransportException;
+use Symfony\Component\Mailer\Transport\Smtp\Stream\AbstractStream;
+
+/**
+ * A stream double that models the server responses as a FIFO buffer, so that an
+ * unread reply left in the buffer desyncs the following reads (unlike the lockstep
+ * DummyStream, whose readLine() always returns the last response).
+ *
+ * The read of the response to the first "end of DATA" command times out once, while
+ * the server reply for that command stays in the buffer, reproducing the pipelining
+ * desync.
+ */
+class TimeoutBufferStream extends AbstractStream
+{
+    /** @var string[] */
+    private array $buffer = [];
+    private array $commands = [];
+    private bool $closed = true;
+    private bool $timeoutArmed = false;
+    private bool $timeoutTriggered = false;
+
+    public function initialize(): void
+    {
+        $this->closed = false;
+        $this->buffer = ['220 localhost ESMTP'."\r\n"];
+    }
+
+    public function write(string $bytes, $debug = true): void
+    {
+        if ($this->closed) {
+            throw new TransportException('Unable to write bytes on the wire.');
+        }
+
+        // Message body chunks are written with $debug === false and get no reply.
+        if (!$debug) {
+            return;
+        }
+
+        $this->commands[] = $bytes;
+
+        if ("\r\n.\r\n" === $bytes) {
+            // Server accepted the message; its reply is queued as usual, but the very
+            // first time we simulate a timeout while reading it back.
+            $this->buffer[] = '250 OK queued as 000501c4054c'."\r\n";
+            if (!$this->timeoutTriggered) {
+                $this->timeoutTriggered = true;
+                $this->timeoutArmed = true;
+            }
+
+            return;
+        }
+
+        $this->buffer[] = match (true) {
+            str_starts_with($bytes, 'HELO'), str_starts_with($bytes, 'EHLO') => '250 localhost'."\r\n",
+            str_starts_with($bytes, 'RSET') => '250 2.0.0 Resetting'."\r\n",
+            str_starts_with($bytes, 'DATA') => '354 Enter message, ending with "." on a line by itself'."\r\n",
+            str_starts_with($bytes, 'QUIT') => '221 Goodbye'."\r\n",
+            default => '250 OK'."\r\n",
+        };
+    }
+
+    public function readLine(): string
+    {
+        if ($this->timeoutArmed) {
+            $this->timeoutArmed = false;
+
+            throw new TransportException('Connection to "localhost" timed out.');
+        }
+
+        return array_shift($this->buffer) ?? '';
+    }
+
+    public function flush(): void
+    {
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getCommands(): array
+    {
+        return $this->commands;
+    }
+
+    protected function getReadConnectionDescription(): string
+    {
+        return 'localhost';
+    }
+
+    public function terminate(): void
+    {
+        parent::terminate();
+        $this->closed = true;
+        $this->buffer = [];
+    }
+}

--- a/src/Symfony/Component/Mailer/Transport/Smtp/SmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/SmtpTransport.php
@@ -142,10 +142,20 @@ class SmtpTransport extends AbstractTransport
             $message = parent::send($message, $envelope);
         } catch (TransportExceptionInterface $e) {
             if ($this->started) {
-                try {
-                    $this->executeCommand("RSET\r\n", [250]);
-                } catch (TransportExceptionInterface) {
-                    // ignore this exception as it probably means that the server error was final
+                if ($e instanceof UnexpectedResponseException) {
+                    // The server replied with an unexpected code: the connection is
+                    // still in sync, so it can be reused after resetting the session.
+                    try {
+                        $this->executeCommand("RSET\r\n", [250]);
+                    } catch (TransportExceptionInterface) {
+                        // ignore this exception as it probably means that the server error was final
+                    }
+                } else {
+                    // Any other failure (timeout, broken pipe, ...) may have left an
+                    // unread reply in the socket buffer. Reusing the connection would
+                    // desync every following command, so close it and reconnect on the
+                    // next message.
+                    $this->stop();
                 }
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #54169
| License       | MIT

When an SMTP read times out in the middle of sending a message, the server's reply for that command can still arrive and stay unread in the socket buffer. `SmtpTransport::send()` then issued `RSET` to recover the session, but `RSET` consumed that stale reply instead of its own response, so every following command read one response too early: the next message's `DATA` command read the leftover `250` where it expected `354`, producing the reported error.

This is why the failure always happens on the message *right after* a timeout — exactly the pattern described in the issue.

The fix keeps the `RSET`-and-reuse recovery only for a genuine protocol error (`UnexpectedResponseException`, where the connection is still in sync). Any other transport failure (timeout, broken pipe, …) now closes the connection so the next message reconnects cleanly instead of inheriting a desynced buffer.

Reproduces with:

```
Expected response code "354" but got code "250", with message "250 OK".
```

## Test verification (RED → GREEN)

The new test drives a FIFO-buffer stream double (`TimeoutBufferStream`) whose read of the first message's end-of-DATA reply times out, leaving that reply buffered — reproducing the pipelining desync. `DummyStream` cannot be used because it answers in lockstep and never leaves an unread reply.

RED — new test on unmodified `6.4` (production change reverted, test kept):

```
1) Symfony\Component\Mailer\Tests\Transport\Smtp\SmtpTransportTest::testConnectionIsResetAfterTimeoutToPreventResponseDesync
Symfony\Component\Mailer\Exception\UnexpectedResponseException: Expected response code "354" but got code "250", with message "250 OK".

ERRORS!
Tests: 1, Assertions: 1, Errors: 1.
```

GREEN — with the fix:

```
OK (1 test, 2 assertions)
```

## Full local suite

The full local Mailer suite was run on both the unmodified `6.4` baseline and this branch (Docker, PHPUnit 9.6): **166 tests, 300 assertions**. The result is iso-or-better — the two non-passing items (`UnsupportedSchemeExceptionTest`, which needs `symfony/phpunit-bridge`'s `ClassExistsMock`, and `SocketStreamTest`, which opens a real socket to `smtp.gmail.com:465`) fail identically on the unmodified baseline; they are environment/network artifacts unrelated to this change. Every `SmtpTransportTest` case is green, including the new one.
