### PR TITLE
[Cache] Implement PruneableInterface on RedisTagAwareAdapter

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/RedisTagAwareAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/RedisTagAwareAdapter.php
@@ -24,6 +24,7 @@ use Symfony\Component\Cache\Exception\LogicException;
 use Symfony\Component\Cache\Marshaller\DeflateMarshaller;
 use Symfony\Component\Cache\Marshaller\MarshallerInterface;
 use Symfony\Component\Cache\Marshaller\TagAwareMarshaller;
+use Symfony\Component\Cache\PruneableInterface;
 use Symfony\Component\Cache\Traits\RedisTrait;
 
 /**
@@ -38,6 +39,7 @@ use Symfony\Component\Cache\Traits\RedisTrait;
  * Design limitations:
  *  - Max 4 billion cache keys per cache tag as limited by Redis Set datatype.
  *    E.g. If you use a "all" items tag for expiry instead of clear(), that limits you to 4 billion cache items also.
+ *  - Tag Sets keep references to expired or evicted items until prune() garbage-collects them.
  *
  * @see https://redis.io/topics/lru-cache#eviction-policies Documentation for Redis eviction policies.
  * @see https://redis.io/topics/data-types#sets Documentation for Redis Set datatype.
@@ -45,7 +47,7 @@ use Symfony\Component\Cache\Traits\RedisTrait;
  * @author Nicolas Grekas <p@tchwork.com>
  * @author André Rømcke <andre.romcke+symfony@gmail.com>
  */
-class RedisTagAwareAdapter extends AbstractTagAwareAdapter
+class RedisTagAwareAdapter extends AbstractTagAwareAdapter implements PruneableInterface
 {
     use RedisTrait;
 
@@ -82,6 +84,90 @@ class RedisTagAwareAdapter extends AbstractTagAwareAdapter
         }
 
         $this->init($redis, $namespace, $defaultLifetime, new TagAwareMarshaller($marshaller));
+    }
+
+    /**
+     * Removes references to expired or evicted items from all the tag Sets of the pool,
+     * and deletes the Sets that reference no existing item anymore.
+     */
+    public function prune(): bool
+    {
+        $prefix = '';
+        $prefixLen = 0;
+        if ($this->redis instanceof \Predis\ClientInterface) {
+            $prefix = $this->redis->getOptions()->prefix ? $this->redis->getOptions()->prefix->getPrefix() : '';
+            $prefixLen = \strlen($prefix);
+        }
+
+        $ok = true;
+        $rootNamespace = '' === $this->namespace ? '' : $this->namespace.static::NS_SEPARATOR;
+
+        if ($this->redis instanceof \Relay\Cluster) {
+            $prefix = Relay::SCAN_PREFIX & $this->redis->getOption(Relay::OPT_SCAN) ? '' : $this->redis->getOption(Relay::OPT_PREFIX);
+            $prefixLen = \strlen($this->redis->getOption(Relay::OPT_PREFIX) ?? '');
+            $pattern = $prefix.$rootNamespace.'*'.static::TAGS_PREFIX.'*';
+
+            foreach ($this->redis->_masters() as $ipAndPort) {
+                $address = implode(':', $ipAndPort);
+                $cursor = null;
+                do {
+                    $keys = $this->redis->scan($cursor, $address, $pattern, 1000);
+                    if (isset($keys[1]) && \is_array($keys[1])) {
+                        $cursor = $keys[0];
+                        $keys = $keys[1];
+                    }
+                    foreach ($keys ?: [] as $key) {
+                        if ($prefixLen) {
+                            $key = substr($key, $prefixLen);
+                        }
+                        $ok = $this->pruneTagSet($key) && $ok;
+                    }
+                } while ($cursor);
+            }
+
+            return $ok;
+        }
+
+        $hosts = $this->getHosts();
+        $host = reset($hosts);
+        if ($host instanceof \Predis\Client) {
+            $connection = $host->getConnection();
+
+            if ($connection instanceof ReplicationInterface) {
+                $hosts = [$host->getClientFor('master')];
+            } elseif ($connection instanceof Predis2ReplicationInterface) {
+                $connection->switchToMaster();
+                $hosts = [$host];
+            }
+        }
+
+        foreach ($hosts as $host) {
+            if ($host instanceof Relay) {
+                $prefix = Relay::SCAN_PREFIX & $host->getOption(Relay::OPT_SCAN) ? '' : $host->getOption(Relay::OPT_PREFIX);
+                $prefixLen = \strlen($host->getOption(Relay::OPT_PREFIX) ?? '');
+            } elseif (!$host instanceof \Predis\ClientInterface) {
+                $prefix = \defined('Redis::SCAN_PREFIX') && (\Redis::SCAN_PREFIX & $host->getOption(\Redis::OPT_SCAN)) ? '' : $host->getOption(\Redis::OPT_PREFIX);
+                $prefixLen = \strlen($host->getOption(\Redis::OPT_PREFIX) ?? '');
+            }
+            $pattern = $prefix.$rootNamespace.'*'.static::TAGS_PREFIX.'*';
+
+            $cursor = null;
+            do {
+                $keys = $host instanceof \Predis\ClientInterface ? $host->scan($cursor ?? 0, ['MATCH' => $pattern, 'COUNT' => 1000]) : $host->scan($cursor, $pattern, 1000);
+                if (isset($keys[1]) && \is_array($keys[1])) {
+                    $cursor = $keys[0];
+                    $keys = $keys[1];
+                }
+                foreach ($keys ?: [] as $key) {
+                    if ($prefixLen) {
+                        $key = substr($key, $prefixLen);
+                    }
+                    $ok = $this->pruneTagSet($key) && $ok;
+                }
+            } while ($cursor);
+        }
+
+        return $ok;
     }
 
     protected function doSave(array $values, int $lifetime, array $addTagData = [], array $delTagData = []): array
@@ -314,5 +400,83 @@ class RedisTagAwareAdapter extends AbstractTagAwareAdapter
         }
 
         return $this->redisEvictionPolicy = '';
+    }
+
+    private function pruneTagSet(string $setId): bool
+    {
+        // Skipping keys that are not Sets tells apart unrelated keys that happen to match the scanned pattern
+
+        $lua = <<<'EOLUA'
+                        if 'set' ~= redis.call('TYPE', KEYS[1]).ok then
+                            return false
+                        end
+
+                        return redis.call('SSCAN', KEYS[1], ARGV[1], 'COUNT', 1000)
+            EOLUA;
+
+        $cursor = '0';
+        do {
+            $results = $this->pipeline(function () use ($lua, $setId, $cursor) {
+                yield 'eval' => $this->redis instanceof \Predis\ClientInterface ? [$lua, 1, $setId, $cursor] : [$lua, [$setId, $cursor], 1];
+            });
+
+            $ids = null;
+            foreach ($results as $result) {
+                if ($result instanceof \RedisException || $result instanceof \Relay\Exception || $result instanceof ErrorInterface) {
+                    CacheItem::log($this->logger, 'Failed to prune tag set "{key}": '.$result->getMessage(), ['key' => $setId, 'exception' => $result]);
+
+                    return false;
+                }
+                if (\is_array($result)) {
+                    [$cursor, $ids] = $result;
+                }
+            }
+
+            if (null === $ids) {
+                return true;
+            }
+
+            $dead = [];
+            if ($ids) {
+                foreach ($this->pipeline(static function () use ($ids) {
+                    foreach ($ids as $id) {
+                        yield 'exists' => [$id];
+                    }
+                }) as $id => $exists) {
+                    if (!$exists) {
+                        $dead[] = $id;
+                    }
+                }
+            }
+
+            if ($dead) {
+                foreach ($this->pipeline(static function () use ($setId, $dead) {
+                    yield 'sRem' => array_merge([$setId], $dead);
+                }) as $result) {
+                }
+
+                // Items saved while pruning might have been removed from the Set right after their reference
+                // was added to it; checking them again and restoring their reference makes no save be lost
+                $revived = [];
+                foreach ($this->pipeline(static function () use ($dead) {
+                    foreach ($dead as $id) {
+                        yield 'exists' => [$id];
+                    }
+                }) as $id => $exists) {
+                    if ($exists) {
+                        $revived[] = $id;
+                    }
+                }
+
+                if ($revived) {
+                    foreach ($this->pipeline(static function () use ($setId, $revived) {
+                        yield 'sAdd' => array_merge([$setId], $revived);
+                    }) as $result) {
+                    }
+                }
+            }
+        } while ('0' !== $cursor);
+
+        return true;
     }
 }

--- a/src/Symfony/Component/Cache/CHANGELOG.md
+++ b/src/Symfony/Component/Cache/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add `AbstractAdapter::createAdapter()` to create the adapter matching a connection
+ * Implement `PruneableInterface` on `RedisTagAwareAdapter` to garbage-collect its tag Sets
 
 8.0
 ---

--- a/src/Symfony/Component/Cache/Tests/Adapter/PredisTagAwareAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PredisTagAwareAdapterTest.php
@@ -18,12 +18,14 @@ use Symfony\Component\Cache\Adapter\RedisTagAwareAdapter;
 #[Group('integration')]
 class PredisTagAwareAdapterTest extends PredisAdapterTest
 {
+    use RedisTagAwarePruneTestTrait;
     use TagAwareTestTrait;
 
     protected function setUp(): void
     {
         parent::setUp();
         $this->skippedTests['testTagItemExpiry'] = 'Testing expiration slows down the test suite';
+        $this->skippedTests['testPrune'] = 'Redis expires items by itself, prune() only garbage-collects tag Sets';
     }
 
     public function createCachePool(int $defaultLifetime = 0, ?string $testMethod = null): CacheItemPoolInterface

--- a/src/Symfony/Component/Cache/Tests/Adapter/PredisTagAwareClusterAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PredisTagAwareClusterAdapterTest.php
@@ -18,12 +18,14 @@ use Symfony\Component\Cache\Adapter\RedisTagAwareAdapter;
 #[Group('integration')]
 class PredisTagAwareClusterAdapterTest extends PredisClusterAdapterTest
 {
+    use RedisTagAwarePruneTestTrait;
     use TagAwareTestTrait;
 
     protected function setUp(): void
     {
         parent::setUp();
         $this->skippedTests['testTagItemExpiry'] = 'Testing expiration slows down the test suite';
+        $this->skippedTests['testPrune'] = 'Redis expires items by itself, prune() only garbage-collects tag Sets';
     }
 
     public function createCachePool(int $defaultLifetime = 0, ?string $testMethod = null): CacheItemPoolInterface

--- a/src/Symfony/Component/Cache/Tests/Adapter/PredisTagAwareReplicationAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PredisTagAwareReplicationAdapterTest.php
@@ -18,12 +18,14 @@ use Symfony\Component\Cache\Adapter\RedisTagAwareAdapter;
 #[Group('integration')]
 class PredisTagAwareReplicationAdapterTest extends PredisRedisReplicationAdapterTest
 {
+    use RedisTagAwarePruneTestTrait;
     use TagAwareTestTrait;
 
     protected function setUp(): void
     {
         parent::setUp();
         $this->skippedTests['testTagItemExpiry'] = 'Testing expiration slows down the test suite';
+        $this->skippedTests['testPrune'] = 'Redis expires items by itself, prune() only garbage-collects tag Sets';
     }
 
     public function createCachePool(int $defaultLifetime = 0, ?string $testMethod = null): CacheItemPoolInterface

--- a/src/Symfony/Component/Cache/Tests/Adapter/RedisTagAwareAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/RedisTagAwareAdapterTest.php
@@ -19,12 +19,14 @@ use Symfony\Component\Cache\Traits\RedisProxy;
 #[Group('integration')]
 class RedisTagAwareAdapterTest extends RedisAdapterTest
 {
+    use RedisTagAwarePruneTestTrait;
     use TagAwareTestTrait;
 
     protected function setUp(): void
     {
         parent::setUp();
         $this->skippedTests['testTagItemExpiry'] = 'Testing expiration slows down the test suite';
+        $this->skippedTests['testPrune'] = 'Redis expires items by itself, prune() only garbage-collects tag Sets';
     }
 
     public function createCachePool(int $defaultLifetime = 0, ?string $testMethod = null): CacheItemPoolInterface

--- a/src/Symfony/Component/Cache/Tests/Adapter/RedisTagAwareArrayAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/RedisTagAwareArrayAdapterTest.php
@@ -18,12 +18,14 @@ use Symfony\Component\Cache\Adapter\RedisTagAwareAdapter;
 #[Group('integration')]
 class RedisTagAwareArrayAdapterTest extends RedisArrayAdapterTest
 {
+    use RedisTagAwarePruneTestTrait;
     use TagAwareTestTrait;
 
     protected function setUp(): void
     {
         parent::setUp();
         $this->skippedTests['testTagItemExpiry'] = 'Testing expiration slows down the test suite';
+        $this->skippedTests['testPrune'] = 'Redis expires items by itself, prune() only garbage-collects tag Sets';
     }
 
     public function createCachePool(int $defaultLifetime = 0, ?string $testMethod = null): CacheItemPoolInterface

--- a/src/Symfony/Component/Cache/Tests/Adapter/RedisTagAwareClusterAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/RedisTagAwareClusterAdapterTest.php
@@ -19,12 +19,14 @@ use Symfony\Component\Cache\Traits\RedisClusterProxy;
 #[Group('integration')]
 class RedisTagAwareClusterAdapterTest extends RedisClusterAdapterTest
 {
+    use RedisTagAwarePruneTestTrait;
     use TagAwareTestTrait;
 
     protected function setUp(): void
     {
         parent::setUp();
         $this->skippedTests['testTagItemExpiry'] = 'Testing expiration slows down the test suite';
+        $this->skippedTests['testPrune'] = 'Redis expires items by itself, prune() only garbage-collects tag Sets';
     }
 
     public function createCachePool(int $defaultLifetime = 0, ?string $testMethod = null): CacheItemPoolInterface

--- a/src/Symfony/Component/Cache/Tests/Adapter/RedisTagAwarePruneTestTrait.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/RedisTagAwarePruneTestTrait.php
@@ -1,0 +1,108 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Tests\Adapter;
+
+use Symfony\Component\Cache\PruneableInterface;
+
+trait RedisTagAwarePruneTestTrait
+{
+    public function testPruneRemovesDanglingReferencesFromTagSets()
+    {
+        $pool = $this->createCachePool();
+        $this->assertInstanceOf(PruneableInterface::class, $pool);
+
+        $tag = 'prune-tag-dangling';
+        foreach (['prune-live', 'prune-dead'] as $key) {
+            $item = $pool->getItem($key);
+            $item->set('value');
+            $item->tag($tag);
+            $pool->save($item);
+        }
+
+        // simulate expiry or eviction happening behind the adapter's back
+        self::$redis->del($this->getPruneRawKey('prune-dead'));
+
+        $this->assertTrue($pool->prune());
+
+        $this->assertSame([$this->getPruneRawKey('prune-live')], self::$redis->sMembers($this->getPruneRawTagKey($tag)));
+        $this->assertTrue($pool->getItem('prune-live')->isHit());
+
+        $pool->invalidateTags([$tag]);
+        $this->assertFalse($pool->getItem('prune-live')->isHit());
+    }
+
+    public function testPruneRemovesOrphanedTagSets()
+    {
+        $pool = $this->createCachePool();
+        $this->assertInstanceOf(PruneableInterface::class, $pool);
+
+        $tag = 'prune-tag-orphaned';
+        $item = $pool->getItem('prune-orphaned');
+        $item->set('value');
+        $item->tag($tag);
+        $pool->save($item);
+
+        $this->assertSame(1, (int) self::$redis->exists($this->getPruneRawTagKey($tag)));
+
+        self::$redis->del($this->getPruneRawKey('prune-orphaned'));
+
+        $this->assertTrue($pool->prune());
+
+        $this->assertSame(0, (int) self::$redis->exists($this->getPruneRawTagKey($tag)));
+    }
+
+    public function testPruneRemovesDanglingReferencesToSubNamespacedItems()
+    {
+        $pool = $this->createCachePool();
+        $this->assertInstanceOf(PruneableInterface::class, $pool);
+        $subPool = $pool->withSubNamespace('prune-sub');
+
+        $tag = 'prune-tag-sub';
+        $item = $subPool->getItem('prune-sub-item');
+        $item->set('value');
+        $item->tag($tag);
+        $subPool->save($item);
+
+        self::$redis->del($this->getPruneRawKey('prune-sub:prune-sub-item'));
+
+        $this->assertTrue($pool->prune());
+
+        $this->assertSame(0, (int) self::$redis->exists($this->getPruneRawTagKey($tag)));
+    }
+
+    public function testPruneSkipsKeysThatAreNotTagSets()
+    {
+        $pool = $this->createCachePool();
+        $this->assertInstanceOf(PruneableInterface::class, $pool);
+
+        $key = "prune-str\1tags\1inside";
+        $item = $pool->getItem($key);
+        $item->set('value');
+        $pool->save($item);
+
+        $this->assertTrue($pool->prune());
+
+        $this->assertTrue($pool->getItem($key)->isHit());
+
+        $pool->deleteItem($key);
+    }
+
+    private function getPruneRawKey(string $key): string
+    {
+        return str_replace('\\', '.', static::class).':'.$key;
+    }
+
+    private function getPruneRawTagKey(string $tag): string
+    {
+        return $this->getPruneRawKey("\1tags\1".$tag);
+    }
+}

--- a/src/Symfony/Component/Cache/Tests/Adapter/RedisTagAwareRelayClusterAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/RedisTagAwareRelayClusterAdapterTest.php
@@ -21,12 +21,14 @@ use Symfony\Component\Cache\Traits\RelayClusterProxy;
 #[Group('integration')]
 class RedisTagAwareRelayClusterAdapterTest extends RelayClusterAdapterTest
 {
+    use RedisTagAwarePruneTestTrait;
     use TagAwareTestTrait;
 
     protected function setUp(): void
     {
         parent::setUp();
         $this->skippedTests['testTagItemExpiry'] = 'Testing expiration slows down the test suite';
+        $this->skippedTests['testPrune'] = 'Redis expires items by itself, prune() only garbage-collects tag Sets';
     }
 
     public function createCachePool(int $defaultLifetime = 0, ?string $testMethod = null): CacheItemPoolInterface


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #47835
| License       | MIT

`RedisTagAwareAdapter` stores the tag <> item relationship as non-volatile Redis Sets, so that tag data survives item eviction. The flip side is that nothing ever removes a reference when the item it points to expires or is evicted, nor when items are removed by `clear()` with a prefix or on a sub-namespace. Long-running pools accumulate dead references, and the Sets of tags that reference nothing anymore stay forever.

This PR implements `PruneableInterface` on the adapter so that `prune()`, e.g. called periodically via the `cache:pool:prune` command, garbage-collects tag entries:

* tag Sets are looked up with `SCAN` on each master, reusing the prefix and namespace handling of `clear()`;
* each Set is iterated with `SSCAN` through a Lua script that skips keys that are not Sets, so that unrelated keys that would match the scanned pattern are left untouched;
* references whose item does not `EXIST` anymore are `SREM`'ed, and a Set that ends up empty is removed by Redis itself;
* to not lose concurrent saves, removed references are checked a second time and restored if their item reappeared meanwhile; the remaining blind spot is read-routed replication setups, where the existence checks can be behind by the replication lag, making the affected item miss tag-invalidation until it expires.

All supported clients are covered: `Redis`, `RedisArray`, `RedisCluster`, `Relay\Relay`, `Relay\Cluster` and Predis, including cluster and replication setups. Cross-node setups work because references are checked and removed with regular client commands that route per key.

Supersedes #50423, rewritten for the current tag layout.

For symfony-docs: the cache pools pruning section should list `RedisTagAwareAdapter` among the pruneable adapters and mention that pruning is what removes stale tag Sets.
