### PR TITLE
[Serializer] Throw on XML data without a root node

### DIFF
--- a/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
@@ -134,7 +134,9 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
             }
         }
 
-        // todo: throw an exception if the root node name is not correctly configured (bc)
+        if (!$rootNode) {
+            throw new NotEncodableValueException('Invalid XML data, it does not contain a root node.');
+        }
 
         if ($rootNode->hasChildNodes()) {
             $data = $this->parseXml($rootNode, $context);

--- a/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
@@ -77,6 +77,13 @@ class XmlEncoderTest extends TestCase
         $this->encoder->decode('<?xml version="1.0"?><!DOCTYPE foo><foo></foo>', 'foo');
     }
 
+    public function testDecodeWithoutRootNode()
+    {
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage('Invalid XML data, it does not contain a root node.');
+        $this->encoder->decode('<?xml version="1.0"?><foo></foo>', 'xml', [XmlEncoder::DECODER_IGNORED_NODE_TYPES => [\XML_ELEMENT_NODE]]);
+    }
+
     public function testAttributes()
     {
         $obj = new ScalarDummy();
@@ -97,7 +104,7 @@ class XmlEncoderTest extends TestCase
                 '@bool-false' => false,
                 '@int' => 3,
                 '@float' => 3.4,
-                '@sring' => 'a',
+                '@string' => 'a',
             ],
         ];
         $expected = '<?xml version="1.0"?>'."\n".
@@ -109,7 +116,7 @@ class XmlEncoderTest extends TestCase
             '<Bar>2</Bar>'.
             '<Bar>3</Bar>'.
             '<a>b</a>'.
-            '<scalars bool-true="1" bool-false="0" int="3" float="3.4" sring="a"/>'.
+            '<scalars bool-true="1" bool-false="0" int="3" float="3.4" string="a"/>'.
             '</response>'."\n";
         $this->assertEquals($expected, $this->encoder->encode($obj, 'xml'));
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #61441
| License       | MIT

`XmlEncoder::decode()` collects the first non-ignored child of the document as the root node. When every child is ignored, `$rootNode` stays `null` and the next line dereferences it:

```php
$encoder->decode('<?xml version="1.0"?><foo></foo>', 'xml', [
    XmlEncoder::DECODER_IGNORED_NODE_TYPES => [\XML_ELEMENT_NODE],
]);

// Error: Call to a member function hasChildNodes() on null
```

Every other malformed-input path in that method throws `NotEncodableValueException`, so this one does too.

It also removes the todo that has sat on the line since 2013, which asked whether decoding should validate the configured root node name. It should not: `root_node_name` is an encoding option, `decode()` deliberately unwraps whatever root it is given, and enforcing it would break the common case of passing a single context array to both `encode()` and `decode()`, since the incoming document's root rarely matches the name chosen for output. See #61466, where implementing that validation silently returned `[]` instead of the decoded data for exactly that setup.

Reported by @mttsch, who also proposed this fix in #61441 and argued against the validation half.

The remaining point of that issue, documenting that `root_node_name` only affects encoding, belongs in symfony-docs.
