### PR TITLE
[FrameworkBundle][SecurityBundle] Fix two tests failing on low-deps and on Windows

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/JsonSchemaConfigDumpPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/JsonSchemaConfigDumpPassTest.php
@@ -25,6 +25,7 @@ use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\Yaml\Yaml;
 
+#[RequiresMethod(JsonSchemaDumper::class, 'dump')]
 #[RequiresMethod(Yaml::class, 'parse')]
 class JsonSchemaConfigDumpPassTest extends TestCase
 {
@@ -33,10 +34,6 @@ class JsonSchemaConfigDumpPassTest extends TestCase
 
     protected function setUp(): void
     {
-        if (!class_exists(JsonSchemaDumper::class)) {
-            $this->markTestSkipped(JsonSchemaDumper::class.' is not available.');
-        }
-
         $this->tempDir = sys_get_temp_dir().'/sf_test_json_schema';
         mkdir($this->tempDir, 0o777, true);
 
@@ -50,7 +47,8 @@ class JsonSchemaConfigDumpPassTest extends TestCase
 
     protected function tearDown(): void
     {
-        if (is_dir($this->tempDir)) {
+        // tearDown() still runs when setUp() did not complete, leaving the properties unset
+        if (isset($this->tempDir) && is_dir($this->tempDir)) {
             if ('\\' === \DIRECTORY_SEPARATOR) {
                 exec('attrib -r '.escapeshellarg($this->readOnlyDir));
             }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Command/DebugRolesCommandTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Command/DebugRolesCommandTest.php
@@ -42,7 +42,7 @@ class DebugRolesCommandTest extends TestCase
               - ROLE_BAZ
 
             EOF;
-        $this->assertStringContainsString($expected, $tester->getDisplay());
+        $this->assertStringContainsString($expected, str_replace(\PHP_EOL, "\n", $tester->getDisplay()));
     }
 
     public function testDebugBuiltInHierarchyWithTreeOption()
@@ -66,7 +66,7 @@ class DebugRolesCommandTest extends TestCase
             └── ROLE_BAZ
 
             EOF;
-        $this->assertStringContainsString($expected, $tester->getDisplay());
+        $this->assertStringContainsString($expected, str_replace(\PHP_EOL, "\n", $tester->getDisplay()));
     }
 
     public function testDebugCustomRoleHierarchy()
@@ -89,7 +89,7 @@ class DebugRolesCommandTest extends TestCase
              * ROLE_FOO
              * ROLE_BAR
             EOF;
-        $this->assertStringContainsString($expected, $tester->getDisplay());
+        $this->assertStringContainsString($expected, str_replace(\PHP_EOL, "\n", $tester->getDisplay()));
     }
 
     public function testDebugCustomRoleHierarchyWithNoArgumentsAsksInteractively()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Two unrelated test-only failures on 8.2.

### `JsonSchemaConfigDumpPassTest` (low-deps)

Five errors on `Unit Tests (8.4, low-deps)`, all pointing at `tearDown()`:

```
Error: Typed property ...\JsonSchemaConfigDumpPassTest::$tempDir must not be accessed before initialization
.../JsonSchemaConfigDumpPassTest.php:53
```

`tearDown()` runs even when `setUp()` did not complete, and `setUp()` skips before assigning `$tempDir` when `JsonSchemaDumper` is missing, which is the low-deps case. Guarding the property is what the reported line needs; moving the requirement into a `#[RequiresMethod]` attribute, like the `Yaml` one right above it, has it checked before the fixture runs at all.

On verification: I could not reproduce the original error locally, including on CI's exact PHPUnit 13.3.1 with `JsonSchemaDumper` hidden, where the tests just skip cleanly. The guard removes the failure mode the stack trace names, and if something else is aborting `setUp()` on that job it will now surface the real cause instead of masking it behind the typed-property error.

### `DebugRolesCommandTest` (Windows)

Three failures on `x86 / minimal-exts / lowest-php`, all `Failed asserting that '\r\n...'`. The test compares heredocs written with `\n` against the raw display, which uses `PHP_EOL`, so those assertions can never match on Windows. Normalized the same way `DebugFirewallCommandTest` in the same directory already does.