### PR TITLE
[DoctrineBridge] Fix `ChainTypedFieldMapper` wiring

### DIFF
--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterDatePointTypePass.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterDatePointTypePass.php
@@ -63,7 +63,7 @@ final class RegisterDatePointTypePass implements CompilerPassInterface
                 }
 
                 // a mapper configured by the application keeps the first say
-                $mapper = new Definition(ChainTypedFieldMapper::class, [[$call[1][0], $mapperDefinition]]);
+                $mapper = new Definition(ChainTypedFieldMapper::class, [$call[1][0], $mapperDefinition]);
             }
 
             $calls[] = ['setTypedFieldMapper', [$mapper]];

--- a/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/CompilerPass/RegisterDatePointTypePassTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/CompilerPass/RegisterDatePointTypePassTest.php
@@ -75,8 +75,8 @@ class RegisterDatePointTypePassTest extends TestCase
         $this->assertCount(1, $calls);
         $chainDef = array_values($calls)[0][1][0];
         $this->assertSame(ChainTypedFieldMapper::class, $chainDef->getClass());
-        $this->assertSame($userMapper, $chainDef->getArgument(0)[0]);
-        $this->assertSame(DefaultTypedFieldMapper::class, $chainDef->getArgument(0)[1]->getClass());
+        $this->assertSame($userMapper, $chainDef->getArgument(0));
+        $this->assertSame(DefaultTypedFieldMapper::class, $chainDef->getArgument(1)->getClass());
     }
 
     public function testEveryEntityManagerConfigurationIsCovered()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

#63772 didn't wire the `ChainTypedFieldMapper` correctly. It accepts a variadic list of `TypedFieldMapper` instances, not an array.

> !! 16:05:34 CRITICAL [php] Uncaught Error: Doctrine\ORM\Mapping\ChainTypedFieldMapper::__construct(): Argument #1 must be of type Doctrine\ORM\Mapping\TypedFieldMapper, array given, called in /8.2/var/cache/dev/ContainerXFIrPMJ/App_KernelDevDebugContainer.php on line 1640 ["exception" => TypeError { … }]
