### PR TITLE
[FrameworkBundle] Guard the `session:clear` test behind the interface it needs

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/SessionClearCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/SessionClearCommandTest.php
@@ -16,12 +16,22 @@ use Symfony\Bundle\FrameworkBundle\Command\SessionClearCommand;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\HttpFoundation\Session\Storage\Handler\ClearableSessionHandlerInterface;
 
-abstract class ClearableSessionHandler implements \SessionHandlerInterface, ClearableSessionHandlerInterface
-{
+// the interface only exists since HttpFoundation 8.2, older versions must not fatal at load time
+if (interface_exists(ClearableSessionHandlerInterface::class)) {
+    abstract class ClearableSessionHandler implements \SessionHandlerInterface, ClearableSessionHandlerInterface
+    {
+    }
 }
 
 class SessionClearCommandTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        if (!interface_exists(ClearableSessionHandlerInterface::class)) {
+            $this->markTestSkipped(ClearableSessionHandlerInterface::class.' is not available.');
+        }
+    }
+
     public function testClearSucceeds()
     {
         $handler = $this->createMock(ClearableSessionHandler::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

`SessionClearCommandTest` declares a fixture implementing `ClearableSessionHandlerInterface` at load time. The interface is new in HttpFoundation 8.2 while FrameworkBundle allows `^7.4|^8.0`, so the lowest-dependency job installs an HttpFoundation without it and the whole FrameworkBundle suite dies before running a single test:

```
Message:  Interface "Symfony\Component\HttpFoundation\Session\Storage\Handler\ClearableSessionHandlerInterface" not found
Location: .../SessionClearCommandTest.php:19
```

Every currently open PR shows this failure, e.g. #63998. The fixture is now declared only when the interface exists and the tests skip without it, the same pattern as #65307. `SessionClearCommand` itself needs no guard: `instanceof` and `::class` on a missing interface are safe, and the command already reports a clear error for handlers that cannot clear.

Verified by hiding the interface file: the suite went from a load-time fatal to 5 skipped tests, and back to 5 green with it restored.
