### PR TITLE
[Console] Fix "regular expression is too large" when wrapping on wide terminals

### DIFF
--- a/src/Symfony/Component/Console/Helper/OutputWrapper.php
+++ b/src/Symfony/Component/Console/Helper/OutputWrapper.php
@@ -60,17 +60,31 @@ final class OutputWrapper
         }
 
         $tagPattern = \sprintf('<(?:(?:%s)|/(?:%s)?)>', self::TAG_OPEN_REGEX_SEGMENT, self::TAG_CLOSE_REGEX_SEGMENT);
-        $limitPattern = "{1,$width}";
         $patternBlocks = [$tagPattern];
         if (!$this->allowCutUrls) {
             $patternBlocks[] = self::URL_PATTERN;
         }
-        $patternBlocks[] = '.';
-        $blocks = implode('|', $patternBlocks);
-        $rowPattern = "(?:$blocks)$limitPattern";
+
+        // Fold each tag/URL to one unused private-use codepoint so that the row quantifier
+        // repeats a single character: PCRE compiles a bounded repetition of a group by
+        // duplicating the group, which hits the compiled-size limit around width 137
+        $map = [];
+        $i = 0;
+        $text = preg_replace_callback('#'.implode('|', $patternBlocks).'#iux', static function ($m) use (&$map, &$i, $text) {
+            do {
+                $placeholder = mb_chr(0xF0000 + $i++, 'UTF-8');
+            } while (str_contains($text, $placeholder));
+            $map[$placeholder] = $m[0];
+
+            return $placeholder;
+        }, $text);
+
+        // 65535 is the highest value a quantifier accepts
+        $rowPattern = '.{1,'.min($width, 65535).'}';
         $pattern = \sprintf('#(?:((?>(%1$s)((?<=[^\S\r\n])[^\S\r\n]?|(?=\r?\n)|$|[^\S\r\n]))|(%1$s))(?:\r?\n)?|(?:\r?\n|$))#imux', $rowPattern);
         $output = rtrim(preg_replace($pattern, '\\1'.$break, $text), $break);
+        $output = str_replace(' '.$break, $break, $output);
 
-        return str_replace(' '.$break, $break, $output);
+        return $map ? strtr($output, $map) : $output;
     }
 }

--- a/src/Symfony/Component/Console/Tests/Descriptor/TextDescriptorTest.php
+++ b/src/Symfony/Component/Console/Tests/Descriptor/TextDescriptorTest.php
@@ -180,6 +180,20 @@ class TextDescriptorTest extends AbstractDescriptorTestCase
         $this->assertStringContainsString('[default: "super-long-default-value"]', $lines[1]);
     }
 
+    public function testWrappingOnWideTerminal()
+    {
+        $output = new BufferedOutput();
+        $option = new InputOption('name', null, InputOption::VALUE_REQUIRED, str_repeat('long description ', 30));
+        (new TextDescriptor())->describe($output, $option, ['terminal_width' => 200, 'raw_output' => true]);
+
+        $lines = explode("\n", rtrim($output->fetch()));
+        $this->assertCount(3, $lines);
+        $this->assertStringContainsString('long description', $lines[0]);
+        foreach ($lines as $line) {
+            $this->assertLessThanOrEqual(200, Helper::width(Helper::removeDecoration(new OutputFormatter(), $line)));
+        }
+    }
+
     public function testUnboundedOutputWhenNotATty()
     {
         $output = new BufferedOutput();

--- a/src/Symfony/Component/Console/Tests/Helper/OutputWrapperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/OutputWrapperTest.php
@@ -68,5 +68,22 @@ class OutputWrapperTest extends TestCase
                 ornare</error> efficitur.
                 EOS,
         ];
+
+        yield 'Width above the PCRE compiled-size limit' => [
+            $baseTextWithUtf8AndUrl,
+            150,
+            false,
+            <<<'EOS'
+                Árvíztűrőtükörfúrógép https://github.com/symfony/symfony Lorem ipsum <comment>dolor</comment> sit amet, consectetur adipiscing elit. Praesent vestibulum nulla quis urna maximus porttitor. Donec
+                ullamcorper risus at <error>libero ornare</error> efficitur.
+                EOS,
+        ];
+
+        yield 'Width above the quantifier limit' => [
+            $baseTextWithUtf8AndUrl,
+            100000,
+            false,
+            $baseTextWithUtf8AndUrl,
+        ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Fixes a bug caused by #63784:

> In OutputWrapper.php line 72:
>
> Warning: preg_replace(): Compilation failed: regular expression is too large at offset 245

The terminal width ends up in the `OutputWrapper` regex as a repetition count on a group, roughly `(?:tag|url|.){1,200}`. PCRE compiles a bounded repetition of a group by copying the group's bytecode once per repetition, and the group appears twice in the pattern. The compiled pattern hits PCRE's size limit at around 137 columns, so any wider terminal made `preg_replace()` fail. Since `preg_replace()` returns `null` on failure, the text being wrapped was also swallowed.

The fix makes the repetition apply to a single character instead of a group: every formatter tag and URL is first replaced with a single unused private-use codepoint, the text is wrapped with `.{1,width}`, and the codepoints are restored afterwards. A bounded repetition of a single character compiles to a counter of constant size, valid up to the quantifier limit of 65535. Each tag and each URL already counted as one repetition unit before, so the wrapped output is unchanged for widths that used to compile.

Descriptions now wrap at the real terminal width on any terminal.
