### PR TITLE
[Console] Fix Psalm error in OutputWrapper

### DIFF
--- a/src/Symfony/Component/Console/Helper/OutputWrapper.php
+++ b/src/Symfony/Component/Console/Helper/OutputWrapper.php
@@ -73,7 +73,7 @@ final class OutputWrapper
         $text = preg_replace_callback('#'.implode('|', $patternBlocks).'#iux', static function ($m) use (&$map, &$i, $text) {
             do {
                 $placeholder = mb_chr(0xF0000 + $i++, 'UTF-8');
-            } while (str_contains($text, $placeholder));
+            } while (false === $placeholder || str_contains($text, $placeholder));
             $map[$placeholder] = $m[0];
 
             return $placeholder;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Follow-up to #65359: `mb_chr()` is typed `string|false`, so Psalm reports the placeholder closure as possibly returning `false`. Skipping `false` values keeps the return a string in every case.
