### PR TITLE
[DependencyInjection][FrameworkBundle] Show lazy proxies as such in dumped arguments

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
@@ -16,6 +16,7 @@ use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\Argument\AbstractArgument;
 use Symfony\Component\DependencyInjection\Argument\ArgumentInterface;
+use Symfony\Component\DependencyInjection\Argument\LazyProxyArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -447,6 +448,17 @@ class JsonDescriptor extends Descriptor
 
         if ($value instanceof AbstractArgument) {
             return ['type' => 'abstract', 'text' => $value->getText()];
+        }
+
+        if ($value instanceof LazyProxyArgument) {
+            [$reference, $interfaces] = $value->getValues();
+
+            $data = ['type' => 'lazy_proxy', 'id' => (string) $reference];
+            if ($interfaces) {
+                $data['interfaces'] = $interfaces;
+            }
+
+            return $data;
         }
 
         if ($value instanceof ArgumentInterface) {

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
@@ -19,6 +19,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\Argument\AbstractArgument;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
+use Symfony\Component\DependencyInjection\Argument\LazyProxyArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
@@ -410,10 +411,12 @@ class TextDescriptor extends Descriptor
                     }
 
                     foreach ($argument->getValues() as $ref) {
-                        $argumentsInformation[] = \sprintf('- Service(%s)', $ref);
+                        $argumentsInformation[] = '- '.($ref instanceof LazyProxyArgument ? self::formatLazyProxyArgument($ref) : \sprintf('Service(%s)', $ref));
                     }
                 } elseif ($argument instanceof ServiceLocatorArgument) {
                     $argumentsInformation[] = \sprintf('Service locator (%d element(s))', \count($argument->getValues()));
+                } elseif ($argument instanceof LazyProxyArgument) {
+                    $argumentsInformation[] = self::formatLazyProxyArgument($argument);
                 } elseif ($argument instanceof Definition) {
                     $argumentsInformation[] = 'Inlined Service';
                 } elseif ($argument instanceof \UnitEnum) {
@@ -751,5 +754,12 @@ class TextDescriptor extends Descriptor
             isset($options['raw_text']) && $options['raw_text'] ? strip_tags($content) : $content,
             isset($options['raw_output']) ? !$options['raw_output'] : true
         );
+    }
+
+    private static function formatLazyProxyArgument(LazyProxyArgument $argument): string
+    {
+        [$reference, $interfaces] = $argument->getValues();
+
+        return \sprintf('Lazy Proxy for Service(%s)%s', (string) $reference, $interfaces ? \sprintf(' implementing "%s"', implode('", "', $interfaces)) : '');
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
@@ -16,6 +16,7 @@ use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\Argument\AbstractArgument;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
+use Symfony\Component\DependencyInjection\Argument\LazyProxyArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -448,6 +449,17 @@ class XmlDescriptor extends Descriptor
 
                 foreach ($this->getArgumentNodes($argument->getValues(), $dom, $container) as $childArgumentXML) {
                     $argumentXML->appendChild($childArgumentXML);
+                }
+            } elseif ($argument instanceof LazyProxyArgument) {
+                [$reference, $interfaces] = $argument->getValues();
+
+                $argumentXML->setAttribute('type', 'lazy_proxy');
+                $argumentXML->setAttribute('id', (string) $reference);
+
+                foreach ($interfaces as $interface) {
+                    $interfaceXML = $dom->createElement('interface');
+                    $interfaceXML->appendChild(new \DOMText($interface));
+                    $argumentXML->appendChild($interfaceXML);
                 }
             } elseif ($argument instanceof Definition) {
                 $argumentXML->appendChild($dom->importNode($this->getContainerDefinitionDocument($argument, null, false, $container)->childNodes->item(0), true));

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/ObjectsProvider.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/ObjectsProvider.php
@@ -16,6 +16,7 @@ use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Suit;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\Argument\AbstractArgument;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
+use Symfony\Component\DependencyInjection\Argument\LazyProxyArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
@@ -225,8 +226,11 @@ class ObjectsProvider
                 ->addArgument(new IteratorArgument([
                     new Reference('definition_1'),
                     new Reference('.definition_2'),
+                    new LazyProxyArgument(new Reference('.definition_2')),
                 ]))
                 ->addArgument(new AbstractArgument('placeholder'))
+                ->addArgument(new LazyProxyArgument(new Reference('.definition_2')))
+                ->addArgument(new LazyProxyArgument(new Reference('.definition_2'), ['Full\\Qualified\\Interface1', 'Full\\Qualified\\Interface2']))
                 ->setFactory(['Full\\Qualified\\FactoryClass', 'get']),
             '.definition_2' => $definition2
                 ->setPublic(false)

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_with_definition_1.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_with_definition_1.json
@@ -71,11 +71,27 @@
                 {
                     "type": "service",
                     "id": ".definition_2"
+                },
+                {
+                    "type": "lazy_proxy",
+                    "id": ".definition_2"
                 }
             ],
             {
                 "type": "abstract",
                 "text": "placeholder"
+            },
+            {
+                "type": "lazy_proxy",
+                "id": ".definition_2"
+            },
+            {
+                "type": "lazy_proxy",
+                "id": ".definition_2",
+                "interfaces": [
+                    "Full\\Qualified\\Interface1",
+                    "Full\\Qualified\\Interface2"
+                ]
             }
         ],
         "file": null,
@@ -83,7 +99,7 @@
         "factory_method": "get",
         "tags": [],
         "usages": [
-          "alias_1"
+            "alias_1"
         ]
     }
 ]

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_with_definition_1.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_with_definition_1.txt
@@ -3,28 +3,31 @@
 [33mInformation for Service "[39m[32mservice_1[39m[33m"[39m
 [33m===================================[39m
 
- ---------------- --------------------------------- 
- [32m Option         [39m [32m Value                           [39m 
- ---------------- --------------------------------- 
-  Service ID       service_1                        
-  Class            Full\Qualified\Class1            
-  Tags             -                                
-  Public           yes                              
-  Synthetic        no                               
-  Lazy             yes                              
-  Shared           yes                              
-  Abstract         yes                              
-  Autowired        no                               
-  Autoconfigured   no                               
-  Factory Class    Full\Qualified\FactoryClass      
-  Factory Method   get                              
-  Arguments        Service(.definition_2)           
-                   %parameter%                      
-                   Inlined Service                  
-                   Array (3 element(s))             
-                   Iterator (2 element(s))          
-                   - Service(definition_1)          
-                   - Service(.definition_2)         
-                   Abstract argument (placeholder)  
-  Usages           alias_1                          
- ---------------- ---------------------------------
+ ---------------- ------------------------------------------------------------------------------------------------------------- 
+ [32m Option         [39m [32m Value                                                                                                       [39m 
+ ---------------- ------------------------------------------------------------------------------------------------------------- 
+  Service ID       service_1                                                                                                    
+  Class            Full\Qualified\Class1                                                                                        
+  Tags             -                                                                                                            
+  Public           yes                                                                                                          
+  Synthetic        no                                                                                                           
+  Lazy             yes                                                                                                          
+  Shared           yes                                                                                                          
+  Abstract         yes                                                                                                          
+  Autowired        no                                                                                                           
+  Autoconfigured   no                                                                                                           
+  Factory Class    Full\Qualified\FactoryClass                                                                                  
+  Factory Method   get                                                                                                          
+  Arguments        Service(.definition_2)                                                                                       
+                   %parameter%                                                                                                  
+                   Inlined Service                                                                                              
+                   Array (3 element(s))                                                                                         
+                   Iterator (3 element(s))                                                                                      
+                   - Service(definition_1)                                                                                      
+                   - Service(.definition_2)                                                                                     
+                   - Lazy Proxy for Service(.definition_2)                                                                      
+                   Abstract argument (placeholder)                                                                              
+                   Lazy Proxy for Service(.definition_2)                                                                        
+                   Lazy Proxy for Service(.definition_2) implementing "Full\Qualified\Interface1", "Full\Qualified\Interface2"  
+  Usages           alias_1                                                                                                      
+ ---------------- -------------------------------------------------------------------------------------------------------------

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_with_definition_1.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/alias_with_definition_1.xml
@@ -20,8 +20,14 @@
   <argument type="iterator">
     <argument type="service" id="definition_1"/>
     <argument type="service" id=".definition_2"/>
+    <argument type="lazy_proxy" id=".definition_2"/>
   </argument>
   <argument type="abstract">placeholder</argument>
+  <argument type="lazy_proxy" id=".definition_2"/>
+  <argument type="lazy_proxy" id=".definition_2">
+    <interface>Full\Qualified\Interface1</interface>
+    <interface>Full\Qualified\Interface2</interface>
+  </argument>
   <usages>
     <usage>alias_1</usage>
   </usages>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_arguments.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_arguments.json
@@ -64,11 +64,27 @@
                     {
                         "type": "service",
                         "id": ".definition_2"
+                    },
+                    {
+                        "type": "lazy_proxy",
+                        "id": ".definition_2"
                     }
                 ],
                 {
                     "type": "abstract",
                     "text": "placeholder"
+                },
+                {
+                    "type": "lazy_proxy",
+                    "id": ".definition_2"
+                },
+                {
+                    "type": "lazy_proxy",
+                    "id": ".definition_2",
+                    "interfaces": [
+                        "Full\\Qualified\\Interface1",
+                        "Full\\Qualified\\Interface2"
+                    ]
                 }
             ],
             "file": null,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_arguments.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_arguments.xml
@@ -21,8 +21,14 @@
     <argument type="iterator">
       <argument type="service" id="definition_1"/>
       <argument type="service" id=".definition_2"/>
+      <argument type="lazy_proxy" id=".definition_2"/>
     </argument>
     <argument type="abstract">placeholder</argument>
+    <argument type="lazy_proxy" id=".definition_2"/>
+    <argument type="lazy_proxy" id=".definition_2">
+      <interface>Full\Qualified\Interface1</interface>
+      <interface>Full\Qualified\Interface2</interface>
+    </argument>
   </definition>
   <definition id="definition_without_class" class="" public="false" synthetic="false" lazy="false" shared="true" abstract="false" autowired="false" autoconfigured="false" deprecated="false" file=""/>
   <definition id="service_container" class="Symfony\Component\DependencyInjection\ContainerInterface" public="true" synthetic="true" lazy="false" shared="true" abstract="false" autowired="false" autoconfigured="false" deprecated="false" file="">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_public.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_public.json
@@ -64,11 +64,27 @@
                     {
                         "type": "service",
                         "id": ".definition_2"
+                    },
+                    {
+                        "type": "lazy_proxy",
+                        "id": ".definition_2"
                     }
                 ],
                 {
                     "type": "abstract",
                     "text": "placeholder"
+                },
+                {
+                    "type": "lazy_proxy",
+                    "id": ".definition_2"
+                },
+                {
+                    "type": "lazy_proxy",
+                    "id": ".definition_2",
+                    "interfaces": [
+                        "Full\\Qualified\\Interface1",
+                        "Full\\Qualified\\Interface2"
+                    ]
                 }
             ],
             "file": null,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_public.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_public.xml
@@ -21,8 +21,14 @@
     <argument type="iterator">
       <argument type="service" id="definition_1"/>
       <argument type="service" id=".definition_2"/>
+      <argument type="lazy_proxy" id=".definition_2"/>
     </argument>
     <argument type="abstract">placeholder</argument>
+    <argument type="lazy_proxy" id=".definition_2"/>
+    <argument type="lazy_proxy" id=".definition_2">
+      <interface>Full\Qualified\Interface1</interface>
+      <interface>Full\Qualified\Interface2</interface>
+    </argument>
   </definition>
   <definition id="definition_without_class" class="" public="false" synthetic="false" lazy="false" shared="true" abstract="false" autowired="false" autoconfigured="false" deprecated="false" file=""/>
   <definition id="service_container" class="Symfony\Component\DependencyInjection\ContainerInterface" public="true" synthetic="true" lazy="false" shared="true" abstract="false" autowired="false" autoconfigured="false" deprecated="false" file="">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_1.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_1.json
@@ -62,11 +62,27 @@
             {
                 "type": "service",
                 "id": ".definition_2"
+            },
+            {
+                "type": "lazy_proxy",
+                "id": ".definition_2"
             }
         ],
         {
             "type": "abstract",
             "text": "placeholder"
+        },
+        {
+            "type": "lazy_proxy",
+            "id": ".definition_2"
+        },
+        {
+            "type": "lazy_proxy",
+            "id": ".definition_2",
+            "interfaces": [
+                "Full\\Qualified\\Interface1",
+                "Full\\Qualified\\Interface2"
+            ]
         }
     ],
     "file": null,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_1.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_1.txt
@@ -1,25 +1,28 @@
- ---------------- --------------------------------- 
- [32m Option         [39m [32m Value                           [39m 
- ---------------- --------------------------------- 
-  Service ID       -                                
-  Class            Full\Qualified\Class1            
-  Tags             -                                
-  Public           yes                              
-  Synthetic        no                               
-  Lazy             yes                              
-  Shared           yes                              
-  Abstract         yes                              
-  Autowired        no                               
-  Autoconfigured   no                               
-  Factory Class    Full\Qualified\FactoryClass      
-  Factory Method   get                              
-  Arguments        Service(.definition_2)           
-                   %parameter%                      
-                   Inlined Service                  
-                   Array (3 element(s))             
-                   Iterator (2 element(s))          
-                   - Service(definition_1)          
-                   - Service(.definition_2)         
-                   Abstract argument (placeholder)  
-  Usages           none                             
- ---------------- --------------------------------- 
+ ---------------- ------------------------------------------------------------------------------------------------------------- 
+ [32m Option         [39m [32m Value                                                                                                       [39m 
+ ---------------- ------------------------------------------------------------------------------------------------------------- 
+  Service ID       -                                                                                                            
+  Class            Full\Qualified\Class1                                                                                        
+  Tags             -                                                                                                            
+  Public           yes                                                                                                          
+  Synthetic        no                                                                                                           
+  Lazy             yes                                                                                                          
+  Shared           yes                                                                                                          
+  Abstract         yes                                                                                                          
+  Autowired        no                                                                                                           
+  Autoconfigured   no                                                                                                           
+  Factory Class    Full\Qualified\FactoryClass                                                                                  
+  Factory Method   get                                                                                                          
+  Arguments        Service(.definition_2)                                                                                       
+                   %parameter%                                                                                                  
+                   Inlined Service                                                                                              
+                   Array (3 element(s))                                                                                         
+                   Iterator (3 element(s))                                                                                      
+                   - Service(definition_1)                                                                                      
+                   - Service(.definition_2)                                                                                     
+                   - Lazy Proxy for Service(.definition_2)                                                                      
+                   Abstract argument (placeholder)                                                                              
+                   Lazy Proxy for Service(.definition_2)                                                                        
+                   Lazy Proxy for Service(.definition_2) implementing "Full\Qualified\Interface1", "Full\Qualified\Interface2"  
+  Usages           none                                                                                                         
+ ---------------- ------------------------------------------------------------------------------------------------------------- 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_1.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_1.xml
@@ -19,6 +19,12 @@
   <argument type="iterator">
     <argument type="service" id="definition_1"/>
     <argument type="service" id=".definition_2"/>
+    <argument type="lazy_proxy" id=".definition_2"/>
   </argument>
   <argument type="abstract">placeholder</argument>
+  <argument type="lazy_proxy" id=".definition_2"/>
+  <argument type="lazy_proxy" id=".definition_2">
+    <interface>Full\Qualified\Interface1</interface>
+    <interface>Full\Qualified\Interface2</interface>
+  </argument>
 </definition>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_1.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_1.json
@@ -62,11 +62,27 @@
             {
                 "type": "service",
                 "id": ".definition_2"
+            },
+            {
+                "type": "lazy_proxy",
+                "id": ".definition_2"
             }
         ],
         {
             "type": "abstract",
             "text": "placeholder"
+        },
+        {
+            "type": "lazy_proxy",
+            "id": ".definition_2"
+        },
+        {
+            "type": "lazy_proxy",
+            "id": ".definition_2",
+            "interfaces": [
+                "Full\\Qualified\\Interface1",
+                "Full\\Qualified\\Interface2"
+            ]
         }
     ],
     "file": null,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_1.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_1.txt
@@ -1,26 +1,29 @@
- ---------------- --------------------------------- 
- [32m Option         [39m [32m Value                           [39m 
- ---------------- --------------------------------- 
-  Service ID       -                                
-  Class            Full\Qualified\Class1            
-  Tags             -                                
-  Public           yes                              
-  Synthetic        no                               
-  Lazy             yes                              
-  Shared           yes                              
-  Abstract         yes                              
-  Autowired        no                               
-  Autoconfigured   no                               
-  Factory Class    Full\Qualified\FactoryClass      
-  Factory Method   get                              
-  Arguments        Service(.definition_2)           
-                   %parameter%                      
-                   Inlined Service                  
-                   Array (3 element(s))             
-                   Iterator (2 element(s))          
-                   - Service(definition_1)          
-                   - Service(.definition_2)         
-                   Abstract argument (placeholder)  
-  Usages           none                             
- ---------------- ---------------------------------
+ ---------------- ------------------------------------------------------------------------------------------------------------- 
+ [32m Option         [39m [32m Value                                                                                                       [39m 
+ ---------------- ------------------------------------------------------------------------------------------------------------- 
+  Service ID       -                                                                                                            
+  Class            Full\Qualified\Class1                                                                                        
+  Tags             -                                                                                                            
+  Public           yes                                                                                                          
+  Synthetic        no                                                                                                           
+  Lazy             yes                                                                                                          
+  Shared           yes                                                                                                          
+  Abstract         yes                                                                                                          
+  Autowired        no                                                                                                           
+  Autoconfigured   no                                                                                                           
+  Factory Class    Full\Qualified\FactoryClass                                                                                  
+  Factory Method   get                                                                                                          
+  Arguments        Service(.definition_2)                                                                                       
+                   %parameter%                                                                                                  
+                   Inlined Service                                                                                              
+                   Array (3 element(s))                                                                                         
+                   Iterator (3 element(s))                                                                                      
+                   - Service(definition_1)                                                                                      
+                   - Service(.definition_2)                                                                                     
+                   - Lazy Proxy for Service(.definition_2)                                                                      
+                   Abstract argument (placeholder)                                                                              
+                   Lazy Proxy for Service(.definition_2)                                                                        
+                   Lazy Proxy for Service(.definition_2) implementing "Full\Qualified\Interface1", "Full\Qualified\Interface2"  
+  Usages           none                                                                                                         
+ ---------------- -------------------------------------------------------------------------------------------------------------
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_1.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_1.xml
@@ -19,6 +19,12 @@
   <argument type="iterator">
     <argument type="service" id="definition_1"/>
     <argument type="service" id=".definition_2"/>
+    <argument type="lazy_proxy" id=".definition_2"/>
   </argument>
   <argument type="abstract">placeholder</argument>
+  <argument type="lazy_proxy" id=".definition_2"/>
+  <argument type="lazy_proxy" id=".definition_2">
+    <interface>Full\Qualified\Interface1</interface>
+    <interface>Full\Qualified\Interface2</interface>
+  </argument>
 </definition>

--- a/src/Symfony/Component/DependencyInjection/Argument/LazyProxyArgument.php
+++ b/src/Symfony/Component/DependencyInjection/Argument/LazyProxyArgument.php
@@ -25,6 +25,7 @@ class LazyProxyArgument implements ArgumentInterface
 
     private Reference $service;
     private array $interfaces;
+    private ?Reference $resolvedReference = null;
 
     /**
      * @param string|string[] $interfaces The interface(s) the proxy should implement, or none to proxy the service's own class
@@ -37,7 +38,7 @@ class LazyProxyArgument implements ArgumentInterface
 
     public function getValues(): array
     {
-        return [$this->service, $this->interfaces];
+        return [$this->service, $this->interfaces, $this->resolvedReference];
     }
 
     public function setValues(array $values): void
@@ -47,6 +48,8 @@ class LazyProxyArgument implements ArgumentInterface
         if (isset($values[1])) {
             $this->setInterfaces($values[1]);
         }
+
+        $this->resolvedReference = $values[2] ?? null;
     }
 
     private function setInterfaces(string|array $interfaces): void

--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckTypeDeclarationsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckTypeDeclarationsPass.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\DependencyInjection\Compiler;
 use Symfony\Component\DependencyInjection\Argument\EnvClosure;
 use Symfony\Component\DependencyInjection\Argument\EnvClosureArgument;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
+use Symfony\Component\DependencyInjection\Argument\LazyProxyArgument;
 use Symfony\Component\DependencyInjection\Argument\RewindableGenerator;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
@@ -191,6 +192,12 @@ final class CheckTypeDeclarationsPass extends AbstractRecursivePass
         }
 
         $type = $reflectionType->getName();
+
+        if ($value instanceof LazyProxyArgument) {
+            if (!$value = $value->getValues()[2]) {
+                return;
+            }
+        }
 
         if ($value instanceof Reference) {
             if (!$this->container->has($value = (string) $value)) {

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveHotPathPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveHotPathPass.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Argument\ArgumentInterface;
+use Symfony\Component\DependencyInjection\Argument\LazyProxyArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
@@ -40,6 +41,10 @@ class ResolveHotPathPass extends AbstractRecursivePass
     protected function processValue(mixed $value, bool $isRoot = false): mixed
     {
         if ($value instanceof ArgumentInterface) {
+            if ($value instanceof LazyProxyArgument && $resolvedReference = $value->getValues()[2]) {
+                $this->processValue($resolvedReference);
+            }
+
             return $value;
         }
 

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveInvalidReferencesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveInvalidReferencesPass.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Argument\ArgumentInterface;
+use Symfony\Component\DependencyInjection\Argument\LazyProxyArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -59,6 +60,14 @@ class ResolveInvalidReferencesPass implements CompilerPassInterface
     {
         if ($value instanceof ServiceClosureArgument) {
             $value->setValues($this->processValue($value->getValues(), 1, 1));
+        } elseif ($value instanceof LazyProxyArgument) {
+            $values = $this->processValue($value->getValues(), 1, 1);
+
+            if (!$values[0] instanceof Reference) {
+                return null;
+            }
+
+            $value->setValues($values);
         } elseif ($value instanceof ArgumentInterface) {
             $value->setValues($this->processValue($value->getValues(), $rootLevel, 1 + $level));
         } elseif ($value instanceof Definition) {

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveLazyProxyPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveLazyProxyPass.php
@@ -22,7 +22,7 @@ use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\TypedReference;
 
 /**
- * Turns lazy proxy arguments into references to generated lazy-loading definitions.
+ * Resolves lazy proxy arguments by generating the lazy-loading definitions that implement them.
  *
  * @author HypeMC <hypemc@gmail.com>
  */
@@ -49,7 +49,9 @@ class ResolveLazyProxyPass extends AbstractRecursivePass
         }
         $this->container->setDefinition($id = '.lazy.'.$id, $definition);
 
-        return new Reference($id);
+        $value->setValues([$reference, $interfaces, new Reference($id)]);
+
+        return $value;
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -1339,11 +1339,13 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
             }
             $value = new ServiceLocator($this->resolveServices(...), $refs, $types);
         } elseif ($value instanceof LazyProxyArgument) {
-            [$reference, $interfaces] = $value->getValues();
+            [$reference, $interfaces, $resolvedReference] = $value->getValues();
 
-            $value = ($definition = ResolveLazyProxyPass::createProxyDefinition($this, $reference, $interfaces))
-                ? $this->createService($definition->setShared(false), $inlineServices, $isConstructorArgument, '.lazy.'.$reference)
-                : $this->doResolveServices($reference, $inlineServices, $isConstructorArgument);
+            $value = null !== $resolvedReference
+                ? $this->doResolveServices($resolvedReference, $inlineServices, $isConstructorArgument)
+                : (($definition = ResolveLazyProxyPass::createProxyDefinition($this, $reference, $interfaces))
+                    ? $this->createService($definition->setShared(false), $inlineServices, $isConstructorArgument, '.lazy.'.$reference)
+                    : $this->doResolveServices($reference, $inlineServices, $isConstructorArgument));
         } elseif ($value instanceof Reference) {
             $value = $this->doGet((string) $value, $value->getInvalidBehavior(), $inlineServices, $isConstructorArgument);
         } elseif ($value instanceof Definition) {

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -19,6 +19,7 @@ use Symfony\Component\DependencyInjection\Argument\EnvClosure;
 use Symfony\Component\DependencyInjection\Argument\EnvClosureArgument;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\Argument\LazyClosure;
+use Symfony\Component\DependencyInjection\Argument\LazyProxyArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocator;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
@@ -1868,6 +1869,10 @@ class PhpDumper extends Dumper
                 }
 
                 ++$calls[$id][0];
+            } elseif ($argument instanceof LazyProxyArgument) {
+                if ($resolvedReference = $argument->getValues()[2]) {
+                    $this->getDefinitionsFromArguments([$resolvedReference], $definitions, $calls, $byConstructor);
+                }
             } elseif (!$argument instanceof Definition) {
                 // no-op
             } elseif (isset($definitions[$argument])) {
@@ -1901,6 +1906,16 @@ class PhpDumper extends Dumper
 
             return \sprintf('[%s]', implode(', ', $code));
         } elseif ($value instanceof ArgumentInterface) {
+            if ($value instanceof LazyProxyArgument) {
+                [$reference, , $resolvedReference] = $value->getValues();
+
+                if (!$resolvedReference) {
+                    throw new RuntimeException(\sprintf('Cannot dump an unresolved lazy proxy argument for service "%s"; run the "ResolveLazyProxyPass" compiler pass first.', $reference));
+                }
+
+                return $this->dumpValue($resolvedReference, $interpolate);
+            }
+
             $scope = [$this->definitionVariables, $this->referenceVariables];
             $this->definitionVariables = $this->referenceVariables = null;
 
@@ -1971,6 +1986,9 @@ class PhpDumper extends Dumper
                     $serviceMap = '';
                     $serviceTypes = '';
                     foreach ($value->getValues() as $k => $v) {
+                        if ($v instanceof LazyProxyArgument) {
+                            $v = $v->getValues()[2] ?? $v;
+                        }
                         if (!$v instanceof Reference) {
                             $serviceMap .= \sprintf("\n            %s => [%s],", $this->export($k), $this->dumpValue($v));
                             $serviceTypes .= \sprintf("\n            %s => '?',", $this->export($k));

--- a/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
@@ -16,6 +16,7 @@ use Symfony\Component\DependencyInjection\Argument\AbstractArgument;
 use Symfony\Component\DependencyInjection\Argument\ArgumentInterface;
 use Symfony\Component\DependencyInjection\Argument\EnvClosureArgument;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
+use Symfony\Component\DependencyInjection\Argument\LazyProxyArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
@@ -310,6 +311,33 @@ class XmlDumper extends Dumper
                 }
                 $envExpr = $this->container->resolveEnvPlaceholders($value->getValue());
                 yield \sprintf('<%s%s>%s</%1$s>', $type, $xmlAttr, $this->encode($envExpr, 0));
+
+                continue;
+            }
+
+            if ($value instanceof LazyProxyArgument) {
+                [$reference, $interfaces] = $value->getValues();
+
+                $xmlAttr .= \sprintf(' type="lazy_proxy" id="%s"', $this->encode((string) $reference));
+                $xmlAttr .= match ($reference->getInvalidBehavior()) {
+                    ContainerInterface::NULL_ON_INVALID_REFERENCE => ' on-invalid="null"',
+                    ContainerInterface::IGNORE_ON_INVALID_REFERENCE => ' on-invalid="ignore"',
+                    ContainerInterface::IGNORE_ON_UNINITIALIZED_REFERENCE => ' on-invalid="ignore_uninitialized"',
+                    default => '',
+                };
+                if (1 === \count($interfaces)) {
+                    $xmlAttr .= \sprintf(' interface="%s"', $this->encode($interfaces[0]));
+                }
+
+                if (1 < \count($interfaces)) {
+                    yield \sprintf('<%s%s>', $type, $xmlAttr);
+                    foreach ($interfaces as $interface) {
+                        yield \sprintf('  <interface>%s</interface>', $this->encode($interface, 0));
+                    }
+                    yield \sprintf('</%s>', $type);
+                } else {
+                    yield \sprintf('<%s%s/>', $type, $xmlAttr);
+                }
 
                 continue;
             }

--- a/src/Symfony/Component/DependencyInjection/Tests/Argument/LazyProxyArgumentTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Argument/LazyProxyArgumentTest.php
@@ -27,14 +27,14 @@ class LazyProxyArgumentTest extends TestCase
     {
         $argument = new LazyProxyArgument($reference = new Reference('a'), $interfaces);
 
-        self::assertSame([$reference, $expectedInterfaces], $argument->getValues());
+        self::assertSame([$reference, $expectedInterfaces, null], $argument->getValues());
     }
 
     public function testGetValuesDefaultsToNoInterface()
     {
         $argument = new LazyProxyArgument($reference = new Reference('a'));
 
-        self::assertSame([$reference, []], $argument->getValues());
+        self::assertSame([$reference, [], null], $argument->getValues());
     }
 
     public function testSetValues()
@@ -42,7 +42,7 @@ class LazyProxyArgumentTest extends TestCase
         $argument = new LazyProxyArgument(new Reference('a'));
         $argument->setValues([$reference = new Reference('b'), 'SomeInterface']);
 
-        self::assertSame([$reference, ['SomeInterface']], $argument->getValues());
+        self::assertSame([$reference, ['SomeInterface'], null], $argument->getValues());
     }
 
     public function testSetValuesKeepsInterfacesWhenNotProvided()
@@ -50,7 +50,15 @@ class LazyProxyArgumentTest extends TestCase
         $argument = new LazyProxyArgument(new Reference('a'), ['SomeInterface']);
         $argument->setValues([$reference = new Reference('b')]);
 
-        self::assertSame([$reference, ['SomeInterface']], $argument->getValues());
+        self::assertSame([$reference, ['SomeInterface'], null], $argument->getValues());
+    }
+
+    public function testSetValuesWithResolvedReference()
+    {
+        $argument = new LazyProxyArgument($reference = new Reference('a'), ['SomeInterface']);
+        $argument->setValues([$reference, ['SomeInterface'], $resolvedReference = new Reference('.lazy.a')]);
+
+        self::assertSame([$reference, ['SomeInterface'], $resolvedReference], $argument->getValues());
     }
 
     #[TestWith([''], 'empty string')]

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
@@ -1543,8 +1543,9 @@ class AutowirePassTest extends TestCase
 
         (new ResolveLazyProxyPass())->process($container);
 
-        $expected = new Reference('.lazy.'.A::class);
+        $expected->setValues([new TypedReference(A::class, A::class), [], new Reference('.lazy.'.A::class)]);
         $this->assertEquals($expected, $container->getDefinition('foo')->getArgument(0));
+        $this->assertTrue($container->getDefinition('.lazy.'.A::class)->isLazy());
     }
 
     public function testLazyServiceAttributeOnAlreadyLazyService()
@@ -1577,7 +1578,7 @@ class AutowirePassTest extends TestCase
 
         (new ResolveLazyProxyPass())->process($container);
 
-        $definition = $container->getDefinition((string) $container->getDefinition('foo')->getArgument(0));
+        $definition = $container->getDefinition((string) $container->getDefinition('foo')->getArgument(0)->getValues()[2]);
 
         $this->assertTrue($definition->isLazy());
         $this->assertSame([['interface' => LazyProxyTestInterface::class]], $definition->getTag('proxy'));

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckTypeDeclarationsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckTypeDeclarationsPassTest.php
@@ -13,8 +13,10 @@ namespace Symfony\Component\DependencyInjection\Tests\Compiler;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
+use Symfony\Component\DependencyInjection\Argument\LazyProxyArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Compiler\CheckTypeDeclarationsPass;
+use Symfony\Component\DependencyInjection\Compiler\ResolveLazyProxyPass;
 use Symfony\Component\DependencyInjection\Compiler\ResolveParameterPlaceHoldersPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -773,6 +775,33 @@ class CheckTypeDeclarationsPassTest extends TestCase
 
         $container->register('bar', BarMethodCall::class)
             ->addMethodCall('setCallable', [new ServiceClosureArgument(new Reference('foo'))]);
+
+        (new CheckTypeDeclarationsPass(true))->process($container);
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testProcessSuccessWhenPassingLazyProxyArgument()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('foo', \stdClass::class);
+        $container->register('bar', Bar::class)
+            ->addArgument(new LazyProxyArgument(new Reference('foo')));
+
+        (new ResolveLazyProxyPass())->process($container);
+        (new CheckTypeDeclarationsPass(true))->process($container);
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testProcessSuccessWhenPassingUnresolvedLazyProxyArgument()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('foo', \stdClass::class);
+        $container->register('bar', Bar::class)
+            ->addArgument(new LazyProxyArgument(new Reference('foo')));
 
         (new CheckTypeDeclarationsPass(true))->process($container);
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveHotPathPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveHotPathPassTest.php
@@ -13,7 +13,9 @@ namespace Symfony\Component\DependencyInjection\Tests\Compiler;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
+use Symfony\Component\DependencyInjection\Argument\LazyProxyArgument;
 use Symfony\Component\DependencyInjection\Compiler\ResolveHotPathPass;
+use Symfony\Component\DependencyInjection\Compiler\ResolveLazyProxyPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
@@ -53,5 +55,23 @@ class ResolveHotPathPassTest extends TestCase
         $this->assertFalse($container->getDefinition('service_container')->hasTag('container.hot_path'));
         $this->assertFalse($container->getDefinition('deprec_with_tag')->hasTag('container.hot_path'));
         $this->assertFalse($container->getDefinition('deprec_ref_notag')->hasTag('container.hot_path'));
+    }
+
+    public function testProcessPropagatesThroughLazyProxyArgument()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('proxied', \stdClass::class);
+        $container->register('foo', \stdClass::class)
+            ->addTag('container.hot_path')
+            ->addArgument(new LazyProxyArgument(new Reference('proxied')));
+
+        (new ResolveLazyProxyPass())->process($container);
+        (new ResolveHotPathPass())->process($container);
+
+        $lazyId = (string) $container->getDefinition('foo')->getArgument(0)->getValues()[2];
+
+        $this->assertTrue($container->getDefinition($lazyId)->hasTag('container.hot_path'));
+        $this->assertTrue($container->getDefinition('proxied')->hasTag('container.hot_path'));
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveInvalidReferencesPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveInvalidReferencesPassTest.php
@@ -12,9 +12,12 @@
 namespace Symfony\Component\DependencyInjection\Tests\Compiler;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
+use Symfony\Component\DependencyInjection\Argument\LazyProxyArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Compiler\DecoratorServicePass;
 use Symfony\Component\DependencyInjection\Compiler\ResolveInvalidReferencesPass;
+use Symfony\Component\DependencyInjection\Compiler\ResolveLazyProxyPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Reference;
@@ -174,6 +177,45 @@ class ResolveInvalidReferencesPassTest extends TestCase
         $this->process($container);
 
         $this->assertSame([null], $container->getDefinition('bar')->getArguments());
+    }
+
+    public function testProcessExcludedServiceBehindLazyProxyAndNullOnInvalid()
+    {
+        $container = new ContainerBuilder();
+        $container->register('foo', \stdClass::class)->addTag('container.excluded');
+        $container->register('bar', \stdClass::class)
+            ->setArguments([new LazyProxyArgument(new Reference('foo', $container::NULL_ON_INVALID_REFERENCE)), 'tail']);
+
+        (new ResolveLazyProxyPass())->process($container);
+        $this->process($container);
+
+        $this->assertSame([null, 'tail'], $container->getDefinition('bar')->getArguments());
+    }
+
+    public function testProcessExcludedServiceBehindLazyProxyAndIgnoreOnInvalid()
+    {
+        $container = new ContainerBuilder();
+        $container->register('foo', \stdClass::class)->addTag('container.excluded');
+        $container->register('bar', \stdClass::class)
+            ->setArguments([new LazyProxyArgument(new Reference('foo', $container::IGNORE_ON_INVALID_REFERENCE)), 'tail']);
+
+        (new ResolveLazyProxyPass())->process($container);
+        $this->process($container);
+
+        $this->assertSame([null, 'tail'], $container->getDefinition('bar')->getArguments());
+    }
+
+    public function testProcessExcludedServiceBehindLazyProxyInCollectionArgument()
+    {
+        $container = new ContainerBuilder();
+        $container->register('foo', \stdClass::class)->addTag('container.excluded');
+        $container->register('bar', \stdClass::class)
+            ->setArguments([new IteratorArgument([new LazyProxyArgument(new Reference('foo', $container::IGNORE_ON_INVALID_REFERENCE))])]);
+
+        (new ResolveLazyProxyPass())->process($container);
+        $this->process($container);
+
+        $this->assertSame([], $container->getDefinition('bar')->getArgument(0)->getValues());
     }
 
     protected function process(ContainerBuilder $container)

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveLazyProxyPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveLazyProxyPassTest.php
@@ -36,7 +36,10 @@ class ResolveLazyProxyPassTest extends TestCase
 
         (new ResolveLazyProxyPass())->process($container);
 
-        $lazyId = (string) $container->getDefinition('foo')->getArgument(0);
+        $argument = $container->getDefinition('foo')->getArgument(0);
+        self::assertInstanceOf(LazyProxyArgument::class, $argument);
+
+        $lazyId = (string) $argument->getValues()[2];
         self::assertStringStartsWith('.lazy.a.', $lazyId);
         self::assertSame(A::class, $container->getDefinition($lazyId)->getClass());
     }
@@ -50,7 +53,7 @@ class ResolveLazyProxyPassTest extends TestCase
 
         (new ResolveLazyProxyPass())->process($container);
 
-        $lazyId = (string) $container->getDefinition('foo')->getArgument(0);
+        $lazyId = (string) $container->getDefinition('foo')->getArgument(0)->getValues()[2];
         self::assertStringStartsWith('.lazy.final_impl.', $lazyId);
         self::assertSame(FinalLazyProxyImplementation::class, $container->getDefinition($lazyId)->getClass());
         self::assertSame([['interface' => LazyProxyTestInterface::class]], $container->getDefinition($lazyId)->getTag('proxy'));
@@ -65,7 +68,7 @@ class ResolveLazyProxyPassTest extends TestCase
 
         (new ResolveLazyProxyPass())->process($container);
 
-        $lazyId = (string) $container->getDefinition('foo')->getArgument(0);
+        $lazyId = (string) $container->getDefinition('foo')->getArgument(0)->getValues()[2];
         self::assertStringStartsWith('.lazy.a.', $lazyId);
         self::assertSame('object', $container->getDefinition($lazyId)->getClass());
         self::assertSame([
@@ -165,14 +168,18 @@ class ResolveLazyProxyPassTest extends TestCase
         $container->register('a', A::class);
         $container->register('foo', Foo::class)
             ->setPublic(true)
-            ->addArgument(new LazyProxyArgument(new TypedReference('a', A::class)));
+            ->addArgument(new LazyProxyArgument($reference = new TypedReference('a', A::class)));
 
         $container->compile();
 
         $argument = $container->getDefinition('foo')->getArgument(0);
-        self::assertInstanceOf(Reference::class, $argument);
-        self::assertNotInstanceOf(LazyProxyArgument::class, $argument);
-        self::assertStringStartsWith('.lazy.a.', (string) $argument);
-        self::assertTrue($container->getDefinition((string) $argument)->isLazy());
+        self::assertInstanceOf(LazyProxyArgument::class, $argument);
+
+        [$service, $interfaces, $resolvedReference] = $argument->getValues();
+        self::assertSame($reference, $service);
+        self::assertSame([], $interfaces);
+        self::assertInstanceOf(Reference::class, $resolvedReference);
+        self::assertStringStartsWith('.lazy.a.', (string) $resolvedReference);
+        self::assertTrue($container->getDefinition((string) $resolvedReference)->isLazy());
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -937,6 +937,25 @@ class ContainerBuilderTest extends TestCase
         $this->assertNull($builder->resolveServices(new LazyProxyArgument(new Reference('bar', ContainerInterface::IGNORE_ON_INVALID_REFERENCE))));
     }
 
+    public function testResolveServicesWithLazyProxyArgumentOnCompiledContainer()
+    {
+        $builder = new ContainerBuilder();
+        $builder->register('bar', 'BarClass')->setPublic(true);
+        $builder->register('foo', 'Bar\FooClass')
+            ->setPublic(true)
+            ->addArgument([new LazyProxyArgument(new Reference('bar'))]);
+        $builder->compile();
+
+        $proxy = $builder->get('foo')->arguments[0];
+
+        $this->assertInstanceOf(\BarClass::class, $proxy);
+        $this->assertFalse($builder->initialized('bar'), 'The proxied service is not instantiated upfront');
+
+        $builder->get('bar')->foo = 'mutated';
+
+        $this->assertSame('mutated', $proxy->foo, 'The proxy resolves to the shared service');
+    }
+
     public function testResolveServices()
     {
         $builder = new ContainerBuilder();

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -2343,6 +2343,54 @@ class PhpDumperTest extends TestCase
         $this->assertSame($container->get('foo'), $bar->foo->initializeLazyObject());
     }
 
+    public function testLazyProxyArgumentInServiceLocator()
+    {
+        $container = new ContainerBuilder();
+        $container->register('foo', Foo::class)
+            ->setPublic(true);
+        $container->register('bar', 'stdClass')
+            ->setPublic(true)
+            ->setProperty('locator', new ServiceLocatorArgument(['foo' => new LazyProxyArgument(new Reference('foo'))]));
+        $container->compile();
+
+        $dumper = new PhpDumper($container);
+        $dump = $dumper->dump(['class' => 'Symfony_DI_PhpDumper_Test_Lazy_Proxy_Argument_In_Service_Locator']);
+
+        $this->assertStringContainsString("'foo' => ['privates', '.lazy.foo.", $dump, 'The locator builds the proxy on demand, not upfront');
+
+        eval('?>'.$dump);
+
+        $container = new \Symfony_DI_PhpDumper_Test_Lazy_Proxy_Argument_In_Service_Locator();
+
+        $locator = $container->get('bar')->locator;
+
+        $foo = $locator->get('foo');
+        $r = new \ReflectionClass(Foo::class);
+        $this->assertTrue($r->isUninitializedLazyObject($foo));
+        $this->assertSame($container->get('foo'), $r->initializeLazyObject($foo));
+    }
+
+    public function testUnresolvedLazyProxyArgumentCannotBeDumped()
+    {
+        $container = new ContainerBuilder();
+        $container->register('foo', Foo::class)
+            ->setPublic(true);
+        $container->register('bar', LazyProxyArgumentConsumer::class)
+            ->setPublic(true)
+            ->addArgument(new LazyProxyArgument(new Reference('foo')));
+        $container->getCompilerPassConfig()->setOptimizationPasses([]);
+        $container->getCompilerPassConfig()->setRemovingPasses([]);
+        $container->getCompilerPassConfig()->setAfterRemovingPasses([]);
+        $container->compile();
+
+        $dumper = new PhpDumper($container);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Cannot dump an unresolved lazy proxy argument for service "foo"; run the "ResolveLazyProxyPass" compiler pass first.');
+
+        $dumper->dump();
+    }
+
     public function testCallableAdapterConsumer()
     {
         $container = new ContainerBuilder();

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/XmlDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/XmlDumperTest.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Argument\AbstractArgument;
 use Symfony\Component\DependencyInjection\Argument\EnvClosureArgument;
+use Symfony\Component\DependencyInjection\Argument\LazyProxyArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
@@ -285,6 +286,35 @@ class XmlDumperTest extends TestCase
 
         $dumper = new XmlDumper($container);
         $this->assertXmlStringEqualsGeneratedXmlFile('services_with_service_closure.xml', $dumper->dump());
+    }
+
+    public function testLazyProxyArgument()
+    {
+        $container = new ContainerBuilder();
+        $container->register('foo', 'Foo')
+            ->addArgument(new LazyProxyArgument(new Reference('bar', ContainerInterface::IGNORE_ON_INVALID_REFERENCE)))
+            ->addArgument(new LazyProxyArgument(new Reference('bar'), 'BarInterface'))
+            ->addArgument(new LazyProxyArgument(new Reference('bar'), ['BarInterface', 'BazInterface']))
+        ;
+
+        $dumper = new XmlDumper($container);
+        $this->assertXmlStringEqualsGeneratedXmlFile('services_with_lazy_proxy_argument.xml', $dumper->dump());
+    }
+
+    public function testLazyProxyArgumentOnCompiledContainer()
+    {
+        $container = new ContainerBuilder();
+        $container->register('bar', 'stdClass');
+        $container->register('foo', 'stdClass')
+            ->setPublic(true)
+            ->addArgument(new LazyProxyArgument(new Reference('bar')))
+        ;
+        $container->compile();
+
+        $dump = (new XmlDumper($container))->dump();
+
+        $this->assertStringContainsString('<argument type="lazy_proxy" id="bar"/>', $dump);
+        $this->assertStringContainsString('<service id=".lazy.bar.', $dump);
     }
 
     public function testEnvClosure()

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_with_lazy_proxy_argument.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_with_lazy_proxy_argument.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd">
+  <services>
+    <service id="service_container" class="Symfony\Component\DependencyInjection\ContainerInterface" public="true" synthetic="true"/>
+    <service id="foo" class="Foo">
+      <argument type="lazy_proxy" id="bar" on-invalid="ignore"/>
+      <argument type="lazy_proxy" id="bar" interface="BarInterface"/>
+      <argument type="lazy_proxy" id="bar">
+        <interface>BarInterface</interface>
+        <interface>BazInterface</interface>
+      </argument>
+    </service>
+  </services>
+</container>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Followup to #65103.

Currently, lazy proxy arguments are resolved by replacing them with a reference to the generated lazy-loading definition, so by the time the container reaches the dumpers there's no trace left that the argument was a lazy proxy:

```xml
<service id="App\Service\Two" class="App\Service\Two" public="true" autowire="true" autoconfigure="true">
  <argument type="service" id=".lazy.App\Service\One"/>
</service>
```

Everything works as expected, but this is inconsistent with how other argument types are represented, e.g. `TaggedIteratorArgument`:

```xml
<service id="config_cache_factory" class="Symfony\Component\Config\ResourceCheckerConfigCacheFactory">
  <argument type="tagged_iterator" tag="config_cache.resource_checker"/>
</service>
```

`debug:container` is affected by the same inconsistency.

With this PR, `ResolveLazyProxyPass` resolves the argument in place: it still generates the lazy-loading definition, but stores a reference to it inside the `LazyProxyArgument` instead of replacing the argument. The declarative form thus stays visible to the dumpers and to `debug:container`:

```xml
<service id="App\Service\Two" class="App\Service\Two" public="true" autowire="true" autoconfigure="true">
  <argument type="lazy_proxy" id="App\Service\One"/>
</service>
```

```shell
$ bin/console debug:container 'App\Service\Two'  

Information for Service "App\Service\Two"
=========================================

 ---------------- ----------------------------------------- 
  Option           Value                                    
 ---------------- ----------------------------------------- 
  Service ID       App\Service\Two                          
  Class            App\Service\Two                          
  Tags             -                                        
  Public           yes                                      
  Synthetic        no                                       
  Lazy             no                                       
  Shared           yes                                      
  Abstract         no                                       
  Autowired        yes                                      
  Autoconfigured   yes                                      
  Arguments        Lazy Proxy for Service(App\Service\One)  
  Usages           none                                     
 ---------------- ----------------------------------------- 
```