### PR TITLE
[MonologBridge] Release command data in ConsoleCommandProcessor when the command terminates

### DIFF
--- a/src/Symfony/Bridge/Monolog/Processor/ConsoleCommandProcessor.php
+++ b/src/Symfony/Bridge/Monolog/Processor/ConsoleCommandProcessor.php
@@ -28,7 +28,7 @@ class ConsoleCommandProcessor implements EventSubscriberInterface, ResetInterfac
 {
     use CompatibilityProcessor;
 
-    private array $commandData;
+    private array $commandDataStack = [];
     private bool $includeArguments;
     private bool $includeOptions;
 
@@ -40,8 +40,8 @@ class ConsoleCommandProcessor implements EventSubscriberInterface, ResetInterfac
 
     private function doInvoke(array|LogRecord $record): array|LogRecord
     {
-        if (isset($this->commandData) && !isset($record['extra']['command'])) {
-            $record['extra']['command'] = $this->commandData;
+        if ($this->commandDataStack && !isset($record['extra']['command'])) {
+            $record['extra']['command'] = $this->commandDataStack[array_key_last($this->commandDataStack)];
         }
 
         return $record;
@@ -52,8 +52,8 @@ class ConsoleCommandProcessor implements EventSubscriberInterface, ResetInterfac
      */
     public function reset()
     {
-        // the command data is set once, on ConsoleEvents::COMMAND, and must outlive any reset
-        // happening while the command is still running
+        // the command data is set on ConsoleEvents::COMMAND and removed on ConsoleEvents::TERMINATE,
+        // it must outlive any reset happening while a command is still running
     }
 
     /**
@@ -61,21 +61,31 @@ class ConsoleCommandProcessor implements EventSubscriberInterface, ResetInterfac
      */
     public function addCommandData(ConsoleEvent $event)
     {
-        $this->commandData = [
+        $commandData = [
             'name' => $event->getCommand()->getName(),
         ];
         if ($this->includeArguments) {
-            $this->commandData['arguments'] = $event->getInput()->getArguments();
+            $commandData['arguments'] = $event->getInput()->getArguments();
         }
         if ($this->includeOptions) {
-            $this->commandData['options'] = $event->getInput()->getOptions();
+            $commandData['options'] = $event->getInput()->getOptions();
         }
+
+        $this->commandDataStack[] = $commandData;
+    }
+
+    public function removeCommandData(): void
+    {
+        array_pop($this->commandDataStack);
     }
 
     public static function getSubscribedEvents(): array
     {
         return [
             ConsoleEvents::COMMAND => ['addCommandData', 1],
+            // lower than ConsoleHandler::onTerminate() (-255) so that records logged
+            // on ConsoleEvents::TERMINATE still carry the command information
+            ConsoleEvents::TERMINATE => ['removeCommandData', -2048],
         ];
     }
 }

--- a/src/Symfony/Bridge/Monolog/Tests/Processor/ConsoleCommandProcessorTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Processor/ConsoleCommandProcessorTest.php
@@ -14,10 +14,15 @@ namespace Symfony\Bridge\Monolog\Tests\Processor;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Monolog\Processor\ConsoleCommandProcessor;
 use Symfony\Bridge\Monolog\Tests\RecordFactory;
+use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\Console\Event\ConsoleEvent;
+use Symfony\Component\Console\Event\ConsoleTerminateEvent;
+use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class ConsoleCommandProcessorTest extends TestCase
 {
@@ -74,12 +79,104 @@ class ConsoleCommandProcessorTest extends TestCase
         $this->assertSame(self::TEST_NAME, $record['extra']['command']['name']);
     }
 
-    private function getConsoleEvent(): ConsoleEvent
+    public function testCommandDataIsRemovedWhenCommandTerminates()
+    {
+        $processor = new ConsoleCommandProcessor();
+        $processor->addCommandData($this->getConsoleEvent());
+
+        $processor->removeCommandData();
+
+        $record = $processor(RecordFactory::create());
+        $this->assertEquals([], $record['extra']);
+
+        $processor->removeCommandData();
+
+        $record = $processor(RecordFactory::create());
+        $this->assertEquals([], $record['extra']);
+    }
+
+    public function testCommandDataIsRestoredWhenNestedCommandTerminates()
+    {
+        $processor = new ConsoleCommandProcessor();
+        $processor->addCommandData($this->getConsoleEvent());
+        $processor->addCommandData($this->getConsoleEvent('some:nested'));
+
+        $record = $processor(RecordFactory::create());
+        $this->assertSame('some:nested', $record['extra']['command']['name']);
+
+        $processor->removeCommandData();
+
+        $record = $processor(RecordFactory::create());
+        $this->assertSame(self::TEST_NAME, $record['extra']['command']['name']);
+    }
+
+    public function testCommandDataOfNestedCommandSurvivesReset()
+    {
+        $processor = new ConsoleCommandProcessor();
+        $processor->addCommandData($this->getConsoleEvent());
+        $processor->addCommandData($this->getConsoleEvent('some:nested'));
+
+        $processor->reset();
+
+        $record = $processor(RecordFactory::create());
+        $this->assertSame('some:nested', $record['extra']['command']['name']);
+    }
+
+    public function testCommandDataFollowsANestedCommandRun()
+    {
+        $processor = new ConsoleCommandProcessor();
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addSubscriber($processor);
+
+        $application = new Application();
+        $application->setAutoExit(false);
+        $application->setCatchExceptions(false);
+        $application->setDispatcher($dispatcher);
+
+        $records = [];
+        $capture = static function (string $key) use ($processor, &$records) {
+            $records[$key] = $processor(RecordFactory::create());
+        };
+
+        $dispatcher->addListener(ConsoleEvents::TERMINATE, static function (ConsoleTerminateEvent $event) use ($capture) {
+            $capture('terminate of '.$event->getCommand()->getName());
+        }, -255);
+
+        $nested = new Command('some:nested');
+        $nested->setCode(static function () use ($capture) {
+            $capture('inside the nested command');
+
+            return 0;
+        });
+
+        $outer = new Command(self::TEST_NAME);
+        $outer->setCode(static function () use ($application, $capture) {
+            $capture('before the nested command');
+            $application->run(new ArrayInput(['command' => 'some:nested']), new NullOutput());
+            $capture('after the nested command');
+
+            return 0;
+        });
+
+        $application->addCommands([$nested, $outer]);
+        $application->run(new ArrayInput(['command' => self::TEST_NAME]), new NullOutput());
+        $capture('after the outer command');
+
+        $this->assertSame(self::TEST_NAME, $records['before the nested command']['extra']['command']['name']);
+        $this->assertSame('some:nested', $records['inside the nested command']['extra']['command']['name']);
+        $this->assertSame('some:nested', $records['terminate of some:nested']['extra']['command']['name']);
+        $this->assertSame(self::TEST_NAME, $records['after the nested command']['extra']['command']['name']);
+        $this->assertSame(self::TEST_NAME, $records['terminate of '.self::TEST_NAME]['extra']['command']['name']);
+        $this->assertSame([], $records['after the outer command']['extra']);
+    }
+
+    private function getConsoleEvent(string $name = self::TEST_NAME): ConsoleEvent
     {
         $input = $this->createStub(InputInterface::class);
         $input->method('getArguments')->willReturn(self::TEST_ARGUMENTS);
         $input->method('getOptions')->willReturn(self::TEST_OPTIONS);
-        $command = new Command(self::TEST_NAME);
+        $command = new Command($name);
 
         return new ConsoleEvent($command, $input, new NullOutput());
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65362
| License       | MIT

`ConsoleCommandProcessor` captures the command data on `ConsoleEvents::COMMAND` and never releases it. In a long-running `messenger:consume` worker that handles a `RunCommandMessage` (e.g. an `#[AsCronTask]` command routed to a regular transport by the Scheduler), the in-process command run overwrites the stored data, and every later log record of the worker is stamped with that stale, unrelated command in `extra.command` — for as long as the worker lives.

This turns the stored data into a stack: pushed on `ConsoleEvents::COMMAND`, popped on `ConsoleEvents::TERMINATE`. When a nested in-process command finishes, the outer command's data is restored, so a worker's records correctly go back to `messenger:consume` after a `RunCommandMessage`.

Before/after, for a worker that ran `app:some-cron-command` via `RunCommandMessage` and then fails an unrelated message:

```diff
- extra.command: {"name": "app:some-cron-command", "arguments": {...}}   (stale, misleading)
+ extra.command: {"name": "messenger:consume", "arguments": {...}}
```

Notes:

- `reset()` stays a no-op, preserving #64768: the data must survive any `kernel.reset` fired while a command is still running. It is now released by the command actually terminating instead of never. The test added in #64768 still passes, and a variant for the nested case is added.
- The pop listener runs at priority -2048, below `ConsoleHandler::onTerminate()` (-255) and the console `ErrorListener` (-128), so records logged during `ConsoleEvents::TERMINATE` (e.g. the exit-code message) still carry the command information.
- `Application::doRunCommand()` dispatches `ConsoleEvents::TERMINATE` on every path after `ConsoleEvents::COMMAND` (success, disabled command, error), so push/pop stays balanced; popping an empty stack is a harmless no-op.
