### PR TITLE
[DoctrineBridge] Fix mapped route params with array-typed arguments

### DIFF
--- a/src/Symfony/Bridge/Doctrine/ArgumentResolver/EntityValueResolver.php
+++ b/src/Symfony/Bridge/Doctrine/ArgumentResolver/EntityValueResolver.php
@@ -59,6 +59,15 @@ final class EntityValueResolver implements ValueResolverInterface
             return [];
         }
 
+        if (!$options->mapping && !$options->id && !\is_array($request->attributes->get($name = $argument->getName()))) {
+            foreach ($request->attributes->get('_route_mapping') ?? [] as $parameter => $attribute) {
+                if ($name === $attribute) {
+                    $options->mapping = [$name => $parameter];
+                    break;
+                }
+            }
+        }
+
         $message = '';
         if ($options->expr instanceof \Closure) {
             if (null === $object = $this->findViaClosure($manager, $options, $request)) {
@@ -119,16 +128,6 @@ final class EntityValueResolver implements ValueResolverInterface
         if ($request->attributes->has($name)) {
             if (\is_array($id = $request->attributes->get($name))) {
                 return false;
-            }
-
-            if (!$options->mapping) {
-                foreach ($request->attributes->get('_route_mapping') ?? [] as $parameter => $attribute) {
-                    if ($name === $attribute) {
-                        $options->mapping = [$name => $parameter];
-
-                        return false;
-                    }
-                }
             }
 
             return $id ?? ($options->stripNull ? false : null);

--- a/src/Symfony/Bridge/Doctrine/Tests/ArgumentResolver/EntityValueResolverTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/ArgumentResolver/EntityValueResolverTest.php
@@ -648,6 +648,32 @@ class EntityValueResolverTest extends TestCase
         $this->assertSame([[$object]], $resolver->resolve($request, $argument));
     }
 
+    public function testResolveArrayWithRouteMapping()
+    {
+        $manager = $this->createMock(ObjectManager::class);
+        $registry = $this->createRegistry($manager);
+        $resolver = new EntityValueResolver($registry);
+
+        $request = new Request();
+        $request->attributes->set('posts', 'john');
+        $request->attributes->set('_route_mapping', ['author' => 'posts']);
+
+        $argument = $this->createArgument('array', new MapEntity(class: \stdClass::class), 'posts');
+
+        $repository = $this->createMock(ObjectRepository::class);
+        $repository->expects($this->once())
+            ->method('findBy')
+            ->with(['author' => 'john'])
+            ->willReturn($objects = [new \stdClass(), new \stdClass()]);
+
+        $manager->expects($this->once())
+            ->method('getRepository')
+            ->with('stdClass')
+            ->willReturn($repository);
+
+        $this->assertSame([$objects], $resolver->resolve($request, $argument));
+    }
+
     public function testArrayArgumentSkipsTheIdentifierLookup()
     {
         $manager = $this->createStub(ObjectManager::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Follow-up to #63949.

One thing that was missed in the original PR is that mapped route parameters don't work with array types, for example:

```php
#[Route('/posts_by/{author:posts}')]
public function authorPosts(#[MapEntity(class: Post::class)] array $posts): Response
{
}
```

This didn't work because the relevant logic was in `getIdentifier()`, which is skipped for array types. This PR moves that logic outside of `getIdentifier()` so it runs for all cases.
