### PR TITLE
[Yaml] Restore the default dump output for sequences of mappings

### DIFF
--- a/src/Symfony/Component/Yaml/Dumper.php
+++ b/src/Symfony/Component/Yaml/Dumper.php
@@ -108,15 +108,14 @@ class Dumper
                 if (Yaml::DUMP_OBJECT_AS_MAP & $flags && ($value instanceof \ArrayObject || $value instanceof \stdClass)) {
                     $dumpObjectAsInlineMap = !(array) $value;
                 }
-                $isSequenceItem = !$dumpAsMap;
+
                 $willBeInlined = $inline - 1 <= 0 || !\is_array($value) && $dumpObjectAsInlineMap || !$value;
-                $isSimpleSequenceHash = !$willBeInlined && $isSequenceItem && \is_array($value) && Inline::isHash($value) && $this->isSimpleSequenceHash($value);
 
                 $output .= \sprintf('%s%s%s%s',
                     $prefix,
                     $dumpAsMap ? Inline::dump($key, $flags).':' : '-',
-                    $willBeInlined || $isSimpleSequenceHash || ($compactNestedMapping && \is_array($value) && Inline::isHash($value)) ? ' ' : "\n",
-                    ($compactNestedMapping && \is_array($value) && Inline::isHash($value)) || $isSimpleSequenceHash ? substr($this->doDump($value, $inline - 1, $indent + 2, $flags, $nestingLevel + 1), $indent + 2) : $this->doDump($value, $inline - 1, $willBeInlined ? 0 : $indent + $this->indentation, $flags, $nestingLevel + 1)
+                    $willBeInlined || ($compactNestedMapping && \is_array($value) && Inline::isHash($value)) ? ' ' : "\n",
+                    $compactNestedMapping && \is_array($value) && Inline::isHash($value) ? substr($this->doDump($value, $inline - 1, $indent + 2, $flags, $nestingLevel + 1), $indent + 2) : $this->doDump($value, $inline - 1, $willBeInlined ? 0 : $indent + $this->indentation, $flags, $nestingLevel + 1)
                 ).($willBeInlined ? "\n" : '');
             }
         }
@@ -184,16 +183,5 @@ class Dumper
         }
 
         return '';
-    }
-
-    private function isSimpleSequenceHash(array $value): bool
-    {
-        foreach ($value as $v) {
-            if (\is_array($v) || $v instanceof TaggedValue) {
-                return false;
-            }
-        }
-
-        return true;
     }
 }

--- a/src/Symfony/Component/Yaml/Tests/DumperTest.php
+++ b/src/Symfony/Component/Yaml/Tests/DumperTest.php
@@ -66,7 +66,8 @@ class DumperTest extends TestCase
             bar:
                    - 1
                    - foo
-                   - a: A
+                   -
+                          a: A
             foobar:
                    foo: bar
                    bar:
@@ -111,16 +112,24 @@ class DumperTest extends TestCase
         }
     }
 
-    public function testDumpSimpleHashesInSequencesCompactly()
+    public function testDumpSimpleHashesInSequences()
     {
         $data = ['servers' => [['url' => 'http://example.com']]];
-        $expected = "servers:\n    - url: 'http://example.com'\n";
+        $expected = "servers:\n    -\n        url: 'http://example.com'\n";
         $this->assertSame($expected, $this->dumper->dump($data, 3));
         $this->assertSameData($data, $this->parser->parse($expected));
 
+        $expected = "servers:\n    - url: 'http://example.com'\n";
+        $this->assertSame($expected, $this->dumper->dump($data, 3, 0, Yaml::DUMP_COMPACT_NESTED_MAPPING));
+        $this->assertSameData($data, $this->parser->parse($expected));
+
         $data = ['servers' => [['url' => 'http://example.com', 'port' => 80]]];
-        $expected = "servers:\n    - url: 'http://example.com'\n      port: 80\n";
+        $expected = "servers:\n    -\n        url: 'http://example.com'\n        port: 80\n";
         $this->assertSame($expected, $this->dumper->dump($data, 3));
+        $this->assertSameData($data, $this->parser->parse($expected));
+
+        $expected = "servers:\n    - url: 'http://example.com'\n      port: 80\n";
+        $this->assertSame($expected, $this->dumper->dump($data, 3, 0, Yaml::DUMP_COMPACT_NESTED_MAPPING));
         $this->assertSameData($data, $this->parser->parse($expected));
     }
 
@@ -168,7 +177,8 @@ class DumperTest extends TestCase
             bar:
                 - 1
                 - foo
-                - a: A
+                -
+                    a: A
             foobar:
                 foo: bar
                 bar:
@@ -189,7 +199,8 @@ class DumperTest extends TestCase
             bar:
                 - 1
                 - foo
-                - a: A
+                -
+                    a: A
             foobar:
                 foo: bar
                 bar:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65287
| License       | MIT

Restores the pre-8.1 default output for sequences of mappings while keeping compact nested mappings available behind `Yaml::DUMP_COMPACT_NESTED_MAPPING`.

Passing `Yaml::DUMP_COMPACT_NESTED_MAPPING` still produces the compact form.

This fixes the behavioral regression introduced by #62967.