### PR TITLE
[ObjectMapper] Only honor an explicitly inbound target #[Map] for the same-name copy

### DIFF
--- a/src/Symfony/Component/ObjectMapper/ObjectMapper.php
+++ b/src/Symfony/Component/ObjectMapper/ObjectMapper.php
@@ -190,8 +190,8 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
                     continue;
                 }
 
-                // when metadata is read from the source, the #[Map] declared on the target property
-                // itself is never surfaced above, so honor its transform for the same-name copy
+                // when metadata is read from the source, an explicitly inbound #[Map] declared on the
+                // target property itself is never surfaced above, so honor its transform here
                 $sameNameMapping = $readMetadataFromTarget ? null : $this->getSameNameTargetMapping($mappedTarget, $propertyName);
 
                 $implicitValues[$propertyName] = $this->getSourceValue($source, $mappedTarget, $this->getRawValue($source, $propertyName), $objectMap, $sameNameMapping, $propertyName);
@@ -284,17 +284,19 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
     }
 
     /**
-     * Returns the unconditional #[Map] declared on the target's own property when it describes a
-     * same-name copy (same source and target property name), so its transform still applies even
-     * when the iteration reads metadata from the source side. Conditional mappings are left to the
-     * regular same-name copy, which does not evaluate conditions.
+     * Returns the unconditional #[Map] declared on the target's own property when it explicitly
+     * describes an inbound same-name copy, so its transform still applies even when the iteration
+     * reads metadata from the source side. A mapping that omits "source" describes how the property
+     * is read when its own class is the source, and must not be applied in this direction.
+     * Conditional mappings are left to the regular same-name copy, which does not evaluate
+     * conditions.
      */
     private function getSameNameTargetMapping(object $target, string $propertyName): ?Mapping
     {
         foreach ($this->metadataFactory->create($target, $propertyName) as $mapping) {
             if (null === $mapping->if
+                && $propertyName === $mapping->source
                 && ($mapping->target ?? $propertyName) === $propertyName
-                && ($mapping->source ?? $propertyName) === $propertyName
             ) {
                 return $mapping;
             }

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/DirectionlessTargetTransform/Product.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/DirectionlessTargetTransform/Product.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\DirectionlessTargetTransform;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(target: ProductInput::class)]
+class Product
+{
+    #[Map(transform: 'strtoupper')]
+    public string $reference = 'sf-1';
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/DirectionlessTargetTransform/ProductInput.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/DirectionlessTargetTransform/ProductInput.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\DirectionlessTargetTransform;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(target: Product::class)]
+class ProductInput
+{
+    public string $reference = 'sf-1';
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
@@ -23,9 +23,6 @@ use Symfony\Component\ObjectMapper\Metadata\ObjectMapperMetadataFactoryInterface
 use Symfony\Component\ObjectMapper\Metadata\ReflectionObjectMapperMetadataFactory;
 use Symfony\Component\ObjectMapper\ObjectMapper;
 use Symfony\Component\ObjectMapper\ObjectMapperInterface;
-use Symfony\Component\ObjectMapper\Tests\Fixtures\SourceCarriesMetadata\Lead as SourceCarriesMetadataLead;
-use Symfony\Component\ObjectMapper\Tests\Fixtures\SourceCarriesMetadata\LeadDto as SourceCarriesMetadataLeadDto;
-use Symfony\Component\ObjectMapper\Tests\Fixtures\SourceCarriesMetadata\TypeDto as SourceCarriesMetadataTypeDto;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\A;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\B;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\C;
@@ -44,6 +41,8 @@ use Symfony\Component\ObjectMapper\Tests\Fixtures\DefaultLazy\OrderTarget;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\DefaultLazy\UserSource;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\DefaultLazy\UserTarget;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\DefaultValueStdClass\TargetDto;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\DirectionlessTargetTransform\Product as DirectionlessTransformProduct;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\DirectionlessTargetTransform\ProductInput as DirectionlessTransformProductInput;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\EmbeddedMapping\Address;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\EmbeddedMapping\User as UserEmbeddedMapping;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\EmbeddedMapping\UserDto;
@@ -138,6 +137,9 @@ use Symfony\Component\ObjectMapper\Tests\Fixtures\ServiceLocator\A as ServiceLoc
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ServiceLocator\B as ServiceLocatorB;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ServiceLocator\ConditionCallable;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ServiceLocator\TransformCallable;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\SourceCarriesMetadata\Lead as SourceCarriesMetadataLead;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\SourceCarriesMetadata\LeadDto as SourceCarriesMetadataLeadDto;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\SourceCarriesMetadata\TypeDto as SourceCarriesMetadataTypeDto;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\SubclassTargetWithTransform\ChildTarget as SubclassTargetWithTransformChildTarget;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\SubclassTargetWithTransform\ParentTarget as SubclassTargetWithTransformParentTarget;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\SubclassTargetWithTransform\Source as SubclassTargetWithTransformSource;
@@ -1130,5 +1132,19 @@ final class ObjectMapperTest extends TestCase
         $this->assertInstanceOf(SourceCarriesMetadataTypeDto::class, $dto->type);
         $this->assertSame(7, $dto->type->id);
         $this->assertSame('moving', $dto->type->name);
+    }
+
+    public function testDirectionlessTargetTransformIsNotAppliedToTheSameNameCopy()
+    {
+        $product = (new ObjectMapper())->map(new DirectionlessTransformProductInput(), DirectionlessTransformProduct::class);
+
+        $this->assertSame('sf-1', $product->reference);
+    }
+
+    public function testDirectionlessTransformIsAppliedWhenItsOwnClassIsTheSource()
+    {
+        $input = (new ObjectMapper())->map(new DirectionlessTransformProduct(), DirectionlessTransformProductInput::class);
+
+        $this->assertSame('SF-1', $input->reference);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | no upstream issue, reported downstream as api-platform/core#8461, details below
| License       | MIT

Follow-up to #65154 ("[ObjectMapper] Fix target property mappings dropped when the source carries metadata"), released in 7.4.16 and 8.1.4.

That change was correct in intent but its filter cannot tell an inbound mapping from an outbound one, so a `#[Map(transform:)]` written for one direction now fires in both.

## The problem

`ObjectMapper` encodes mapping direction by which side the metadata is read from. `doMap()` resolves `$mapping->source` only when reading from the target, and `$mapping->target` only when reading from the source:

```php
$sourcePropertyName = $readMetadataFromTarget ? $mapping->source ?? $propertyName : $propertyName;
$targetPropertyName = $mapping->target ?? $propertyName;
```

The same-name cross-read added in #65154 discards that distinction. Its filter defaults both sides to the property name:

```php
if (null === $mapping->if
    && ($mapping->target ?? $propertyName) === $propertyName
    && ($mapping->source ?? $propertyName) === $propertyName
) {
```

so these three become indistinguishable:

| declaration | intent | matched before |
| --- | --- | --- |
| `#[Map(transform: T)]` | outbound (its own class is the source) | yes |
| `#[Map(target: 'id', transform: T)]` | outbound | yes |
| `#[Map(source: 'id', transform: T)]` | inbound | yes |

Only the third describes an inbound copy.

## Before / after

```php
#[Map(target: ProductInput::class)]
class Product
{
    #[Map(transform: 'strtoupper')]
    public string $reference = 'sf-1';
}

#[Map(target: Product::class)]
class ProductInput
{
    public string $reference = 'sf-1';
}

$product = (new ObjectMapper())->map(new ProductInput(), Product::class);
```

- **before:** `$product->reference === 'SF-1'`. The transform declared for `Product` → `ProductInput` also ran on the way in
- **after:** `$product->reference === 'sf-1'`

Mapping the other way is unchanged and still applies the transform:

```php
$input = (new ObjectMapper())->map(new Product(), ProductInput::class);
// 'SF-1', before and after
```

## The fix

Require the target-side mapping to name its source explicitly before honoring it in the cross-read:

```diff
 if (null === $mapping->if
+    && $propertyName === $mapping->source
     && ($mapping->target ?? $propertyName) === $propertyName
-    && ($mapping->source ?? $propertyName) === $propertyName
 ) {
```

#65154's own fixture declares `#[Map(source: 'type', transform: [ToTypeDto::class, 'transform'])]` on `LeadDto`, so it still matches and `testSameNameTargetPropertyMappingIsHonoredWhenSourceCarriesMetadata` passes unmodified. No existing test or fixture is touched.

This also lines the runtime back up with the documented model. The docs teach a bare `transform` on the class that is the *source*:

```php
#[Map(target: Product::class)]
class ProductInput
{
    #[Map(transform: 'intval')]
    public string $stockLevel = '100';
}
```

and state that target-side `#[Map(source: ...)]` applies when the source class does not map the property.

## How it was found

Reported downstream: api-platform/core#8461. API Platform maps DTOs to Doctrine entities, and an entity carrying `#[Map(transform: 'strval')]` on `$id` for the entity → DTO direction started transforming on writes too, pushing a string into a `?int` setter:

```
Expected argument of type "?int", "string" given at property path "id"
```

Bisected to #65154: pinning `symfony/object-mapper` to 8.1.1 passes, 8.1.4 fails.

## Note for the merge-up: the blast radius differs between 7.4 and 8.x

Worth flagging for whoever merges this up, because the 7.4 test coverage does **not** demonstrate the 8.x exposure.

On 7.4, `$readMetadataFromTarget === false` is only reached when the source class itself carries a `#[Map]` attribute. The affected population is small.

On 8.x, FrameworkBundle registers `ReverseClassObjectMapperMetadataFactory`, which puts source classes into a class map wholesale. That drives many more mappings down the `$readMetadataFromTarget === false` path, so a bare target-side `transform` fires inbound for a much wider set of applications. That is why this surfaced in an API Platform app on 8.x rather than in a plain 7.4 one.

I could not run the FrameworkBundle functional tests locally (they need a full root install). I checked its ObjectMapper fixtures by hand. Every `#[Map(transform:)]` there is declared on a source-side class, so none should be affected. The 8.x FrameworkBundle suite is still the real gate, and deserves attention on the merge-up rather than being assumed green from this branch.

## Backward compatibility

The behaviour being removed shipped in 7.4.16 (2026-08-05) and 8.1.4 (2026-08-06), so it has been out for roughly ten days. Someone could in principle have started relying on a bare target-side `transform` firing inbound, but:

- it is undocumented, and contradicts the documented meaning of a bare `transform`
- anyone who wants an inbound transform has `#[Map(source: '<name>', transform: ...)]`, which is unaffected and is the shape #65154's own fixture uses

7.3 does not have the cross-read at all, so 7.4 is the lowest branch where this applies.

