### PR TITLE
 Fix PHP 8.6 deprecations

### DIFF
--- a/.github/deprecation-ignore
+++ b/.github/deprecation-ignore
@@ -2,3 +2,9 @@
 # These are vendor-internal: ORM has not yet migrated SchemaTool to the DBAL
 # Schema/Table editor API. Symfony's own schema code already uses the editor API.
 %^Doctrine\\DBAL\\Schema\\(Table|Schema)::\w+\(?\)? is deprecated%
+
+# spl_object_hash() is deprecated as of PHP 8.6. Symfony's own code uses
+# spl_object_id() but some dependencies still call it: masterminds/html5,
+# doctrine/collections, doctrine/dbal and the sebastian/* packages that ship
+# with PHPUnit.
+%^Function spl_object_hash\(\) is deprecated%

--- a/src/Symfony/Bridge/Doctrine/ContainerAwareEventManager.php
+++ b/src/Symfony/Bridge/Doctrine/ContainerAwareEventManager.php
@@ -220,7 +220,7 @@ class ContainerAwareEventManager extends EventManager
             return '_service_'.$listener;
         }
 
-        return spl_object_hash($listener);
+        return spl_object_id($listener);
     }
 
     private function getMethod(object $listener, string $event): string

--- a/src/Symfony/Bridge/Doctrine/Tests/TestRepositoryFactory.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/TestRepositoryFactory.php
@@ -49,6 +49,6 @@ final class TestRepositoryFactory implements RepositoryFactory
 
     private function getRepositoryHash(EntityManagerInterface $entityManager, string $entityName): string
     {
-        return $entityManager->getClassMetadata($entityName)->getName().spl_object_hash($entityManager);
+        return $entityManager->getClassMetadata($entityName)->getName()."\0".spl_object_id($entityManager);
     }
 }

--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/Deprecation.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/Deprecation.php
@@ -244,13 +244,24 @@ class Deprecation
         }
 
         $method = $this->originatingMethod();
-        $groups = class_exists(Groups::class, false) ? [new Groups(), 'groups'] : [Test::class, 'getGroups'];
 
-        return 0 === strpos($method, 'testLegacy')
+        if (0 === strpos($method, 'testLegacy')
             || 0 === strpos($method, 'provideLegacy')
             || 0 === strpos($method, 'getLegacy')
             || strpos($this->originClass, '\Legacy')
-            || \in_array('legacy', $groups($this->originClass, $method), true);
+        ) {
+            return true;
+        }
+
+        // The method can be inherited from an internal class, in which case it has no
+        // doc block nor any file/line to read annotations or attributes from.
+        if (!method_exists($this->originClass, $method) || (new \ReflectionMethod($this->originClass, $method))->isInternal()) {
+            return false;
+        }
+
+        $groups = class_exists(Groups::class, false) ? [new Groups(), 'groups'] : [Test::class, 'getGroups'];
+
+        return \in_array('legacy', $groups($this->originClass, $method), true);
     }
 
     /**

--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/DeprecationTest.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/DeprecationTest.php
@@ -72,6 +72,20 @@ class DeprecationTest extends TestCase
         $this->assertTrue($deprecation->isLegacy('whatever'));
     }
 
+    public function testMethodInheritedFromAnInternalClassIsNotLegacy()
+    {
+        $object = new class extends \ArrayObject {
+        };
+        $deprecation = new Deprecation('💩', [
+            [],
+            [],
+            [],
+            ['class' => \ArrayObject::class, 'function' => 'count', 'object' => $object, 'file' => __FILE__],
+        ], __FILE__);
+
+        $this->assertFalse($deprecation->isLegacy());
+    }
+
     public function testItCanBeConvertedToAString()
     {
         $deprecation = new Deprecation('💩', $this->debugBacktrace(), __FILE__);

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/Functional/WebProfilerBundleKernel.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/Functional/WebProfilerBundleKernel.php
@@ -74,12 +74,12 @@ class WebProfilerBundleKernel extends Kernel
 
     public function getCacheDir(): string
     {
-        return sys_get_temp_dir().'/cache-'.spl_object_hash($this);
+        return sys_get_temp_dir().'/cache-'.spl_object_id($this);
     }
 
     public function getLogDir(): string
     {
-        return sys_get_temp_dir().'/log-'.spl_object_hash($this);
+        return sys_get_temp_dir().'/log-'.spl_object_id($this);
     }
 
     protected function build(ContainerBuilder $container): void

--- a/src/Symfony/Component/BrowserKit/HttpBrowser.php
+++ b/src/Symfony/Component/BrowserKit/HttpBrowser.php
@@ -99,6 +99,8 @@ class HttpBrowser extends AbstractBrowser
                     $v = $vars;
                 } elseif (method_exists($v, '__toString')) {
                     $v = (string) $v;
+                } else {
+                    $v = [];
                 }
             }
         });

--- a/src/Symfony/Component/Cache/Adapter/ProxyAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/ProxyAdapter.php
@@ -39,7 +39,7 @@ class ProxyAdapter implements AdapterInterface, CacheInterface, PruneableInterfa
     public function __construct(CacheItemPoolInterface $pool, string $namespace = '', int $defaultLifetime = 0)
     {
         $this->pool = $pool;
-        $this->poolHash = spl_object_hash($pool);
+        $this->poolHash = spl_object_id($pool);
         if ('' !== $namespace) {
             \assert('' !== CacheItem::validateKey($namespace));
             $this->namespace = $namespace;

--- a/src/Symfony/Component/Console/Helper/ProcessHelper.php
+++ b/src/Symfony/Component/Console/Helper/ProcessHelper.php
@@ -59,7 +59,7 @@ class ProcessHelper extends Helper
         }
 
         if ($verbosity <= $output->getVerbosity()) {
-            $output->write($formatter->start(spl_object_hash($process), $this->escapeString($process->getCommandLine())));
+            $output->write($formatter->start(spl_object_id($process), $this->escapeString($process->getCommandLine())));
         }
 
         if ($output->isDebug()) {
@@ -70,7 +70,7 @@ class ProcessHelper extends Helper
 
         if ($verbosity <= $output->getVerbosity()) {
             $message = $process->isSuccessful() ? 'Command ran successfully' : \sprintf('%s Command did not run successfully', $process->getExitCode());
-            $output->write($formatter->stop(spl_object_hash($process), $message, $process->isSuccessful()));
+            $output->write($formatter->stop(spl_object_id($process), $message, $process->isSuccessful()));
         }
 
         if (!$process->isSuccessful() && null !== $error) {
@@ -117,7 +117,7 @@ class ProcessHelper extends Helper
         $formatter = $this->getHelperSet()->get('debug_formatter');
 
         return function ($type, $buffer) use ($output, $process, $callback, $formatter) {
-            $output->write($formatter->progress(spl_object_hash($process), $this->escapeString($buffer), Process::ERR === $type));
+            $output->write($formatter->progress(spl_object_id($process), $this->escapeString($buffer), Process::ERR === $type));
 
             if (null !== $callback) {
                 $callback($type, $buffer);

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -1037,7 +1037,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      */
     private function createService(Definition $definition, array &$inlineServices, bool $isConstructorArgument = false, ?string $id = null, bool|object $tryProxy = true): mixed
     {
-        if (null === $id && isset($inlineServices[$h = spl_object_hash($definition)])) {
+        if (null === $id && isset($inlineServices[$h = "\0".spl_object_id($definition)])) {
             return $inlineServices[$h];
         }
 
@@ -1067,7 +1067,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
             if (\is_array($callable) && (
                 'Closure' !== $class
                 || $callable[0] instanceof Reference
-                || $callable[0] instanceof Definition && !isset($inlineServices[spl_object_hash($callable[0])])
+                || $callable[0] instanceof Definition && !isset($inlineServices["\0".spl_object_id($callable[0])])
             )) {
                 $initializer = function () use ($callable, &$inlineServices) {
                     return $this->doResolveServices($callable[0], $inlineServices);
@@ -1200,7 +1200,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
             // evict the partially-configured instance, but only if this frame shared it; in the
             // proxy-initializer frame, the cached proxy must stay so a retry re-runs the initializer
             if (true === $tryProxy || !$definition->isLazy()) {
-                unset($inlineServices[$id ?? spl_object_hash($definition)]);
+                unset($inlineServices[$id ?? "\0".spl_object_id($definition)]);
 
                 if (null !== $id) {
                     unset($this->services[$id], $this->privates[$id]);
@@ -1698,7 +1698,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
 
     private function shareService(Definition $definition, mixed $service, ?string $id, array &$inlineServices): void
     {
-        $inlineServices[$id ?? spl_object_hash($definition)] = $service;
+        $inlineServices[$id ?? "\0".spl_object_id($definition)] = $service;
 
         if (null !== $id && $definition->isShared()) {
             if ($definition->isPrivate() && $this->isCompiled()) {

--- a/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
@@ -34,7 +34,7 @@ class TraceableEventDispatcher implements EventDispatcherInterface, ResetInterfa
     protected $stopwatch;
 
     /**
-     * @var \SplObjectStorage<WrappedListener, array{string, string}>|null
+     * @var \SplObjectStorage<WrappedListener, array{string, int}>|null
      */
     private ?\SplObjectStorage $callStack = null;
     private EventDispatcherInterface $dispatcher;
@@ -44,7 +44,7 @@ class TraceableEventDispatcher implements EventDispatcherInterface, ResetInterfa
     private array $calledListenerInfos = [];
     private array $calledOriginalListeners = [];
     private ?RequestStack $requestStack;
-    private string $currentRequestHash = '';
+    private int $currentRequestHash = 0;
 
     public function __construct(EventDispatcherInterface $dispatcher, Stopwatch $stopwatch, ?LoggerInterface $logger = null, ?RequestStack $requestStack = null)
     {
@@ -127,7 +127,7 @@ class TraceableEventDispatcher implements EventDispatcherInterface, ResetInterfa
 
         $this->callStack ??= new \SplObjectStorage();
 
-        $currentRequestHash = $this->currentRequestHash = $this->requestStack && ($request = $this->requestStack->getCurrentRequest()) ? spl_object_hash($request) : '';
+        $currentRequestHash = $this->currentRequestHash = $this->requestStack && ($request = $this->requestStack->getCurrentRequest()) ? spl_object_id($request) : 0;
 
         if (null !== $this->logger && $event instanceof StoppableEventInterface && $event->isPropagationStopped()) {
             $this->logger->debug(\sprintf('The "%s" event is already stopped. No listeners have been called.', $eventName));
@@ -162,7 +162,7 @@ class TraceableEventDispatcher implements EventDispatcherInterface, ResetInterfa
             return [];
         }
 
-        $hash = $request ? spl_object_hash($request) : null;
+        $hash = $request ? spl_object_id($request) : null;
         $called = [];
 
         foreach ($this->calledListenerInfos as $requestHash => $eventInfos) {
@@ -192,7 +192,7 @@ class TraceableEventDispatcher implements EventDispatcherInterface, ResetInterfa
             return [];
         }
 
-        $hash = $request ? spl_object_hash($request) : null;
+        $hash = $request ? spl_object_id($request) : null;
         $calledListeners = [];
 
         foreach ($this->calledOriginalListeners as $requestHash => $eventListeners) {
@@ -224,7 +224,7 @@ class TraceableEventDispatcher implements EventDispatcherInterface, ResetInterfa
     public function getOrphanedEvents(?Request $request = null): array
     {
         if ($request) {
-            return $this->orphanedEvents[spl_object_hash($request)] ?? [];
+            return $this->orphanedEvents[spl_object_id($request)] ?? [];
         }
 
         if (!$this->orphanedEvents) {
@@ -242,7 +242,7 @@ class TraceableEventDispatcher implements EventDispatcherInterface, ResetInterfa
         $this->callStack = null;
         $this->wrappedListeners = [];
         $this->orphanedEvents = [];
-        $this->currentRequestHash = '';
+        $this->currentRequestHash = 0;
         $this->dispatchDepth = [];
         $this->calledListenerInfos = [];
         $this->calledOriginalListeners = [];

--- a/src/Symfony/Component/EventDispatcher/Tests/Debug/TraceableEventDispatcherTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/Debug/TraceableEventDispatcherTest.php
@@ -366,7 +366,7 @@ class TraceableEventDispatcherTest extends TestCase
 
         // repeated invocations are aggregated as a counter, the stored state must not grow
         $p = (new \ReflectionObject($tdispatcher))->getProperty('calledListenerInfos');
-        $this->assertCount(1, $p->getValue($tdispatcher)['']['foo']);
+        $this->assertCount(1, $p->getValue($tdispatcher)[0]['foo']);
     }
 
     public function testCallStackIsNotLeakingWithMultipleListeners()
@@ -456,7 +456,7 @@ class TraceableEventDispatcherTest extends TestCase
         $this->assertCount(2, $tdispatcher->getCalledListeners());
 
         $p = (new \ReflectionObject($tdispatcher))->getProperty('calledListenerInfos');
-        $this->assertCount(1, $p->getValue($tdispatcher)['']['foo']);
+        $this->assertCount(1, $p->getValue($tdispatcher)[0]['foo']);
     }
 
     public function testCallStackIsNotLeakingWhenListenerIsAddedBetweenDispatches()

--- a/src/Symfony/Component/Form/ChoiceList/Factory/CachingFactoryDecorator.php
+++ b/src/Symfony/Component/Form/ChoiceList/Factory/CachingFactoryDecorator.php
@@ -52,11 +52,11 @@ class CachingFactoryDecorator implements ChoiceListFactoryInterface, ResetInterf
     public static function generateHash(mixed $value, string $namespace = ''): string
     {
         if (\is_object($value)) {
-            $value = spl_object_hash($value);
+            $value = spl_object_id($value);
         } elseif (\is_array($value)) {
             array_walk_recursive($value, static function (&$v) {
                 if (\is_object($v)) {
-                    $v = spl_object_hash($v);
+                    $v = spl_object_id($v);
                 }
             });
         }

--- a/src/Symfony/Component/Form/Extension/DataCollector/FormDataCollector.php
+++ b/src/Symfony/Component/Form/Extension/DataCollector/FormDataCollector.php
@@ -91,12 +91,12 @@ class FormDataCollector extends DataCollector implements FormDataCollectorInterf
 
     public function associateFormWithView(FormInterface $form, FormView $view): void
     {
-        $this->formsByView[spl_object_hash($view)] = spl_object_hash($form);
+        $this->formsByView[spl_object_id($view)] = spl_object_id($form);
     }
 
     public function collectConfiguration(FormInterface $form): void
     {
-        $hash = spl_object_hash($form);
+        $hash = spl_object_id($form);
 
         if (!isset($this->dataByForm[$hash])) {
             $this->dataByForm[$hash] = [];
@@ -114,7 +114,7 @@ class FormDataCollector extends DataCollector implements FormDataCollectorInterf
 
     public function collectDefaultData(FormInterface $form): void
     {
-        $hash = spl_object_hash($form);
+        $hash = spl_object_id($form);
 
         if (!isset($this->dataByForm[$hash])) {
             // field was created by form event
@@ -133,7 +133,7 @@ class FormDataCollector extends DataCollector implements FormDataCollectorInterf
 
     public function collectSubmittedData(FormInterface $form): void
     {
-        $hash = spl_object_hash($form);
+        $hash = spl_object_id($form);
 
         if (!isset($this->dataByForm[$hash])) {
             // field was created by form event
@@ -156,7 +156,7 @@ class FormDataCollector extends DataCollector implements FormDataCollectorInterf
 
             // Expand current form if there are children with errors
             if (empty($this->dataByForm[$hash]['has_children_error'])) {
-                $childData = $this->dataByForm[spl_object_hash($child)];
+                $childData = $this->dataByForm[spl_object_id($child)];
                 $this->dataByForm[$hash]['has_children_error'] = !empty($childData['has_children_error']) || !empty($childData['errors']);
             }
         }
@@ -164,7 +164,7 @@ class FormDataCollector extends DataCollector implements FormDataCollectorInterf
 
     public function collectViewVariables(FormView $view): void
     {
-        $hash = spl_object_hash($view);
+        $hash = spl_object_id($view);
 
         if (!isset($this->dataByView[$hash])) {
             $this->dataByView[$hash] = [];
@@ -239,7 +239,7 @@ class FormDataCollector extends DataCollector implements FormDataCollectorInterf
 
     private function &recursiveBuildPreliminaryFormTree(FormInterface $form, array &$outputByHash): array
     {
-        $hash = spl_object_hash($form);
+        $hash = spl_object_id($form);
 
         $output = &$outputByHash[$hash];
         $output = $this->dataByForm[$hash]
@@ -256,11 +256,11 @@ class FormDataCollector extends DataCollector implements FormDataCollectorInterf
 
     private function &recursiveBuildFinalFormTree(?FormInterface $form, FormView $view, array &$outputByHash): array
     {
-        $viewHash = spl_object_hash($view);
+        $viewHash = spl_object_id($view);
         $formHash = null;
 
         if (null !== $form) {
-            $formHash = spl_object_hash($form);
+            $formHash = spl_object_id($form);
         } elseif (isset($this->formsByView[$viewHash])) {
             // The FormInterface instance of the CSRF token is never contained in
             // the FormInterface tree of the form, so we need to get the

--- a/src/Symfony/Component/Form/Extension/DataCollector/FormDataExtractor.php
+++ b/src/Symfony/Component/Form/Extension/DataCollector/FormDataExtractor.php
@@ -88,7 +88,7 @@ class FormDataExtractor implements FormDataExtractorInterface
             $errorData = [
                 'message' => $error->getMessage(),
                 'origin' => \is_object($error->getOrigin())
-                    ? spl_object_hash($error->getOrigin())
+                    ? spl_object_id($error->getOrigin())
                     : null,
                 'trace' => [],
             ];

--- a/src/Symfony/Component/Form/Tests/Extension/DataCollector/FormDataCollectorTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/DataCollector/FormDataCollectorTest.php
@@ -98,8 +98,8 @@ class FormDataCollectorTest extends TestCase
                 'name' => $formData,
             ],
             'forms_by_hash' => [
-                spl_object_hash($this->form) => $formData,
-                spl_object_hash($this->childForm) => $childFormData,
+                spl_object_id($this->form) => $formData,
+                spl_object_id($this->childForm) => $childFormData,
             ],
             'nb_errors' => 0,
         ], $this->dataCollector->getData());
@@ -129,7 +129,7 @@ class FormDataCollectorTest extends TestCase
                 'form1' => $form1Data,
             ],
             'forms_by_hash' => [
-                spl_object_hash($form1) => $form1Data,
+                spl_object_id($form1) => $form1Data,
             ],
             'nb_errors' => 0,
         ], $this->dataCollector->getData());
@@ -152,8 +152,8 @@ class FormDataCollectorTest extends TestCase
                 'form2' => $form2Data,
             ],
             'forms_by_hash' => [
-                spl_object_hash($form1) => $form1Data,
-                spl_object_hash($form2) => $form2Data,
+                spl_object_id($form1) => $form1Data,
+                spl_object_id($form2) => $form2Data,
             ],
             'nb_errors' => 0,
         ], $this->dataCollector->getData());
@@ -179,7 +179,7 @@ class FormDataCollectorTest extends TestCase
                 'name' => $formData,
             ],
             'forms_by_hash' => [
-                spl_object_hash($this->form) => $formData,
+                spl_object_id($this->form) => $formData,
             ],
             'nb_errors' => 0,
         ], $this->dataCollector->getData());
@@ -206,7 +206,7 @@ class FormDataCollectorTest extends TestCase
                 'name' => $formData,
             ],
             'forms_by_hash' => [
-                spl_object_hash($this->form) => $formData,
+                spl_object_id($this->form) => $formData,
             ],
             'nb_errors' => 0,
         ], $this->dataCollector->getData());
@@ -225,7 +225,7 @@ class FormDataCollectorTest extends TestCase
                 'name' => $formData,
             ],
             'forms_by_hash' => [
-                spl_object_hash($this->form) => $formData,
+                spl_object_id($this->form) => $formData,
             ],
             'nb_errors' => 0,
         ], $this->dataCollector->getData());
@@ -294,8 +294,8 @@ class FormDataCollectorTest extends TestCase
                 'name' => $formData,
             ],
             'forms_by_hash' => [
-                spl_object_hash($this->form) => $formData,
-                spl_object_hash($this->childForm) => $childFormData,
+                spl_object_id($this->form) => $formData,
+                spl_object_id($this->childForm) => $childFormData,
             ],
             'nb_errors' => 0,
         ], $this->dataCollector->getData());
@@ -364,9 +364,9 @@ class FormDataCollectorTest extends TestCase
                 'name' => $formData,
             ],
             'forms_by_hash' => [
-                spl_object_hash($this->form) => $formData,
-                spl_object_hash($child1) => $child1Data,
-                spl_object_hash($child2) => $child2Data,
+                spl_object_id($this->form) => $formData,
+                spl_object_id($child1) => $child1Data,
+                spl_object_id($child2) => $child2Data,
             ],
             'nb_errors' => 0,
         ], $this->dataCollector->getData());
@@ -385,9 +385,9 @@ class FormDataCollectorTest extends TestCase
                 'name' => $formData,
             ],
             'forms_by_hash' => [
-                spl_object_hash($this->form) => $formData,
-                spl_object_hash($child1) => $child1Data,
-                spl_object_hash($child2) => $child2Data,
+                spl_object_id($this->form) => $formData,
+                spl_object_id($child1) => $child1Data,
+                spl_object_id($child2) => $child2Data,
             ],
             'nb_errors' => 0,
         ], $this->dataCollector->getData());
@@ -427,7 +427,7 @@ class FormDataCollectorTest extends TestCase
                 'name' => $formData,
             ],
             'forms_by_hash' => [
-                spl_object_hash($this->form) => $formData,
+                spl_object_id($this->form) => $formData,
                 // no child entry
             ],
             'nb_errors' => 0,
@@ -476,8 +476,8 @@ class FormDataCollectorTest extends TestCase
                 'name' => $formData,
             ],
             'forms_by_hash' => [
-                spl_object_hash($this->form) => $formData,
-                spl_object_hash($this->childForm) => $childFormData,
+                spl_object_id($this->form) => $formData,
+                spl_object_id($this->childForm) => $childFormData,
             ],
             'nb_errors' => 0,
         ], $this->dataCollector->getData());

--- a/src/Symfony/Component/Form/Tests/Extension/DataCollector/FormDataExtractorTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/DataCollector/FormDataExtractorTest.php
@@ -263,7 +263,7 @@ class FormDataExtractorTest extends TestCase
                 'norm' => 'Foobar',
             ],
             'errors' => [
-                ['message' => 'Invalid!', 'origin' => spl_object_hash($form), 'trace' => []],
+                ['message' => 'Invalid!', 'origin' => spl_object_id($form), 'trace' => []],
             ],
             'synchronized' => true,
         ], $this->dataExtractor->extractSubmittedData($form));
@@ -284,7 +284,7 @@ class FormDataExtractorTest extends TestCase
                 'norm' => 'Foobar',
             ],
             'errors' => [
-                ['message' => 'Invalid!', 'origin' => spl_object_hash($form), 'trace' => []],
+                ['message' => 'Invalid!', 'origin' => spl_object_id($form), 'trace' => []],
             ],
             'synchronized' => true,
         ], $this->dataExtractor->extractSubmittedData($form));
@@ -299,7 +299,7 @@ class FormDataExtractorTest extends TestCase
 
         $form->submit('Foobar');
         $form->addError(new FormError('Invalid!', null, [], null, $violation));
-        $origin = spl_object_hash($form);
+        $origin = spl_object_id($form);
 
         if (class_exists(WordCount::class)) {
             $expectedFormat = <<<"EODUMP"
@@ -310,7 +310,7 @@ class FormDataExtractorTest extends TestCase
                   "errors" => array:1 [
                     0 => array:3 [
                       "message" => "Invalid!"
-                      "origin" => "$origin"
+                      "origin" => $origin
                       "trace" => array:2 [
                         0 => Symfony\Component\Validator\ConstraintViolation {
                           -message: "Foo"
@@ -340,7 +340,7 @@ class FormDataExtractorTest extends TestCase
                   "errors" => array:1 [
                     0 => array:3 [
                       "message" => "Invalid!"
-                      "origin" => "$origin"
+                      "origin" => $origin
                       "trace" => array:2 [
                         0 => Symfony\Component\Validator\ConstraintViolation {
                           -message: "Foo"

--- a/src/Symfony/Component/HttpClient/HttpClientTrait.php
+++ b/src/Symfony/Component/HttpClient/HttpClientTrait.php
@@ -354,6 +354,8 @@ trait HttpClientTrait
                         $v = $vars;
                     } elseif ($v instanceof \Stringable) {
                         $v = (string) $v;
+                    } else {
+                        $v = [];
                     }
                 }
             });

--- a/src/Symfony/Component/HttpClient/Tests/HttpClientTraitTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/HttpClientTraitTest.php
@@ -69,6 +69,14 @@ class HttpClientTraitTest extends TestCase
         $this->assertContains('Content-Type: application/x-www-form-urlencoded; charset=utf-8', $options['headers']);
     }
 
+    public function testNormalizeBodyWithObjectWithoutPublicProperties()
+    {
+        $headers = [];
+        $body = self::normalizeBody(['foo' => 'bar', 'baz' => json_decode('{}')], $headers);
+
+        $this->assertSame('foo=bar', $body);
+    }
+
     public function testNormalizeBodyMultipart()
     {
         $file = fopen('php://memory', 'r+');

--- a/src/Symfony/Component/HttpKernel/DataCollector/LoggerDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/LoggerDataCollector.php
@@ -234,10 +234,10 @@ class LoggerDataCollector extends DataCollector implements LateDataCollectorInte
             $exception = $log['context']['exception'];
 
             if ($exception instanceof SilencedErrorContext) {
-                if (isset($silencedLogs[$h = spl_object_hash($exception)])) {
+                if (isset($silencedLogs[$id = spl_object_id($exception)])) {
                     continue;
                 }
-                $silencedLogs[$h] = true;
+                $silencedLogs[$id] = true;
 
                 if (!isset($sanitizedLogs[$message])) {
                     $sanitizedLogs[$message] = $log + [
@@ -313,10 +313,10 @@ class LoggerDataCollector extends DataCollector implements LateDataCollectorInte
             if ($this->isSilencedOrDeprecationErrorLog($log)) {
                 $exception = $log['context']['exception'];
                 if ($exception instanceof SilencedErrorContext) {
-                    if (isset($silencedLogs[$h = spl_object_hash($exception)])) {
+                    if (isset($silencedLogs[$id = spl_object_id($exception)])) {
                         continue;
                     }
-                    $silencedLogs[$h] = true;
+                    $silencedLogs[$id] = true;
                     $count['scream_count'] += $exception->count;
                 } else {
                     ++$count['deprecation_count'];

--- a/src/Symfony/Component/Lock/Store/DoctrineDbalPostgreSqlStore.php
+++ b/src/Symfony/Component/Lock/Store/DoctrineDbalPostgreSqlStore.php
@@ -302,7 +302,7 @@ class DoctrineDbalPostgreSqlStore implements BlockingSharedLockStoreInterface, B
 
     private function getInternalStore(): SharedLockStoreInterface
     {
-        $namespace = spl_object_hash($this->conn);
+        $namespace = spl_object_id($this->conn);
 
         return self::$storeRegistry[$namespace] ??= new InMemoryStore();
     }

--- a/src/Symfony/Component/Lock/Store/PostgreSqlStore.php
+++ b/src/Symfony/Component/Lock/Store/PostgreSqlStore.php
@@ -301,7 +301,7 @@ class PostgreSqlStore implements BlockingSharedLockStoreInterface, BlockingStore
 
     private function getInternalStore(): SharedLockStoreInterface
     {
-        $namespace = spl_object_hash($this->getConnection());
+        $namespace = spl_object_id($this->getConnection());
 
         return self::$storeRegistry[$namespace] ??= new InMemoryStore();
     }

--- a/src/Symfony/Component/Lock/Tests/LockTest.php
+++ b/src/Symfony/Component/Lock/Tests/LockTest.php
@@ -475,18 +475,18 @@ class LockTest extends TestCase
             public function save(Key $key): void
             {
                 $key->reduceLifetime($this->initialTtl);
-                $this->keys[spl_object_hash($key)] = $key;
+                $this->keys[spl_object_id($key)] = $key;
                 $this->checkNotExpired($key);
             }
 
             public function delete(Key $key): void
             {
-                unset($this->keys[spl_object_hash($key)]);
+                unset($this->keys[spl_object_id($key)]);
             }
 
             public function exists(Key $key): bool
             {
-                return isset($this->keys[spl_object_hash($key)]);
+                return isset($this->keys[spl_object_id($key)]);
             }
 
             public function putOffExpiration(Key $key, $ttl): void
@@ -519,18 +519,18 @@ class LockTest extends TestCase
             public function save(Key $key): void
             {
                 $key->reduceLifetime($this->initialTtl);
-                $this->keys[spl_object_hash($key)] = $key;
+                $this->keys[spl_object_id($key)] = $key;
                 $this->checkNotExpired($key);
             }
 
             public function delete(Key $key): void
             {
-                unset($this->keys[spl_object_hash($key)]);
+                unset($this->keys[spl_object_id($key)]);
             }
 
             public function exists(Key $key): bool
             {
-                return isset($this->keys[spl_object_hash($key)]);
+                return isset($this->keys[spl_object_id($key)]);
             }
 
             public function putOffExpiration(Key $key, $ttl): void

--- a/src/Symfony/Component/Routing/Generator/UrlGenerator.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGenerator.php
@@ -295,6 +295,8 @@ class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInt
                     $v = $vars;
                 } elseif (method_exists($v, '__toString')) {
                     $v = (string) $v;
+                } else {
+                    $v = [];
                 }
             }
         });

--- a/src/Symfony/Component/Scheduler/Tests/Trigger/CallbackTriggerTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/Trigger/CallbackTriggerTest.php
@@ -19,7 +19,7 @@ class CallbackTriggerTest extends TestCase
     public function testToString()
     {
         $trigger = new CallbackTrigger(static fn () => null);
-        $this->assertMatchesRegularExpression('/^[\da-f]{32}$/', (string) $trigger);
+        $this->assertMatchesRegularExpression('/^\d+$/', (string) $trigger);
 
         $trigger = new CallbackTrigger(static fn () => null, '');
         $this->assertSame('', (string) $trigger);

--- a/src/Symfony/Component/Scheduler/Trigger/CallbackTrigger.php
+++ b/src/Symfony/Component/Scheduler/Trigger/CallbackTrigger.php
@@ -22,7 +22,7 @@ final class CallbackTrigger implements TriggerInterface
     public function __construct(callable $callback, ?string $description = null)
     {
         $this->callback = $callback(...);
-        $this->description = $description ?? spl_object_hash($this->callback);
+        $this->description = $description ?? spl_object_id($this->callback);
     }
 
     public function __toString(): string

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -173,19 +173,19 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
      */
     protected function isCircularReference(object $object, array &$context): bool
     {
-        $objectHash = spl_object_hash($object);
+        $objectId = spl_object_id($object);
 
         $circularReferenceLimit = $context[self::CIRCULAR_REFERENCE_LIMIT] ?? $this->defaultContext[self::CIRCULAR_REFERENCE_LIMIT];
-        if (isset($context[self::CIRCULAR_REFERENCE_LIMIT_COUNTERS][$objectHash])) {
-            if ($context[self::CIRCULAR_REFERENCE_LIMIT_COUNTERS][$objectHash] >= $circularReferenceLimit) {
-                unset($context[self::CIRCULAR_REFERENCE_LIMIT_COUNTERS][$objectHash]);
+        if (isset($context[self::CIRCULAR_REFERENCE_LIMIT_COUNTERS][$objectId])) {
+            if ($context[self::CIRCULAR_REFERENCE_LIMIT_COUNTERS][$objectId] >= $circularReferenceLimit) {
+                unset($context[self::CIRCULAR_REFERENCE_LIMIT_COUNTERS][$objectId]);
 
                 return true;
             }
 
-            ++$context[self::CIRCULAR_REFERENCE_LIMIT_COUNTERS][$objectHash];
+            ++$context[self::CIRCULAR_REFERENCE_LIMIT_COUNTERS][$objectId];
         } else {
-            $context[self::CIRCULAR_REFERENCE_LIMIT_COUNTERS][$objectHash] = 1;
+            $context[self::CIRCULAR_REFERENCE_LIMIT_COUNTERS][$objectId] = 1;
         }
 
         return false;

--- a/src/Symfony/Component/Validator/Context/ExecutionContext.php
+++ b/src/Symfony/Component/Validator/Context/ExecutionContext.php
@@ -268,7 +268,7 @@ class ExecutionContext implements ExecutionContextInterface
     public function generateCacheKey(object $object): string
     {
         if (!isset($this->cachedObjectsRefs[$object])) {
-            $this->cachedObjectsRefs[$object] = spl_object_hash($object);
+            $this->cachedObjectsRefs[$object] = spl_object_id($object);
         }
 
         return $this->cachedObjectsRefs[$object];

--- a/src/Symfony/Component/Validator/Tests/Fixtures/FakeMetadataFactory.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/FakeMetadataFactory.php
@@ -21,10 +21,10 @@ class FakeMetadataFactory implements MetadataFactoryInterface
 
     public function getMetadataFor($class): MetadataInterface
     {
-        $hash = null;
+        $objectId = null;
 
         if (\is_object($class)) {
-            $hash = spl_object_hash($class);
+            $objectId = spl_object_id($class);
             $class = $class::class;
         }
 
@@ -33,8 +33,8 @@ class FakeMetadataFactory implements MetadataFactoryInterface
         }
 
         if (!isset($this->metadatas[$class])) {
-            if (isset($this->metadatas[$hash])) {
-                return $this->metadatas[$hash];
+            if (isset($this->metadatas[$objectId])) {
+                return $this->metadatas[$objectId];
             }
 
             throw new NoSuchMetadataException(sprintf('No metadata for "%s"', $class));
@@ -45,10 +45,10 @@ class FakeMetadataFactory implements MetadataFactoryInterface
 
     public function hasMetadataFor($class): bool
     {
-        $hash = null;
+        $objectId = null;
 
         if (\is_object($class)) {
-            $hash = spl_object_hash($class);
+            $objectId = spl_object_id($class);
             $class = $class::class;
         }
 
@@ -56,7 +56,7 @@ class FakeMetadataFactory implements MetadataFactoryInterface
             return false;
         }
 
-        return isset($this->metadatas[$class]) || isset($this->metadatas[$hash]);
+        return isset($this->metadatas[$class]) || isset($this->metadatas[$objectId]);
     }
 
     public function addMetadata($metadata)
@@ -66,7 +66,7 @@ class FakeMetadataFactory implements MetadataFactoryInterface
 
     public function addMetadataForValue($value, MetadataInterface $metadata)
     {
-        $key = \is_object($value) ? spl_object_hash($value) : $value;
+        $key = \is_object($value) ? spl_object_id($value) : $value;
         $this->metadatas[$key] = $metadata;
     }
 }

--- a/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php
+++ b/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php
@@ -442,7 +442,7 @@ class RecursiveContextualValidator implements ContextualValidatorInterface
             // Replace the "Default" group by the group sequence defined
             // for the class, if applicable.
             // This is done after checking the cache, so that
-            // spl_object_hash() isn't called for this sequence and
+            // spl_object_id() isn't called for this sequence and
             // "Default" is used instead in the cache. This is useful
             // if the getters below return different group sequences in
             // every call.
@@ -776,11 +776,11 @@ class RecursiveContextualValidator implements ContextualValidatorInterface
         if ($this->context instanceof ExecutionContext) {
             $cacheKey = $this->context->generateCacheKey($object);
         } else {
-            $cacheKey = spl_object_hash($object);
+            $cacheKey = spl_object_id($object);
         }
 
         if ($dependsOnPropertyPath) {
-            $cacheKey .= $this->context->getPropertyPath();
+            $cacheKey .= "\0".$this->context->getPropertyPath();
         }
 
         return $cacheKey;

--- a/src/Symfony/Component/VarDumper/Caster/SplCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/SplCaster.php
@@ -262,12 +262,23 @@ class SplCaster
     private static function castSplArray(\ArrayObject|\ArrayIterator $c, array $a, Stub $stub, bool $isNested): array
     {
         $prefix = Caster::PREFIX_VIRTUAL;
-        $flags = $c->getFlags();
+        $hasDebugInfo = method_exists($c, '__debugInfo');
 
-        if (!($flags & \ArrayObject::STD_PROP_LIST)) {
-            $c->setFlags(\ArrayObject::STD_PROP_LIST);
-            $a = Caster::castObject($c, $c::class, method_exists($c, '__debugInfo'), $stub->class);
-            $c->setFlags($flags);
+        if ($c instanceof \ArrayObject) {
+            $flags = $c->getFlags();
+
+            if (!($flags & \ArrayObject::STD_PROP_LIST)) {
+                $c->setFlags(\ArrayObject::STD_PROP_LIST);
+                $a = Caster::castObject($c, $c::class, $hasDebugInfo, $stub->class);
+                $c->setFlags($flags);
+            }
+        } else {
+            // ArrayIterator::getFlags() and ArrayIterator::setFlags() are deprecated as of PHP 8.6
+            [$flags, , $properties] = $c->__serialize();
+
+            if (!($flags & \ArrayObject::STD_PROP_LIST)) {
+                $a = $properties;
+            }
         }
 
         unset($a["\0ArrayObject\0storage"], $a["\0ArrayIterator\0storage"]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

PHP 8.6 merged a batch of deprecations that make the test suite fail. Tested against `php-src` master built locally. One commit per deprecation.

### `spl_object_hash()`

Deprecated in favour of `spl_object_id()`. Every identifier Symfony built with it was only ever used as an array key or for identity comparison, so the replacement is behavior-neutral.

Ids are not fixed-width the way hashes were, which matters in the few places that build a longer key out of one. `RecursiveContextualValidator::generateCacheKey()` appends the property path, so `1` + `23` and `12` + `3` would collide; it now separates them with a `"\0"`. `ContainerBuilder` keys `$inlineServices` by service id *or* object id, so those get the same separator to keep a numeric service id from colliding. Everywhere else the id is used raw.

`TraceableEventDispatcher::$currentRequestHash` becomes an `int` keyed on `0` rather than `''` when there is no request: `null` would have traded this deprecation for the new "Using null as an array offset" one.

Deprecated calls remain in dependencies we don't control, hence the `deprecation-ignore` entry: masterminds/html5, doctrine/collections, doctrine/dbal, and sebastian/recursion-context (which silences it rather than break BC). PHPUnit itself and sebastian/exporter already migrated in their latest releases.

### `ArrayIterator::getFlags()` / `::setFlags()`

Deprecated on `ArrayIterator` but *not* on `ArrayObject`, so `SplCaster::castSplArray()` now branches. For `ArrayIterator`, `__serialize()` returns both the flags and the property table, which is all the caster needs, and it has the nice side effect of no longer mutating the object being dumped.

Note the deprecation leaves no way to read an `ArrayIterator`'s flags via a dedicated API even though the constructor still accepts them.

### Objects passed to `http_build_query()`

Object values in `$data` may no longer be interpreted as arrays. The casters in `HttpClientTrait`, `UrlGenerator` and `HttpBrowser` already replaced objects by their public properties, except when there were none and the object wasn't stringable. Casting those to an empty array produces the exact same query string.

### PhpUnit bridge crash

Not a deprecation of its own, but it hid all of the above: resolving the origin of a deprecation can land on a method a userland class inherits from an internal one (`FilterIterator::rewind()`, reached from PHPUnit's group filters). Reading its groups makes PHPUnit fatal with `DocBlock::__construct(): Argument #4 ($startLine) must be of type int, false given`, because internal methods have no start line.

### Not fixed here: a php-src regression

The Twig bridge form-layout tests fail on PHP 8.6 for a reason unrelated to deprecations: nested `yield from` duplicates the last yielded value, which breaks every `{% for %}` in a Twig template.

```php
function a() { yield "Q"; }
function b() { yield from a(); yield from []; }
function c() { yield from b(); }

var_dump(iterator_to_array(c(), false)); // ["Q", "Q"] on 8.6, ["Q"] before
```

Bisected to php/php-src@0ccff767634 ("Fix GH-15375: nested "yield from" skips items after valid()/next()"); reverting it locally makes the whole suite green. That commit is also on the PHP-8.4 and PHP-8.5 branches, so it will ship there too. [Reported separately upstream](https://github.com/php/php-src/issues/23301).

### Verification

All 64 component/bridge/bundle suites pass on PHP 8.6.0-dev (with the php-src commit above reverted), with `--exclude-group tty,benchmark,intl-data,integration,transient`.
