### PR TITLE
[Console][DependencyInjection][HttpKernel] Support union and intersection types as controller and command arguments

### DIFF
--- a/src/Symfony/Component/Console/ArgumentResolver/ArgumentResolver.php
+++ b/src/Symfony/Component/Console/ArgumentResolver/ArgumentResolver.php
@@ -129,7 +129,7 @@ final class ArgumentResolver implements ArgumentResolverInterface
 
             $reasons = array_map(static fn (NearMissValueResolverException $e) => $e->getMessage(), $valueResolverExceptions);
             if (!$reasons) {
-                $reasons[] = \sprintf('The parameter has no #[Argument], #[Option], or #[MapInput] attribute, and its type "%s" cannot be auto-resolved.', $typeName ?? 'unknown');
+                $reasons[] = \sprintf('The parameter has no #[Argument], #[Option], or #[MapInput] attribute, and its type "%s" cannot be auto-resolved.', $typeName ?? self::formatType($type));
                 $reasons[] = 'Add an attribute to map this parameter to command input.';
             }
 
@@ -159,5 +159,15 @@ final class ArgumentResolver implements ArgumentResolverInterface
             new Resolver\DefaultValueResolver(),
             new Resolver\VariadicValueResolver(),
         ];
+    }
+
+    private static function formatType(?\ReflectionType $type): string
+    {
+        return match (true) {
+            $type instanceof \ReflectionNamedType => $type->getName(),
+            $type instanceof \ReflectionUnionType => implode('|', array_map(static fn ($t) => $t instanceof \ReflectionIntersectionType ? '('.self::formatType($t).')' : self::formatType($t), $type->getTypes())),
+            $type instanceof \ReflectionIntersectionType => implode('&', array_map(self::formatType(...), $type->getTypes())),
+            default => 'unknown',
+        };
     }
 }

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Allow a callable for the `description` and `help` options of `#[AsCommand]`, and for the `description` option of `#[Argument]` and `#[Option]`
  * Add `GitlabCiReporter` to emit reports in the GitLab Code Quality format
  * Wrap the descriptions in `TextDescriptor` output to the terminal width; pass the `terminal_width` describe option to control it
+ * Allow union and intersection type-hints when autowiring arguments of invokable commands
 
 8.1
 ---

--- a/src/Symfony/Component/Console/DependencyInjection/RegisterCommandArgumentLocatorsPass.php
+++ b/src/Symfony/Component/Console/DependencyInjection/RegisterCommandArgumentLocatorsPass.php
@@ -127,7 +127,7 @@ final class RegisterCommandArgumentLocatorsPass implements CompilerPassInterface
                         $arguments[$p->name] = $bindingValue;
 
                         continue;
-                    } elseif (!$autowire || (!($autowireAttributes = $p->getAttributes(Autowire::class, \ReflectionAttribute::IS_INSTANCEOF)) && (!$type || '\\' !== $target[0]))) {
+                    } elseif (!$autowire || (!($autowireAttributes = $p->getAttributes(Autowire::class, \ReflectionAttribute::IS_INSTANCEOF)) && (!$type || !\in_array($target[0], ['\\', '('], true)))) {
                         continue;
                     } elseif (!$autowireAttributes && is_subclass_of($type, \UnitEnum::class)) {
                         // Do not attempt to register enum typed arguments if not already present in bindings
@@ -159,7 +159,9 @@ final class RegisterCommandArgumentLocatorsPass implements CompilerPassInterface
                         continue;
                     }
 
-                    if ($type && !$p->isOptional() && !$p->allowsNull() && !class_exists($type) && !interface_exists($type, false)) {
+                    $types = $type ? array_diff(preg_split('/[()|&]++/', $type, -1, \PREG_SPLIT_NO_EMPTY), ['int', 'string', 'array', 'bool', 'float', 'iterable', 'object', 'callable', 'null']) : [];
+
+                    if ($types && !$p->isOptional() && !$p->allowsNull() && $types !== array_filter($types, static fn ($t) => class_exists($t) || interface_exists($t, false))) {
                         $message = \sprintf('Cannot determine command argument for "%s::%s()": the $%s argument is type-hinted with the non-existent class or interface: "%s".', $class, $method->name, $p->name, $type);
 
                         // See if the type-hint lives in the same namespace as the command

--- a/src/Symfony/Component/Console/Tests/ArgumentResolver/ArgumentResolverTest.php
+++ b/src/Symfony/Component/Console/Tests/ArgumentResolver/ArgumentResolverTest.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Tests\ArgumentResolver;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\ArgumentResolver\ArgumentResolver;
+use Symfony\Component\Console\Input\ArrayInput;
+
+class ArgumentResolverTest extends TestCase
+{
+    public function testUnresolvableIntersectionTypeIsReported()
+    {
+        $command = static fn (DummyInterfaceA&DummyInterfaceB $service) => 0;
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage(\sprintf('its type "%s&%s" cannot be auto-resolved', DummyInterfaceA::class, DummyInterfaceB::class));
+
+        (new ArgumentResolver())->getArguments(new ArrayInput([]), $command);
+    }
+
+    public function testUnresolvableDnfTypeIsReported()
+    {
+        $command = static fn ((DummyInterfaceA&DummyInterfaceB)|DummyClass $service) => 0;
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage(\sprintf('its type "(%s&%s)|%s" cannot be auto-resolved', DummyInterfaceA::class, DummyInterfaceB::class, DummyClass::class));
+
+        (new ArgumentResolver())->getArguments(new ArrayInput([]), $command);
+    }
+}
+
+interface DummyInterfaceA
+{
+}
+
+interface DummyInterfaceB
+{
+}
+
+class DummyClass
+{
+}

--- a/src/Symfony/Component/Console/Tests/ArgumentResolver/ValueResolver/ServiceValueResolverTest.php
+++ b/src/Symfony/Component/Console/Tests/ArgumentResolver/ValueResolver/ServiceValueResolverTest.php
@@ -186,6 +186,47 @@ class ServiceValueResolverTest extends TestCase
         iterator_to_array($resolver->resolve('dummy', $input, $member));
     }
 
+    public function testCompositeTypeIsResolvedThroughServiceLocator()
+    {
+        $service = new DummyCompositeService();
+
+        $resolver = new ServiceValueResolver(new ServiceLocator([
+            'app:test' => static fn () => new ServiceLocator([
+                'dummy' => static fn () => $service,
+            ]),
+        ]));
+
+        $input = new ArrayInput(['app:test'], new InputDefinition([
+            new InputArgument('command'),
+        ]));
+
+        $function = static fn (DummyServiceInterfaceA&DummyServiceInterfaceB $dummy) => null;
+        $reflection = new \ReflectionFunction($function);
+        $parameter = $reflection->getParameters()[0];
+        $member = new ReflectionMember($parameter);
+
+        $this->assertSame([$service], $resolver->resolve('dummy', $input, $member));
+    }
+
+    public function testDoesNotFallBackToTypeNameForCompositeTypes()
+    {
+        $resolver = new ServiceValueResolver(new ServiceLocator([
+            DummyServiceInterfaceA::class => static fn () => new DummyCompositeService(),
+            DummyServiceInterfaceB::class => static fn () => new DummyCompositeService(),
+        ]));
+
+        $input = new ArrayInput(['app:test'], new InputDefinition([
+            new InputArgument('command'),
+        ]));
+
+        $function = static fn (DummyServiceInterfaceA&DummyServiceInterfaceB $dummy) => null;
+        $reflection = new \ReflectionFunction($function);
+        $parameter = $reflection->getParameters()[0];
+        $member = new ReflectionMember($parameter);
+
+        $this->assertSame([], $resolver->resolve('dummy', $input, $member));
+    }
+
     public function testDoesNotResolveWhenNoCommandArgument()
     {
         $resolver = new ServiceValueResolver(new ServiceLocator([
@@ -208,5 +249,17 @@ class ServiceValueResolverTest extends TestCase
 }
 
 class DummyService
+{
+}
+
+interface DummyServiceInterfaceA
+{
+}
+
+interface DummyServiceInterfaceB
+{
+}
+
+class DummyCompositeService implements DummyServiceInterfaceA, DummyServiceInterfaceB
 {
 }

--- a/src/Symfony/Component/Console/Tests/DependencyInjection/RegisterCommandArgumentLocatorsPassTest.php
+++ b/src/Symfony/Component/Console/Tests/DependencyInjection/RegisterCommandArgumentLocatorsPassTest.php
@@ -244,6 +244,61 @@ class RegisterCommandArgumentLocatorsPassTest extends TestCase
         $this->assertInstanceOf(NullLogger::class, $locator->get('logger'));
     }
 
+    public function testProcessCompositeTypeArguments()
+    {
+        $container = new ContainerBuilder();
+        $container->register('console.argument_resolver.service')->addArgument(null);
+
+        $command = new Definition(CommandWithCompositeTypes::class);
+        $command->addTag('console.command', ['command' => 'test:command']);
+        $command->addTag('console.command.service_arguments');
+        $container->setDefinition('test.command', $command);
+
+        $pass = new RegisterCommandArgumentLocatorsPass();
+        $pass->process($container);
+
+        $serviceResolverDef = $container->getDefinition('console.argument_resolver.service');
+        $commands = $container->getDefinition((string) $serviceResolverDef->getArgument(0))->getArgument(0);
+        $locator = $container->getDefinition((string) $commands['test:command']->getValues()[0]);
+        $locator = $container->getDefinition((string) $locator->getFactory()[0]);
+
+        $expected = [
+            'intersection' => new ServiceClosureArgument(new TypedReference($type = CombinedTypeA::class.'&'.CombinedTypeB::class, $type, ContainerInterface::RUNTIME_EXCEPTION_ON_INVALID_REFERENCE, 'intersection')),
+            'union' => new ServiceClosureArgument(new TypedReference($type = CombinedTypeA::class.'|'.CombinedTypeB::class, $type, ContainerInterface::RUNTIME_EXCEPTION_ON_INVALID_REFERENCE, 'union')),
+            'nullableIntersection' => new ServiceClosureArgument(new TypedReference($type = '('.CombinedTypeA::class.'&'.CombinedTypeB::class.')|null', $type, ContainerInterface::IGNORE_ON_INVALID_REFERENCE, 'nullableIntersection')),
+        ];
+        $this->assertEquals($expected, $locator->getArgument(0));
+    }
+
+    public function testProcessCompositeTypesAreAutowired()
+    {
+        $container = new ContainerBuilder();
+        $resolver = $container->register('console.argument_resolver.service', 'stdClass')->addArgument(null);
+
+        $container->register('combined', CombinedTypeService::class);
+        $container->setAlias(CombinedTypeA::class, 'combined');
+        $container->setAlias(CombinedTypeB::class, 'combined');
+
+        $command = new Definition(CommandWithCompositeTypes::class);
+        $command->addTag('console.command', ['command' => 'test:command']);
+        $command->addTag('console.command.service_arguments');
+        $container->setDefinition('test.command', $command);
+
+        $pass = new RegisterCommandArgumentLocatorsPass();
+        $pass->process($container);
+
+        $locatorId = (string) $resolver->getArgument(0);
+        $container->getDefinition($locatorId)->setPublic(true);
+
+        $container->compile();
+
+        $locator = $container->get($locatorId)->get('test:command');
+
+        $this->assertInstanceOf(CombinedTypeService::class, $locator->get('intersection'));
+        $this->assertInstanceOf(CombinedTypeService::class, $locator->get('union'));
+        $this->assertInstanceOf(CombinedTypeService::class, $locator->get('nullableIntersection'));
+    }
+
     public function testProcessThrowsOnMissingArgumentAttribute()
     {
         $container = new ContainerBuilder();
@@ -320,6 +375,28 @@ class CommandWithTarget
     public function __invoke(
         #[Target('request.logger')]
         LoggerInterface $logger,
+    ): void {
+    }
+}
+
+interface CombinedTypeA
+{
+}
+
+interface CombinedTypeB
+{
+}
+
+class CombinedTypeService implements CombinedTypeA, CombinedTypeB
+{
+}
+
+class CommandWithCompositeTypes
+{
+    public function __invoke(
+        CombinedTypeA&CombinedTypeB $intersection,
+        CombinedTypeA|CombinedTypeB $union,
+        (CombinedTypeA&CombinedTypeB)|null $nullableIntersection,
     ): void {
     }
 }

--- a/src/Symfony/Component/Console/composer.json
+++ b/src/Symfony/Component/Console/composer.json
@@ -26,7 +26,7 @@
     "require-dev": {
         "psr/log": "^1|^2|^3",
         "symfony/config": "^7.4|^8.0",
-        "symfony/dependency-injection": "^8.1",
+        "symfony/dependency-injection": "^8.2",
         "symfony/event-dispatcher": "^8.1",
         "symfony/filesystem": "^7.4|^8.0",
         "symfony/http-foundation": "^7.4|^8.0",
@@ -44,7 +44,7 @@
         "psr/log-implementation": "1.0|2.0|3.0"
     },
     "conflict": {
-        "symfony/dependency-injection": "<8.1",
+        "symfony/dependency-injection": "<8.2",
         "symfony/event-dispatcher": "<8.1"
     },
     "autoload": {

--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
@@ -460,12 +460,14 @@ class AutowirePass extends AbstractRecursivePass
             return $reference;
         }
 
-        if ($filterType && false !== $m = strpbrk($type, '&|')) {
-            $types = array_diff(explode($m[0], $type), ['int', 'string', 'array', 'bool', 'float', 'iterable', 'object', 'callable', 'null']);
+        if ($filterType && strpbrk($type, '&|')) {
+            // a top-level "|" always outranks "&"
+            $glue = str_contains($type, '|') ? '|' : '&';
+            $types = array_diff(explode($glue, $type), ['int', 'string', 'array', 'bool', 'float', 'iterable', 'object', 'callable', 'null']);
 
             sort($types);
 
-            $type = implode($m[0], $types);
+            $type = implode($glue, $types);
         }
 
         $name = $target = (array_filter($reference->getAttributes(), static fn ($a) => $a instanceof Target)[0] ?? null)?->name;

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
@@ -485,6 +485,23 @@ class AutowirePassTest extends TestCase
         $this->assertSame('b', (string) $definition->getArgument(0));
     }
 
+    public function testNullableIntersectionTypedReferenceIsAutowired()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('b', \stdClass::class);
+        $container->setAlias(CollisionInterface::class, 'b');
+        $container->setAlias(AnotherInterface::class, 'b');
+
+        $container->register('some_locator', 'stdClass')
+            ->addArgument(new TypedReference($type = '('.CollisionInterface::class.'&'.AnotherInterface::class.')|null', $type, ContainerBuilder::IGNORE_ON_INVALID_REFERENCE))
+            ->addTag('container.service_locator');
+
+        (new AutowirePass())->process($container);
+
+        $this->assertSame('b', (string) $container->getDefinition('some_locator')->getArgument(0));
+    }
+
     public function testParameterWithNullUnionIsAutowired()
     {
         $container = new ContainerBuilder();

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -13,6 +13,7 @@ CHANGELOG
  * Prefix the property path to each violation message reported by `RequestPayloadValueResolver`
  * Add `SourceValueResolverInterface` to let a value resolver stage a raw value for the resolvers that follow it, so `#[MapQueryParameter]` accepts any type another resolver can build
  * Deprecate the `HIncludeFragmentRenderer` class, use the `EsiFragmentRenderer` or `InlineFragmentRenderer`, or Symfony UX Turbo, instead
+ * Allow union and intersection type-hints when autowiring controller arguments
 
 8.1
 ---

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterControllerArgumentLocatorsPass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterControllerArgumentLocatorsPass.php
@@ -153,7 +153,7 @@ class RegisterControllerArgumentLocatorsPass implements CompilerPassInterface
                         $args[$p->name] = $bindingValue;
 
                         continue;
-                    } elseif (!$autowire || (!($autowireAttributes = $p->getAttributes(Autowire::class, \ReflectionAttribute::IS_INSTANCEOF)) && (!$type || '\\' !== $target[0]))) {
+                    } elseif (!$autowire || (!($autowireAttributes = $p->getAttributes(Autowire::class, \ReflectionAttribute::IS_INSTANCEOF)) && (!$type || !\in_array($target[0], ['\\', '('], true)))) {
                         continue;
                     } elseif (!$autowireAttributes && is_subclass_of($type, \UnitEnum::class)) {
                         // do not attempt to register enum typed arguments if not already present in bindings
@@ -185,7 +185,9 @@ class RegisterControllerArgumentLocatorsPass implements CompilerPassInterface
                         continue;
                     }
 
-                    if ($type && !$p->isOptional() && !$p->allowsNull() && !class_exists($type) && !interface_exists($type, false)) {
+                    $types = $type ? array_diff(preg_split('/[()|&]++/', $type, -1, \PREG_SPLIT_NO_EMPTY), ['int', 'string', 'array', 'bool', 'float', 'iterable', 'object', 'callable', 'null']) : [];
+
+                    if ($types && !$p->isOptional() && !$p->allowsNull() && $types !== array_filter($types, static fn ($t) => class_exists($t) || interface_exists($t, false))) {
                         $message = \sprintf('Cannot determine controller argument for "%s::%s()": the $%s argument is type-hinted with the non-existent class or interface: "%s".', $class, $r->name, $p->name, $type);
 
                         // see if the type-hint lives in the same namespace as the controller

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/RegisterControllerArgumentLocatorsPassTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/RegisterControllerArgumentLocatorsPassTest.php
@@ -25,6 +25,7 @@ use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\ServiceLocator;
@@ -648,6 +649,176 @@ class RegisterControllerArgumentLocatorsPassTest extends TestCase
 
         $this->assertSame([['allowControllers', [[RegisterTestController::class]]]], $controllerResolver->getMethodCalls());
     }
+
+    public function testCompositeTypeArguments()
+    {
+        $container = new ContainerBuilder();
+        $resolver = $container->register('argument_resolver.service')->addArgument([]);
+
+        $container->register('foo', WithCompositeTypes::class)
+            ->addTag('controller.service_arguments');
+
+        (new RegisterControllerArgumentLocatorsPass())->process($container);
+
+        $locator = $container->getDefinition((string) $resolver->getArgument(0))->getArgument(0);
+
+        $expected = [
+            'foo::intersectionAction' => new TypedReference($type = CombinedTypeA::class.'&'.CombinedTypeB::class, $type, ContainerInterface::RUNTIME_EXCEPTION_ON_INVALID_REFERENCE, 'service'),
+            'foo::unionAction' => new TypedReference($type = CombinedTypeA::class.'|'.CombinedTypeB::class, $type, ContainerInterface::RUNTIME_EXCEPTION_ON_INVALID_REFERENCE, 'service'),
+            'foo::nullableUnionAction' => new TypedReference($type = CombinedTypeA::class.'|'.CombinedTypeB::class.'|null', $type, ContainerInterface::IGNORE_ON_INVALID_REFERENCE, 'service'),
+            'foo::nullableIntersectionAction' => new TypedReference($type = '('.CombinedTypeA::class.'&'.CombinedTypeB::class.')|null', $type, ContainerInterface::IGNORE_ON_INVALID_REFERENCE, 'service'),
+            'foo::dnfAction' => new TypedReference($type = '('.CombinedTypeA::class.'&'.CombinedTypeB::class.')|'.ControllerDummy::class, $type, ContainerInterface::RUNTIME_EXCEPTION_ON_INVALID_REFERENCE, 'service'),
+        ];
+
+        foreach ($expected as $key => $reference) {
+            $methodLocator = $container->getDefinition((string) $locator[$key]->getValues()[0]);
+            $methodLocator = $container->getDefinition((string) $methodLocator->getFactory()[0]);
+
+            $this->assertEquals(['service' => new ServiceClosureArgument($reference)], $methodLocator->getArgument(0), $key);
+        }
+    }
+
+    public function testCompositeTypesAreAutowired()
+    {
+        $container = new ContainerBuilder();
+        $resolver = $container->register('argument_resolver.service', 'stdClass')->addArgument([]);
+
+        $container->register('combined', CombinedTypeService::class);
+        $container->setAlias(CombinedTypeA::class, 'combined');
+        $container->setAlias(CombinedTypeB::class, 'combined');
+
+        $container->register('foo', WithCompositeTypes::class)
+            ->addTag('controller.service_arguments');
+
+        (new RegisterControllerArgumentLocatorsPass())->process($container);
+
+        $locatorId = (string) $resolver->getArgument(0);
+        $container->getDefinition($locatorId)->setPublic(true);
+
+        $container->compile();
+
+        $locator = $container->get($locatorId);
+
+        $this->assertInstanceOf(CombinedTypeService::class, $locator->get('foo::intersectionAction')->get('service'));
+        $this->assertInstanceOf(CombinedTypeService::class, $locator->get('foo::unionAction')->get('service'));
+        $this->assertInstanceOf(CombinedTypeService::class, $locator->get('foo::nullableUnionAction')->get('service'));
+        $this->assertInstanceOf(CombinedTypeService::class, $locator->get('foo::nullableIntersectionAction')->get('service'));
+    }
+
+    public function testMixedDnfTypeIsNotAutowired()
+    {
+        $container = new ContainerBuilder();
+        $resolver = $container->register('argument_resolver.service', 'stdClass')->addArgument([]);
+
+        $container->register('combined', CombinedTypeService::class);
+        $container->setAlias(CombinedTypeA::class, 'combined');
+        $container->setAlias(CombinedTypeB::class, 'combined');
+
+        $container->register('foo', WithCompositeTypes::class)
+            ->addTag('controller.service_arguments');
+
+        (new RegisterControllerArgumentLocatorsPass())->process($container);
+
+        $locatorId = (string) $resolver->getArgument(0);
+        $container->getDefinition($locatorId)->setPublic(true);
+
+        $container->compile();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage(\sprintf('Cannot autowire service "service" required by "foo::dnfAction()": it has type "(%s&%s)|%s" but this class was not found.', CombinedTypeA::class, CombinedTypeB::class, ControllerDummy::class));
+
+        $container->get($locatorId)->get('foo::dnfAction')->get('service');
+    }
+
+    public function testCompositeTypeWithoutMatchingAlias()
+    {
+        $container = new ContainerBuilder();
+        $resolver = $container->register('argument_resolver.service', 'stdClass')->addArgument([]);
+
+        $container->register('combined', CombinedTypeService::class);
+        $container->setAlias(CombinedTypeA::class, 'combined');
+
+        $container->register('foo', WithCompositeTypes::class)
+            ->addTag('controller.service_arguments');
+
+        (new RegisterControllerArgumentLocatorsPass())->process($container);
+
+        $locatorId = (string) $resolver->getArgument(0);
+        $container->getDefinition($locatorId)->setPublic(true);
+
+        $container->compile();
+
+        $locator = $container->get($locatorId);
+
+        $this->assertFalse($locator->get('foo::nullableUnionAction')->has('service'));
+        $this->assertFalse($locator->get('foo::nullableIntersectionAction')->has('service'));
+    }
+
+    public function testIntersectionTypeWithoutMatchingAliasThrows()
+    {
+        $container = new ContainerBuilder();
+        $resolver = $container->register('argument_resolver.service', 'stdClass')->addArgument([]);
+
+        $container->register('combined', CombinedTypeService::class);
+        $container->setAlias(CombinedTypeA::class, 'combined');
+
+        $container->register('foo', WithCompositeTypes::class)
+            ->addTag('controller.service_arguments');
+
+        (new RegisterControllerArgumentLocatorsPass())->process($container);
+
+        $locatorId = (string) $resolver->getArgument(0);
+        $container->getDefinition($locatorId)->setPublic(true);
+
+        $container->compile();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage(\sprintf('Cannot autowire service "service" required by "foo::intersectionAction()": it has type "%s&%s" but this class was not found.', CombinedTypeA::class, CombinedTypeB::class));
+
+        $container->get($locatorId)->get('foo::intersectionAction')->get('service');
+    }
+
+    public function testTargetedCompositeTypeIsAutowired()
+    {
+        $container = new ContainerBuilder();
+        $resolver = $container->register('argument_resolver.service', 'stdClass')->addArgument([]);
+
+        $container->register('combined', CombinedTypeService::class);
+        $container->setAlias('.'.CombinedTypeA::class.' $some.service', 'combined');
+        $container->setAlias('.'.CombinedTypeB::class.' $some.service', 'combined');
+
+        $container->register('foo', WithTargetedIntersection::class)
+            ->addTag('controller.service_arguments');
+
+        (new RegisterControllerArgumentLocatorsPass())->process($container);
+
+        $locatorId = (string) $resolver->getArgument(0);
+        $container->getDefinition($locatorId)->setPublic(true);
+
+        $container->compile();
+
+        $this->assertInstanceOf(CombinedTypeService::class, $container->get($locatorId)->get('foo::fooAction')->get('service'));
+    }
+
+    public function testUnionTypeWithBuiltinIsAutowired()
+    {
+        $container = new ContainerBuilder();
+        $resolver = $container->register('argument_resolver.service', 'stdClass')->addArgument([]);
+
+        $container->register(ControllerDummy::class, ControllerDummy::class);
+
+        $container->register('foo', WithUnionWithBuiltinType::class)
+            ->addTag('controller.service_arguments');
+
+        (new RegisterControllerArgumentLocatorsPass())->process($container);
+
+        $locatorId = (string) $resolver->getArgument(0);
+        $container->getDefinition($locatorId)->setPublic(true);
+
+        $container->compile();
+
+        $this->assertInstanceOf(ControllerDummy::class, $container->get($locatorId)->get('foo::fooAction')->get('service'));
+    }
 }
 
 class RegisterTestController
@@ -830,5 +1001,56 @@ class WithAutowireIteratorAndAutowireLocator
         #[AutowireLocator(['bar', 'baz'])] ContainerInterface $container1,
         #[AutowireLocator(['foo' => new Autowire('%some.parameter%')])] ContainerInterface $container2,
     ) {
+    }
+}
+
+interface CombinedTypeA
+{
+}
+
+interface CombinedTypeB
+{
+}
+
+class CombinedTypeService implements CombinedTypeA, CombinedTypeB
+{
+}
+
+class WithCompositeTypes
+{
+    public function intersectionAction(CombinedTypeA&CombinedTypeB $service)
+    {
+    }
+
+    public function unionAction(CombinedTypeA|CombinedTypeB $service)
+    {
+    }
+
+    public function nullableUnionAction(CombinedTypeA|CombinedTypeB|null $service)
+    {
+    }
+
+    public function nullableIntersectionAction((CombinedTypeA&CombinedTypeB)|null $service)
+    {
+    }
+
+    public function dnfAction((CombinedTypeA&CombinedTypeB)|ControllerDummy $service)
+    {
+    }
+}
+
+class WithTargetedIntersection
+{
+    public function fooAction(
+        #[Target('some.service')]
+        CombinedTypeA&CombinedTypeB $service,
+    ) {
+    }
+}
+
+class WithUnionWithBuiltinType
+{
+    public function fooAction(ControllerDummy|string $service)
+    {
     }
 }

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -31,7 +31,7 @@
         "symfony/config": "^7.4|^8.0",
         "symfony/console": "^7.4|^8.0",
         "symfony/css-selector": "^7.4|^8.0",
-        "symfony/dependency-injection": "^8.1",
+        "symfony/dependency-injection": "^8.2",
         "symfony/dom-crawler": "^7.4|^8.0",
         "symfony/expression-language": "^7.4|^8.0",
         "symfony/finder": "^7.4|^8.0",
@@ -54,7 +54,7 @@
         "psr/log-implementation": "1.0|2.0|3.0"
     },
     "conflict": {
-        "symfony/dependency-injection": "<8.1",
+        "symfony/dependency-injection": "<8.2",
         "symfony/flex": "<2.10",
         "symfony/http-client-contracts": "<2.5",
         "symfony/serializer": "<7.4.15|>=8.0,<8.0.15|>=8.1,<8.1.2",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Union and intersection types already work for constructor arguments:

```php
class MyService
{
    public function __construct(
        private DecoderInterface&DenormalizerInterface $serializer,
    ) {
    }
}
```

The same type-hint on a controller action or on an invokable command was rejected with *"the $serializer argument is type-hinted with the non-existent class or interface"*. This PR makes both behave like constructor arguments:

```php
class MyController
{
    public function index(DecoderInterface&DenormalizerInterface $serializer): Response
    {
    }
}

#[AsCommand('app:my-command')]
class MyCommand
{
    public function __invoke(DecoderInterface&DenormalizerInterface $serializer): int
    {
    }
}
```

Nullable intersections `(A&B)|null`, nullable unions `A|B|null` and unions that mix a class with a builtin type such as `A|string` are supported too, and `#[Target]` works with all of them.

### Resolution rules

These are the constructor autowiring rules, applied unchanged:

* an intersection `A&B` resolves when the alias for `A` and the alias for `B` point to the same service;
* a union `A|B` follows the same rule. Every member must alias the same service. It is not "first match wins";
* builtin members are ignored, so `A|string` resolves as `A`;
* mixed DNF types such as `(A&B)|C` are not autowirable and report `Cannot autowire service "..." but this class was not found`. Use `#[Autowire(service: 'id')]` to pin a service by hand.

### Dependency injection

`AutowirePass` normalizes a composite type before looking up the alias. It used to split on whichever of `&` or `|` came first, which broke `(A&B)|null` into `(A` and `B)|null`, so no alias could ever match. A top-level `|` always outranks `&`, so the split now uses `|` whenever the type contains one.

Controller and command argument locators are the only places that produce such a type string, so `symfony/dependency-injection` is bumped to `^8.2` in Console and HttpKernel: with 8.1 a nullable intersection would be dropped from the locator and fail at runtime.

### Documentation

The docs should cover the supported type shapes, the "every member aliases the same service" rule, the DNF limitation, and that `#[Autowire(service:)]` stays the way to pin a concrete service id.
