### PR TITLE
[HttpFoundation] Add create_sid() to session handlers

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/AbstractSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/AbstractSessionHandler.php
@@ -38,6 +38,14 @@ abstract class AbstractSessionHandler implements \SessionHandlerInterface, \Sess
         return true;
     }
 
+    /**
+     * @return string
+     */
+    public function create_sid()
+    {
+        return session_create_id() ?: throw new \RuntimeException('Unable to create a session ID.');
+    }
+
     abstract protected function doRead(#[\SensitiveParameter] string $sessionId): string;
 
     abstract protected function doWrite(#[\SensitiveParameter] string $sessionId, string $data): bool;

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MarshallingSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MarshallingSessionHandler.php
@@ -37,6 +37,14 @@ class MarshallingSessionHandler implements \SessionHandlerInterface, \SessionUpd
         return $this->handler->close();
     }
 
+    /**
+     * @return string
+     */
+    public function create_sid()
+    {
+        return session_create_id() ?: throw new \RuntimeException('Unable to create a session ID.');
+    }
+
     public function destroy(#[\SensitiveParameter] string $sessionId): bool
     {
         return $this->handler->destroy($sessionId);

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MigratingSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MigratingSessionHandler.php
@@ -38,6 +38,14 @@ class MigratingSessionHandler implements \SessionHandlerInterface, \SessionUpdat
         $this->writeOnlyHandler = $writeOnlyHandler;
     }
 
+    /**
+     * @return string
+     */
+    public function create_sid()
+    {
+        return session_create_id() ?: throw new \RuntimeException('Unable to create a session ID.');
+    }
+
     public function close(): bool
     {
         $result = $this->currentHandler->close();

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Proxy/SessionHandlerProxy.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Proxy/SessionHandlerProxy.php
@@ -64,6 +64,14 @@ class SessionHandlerProxy extends AbstractProxy implements \SessionHandlerInterf
         return $this->handler->gc($maxlifetime);
     }
 
+    /**
+     * @return string
+     */
+    public function create_sid()
+    {
+        return session_create_id() ?: throw new \RuntimeException('Unable to create a session ID.');
+    }
+
     public function validateId(#[\SensitiveParameter] string $sessionId): bool
     {
         return !$this->handler instanceof \SessionUpdateTimestampHandlerInterface || $this->handler->validateId($sessionId);

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/SessionIdInterfaceTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/SessionIdInterfaceTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Tests\Session\Storage\Handler;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Marshaller\DefaultMarshaller;
+use Symfony\Component\HttpFoundation\Session\Storage\Handler\MarshallingSessionHandler;
+use Symfony\Component\HttpFoundation\Session\Storage\Handler\MigratingSessionHandler;
+use Symfony\Component\HttpFoundation\Session\Storage\Handler\NullSessionHandler;
+use Symfony\Component\HttpFoundation\Session\Storage\Handler\StrictSessionHandler;
+use Symfony\Component\HttpFoundation\Session\Storage\Proxy\SessionHandlerProxy;
+
+class SessionIdInterfaceTest extends TestCase
+{
+    /**
+     * @dataProvider provideHandlers
+     */
+    public function testHandlersCreateSessionIds(\SessionHandlerInterface $handler)
+    {
+        $this->assertMatchesRegularExpression('/^[a-zA-Z0-9,-]{22,}$/', $handler->create_sid());
+    }
+
+    public static function provideHandlers(): iterable
+    {
+        yield 'null' => [new NullSessionHandler()];
+        yield 'strict' => [new StrictSessionHandler(new \SessionHandler())];
+        yield 'migrating' => [new MigratingSessionHandler(new NullSessionHandler(), new NullSessionHandler())];
+        yield 'proxy' => [new SessionHandlerProxy(new NullSessionHandler())];
+
+        if (class_exists(DefaultMarshaller::class)) {
+            yield 'marshalling' => [new MarshallingSessionHandler(new NullSessionHandler(), new DefaultMarshaller())];
+        }
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Proxy/SessionHandlerProxyTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Proxy/SessionHandlerProxyTest.php
@@ -202,4 +202,7 @@ class SessionHandlerProxyTest extends TestCase
 
 abstract class TestSessionHandler implements \SessionHandlerInterface, \SessionUpdateTimestampHandlerInterface
 {
+    abstract public function create_sid();
+
+    abstract public function validateId(string $id): bool;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

php/php-src@6901c87 landed this morning, implementing the [PHP 8.6 deprecation](https://wiki.php.net/rfc/deprecations_php_8_6) for session handlers that lack `create_sid()` and `validateId()`. Our handlers already provide `validateId()` and `updateTimestamp()` through `SessionUpdateTimestampHandlerInterface`, but none of them declares `create_sid()`, so all of them are non-compliant. Only `NativeFileSessionHandler` escapes it, by extending `\SessionHandler`.

`session_create_id()` is exactly what PHP falls back to when a handler has no `create_sid()`, so spelling it out is a no-op today: same IDs, same length, same `session_regenerate_id()` behaviour. Verified against 8.5 and 8.6 with `use_strict_mode=1`, and by diffing a full session lifecycle with and without the patch.

No handler delegates `create_sid()` to the one it wraps. PHP only ever sees the outermost handler, so the inner `create_sid()` is ignored as things stand — delegating would be a behavior change smuggled into a compatibility fix, and for `StrictSessionHandler` wrapping a native `\SessionHandler` it would also mean calling a method that throws `Error: Session is not active` outside a session.

### Why no return type, and no `SessionIdInterface`

Both `session_set_save_handler()` and the new class check look for the *method*, not the interface, so the bare method is enough. That matters on a maintenance branch: `AbstractSessionHandler` is meant to be extended, PHP already accepts a `create_sid()` method without the interface, so a userland handler may well have one. Declaring `create_sid(): string` on the parent fatals on any child whose signature is not covariant:

```
Declaration of App\LegacyHandler::create_sid() must be compatible with
…\AbstractSessionHandler::create_sid(): string
```

Untyped, every shape keeps loading — no override, untyped, `: string`, `: string|false`, `#[\ReturnTypeWillChange]`. Implementing `SessionIdInterface` would force the return type back in (or trade the warning for a tentative-return-type deprecation), so the classes stay out of it here.

### Two upstream problems this surfaced

The php-src commit does more than the RFC proposed. Besides the `E_DEPRECATED` in `session_set_save_handler()`, it adds an `E_WARNING` raised from an `interface_gets_implemented` hook, for *any* class implementing `SessionHandlerInterface`. That hook has two issues:

**1. It is sensitive to the order interfaces are listed in.** The hook runs while `SessionHandlerInterface` is being attached, before the sibling interfaces are linked, so it only sees the methods the class declares itself:

```php
abstract class A implements SessionHandlerInterface, SessionIdInterface {}  // warns
abstract class B implements SessionIdInterface, SessionHandlerInterface {}  // silent
```

Implementing `SessionIdInterface` should satisfy the check either way.

**2. It fires for generated test doubles, which nobody can fix.** `createMock(\SessionHandlerInterface::class)` produces a class implementing only that interface, so every mock of it warns:

```
Class Mock_SessionHandlerInterface_b7dde12f implementing SessionHandlerInterface
is missing the create_sid() method which will be required in PHP 9.0
```

With `failOnWarning="true"` that fails the suite, and there is nothing HttpFoundation or PHPUnit can do about it short of not mocking the interface. So `Unit Tests (8.6)` stays red on this PR for reasons it cannot address — everything Symfony owns is clean, and `session_set_save_handler()` no longer deprecates for any of our handlers.
