### PR TITLE
[DependencyInjection][FrameworkBundle] Add `#[AutowireClassMap]` to inject a class map built from resource tags

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
@@ -18,6 +18,7 @@ use Symfony\Component\DependencyInjection\Argument\AbstractArgument;
 use Symfony\Component\DependencyInjection\Argument\ArgumentInterface;
 use Symfony\Component\DependencyInjection\Argument\LazyProxyArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
+use Symfony\Component\DependencyInjection\Argument\TaggedClassMapArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
@@ -448,6 +449,10 @@ class JsonDescriptor extends Descriptor
 
         if ($value instanceof AbstractArgument) {
             return ['type' => 'abstract', 'text' => $value->getText()];
+        }
+
+        if ($value instanceof TaggedClassMapArgument) {
+            return ['type' => 'tagged_class_map', 'tag' => $value->getTag(), 'map' => $value->getValues()];
         }
 
         if ($value instanceof LazyProxyArgument) {

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
@@ -22,6 +22,7 @@ use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\Argument\LazyProxyArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
+use Symfony\Component\DependencyInjection\Argument\TaggedClassMapArgument;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -412,6 +413,12 @@ class TextDescriptor extends Descriptor
 
                     foreach ($argument->getValues() as $ref) {
                         $argumentsInformation[] = '- '.($ref instanceof LazyProxyArgument ? self::formatLazyProxyArgument($ref) : \sprintf('Service(%s)', $ref));
+                    }
+                } elseif ($argument instanceof TaggedClassMapArgument) {
+                    $argumentsInformation[] = \sprintf('Tagged class map for "%s"%s', $argument->getTag(), $options['is_debug'] ? '' : \sprintf(' (%d element(s))', \count($argument->getValues())));
+
+                    foreach ($argument->getValues() as $key => $class) {
+                        $argumentsInformation[] = \sprintf('- %s => %s', $key, $class);
                     }
                 } elseif ($argument instanceof ServiceLocatorArgument) {
                     $argumentsInformation[] = \sprintf('Service locator (%d element(s))', \count($argument->getValues()));

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
@@ -19,6 +19,7 @@ use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\Argument\LazyProxyArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
+use Symfony\Component\DependencyInjection\Argument\TaggedClassMapArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
@@ -446,6 +447,13 @@ class XmlDescriptor extends Descriptor
                 $argumentXML->setAttribute('id', (string) $argument);
             } elseif ($argument instanceof IteratorArgument || $argument instanceof ServiceLocatorArgument) {
                 $argumentXML->setAttribute('type', $argument instanceof IteratorArgument ? 'iterator' : 'service_locator');
+
+                foreach ($this->getArgumentNodes($argument->getValues(), $dom, $container) as $childArgumentXML) {
+                    $argumentXML->appendChild($childArgumentXML);
+                }
+            } elseif ($argument instanceof TaggedClassMapArgument) {
+                $argumentXML->setAttribute('type', 'tagged_class_map');
+                $argumentXML->setAttribute('tag', $argument->getTag());
 
                 foreach ($this->getArgumentNodes($argument->getValues(), $dom, $container) as $childArgumentXML) {
                     $argumentXML->appendChild($childArgumentXML);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/AbstractDescriptorTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/AbstractDescriptorTestCase.php
@@ -13,12 +13,14 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\Console\Descriptor;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
+use PHPUnit\Framework\Attributes\RequiresMethod;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\FooUnitEnum;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\DependencyInjection\Alias;
+use Symfony\Component\DependencyInjection\Argument\TaggedClassMapArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
@@ -120,6 +122,18 @@ abstract class AbstractDescriptorTestCase extends TestCase
     public static function getDescribeContainerDefinitionTestData(): array
     {
         return static::getDescriptionTestData(ObjectsProvider::getContainerDefinitions());
+    }
+
+    #[DataProvider('getDescribeContainerDefinitionWithTaggedClassMapTestData')]
+    #[RequiresMethod(TaggedClassMapArgument::class, 'getTag')]
+    public function testDescribeContainerDefinitionWithTaggedClassMap(Definition $definition, $expectedDescription, $file)
+    {
+        $this->assertDescription($expectedDescription, $definition);
+    }
+
+    public static function getDescribeContainerDefinitionWithTaggedClassMapTestData(): array
+    {
+        return static::getDescriptionTestData(ObjectsProvider::getContainerDefinitionsWithTaggedClassMap());
     }
 
     #[DataProvider('getDescribeContainerDefinitionWithArgumentsShownTestData')]

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/ObjectsProvider.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/ObjectsProvider.php
@@ -17,6 +17,7 @@ use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\Argument\AbstractArgument;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\Argument\LazyProxyArgument;
+use Symfony\Component\DependencyInjection\Argument\TaggedClassMapArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
@@ -248,6 +249,18 @@ class ObjectsProvider
                 ->setFile('/path/to/file')
                 ->setFactory([new Definition('Full\\Qualified\\FactoryClass'), 'get']),
             'definition_without_class' => new Definition(),
+        ];
+    }
+
+    public static function getContainerDefinitionsWithTaggedClassMap()
+    {
+        $taggedClassMap = new TaggedClassMapArgument('app.message', 'format');
+        $taggedClassMap->setValues(['foo' => 'Full\\Qualified\\FooMessage']);
+
+        return [
+            'definition_tagged_class_map' => (new Definition('Full\\Qualified\\Class1'))
+                ->setPublic(true)
+                ->addArgument($taggedClassMap),
         ];
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_tagged_class_map.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_tagged_class_map.json
@@ -1,0 +1,23 @@
+{
+    "class": "Full\\Qualified\\Class1",
+    "public": true,
+    "synthetic": false,
+    "lazy": false,
+    "shared": true,
+    "abstract": false,
+    "autowire": false,
+    "autoconfigure": false,
+    "deprecated": false,
+    "arguments": [
+        {
+            "type": "tagged_class_map",
+            "tag": "app.message",
+            "map": {
+                "foo": "Full\\Qualified\\FooMessage"
+            }
+        }
+    ],
+    "file": null,
+    "tags": [],
+    "usages": []
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_tagged_class_map.md
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_tagged_class_map.md
@@ -1,0 +1,11 @@
+- Class: `Full\Qualified\Class1`
+- Public: yes
+- Synthetic: no
+- Lazy: no
+- Shared: yes
+- Abstract: no
+- Autowired: no
+- Autoconfigured: no
+- Deprecated: no
+- Arguments: yes
+- Usages: none

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_tagged_class_map.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_tagged_class_map.txt
@@ -1,0 +1,17 @@
+ ---------------- --------------------------------------------------- 
+ [32m Option         [39m [32m Value                                             [39m 
+ ---------------- --------------------------------------------------- 
+  Service ID       -                                                  
+  Class            Full\Qualified\Class1                              
+  Tags             -                                                  
+  Public           yes                                                
+  Synthetic        no                                                 
+  Lazy             no                                                 
+  Shared           yes                                                
+  Abstract         no                                                 
+  Autowired        no                                                 
+  Autoconfigured   no                                                 
+  Arguments        Tagged class map for "app.message" (1 element(s))  
+                   - foo => Full\Qualified\FooMessage                 
+  Usages           none                                               
+ ---------------- --------------------------------------------------- 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_tagged_class_map.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_tagged_class_map.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definition class="Full\Qualified\Class1" public="true" synthetic="false" lazy="false" shared="true" abstract="false" autowired="false" autoconfigured="false" deprecated="false" file="">
+  <argument type="tagged_class_map" tag="app.message">
+    <argument key="foo">Full\Qualified\FooMessage</argument>
+  </argument>
+</definition>

--- a/src/Symfony/Component/DependencyInjection/Argument/TaggedClassMapArgument.php
+++ b/src/Symfony/Component/DependencyInjection/Argument/TaggedClassMapArgument.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Argument;
+
+/**
+ * Represents a map of classes found by resource tag name.
+ */
+final class TaggedClassMapArgument implements ArgumentInterface
+{
+    use ArgumentTrait;
+
+    private array $values = [];
+    private string $indexAttribute;
+
+    /**
+     * @param string      $tag            The tag name identifying the target classes
+     * @param string|null $indexAttribute The name of the attribute that defines the key referencing each class in the
+     *                                    tagged collection; defaults to the tag's last dot-segment
+     * @param string[]    $exclude        FQCNs to exclude from the class map
+     */
+    public function __construct(
+        private string $tag,
+        ?string $indexAttribute = null,
+        private array $exclude = [],
+    ) {
+        $this->indexAttribute = $indexAttribute ?? (preg_match('/[^.]++$/', $tag, $matches) ? $matches[0] : $tag);
+    }
+
+    public function getTag(): string
+    {
+        return $this->tag;
+    }
+
+    public function getIndexAttribute(): string
+    {
+        return $this->indexAttribute;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getExclude(): array
+    {
+        return $this->exclude;
+    }
+
+    public function getValues(): array
+    {
+        return $this->values;
+    }
+
+    public function setValues(array $values): void
+    {
+        $this->values = $values;
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Attribute/AutowireClassMap.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/AutowireClassMap.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Attribute;
+
+use Symfony\Component\DependencyInjection\Argument\TaggedClassMapArgument;
+
+/**
+ * Autowires a map of classes based on a resource tag name.
+ */
+#[\Attribute(\Attribute::TARGET_PARAMETER)]
+final class AutowireClassMap extends Autowire
+{
+    /**
+     * @param string          $tag            A tag name to search for to populate the map
+     * @param string|null     $indexAttribute The name of the attribute that defines the key referencing each class
+     *                                        in the tagged collection; defaults to the tag's last dot-segment
+     * @param string|string[] $exclude        A FQCN or a list of FQCNs to exclude
+     */
+    public function __construct(
+        string $tag,
+        ?string $indexAttribute = null,
+        string|array $exclude = [],
+    ) {
+        parent::__construct(new TaggedClassMapArgument($tag, $indexAttribute, (array) $exclude));
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
  * Add a `factory` argument to the `#[Autoconfigure]` attribute, and support the `factory` key under `_instanceof`
  * Add `Preloader::ignore()` to exclude classes or namespace prefixes from preloading
  * Allow computing resource tag attributes per tagged class when using `#[AutoconfigureResourceTag]`, `#[Autoconfigure]` or `_instanceof`, like for regular tags
+ * Add `#[AutowireClassMap]` attribute, `TaggedClassMapArgument`, the `!tagged_class_map` YAML tag and the `tagged_class_map()` PHP-DSL function to inject a map of classes found by resource tag name
 
 8.1
 ---

--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckTypeDeclarationsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckTypeDeclarationsPass.php
@@ -18,6 +18,7 @@ use Symfony\Component\DependencyInjection\Argument\LazyProxyArgument;
 use Symfony\Component\DependencyInjection\Argument\RewindableGenerator;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
+use Symfony\Component\DependencyInjection\Argument\TaggedClassMapArgument;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
@@ -274,6 +275,8 @@ final class CheckTypeDeclarationsPass extends AbstractRecursivePass
                 $class = $value->isStringable() ? EnvClosure::class : \Closure::class;
             } elseif ($value instanceof ServiceLocatorArgument) {
                 $class = ServiceLocator::class;
+            } elseif ($value instanceof TaggedClassMapArgument) {
+                $class = 'array';
             } elseif (\is_object($value)) {
                 $class = $value::class;
             } else {

--- a/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
@@ -73,6 +73,7 @@ class PassConfig
             new ServiceLocatorTagPass(),
             new ResolveLazyProxyPass(),
             new ResolveTaggedIteratorArgumentPass(),
+            new ResolveTaggedClassMapArgumentPass(),
             new ResolveServiceSubscribersPass(),
             new ResolveReferencesToAliasesPass(),
             new ResolveInvalidReferencesPass(),

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveBindingsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveBindingsPass.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\DependencyInjection\Compiler;
 use Symfony\Component\DependencyInjection\Argument\AbstractArgument;
 use Symfony\Component\DependencyInjection\Argument\BoundArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
+use Symfony\Component\DependencyInjection\Argument\TaggedClassMapArgument;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\DependencyInjection\Attribute\Target;
@@ -137,8 +138,8 @@ class ResolveBindingsPass extends AbstractRecursivePass
                 continue;
             }
 
-            if (null !== $bindingValue && !$bindingValue instanceof Reference && !$bindingValue instanceof Definition && !$bindingValue instanceof TaggedIteratorArgument && !$bindingValue instanceof ServiceLocatorArgument) {
-                throw new InvalidArgumentException(\sprintf('Invalid value for binding key "%s" for service "%s": expected "%s", "%s", "%s", "%s" or null, "%s" given.', $key, $this->currentId, Reference::class, Definition::class, TaggedIteratorArgument::class, ServiceLocatorArgument::class, get_debug_type($bindingValue)));
+            if (null !== $bindingValue && !$bindingValue instanceof Reference && !$bindingValue instanceof Definition && !$bindingValue instanceof TaggedIteratorArgument && !$bindingValue instanceof ServiceLocatorArgument && !$bindingValue instanceof TaggedClassMapArgument) {
+                throw new InvalidArgumentException(\sprintf('Invalid value for binding key "%s" for service "%s": expected "%s", "%s", "%s", "%s", "%s" or null, "%s" given.', $key, $this->currentId, Reference::class, Definition::class, TaggedIteratorArgument::class, ServiceLocatorArgument::class, TaggedClassMapArgument::class, get_debug_type($bindingValue)));
             }
         }
 

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveTaggedClassMapArgumentPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveTaggedClassMapArgumentPass.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Argument\TaggedClassMapArgument;
+use Symfony\Component\DependencyInjection\Attribute\AsTaggedItem;
+
+/**
+ * Resolves all TaggedClassMapArgument arguments.
+ *
+ * Based on {@see PriorityTaggedServiceTrait::findAndSortTaggedServices()}, but resolves
+ * tagged resources to their classes instead of services to references.
+ */
+final class ResolveTaggedClassMapArgumentPass extends AbstractRecursivePass
+{
+    protected bool $skipScalars = true;
+
+    protected function processValue(mixed $value, bool $isRoot = false): mixed
+    {
+        if (!$value instanceof TaggedClassMapArgument) {
+            return parent::processValue($value, $isRoot);
+        }
+
+        $indexAttribute = $value->getIndexAttribute();
+        $exclude = $value->getExclude();
+        $parameterBag = $this->container->getParameterBag();
+        $resources = [];
+
+        foreach ($this->container->findTaggedResourceIds($value->getTag(), false) as $resourceId => $attributes) {
+            $definition = $this->container->getDefinition($resourceId);
+
+            if ($definition->isAbstract()) {
+                continue;
+            }
+
+            $class = $definition->getClass();
+
+            if (\in_array($class, $exclude, true)) {
+                continue;
+            }
+
+            $defaultIndex = $defaultPriority = null;
+            $phpAttributes = $definition->isAutoconfigured() && !$definition->hasTag('container.ignore_attributes') ? $this->container->getReflectionClass($class)?->getAttributes(AsTaggedItem::class) : [];
+
+            foreach ($phpAttributes ??= [] as $i => $attribute) {
+                $attribute = $attribute->newInstance();
+                $phpAttributes[$i] = [
+                    'priority' => $attribute->priority,
+                    $indexAttribute => $attribute->index,
+                ];
+                if (null === $defaultPriority) {
+                    $defaultPriority = $attribute->priority ?? 0;
+                    $defaultIndex = $attribute->index;
+                }
+            }
+            if (1 >= \count($phpAttributes)) {
+                $phpAttributes = [];
+            }
+
+            $attributes = array_values($attributes);
+            for ($i = 0; $i < \count($attributes); ++$i) {
+                if (!($attribute = $attributes[$i]) && $phpAttributes) {
+                    array_splice($attributes, $i--, 1, $phpAttributes);
+                    continue;
+                }
+
+                $priority = $attribute['priority'] ?? $defaultPriority ?? 0;
+                $index = isset($attribute[$indexAttribute]) ? $parameterBag->resolveValue($attribute[$indexAttribute]) : ($defaultIndex ?? $class);
+
+                $resources[] = [$priority, $i, $index, $class];
+            }
+        }
+
+        uasort($resources, static fn ($a, $b) => $b[0] <=> $a[0] ?: $a[1] <=> $b[1]);
+
+        $classMap = [];
+        foreach ($resources as [, , $index, $class]) {
+            $classMap[$index] ??= $class;
+        }
+
+        $value->setValues($classMap);
+
+        return $value;
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -31,6 +31,7 @@ use Symfony\Component\DependencyInjection\Argument\RewindableGenerator;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocator;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
+use Symfony\Component\DependencyInjection\Argument\TaggedClassMapArgument;
 use Symfony\Component\DependencyInjection\Attribute\Target;
 use Symfony\Component\DependencyInjection\Compiler\Compiler;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
@@ -1331,6 +1332,8 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
 
                 return $count;
             });
+        } elseif ($value instanceof TaggedClassMapArgument) {
+            $value = $value->getValues();
         } elseif ($value instanceof ServiceLocatorArgument) {
             $refs = $types = [];
             foreach ($value->getValues() as $k => $v) {

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -23,6 +23,7 @@ use Symfony\Component\DependencyInjection\Argument\LazyProxyArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocator;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
+use Symfony\Component\DependencyInjection\Argument\TaggedClassMapArgument;
 use Symfony\Component\DependencyInjection\Compiler\AnalyzeServiceReferencesPass;
 use Symfony\Component\DependencyInjection\Compiler\CheckCircularReferencesPass;
 use Symfony\Component\DependencyInjection\Compiler\ServiceReferenceGraphNode;
@@ -1956,6 +1957,10 @@ class PhpDumper extends Dumper
                     $code = \sprintf('new \\%s(%s, %s)', EnvClosure::class, $closure, $this->export($value->getDefault()));
 
                     return $value->isStringable() ? $code : (null !== $value->getDefault() ? $code.'->__invoke(...)' : $closure);
+                }
+
+                if ($value instanceof TaggedClassMapArgument) {
+                    return $this->dumpValue($value->getValues(), $interpolate);
                 }
 
                 if ($value instanceof IteratorArgument) {

--- a/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
@@ -19,6 +19,7 @@ use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\Argument\LazyProxyArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
+use Symfony\Component\DependencyInjection\Argument\TaggedClassMapArgument;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Definition;
@@ -365,6 +366,26 @@ class XmlDumper extends Dumper
                 }
                 if (!$tag->excludeSelf()) {
                     $xmlAttr .= ' exclude-self="false"';
+                }
+
+                if (1 < \count($excludes)) {
+                    yield \sprintf('<%s%s>', $type, $xmlAttr);
+                    foreach ($excludes as $exclude) {
+                        yield \sprintf('  <exclude>%s</exclude>', $this->encode($exclude, 0));
+                    }
+                    yield \sprintf('</%s>', $type);
+                } else {
+                    yield \sprintf('<%s%s/>', $type, $xmlAttr);
+                }
+            } elseif ($value instanceof TaggedClassMapArgument) {
+                $xmlAttr .= \sprintf(' type="tagged_class_map" tag="%s"', $this->encode($value->getTag()));
+
+                $defaultIndexAttribute = preg_match('/[^.]++$/', $value->getTag(), $matches) ? $matches[0] : $value->getTag();
+                if ($defaultIndexAttribute !== $value->getIndexAttribute()) {
+                    $xmlAttr .= \sprintf(' index-by="%s"', $this->encode($value->getIndexAttribute()));
+                }
+                if (1 === \count($excludes = $value->getExclude())) {
+                    $xmlAttr .= \sprintf(' exclude="%s"', $this->encode($excludes[0]));
                 }
 
                 if (1 < \count($excludes)) {

--- a/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
@@ -19,6 +19,7 @@ use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\Argument\LazyProxyArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
+use Symfony\Component\DependencyInjection\Argument\TaggedClassMapArgument;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Definition;
@@ -276,6 +277,24 @@ class YamlDumper extends Dumper
         }
         if ($value instanceof ArgumentInterface) {
             $tag = $value;
+
+            if ($value instanceof TaggedClassMapArgument) {
+                $defaultIndexAttribute = preg_match('/[^.]++$/', $value->getTag(), $matches) ? $matches[0] : $value->getTag();
+
+                if ($defaultIndexAttribute === $value->getIndexAttribute() && !$value->getExclude()) {
+                    return new TaggedValue('tagged_class_map', $value->getTag());
+                }
+
+                $content = ['tag' => $value->getTag()];
+                if ($defaultIndexAttribute !== $value->getIndexAttribute()) {
+                    $content['index_by'] = $value->getIndexAttribute();
+                }
+                if ($excludes = $value->getExclude()) {
+                    $content['exclude'] = 1 === \count($excludes) ? $excludes[0] : $excludes;
+                }
+
+                return new TaggedValue('tagged_class_map', $content);
+            }
 
             if ($value instanceof TaggedIteratorArgument || ($value instanceof ServiceLocatorArgument && $tag = $value->getTaggedIteratorArgument())) {
                 if (null === $tag->getIndexAttribute()) {

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/ContainerConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/ContainerConfigurator.php
@@ -15,6 +15,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator;
 use Symfony\Component\DependencyInjection\Argument\AbstractArgument;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
+use Symfony\Component\DependencyInjection\Argument\TaggedClassMapArgument;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -202,6 +203,18 @@ function tagged_locator(string $tag, ?string $indexAttribute = null, string|arra
     }
 
     return new ServiceLocatorArgument(new TaggedIteratorArgument($tag, $indexAttribute, true, (array) $exclude, $excludeSelf));
+}
+
+/**
+ * Creates a class map by resource tag name.
+ *
+ * @param string          $tag            The tag name identifying the target classes
+ * @param string|null     $indexAttribute The name of the attribute that defines the key referencing each class in the tagged collection; defaults to the tag's last dot-segment
+ * @param string|string[] $exclude        A FQCN or a list of FQCNs to exclude from the class map
+ */
+function tagged_class_map(string $tag, ?string $indexAttribute = null, string|array $exclude = []): TaggedClassMapArgument
+{
+    return new TaggedClassMapArgument($tag, $indexAttribute, (array) $exclude);
 }
 
 /**

--- a/src/Symfony/Component/DependencyInjection/Loader/ContentLoaderTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/ContentLoaderTrait.php
@@ -19,6 +19,7 @@ use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\Argument\LazyProxyArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
+use Symfony\Component\DependencyInjection\Argument\TaggedClassMapArgument;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -857,6 +858,20 @@ trait ContentLoaderTrait
                 }
 
                 return $argument;
+            }
+            if ('tagged_class_map' === $value->getTag()) {
+                if (\is_array($argument) && isset($argument['tag']) && $argument['tag']) {
+                    if ($diff = array_diff(array_keys($argument), $supportedKeys = ['tag', 'index_by', 'exclude'])) {
+                        throw new InvalidArgumentException(\sprintf('"!tagged_class_map" tag contains unsupported key "%s"; supported ones are "%s".', implode('", "', $diff), implode('", "', $supportedKeys)));
+                    }
+
+                    return new TaggedClassMapArgument($argument['tag'], $argument['index_by'] ?? null, (array) ($argument['exclude'] ?? null));
+                }
+                if (\is_string($argument) && $argument) {
+                    return new TaggedClassMapArgument($argument);
+                }
+
+                throw new InvalidArgumentException(\sprintf('"!tagged_class_map" tags only accept a non empty string or an array with a key "tag" in "%s".', $file));
             }
             if ('service' === $value->getTag()) {
                 if ($isParameter) {

--- a/src/Symfony/Component/DependencyInjection/Tests/Argument/TaggedClassMapArgumentTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Argument/TaggedClassMapArgumentTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Argument;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Argument\TaggedClassMapArgument;
+
+class TaggedClassMapArgumentTest extends TestCase
+{
+    public function testWithIndexAttribute()
+    {
+        $argument = new TaggedClassMapArgument('app.my_tag', 'key', ['Foo', 'Bar']);
+
+        $this->assertSame('app.my_tag', $argument->getTag());
+        $this->assertSame('key', $argument->getIndexAttribute());
+        $this->assertSame(['Foo', 'Bar'], $argument->getExclude());
+    }
+
+    public function testIndexAttributeDefaultsToTagLastDotSegment()
+    {
+        $argument = new TaggedClassMapArgument('app.my_tag');
+
+        $this->assertSame('my_tag', $argument->getIndexAttribute());
+        $this->assertSame([], $argument->getExclude());
+    }
+
+    public function testIndexAttributeDefaultsToTagWithoutDots()
+    {
+        $argument = new TaggedClassMapArgument('my_tag');
+
+        $this->assertSame('my_tag', $argument->getIndexAttribute());
+    }
+
+    public function testSetValues()
+    {
+        $argument = new TaggedClassMapArgument('my_tag');
+
+        $this->assertSame([], $argument->getValues());
+
+        $argument->setValues(['key' => 'Foo']);
+
+        $this->assertSame(['key' => 'Foo'], $argument->getValues());
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Attribute/AutowireClassMapTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Attribute/AutowireClassMapTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Attribute;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Argument\TaggedClassMapArgument;
+use Symfony\Component\DependencyInjection\Attribute\AutowireClassMap;
+
+class AutowireClassMapTest extends TestCase
+{
+    public function testTagOnly()
+    {
+        $attribute = new AutowireClassMap('my_tag');
+
+        $this->assertEquals(new TaggedClassMapArgument('my_tag'), $attribute->value);
+    }
+
+    public function testStringExclude()
+    {
+        $attribute = new AutowireClassMap('my_tag', 'key', 'Foo');
+
+        $this->assertEquals(new TaggedClassMapArgument('my_tag', 'key', ['Foo']), $attribute->value);
+    }
+
+    public function testArrayExclude()
+    {
+        $attribute = new AutowireClassMap('my_tag', exclude: ['Foo', 'Bar']);
+
+        $this->assertEquals(new TaggedClassMapArgument('my_tag', null, ['Foo', 'Bar']), $attribute->value);
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckTypeDeclarationsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckTypeDeclarationsPassTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\Argument\LazyProxyArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
+use Symfony\Component\DependencyInjection\Argument\TaggedClassMapArgument;
 use Symfony\Component\DependencyInjection\Compiler\CheckTypeDeclarationsPass;
 use Symfony\Component\DependencyInjection\Compiler\ResolveLazyProxyPass;
 use Symfony\Component\DependencyInjection\Compiler\ResolveParameterPlaceHoldersPass;
@@ -400,6 +401,19 @@ class CheckTypeDeclarationsPassTest extends TestCase
 
         $container->register('bar', BarMethodCall::class)
             ->addMethodCall('setIterable', [new IteratorArgument([])]);
+
+        (new CheckTypeDeclarationsPass(true))->process($container);
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testProcessSuccessWhenPassingATaggedClassMapArgumentToArrayOrIterable()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('bar', BarMethodCall::class)
+            ->addMethodCall('setArray', [new TaggedClassMapArgument('my_tag')])
+            ->addMethodCall('setIterable', [new TaggedClassMapArgument('my_tag')]);
 
         (new CheckTypeDeclarationsPass(true))->process($container);
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/IntegrationTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/IntegrationTest.php
@@ -63,6 +63,7 @@ use Symfony\Component\DependencyInjection\Tests\Fixtures\ResourceTaggedWithCalla
 use Symfony\Component\DependencyInjection\Tests\Fixtures\ResourceTaggedWithClosureInterface;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\ResourceTaggedWithClosureMarkerInterface;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\StaticMethodTag;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\TaggedClassMapConsumer;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\TaggedConsumerWithExclude;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\TaggedIteratorConsumer;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\TaggedIteratorConsumerWithDefaultIndexMethod;
@@ -518,6 +519,32 @@ class IntegrationTest extends TestCase
         $this->assertTrue($container->getDefinition('interface')->hasTag('container.excluded'));
     }
 
+    public function testAutoconfiguredResourceTagWithCallableArrayAttributesViaClassMap()
+    {
+        $container = new ContainerBuilder();
+        $container->register(ResourceTaggedWithCallableInterface::class)
+            ->setAbstract(true)
+            ->setAutoconfigured(true)
+        ;
+        $container->register(FooResourceTaggedWithCallable::class, FooResourceTaggedWithCallable::class)
+            ->setAutoconfigured(true)
+        ;
+        $container->register(BarResourceTaggedWithCallable::class, BarResourceTaggedWithCallable::class)
+            ->setAutoconfigured(true)
+        ;
+        $container->register(TaggedClassMapConsumer::class)
+            ->setAutowired(true)
+            ->setPublic(true)
+        ;
+
+        $container->compile();
+
+        $this->assertSame([
+            'foo' => FooResourceTaggedWithCallable::class,
+            'bar' => BarResourceTaggedWithCallable::class,
+        ], $container->get(TaggedClassMapConsumer::class)->getParam());
+    }
+
     public function testAutoconfiguredTagWithCallableArrayAttributesFromYaml()
     {
         $container = new ContainerBuilder();
@@ -717,6 +744,27 @@ class IntegrationTest extends TestCase
 
         $param = iterator_to_array($s->getParam()->getIterator());
         $this->assertSame(['bar_tab_class_with_defaultmethod' => $container->get(BarTagClass::class), 'foo' => $container->get(FooTagClass::class)], $param);
+    }
+
+    public function testTaggedClassMapConfiguredViaAttribute()
+    {
+        $container = new ContainerBuilder();
+        $container->register(BarTagClass::class, BarTagClass::class)
+            ->addResourceTag('foo_bar', ['foo' => 'bar'])
+        ;
+        $container->register(FooTagClass::class, FooTagClass::class)
+            ->addResourceTag('foo_bar', ['foo' => 'foo'])
+        ;
+        $container->register(TaggedClassMapConsumer::class)
+            ->setAutowired(true)
+            ->setPublic(true)
+        ;
+
+        $container->compile();
+
+        $s = $container->get(TaggedClassMapConsumer::class);
+
+        $this->assertSame(['bar' => BarTagClass::class, 'foo' => FooTagClass::class], $s->getParam());
     }
 
     #[IgnoreDeprecations]

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveBindingsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveBindingsPassTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Argument\AbstractArgument;
 use Symfony\Component\DependencyInjection\Argument\BoundArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
+use Symfony\Component\DependencyInjection\Argument\TaggedClassMapArgument;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\Attribute\Target;
 use Symfony\Component\DependencyInjection\Compiler\AutowireRequiredMethodsPass;
@@ -302,6 +303,19 @@ class ResolveBindingsPassTest extends TestCase
         $this->assertInstanceOf(TaggedIteratorArgument::class, $container->getDefinition('bar')->getArgument(0));
 
         spl_autoload_unregister($autoloader);
+    }
+
+    public function testTaggedClassMapBinding()
+    {
+        $container = new ContainerBuilder();
+        $definition = $container->register('bar', NamedIterableArgumentDummy::class);
+        $definition->setBindings([
+            '$items' => new TaggedClassMapArgument('foo'),
+        ]);
+
+        (new ResolveBindingsPass())->process($container);
+
+        $this->assertInstanceOf(TaggedClassMapArgument::class, $container->getDefinition('bar')->getArgument(0));
     }
 
     public function testBindWithTarget()

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveTaggedClassMapArgumentPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveTaggedClassMapArgumentPassTest.php
@@ -1,0 +1,211 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Compiler;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Argument\TaggedClassMapArgument;
+use Symfony\Component\DependencyInjection\Compiler\ResolveTaggedClassMapArgumentPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\BarTagClass;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\BazTagClass;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\FooTagClass;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\QuxTagClass;
+
+class ResolveTaggedClassMapArgumentPassTest extends TestCase
+{
+    public function testProcess()
+    {
+        $container = new ContainerBuilder();
+        $container->register(BarTagClass::class, BarTagClass::class)->addResourceTag('my_tag', ['key' => 'bar']);
+        $container->register(FooTagClass::class, FooTagClass::class)->addResourceTag('my_tag', ['key' => 'foo']);
+        $container->register('service', 'stdClass')->setArguments([new TaggedClassMapArgument('my_tag', 'key')]);
+
+        (new ResolveTaggedClassMapArgumentPass())->process($container);
+
+        $expected = new TaggedClassMapArgument('my_tag', 'key');
+        $expected->setValues([
+            'bar' => BarTagClass::class,
+            'foo' => FooTagClass::class,
+        ]);
+        $this->assertEquals($expected, $container->getDefinition('service')->getArgument(0));
+    }
+
+    public function testProcessWithDefaultIndexAttribute()
+    {
+        $container = new ContainerBuilder();
+        $container->register(BarTagClass::class, BarTagClass::class)->addResourceTag('app.my_tag', ['my_tag' => 'bar']);
+        $container->register(FooTagClass::class, FooTagClass::class)->addResourceTag('app.my_tag', ['my_tag' => 'foo']);
+        $container->register('service', 'stdClass')->setArguments([new TaggedClassMapArgument('app.my_tag')]);
+
+        (new ResolveTaggedClassMapArgumentPass())->process($container);
+
+        $expected = new TaggedClassMapArgument('app.my_tag');
+        $expected->setValues([
+            'bar' => BarTagClass::class,
+            'foo' => FooTagClass::class,
+        ]);
+        $this->assertEquals($expected, $container->getDefinition('service')->getArgument(0));
+    }
+
+    public function testProcessFallsBackToAsTaggedItemIndex()
+    {
+        $container = new ContainerBuilder();
+        $container->register(BarTagClass::class, BarTagClass::class)->setAutoconfigured(true)->addResourceTag('my_tag');
+        $container->register(FooTagClass::class, FooTagClass::class)->setAutoconfigured(true)->addResourceTag('my_tag', ['key' => 'foo']);
+        $container->register('service', 'stdClass')->setArguments([new TaggedClassMapArgument('my_tag', 'key')]);
+
+        (new ResolveTaggedClassMapArgumentPass())->process($container);
+
+        $expected = new TaggedClassMapArgument('my_tag', 'key');
+        $expected->setValues([
+            'bar_tag_class' => BarTagClass::class,
+            'foo' => FooTagClass::class,
+        ]);
+        $this->assertEquals($expected, $container->getDefinition('service')->getArgument(0));
+    }
+
+    public function testProcessFallsBackToClassName()
+    {
+        $container = new ContainerBuilder();
+        $container->register(BarTagClass::class, BarTagClass::class)->addResourceTag('my_tag');
+        $container->register('service', 'stdClass')->setArguments([new TaggedClassMapArgument('my_tag')]);
+
+        (new ResolveTaggedClassMapArgumentPass())->process($container);
+
+        $expected = new TaggedClassMapArgument('my_tag');
+        $expected->setValues([
+            BarTagClass::class => BarTagClass::class,
+        ]);
+        $this->assertEquals($expected, $container->getDefinition('service')->getArgument(0));
+    }
+
+    public function testProcessResolvesParameters()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('my_key', 'bar');
+        $container->register(BarTagClass::class, BarTagClass::class)->addResourceTag('my_tag', ['key' => '%my_key%']);
+        $container->register('service', 'stdClass')->setArguments([new TaggedClassMapArgument('my_tag', 'key')]);
+
+        (new ResolveTaggedClassMapArgumentPass())->process($container);
+
+        $expected = new TaggedClassMapArgument('my_tag', 'key');
+        $expected->setValues([
+            'bar' => BarTagClass::class,
+        ]);
+        $this->assertEquals($expected, $container->getDefinition('service')->getArgument(0));
+    }
+
+    public function testProcessWithExclude()
+    {
+        $container = new ContainerBuilder();
+        $container->register(BarTagClass::class, BarTagClass::class)->addResourceTag('my_tag', ['key' => 'bar']);
+        $container->register(FooTagClass::class, FooTagClass::class)->addResourceTag('my_tag', ['key' => 'foo']);
+        $container->register('service', 'stdClass')->setArguments([new TaggedClassMapArgument('my_tag', 'key', [FooTagClass::class])]);
+
+        (new ResolveTaggedClassMapArgumentPass())->process($container);
+
+        $expected = new TaggedClassMapArgument('my_tag', 'key', [FooTagClass::class]);
+        $expected->setValues([
+            'bar' => BarTagClass::class,
+        ]);
+        $this->assertEquals($expected, $container->getDefinition('service')->getArgument(0));
+    }
+
+    public function testProcessSortsByPriority()
+    {
+        $container = new ContainerBuilder();
+        $container->register(BarTagClass::class, BarTagClass::class)->addResourceTag('my_tag', ['key' => 'bar']);
+        $container->register(FooTagClass::class, FooTagClass::class)->addResourceTag('my_tag', ['key' => 'foo', 'priority' => 10]);
+        $container->register('service', 'stdClass')->setArguments([new TaggedClassMapArgument('my_tag', 'key')]);
+
+        (new ResolveTaggedClassMapArgumentPass())->process($container);
+
+        $this->assertSame([
+            'foo' => FooTagClass::class,
+            'bar' => BarTagClass::class,
+        ], $container->getDefinition('service')->getArgument(0)->getValues());
+    }
+
+    public function testProcessHighestPriorityWinsOnDuplicateIndex()
+    {
+        $container = new ContainerBuilder();
+        $container->register(BarTagClass::class, BarTagClass::class)->addResourceTag('my_tag', ['key' => 'same']);
+        $container->register(FooTagClass::class, FooTagClass::class)->addResourceTag('my_tag', ['key' => 'same', 'priority' => 10]);
+        $container->register('service', 'stdClass')->setArguments([new TaggedClassMapArgument('my_tag', 'key')]);
+
+        (new ResolveTaggedClassMapArgumentPass())->process($container);
+
+        $expected = new TaggedClassMapArgument('my_tag', 'key');
+        $expected->setValues([
+            'same' => FooTagClass::class,
+        ]);
+        $this->assertEquals($expected, $container->getDefinition('service')->getArgument(0));
+    }
+
+    public function testProcessFallsBackToAsTaggedItemPriority()
+    {
+        $container = new ContainerBuilder();
+        $container->register(BarTagClass::class, BarTagClass::class)->addResourceTag('my_tag', ['key' => 'bar']);
+        $container->register(BazTagClass::class, BazTagClass::class)->setAutoconfigured(true)->addResourceTag('my_tag');
+        $container->register('service', 'stdClass')->setArguments([new TaggedClassMapArgument('my_tag', 'key')]);
+
+        (new ResolveTaggedClassMapArgumentPass())->process($container);
+
+        $this->assertSame([
+            'baz_tag_class' => BazTagClass::class,
+            'bar' => BarTagClass::class,
+        ], $container->getDefinition('service')->getArgument(0)->getValues());
+    }
+
+    public function testProcessWithRepeatedAsTaggedItemAttributes()
+    {
+        $container = new ContainerBuilder();
+        $container->register(BarTagClass::class, BarTagClass::class)->addResourceTag('my_tag', ['key' => 'bar']);
+        $container->register(QuxTagClass::class, QuxTagClass::class)->setAutoconfigured(true)->addResourceTag('my_tag');
+        $container->register('service', 'stdClass')->setArguments([new TaggedClassMapArgument('my_tag', 'key')]);
+
+        (new ResolveTaggedClassMapArgumentPass())->process($container);
+
+        $this->assertSame([
+            'qux_one' => QuxTagClass::class,
+            'qux_two' => QuxTagClass::class,
+            'bar' => BarTagClass::class,
+        ], $container->getDefinition('service')->getArgument(0)->getValues());
+    }
+
+    public function testProcessSkipsAbstractResources()
+    {
+        $container = new ContainerBuilder();
+        $container->register(BarTagClass::class, BarTagClass::class)->addResourceTag('my_tag', ['key' => 'bar']);
+        $container->register('.abstract.resource', FooTagClass::class)->setAbstract(true)->addResourceTag('my_tag', ['key' => 'foo']);
+        $container->register('service', 'stdClass')->setArguments([new TaggedClassMapArgument('my_tag', 'key')]);
+
+        (new ResolveTaggedClassMapArgumentPass())->process($container);
+
+        $this->assertSame([
+            'bar' => BarTagClass::class,
+        ], $container->getDefinition('service')->getArgument(0)->getValues());
+    }
+
+    public function testProcessThrowsOnNonExcludedService()
+    {
+        $container = new ContainerBuilder();
+        $container->register(BarTagClass::class, BarTagClass::class)->addTag('my_tag', ['key' => 'bar']);
+        $container->register('service', 'stdClass')->setArguments([new TaggedClassMapArgument('my_tag', 'key')]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(\sprintf('The resource "%s" tagged "my_tag" is missing the "container.excluded" tag; did you mean to use "resource_tags" instead of "tags"?', BarTagClass::class));
+
+        (new ResolveTaggedClassMapArgumentPass())->process($container);
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -29,6 +29,7 @@ use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\Argument\LazyProxyArgument;
 use Symfony\Component\DependencyInjection\Argument\RewindableGenerator;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
+use Symfony\Component\DependencyInjection\Argument\TaggedClassMapArgument;
 use Symfony\Component\DependencyInjection\Attribute\AsTaggedItem;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\DependencyInjection\ChildDefinition;
@@ -963,6 +964,18 @@ class ContainerBuilderTest extends TestCase
         $this->assertEquals($builder->get('foo'), $builder->resolveServices(new Reference('foo')), '->resolveServices() resolves service references to service instances');
         $this->assertEquals(['foo' => ['foo', $builder->get('foo')]], $builder->resolveServices(['foo' => ['foo', new Reference('foo')]]), '->resolveServices() resolves service references to service instances in nested arrays');
         $this->assertEquals($builder->get('foo'), $builder->resolveServices(new Expression('service("foo")')), '->resolveServices() resolves expressions');
+    }
+
+    public function testResolveServicesWithTaggedClassMapArgument()
+    {
+        $builder = new ContainerBuilder();
+        $argument = new TaggedClassMapArgument('foo');
+
+        $this->assertSame([], $builder->resolveServices($argument), '->resolveServices() resolves tagged class maps to their values');
+
+        $argument->setValues(['key' => 'Foo']);
+
+        $this->assertSame(['key' => 'Foo'], $builder->resolveServices($argument));
     }
 
     public function testResolveServicesWithDecoratedDefinition()

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -25,6 +25,7 @@ use Symfony\Component\DependencyInjection\Argument\RewindableGenerator;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocator as ArgumentServiceLocator;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
+use Symfony\Component\DependencyInjection\Argument\TaggedClassMapArgument;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\DependencyInjection\Attribute\AutowireCallable;
@@ -70,10 +71,12 @@ use Symfony\Component\DependencyInjection\Tests\Compiler\MyInlineService;
 use Symfony\Component\DependencyInjection\Tests\Compiler\SingleMethodInterface;
 use Symfony\Component\DependencyInjection\Tests\Compiler\Wither;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\Bar;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\BarTagClass;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\CustomDefinition;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\DependencyContainer;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\DependencyContainerInterface;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\FooClassWithEnumAttribute;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\FooTagClass;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\FooUnitEnum;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\FooWithAbstractArgument;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\NewInInitializer;
@@ -383,6 +386,25 @@ class PhpDumperTest extends TestCase
         $this->assertCount(1, $firstIteration);
         $this->assertSame($firstIteration, $secondIteration);
         $this->assertSame(1, PhpDumperTest_TaggedIteratorService::$constructed);
+    }
+
+    public function testTaggedClassMapArgument()
+    {
+        $container = new ContainerBuilder();
+        $container->register(BarTagClass::class, BarTagClass::class)->addResourceTag('my_tag', ['key' => 'bar']);
+        $container->register(FooTagClass::class, FooTagClass::class)->addResourceTag('my_tag', ['key' => 'foo']);
+        $container->register('tagged_class_map', 'stdClass')
+            ->setProperty('classMap', new TaggedClassMapArgument('my_tag', 'key'))
+            ->setPublic(true);
+
+        $container->compile();
+
+        $dumper = new PhpDumper($container);
+        eval('?>'.$dumper->dump(['class' => 'Symfony_DI_PhpDumper_Test_Tagged_Class_Map']));
+
+        $compiled = new \Symfony_DI_PhpDumper_Test_Tagged_Class_Map();
+
+        $this->assertSame(['bar' => BarTagClass::class, 'foo' => FooTagClass::class], $compiled->get('tagged_class_map')->classMap);
     }
 
     public function testDumpAsFilesWithLazyFactoriesInlined()

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/XmlDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/XmlDumperTest.php
@@ -20,6 +20,7 @@ use Symfony\Component\DependencyInjection\Argument\EnvClosureArgument;
 use Symfony\Component\DependencyInjection\Argument\LazyProxyArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
+use Symfony\Component\DependencyInjection\Argument\TaggedClassMapArgument;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\Compiler\AutowirePass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -231,6 +232,27 @@ class XmlDumperTest extends TestCase
 
         $dumper = new XmlDumper($container);
         $this->assertXmlStringEqualsGeneratedXmlFile('services_with_tagged_arguments.xml', $dumper->dump());
+    }
+
+    public function testTaggedClassMapArguments()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('foo_tagged_class_map', 'Bar')
+            ->setPublic(true)
+            ->addArgument(new TaggedClassMapArgument('foo_tag'))
+        ;
+        $container->register('foo2_tagged_class_map', 'Bar')
+            ->setPublic(true)
+            ->addArgument(new TaggedClassMapArgument('foo_tag', 'key', ['baz']))
+        ;
+        $container->register('foo3_tagged_class_map', 'Bar')
+            ->setPublic(true)
+            ->addArgument(new TaggedClassMapArgument('foo_tag', null, ['baz', 'qux']))
+        ;
+
+        $dumper = new XmlDumper($container);
+        $this->assertXmlStringEqualsGeneratedXmlFile('services_with_tagged_class_map_arguments.xml', $dumper->dump());
     }
 
     #[IgnoreDeprecations]

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/YamlDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/YamlDumperTest.php
@@ -20,6 +20,7 @@ use Symfony\Component\DependencyInjection\Argument\AbstractArgument;
 use Symfony\Component\DependencyInjection\Argument\EnvClosureArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
+use Symfony\Component\DependencyInjection\Argument\TaggedClassMapArgument;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\Compiler\AutowirePass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -137,6 +138,18 @@ class YamlDumperTest extends TestCase
 
         $dumper = new YamlDumper($container);
         $this->assertStringEqualsGeneratedFile('services_with_tagged_argument.yml', $dumper->dump());
+    }
+
+    public function testTaggedClassMapArguments()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('foo_service_tagged_class_map', 'Bar')->addArgument(new TaggedClassMapArgument('foo'));
+        $container->register('foo2_service_tagged_class_map', 'Bar')->addArgument(new TaggedClassMapArgument('foo', 'key', ['Baz']));
+        $container->register('foo3_service_tagged_class_map', 'Bar')->addArgument(new TaggedClassMapArgument('foo', null, ['Baz', 'Qux']));
+
+        $dumper = new YamlDumper($container);
+        $this->assertStringEqualsGeneratedFile('services_with_tagged_class_map_argument.yml', $dumper->dump());
     }
 
     #[IgnoreDeprecations]

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/BazTagClass.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/BazTagClass.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+use Symfony\Component\DependencyInjection\Attribute\AsTaggedItem;
+
+#[AsTaggedItem('baz_tag_class', priority: 20)]
+class BazTagClass
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/QuxTagClass.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/QuxTagClass.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+use Symfony\Component\DependencyInjection\Attribute\AsTaggedItem;
+
+#[AsTaggedItem('qux_one', priority: 30)]
+#[AsTaggedItem('qux_two')]
+class QuxTagClass
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TaggedClassMapConsumer.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TaggedClassMapConsumer.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+use Symfony\Component\DependencyInjection\Attribute\AutowireClassMap;
+
+final class TaggedClassMapConsumer
+{
+    public function __construct(
+        #[AutowireClassMap('foo_bar', indexAttribute: 'foo')]
+        private array $param,
+    ) {
+    }
+
+    public function getParam(): array
+    {
+        return $this->param;
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_with_tagged_class_map_arguments.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_with_tagged_class_map_arguments.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd">
+  <services>
+    <service id="service_container" class="Symfony\Component\DependencyInjection\ContainerInterface" public="true" synthetic="true"/>
+    <service id="foo_tagged_class_map" class="Bar" public="true">
+      <argument type="tagged_class_map" tag="foo_tag"/>
+    </service>
+    <service id="foo2_tagged_class_map" class="Bar" public="true">
+      <argument type="tagged_class_map" tag="foo_tag" index-by="key" exclude="baz"/>
+    </service>
+    <service id="foo3_tagged_class_map" class="Bar" public="true">
+      <argument type="tagged_class_map" tag="foo_tag">
+        <exclude>baz</exclude>
+        <exclude>qux</exclude>
+      </argument>
+    </service>
+  </services>
+</container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/bad_empty_tagged_class_map.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/bad_empty_tagged_class_map.yml
@@ -1,0 +1,4 @@
+services:
+    foo_service:
+        class: Foo
+        arguments: [!tagged_class_map '']

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/bad_tagged_class_map.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/bad_tagged_class_map.yml
@@ -1,0 +1,4 @@
+services:
+    foo_service:
+        class: Foo
+        arguments: [!tagged_class_map { tag: foo, index_attribute: key }]

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_with_tagged_class_map_argument.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_with_tagged_class_map_argument.yml
@@ -1,0 +1,15 @@
+
+services:
+    service_container:
+        class: Symfony\Component\DependencyInjection\ContainerInterface
+        public: true
+        synthetic: true
+    foo_service_tagged_class_map:
+        class: Bar
+        arguments: [!tagged_class_map foo]
+    foo2_service_tagged_class_map:
+        class: Bar
+        arguments: [!tagged_class_map { tag: foo, index_by: key, exclude: Baz }]
+    foo3_service_tagged_class_map:
+        class: Bar
+        arguments: [!tagged_class_map { tag: foo, exclude: [Baz, Qux] }]

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/Configurator/ContainerConfiguratorTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/Configurator/ContainerConfiguratorTest.php
@@ -15,11 +15,13 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
+use Symfony\Component\DependencyInjection\Argument\TaggedClassMapArgument;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 
+use function Symfony\Component\DependencyInjection\Loader\Configurator\tagged_class_map;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\tagged_iterator;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\tagged_locator;
 
@@ -75,6 +77,13 @@ class ContainerConfiguratorTest extends TestCase
 
         $this->assertInstanceOf(ServiceLocatorArgument::class, $argument);
         $this->assertSame(['get_something'], $argument->getTaggedIteratorArgument()->getExclude());
+    }
+
+    public function testTaggedClassMap()
+    {
+        $this->assertEquals(new TaggedClassMapArgument('foo'), tagged_class_map('foo'));
+        $this->assertEquals(new TaggedClassMapArgument('foo', 'key', ['Baz']), tagged_class_map('foo', 'key', 'Baz'));
+        $this->assertEquals(new TaggedClassMapArgument('foo', null, ['Baz', 'Qux']), tagged_class_map('foo', exclude: ['Baz', 'Qux']));
     }
 
     public function testTaggedIteratorAcceptsNullExclude()

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -27,6 +27,7 @@ use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\Argument\LazyProxyArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
+use Symfony\Component\DependencyInjection\Argument\TaggedClassMapArgument;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\Compiler\DecoratorServicePass;
 use Symfony\Component\DependencyInjection\Compiler\ResolveBindingsPass;
@@ -441,6 +442,39 @@ class YamlFileLoaderTest extends TestCase
 
         $taggedIterator = new TaggedIteratorArgument('foo', null, true);
         $this->assertEquals(new ServiceLocatorArgument($taggedIterator), $container->getDefinition('bar_service_tagged_locator')->getArgument(0));
+    }
+
+    public function testTaggedClassMapArguments()
+    {
+        $container = new ContainerBuilder();
+        $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
+        $loader->load('services_with_tagged_class_map_argument.yml');
+
+        $this->assertEquals(new TaggedClassMapArgument('foo'), $container->getDefinition('foo_service_tagged_class_map')->getArgument(0));
+        $this->assertEquals(new TaggedClassMapArgument('foo', 'key', ['Baz']), $container->getDefinition('foo2_service_tagged_class_map')->getArgument(0));
+        $this->assertEquals(new TaggedClassMapArgument('foo', null, ['Baz', 'Qux']), $container->getDefinition('foo3_service_tagged_class_map')->getArgument(0));
+    }
+
+    public function testTaggedClassMapArgumentWithUnsupportedKey()
+    {
+        $container = new ContainerBuilder();
+        $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('"!tagged_class_map" tag contains unsupported key "index_attribute"; supported ones are "tag", "index_by", "exclude".');
+
+        $loader->load('bad_tagged_class_map.yml');
+    }
+
+    public function testTaggedClassMapArgumentWithInvalidArgument()
+    {
+        $container = new ContainerBuilder();
+        $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('"!tagged_class_map" tags only accept a non empty string or an array with a key "tag" in');
+
+        $loader->load('bad_empty_tagged_class_map.yml');
     }
 
     #[IgnoreDeprecations]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Follow-up to #65434, which was extracted from this PR and is now merged.

Currently, consuming resource tags requires writing a compiler pass.

This PR adds a generic way to inject a map of `index => FQCN` built from a resource tag, without the need for a compiler pass:

```php
use Symfony\Component\DependencyInjection\Attribute\AutowireClassMap;

final class MessageRegistry
{
    public function __construct(
        #[AutowireClassMap('app.message', indexAttribute: 'format')]
        private array $messageClasses, // e.g. ['foo' => FooMessage::class, 'bar' => BarMessage::class]
    ) {
    }
}
```

```php
#[AutoconfigureResourceTag('app.message', ['format' => 'foo'])]
final class FooMessage
{
}
```

Combined with #64652 and #65434, the map keys can be computed per class:

```php
#[AutoconfigureResourceTag('app.message', attributes: static function (string $class): array {
    return ['format' => $class::getFormat()];
})]
interface MessageInterface
{
    public static function getFormat(): string;
}
```

The same is available in YAML and the PHP-DSL:

```yaml
services:
    App\MessageRegistry:
        arguments: [!tagged_class_map { tag: app.message, index_by: format, exclude: [App\Message\Internal] }]
        # or the short form:
        # arguments: [!tagged_class_map app.message]
```

```php
use function Symfony\Component\DependencyInjection\Loader\Configurator\tagged_class_map;

$services->set(App\MessageRegistry::class)
    ->args([tagged_class_map('app.message', 'format', exclude: [App\Message\Internal::class])]);
```

The behavior mirrors `tagged_iterator`/`tagged_locator` where it applies:
- `indexAttribute` defaults to the tag's last dot-segment (`app.message` -> `message`); a class whose tag carries no such attribute falls back to `#[AsTaggedItem]`'s index, then to the FQCN itself;
- `priority` is read from the tag attributes, then from `#[AsTaggedItem]`; on duplicate indexes the highest priority wins, then the registration order;
- abstract classes and interfaces never end up in the map, only concrete classes do.

For the documentation:
- `#[AutowireClassMap(tag, indexAttribute, exclude)]` on a parameter, `!tagged_class_map` in YAML (string or `{ tag, index_by, exclude }`), `tagged_class_map()` in the PHP-DSL, and `TaggedClassMapArgument` for bindings;
- the map values are class-strings, not services: the tagged classes are excluded resources and are never instantiated by the container;
- index and priority resolution rules as listed above, including the `#[AsTaggedItem]` fallbacks.
