### PR TITLE
[Translation] Read CSV translations without SplFileObject

### DIFF
--- a/src/Symfony/Component/Translation/Loader/CsvFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/CsvFileLoader.php
@@ -28,23 +28,19 @@ class CsvFileLoader extends FileLoader
     {
         $messages = [];
 
-        try {
-            $file = new \SplFileObject($resource, 'rb');
-        } catch (\RuntimeException $e) {
-            throw new NotFoundResourceException(\sprintf('Error opening file "%s".', $resource), 0, $e);
+        if (!$file = @fopen($resource, 'r')) {
+            throw new NotFoundResourceException(\sprintf('Error opening file "%s".', $resource));
         }
 
-        $file->setFlags(\SplFileObject::READ_CSV | \SplFileObject::SKIP_EMPTY | \SplFileObject::DROP_NEW_LINE);
-        $file->setCsvControl($this->delimiter, $this->enclosure, $this->escape);
-
-        foreach ($file as $data) {
-            if (false === $data) {
-                continue;
+        try {
+            while (false !== $data = fgetcsv($file, null, $this->delimiter, $this->enclosure, $this->escape)) {
+                // empty lines are read as [null]
+                if (isset($data[1]) && 2 === \count($data) && !str_starts_with($data[0], '#')) {
+                    $messages[$data[0]] = $data[1];
+                }
             }
-
-            if (!str_starts_with($data[0], '#') && isset($data[1]) && 2 === \count($data)) {
-                $messages[$data[0]] = $data[1];
-            }
+        } finally {
+            fclose($file);
         }
 
         return $messages;

--- a/src/Symfony/Component/Translation/Tests/Fixtures/csv-edge-cases.csv
+++ b/src/Symfony/Component/Translation/Tests/Fixtures/csv-edge-cases.csv
@@ -1,0 +1,8 @@
+foo;bar
+
+#comment;ignored
+"multi
+line";value
+"with;delimiter";ok
+not-enough-columns
+too;many;columns

--- a/src/Symfony/Component/Translation/Tests/Loader/CsvFileLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/CsvFileLoaderTest.php
@@ -41,6 +41,18 @@ class CsvFileLoaderTest extends TestCase
         $this->assertEquals([new FileResource($resource)], $catalogue->getResources());
     }
 
+    public function testLoadEdgeCases()
+    {
+        $loader = new CsvFileLoader();
+        $catalogue = $loader->load(__DIR__.'/../Fixtures/csv-edge-cases.csv', 'en', 'domain1');
+
+        $this->assertSame([
+            'foo' => 'bar',
+            "multi\nline" => 'value',
+            'with;delimiter' => 'ok',
+        ], $catalogue->all('domain1'));
+    }
+
     public function testLoadNonExistingResource()
     {
         $this->expectException(NotFoundResourceException::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Anticipating another [PHP 8.6 deprecation](https://wiki.php.net/rfc/deprecations_php_8_6): `SplFileObject::fgetcsv()`, `::fputcsv()`, `::setCsvControl()` and `::getCsvControl()`. The procedural `fgetcsv()`/`fputcsv()` functions are explicitly *not* part of it, so this is just a matter of reading the handle directly.

`str_getcsv()` per line would have been the smaller diff but it breaks enclosed fields that span several lines, which the `valid.csv` fixture already exercises. `fgetcsv()` on the handle keeps that working.

One behavioral detail: empty lines used to be filtered out by `SplFileObject::SKIP_EMPTY` before reaching the loop. `fgetcsv()` returns them as `[null]`, so the conditions are reordered to skip them before `$data[0]` is read — otherwise `str_starts_with(null, '#')` would deprecate on its own.

I checked the two implementations produce identical output on the existing fixtures plus empty lines, whitespace-only lines, comments, missing/extra columns, empty keys and values, a BOM, a missing trailing newline, multiline enclosed fields and delimiters inside enclosures. The new `testLoadEdgeCases` locks the interesting subset in, and passes against the old implementation too — it documents behaviour rather than the refactor.

The delimiter, enclosure and escape characters set through `setCsvControl()` are passed to `fgetcsv()` unchanged, so custom ones keep working.

`SplCaster::castFileObject()` also calls `getCsvControl()`, but dropping it changes dump output, so that one is left for a separate discussion.
