### PR TITLE
[HttpFoundation] Declare create_sid() on session handlers

### DIFF
--- a/.github/expected-missing-return-types.diff
+++ b/.github/expected-missing-return-types.diff
@@ -7668,6 +7668,36 @@ diff --git a/src/Symfony/Component/HttpFoundation/Session/SessionInterface.php b
 +    public function registerBag(SessionBagInterface $bag): void;
  
      /**
+diff --git a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/AbstractSessionHandler.php b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/AbstractSessionHandler.php
+--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/AbstractSessionHandler.php
++++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/AbstractSessionHandler.php
+@@ -42,5 +42,5 @@ abstract class AbstractSessionHandler implements \SessionHandlerInterface, \Sess
+      * @return string
+      */
+-    public function create_sid()
++    public function create_sid(): string
+     {
+         return session_create_id() ?: throw new \RuntimeException('Unable to create a session ID.');
+diff --git a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MarshallingSessionHandler.php b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MarshallingSessionHandler.php
+--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MarshallingSessionHandler.php
++++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MarshallingSessionHandler.php
+@@ -41,5 +41,5 @@ class MarshallingSessionHandler implements \SessionHandlerInterface, \SessionUpd
+      * @return string
+      */
+-    public function create_sid()
++    public function create_sid(): string
+     {
+         return session_create_id() ?: throw new \RuntimeException('Unable to create a session ID.');
+diff --git a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MigratingSessionHandler.php b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MigratingSessionHandler.php
+--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MigratingSessionHandler.php
++++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MigratingSessionHandler.php
+@@ -42,5 +42,5 @@ class MigratingSessionHandler implements \SessionHandlerInterface, \SessionUpdat
+      * @return string
+      */
+-    public function create_sid()
++    public function create_sid(): string
+     {
+         return session_create_id() ?: throw new \RuntimeException('Unable to create a session ID.');
 diff --git a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
 --- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
 +++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
@@ -7871,6 +7901,16 @@ diff --git a/src/Symfony/Component/HttpFoundation/Session/Storage/Proxy/Abstract
 +    public function setName(string $name): void
      {
          if ($this->isActive()) {
+diff --git a/src/Symfony/Component/HttpFoundation/Session/Storage/Proxy/SessionHandlerProxy.php b/src/Symfony/Component/HttpFoundation/Session/Storage/Proxy/SessionHandlerProxy.php
+--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Proxy/SessionHandlerProxy.php
++++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Proxy/SessionHandlerProxy.php
+@@ -68,5 +68,5 @@ class SessionHandlerProxy extends AbstractProxy implements \SessionHandlerInterf
+      * @return string
+      */
+-    public function create_sid()
++    public function create_sid(): string
+     {
+         return session_create_id() ?: throw new \RuntimeException('Unable to create a session ID.');
 diff --git a/src/Symfony/Component/HttpFoundation/Session/Storage/SessionStorageInterface.php b/src/Symfony/Component/HttpFoundation/Session/Storage/SessionStorageInterface.php
 --- a/src/Symfony/Component/HttpFoundation/Session/Storage/SessionStorageInterface.php
 +++ b/src/Symfony/Component/HttpFoundation/Session/Storage/SessionStorageInterface.php

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/AbstractSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/AbstractSessionHandler.php
@@ -38,6 +38,14 @@ abstract class AbstractSessionHandler implements \SessionHandlerInterface, \Sess
         return true;
     }
 
+    /**
+     * @return string
+     */
+    public function create_sid()
+    {
+        return session_create_id() ?: throw new \RuntimeException('Unable to create a session ID.');
+    }
+
     abstract protected function doRead(#[\SensitiveParameter] string $sessionId): string;
 
     abstract protected function doWrite(#[\SensitiveParameter] string $sessionId, string $data): bool;

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MarshallingSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MarshallingSessionHandler.php
@@ -37,6 +37,14 @@ class MarshallingSessionHandler implements \SessionHandlerInterface, \SessionUpd
         return $this->handler->close();
     }
 
+    /**
+     * @return string
+     */
+    public function create_sid()
+    {
+        return session_create_id() ?: throw new \RuntimeException('Unable to create a session ID.');
+    }
+
     public function destroy(#[\SensitiveParameter] string $sessionId): bool
     {
         return $this->handler->destroy($sessionId);

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MigratingSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MigratingSessionHandler.php
@@ -38,6 +38,14 @@ class MigratingSessionHandler implements \SessionHandlerInterface, \SessionUpdat
         $this->writeOnlyHandler = $writeOnlyHandler;
     }
 
+    /**
+     * @return string
+     */
+    public function create_sid()
+    {
+        return session_create_id() ?: throw new \RuntimeException('Unable to create a session ID.');
+    }
+
     public function close(): bool
     {
         $result = $this->currentHandler->close();

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Proxy/SessionHandlerProxy.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Proxy/SessionHandlerProxy.php
@@ -64,6 +64,14 @@ class SessionHandlerProxy extends AbstractProxy implements \SessionHandlerInterf
         return $this->handler->gc($maxlifetime);
     }
 
+    /**
+     * @return string
+     */
+    public function create_sid()
+    {
+        return session_create_id() ?: throw new \RuntimeException('Unable to create a session ID.');
+    }
+
     public function validateId(#[\SensitiveParameter] string $sessionId): bool
     {
         return !$this->handler instanceof \SessionUpdateTimestampHandlerInterface || $this->handler->validateId($sessionId);

--- a/src/Symfony/Component/HttpFoundation/Tests/Fixtures/BareSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Fixtures/BareSessionHandler.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Tests\Fixtures;
+
+/**
+ * A session handler that provides nothing more than \SessionHandlerInterface does.
+ *
+ * Mocking the interface directly is not an option: PHP 8.6 warns about any class
+ * implementing it without create_sid() and validateId(), which the generated
+ * doubles would not have. It does not implement \SessionIdInterface nor
+ * \SessionUpdateTimestampHandlerInterface on purpose, as handlers are wrapped
+ * differently depending on whether they do.
+ */
+abstract class BareSessionHandler implements \SessionHandlerInterface
+{
+    abstract public function create_sid(): string;
+
+    abstract public function validateId(string $id): bool;
+}

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MigratingSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MigratingSessionHandlerTest.php
@@ -13,12 +13,13 @@ namespace Symfony\Component\HttpFoundation\Tests\Session\Storage\Handler;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Session\Storage\Handler\MigratingSessionHandler;
+use Symfony\Component\HttpFoundation\Tests\Fixtures\BareSessionHandler;
 
 class MigratingSessionHandlerTest extends TestCase
 {
     public function testInstanceOf()
     {
-        $dualHandler = new MigratingSessionHandler($this->createStub(\SessionHandlerInterface::class), $this->createStub(\SessionHandlerInterface::class));
+        $dualHandler = new MigratingSessionHandler($this->createStub(BareSessionHandler::class), $this->createStub(BareSessionHandler::class));
 
         $this->assertInstanceOf(\SessionHandlerInterface::class, $dualHandler);
         $this->assertInstanceOf(\SessionUpdateTimestampHandlerInterface::class, $dualHandler);
@@ -26,12 +27,12 @@ class MigratingSessionHandlerTest extends TestCase
 
     public function testClose()
     {
-        $currentHandler = $this->createMock(\SessionHandlerInterface::class);
+        $currentHandler = $this->createMock(BareSessionHandler::class);
         $currentHandler->expects($this->once())
             ->method('close')
             ->willReturn(true);
 
-        $writeOnlyHandler = $this->createMock(\SessionHandlerInterface::class);
+        $writeOnlyHandler = $this->createMock(BareSessionHandler::class);
         $writeOnlyHandler->expects($this->once())
             ->method('close')
             ->willReturn(false);
@@ -44,8 +45,8 @@ class MigratingSessionHandlerTest extends TestCase
 
     public function testDestroy()
     {
-        $currentHandler = $this->createMock(\SessionHandlerInterface::class);
-        $writeOnlyHandler = $this->createMock(\SessionHandlerInterface::class);
+        $currentHandler = $this->createMock(BareSessionHandler::class);
+        $writeOnlyHandler = $this->createMock(BareSessionHandler::class);
         $dualHandler = new MigratingSessionHandler($currentHandler, $writeOnlyHandler);
         $dualHandler->open('/path/to/save/location', 'xyz');
 
@@ -70,13 +71,13 @@ class MigratingSessionHandlerTest extends TestCase
     {
         $maxlifetime = 357;
 
-        $currentHandler = $this->createMock(\SessionHandlerInterface::class);
+        $currentHandler = $this->createMock(BareSessionHandler::class);
         $currentHandler->expects($this->once())
             ->method('gc')
             ->with($maxlifetime)
             ->willReturn(1);
 
-        $writeOnlyHandler = $this->createMock(\SessionHandlerInterface::class);
+        $writeOnlyHandler = $this->createMock(BareSessionHandler::class);
         $writeOnlyHandler->expects($this->once())
             ->method('gc')
             ->with($maxlifetime)
@@ -91,13 +92,13 @@ class MigratingSessionHandlerTest extends TestCase
         $savePath = '/path/to/save/location';
         $sessionName = 'xyz';
 
-        $currentHandler = $this->createMock(\SessionHandlerInterface::class);
+        $currentHandler = $this->createMock(BareSessionHandler::class);
         $currentHandler->expects($this->once())
             ->method('open')
             ->with($savePath, $sessionName)
             ->willReturn(true);
 
-        $writeOnlyHandler = $this->createMock(\SessionHandlerInterface::class);
+        $writeOnlyHandler = $this->createMock(BareSessionHandler::class);
         $writeOnlyHandler->expects($this->once())
             ->method('open')
             ->with($savePath, $sessionName)
@@ -114,13 +115,13 @@ class MigratingSessionHandlerTest extends TestCase
         $sessionId = 'xyz';
         $readValue = 'something';
 
-        $currentHandler = $this->createMock(\SessionHandlerInterface::class);
+        $currentHandler = $this->createMock(BareSessionHandler::class);
         $currentHandler->expects($this->once())
             ->method('read')
             ->with($sessionId)
             ->willReturn($readValue);
 
-        $writeOnlyHandler = $this->createMock(\SessionHandlerInterface::class);
+        $writeOnlyHandler = $this->createMock(BareSessionHandler::class);
         $writeOnlyHandler->expects($this->never())
             ->method('read');
 
@@ -135,13 +136,13 @@ class MigratingSessionHandlerTest extends TestCase
         $sessionId = 'xyz';
         $data = 'my-serialized-data';
 
-        $currentHandler = $this->createMock(\SessionHandlerInterface::class);
+        $currentHandler = $this->createMock(BareSessionHandler::class);
         $currentHandler->expects($this->once())
             ->method('write')
             ->with($sessionId, $data)
             ->willReturn(true);
 
-        $writeOnlyHandler = $this->createMock(\SessionHandlerInterface::class);
+        $writeOnlyHandler = $this->createMock(BareSessionHandler::class);
         $writeOnlyHandler->expects($this->once())
             ->method('write')
             ->with($sessionId, $data)
@@ -158,13 +159,13 @@ class MigratingSessionHandlerTest extends TestCase
         $sessionId = 'xyz';
         $readValue = 'something';
 
-        $currentHandler = $this->createMock(\SessionHandlerInterface::class);
+        $currentHandler = $this->createMock(BareSessionHandler::class);
         $currentHandler->expects($this->once())
             ->method('read')
             ->with($sessionId)
             ->willReturn($readValue);
 
-        $writeOnlyHandler = $this->createMock(\SessionHandlerInterface::class);
+        $writeOnlyHandler = $this->createMock(BareSessionHandler::class);
         $writeOnlyHandler->expects($this->never())
             ->method('read');
 
@@ -179,13 +180,13 @@ class MigratingSessionHandlerTest extends TestCase
         $sessionId = 'xyz';
         $data = 'my-serialized-data';
 
-        $currentHandler = $this->createMock(\SessionHandlerInterface::class);
+        $currentHandler = $this->createMock(BareSessionHandler::class);
         $currentHandler->expects($this->once())
             ->method('write')
             ->with($sessionId, $data)
             ->willReturn(true);
 
-        $writeOnlyHandler = $this->createMock(\SessionHandlerInterface::class);
+        $writeOnlyHandler = $this->createMock(BareSessionHandler::class);
         $writeOnlyHandler->expects($this->once())
             ->method('write')
             ->with($sessionId, $data)

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/SessionIdInterfaceTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/SessionIdInterfaceTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Tests\Session\Storage\Handler;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Marshaller\DefaultMarshaller;
+use Symfony\Component\HttpFoundation\Session\Storage\Handler\MarshallingSessionHandler;
+use Symfony\Component\HttpFoundation\Session\Storage\Handler\MigratingSessionHandler;
+use Symfony\Component\HttpFoundation\Session\Storage\Handler\NullSessionHandler;
+use Symfony\Component\HttpFoundation\Session\Storage\Handler\StrictSessionHandler;
+use Symfony\Component\HttpFoundation\Session\Storage\Proxy\SessionHandlerProxy;
+
+class SessionIdInterfaceTest extends TestCase
+{
+    /**
+     * @dataProvider provideHandlers
+     */
+    public function testHandlersCreateSessionIds(\SessionHandlerInterface $handler)
+    {
+        $this->assertMatchesRegularExpression('/^[a-zA-Z0-9,-]{22,}$/', $handler->create_sid());
+    }
+
+    public static function provideHandlers(): iterable
+    {
+        yield 'null' => [new NullSessionHandler()];
+        yield 'strict' => [new StrictSessionHandler(new \SessionHandler())];
+        yield 'migrating' => [new MigratingSessionHandler(new NullSessionHandler(), new NullSessionHandler())];
+        yield 'proxy' => [new SessionHandlerProxy(new NullSessionHandler())];
+
+        if (class_exists(DefaultMarshaller::class)) {
+            yield 'marshalling' => [new MarshallingSessionHandler(new NullSessionHandler(), new DefaultMarshaller())];
+        }
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/StrictSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/StrictSessionHandlerTest.php
@@ -14,12 +14,13 @@ namespace Symfony\Component\HttpFoundation\Tests\Session\Storage\Handler;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Session\Storage\Handler\AbstractSessionHandler;
 use Symfony\Component\HttpFoundation\Session\Storage\Handler\StrictSessionHandler;
+use Symfony\Component\HttpFoundation\Tests\Fixtures\BareSessionHandler;
 
 class StrictSessionHandlerTest extends TestCase
 {
     public function testOpen()
     {
-        $handler = $this->createMock(\SessionHandlerInterface::class);
+        $handler = $this->createMock(BareSessionHandler::class);
         $handler->expects($this->once())->method('open')
             ->with('path', 'name')->willReturn(true);
         $proxy = new StrictSessionHandler($handler);
@@ -31,7 +32,7 @@ class StrictSessionHandlerTest extends TestCase
 
     public function testCloseSession()
     {
-        $handler = $this->createMock(\SessionHandlerInterface::class);
+        $handler = $this->createMock(BareSessionHandler::class);
         $handler->expects($this->once())->method('close')
             ->willReturn(true);
         $proxy = new StrictSessionHandler($handler);
@@ -41,7 +42,7 @@ class StrictSessionHandlerTest extends TestCase
 
     public function testValidateIdOK()
     {
-        $handler = $this->createMock(\SessionHandlerInterface::class);
+        $handler = $this->createMock(BareSessionHandler::class);
         $handler->expects($this->once())->method('read')
             ->with('id')->willReturn('data');
         $proxy = new StrictSessionHandler($handler);
@@ -51,7 +52,7 @@ class StrictSessionHandlerTest extends TestCase
 
     public function testValidateIdKO()
     {
-        $handler = $this->createMock(\SessionHandlerInterface::class);
+        $handler = $this->createMock(BareSessionHandler::class);
         $handler->expects($this->once())->method('read')
             ->with('id')->willReturn('');
         $proxy = new StrictSessionHandler($handler);
@@ -61,7 +62,7 @@ class StrictSessionHandlerTest extends TestCase
 
     public function testRead()
     {
-        $handler = $this->createMock(\SessionHandlerInterface::class);
+        $handler = $this->createMock(BareSessionHandler::class);
         $handler->expects($this->once())->method('read')
             ->with('id')->willReturn('data');
         $proxy = new StrictSessionHandler($handler);
@@ -71,7 +72,7 @@ class StrictSessionHandlerTest extends TestCase
 
     public function testReadWithValidateIdOK()
     {
-        $handler = $this->createMock(\SessionHandlerInterface::class);
+        $handler = $this->createMock(BareSessionHandler::class);
         $handler->expects($this->once())->method('read')
             ->with('id')->willReturn('data');
         $proxy = new StrictSessionHandler($handler);
@@ -82,7 +83,7 @@ class StrictSessionHandlerTest extends TestCase
 
     public function testReadWithValidateIdMismatch()
     {
-        $handler = $this->createMock(\SessionHandlerInterface::class);
+        $handler = $this->createMock(BareSessionHandler::class);
         $handler->expects($this->exactly(2))->method('read')
             ->willReturnCallback(function (...$args) {
                 static $series = [
@@ -104,7 +105,7 @@ class StrictSessionHandlerTest extends TestCase
 
     public function testUpdateTimestamp()
     {
-        $handler = $this->createMock(\SessionHandlerInterface::class);
+        $handler = $this->createMock(BareSessionHandler::class);
         $handler->expects($this->once())->method('write')
             ->with('id', 'data')->willReturn(true);
         $proxy = new StrictSessionHandler($handler);
@@ -114,7 +115,7 @@ class StrictSessionHandlerTest extends TestCase
 
     public function testWrite()
     {
-        $handler = $this->createMock(\SessionHandlerInterface::class);
+        $handler = $this->createMock(BareSessionHandler::class);
         $handler->expects($this->once())->method('write')
             ->with('id', 'data')->willReturn(true);
         $proxy = new StrictSessionHandler($handler);
@@ -124,7 +125,7 @@ class StrictSessionHandlerTest extends TestCase
 
     public function testWriteEmptyNewSession()
     {
-        $handler = $this->createMock(\SessionHandlerInterface::class);
+        $handler = $this->createMock(BareSessionHandler::class);
         $handler->expects($this->once())->method('read')
             ->with('id')->willReturn('');
         $handler->expects($this->never())->method('write');
@@ -139,7 +140,7 @@ class StrictSessionHandlerTest extends TestCase
 
     public function testWriteEmptyExistingSession()
     {
-        $handler = $this->createMock(\SessionHandlerInterface::class);
+        $handler = $this->createMock(BareSessionHandler::class);
         $handler->expects($this->once())->method('read')
             ->with('id')->willReturn('data');
         $handler->expects($this->never())->method('write');
@@ -153,7 +154,7 @@ class StrictSessionHandlerTest extends TestCase
 
     public function testDestroy()
     {
-        $handler = $this->createMock(\SessionHandlerInterface::class);
+        $handler = $this->createMock(BareSessionHandler::class);
         $handler->expects($this->once())->method('destroy')
             ->with('id')->willReturn(true);
         $proxy = new StrictSessionHandler($handler);
@@ -164,7 +165,7 @@ class StrictSessionHandlerTest extends TestCase
 
     public function testDestroyNewSession()
     {
-        $handler = $this->createMock(\SessionHandlerInterface::class);
+        $handler = $this->createMock(BareSessionHandler::class);
         $handler->expects($this->once())->method('read')
             ->with('id')->willReturn('');
         $handler->expects($this->once())->method('destroy')->willReturn(true);
@@ -177,7 +178,7 @@ class StrictSessionHandlerTest extends TestCase
 
     public function testDestroyNonEmptyNewSession()
     {
-        $handler = $this->createMock(\SessionHandlerInterface::class);
+        $handler = $this->createMock(BareSessionHandler::class);
         $handler->expects($this->once())->method('read')
             ->with('id')->willReturn('');
         $handler->expects($this->once())->method('write')
@@ -194,7 +195,7 @@ class StrictSessionHandlerTest extends TestCase
 
     public function testGc()
     {
-        $handler = $this->createMock(\SessionHandlerInterface::class);
+        $handler = $this->createMock(BareSessionHandler::class);
         $handler->expects($this->once())->method('gc')
             ->with(123)->willReturn(1);
         $proxy = new StrictSessionHandler($handler);

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Proxy/SessionHandlerProxyTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Proxy/SessionHandlerProxyTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Session\Storage\Handler\StrictSessionHandler;
 use Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage;
 use Symfony\Component\HttpFoundation\Session\Storage\Proxy\SessionHandlerProxy;
+use Symfony\Component\HttpFoundation\Tests\Fixtures\BareSessionHandler;
 
 /**
  * Tests for SessionHandlerProxy class.
@@ -29,7 +30,7 @@ class SessionHandlerProxyTest extends TestCase
 {
     public function testOpenTrue()
     {
-        $handler = $this->createMock(\SessionHandlerInterface::class);
+        $handler = $this->createMock(BareSessionHandler::class);
         $proxy = new SessionHandlerProxy($handler);
         $handler->expects($this->once())
             ->method('open')
@@ -42,7 +43,7 @@ class SessionHandlerProxyTest extends TestCase
 
     public function testOpenFalse()
     {
-        $handler = $this->createMock(\SessionHandlerInterface::class);
+        $handler = $this->createMock(BareSessionHandler::class);
         $proxy = new SessionHandlerProxy($handler);
         $handler->expects($this->once())
             ->method('open')
@@ -55,7 +56,7 @@ class SessionHandlerProxyTest extends TestCase
 
     public function testClose()
     {
-        $handler = $this->createMock(\SessionHandlerInterface::class);
+        $handler = $this->createMock(BareSessionHandler::class);
         $proxy = new SessionHandlerProxy($handler);
         $handler->expects($this->once())
             ->method('close')
@@ -68,7 +69,7 @@ class SessionHandlerProxyTest extends TestCase
 
     public function testCloseFalse()
     {
-        $handler = $this->createMock(\SessionHandlerInterface::class);
+        $handler = $this->createMock(BareSessionHandler::class);
         $proxy = new SessionHandlerProxy($handler);
         $handler->expects($this->once())
             ->method('close')
@@ -81,7 +82,7 @@ class SessionHandlerProxyTest extends TestCase
 
     public function testRead()
     {
-        $handler = $this->createMock(\SessionHandlerInterface::class);
+        $handler = $this->createMock(BareSessionHandler::class);
         $proxy = new SessionHandlerProxy($handler);
         $handler->expects($this->once())
             ->method('read')
@@ -93,7 +94,7 @@ class SessionHandlerProxyTest extends TestCase
 
     public function testWrite()
     {
-        $handler = $this->createMock(\SessionHandlerInterface::class);
+        $handler = $this->createMock(BareSessionHandler::class);
         $proxy = new SessionHandlerProxy($handler);
         $handler->expects($this->once())
             ->method('write')
@@ -105,7 +106,7 @@ class SessionHandlerProxyTest extends TestCase
 
     public function testDestroy()
     {
-        $handler = $this->createMock(\SessionHandlerInterface::class);
+        $handler = $this->createMock(BareSessionHandler::class);
         $proxy = new SessionHandlerProxy($handler);
         $handler->expects($this->once())
             ->method('destroy')
@@ -117,7 +118,7 @@ class SessionHandlerProxyTest extends TestCase
 
     public function testGc()
     {
-        $handler = $this->createMock(\SessionHandlerInterface::class);
+        $handler = $this->createMock(BareSessionHandler::class);
         $proxy = new SessionHandlerProxy($handler);
         $handler->expects($this->once())
             ->method('gc')
@@ -129,7 +130,7 @@ class SessionHandlerProxyTest extends TestCase
 
     public function testValidateIdWithoutUpdateTimestampHandler()
     {
-        $proxy = new SessionHandlerProxy($this->createStub(\SessionHandlerInterface::class));
+        $proxy = new SessionHandlerProxy($this->createStub(BareSessionHandler::class));
 
         $this->assertTrue($proxy->validateId('id'));
     }
@@ -172,7 +173,7 @@ class SessionHandlerProxyTest extends TestCase
 
     public function testUpdateTimestampWithoutUpdateTimestampHandler()
     {
-        $handler = $this->createMock(\SessionHandlerInterface::class);
+        $handler = $this->createMock(BareSessionHandler::class);
         $handler->expects($this->once())
             ->method('write')
             ->willReturn(true);
@@ -200,6 +201,6 @@ class SessionHandlerProxyTest extends TestCase
     }
 }
 
-abstract class TestSessionHandler implements \SessionHandlerInterface, \SessionUpdateTimestampHandlerInterface
+abstract class TestSessionHandler extends BareSessionHandler implements \SessionUpdateTimestampHandlerInterface
 {
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

php/php-src@6901c87 landed yesterday and implements the [PHP 8.6 deprecation](https://wiki.php.net/rfc/deprecations_php_8_6) for session handlers without `create_sid()` and `validateId()`. Our handlers already provide `validateId()` and `updateTimestamp()` through `SessionUpdateTimestampHandlerInterface`, but none declares `create_sid()`, so on 8.6 every application gets an `E_WARNING` per handler class at declaration time plus an `E_DEPRECATED` at `session_set_save_handler()`. 6.4 is maintained until Nov 2027 and 8.6 ships Nov 2026, so it is worth fixing here and not only on the feature branch.

`session_create_id()` is exactly what PHP falls back to when a handler has no `create_sid()`, so returning it changes nothing today: same IDs, same length, same `session_regenerate_id()` behaviour. Verified on 8.5 and 8.6 with `use_strict_mode=1`, and by diffing a full session lifecycle with and without the patch.

### Why no `SessionIdInterface` and no return type here

`AbstractSessionHandler` is meant to be extended, so declaring `create_sid(): string` would fatal on any subclass that already declares the method with a different signature — and PHP accepts a bare `create_sid()` today, so such subclasses exist in the wild:

| existing subclass signature | with `create_sid(): string` on the parent |
| --- | --- |
| `create_sid()` | **fatal** |
| `#[\ReturnTypeWillChange] create_sid()` | **fatal** |
| `create_sid(): string\|false` | **fatal** |
| `create_sid(): string` | ok |

Declaring the method without a native return type is compatible with all four, and `ext/session` accepts a plain method for both of its checks — it looks the method up in the class' function table and only falls back to `instanceof SessionIdInterface`. So this silences both diagnostics without any BC risk. #65369 does the typed, `SessionIdInterface`-implementing version on 8.2.

### Test doubles

`createMock(\SessionHandlerInterface::class)` produces a class implementing only that interface, so every generated double warned too. The three test classes now mock a `BareSessionHandler` fixture instead, which adds nothing to the interface beyond the two methods PHP 9.0 will require. It deliberately implements neither `SessionIdInterface` nor `SessionUpdateTimestampHandlerInterface`, since handlers get wrapped differently depending on whether they do.

Worth noting for the RFC discussion: this class-declaration `E_WARNING` is not part of it, which only proposed the deprecation in `session_set_save_handler()`. The hook is also sensitive to the order interfaces are listed in, so a class that properly implements `SessionIdInterface` can still be reported:

```php
abstract class A implements SessionHandlerInterface, SessionIdInterface {}  // warns
abstract class B implements SessionIdInterface, SessionHandlerInterface {}  // silent
```

Both look worth revisiting upstream, since every project mocking `SessionHandlerInterface` hits the first one.