### PR TITLE
Move misplaced CHANGELOG entries to the 8.2 section

### DIFF
--- a/src/Symfony/Bridge/Doctrine/CHANGELOG.md
+++ b/src/Symfony/Bridge/Doctrine/CHANGELOG.md
@@ -11,14 +11,14 @@ CHANGELOG
  * Deprecate `DoctrineOpenTransactionLoggerMiddleware` in favor of the new `DoctrineDbalOpenTransactionLoggerMiddleware`
  * Deprecate `DoctrinePingConnectionMiddleware` in favor of the new `DoctrineDbalPingConnectionMiddleware`
  * Add `DoctrineDbalTransactionMiddleware` to wrap all handlers in a single DBAL transaction without requiring the ORM
+ * Map the `DatePoint`, `DayPoint` and `TimePoint` property types to their Doctrine types, so schema tools detect them without an explicit `type`
+ * Load a list of entities into `array`-typed controller and command arguments with `#[MapEntity]`, using `findBy()`
 
 8.1
 ---
 
  * Add option `uid_format` to `EntityType`
  * Deprecate setting an `$aliasMap` in `RegisterMappingsPass`; namespace aliases are no longer supported in Doctrine
- * Map the `DatePoint`, `DayPoint` and `TimePoint` property types to their Doctrine types, so schema tools detect them without an explicit `type`
- * Load a list of entities into `array`-typed controller and command arguments with `#[MapEntity]`, using `findBy()`
 
 8.0
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -21,12 +21,14 @@ CHANGELOG
  * Resolve `debug:config` paths whose keys contain dots, e.g. `debug:config framework options.option.main`
  * Add a `priority` option to `framework.messenger.transports` to order the receivers `messenger:consume --all` consumes
  * Deprecate the `framework.fragments.hinclude_default_template` config option and the `fragment.renderer.hinclude.global_template` parameter; use ESI or inline rendering, or Symfony UX Turbo, instead
+ * Add the `session:clear` command to remove all sessions from the configured handler
+ * Generate JSON schema for YAML configuration of bundles
+ * Add support for rate limited transports
 
 8.1
 ---
 
  * Add `framework.validation.property_metadata_existence_check` config option
- * Add the `session:clear` command to remove all sessions from the configured handler
  * Deprecate `json_streamer.value_transformer.date_time_to_string` and `json_streamer.value_transformer.string_to_date_time` services, date times are handled as value objects
  * Deprecate `json_streamer.value_transformer` tag, use `json_streamer.property_value_transformer` instead
  * Add `marshaller` option to cache pool configuration to allow per-pool marshaller services
@@ -34,7 +36,6 @@ CHANGELOG
  * Add support for configuring JsonStreamer's `default_options`
  * Add project-scoped `flock` and `semaphore` lock store services
  * Add `createFormFlowBuilder` method to `AbstractController` and `ControllerHelper`
- * Generate JSON schema for YAML configuration of bundles
  * Deprecate setting the `framework.profiler.collect_serializer_data` config option
  * Deprecate the `framework.http_cache.terminate_on_cache_hit` config option
  * Add support for `framework.secrets.decryption_env_var` to contain dots
@@ -95,7 +96,6 @@ CHANGELOG
  * Deprecate `ConfigBuilderCacheWarmer`, return PHP arrays from your config instead
  * Add support for selecting the appropriate error renderer based on the `APP_RUNTIME_MODE` env var
  * Add `KernelInterface::getShareDir()`, `APP_SHARE_DIR` and `%kernel.share_dir%` to store application data that are shared between all front-end servers
- * Add support for rate limited transports
 
 7.3
 ---

--- a/src/Symfony/Component/Cache/CHANGELOG.md
+++ b/src/Symfony/Component/Cache/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add `AbstractAdapter::createAdapter()` to create the adapter matching a connection
  * Implement `PruneableInterface` on `RedisTagAwareAdapter` to garbage-collect its tag Sets
+ * Add `PdoTagAwareAdapter`
 
 8.0
 ---
@@ -16,7 +17,6 @@ CHANGELOG
 ---
 
  * Bump ext-redis to 6.1 and ext-relay to 0.12 minimum
- * Add `PdoTagAwareAdapter`
 
 7.3
 ---

--- a/src/Symfony/Component/Config/CHANGELOG.md
+++ b/src/Symfony/Component/Config/CHANGELOG.md
@@ -1,7 +1,7 @@
 CHANGELOG
 =========
 
-8.1
+8.2
 ---
 
  * Add `JsonSchemaDumper` to dump JSON Schema from configuration node definitions

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -7,13 +7,13 @@ CHANGELOG
  * Add `InputOption::HIDDEN` and `InputOption::DEPRECATED` modes
  * Allow a callable for the `description` and `help` options of `#[AsCommand]`, and for the `description` option of `#[Argument]` and `#[Option]`
  * Add `GitlabCiReporter` to emit reports in the GitLab Code Quality format
+ * Wrap the descriptions in `TextDescriptor` output to the terminal width; pass the `terminal_width` describe option to control it
 
 8.1
 ---
 
  * Add `ConsoleBundle` for console applications with DI, autodiscovery and autowiring
  * Pad styled `SymfonyStyle` blocks with the ECH ANSI sequence on decorated outputs so trailing cells are excluded from copy selections
- * Wrap the descriptions in `TextDescriptor` output to the terminal width; pass the `terminal_width` describe option to control it
  * Add optional `$container` parameter to `Application` for automatic service wiring from a PSR container
  * Add `SymfonyStyle::outlineBlock()` and convenience methods `outlineSuccess()`, `outlineError()`, `outlineWarning()`, `outlineNote()`, `outlineInfo()`, `outlineCaution()` for border-only message blocks with the type label embedded in the top border
  * Add `TraceableValueResolver` to help inspecting value resolvers performances

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -12,11 +12,11 @@ CHANGELOG
  * Reject a `Cookie` whose name uses the `__Secure-`/`__Host-` prefix when its attributes break the prefix contract
  * Deprecate the `Request::$trustedHosts` property, it is never populated anymore
  * Report the actual header value when the `ResponseHeaderSame` constraint fails
+ * Add `ClearableSessionHandlerInterface` for clearing all session data
 
 8.1
 ---
 
- * Add `ClearableSessionHandlerInterface` for clearing all session data
  * Add `BinaryFileResponse::shouldDeleteFileAfterSend()`
  * Deprecate setting public properties of `Request` and `Response` objects directly; use setters or constructor arguments instead
  * Add `SessionHasFlashMessage` test constraint

--- a/src/Symfony/Component/PropertyInfo/CHANGELOG.md
+++ b/src/Symfony/Component/PropertyInfo/CHANGELOG.md
@@ -7,12 +7,12 @@ CHANGELOG
  * Allow defining accessors and mutators via a `#[WithAccessors]` attribute
  * Gather data from property hooks in ReflectionExtractor
  * Add `PropertyNameExtractorInterface` and `getPropertyName()` to enable property name extraction from an accessor or mutator
+ * Support `enable_default_groups` context option in `SerializerExtractor`
 
 8.1
 ---
 
  * Add support for property hook settable types in `ReflectionExtractor`
- * Support `enable_default_groups` context option in `SerializerExtractor`
 
 7.3
 ---

--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -13,6 +13,8 @@ CHANGELOG
  * Add the `XmlEncoder::BOOLEAN_REPR` context option to choose the strings representing booleans when encoding, e.g. `['true', 'false']`
  * Add support for denormalizing arrays of union types, e.g. `array<Foo|Bar>`
  * Add support for configuring serialized names and paths per group, with repeatable `#[SerializedName]` and `#[SerializedPath]` attributes, a `serialized` key in YAML and a `<serialized>` element in XML
+ * Enable using `#[WithAccessors]` from the PropertyInfo component with the serializer
+ * Add `AbstractNormalizer::ENABLE_DEFAULT_GROUPS` context option to opt into implicit `Default` and class-short-name groups for attributes without explicit `#[Groups]`, mirroring Validator group conventions
 
 8.1
 ---
@@ -22,8 +24,6 @@ CHANGELOG
  * Add `AbstractObjectNormalizer::ENABLE_TYPE_CONVERSION` for scalar type transformation
  * Add `COLLECT_EXTRA_ATTRIBUTES_ERRORS` option to `Serializer` to collect extra-attributes errors during denormalization
  * Deprecate `PartialDenormalizationException::getErrors()`, use `getNotNormalizableValueErrors()` instead
- * Enable using `#[WithAccessors]` from the PropertyInfo component with the serializer
- * Add `AbstractNormalizer::ENABLE_DEFAULT_GROUPS` context option to opt into implicit `Default` and class-short-name groups for attributes without explicit `#[Groups]`, mirroring Validator group conventions
 
 8.0
 ---

--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
  * Add the `message` option to the `Callback` constraint; the callback must then return a boolean, and a violation is raised when it returns `false`
  * Allow passing `int`, `float`, `\Stringable` and `\DateTimeInterface` values to `ConstraintViolationBuilderInterface::setParameter()`
  * Stop narrowing the `File` constraint's `mimeTypes` option with mime types auto-derived from the matched extension when `extensions` is configured
+ * Add support for reading objects properties with `Unique` constraint `fields` option
 
 8.1
 ---
@@ -450,7 +451,6 @@ CHANGELOG
  * Add support for multiple fields containing nested constraints in `Composite` constraints
  * Add the `stopOnFirstError` option to the `Unique` constraint to validate all elements
  * Add support for closures in the `When` constraint
- * Add support for reading objects properties with `Unique` constraint `fields` option
 
 7.2
 ---


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Several CHANGELOG entries document features introduced on the 8.2 branch but were filed under an older version heading (`8.1`, `7.4` or `7.3`). This happens when a PR is opened against a maintenance branch and later retargeted to the feature branch without moving its changelog entry.

This moves each of these entries to the `8.2` section of its component. Every moved entry was checked against the commit that introduced it: each one comes from a commit that exists only on 8.2 and is absent from 8.1.

Moved entries and the PRs that introduced them:

- #63772
- #63949
- #63690
- #62125
- #59985
- #58296
- #63784
- #63998
- #63864
- #48951
