### PR TITLE
[DoctrineBridge] Fix explicit MapEntity mapping being overwritten by a route mapping

### DIFF
--- a/src/Symfony/Bridge/Doctrine/ArgumentResolver/EntityValueResolver.php
+++ b/src/Symfony/Bridge/Doctrine/ArgumentResolver/EntityValueResolver.php
@@ -112,11 +112,13 @@ final class EntityValueResolver implements ValueResolverInterface
                 return false;
             }
 
-            foreach ($request->attributes->get('_route_mapping') ?? [] as $parameter => $attribute) {
-                if ($name === $attribute) {
-                    $options->mapping = [$name => $parameter];
+            if (!$options->mapping) {
+                foreach ($request->attributes->get('_route_mapping') ?? [] as $parameter => $attribute) {
+                    if ($name === $attribute) {
+                        $options->mapping = [$name => $parameter];
 
-                    return false;
+                        return false;
+                    }
                 }
             }
 

--- a/src/Symfony/Bridge/Doctrine/Tests/ArgumentResolver/EntityValueResolverTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/ArgumentResolver/EntityValueResolverTest.php
@@ -291,6 +291,39 @@ class EntityValueResolverTest extends TestCase
         $this->assertSame([$object], $resolver->resolve($request, $argument));
     }
 
+    public function testResolveWithExplicitMappingTakesPrecedenceOverRouteMapping()
+    {
+        $manager = $this->createMock(ObjectManager::class);
+        $registry = $this->createRegistry($manager);
+        $resolver = new EntityValueResolver($registry);
+
+        $request = new Request();
+        $request->attributes->set('post', 'abc');
+        $request->attributes->set('_route_mapping', ['ref' => 'post']);
+
+        $argument = $this->createArgument(
+            'stdClass',
+            new MapEntity(mapping: ['post' => 'reference']),
+            'post'
+        );
+
+        $manager->expects($this->never())
+            ->method('getClassMetadata');
+
+        $repository = $this->createMock(ObjectRepository::class);
+        $repository->expects($this->once())
+            ->method('findOneBy')
+            ->with(['reference' => 'abc'])
+            ->willReturn($object = new \stdClass());
+
+        $manager->expects($this->once())
+            ->method('getRepository')
+            ->with('stdClass')
+            ->willReturn($repository);
+
+        $this->assertSame([$object], $resolver->resolve($request, $argument));
+    }
+
     public function testResolveWithRouteMapping()
     {
         $manager = $this->createMock(ObjectManager::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Since 8.1, a mapped route parameter overwrites an explicit `mapping` passed to `#[MapEntity]`.

```php
#[Route('/post/{ref:post}')]
public function show(
    #[MapEntity(class: Post::class, mapping: ['post' => 'reference'])] Post $post,
) {
}
```

| branch | query |
| --- | --- |
| 7.4 and 8.0 | `findOneBy(['reference' => 'abc'])` |
| 8.1 and 8.2 | `findOneBy(['ref' => 'abc'])` |

#62917 moved the `if ($options->mapping || $options->exclude) { return false; }` check out of `getIdentifier()` and into `findById()`, where it no longer stops the `_route_mapping` loop from running. The loop then reassigns `$options->mapping` and the explicit mapping is lost.

This restores the 7.4 behaviour by skipping the loop when a mapping is already set.

Spotted while reviewing #65364, which carries the same one-line guard on 8.2 as part of an unrelated fix for array-typed arguments. That guard should come from here through the merge-up instead.
