### PR TITLE
[Mime] Add `AbstractPart::setContentTypeParameter()`

### DIFF
--- a/src/Symfony/Component/Mime/CHANGELOG.md
+++ b/src/Symfony/Component/Mime/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Support `binary` as a `Content-Transfer-Encoding`
  * Add PGP/MIME signing and encryption support with the `PgpSigner` and `PgpEncrypter` classes
+ * Add `AbstractPart::setContentTypeParameter()`
 
 8.0
 ---

--- a/src/Symfony/Component/Mime/Part/AbstractPart.php
+++ b/src/Symfony/Component/Mime/Part/AbstractPart.php
@@ -30,6 +30,25 @@ abstract class AbstractPart
         return $this->headers;
     }
 
+    /**
+     * Sets a parameter of the "Content-Type" header, e.g. "method" for "text/calendar".
+     *
+     * @return $this
+     */
+    public function setContentTypeParameter(string $name, string $value): static
+    {
+        if (!$this->headers->has('Content-Type')) {
+            $this->headers->addParameterizedHeader('Content-Type', $this->getMediaType().'/'.$this->getMediaSubtype());
+        }
+
+        $this->headers->setHeaderParameter('Content-Type', $name, $value);
+
+        return $this;
+    }
+
+    /**
+     * @return Headers A copy of the headers; changes made to it are not persisted on the part
+     */
     public function getPreparedHeaders(): Headers
     {
         $headers = clone $this->headers;

--- a/src/Symfony/Component/Mime/Tests/Part/TextPartTest.php
+++ b/src/Symfony/Component/Mime/Tests/Part/TextPartTest.php
@@ -240,4 +240,28 @@ class TextPartTest extends TestCase
         $this->assertEquals($expected->toString(), $p->toString());
         $this->assertEquals($expected->toString(), $n->toString());
     }
+
+    public function testSetContentTypeParameter()
+    {
+        $p = (new TextPart('BEGIN:VCALENDAR', 'utf-8', 'calendar', '8bit'))
+            ->setContentTypeParameter('method', 'REQUEST')
+            ->setContentTypeParameter('component', 'VEVENT');
+
+        $this->assertSame('calendar', $p->getMediaSubtype());
+        $this->assertSame(
+            'Content-Type: text/calendar; method=REQUEST; component=VEVENT; charset=utf-8',
+            $p->getPreparedHeaders()->get('Content-Type')->toString()
+        );
+    }
+
+    public function testSetContentTypeParameterOverwritesAndSurvivesSerialization()
+    {
+        $p = (new TextPart('content'))->setContentTypeParameter('method', 'PUBLISH');
+        $p->setContentTypeParameter('method', 'REQUEST');
+
+        $n = unserialize(serialize($p));
+
+        $this->assertStringContainsString('method=REQUEST', $n->getPreparedHeaders()->get('Content-Type')->toString());
+        $this->assertStringNotContainsString('PUBLISH', $n->getPreparedHeaders()->get('Content-Type')->toString());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Setting a parameter on a part's `Content-Type` header is possible today, but the three obvious ways to do it all fail, and the one that works is the least discoverable.

```php
$part = new TextPart($ics, 'utf-8', 'calendar', '8bit');

$part->getHeaders()->setHeaderParameter('Content-Type', 'method', 'REQUEST');
// LogicException: Unable to set parameter "method" on header "Content-Type" as the header is not defined.

$part->getPreparedHeaders()->setHeaderParameter('Content-Type', 'method', 'REQUEST');
// no error, no effect: getPreparedHeaders() returns a copy

new TextPart($ics, 'utf-8', 'calendar; method=REQUEST', '8bit');
// right output, but getMediaSubtype() now returns "calendar; method=REQUEST"

$part->getHeaders()->addParameterizedHeader('Content-Type', 'text/calendar', ['method' => 'REQUEST']);
// works, but you restate the media type the part already knows
```

This adds a setter that does the last one for you:

```php
$part = (new TextPart($ics, 'utf-8', 'calendar', '8bit'))
    ->setContentTypeParameter('method', 'REQUEST')
    ->setContentTypeParameter('component', 'VEVENT');

// Content-Type: text/calendar; method=REQUEST; component=VEVENT; charset=utf-8
// getMediaSubtype() === 'calendar'
```

It writes to the part's own headers rather than keeping separate state, so parameters survive serialization for free and no `__serialize()` implementation changes. It sits on `AbstractPart`, so `DataPart` and the multipart parts get it too.

The second case above is the only one of the four that fails silently, so this also documents that `getPreparedHeaders()` returns a copy. Persisting writes made to that copy, or freezing it, would both break what the method is for, which is computing the final headers on demand. The first case still throws, and that is fine: the exception comes from `Headers`, which has no way to know it belongs to a part, so it cannot point at the new method without being wrong for every other caller. The third case still works and is left alone, since rejecting parameters in the subtype would break code that relies on the output today.

The case that motivated this is a calendar invitation, where the `method` parameter has to match the `METHOD:` property in the body for a client to show an Accept or Decline UI:

```php
$invite = (new TextPart($ics, 'utf-8', 'calendar', '8bit'))
    ->setContentTypeParameter('method', 'REQUEST');

$email->setBody(new AlternativePart($text, $html, $invite));
```

Points the documentation should carry:

 * `setContentTypeParameter()`, and that the parameter is applied on top of the media type the part already knows
 * that `getPreparedHeaders()` returns a copy, so changes to it do not reach the part
 * the calendar example above, including that RFC 6047 wants the calendar part last in the alternative
