### PR TITLE
[DomCrawler] Fix matches(), closest() and children() for selectors with a combinator or a positional pseudo-class

### DIFF
--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -409,10 +409,15 @@ class Crawler implements \Countable, \IteratorAggregate
             return false;
         }
 
-        $converter = $this->createCssSelectorConverter();
-        $xpath = $converter->toXPath($selector, 'self::');
+        $node = $this->getNode(0);
 
-        return 0 !== $this->filterRelativeXPath($xpath)->count();
+        foreach ($this->matchingNodes($selector, $this->rootNode($node)) as $candidate) {
+            if ($candidate->isSameNode($node)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**
@@ -429,14 +434,16 @@ class Crawler implements \Countable, \IteratorAggregate
         }
 
         $domNode = $this->getNode(0);
+        $matching = $this->matchingNodes($selector, $this->rootNode($domNode));
 
         while (null !== $domNode && \XML_ELEMENT_NODE === $domNode->nodeType) {
-            $node = $this->createSubCrawler($domNode);
-            if ($node->matches($selector)) {
-                return $node;
+            foreach ($matching as $candidate) {
+                if ($candidate->isSameNode($domNode)) {
+                    return $this->createSubCrawler($domNode);
+                }
             }
 
-            $domNode = $node->getNode(0)->parentNode;
+            $domNode = $domNode->parentNode;
         }
 
         return null;
@@ -506,10 +513,24 @@ class Crawler implements \Countable, \IteratorAggregate
         }
 
         if (null !== $selector) {
-            $converter = $this->createCssSelectorConverter();
-            $xpath = $converter->toXPath($selector, 'child::');
+            $parents = [];
+            $roots = [];
+            foreach ($this->nodes as $node) {
+                $parents[spl_object_id($node)] = true;
+                $roots[spl_object_id($root = $this->rootNode($node))] = $root;
+            }
 
-            return $this->filterRelativeXPath($xpath);
+            $crawler = $this->createSubCrawler(null);
+
+            foreach ($roots as $root) {
+                foreach ($this->matchingNodes($selector, $root) as $candidate) {
+                    if (null !== $candidate->parentNode && isset($parents[spl_object_id($candidate->parentNode)])) {
+                        $crawler->add($candidate);
+                    }
+                }
+            }
+
+            return $crawler;
         }
 
         $node = $this->getNode(0)->firstChild;
@@ -1222,6 +1243,40 @@ class Crawler implements \Countable, \IteratorAggregate
         }
 
         return new CssSelectorConverter($this->isHtml);
+    }
+
+    /**
+     * Returns every node matching the selector in the tree the given node belongs to.
+     *
+     * The whole tree is searched because a selector can constrain the ancestors or
+     * the siblings of the node it selects. The root is the topmost ancestor rather
+     * than the document, so that a node detached from the document still matches.
+     *
+     * @return \DOMNode[]
+     */
+    private function matchingNodes(string $selector, \DOMNode $root): array
+    {
+        if (null === $this->document) {
+            return [];
+        }
+
+        $converter = $this->createCssSelectorConverter();
+        $xpath = $converter->toXPath($selector);
+        $domxpath = $this->createDOMXPath($this->document, $this->findNamespacePrefixes($xpath));
+
+        return iterator_to_array($domxpath->query($xpath, $root), false);
+    }
+
+    /**
+     * Returns the topmost ancestor of the node, which is the document unless the node is detached from it.
+     */
+    private function rootNode(\DOMNode $node): \DOMNode
+    {
+        while (null !== $parent = $node->parentNode) {
+            $node = $parent;
+        }
+
+        return $node;
     }
 
     /**

--- a/src/Symfony/Component/DomCrawler/Tests/AbstractCrawlerTestCase.php
+++ b/src/Symfony/Component/DomCrawler/Tests/AbstractCrawlerTestCase.php
@@ -985,6 +985,13 @@ abstract class AbstractCrawlerTestCase extends TestCase
         yield ['#bar', true, '.bar'];
         yield ['#bar', true, '.other'];
         yield ['#bar', false, '.foo'];
+
+        yield ['#foo', true, 'body > div'];
+        yield ['#foo', false, 'div div'];
+
+        yield ['#bar', true, 'div div'];
+        yield ['#bar', true, '#foo div'];
+        yield ['#bar', false, '#bar div'];
     }
 
     /** @dataProvider provideMatchTests */
@@ -1005,6 +1012,69 @@ abstract class AbstractCrawlerTestCase extends TestCase
         $crawler = $this->createCrawler($this->getDoctype().$html);
         $node = $crawler->filter($mainNodeSelector);
         $this->assertSame($expected, $node->matches($selector));
+    }
+
+    public function testMatchWithPositionalSelector()
+    {
+        $crawler = $this->createCrawler($this->getDoctype().'<ul><li class="a">One</li><li class="b">Two</li><li class="c">Three</li></ul>');
+        $items = $crawler->filter('li');
+
+        $this->assertTrue($items->eq(0)->matches('li:first-child'));
+        $this->assertTrue($items->eq(1)->matches('li:nth-child(2)'));
+        $this->assertTrue($items->eq(1)->matches('li:nth-of-type(2)'));
+        $this->assertTrue($items->eq(2)->matches('li:last-child'));
+
+        $this->assertFalse($items->eq(0)->matches('li:nth-child(2)'));
+        $this->assertFalse($items->eq(2)->matches('li:first-child'));
+    }
+
+    public function testMatchAndChildrenWithNodeDetachedFromTheDocument()
+    {
+        $crawler = $this->createCrawler($this->getDoctype().'<html lang="en"><body><div id="foo"><span class="a"></span></div></body></html>');
+        $foo = $crawler->filter('#foo');
+
+        $fooNode = $foo->getNode(0);
+        $fooNode->parentNode->replaceChild($fooNode->ownerDocument->createElement('ol'), $fooNode);
+
+        $this->assertTrue($foo->matches('#foo'));
+        $this->assertSame('a', $foo->children('span')->attr('class'));
+    }
+
+    public function testChildrenWithNodesFromSeveralTrees()
+    {
+        $crawler = $this->createCrawler($this->getDoctype().'<html lang="en"><body><ul id="kept"><li class="a"></li></ul><ul id="cut"><li class="b"></li></ul></body></html>');
+
+        $kept = $crawler->filter('#kept')->getNode(0);
+        $cut = $crawler->filter('#cut')->getNode(0);
+        $cut->parentNode->removeChild($cut);
+
+        $both = $this->createCrawler();
+        $both->add($kept);
+        $both->add($cut);
+
+        $this->assertSame(['a', 'b'], $both->children('li')->each(static fn ($node) => $node->attr('class')));
+    }
+
+    public function testClosestWithPositionalSelector()
+    {
+        $crawler = $this->createCrawler($this->getDoctype().'<ul><li class="a">One</li><li class="b">Two</li><li class="c">Three</li></ul>');
+        $second = $crawler->filter('li')->eq(1);
+
+        $closest = $second->closest('li:nth-child(2)');
+        $this->assertInstanceOf(Crawler::class, $closest);
+        $this->assertSame('b', $closest->attr('class'));
+
+        $this->assertNull($second->closest('li:nth-child(3)'));
+    }
+
+    public function testChildrenWithPositionalSelector()
+    {
+        $crawler = $this->createCrawler($this->getDoctype().'<ul><li class="a">One</li><li class="b">Two</li><li class="c">Three</li></ul>');
+        $list = $crawler->filter('ul');
+
+        $this->assertSame('b', $list->children('li:nth-child(2)')->attr('class'));
+        $this->assertSame('a', $list->children('li:first-child')->attr('class'));
+        $this->assertSame(0, $list->children('li:nth-child(4)')->count());
     }
 
     public function testClosest()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`Crawler::matches()`, `closest()` and `children($selector)` give wrong answers for any selector that is not a single step.

```php
$crawler = new Crawler('<ul><li class="a">One</li><li class="b">Two</li></ul>');
$second = $crawler->filter('li')->eq(1);

$second->matches('li:nth-child(2)');            // false, expected true
$second->matches('ul li');                      // false, expected true
$second->closest('li:nth-child(2)')->nodeName(); // "ul", expected "li"
$crawler->filter('ul')->children('li:nth-child(2)')->count(); // 0, expected 1
```

It goes both ways: on `<body><div id="foo"><div><div id="bar"></div></div></div></body>`, `#foo` currently *matches* `div div` although it has no `div` ancestor.

The three methods asked `CssSelectorConverter::toXPath()` for a translation with a `self::` or `child::` prefix, but the prefix replaces the axis of the first location step only. A selector with a combinator or a positional pseudo-class translates to a path of several steps, and the subject is the last one:

```
li:nth-child(2)  ->  descendant-or-self::*/*[(name() = 'li') and (position() = 2)]
   with self::   ->  self::*/*[...]     asks about the children of the node
   with child::  ->  child::*/*[...]    asks about its grandchildren
ul li            ->  descendant-or-self::ul/descendant-or-self::*/li
   with self::   ->  self::ul/...       asks whether the node is a ul holding an li
```

So the answer was only right when the selector was a single step. `closest()` inherits this from `matches()`, which is why it returns an element that does not match the selector at all.

The selector is now evaluated once with its normal axis, and the result is intersected with the node, its ancestors or its children. The tree is searched from the topmost ancestor rather than from the document, so a node detached from the document still matches, as it did before.

Behaviour for single step selectors is unchanged. No public API changes.

### Checks

Revert-verify: with the fix reverted, 6 of the 8 added tests fail with the expected diff. The two others pass on 6.4 and guard behaviour this change could have broken: matching a node detached from the document, and `children()` on a crawler holding nodes from two different trees.

Suites on 6.4: DomCrawler 575, BrowserKit 242, CssSelector 524, all green. php-cs-fixer clean. No changelog entry, since this is a bugfix.

The evaluation now walks the tree instead of the node, so its cost follows the size of the document rather than being constant. Measured on one node, per call:

| document | `matches()` | `children()` | `closest()` |
| --- | --- | --- | --- |
| 153 elements | 0.023 -> 0.036 ms | 0.023 -> 0.064 ms | 0.050 -> 0.024 ms |
| 3003 elements | 0.022 -> 0.262 ms | 0.023 -> 0.834 ms | 0.062 -> 0.072 ms |

`closest()` is faster because it now runs one query instead of one per ancestor level. `children()` over a crawler holding 200 nodes goes from 1.19 ms to 0.93 ms, because the query is shared across the nodes of a tree.

### Merge-up

7.4 and later moved these tests from `Tests/AbstractCrawlerTestCase.php` to `Tests/CrawlerTest.php` and use the `#[DataProvider]` attribute, so the test hunk needs to be applied to that file. `provideMatchTests()` and the three methods are otherwise identical, and `Crawler.php` merges as is.
