### PR TITLE
[Scheduler] Deprecate Schedule::with()

### DIFF
--- a/UPGRADE-8.2.md
+++ b/UPGRADE-8.2.md
@@ -134,6 +134,30 @@ Notifier
 
  * Deprecate `NovuSubscriberRecipient::getOverrides()` and its `$overrides` constructor parameter, pass overrides to `NovuOptions` instead
 
+Scheduler
+---------
+
+ * Deprecate `Schedule::with()`. It returns a schedule that keeps only the event dispatcher, so a lock or a
+   state set on the original schedule is silently dropped, and the resulting schedule then runs unlocked.
+
+   To derive a schedule from another one, clone it. The clone shares the dispatcher, the lock and the state,
+   and its list of messages is independent, so adding to one does not affect the other:
+
+   ```php
+   $new = clone $schedule;
+   $new->add($message);
+   ```
+
+   To build an unrelated schedule, which is what `with()` actually did, construct one:
+
+   ```php
+   // before
+   $new = $schedule->with($message);
+
+   // after
+   $new = (new Schedule($dispatcher))->add($message);
+   ```
+
 Security
 --------
 

--- a/src/Symfony/Component/Scheduler/CHANGELOG.md
+++ b/src/Symfony/Component/Scheduler/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add a "Next Run In" column to `debug:scheduler` showing the time until the next run
  * Add `env` option to `#[AsCronTask]` and `#[AsPeriodicTask]` to restrict a task to one or more environments
+ * Deprecate `Schedule::with()`, use `add()` on a new `Schedule` instead
 
 8.1
 ---

--- a/src/Symfony/Component/Scheduler/Schedule.php
+++ b/src/Symfony/Component/Scheduler/Schedule.php
@@ -33,8 +33,13 @@ final class Schedule implements ScheduleProviderInterface
     ) {
     }
 
+    /**
+     * @deprecated since Symfony 8.2, clone the schedule or use "add()" on a new Schedule instead
+     */
     public function with(RecurringMessage $message, RecurringMessage ...$messages): static
     {
+        trigger_deprecation('symfony/scheduler', '8.2', 'The "%s()" method is deprecated and will be removed in 9.0, clone the schedule or use "add()" on a new "%s" instead.', __METHOD__, self::class);
+
         return static::doAdd(new self($this->dispatcher), $message, ...$messages);
     }
 

--- a/src/Symfony/Component/Scheduler/Tests/Generator/MessageGeneratorTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/Generator/MessageGeneratorTest.php
@@ -110,7 +110,7 @@ class MessageGeneratorTest extends TestCase
 
             public function __construct(array $schedule)
             {
-                $this->schedule = (new Schedule())->with(...$schedule);
+                $this->schedule = (new Schedule())->add(...$schedule);
                 $this->schedule->stateful(new ArrayAdapter());
             }
 

--- a/src/Symfony/Component/Scheduler/Tests/ScheduleTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/ScheduleTest.php
@@ -11,10 +11,14 @@
 
 namespace Symfony\Component\Scheduler\Tests;
 
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Lock\LockInterface;
 use Symfony\Component\Scheduler\Exception\LogicException;
 use Symfony\Component\Scheduler\RecurringMessage;
 use Symfony\Component\Scheduler\Schedule;
+use Symfony\Contracts\Cache\CacheInterface;
 
 class ScheduleTest extends TestCase
 {
@@ -26,5 +30,44 @@ class ScheduleTest extends TestCase
         $this->expectException(LogicException::class);
 
         $schedule->add(RecurringMessage::cron('* * * * *', new \stdClass()));
+    }
+
+    public function testCloneKeepsTheLockAndTheStateAndDetachesTheMessages()
+    {
+        $schedule = (new Schedule())
+            ->lock($lock = $this->createStub(LockInterface::class))
+            ->stateful($state = $this->createStub(CacheInterface::class));
+        $schedule->add(RecurringMessage::cron('* * * * *', new \stdClass()));
+
+        $new = clone $schedule;
+        $new->add(RecurringMessage::cron('*/5 * * * *', new \stdClass()));
+
+        $this->assertSame($lock, $new->getLock());
+        $this->assertSame($state, $new->getState());
+        $this->assertCount(1, $schedule->getRecurringMessages());
+        $this->assertCount(2, $new->getRecurringMessages());
+    }
+
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
+    public function testWithIsDeprecated()
+    {
+        $this->expectUserDeprecationMessage('Since symfony/scheduler 8.2: The "Symfony\Component\Scheduler\Schedule::with()" method is deprecated and will be removed in 9.0, clone the schedule or use "add()" on a new "Symfony\Component\Scheduler\Schedule" instead.');
+
+        (new Schedule())->with(RecurringMessage::cron('* * * * *', new \stdClass()));
+    }
+
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
+    public function testWithDoesNotCarryTheLockAndTheState()
+    {
+        $schedule = (new Schedule())
+            ->lock($this->createStub(LockInterface::class))
+            ->stateful($this->createStub(CacheInterface::class));
+
+        $new = $schedule->with(RecurringMessage::cron('* * * * *', new \stdClass()));
+
+        $this->assertNull($new->getLock());
+        $this->assertNull($new->getState());
     }
 }

--- a/src/Symfony/Component/Scheduler/composer.json
+++ b/src/Symfony/Component/Scheduler/composer.json
@@ -21,7 +21,8 @@
     ],
     "require": {
         "php": ">=8.4.1",
-        "symfony/clock": "^7.4|^8.0"
+        "symfony/clock": "^7.4|^8.0",
+        "symfony/deprecation-contracts": "^2.5|^3"
     },
     "require-dev": {
         "dragonmantank/cron-expression": "^3.1",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Issues        | -
| License       | MIT

`Schedule::with()` is named like a wither but is a factory:

```php
public function with(...): static { return static::doAdd(new self($this->dispatcher), ...); }
public function add(...): static  { $this->setRestart(true); return static::doAdd($this, ...); }
```

The only thing it carries over is the event dispatcher. Everything else is dropped, including the lock and the state:

```php
$new = $schedule->lock($lock)->stateful($cache)->with($message);
$new->getLock();  // null
$new->getState(); // null
```

Losing the lock is not just surprising, it means the resulting schedule runs without locking, so two workers can process it concurrently. That was reported in #64324.

Copying more state onto the new instance is not the fix. `with()` also drops the parent's messages and always has, so it was never a copy operation, and `shouldRestart` is a transient signal consumed once by `MessageGenerator` rather than a setting to inherit.

Deprecating it instead, because the two things people actually want are both already available.

To derive a schedule from an existing one, which is what the report was after, clone it:

```php
$new = clone $schedule;
$new->add($message);
```

The clone shares the dispatcher, the lock and the state, and its message list is independent, so adding to one does not affect the other. No new API is needed for this, it works today.

To build an unrelated schedule, which is what `with()` actually did, construct one:

```php
// before
$new = $schedule->with($message);

// after
$new = (new Schedule($dispatcher))->add($message);
```

There is one call site in the whole repository, `MessageGeneratorTest`, and it already operates on a fresh `Schedule`, so it becomes `add()` with no change in behaviour.

One difference worth knowing when migrating to `add()`: it sets the restart flag and `with()` does not. On a schedule that has not been consumed yet, which is the migration case, that has no effect.
