### PR TITLE
[ObjectMapper] Allow #[Map] on abstract classes

### DIFF
--- a/src/Symfony/Component/ObjectMapper/DependencyInjection/ReverseMappingPass.php
+++ b/src/Symfony/Component/ObjectMapper/DependencyInjection/ReverseMappingPass.php
@@ -28,7 +28,7 @@ final class ReverseMappingPass implements CompilerPassInterface
         $reverseClassObjectMapperMetadataFactory = $container->getDefinition('object_mapper.metadata_factory.reverse_class');
 
         $classes = [];
-        foreach ($container->findTaggedResourceIds('object_mapper.map') as $tags) {
+        foreach ($container->findTaggedResourceIds('object_mapper.map', false) as $tags) {
             foreach ($tags as $tag) {
                 if (!isset($tag['source'], $tag['target'])) {
                     continue;

--- a/src/Symfony/Component/ObjectMapper/Tests/DependencyInjection/ReverseMappingPassTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/DependencyInjection/ReverseMappingPassTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\DependencyInjection;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\ObjectMapper\DependencyInjection\ReverseMappingPass;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\Quote;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\QuoteRequestView;
+
+final class ReverseMappingPassTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        if (!class_exists(ContainerBuilder::class)) {
+            self::markTestSkipped('The DependencyInjection component is not available.');
+        }
+    }
+
+    public function testProcessAcceptsAbstractResources()
+    {
+        $container = new ContainerBuilder();
+
+        $factory = new Definition();
+        $factory->setArguments([null, []]);
+        $container->setDefinition('object_mapper.metadata_factory.reverse_class', $factory);
+
+        $definition = new Definition(QuoteRequestView::class);
+        $definition->setAbstract(true);
+        $definition->addResourceTag('object_mapper.map', [
+            'source' => Quote::class,
+            'target' => QuoteRequestView::class,
+        ]);
+        $container->setDefinition(QuoteRequestView::class, $definition);
+
+        (new ReverseMappingPass())->process($container);
+
+        $this->assertSame([Quote::class => [QuoteRequestView::class]], $factory->getArgument(1));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Putting `#[Map]` on an abstract class breaks container compilation:

```
The resource "App\Dto\BaseView" tagged "object_mapper.map" must have a class and not be abstract.
```

`ContainerBuilder::findTaggedResourceIds()` throws on abstract definitions unless the caller opts out, and `ReverseMappingPass` never does. `MessengerPass` and `TagDecoratorPass` both pass `false` already, so this aligns the third caller with them.

An abstract class is a normal thing to annotate: the attribute describes the mapping its children inherit through the class map, and nothing needs to instantiate the parent.

Spotted while reviewing #64121, which carries the same one-line change as part of an unrelated feature.

Merge-up note: 8.2 has the same bug and already has `Tests/DependencyInjection/ReverseMappingPassTest.php`, so the file conflicts add/add. Keep the 8.2 version and append `testProcessAcceptsAbstractResources()` from here, then apply the same one-line change to the pass.
