### PR TITLE
[FrameworkBundle][HttpKernel] Let source value resolvers stage a value for the resolvers that follow them

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/UidTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/UidTest.php
@@ -28,8 +28,8 @@ class UidTest extends AbstractWebTestCase
         $client = $this->createClient(['test_case' => 'Uid', 'root_config' => 'config_disabled.yml']);
         $client->catchExceptions(false);
 
-        $this->expectException(\TypeError::class);
-        $this->expectExceptionMessage('Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Controller\UidController::anyFormat(): Argument #1 ($userId) must be of type Symfony\Component\Uid\UuidV1, string given');
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Controller "Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Controller\UidController::anyFormat" requires the "$userId" argument that could not be resolved. The "userId" request attribute holds a "string", which cannot be passed to a parameter typed "Symfony\Component\Uid\UuidV1".');
 
         $client->request('GET', '/1/uuid-v1/'.new UuidV1());
     }

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
  * Seed the query bag from the `_query` route default when a route is matched
  * Deserialize the query parameter named by `#[MapQueryString(key:)]` as JSON when it holds a string, e.g. `?filter={"page":1}`
  * Prefix the property path to each violation message reported by `RequestPayloadValueResolver`
+ * Add `SourceValueResolverInterface` to let a value resolver stage a raw value for the resolvers that follow it, so `#[MapQueryParameter]` accepts any type another resolver can build
  * Deprecate the `HIncludeFragmentRenderer` class, use the `EsiFragmentRenderer` or `InlineFragmentRenderer`, or Symfony UX Turbo, instead
 
 8.1

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver.php
@@ -56,27 +56,42 @@ final class ArgumentResolver implements ArgumentResolverInterface
             $disabledResolvers = [];
 
             if ($this->namedResolvers && $attributes = $metadata->getAttributesOfType(ValueResolver::class, $metadata::IS_INSTANCEOF)) {
-                $resolverName = null;
+                $resolverNames = [];
                 foreach ($attributes as $attribute) {
                     if ($attribute->disabled) {
                         $disabledResolvers[$attribute->resolver] = true;
-                    } elseif ($resolverName) {
-                        throw new \LogicException(\sprintf('You can only pin one resolver per argument, but argument "$%s" of "%s()" has more.', $metadata->getName(), $metadata->getControllerName()));
                     } else {
-                        $resolverName = $attribute->resolver;
+                        $resolverNames[] = $attribute->resolver;
                     }
                 }
 
-                if ($resolverName) {
-                    if (!$this->namedResolvers->has($resolverName)) {
-                        throw new ResolverNotFoundException($resolverName, $this->namedResolvers instanceof ServiceProviderInterface ? array_keys($this->namedResolvers->getProvidedServices()) : []);
+                if ($resolverNames) {
+                    // Several resolvers can be pinned when exactly one of them selects the source of
+                    // the value: that one runs first, the others convert what it stages.
+                    $sourceNames = array_values(array_filter($resolverNames, fn ($name) => $this->namedResolvers->has($name) && $this->namedResolvers->get($name) instanceof SourceValueResolverInterface));
+
+                    if (1 < \count($resolverNames) && 1 !== \count($sourceNames)) {
+                        throw new \LogicException(\sprintf('You can only pin one resolver per argument, but argument "$%s" of "%s()" has more.', $metadata->getName(), $metadata->getControllerName()));
                     }
 
-                    $argumentValueResolvers = [
-                        $this->namedResolvers->get($resolverName),
-                        new RequestAttributeValueResolver(),
-                        new DefaultValueResolver(),
-                    ];
+                    $pinnedResolvers = [];
+                    foreach ([...$sourceNames, ...array_diff($resolverNames, $sourceNames)] as $resolverName) {
+                        if (!$this->namedResolvers->has($resolverName)) {
+                            throw new ResolverNotFoundException($resolverName, $this->namedResolvers instanceof ServiceProviderInterface ? array_keys($this->namedResolvers->getProvidedServices()) : []);
+                        }
+
+                        $pinnedResolvers[] = $this->namedResolvers->get($resolverName);
+                    }
+
+                    // A source resolver only selects where the value comes from: keep the whole chain
+                    // behind it so that the resolver able to build the argument type still runs.
+                    $argumentValueResolvers = $sourceNames
+                        ? [...$pinnedResolvers, ...$this->argumentValueResolvers]
+                        : [
+                            $pinnedResolvers[0],
+                            new RequestAttributeValueResolver(),
+                            new DefaultValueResolver(),
+                        ];
                 }
             }
 

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/QueryParameterValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/QueryParameterValueResolver.php
@@ -13,20 +13,25 @@ namespace Symfony\Component\HttpKernel\Controller\ArgumentResolver;
 
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\MapQueryParameter;
+use Symfony\Component\HttpKernel\Controller\SourceValueResolverInterface;
 use Symfony\Component\HttpKernel\Controller\ValueResolverInterface;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
 use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpKernel\Exception\NearMissValueResolverException;
 use Symfony\Component\Uid\AbstractUid;
 
 /**
  * Resolve arguments of type: array, string, int, float, bool, \BackedEnum from query parameters.
+ *
+ * Arguments of any other class type are staged in the request attributes so that a type-aware
+ * resolver further down the chain can convert them.
  *
  * @author Ruud Kamphuis <ruud@ticketswap.com>
  * @author Nicolas Grekas <p@tchwork.com>
  * @author Mateusz Anders <anders_mateusz@outlook.com>
  * @author Ionut Enache <i.ovidiuenache@yahoo.com>
  */
-final class QueryParameterValueResolver implements ValueResolverInterface
+final class QueryParameterValueResolver implements ValueResolverInterface, SourceValueResolverInterface
 {
     public function resolve(Request $request, ArgumentMetadata $argument): array
     {
@@ -78,6 +83,24 @@ final class QueryParameterValueResolver implements ValueResolverInterface
         if (is_subclass_of($type, AbstractUid::class)) {
             $uidType = $type;
             $type = 'uid';
+        }
+
+        if (null === $uidType
+            && null !== $type
+            && !$argument->isVariadic()
+            && !\in_array($type, ['array', 'string', 'int', 'float', 'bool'], true)
+            && !is_subclass_of($type, \BackedEnum::class)
+            && (class_exists($type) || interface_exists($type))
+        ) {
+            if (\is_array($value)) {
+                throw HttpException::fromStatusCode($validationFailedCode, \sprintf('Invalid query parameter "%s".', $name));
+            }
+
+            // Stage the raw value under the argument name so that a resolver able to build this type,
+            // such as DateTimeValueResolver or EntityValueResolver, picks it up from the attributes.
+            $request->attributes->set($argument->getName(), $value);
+
+            throw new NearMissValueResolverException(\sprintf('#[MapQueryParameter] cannot build controller argument "$%s" of type "%s" by itself; no resolver converted the staged value.', $argument->getName(), $type));
         }
 
         $enumType = null;

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestAttributeValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestAttributeValueResolver.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\HttpKernel\Controller\ArgumentResolver;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Controller\ValueResolverInterface;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
+use Symfony\Component\HttpKernel\Exception\NearMissValueResolverException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
@@ -70,6 +71,12 @@ final class RequestAttributeValueResolver implements ValueResolverInterface
             } catch (\TypeError) {
                 throw new NotFoundHttpException(\sprintf('The value for the "%s" route parameter is invalid.', $name));
             }
+        } elseif (null !== $value && !\is_object($value) && (class_exists($type) || interface_exists($type))) {
+            // A non-object can never satisfy a class-typed parameter; abstain so that the failure
+            // is reported as an unresolvable argument instead of a TypeError in the controller.
+            // Mismatching objects are passed through: a listener on kernel.controller_arguments
+            // may still replace them, as ErrorListener does for FlattenException.
+            throw new NearMissValueResolverException(\sprintf('The "%s" request attribute holds a "%s", which cannot be passed to a parameter typed "%s".', $name, get_debug_type($value), $type));
         }
 
         return [$value];

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestHeaderValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestHeaderValueResolver.php
@@ -14,11 +14,13 @@ namespace Symfony\Component\HttpKernel\Controller\ArgumentResolver;
 use Symfony\Component\HttpFoundation\AcceptHeader;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\MapRequestHeader;
+use Symfony\Component\HttpKernel\Controller\SourceValueResolverInterface;
 use Symfony\Component\HttpKernel\Controller\ValueResolverInterface;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
 use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpKernel\Exception\NearMissValueResolverException;
 
-final class RequestHeaderValueResolver implements ValueResolverInterface
+final class RequestHeaderValueResolver implements ValueResolverInterface, SourceValueResolverInterface
 {
     public function resolve(Request $request, ArgumentMetadata $argument): array
     {
@@ -27,12 +29,28 @@ final class RequestHeaderValueResolver implements ValueResolverInterface
         }
 
         $type = $argument->getType();
+        $name = $attribute->name ?? strtolower(preg_replace('/[a-z]\K[A-Z]/', '-$0', $argument->getName()));
 
         if (!\in_array($type, ['string', 'array', AcceptHeader::class])) {
-            throw new \LogicException(\sprintf('Could not resolve the argument typed "%s". Valid types are "array", "string" or "%s".', $type, AcceptHeader::class));
+            if (null === $type || $argument->isVariadic() || !class_exists($type) && !interface_exists($type)) {
+                throw new \LogicException(\sprintf('Could not resolve the argument typed "%s". Valid types are "array", "string" or "%s".', $type, AcceptHeader::class));
+            }
+
+            if (!$request->headers->has($name)) {
+                if ($argument->isNullable() || $argument->hasDefaultValue()) {
+                    return [];
+                }
+
+                throw HttpException::fromStatusCode($attribute->validationFailedStatusCode, \sprintf('Missing header "%s".', $name));
+            }
+
+            // Stage the raw header under the argument name so that a resolver able to build this type,
+            // such as DateTimeValueResolver or UidValueResolver, picks it up from the attributes.
+            $request->attributes->set($argument->getName(), $request->headers->get($name));
+
+            throw new NearMissValueResolverException(\sprintf('#[MapRequestHeader] cannot build controller argument "$%s" of type "%s" by itself; no resolver converted the staged value.', $argument->getName(), $type));
         }
 
-        $name = $attribute->name ?? strtolower(preg_replace('/[a-z]\K[A-Z]/', '-$0', $argument->getName()));
         $value = null;
 
         if ($request->headers->has($name)) {

--- a/src/Symfony/Component/HttpKernel/Controller/SourceValueResolverInterface.php
+++ b/src/Symfony/Component/HttpKernel/Controller/SourceValueResolverInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Controller;
+
+/**
+ * Marks a value resolver that selects where a value comes from, leaving its type to another resolver.
+ *
+ * Such a resolver reads a raw value from the request (a query parameter, a header, the body) and, when it
+ * cannot build the argument type itself, stages that value in the request attributes and abstains. The
+ * resolvers registered after it then see the value exactly as if it had come from the route, so the
+ * existing type-aware resolvers apply without knowing which bag the value came from.
+ *
+ * Pinning such a resolver with a #[ValueResolver] attribute keeps the whole resolver chain behind it,
+ * instead of narrowing it to the request-attribute and default resolvers.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+interface SourceValueResolverInterface
+{
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/QueryParameterValueResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/QueryParameterValueResolverTest.php
@@ -21,6 +21,7 @@ use Symfony\Component\HttpKernel\Controller\ValueResolverInterface;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpKernel\Exception\NearMissValueResolverException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Tests\Fixtures\Suit;
 use Symfony\Component\Uid\Ulid;
@@ -47,11 +48,45 @@ class QueryParameterValueResolverTest extends TestCase
         $this->assertEquals($expected, $this->resolver->resolve($request, $metadata));
     }
 
-    #[DataProvider('invalidArgumentTypeProvider')]
-    public function testResolvingWithInvalidArgumentType(Request $request, ArgumentMetadata $metadata, string $exceptionMessage)
+    public function testStagingArgumentTypesItCannotBuild()
     {
+        $request = Request::create('/', 'GET', ['standardClass' => 'test']);
+        $metadata = new ArgumentMetadata('standardClass', \stdClass::class, false, false, false, false, [new MapQueryParameter()]);
+
+        try {
+            $this->resolver->resolve($request, $metadata);
+            $this->fail(NearMissValueResolverException::class.' was not thrown.');
+        } catch (NearMissValueResolverException $e) {
+            $this->assertSame('#[MapQueryParameter] cannot build controller argument "$standardClass" of type "stdClass" by itself; no resolver converted the staged value.', $e->getMessage());
+        }
+
+        // the raw value is left in the attributes for a type-aware resolver further down the chain
+        $this->assertSame('test', $request->attributes->get($metadata->getName()));
+    }
+
+    public function testStagingRejectsAnArrayValue()
+    {
+        $request = Request::create('/', 'GET', ['standardClass' => ['test']]);
+        $metadata = new ArgumentMetadata('standardClass', \stdClass::class, false, false, false, false, [new MapQueryParameter()]);
+
+        try {
+            $this->resolver->resolve($request, $metadata);
+            $this->fail(HttpException::class.' was not thrown.');
+        } catch (HttpException $e) {
+            $this->assertSame(404, $e->getStatusCode());
+            $this->assertSame('Invalid query parameter "standardClass".', $e->getMessage());
+        }
+
+        $this->assertFalse($request->attributes->has($metadata->getName()));
+    }
+
+    public function testResolvingVariadicOfUnsupportedType()
+    {
+        $request = Request::create('/', 'GET', ['standardClass' => 'test']);
+        $metadata = new ArgumentMetadata('standardClass', \stdClass::class, true, false, false, false, [new MapQueryParameter()]);
+
         $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage($exceptionMessage);
+        $this->expectExceptionMessage('#[MapQueryParameter] cannot be used on controller argument "...$standardClass" of type "stdClass"; one of array, string, int, float, bool, uid or \BackedEnum should be used.');
 
         $this->resolver->resolve($request, $metadata);
     }
@@ -232,28 +267,6 @@ class QueryParameterValueResolverTest extends TestCase
             Request::create('/', 'GET', ['groupId' => '01E439TP9XJZ9RPFH3T1PYBCR8']),
             new ArgumentMetadata('groupId', Ulid::class, false, true, false, false, [new MapQueryParameter()]),
             [Ulid::fromString('01E439TP9XJZ9RPFH3T1PYBCR8')],
-        ];
-    }
-
-    /**
-     * @return iterable<string, array{
-     *   Request,
-     *   ArgumentMetadata,
-     *   string,
-     * }>
-     */
-    public static function invalidArgumentTypeProvider(): iterable
-    {
-        yield 'unsupported type' => [
-            Request::create('/', 'GET', ['standardClass' => 'test']),
-            new ArgumentMetadata('standardClass', \stdClass::class, false, false, false, false, [new MapQueryParameter()]),
-            '#[MapQueryParameter] cannot be used on controller argument "$standardClass" of type "stdClass"; one of array, string, int, float, bool, uid or \BackedEnum should be used.',
-        ];
-
-        yield 'unsupported type variadic' => [
-            Request::create('/', 'GET', ['standardClass' => 'test']),
-            new ArgumentMetadata('standardClass', \stdClass::class, true, false, false, false, [new MapQueryParameter()]),
-            '#[MapQueryParameter] cannot be used on controller argument "...$standardClass" of type "stdClass"; one of array, string, int, float, bool, uid or \BackedEnum should be used.',
         ];
     }
 

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/RequestAttributeValueResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/RequestAttributeValueResolverTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver\RequestAttributeValueResolver;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
+use Symfony\Component\HttpKernel\Exception\NearMissValueResolverException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class RequestAttributeValueResolverTest extends TestCase
@@ -166,5 +167,56 @@ class RequestAttributeValueResolverTest extends TestCase
 
         $this->expectException(NotFoundHttpException::class);
         iterator_to_array($resolver->resolve($request, $metadata));
+    }
+
+    public function testInstanceOfClassTypeIsReturned()
+    {
+        $resolver = new RequestAttributeValueResolver();
+        $request = new Request();
+        $value = new \ArrayObject();
+        $request->attributes->set('dto', $value);
+        $metadata = new ArgumentMetadata('dto', \ArrayObject::class, false, false, null);
+
+        $this->assertSame([$value], iterator_to_array($resolver->resolve($request, $metadata)));
+    }
+
+    public function testInstanceOfInterfaceTypeIsReturned()
+    {
+        $resolver = new RequestAttributeValueResolver();
+        $request = new Request();
+        $value = new \ArrayObject();
+        $request->attributes->set('dto', $value);
+        $metadata = new ArgumentMetadata('dto', \Countable::class, false, false, null);
+
+        $this->assertSame([$value], iterator_to_array($resolver->resolve($request, $metadata)));
+    }
+
+    public function testNonObjectForClassTypeAbstains()
+    {
+        $resolver = new RequestAttributeValueResolver();
+        $request = new Request();
+        $request->attributes->set('dto', 'abc');
+        $metadata = new ArgumentMetadata('dto', \stdClass::class, false, false, null);
+
+        $this->expectException(NearMissValueResolverException::class);
+        $this->expectExceptionMessage('The "dto" request attribute holds a "string", which cannot be passed to a parameter typed "stdClass".');
+
+        iterator_to_array($resolver->resolve($request, $metadata));
+    }
+
+    /**
+     * A mismatching object must be passed through: a listener on kernel.controller_arguments
+     * can still replace it, as ErrorListener does when it turns the "exception" attribute
+     * into the FlattenException the error controller expects.
+     */
+    public function testObjectOfAnotherClassIsReturned()
+    {
+        $resolver = new RequestAttributeValueResolver();
+        $request = new Request();
+        $value = new \Exception('foo');
+        $request->attributes->set('exception', $value);
+        $metadata = new ArgumentMetadata('exception', \stdClass::class, false, false, null);
+
+        $this->assertSame([$value], iterator_to_array($resolver->resolve($request, $metadata)));
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/RequestHeaderValueResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/RequestHeaderValueResolverTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\HttpKernel\Attribute\MapRequestHeader;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver\RequestHeaderValueResolver;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
 use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpKernel\Exception\NearMissValueResolverException;
 
 class RequestHeaderValueResolverTest extends TestCase
 {
@@ -219,5 +220,55 @@ class RequestHeaderValueResolverTest extends TestCase
         $arguments = $resolver->resolve(Request::create('/'), $metadata);
 
         self::assertEquals([[]], $arguments);
+    }
+
+    public function testStagingArgumentTypesItCannotBuild()
+    {
+        $metadata = new ArgumentMetadata('since', \DateTimeImmutable::class, false, false, null, false, [
+            new MapRequestHeader('x-since'),
+        ]);
+
+        $request = Request::create('/');
+        $request->headers->set('x-since', '2026-01-15');
+
+        $resolver = new RequestHeaderValueResolver();
+
+        try {
+            $resolver->resolve($request, $metadata);
+            $this->fail(NearMissValueResolverException::class.' was not thrown.');
+        } catch (NearMissValueResolverException $e) {
+            $this->assertSame('#[MapRequestHeader] cannot build controller argument "$since" of type "DateTimeImmutable" by itself; no resolver converted the staged value.', $e->getMessage());
+        }
+
+        // the raw value is left in the attributes for a type-aware resolver further down the chain
+        $this->assertSame('2026-01-15', $request->attributes->get('since'));
+    }
+
+    public function testMissingHeaderForAStagedArgumentType()
+    {
+        $metadata = new ArgumentMetadata('since', \DateTimeImmutable::class, false, false, null, false, [
+            new MapRequestHeader('x-since'),
+        ]);
+
+        $resolver = new RequestHeaderValueResolver();
+
+        try {
+            $resolver->resolve(Request::create('/'), $metadata);
+            $this->fail(HttpException::class.' was not thrown.');
+        } catch (HttpException $e) {
+            $this->assertSame(400, $e->getStatusCode());
+            $this->assertSame('Missing header "x-since".', $e->getMessage());
+        }
+    }
+
+    public function testMissingHeaderForANullableStagedArgumentType()
+    {
+        $metadata = new ArgumentMetadata('since', \DateTimeImmutable::class, false, false, null, true, [
+            new MapRequestHeader('x-since'),
+        ]);
+
+        $resolver = new RequestHeaderValueResolver();
+
+        $this->assertSame([], $resolver->resolve(Request::create('/'), $metadata));
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolverTest.php
@@ -17,13 +17,20 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+use Symfony\Component\HttpKernel\Attribute\MapDateTime;
+use Symfony\Component\HttpKernel\Attribute\MapQueryParameter;
+use Symfony\Component\HttpKernel\Attribute\MapRequestHeader;
 use Symfony\Component\HttpKernel\Attribute\ValueResolver;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver;
+use Symfony\Component\HttpKernel\Controller\ArgumentResolver\DateTimeValueResolver;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver\DefaultValueResolver;
+use Symfony\Component\HttpKernel\Controller\ArgumentResolver\QueryParameterValueResolver;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver\RequestAttributeValueResolver;
+use Symfony\Component\HttpKernel\Controller\ArgumentResolver\RequestHeaderValueResolver;
 use Symfony\Component\HttpKernel\Controller\ValueResolverInterface;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadataFactory;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NearMissValueResolverException;
 use Symfony\Component\HttpKernel\Exception\ResolverNotFoundException;
 use Symfony\Component\HttpKernel\Tests\Fixtures\Controller\ExtendingRequest;
@@ -326,6 +333,148 @@ class ArgumentResolverTest extends TestCase
         $this->assertSame([1], $resolver->getArguments($request, $controller));
     }
 
+    public function testSourceResolverStagesTheValueForATypeResolver()
+    {
+        $resolver = self::getResolver(
+            [new DateTimeValueResolver(), new RequestAttributeValueResolver(), new DefaultValueResolver()],
+            [QueryParameterValueResolver::class => new QueryParameterValueResolver()],
+        );
+
+        $request = Request::create('/?from=2026-01-15');
+        $controller = (new ArgumentResolverTestController())->controllerWithQueryDateTime(...);
+
+        $arguments = $resolver->getArguments($request, $controller);
+
+        $this->assertCount(1, $arguments);
+        $this->assertInstanceOf(\DateTimeImmutable::class, $arguments[0]);
+        $this->assertSame('2026-01-15', $arguments[0]->format('Y-m-d'));
+    }
+
+    public function testSourceResolverStagesTheValueUnderTheArgumentName()
+    {
+        $resolver = self::getResolver(
+            [new DateTimeValueResolver(), new RequestAttributeValueResolver(), new DefaultValueResolver()],
+            [QueryParameterValueResolver::class => new QueryParameterValueResolver()],
+        );
+
+        $request = Request::create('/?d=2026-01-15');
+        $controller = (new ArgumentResolverTestController())->controllerWithRenamedQueryDateTime(...);
+
+        $arguments = $resolver->getArguments($request, $controller);
+
+        $this->assertCount(1, $arguments);
+        $this->assertSame('2026-01-15', $arguments[0]->format('Y-m-d'));
+    }
+
+    public function testHeaderSourceResolverStagesTheValueForATypeResolver()
+    {
+        $resolver = self::getResolver(
+            [new DateTimeValueResolver(), new RequestAttributeValueResolver(), new DefaultValueResolver()],
+            [RequestHeaderValueResolver::class => new RequestHeaderValueResolver()],
+        );
+
+        $request = Request::create('/');
+        $request->headers->set('x-since', '2026-01-15');
+        $controller = (new ArgumentResolverTestController())->controllerWithHeaderDateTime(...);
+
+        $arguments = $resolver->getArguments($request, $controller);
+
+        $this->assertCount(1, $arguments);
+        $this->assertSame('2026-01-15', $arguments[0]->format('Y-m-d'));
+    }
+
+    public function testSourceResolverStillReportsWhenNothingTypesTheValue()
+    {
+        $resolver = self::getResolver(
+            [new RequestAttributeValueResolver(), new DefaultValueResolver()],
+            [QueryParameterValueResolver::class => new QueryParameterValueResolver()],
+        );
+
+        $request = Request::create('/?from=2026-01-15');
+        $controller = (new ArgumentResolverTestController())->controllerWithQueryDateTime(...);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/no resolver converted the staged value/');
+
+        $resolver->getArguments($request, $controller);
+    }
+
+    public function testSourceResolverRunsFirstWhenPinnedTogetherWithATypeResolver()
+    {
+        $resolver = self::getResolver(
+            [new RequestAttributeValueResolver(), new DefaultValueResolver()],
+            [
+                QueryParameterValueResolver::class => new QueryParameterValueResolver(),
+                DateTimeValueResolver::class => new DateTimeValueResolver(),
+            ],
+        );
+
+        $request = Request::create('/?to=15/01/2026');
+        $controller = (new ArgumentResolverTestController())->controllerWithFormattedQueryDateTime(...);
+
+        $arguments = $resolver->getArguments($request, $controller);
+
+        $this->assertCount(1, $arguments);
+        $this->assertSame('2026-01-15', $arguments[0]->format('Y-m-d'));
+    }
+
+    public function testPinningTwoSourceResolversIsRejected()
+    {
+        $resolver = self::getResolver(
+            [new DefaultValueResolver()],
+            [
+                QueryParameterValueResolver::class => new QueryParameterValueResolver(),
+                RequestHeaderValueResolver::class => new RequestHeaderValueResolver(),
+            ],
+        );
+
+        $request = Request::create('/?from=2026-01-15');
+        $controller = (new ArgumentResolverTestController())->controllerWithTwoSourceResolvers(...);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessageMatches('/You can only pin one resolver per argument/');
+
+        $resolver->getArguments($request, $controller);
+    }
+
+    public function testPinningTwoNonSourceResolversIsRejected()
+    {
+        $resolver = self::getResolver(
+            [new DefaultValueResolver()],
+            [
+                DateTimeValueResolver::class => new DateTimeValueResolver(),
+                TestEntityValueResolver::class => new TestEntityValueResolver(),
+            ],
+        );
+
+        $request = Request::create('/');
+        $controller = (new ArgumentResolverTestController())->controllerWithTwoNonSourceResolvers(...);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessageMatches('/You can only pin one resolver per argument/');
+
+        $resolver->getArguments($request, $controller);
+    }
+
+    public function testSourceResolverRejectsAnArrayForASingleValueArgument()
+    {
+        $resolver = self::getResolver(
+            [new DateTimeValueResolver(), new RequestAttributeValueResolver(), new DefaultValueResolver()],
+            [QueryParameterValueResolver::class => new QueryParameterValueResolver()],
+        );
+
+        $request = Request::create('/?from[]=2026-01-15');
+        $controller = (new ArgumentResolverTestController())->controllerWithQueryDateTime(...);
+
+        try {
+            $resolver->getArguments($request, $controller);
+            $this->fail(HttpException::class.' was not thrown.');
+        } catch (HttpException $e) {
+            $this->assertSame(404, $e->getStatusCode());
+            $this->assertSame('Invalid query parameter "from".', $e->getMessage());
+        }
+    }
+
     public function testManyTargetedResolvers()
     {
         $resolver = self::getResolver(namedResolvers: []);
@@ -454,6 +603,30 @@ class ArgumentResolverTestController
     }
 
     public function controllerTargetingResolver(#[ValueResolver(DefaultValueResolver::class)] int $foo = 1)
+    {
+    }
+
+    public function controllerWithQueryDateTime(#[MapQueryParameter] \DateTimeImmutable $from)
+    {
+    }
+
+    public function controllerWithRenamedQueryDateTime(#[MapQueryParameter('d')] \DateTimeImmutable $from)
+    {
+    }
+
+    public function controllerWithHeaderDateTime(#[MapRequestHeader('x-since')] \DateTimeImmutable $since)
+    {
+    }
+
+    public function controllerWithFormattedQueryDateTime(#[MapDateTime(format: 'd/m/Y')] #[MapQueryParameter] \DateTimeImmutable $to)
+    {
+    }
+
+    public function controllerWithTwoSourceResolvers(#[MapQueryParameter] #[MapRequestHeader] \DateTimeImmutable $from)
+    {
+    }
+
+    public function controllerWithTwoNonSourceResolvers(#[MapDateTime] #[ValueResolver(TestEntityValueResolver::class)] \DateTimeImmutable $from)
     {
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Today a value resolver has to know both where a value comes from and what type to build from it. `#[MapQueryParameter]` reads the query bag and can build `array`, `string`, `int`, `float`, `bool`, uids and backed enums. Anything else is rejected:

```
#[MapQueryParameter] cannot be used on controller argument "$from" of type "DateTimeImmutable";
one of array, string, int, float, bool, uid or \BackedEnum should be used.
```

Meanwhile `DateTimeValueResolver`, `UidValueResolver`, `BackedEnumValueResolver` and Doctrine's `EntityValueResolver` all know how to build their type, but only read from `$request->attributes`. So the two halves exist and cannot meet: a date can come from the route but not from the query string, and stacking the two attributes raises `You can only pin one resolver per argument`.

This makes the two halves composable, without a new attribute and without touching `ValueResolverInterface`.

A resolver that selects a source now implements `SourceValueResolverInterface`. When it reads a value it cannot type itself, it stages the raw value in `$request->attributes` under the argument name and throws a `NearMissValueResolverException`, which by design does not interrupt the chain. The resolvers that follow see the value exactly as if it had come from the route.

```php
public function __invoke(
    #[MapQueryParameter] \DateTimeImmutable $from,                          // ?from=2026-01-15
    #[MapQueryParameter] #[MapDateTime(format: 'd/m/Y')] \DateTimeImmutable $to,
    #[MapRequestHeader('x-trace')] Ulid $traceId,
    #[MapQueryParameter] int $page,                                         // unchanged
) {
}
```

Two resolvers are marked: `QueryParameterValueResolver` and `RequestHeaderValueResolver`. Scalars, uids and enums keep resolving directly inside them, so nothing changes for the types they already handled. Only scalar values are staged: an array query value for a class-typed argument (e.g. `?from[]=x`) is rejected with `validationFailedStatusCode`, like arrays for scalar types, and a missing header raises the same `Missing header` exception as for the supported types.

Pinning also had to be relaxed. A pinned resolver used to replace the whole chain with itself plus the request-attribute and default resolvers, which left no type resolver to convert what was staged. A pinned source resolver now keeps the chain behind it, and several resolvers may be pinned when exactly one of them is a source. That is what makes `#[MapQueryParameter] #[MapDateTime(format:)]` work: `DateTimeValueResolver` reads the format off the attribute wherever it runs from.

Doctrine's `EntityValueResolver` reads the identifier from the same place, so `#[MapQueryParameter] Post $post` now loads an entity from a query parameter. That is a deliberate consequence, worth a look before merging.

### Behaviour changes

 * Using one of these attributes on a class type nothing can build used to raise a `LogicException` at resolution time. It now stages, and if no resolver converts the value the failure is reported through the usual "argument could not be resolved" message with `no resolver converted the staged value` as the reason. Variadic arguments keep the `LogicException`: nothing downstream consumes a list of raw values, so nothing is staged for them.
 * `RequestAttributeValueResolver` now abstains with an explanatory near-miss message when a class-typed argument holds a non-object value, instead of passing the raw value to the controller where it raised a `TypeError`. This closes the reported gap for staged values that nothing converts, and covers plain route parameters as well. Mismatching objects still pass through, because a `kernel.controller_arguments` listener may replace them, which is how `ErrorListener` turns the `exception` attribute into the `FlattenException` an error controller expects.
 * As a consequence, a nullable argument whose staged value no resolver converts resolves to `null`, following the normal chain semantics for nullable arguments nothing resolves.

### Known limits

Console has the same split, in `BuiltinTypeValueResolver` and friends, but no equivalent of the request attributes to stage into, so this does not reach it.

### Points for the documentation

 * `#[MapQueryParameter]` and `#[MapRequestHeader]` accept any type another resolver can build, not just scalars
 * `#[MapDateTime]` can be combined with them to pass a format
 * the value is staged in the request attributes under the argument name, so it is visible to anything reading the request afterwards
 * only single scalar values are staged: arrays are rejected with `validationFailedStatusCode`, and variadic class-typed arguments stay unsupported
