### PR TITLE
[Notifier][Mercure] Add support for Mercure 0.8

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Mercure/Tests/Fixtures/DummyHub.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mercure/Tests/Fixtures/DummyHub.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Notifier\Bridge\Mercure\Tests\Fixtures;
 use Symfony\Component\Mercure\HubInterface;
 use Symfony\Component\Mercure\Jwt\TokenFactoryInterface;
 use Symfony\Component\Mercure\Jwt\TokenProviderInterface;
+use Symfony\Component\Mercure\ProtocolVersion;
 use Symfony\Component\Mercure\Update;
 
 class DummyHub implements HubInterface
@@ -36,6 +37,14 @@ class DummyHub implements HubInterface
     }
 
     public function publish(Update $update): string
+    {
+    }
+
+    public function getProtocolVersion(): ProtocolVersion
+    {
+    }
+
+    public function getCookieName(): string
     {
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Mercure/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Mercure/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=8.2",
-        "symfony/mercure": "^0.5.2|^0.6|^0.7",
+        "symfony/mercure": "^0.5.2|^0.6|^0.7|^0.8",
         "symfony/notifier": "^7.3|^8.0",
         "symfony/service-contracts": "^2.5|^3"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65387
| License       | MIT

`symfony/mercure` 0.8 adds `getProtocolVersion()` and `getCookieName()` to `HubInterface`. The bridge code needs no change: `MercureTransport` only calls `HubInterface::publish()`, and every other symbol the bridge and its tests borrow from `symfony/mercure` still exists in 0.8 with the same signature. The grants rework does not reach the bridge either, because it never uses `FactoryTokenProvider` and `DummyHub::getFactory()` returns `null`. Only the `DummyHub` test fixture breaks, since it no longer implements the whole interface.

I ran the Mercure bridge suite against `symfony/mercure` 0.5.2, 0.6.5, 0.7.2 and 0.8.0. All 29 tests pass on each of the four. With the fixture left as it was, 0.8.0 stops before the first test with "DummyHub contains 2 abstract methods and must therefore be declared abstract", while the three older versions keep passing.

The jobs here install `symfony/mercure` 0.7.2, because the root `composer.json` requires `symfony/mercure-bundle: ^0.3|^0.4`, and 0.5.0 is the first bundle release that asks for `^0.8`. So this pull request is not covered against 0.8 by CI. Widening that dev constraint is a separate change.

Targeting 7.4, same as #62524 did for Mercure 0.7.

cc @dunglas @Kocal
