### PR TITLE
[DomCrawler] Add HtmlCrawler backed by the native HTML parser

### DIFF
--- a/UPGRADE-8.2.md
+++ b/UPGRADE-8.2.md
@@ -37,6 +37,11 @@ DoctrineBridge
    Also note that `DoctrineDbalPingConnectionMiddleware` does not reset closed entity managers as its deprecated
    counterpart did: workers already reset them between messages
 
+DomCrawler
+----------
+
+ * Deprecate the `$document` and `$xpath` properties of `FormField`, they are not used anymore
+
 Form
 ----
 

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -21,6 +21,14 @@ parameters:
     ignoreErrors:
         # Added in PHP 8.4
         - '#^Class BcMath\\Number not found\.$#'
+        # the property is deprecated but still populated, so that a subclass reading it keeps working
+        -
+            message: '#^Access to deprecated property \$xpath of class Symfony\\Component\\DomCrawler\\Field\\FormField#'
+            path: src/Symfony/Component/DomCrawler/Field/FormField.php
+        # createSubCrawler() builds a crawler of the current class on purpose, so that a subclass keeps its own type
+        -
+            message: '#^Unsafe usage of new static\(\)\.$#'
+            path: src/Symfony/Component/DomCrawler/HtmlCrawler.php
         # DeferredBatchMessage::$acked aliases a bool that batch handlers flip during dispatch()
         -
             message: '#^If condition is always false\.$#'

--- a/src/Symfony/Component/DomCrawler/AbstractHtmlUriElement.php
+++ b/src/Symfony/Component/DomCrawler/AbstractHtmlUriElement.php
@@ -12,26 +12,26 @@
 namespace Symfony\Component\DomCrawler;
 
 /**
- * Any HTML element that can link to an URI.
+ * Any HTML element that can link to an URI, backed by the native HTML parser.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-abstract class AbstractUriElement
+abstract class AbstractHtmlUriElement
 {
     use UriElementTrait;
 
-    protected \DOMElement $node;
+    protected \Dom\Element $node;
     protected ?string $method;
 
     /**
-     * @param \DOMElement $node       A \DOMElement instance
-     * @param string|null $currentUri The URI of the page where the link is embedded (or the base href)
-     * @param string|null $method     The method to use for the link (GET by default)
+     * @param \Dom\Element $node       A \Dom\Element instance
+     * @param string|null  $currentUri The URI of the page where the link is embedded (or the base href)
+     * @param string|null  $method     The method to use for the link (GET by default)
      *
      * @throws \InvalidArgumentException if the node is not a link
      */
     public function __construct(
-        \DOMElement $node,
+        \Dom\Element $node,
         protected ?string $currentUri = null,
         ?string $method = 'GET',
     ) {
@@ -44,17 +44,17 @@ abstract class AbstractUriElement
     /**
      * Gets the node associated with this link.
      */
-    public function getNode(): \DOMElement
+    public function getNode(): \Dom\Element
     {
         return $this->node;
     }
 
     /**
-     * Sets current \DOMElement instance.
+     * Sets current \Dom\Element instance.
      *
-     * @param \DOMElement $node A \DOMElement instance
+     * @param \Dom\Element $node A \Dom\Element instance
      *
      * @throws \LogicException If given node is not an anchor
      */
-    abstract protected function setNode(\DOMElement $node): void;
+    abstract protected function setNode(\Dom\Element $node): void;
 }

--- a/src/Symfony/Component/DomCrawler/CHANGELOG.md
+++ b/src/Symfony/Component/DomCrawler/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG
 8.2
 ---
 
+ * Add `HtmlCrawler`, `HtmlForm`, `HtmlLink`, `HtmlImage` and the `Html*FormField` classes, backed by the native HTML parser and its selector engine
+ * Deprecate the `$document` and `$xpath` properties of `FormField`, they are not used anymore
  * Add `ChoiceFormField::selectByText()` to select an option by its visible text content
 
 8.1

--- a/src/Symfony/Component/DomCrawler/DomTraversalTrait.php
+++ b/src/Symfony/Component/DomCrawler/DomTraversalTrait.php
@@ -27,6 +27,12 @@ trait DomTraversalTrait
 {
     /**
      * Returns the closest ancestor with the given tag name, the node itself excluded.
+     *
+     * @template T of \DOMElement|\Dom\Element
+     *
+     * @param T $node
+     *
+     * @return T|null
      */
     private static function findAncestor(\DOMElement|\Dom\Element $node, string $localName): \DOMElement|\Dom\Element|null
     {

--- a/src/Symfony/Component/DomCrawler/DomTraversalTrait.php
+++ b/src/Symfony/Component/DomCrawler/DomTraversalTrait.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DomCrawler;
+
+/**
+ * Tree lookups expressed with the members both DOM APIs share.
+ *
+ * The classic and the native DOM are distinct class hierarchies, but they
+ * expose the same names for traversal, so the lookups below work on either of
+ * them. Only \Dom\Element has a selector engine, hence no selector is used here.
+ *
+ * @internal
+ */
+trait DomTraversalTrait
+{
+    /**
+     * Returns the closest ancestor with the given tag name, the node itself excluded.
+     */
+    protected static function findAncestor(\DOMElement|\Dom\Element $node, string $localName): \DOMElement|\Dom\Element|null
+    {
+        $parent = $node->parentNode;
+
+        while ($parent instanceof \DOMElement || $parent instanceof \Dom\Element) {
+            if ($localName === $parent->localName) {
+                return $parent;
+            }
+
+            $parent = $parent->parentNode;
+        }
+
+        return null;
+    }
+
+    /**
+     * Collects the descendant elements accepted by the given predicate, in document order.
+     *
+     * @param callable(\DOMElement|\Dom\Element): bool $accept
+     *
+     * @return list<\DOMElement|\Dom\Element>
+     */
+    protected static function collectDescendants(\DOMElement|\Dom\Element|\DOMDocument|\Dom\Document $root, callable $accept): array
+    {
+        $found = [];
+        $walk = static function ($node) use (&$walk, &$found, $accept): void {
+            foreach ($node->childNodes as $child) {
+                if (!$child instanceof \DOMElement && !$child instanceof \Dom\Element) {
+                    continue;
+                }
+
+                if ($accept($child)) {
+                    $found[] = $child;
+                }
+
+                $walk($child);
+            }
+        };
+        $walk($root);
+
+        return $found;
+    }
+}

--- a/src/Symfony/Component/DomCrawler/DomTraversalTrait.php
+++ b/src/Symfony/Component/DomCrawler/DomTraversalTrait.php
@@ -18,6 +18,9 @@ namespace Symfony\Component\DomCrawler;
  * expose the same names for traversal, so the lookups below work on either of
  * them. Only \Dom\Element has a selector engine, hence no selector is used here.
  *
+ * The lookups are private: a shipped class carries its protected members as part
+ * of its extension contract, and these are an implementation detail.
+ *
  * @internal
  */
 trait DomTraversalTrait
@@ -25,7 +28,7 @@ trait DomTraversalTrait
     /**
      * Returns the closest ancestor with the given tag name, the node itself excluded.
      */
-    protected static function findAncestor(\DOMElement|\Dom\Element $node, string $localName): \DOMElement|\Dom\Element|null
+    private static function findAncestor(\DOMElement|\Dom\Element $node, string $localName): \DOMElement|\Dom\Element|null
     {
         $parent = $node->parentNode;
 
@@ -47,7 +50,7 @@ trait DomTraversalTrait
      *
      * @return list<\DOMElement|\Dom\Element>
      */
-    protected static function collectDescendants(\DOMElement|\Dom\Element|\DOMDocument|\Dom\Document $root, callable $accept): array
+    private static function collectDescendants(\DOMElement|\Dom\Element|\DOMDocument|\Dom\Document $root, callable $accept): array
     {
         $found = [];
         $walk = static function ($node) use (&$walk, &$found, $accept): void {

--- a/src/Symfony/Component/DomCrawler/Field/ChoiceFormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/ChoiceFormField.php
@@ -275,7 +275,7 @@ class ChoiceFormField extends FormField
             }
 
             $found = false;
-            foreach ($this->xpath->query('descendant::option', $this->node) as $option) {
+            foreach (self::collectDescendants($this->node, static fn ($node) => 'option' === $node->localName) as $option) {
                 $optionValue = $this->buildOptionValue($option);
                 $this->options[] = $optionValue;
 

--- a/src/Symfony/Component/DomCrawler/Field/ChoiceFormFieldTrait.php
+++ b/src/Symfony/Component/DomCrawler/Field/ChoiceFormFieldTrait.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\DomCrawler\Field;
 
+use Symfony\Component\DomCrawler\DomTraversalTrait;
+
 /**
  * Holds the choice logic shared by the classic and the native choice fields.
  *
@@ -22,6 +24,8 @@ namespace Symfony\Component\DomCrawler\Field;
  */
 trait ChoiceFormFieldTrait
 {
+    use DomTraversalTrait;
+
     private string $type;
     private bool $multiple;
     private array $options;

--- a/src/Symfony/Component/DomCrawler/Field/ChoiceFormFieldTrait.php
+++ b/src/Symfony/Component/DomCrawler/Field/ChoiceFormFieldTrait.php
@@ -1,0 +1,361 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DomCrawler\Field;
+
+/**
+ * Holds the choice logic shared by the classic and the native choice fields.
+ *
+ * The using class declares initialize() and addChoice() with the element type it
+ * accepts, so that each of them keeps an exact signature, and calls
+ * initializeChoices() and attachChoice() to do the work.
+ *
+ * @internal
+ */
+trait ChoiceFormFieldTrait
+{
+    private string $type;
+    private bool $multiple;
+    private array $options;
+    private bool $validationDisabled = false;
+
+    /**
+     * Returns true if the field should be included in the submitted values.
+     *
+     * @return bool true if the field should be included in the submitted values, false otherwise
+     */
+    public function hasValue(): bool
+    {
+        // don't send a value for unchecked checkboxes
+        if (\in_array($this->type, ['checkbox', 'radio'], true) && null === $this->value) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Check if the current selected option is disabled.
+     */
+    public function isDisabled(): bool
+    {
+        if ('checkbox' === $this->type) {
+            return parent::isDisabled();
+        }
+
+        if (parent::isDisabled() && 'select' === $this->type) {
+            return true;
+        }
+
+        foreach ($this->options as $option) {
+            if ($option['value'] == $this->value && $option['disabled']) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Sets the value of the field.
+     */
+    public function select(string|array|bool $value): void
+    {
+        $this->setValue($value);
+    }
+
+    /**
+     * Selects an option by its visible text content.
+     *
+     * The match is case-sensitive and performed after collapsing ASCII
+     * whitespace sequences in both the input and the option text. The
+     * `label` attribute of <option> elements is not honored; only the
+     * textual content is considered.
+     *
+     * When several options share the same text, the first one wins.
+     * Disabled options remain selectable, mirroring select().
+     *
+     * For `<select multiple>`, an array of texts can be passed to select
+     * several options at once.
+     *
+     * @see self::normalizeWhitespace()
+     *
+     * @throws \LogicException           When the field is not a select
+     * @throws \InvalidArgumentException When no option matches the given text
+     */
+    public function selectByText(string|array $text): void
+    {
+        if ('select' !== $this->type) {
+            throw new \LogicException(\sprintf('You cannot call selectByText() on "%s" as it is not a select (%s).', $this->name, $this->type));
+        }
+
+        $texts = (array) $text;
+        $values = [];
+        foreach ($texts as $needle) {
+            $values[] = $this->resolveTextToValue($needle);
+        }
+
+        $this->setValue(\is_array($text) ? $values : $values[0]);
+    }
+
+    /**
+     * Ticks a checkbox.
+     *
+     * @throws \LogicException When the type provided is not correct
+     */
+    public function tick(): void
+    {
+        if ('checkbox' !== $this->type) {
+            throw new \LogicException(\sprintf('You cannot tick "%s" as it is not a checkbox (%s).', $this->name, $this->type));
+        }
+
+        $this->setValue(true);
+    }
+
+    /**
+     * Unticks a checkbox.
+     *
+     * @throws \LogicException When the type provided is not correct
+     */
+    public function untick(): void
+    {
+        if ('checkbox' !== $this->type) {
+            throw new \LogicException(\sprintf('You cannot untick "%s" as it is not a checkbox (%s).', $this->name, $this->type));
+        }
+
+        $this->setValue(false);
+    }
+
+    /**
+     * Sets the value of the field.
+     *
+     * @throws \InvalidArgumentException When value type provided is not correct
+     */
+    public function setValue(string|array|bool|null $value): void
+    {
+        if ('checkbox' === $this->type && false === $value) {
+            // uncheck
+            $this->value = null;
+        } elseif ('checkbox' === $this->type && true === $value) {
+            // check
+            $this->value = $this->options[0]['value'];
+        } else {
+            if (\is_array($value)) {
+                if (!$this->multiple) {
+                    throw new \InvalidArgumentException(\sprintf('The value for "%s" cannot be an array.', $this->name));
+                }
+
+                foreach ($value as $v) {
+                    if (!$this->containsOption($v, $this->options)) {
+                        throw new \InvalidArgumentException(\sprintf('Input "%s" cannot take "%s" as a value (possible values: "%s").', $this->name, $v, implode('", "', $this->availableOptionValues())));
+                    }
+                }
+            } elseif (!$this->containsOption($value, $this->options)) {
+                throw new \InvalidArgumentException(\sprintf('Input "%s" cannot take "%s" as a value (possible values: "%s").', $this->name, $value, implode('", "', $this->availableOptionValues())));
+            }
+
+            if ($this->multiple) {
+                $value = (array) $value;
+            }
+
+            if (\is_array($value)) {
+                $this->value = $value;
+            } else {
+                parent::setValue($value);
+            }
+        }
+    }
+
+    /**
+     * Returns the type of the choice field (radio, select, or checkbox).
+     */
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    /**
+     * Returns true if the field accepts multiple values.
+     */
+    public function isMultiple(): bool
+    {
+        return $this->multiple;
+    }
+
+    /**
+     * Checks whether given value is in the existing options.
+     *
+     * @internal
+     */
+    public function containsOption(string $optionValue, array $options): bool
+    {
+        if ($this->validationDisabled) {
+            return true;
+        }
+
+        foreach ($options as $option) {
+            if ($option['value'] == $optionValue) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns list of available field options.
+     *
+     * @internal
+     */
+    public function availableOptionValues(): array
+    {
+        $values = [];
+
+        foreach ($this->options as $option) {
+            $values[] = $option['value'];
+        }
+
+        return $values;
+    }
+
+    /**
+     * Disables the internal validation of the field.
+     *
+     * @internal
+     *
+     * @return $this
+     */
+    public function disableValidation(): static
+    {
+        $this->validationDisabled = true;
+
+        return $this;
+    }
+
+    /**
+     * Reads the type, the options and the initial value out of the node.
+     */
+    private function initializeChoices(): void
+    {
+        $this->value = null;
+        $this->options = [];
+        $this->multiple = false;
+
+        if ('input' === $this->node->localName) {
+            $this->type = strtolower($this->node->getAttribute('type') ?? '');
+            $optionValue = $this->buildOptionValue($this->node);
+            $this->options[] = $optionValue;
+
+            if ($this->node->hasAttribute('checked')) {
+                $this->value = $optionValue['value'];
+            }
+
+            return;
+        }
+
+        $this->type = 'select';
+        if ($this->node->hasAttribute('multiple')) {
+            $this->multiple = true;
+            $this->value = [];
+            $this->name = str_replace('[]', '', $this->name);
+        }
+
+        $found = false;
+        foreach (self::collectDescendants($this->node, static fn ($node) => 'option' === $node->localName) as $option) {
+            $optionValue = $this->buildOptionValue($option);
+            $this->options[] = $optionValue;
+
+            if ($option->hasAttribute('selected')) {
+                $found = true;
+                if ($this->multiple) {
+                    $this->value[] = $optionValue['value'];
+                } else {
+                    $this->value = $optionValue['value'];
+                }
+            }
+        }
+
+        // if no option is selected and if it is a simple select box, take the first option as the value
+        if (!$found && !$this->multiple && $this->options) {
+            $this->value = $this->options[0]['value'];
+        }
+    }
+
+    /**
+     * Adds the given node to the current options.
+     *
+     * @throws \LogicException When choice provided is neither multiple, radio nor select,
+     *                         or when the node tag does not match the field type
+     */
+    private function attachChoice(\DOMElement|\Dom\Element $node): void
+    {
+        if (!$this->multiple && !\in_array($this->type, ['radio', 'select'], true)) {
+            throw new \LogicException(\sprintf('Unable to add a choice for "%s" as it is neither multiple, a radio button nor a select field (type is "%s").', $this->name, $this->type));
+        }
+
+        $expectedTag = 'select' === $this->type ? 'option' : 'input';
+        if ($expectedTag !== $node->localName) {
+            throw new \LogicException(\sprintf('Unable to add a choice for "%s": expected an "%s" tag, got "%s".', $this->name, $expectedTag, $node->localName));
+        }
+
+        $option = $this->buildOptionValue($node);
+        $this->options[] = $option;
+
+        if ($node->hasAttribute('select' === $this->type ? 'selected' : 'checked')) {
+            if ($this->multiple) {
+                $this->value[] = $option['value'];
+            } else {
+                $this->value = $option['value'];
+            }
+        }
+    }
+
+    /**
+     * Collapses sequences of HTML5 ASCII whitespace into a single space and trims the result,
+     * the same way Crawler::text() does, so the text passed by the caller matches what a user
+     * sees. Non-ASCII whitespace, e.g. U+00A0 or U+2028, is left untouched.
+     */
+    private static function normalizeWhitespace(string $string): string
+    {
+        return trim(preg_replace("/(?:[ \n\r\t\x0C]{2,}+|[\n\r\t\x0C])/", ' ', $string), " \n\r\t\x0C");
+    }
+
+    private function resolveTextToValue(string $text): string
+    {
+        $needle = self::normalizeWhitespace($text);
+        foreach ($this->options as $option) {
+            if ($option['text'] === $needle) {
+                return $option['value'];
+            }
+        }
+
+        throw new \InvalidArgumentException(\sprintf('Input "%s" has no option with text "%s" (possible texts: "%s").', $this->name, $text, implode('", "', array_column($this->options, 'text'))));
+    }
+
+    /**
+     * Returns option value, normalized text content and disabled flag.
+     *
+     * The text content is read instead of the node value, because the native DOM
+     * reports a null node value for an element, as the DOM standard requires.
+     */
+    private function buildOptionValue(\DOMElement|\Dom\Element $node): array
+    {
+        $option = [];
+
+        $defaultDefaultValue = 'select' === $this->node->localName ? '' : 'on';
+        $defaultValue = $node->textContent ?: $defaultDefaultValue;
+        $option['value'] = $node->hasAttribute('value') ? $node->getAttribute('value') : $defaultValue;
+        $option['text'] = self::normalizeWhitespace($node->textContent);
+        $option['disabled'] = $node->hasAttribute('disabled');
+
+        return $option;
+    }
+}

--- a/src/Symfony/Component/DomCrawler/Field/FileFormFieldTrait.php
+++ b/src/Symfony/Component/DomCrawler/Field/FileFormFieldTrait.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DomCrawler\Field;
+
+/**
+ * Holds the upload handling shared by the classic and the native file fields.
+ *
+ * @internal
+ */
+trait FileFormFieldTrait
+{
+    /**
+     * Sets the PHP error code associated with the field.
+     *
+     * @param int $error The error code (one of UPLOAD_ERR_INI_SIZE, UPLOAD_ERR_FORM_SIZE, UPLOAD_ERR_PARTIAL, UPLOAD_ERR_NO_FILE, UPLOAD_ERR_NO_TMP_DIR, UPLOAD_ERR_CANT_WRITE, or UPLOAD_ERR_EXTENSION)
+     *
+     * @throws \InvalidArgumentException When error code doesn't exist
+     */
+    public function setErrorCode(int $error): void
+    {
+        if (!\in_array($error, [\UPLOAD_ERR_INI_SIZE, \UPLOAD_ERR_FORM_SIZE, \UPLOAD_ERR_PARTIAL, \UPLOAD_ERR_NO_FILE, \UPLOAD_ERR_NO_TMP_DIR, \UPLOAD_ERR_CANT_WRITE, \UPLOAD_ERR_EXTENSION], true)) {
+            throw new \InvalidArgumentException(\sprintf('The error code "%s" is not valid.', $error));
+        }
+
+        $this->value = ['name' => '', 'type' => '', 'tmp_name' => '', 'error' => $error, 'size' => 0];
+    }
+
+    /**
+     * Sets the value of the field.
+     */
+    public function upload(?string $value): void
+    {
+        $this->setValue($value);
+    }
+
+    /**
+     * Sets the value of the field.
+     */
+    public function setValue(?string $value): void
+    {
+        if (null !== $value && is_readable($value)) {
+            $error = \UPLOAD_ERR_OK;
+            $size = filesize($value);
+            $info = pathinfo($value);
+            $name = $info['basename'];
+
+            // copy to a tmp location
+            $tmp = tempnam(sys_get_temp_dir(), $name);
+            if (\array_key_exists('extension', $info)) {
+                unlink($tmp);
+                $tmp .= '.'.$info['extension'];
+            }
+            if (is_file($tmp)) {
+                unlink($tmp);
+            }
+            copy($value, $tmp);
+            $value = $tmp;
+        } else {
+            $error = \UPLOAD_ERR_NO_FILE;
+            $size = 0;
+            $name = '';
+            $value = '';
+        }
+
+        $this->value = ['name' => $name, 'type' => '', 'tmp_name' => $value, 'error' => $error, 'size' => $size];
+    }
+}

--- a/src/Symfony/Component/DomCrawler/Field/FormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/FormField.php
@@ -57,10 +57,11 @@ abstract class FormField
     {
         if ($this->node->hasAttribute('id')) {
             $id = $this->node->getAttribute('id');
-            $labels = self::collectDescendants($this->node->ownerDocument, static fn ($node) => 'label' === $node->localName && $id === $node->getAttribute('for'));
 
-            if ($labels) {
-                return $labels[0];
+            foreach ($this->node->ownerDocument->getElementsByTagName('label') as $label) {
+                if ($id === $label->getAttribute('for')) {
+                    return $label;
+                }
             }
         }
 

--- a/src/Symfony/Component/DomCrawler/Field/FormFieldTrait.php
+++ b/src/Symfony/Component/DomCrawler/Field/FormFieldTrait.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DomCrawler\Field;
+
+/**
+ * Holds the field state shared by the classic and the native form fields.
+ *
+ * The using class declares the $node property with the element type it
+ * accepts, so that each of them keeps an exact signature.
+ *
+ * @internal
+ */
+trait FormFieldTrait
+{
+    /**
+     * Returns the name of the field.
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * Gets the value of the field.
+     */
+    public function getValue(): string|array|null
+    {
+        return $this->value;
+    }
+
+    /**
+     * Sets the value of the field.
+     */
+    public function setValue(?string $value): void
+    {
+        $this->value = $value ?? '';
+    }
+
+    /**
+     * Returns true if the field should be included in the submitted values.
+     */
+    public function hasValue(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Check if the current field is disabled.
+     */
+    public function isDisabled(): bool
+    {
+        return $this->node->hasAttribute('disabled');
+    }
+
+    /**
+     * Initializes the form field.
+     */
+    abstract protected function initialize(): void;
+}

--- a/src/Symfony/Component/DomCrawler/Field/HtmlChoiceFormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/HtmlChoiceFormField.php
@@ -12,13 +12,13 @@
 namespace Symfony\Component\DomCrawler\Field;
 
 /**
- * ChoiceFormField represents a choice form field.
+ * HtmlChoiceFormField represents a choice form field.
  *
  * It is constructed from an HTML select tag, or an HTML checkbox, or radio inputs.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class ChoiceFormField extends FormField
+class HtmlChoiceFormField extends HtmlFormField
 {
     use ChoiceFormFieldTrait;
 
@@ -28,7 +28,7 @@ class ChoiceFormField extends FormField
      * @throws \LogicException When choice provided is neither multiple, radio nor select,
      *                         or when the node tag does not match the field type
      */
-    public function addChoice(\DOMElement $node): void
+    public function addChoice(\Dom\Element $node): void
     {
         $this->attachChoice($node);
     }
@@ -41,11 +41,15 @@ class ChoiceFormField extends FormField
     protected function initialize(): void
     {
         if ('input' !== $this->node->localName && 'select' !== $this->node->localName) {
-            throw new \LogicException(\sprintf('A ChoiceFormField can only be created from an input or select tag (%s given).', $this->node->localName));
+            throw new \LogicException(\sprintf('An HtmlChoiceFormField can only be created from an input or select tag (%s given).', $this->node->localName));
         }
 
-        if ('input' === $this->node->localName && 'checkbox' !== strtolower($this->node->getAttribute('type')) && 'radio' !== strtolower($this->node->getAttribute('type'))) {
-            throw new \LogicException(\sprintf('A ChoiceFormField can only be created from an input tag with a type of checkbox or radio (given type is "%s").', $this->node->getAttribute('type')));
+        if ('input' === $this->node->localName) {
+            $type = strtolower($this->node->getAttribute('type') ?? '');
+
+            if ('checkbox' !== $type && 'radio' !== $type) {
+                throw new \LogicException(\sprintf('An HtmlChoiceFormField can only be created from an input tag with a type of checkbox or radio (given type is "%s").', $this->node->getAttribute('type')));
+            }
         }
 
         $this->initializeChoices();

--- a/src/Symfony/Component/DomCrawler/Field/HtmlFileFormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/HtmlFileFormField.php
@@ -12,11 +12,11 @@
 namespace Symfony\Component\DomCrawler\Field;
 
 /**
- * FileFormField represents a file form field (an HTML file input tag).
+ * HtmlFileFormField represents a file form field (an HTML file input tag).
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class FileFormField extends FormField
+class HtmlFileFormField extends HtmlFormField
 {
     use FileFormFieldTrait;
 
@@ -35,12 +35,12 @@ class FileFormField extends FormField
      */
     protected function initialize(): void
     {
-        if ('input' !== $this->node->nodeName) {
-            throw new \LogicException(\sprintf('A FileFormField can only be created from an input tag (%s given).', $this->node->nodeName));
+        if ('input' !== $this->node->localName) {
+            throw new \LogicException(\sprintf('An HtmlFileFormField can only be created from an input tag (%s given).', $this->node->localName));
         }
 
-        if ('file' !== strtolower($this->node->getAttribute('type'))) {
-            throw new \LogicException(\sprintf('A FileFormField can only be created from an input tag with a type of file (given type is "%s").', $this->node->getAttribute('type')));
+        if ('file' !== strtolower($this->node->getAttribute('type') ?? '')) {
+            throw new \LogicException(\sprintf('An HtmlFileFormField can only be created from an input tag with a type of file (given type is "%s").', $this->node->getAttribute('type')));
         }
 
         $this->setValue(null);

--- a/src/Symfony/Component/DomCrawler/Field/HtmlFormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/HtmlFormField.php
@@ -45,10 +45,11 @@ abstract class HtmlFormField
     {
         if ($this->node->hasAttribute('id')) {
             $id = $this->node->getAttribute('id');
-            $labels = self::collectDescendants($this->node->ownerDocument, static fn ($node) => 'label' === $node->localName && $id === $node->getAttribute('for'));
 
-            if ($labels) {
-                return $labels[0];
+            foreach ($this->node->ownerDocument->getElementsByTagName('label') as $label) {
+                if ($id === $label->getAttribute('for')) {
+                    return $label;
+                }
             }
         }
 

--- a/src/Symfony/Component/DomCrawler/Field/HtmlFormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/HtmlFormField.php
@@ -14,38 +14,26 @@ namespace Symfony\Component\DomCrawler\Field;
 use Symfony\Component\DomCrawler\DomTraversalTrait;
 
 /**
- * FormField is the abstract class for all form fields.
+ * HtmlFormField is the abstract class for all form fields backed by the native HTML parser.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-abstract class FormField
+abstract class HtmlFormField
 {
     use DomTraversalTrait;
     use FormFieldTrait;
 
     protected string $name;
     protected string|array|null $value = null;
-
-    /**
-     * @deprecated since Symfony 8.2, not used anymore
-     */
-    protected \DOMDocument $document;
-
-    /**
-     * @deprecated since Symfony 8.2, not used anymore
-     */
-    protected \DOMXPath $xpath;
-
     protected bool $disabled = false;
 
     /**
-     * @param \DOMElement $node The node associated with this field
+     * @param \Dom\Element $node The node associated with this field
      */
     public function __construct(
-        protected \DOMElement $node,
+        protected \Dom\Element $node,
     ) {
-        $this->name = $node->getAttribute('name');
-        $this->xpath = new \DOMXPath($node->ownerDocument);
+        $this->name = $node->getAttribute('name') ?? '';
 
         $this->initialize();
     }
@@ -53,7 +41,7 @@ abstract class FormField
     /**
      * Returns the label tag associated to the field or null if none.
      */
-    public function getLabel(): ?\DOMElement
+    public function getLabel(): ?\Dom\Element
     {
         if ($this->node->hasAttribute('id')) {
             $id = $this->node->getAttribute('id');

--- a/src/Symfony/Component/DomCrawler/Field/HtmlInputFormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/HtmlInputFormField.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DomCrawler\Field;
+
+/**
+ * HtmlInputFormField represents an input form field (an HTML input tag).
+ *
+ * For inputs with type of file, checkbox, or radio, there are other more
+ * specialized classes (cf. HtmlFileFormField and HtmlChoiceFormField).
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class HtmlInputFormField extends HtmlFormField
+{
+    /**
+     * Initializes the form field.
+     *
+     * @throws \LogicException When node type is incorrect
+     */
+    protected function initialize(): void
+    {
+        if ('input' !== $this->node->localName && 'button' !== $this->node->localName) {
+            throw new \LogicException(\sprintf('An HtmlInputFormField can only be created from an input or button tag (%s given).', $this->node->localName));
+        }
+
+        $type = strtolower($this->node->getAttribute('type') ?? '');
+        if ('checkbox' === $type) {
+            throw new \LogicException('Checkboxes should be instances of HtmlChoiceFormField.');
+        }
+
+        if ('file' === $type) {
+            throw new \LogicException('File inputs should be instances of HtmlFileFormField.');
+        }
+
+        $this->value = $this->node->getAttribute('value') ?? '';
+    }
+}

--- a/src/Symfony/Component/DomCrawler/Field/HtmlTextareaFormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/HtmlTextareaFormField.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DomCrawler\Field;
+
+/**
+ * HtmlTextareaFormField represents a textarea form field (an HTML textarea tag).
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class HtmlTextareaFormField extends HtmlFormField
+{
+    /**
+     * Initializes the form field.
+     *
+     * @throws \LogicException When node type is incorrect
+     */
+    protected function initialize(): void
+    {
+        if ('textarea' !== $this->node->localName) {
+            throw new \LogicException(\sprintf('An HtmlTextareaFormField can only be created from a textarea tag (%s given).', $this->node->localName));
+        }
+
+        // the HTML parser reads the content of a textarea as raw text, so what it
+        // holds is already the value, comment-looking markup included
+        $this->value = $this->node->textContent;
+    }
+}

--- a/src/Symfony/Component/DomCrawler/Form.php
+++ b/src/Symfony/Component/DomCrawler/Form.php
@@ -21,6 +21,10 @@ use Symfony\Component\DomCrawler\Field\FormField;
  */
 class Form extends Link implements \ArrayAccess
 {
+    use DomTraversalTrait;
+
+    private const FIELD_TAGS = ['input', 'button', 'textarea', 'select'];
+
     private \DOMElement $button;
     private FormFieldRegistry $fields;
 
@@ -391,8 +395,6 @@ class Form extends Link implements \ArrayAccess
     {
         $this->fields = new FormFieldRegistry();
 
-        $xpath = new \DOMXPath($this->node->ownerDocument);
-
         // add submitted button if it has a valid name
         if ('form' !== $this->button->nodeName && $this->button->hasAttribute('name') && $this->button->getAttribute('name')) {
             if ('input' == $this->button->nodeName && 'image' == strtolower($this->button->getAttribute('type'))) {
@@ -416,14 +418,26 @@ class Form extends Link implements \ArrayAccess
 
         // find form elements corresponding to the current form
         if ($this->node->hasAttribute('id')) {
-            // corresponding elements are either descendants or have a matching HTML5 form attribute
-            $formId = Crawler::xpathLiteral($this->node->getAttribute('id'));
+            // corresponding elements are either descendants of the form or carry a matching HTML5 form attribute,
+            // so the whole document has to be walked
+            $formId = $this->node->getAttribute('id');
 
-            $fieldNodes = $xpath->query(\sprintf('( descendant::input[@form=%s] | descendant::button[@form=%1$s] | descendant::textarea[@form=%1$s] | descendant::select[@form=%1$s] | //form[@id=%1$s]//input[not(@form)] | //form[@id=%1$s]//button[not(@form)] | //form[@id=%1$s]//textarea[not(@form)] | //form[@id=%1$s]//select[not(@form)] )[( not(ancestor::template) or ancestor::turbo-stream )]', $formId));
+            $fieldNodes = self::collectDescendants($this->node->ownerDocument, static function ($node) use ($formId): bool {
+                if (!\in_array($node->localName, self::FIELD_TAGS, true) || !self::isSubmittable($node)) {
+                    return false;
+                }
+
+                if ($node->hasAttribute('form')) {
+                    return $formId === $node->getAttribute('form');
+                }
+
+                return $formId === self::findAncestor($node, 'form')?->getAttribute('id');
+            });
         } else {
-            // do the xpath query with $this->node as the context node, to only find descendant elements
-            // however, descendant elements with form attribute are not part of this form
-            $fieldNodes = $xpath->query('( descendant::input[not(@form)] | descendant::button[not(@form)] | descendant::textarea[not(@form)] | descendant::select[not(@form)] )[( not(ancestor::template) or ancestor::turbo-stream )]', $this->node);
+            // only descendant elements belong to this form, and those carrying a form attribute belong to another one
+            $fieldNodes = self::collectDescendants($this->node, static fn ($node): bool => \in_array($node->localName, self::FIELD_TAGS, true)
+                && !$node->hasAttribute('form')
+                && self::isSubmittable($node));
         }
 
         foreach ($fieldNodes as $node) {
@@ -459,5 +473,15 @@ class Form extends Link implements \ArrayAccess
         } elseif ('textarea' == $nodeName) {
             $this->set(new Field\TextareaFormField($node));
         }
+    }
+
+    /**
+     * Tells whether a field takes part in a submission.
+     *
+     * Fields inside a template are inert, unless a turbo-stream brings them back.
+     */
+    private static function isSubmittable(\DOMElement|\Dom\Element $node): bool
+    {
+        return !self::findAncestor($node, 'template') || self::findAncestor($node, 'turbo-stream');
     }
 }

--- a/src/Symfony/Component/DomCrawler/FormFieldRegistryTrait.php
+++ b/src/Symfony/Component/DomCrawler/FormFieldRegistryTrait.php
@@ -1,0 +1,110 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DomCrawler;
+
+/**
+ * Holds the name handling shared by the classic and the native field registries.
+ *
+ * The using class declares add(), get() and set() with the field type it accepts,
+ * so that each registry holds one kind of field only.
+ *
+ * @internal
+ */
+trait FormFieldRegistryTrait
+{
+    private array $fields = [];
+    private string $base = '';
+
+    /**
+     * Removes a field based on the fully qualified name and its children from the registry.
+     */
+    public function remove(string $name): void
+    {
+        $segments = $this->getSegments($name);
+        $target = &$this->fields;
+        while (\count($segments) > 1) {
+            $path = array_shift($segments);
+            if (!\is_array($target) || !\array_key_exists($path, $target)) {
+                return;
+            }
+            $target = &$target[$path];
+        }
+        unset($target[array_shift($segments)]);
+    }
+
+    /**
+     * Tests whether the form has the given field based on the fully qualified name.
+     */
+    public function has(string $name): bool
+    {
+        try {
+            $this->get($name);
+
+            return true;
+        } catch (\InvalidArgumentException) {
+            return false;
+        }
+    }
+
+    /**
+     * Returns the list of field with their value.
+     *
+     * @return array The list of fields as [string] Fully qualified name => (mixed) value)
+     */
+    public function all(): array
+    {
+        return $this->walk($this->fields, $this->base);
+    }
+
+    /**
+     * Transforms a PHP array in a list of fully qualified name / value.
+     */
+    private function walk(array $array, ?string $base = '', array &$output = []): array
+    {
+        foreach ($array as $k => $v) {
+            $path = $base ? \sprintf('%s[%s]', $base, $k) : $k;
+            if (\is_array($v)) {
+                $this->walk($v, $path, $output);
+            } else {
+                $output[$path] = $v;
+            }
+        }
+
+        return $output;
+    }
+
+    /**
+     * Splits a field name into segments as a web browser would do.
+     *
+     *     getSegments('base[foo][3][]') = ['base', 'foo, '3', ''];
+     *
+     * @return string[]
+     */
+    private function getSegments(string $name): array
+    {
+        if (preg_match('/^(?P<base>[^[]+)(?P<extra>(\[.*)|$)/', $name, $m)) {
+            $segments = [$m['base']];
+            while (!empty($m['extra'])) {
+                $extra = $m['extra'];
+                if (preg_match('/^\[(?P<segment>.*?)\](?P<extra>.*)$/', $extra, $m)) {
+                    $segments[] = $m['segment'];
+                } else {
+                    $segments[] = $extra;
+                }
+            }
+
+            return $segments;
+        }
+
+        return [$name];
+    }
+}

--- a/src/Symfony/Component/DomCrawler/FormFieldRegistryTrait.php
+++ b/src/Symfony/Component/DomCrawler/FormFieldRegistryTrait.php
@@ -26,6 +26,8 @@ trait FormFieldRegistryTrait
 
     /**
      * Removes a field based on the fully qualified name and its children from the registry.
+     *
+     * @psalm-suppress UnsupportedPropertyReferenceUsage the property is declared in this trait
      */
     public function remove(string $name): void
     {

--- a/src/Symfony/Component/DomCrawler/FormTrait.php
+++ b/src/Symfony/Component/DomCrawler/FormTrait.php
@@ -1,0 +1,257 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DomCrawler;
+
+/**
+ * Holds the form logic shared by the classic and the native form.
+ *
+ * The using class declares the members that name a node or a field type, so that
+ * each of them keeps an exact signature, and holds its own field registry.
+ *
+ * @internal
+ */
+trait FormTrait
+{
+    use DomTraversalTrait;
+
+    private const FIELD_TAGS = ['input', 'button', 'textarea', 'select'];
+
+    /**
+     * Sets the value of the fields.
+     *
+     * @param array $values An array of field values
+     *
+     * @return $this
+     */
+    public function setValues(array $values): static
+    {
+        foreach ($values as $name => $value) {
+            $this->fields->set($name, $value);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Gets the field values as PHP.
+     *
+     * This method converts fields with the array notation
+     * (like foo[bar] to arrays) like PHP does.
+     */
+    public function getPhpValues(): array
+    {
+        $values = [];
+        foreach ($this->getValues() as $name => $value) {
+            $qs = http_build_query([$name => $value], '', '&');
+            if ($qs) {
+                parse_str($qs, $expandedValue);
+                $varName = substr($name, 0, \strlen(key($expandedValue)));
+                $values[] = [$varName => current($expandedValue)];
+            }
+        }
+
+        return array_replace_recursive([], ...$values);
+    }
+
+    /**
+     * Gets the file field values as PHP.
+     *
+     * This method converts fields with the array notation
+     * (like foo[bar] to arrays) like PHP does.
+     * The returned array is consistent with the array for field values
+     * (@see getPhpValues), rather than uploaded files found in $_FILES.
+     * For a compound file field foo[bar] it will create foo[bar][name],
+     * instead of foo[name][bar] which would be found in $_FILES.
+     */
+    public function getPhpFiles(): array
+    {
+        $values = [];
+        foreach ($this->getFiles() as $name => $value) {
+            $qs = http_build_query([$name => $value], '', '&');
+            if ($qs) {
+                parse_str($qs, $expandedValue);
+                $varName = substr($name, 0, \strlen(key($expandedValue)));
+
+                array_walk_recursive(
+                    $expandedValue,
+                    static function (&$value, $key) {
+                        if (ctype_digit($value) && ('size' === $key || 'error' === $key)) {
+                            $value = (int) $value;
+                        }
+                    }
+                );
+
+                reset($expandedValue);
+
+                $values[] = [$varName => current($expandedValue)];
+            }
+        }
+
+        return array_replace_recursive([], ...$values);
+    }
+
+    /**
+     * Gets the URI of the form.
+     *
+     * The returned URI is not the same as the form "action" attribute.
+     * This method merges the value if the method is GET to mimics
+     * browser behavior.
+     */
+    public function getUri(): string
+    {
+        $uri = parent::getUri();
+
+        if (!\in_array($this->getMethod(), ['POST', 'PUT', 'DELETE', 'PATCH'], true)) {
+            $currentParameters = [];
+            if ($query = parse_url($uri, \PHP_URL_QUERY)) {
+                parse_str($query, $currentParameters);
+            }
+
+            $queryString = http_build_query(array_merge($currentParameters, $this->getValues()), '', '&');
+
+            $pos = strpos($uri, '?');
+            $base = false === $pos ? $uri : substr($uri, 0, $pos);
+            $uri = rtrim($base.'?'.$queryString, '?');
+        }
+
+        return $uri;
+    }
+
+    /**
+     * Gets the form method.
+     *
+     * If no method is defined in the form, GET is returned.
+     */
+    public function getMethod(): string
+    {
+        if (null !== $this->method) {
+            return $this->method;
+        }
+
+        // If the form was created from a button rather than the form node, check for HTML5 method override
+        if ($this->button !== $this->node && $this->button->getAttribute('formmethod')) {
+            return strtoupper($this->button->getAttribute('formmethod'));
+        }
+
+        return $this->node->getAttribute('method') ? strtoupper($this->node->getAttribute('method')) : 'GET';
+    }
+
+    /**
+     * Gets the form name.
+     *
+     * If no name is defined on the form, an empty string is returned.
+     */
+    public function getName(): string
+    {
+        return $this->node->getAttribute('name') ?? '';
+    }
+
+    /**
+     * Returns true if the named field exists.
+     */
+    public function has(string $name): bool
+    {
+        return $this->fields->has($name);
+    }
+
+    /**
+     * Removes a field from the form.
+     */
+    public function remove(string $name): void
+    {
+        $this->fields->remove($name);
+    }
+
+    /**
+     * Returns true if the named field exists.
+     *
+     * @param string $name The field name
+     */
+    public function offsetExists(mixed $name): bool
+    {
+        return $this->has($name);
+    }
+
+    /**
+     * Sets the value of a field.
+     *
+     * @param string       $name  The field name
+     * @param string|array $value The value of the field
+     *
+     * @throws \InvalidArgumentException if the field does not exist
+     */
+    public function offsetSet(mixed $name, mixed $value): void
+    {
+        $this->fields->set($name, $value);
+    }
+
+    /**
+     * Removes a field from the form.
+     *
+     * @param string $name The field name
+     */
+    public function offsetUnset(mixed $name): void
+    {
+        $this->fields->remove($name);
+    }
+
+    protected function getRawUri(): string
+    {
+        // If the form was created from a button rather than the form node, check for HTML5 action overrides
+        if ($this->button !== $this->node && $this->button->getAttribute('formaction')) {
+            return $this->button->getAttribute('formaction');
+        }
+
+        return $this->node->getAttribute('action') ?? '';
+    }
+
+    /**
+     * Returns the nodes of the fields that belong to this form, in document order.
+     *
+     * @return list<\DOMElement|\Dom\Element>
+     */
+    private function collectFieldNodes(): array
+    {
+        if (!$this->node->hasAttribute('id')) {
+            // only descendant elements belong to this form, and those carrying a form attribute belong to another one
+            return self::collectDescendants($this->node, static fn ($node): bool => \in_array($node->localName, self::FIELD_TAGS, true)
+                && !$node->hasAttribute('form')
+                && self::isSubmittable($node));
+        }
+
+        // corresponding elements are either descendants of the form or carry a matching HTML5 form attribute,
+        // so the whole document has to be walked
+        $formId = $this->node->getAttribute('id');
+
+        return self::collectDescendants($this->node->ownerDocument, static function ($node) use ($formId): bool {
+            if (!\in_array($node->localName, self::FIELD_TAGS, true) || !self::isSubmittable($node)) {
+                return false;
+            }
+
+            if ($node->hasAttribute('form')) {
+                return $formId === $node->getAttribute('form');
+            }
+
+            return $formId === self::findAncestor($node, 'form')?->getAttribute('id');
+        });
+    }
+
+    /**
+     * Tells whether a field takes part in a submission.
+     *
+     * Fields inside a template are inert, unless a turbo-stream brings them back.
+     */
+    private static function isSubmittable(\DOMElement|\Dom\Element $node): bool
+    {
+        return !self::findAncestor($node, 'template') || self::findAncestor($node, 'turbo-stream');
+    }
+}

--- a/src/Symfony/Component/DomCrawler/FormTrait.php
+++ b/src/Symfony/Component/DomCrawler/FormTrait.php
@@ -207,8 +207,8 @@ trait FormTrait
     protected function getRawUri(): string
     {
         // If the form was created from a button rather than the form node, check for HTML5 action overrides
-        if ($this->button !== $this->node && $this->button->getAttribute('formaction')) {
-            return $this->button->getAttribute('formaction');
+        if ($this->button !== $this->node && $formAction = $this->button->getAttribute('formaction')) {
+            return $formAction;
         }
 
         return $this->node->getAttribute('action') ?? '';

--- a/src/Symfony/Component/DomCrawler/HtmlCrawler.php
+++ b/src/Symfony/Component/DomCrawler/HtmlCrawler.php
@@ -37,12 +37,12 @@ class HtmlCrawler implements \Countable, \IteratorAggregate
     private ?\Dom\Document $document = null;
 
     /**
-     * @var list<\Dom\Node>
+     * @var array<int, \Dom\Node>
      */
     private array $nodes = [];
 
     /**
-     * @param \Dom\NodeList<\Dom\Node>|\Dom\Node|\Dom\Node[]|string|null $node A Node to use as the base for the crawling
+     * @param \Dom\NodeList|\Dom\Node|\Dom\Node[]|string|null $node A Node to use as the base for the crawling
      */
     public function __construct(
         \Dom\NodeList|\Dom\Node|array|string|null $node = null,
@@ -79,7 +79,7 @@ class HtmlCrawler implements \Countable, \IteratorAggregate
      * This method uses the appropriate specialized add*() method based
      * on the type of the argument.
      *
-     * @param \Dom\NodeList<\Dom\Node>|\Dom\Node|\Dom\Node[]|string|null $node
+     * @param \Dom\NodeList|\Dom\Node|\Dom\Node[]|string|null $node
      */
     public function add(\Dom\NodeList|\Dom\Node|array|string|null $node): void
     {
@@ -112,15 +112,10 @@ class HtmlCrawler implements \Countable, \IteratorAggregate
         }
     }
 
-    /**
-     * @param \Dom\NodeList<\Dom\Node> $nodes
-     */
     public function addNodeList(\Dom\NodeList $nodes): void
     {
         foreach ($nodes as $node) {
-            if ($node instanceof \Dom\Node) {
-                $this->addNode($node);
-            }
+            $this->addNode($node);
         }
     }
 
@@ -386,11 +381,9 @@ class HtmlCrawler implements \Countable, \IteratorAggregate
      */
     public function nodeName(): string
     {
-        if (!$this->nodes) {
+        if (!$node = $this->getNode(0)) {
             throw new \InvalidArgumentException('The current node list is empty.');
         }
-
-        $node = $this->getNode(0);
 
         return $node instanceof \Dom\Element ? $node->localName : $node->nodeName;
     }
@@ -407,7 +400,7 @@ class HtmlCrawler implements \Countable, \IteratorAggregate
      */
     public function text(?string $default = null, bool $normalizeWhitespace = true): string
     {
-        if (!$this->nodes) {
+        if (!$node = $this->getNode(0)) {
             if (null !== $default) {
                 return $default;
             }
@@ -415,7 +408,7 @@ class HtmlCrawler implements \Countable, \IteratorAggregate
             throw new \InvalidArgumentException('The current node list is empty.');
         }
 
-        $text = $this->getNode(0)->textContent;
+        $text = $node->textContent;
 
         if ($normalizeWhitespace) {
             return $this->normalizeWhitespace($text);
@@ -455,7 +448,7 @@ class HtmlCrawler implements \Countable, \IteratorAggregate
      */
     public function html(?string $default = null): string
     {
-        if (!$this->nodes || !$this->getNode(0) instanceof \Dom\Element) {
+        if (!($node = $this->getNode(0)) instanceof \Dom\Element) {
             if (null !== $default) {
                 return $default;
             }
@@ -463,7 +456,7 @@ class HtmlCrawler implements \Countable, \IteratorAggregate
             throw new \InvalidArgumentException('The current node list is empty.');
         }
 
-        return $this->getNode(0)->innerHTML;
+        return $node->innerHTML;
     }
 
     /**
@@ -473,14 +466,22 @@ class HtmlCrawler implements \Countable, \IteratorAggregate
      */
     public function outerHtml(): string
     {
-        if (!$this->nodes || !($node = $this->getNode(0)) instanceof \Dom\Element) {
+        if (!($node = $this->getNode(0)) instanceof \Dom\Element) {
             throw new \InvalidArgumentException('The current node list is empty.');
         }
 
-        // \Dom\Element::$outerHTML was added in PHP 8.5
+        // \Dom\Element::$outerHTML was added in PHP 8.5, so the document serializes the node
         $document = $node->ownerDocument;
 
-        return $document instanceof \Dom\HTMLDocument ? $document->saveHtml($node) : $document->saveXml($node);
+        if ($document instanceof \Dom\HTMLDocument) {
+            return $document->saveHtml($node);
+        }
+
+        if ($document instanceof \Dom\XMLDocument) {
+            return $document->saveXml($node);
+        }
+
+        throw new \LogicException(\sprintf('Unable to serialize a node of a "%s" document.', get_debug_type($document)));
     }
 
     /**
@@ -506,7 +507,15 @@ class HtmlCrawler implements \Countable, \IteratorAggregate
         }
 
         if (isset($data[0]) && $data[0] instanceof \Dom\NodeList) {
-            return $this->createSubCrawler($data);
+            $crawler = $this->createSubCrawler(null);
+
+            foreach ($data as $nodeList) {
+                if ($nodeList instanceof \Dom\NodeList) {
+                    $crawler->addNodeList($nodeList);
+                }
+            }
+
+            return $crawler;
         }
 
         return $data;
@@ -792,7 +801,7 @@ class HtmlCrawler implements \Countable, \IteratorAggregate
                 REGEXP,
             static fn (array $m) => isset($m['name']) && '' !== $m['name'] ? self::XPATH_PREFIX.':'.$m['name'] : $m[0],
             $xpath
-        );
+        ) ?? $xpath;
     }
 
     /**
@@ -972,7 +981,7 @@ class HtmlCrawler implements \Countable, \IteratorAggregate
     /**
      * Creates a crawler for some subnodes.
      *
-     * @param \Dom\NodeList<\Dom\Node>|\Dom\Node|\Dom\Node[]|string|null $nodes
+     * @param \Dom\NodeList|\Dom\Node|\Dom\Node[]|string|null $nodes
      */
     private function createSubCrawler(\Dom\NodeList|\Dom\Node|array|string|null $nodes): static
     {

--- a/src/Symfony/Component/DomCrawler/HtmlCrawler.php
+++ b/src/Symfony/Component/DomCrawler/HtmlCrawler.php
@@ -33,7 +33,7 @@ class HtmlCrawler implements \Countable, \IteratorAggregate
     private const HTML_NAMESPACE = 'http://www.w3.org/1999/xhtml';
     private const XPATH_PREFIX = 'html';
 
-    protected ?string $baseHref;
+    private ?string $baseHref;
     private ?\Dom\Document $document = null;
 
     /**
@@ -473,11 +473,14 @@ class HtmlCrawler implements \Countable, \IteratorAggregate
      */
     public function outerHtml(): string
     {
-        if (!$this->nodes || !$this->getNode(0) instanceof \Dom\Element) {
+        if (!$this->nodes || !($node = $this->getNode(0)) instanceof \Dom\Element) {
             throw new \InvalidArgumentException('The current node list is empty.');
         }
 
-        return $this->getNode(0)->outerHTML;
+        // \Dom\Element::$outerHTML was added in PHP 8.5
+        $document = $node->ownerDocument;
+
+        return $document instanceof \Dom\HTMLDocument ? $document->saveHtml($node) : $document->saveXml($node);
     }
 
     /**
@@ -531,7 +534,7 @@ class HtmlCrawler implements \Countable, \IteratorAggregate
                 } elseif ('_name' === $attribute) {
                     $elements[] = $node instanceof \Dom\Element ? $node->localName : $node->nodeName;
                 } else {
-                    $elements[] = $node instanceof \Dom\Element && $node->hasAttribute($attribute) ? $node->getAttribute($attribute) : null;
+                    $elements[] = $node instanceof \Dom\Element ? $node->getAttribute($attribute) ?? '' : '';
                 }
             }
 
@@ -581,6 +584,131 @@ class HtmlCrawler implements \Countable, \IteratorAggregate
         }
 
         return $crawler;
+    }
+
+    /**
+     * Selects links by name or alt value for clickable images.
+     */
+    public function selectLink(string $value): static
+    {
+        $value = ' '.$value.' ';
+
+        return $this->select('a', static function (\Dom\Element $node) use ($value): bool {
+            if (str_contains(' '.self::normalizeSpace($node->textContent).' ', $value)) {
+                return true;
+            }
+
+            // \Dom\Element::$children was added in PHP 8.5
+            foreach ($node->childNodes as $child) {
+                if ($child instanceof \Dom\Element && 'img' === $child->localName && str_contains(' '.self::normalizeSpace($child->getAttribute('alt') ?? '').' ', $value)) {
+                    return true;
+                }
+            }
+
+            return false;
+        });
+    }
+
+    /**
+     * Selects images by alt value.
+     */
+    public function selectImage(string $value): static
+    {
+        return $this->select('img', static fn (\Dom\Element $node): bool => str_contains(self::normalizeSpace($node->getAttribute('alt') ?? ''), $value));
+    }
+
+    /**
+     * Selects a button by name or alt value for images.
+     */
+    public function selectButton(string $value): static
+    {
+        $paddedValue = ' '.$value.' ';
+
+        return $this->select('input, button', static function (\Dom\Element $node) use ($value, $paddedValue): bool {
+            if ($value === $node->getAttribute('id') || $value === $node->getAttribute('name')) {
+                return true;
+            }
+
+            $hasValue = static fn (string $attribute): bool => str_contains(' '.self::normalizeSpace($node->getAttribute($attribute) ?? '').' ', $paddedValue);
+
+            if ('button' === $node->localName) {
+                return $hasValue('value') || str_contains(' '.self::normalizeSpace($node->textContent).' ', $paddedValue);
+            }
+
+            $type = strtolower($node->getAttribute('type') ?? '');
+
+            if ((str_contains($type, 'submit') || str_contains($type, 'button')) && $hasValue('value')) {
+                return true;
+            }
+
+            return str_contains($type, 'image') && $hasValue('alt');
+        });
+    }
+
+    /**
+     * Returns a Link object for the first node in the list.
+     *
+     * @throws \InvalidArgumentException If the current node list is empty or the node is not an element
+     */
+    public function link(string $method = 'get'): HtmlLink
+    {
+        return new HtmlLink($this->getFirstElement(), $this->baseHref, $method);
+    }
+
+    /**
+     * @return HtmlLink[]
+     *
+     * @throws \InvalidArgumentException If the current node list contains non-elements
+     */
+    public function links(): array
+    {
+        $links = [];
+        foreach ($this->nodes as $node) {
+            $links[] = new HtmlLink($this->assertElement($node), $this->baseHref, 'get');
+        }
+
+        return $links;
+    }
+
+    /**
+     * Returns an Image object for the first node in the list.
+     *
+     * @throws \InvalidArgumentException If the current node list is empty or the node is not an element
+     */
+    public function image(): HtmlImage
+    {
+        return new HtmlImage($this->getFirstElement(), $this->baseHref);
+    }
+
+    /**
+     * @return HtmlImage[]
+     *
+     * @throws \InvalidArgumentException If the current node list contains non-elements
+     */
+    public function images(): array
+    {
+        $images = [];
+        foreach ($this->nodes as $node) {
+            $images[] = new HtmlImage($this->assertElement($node), $this->baseHref);
+        }
+
+        return $images;
+    }
+
+    /**
+     * Returns a Form object for the first node in the list.
+     *
+     * @throws \InvalidArgumentException If the current node list is empty or the node is not an element
+     */
+    public function form(?array $values = null, ?string $method = null): HtmlForm
+    {
+        $form = new HtmlForm($this->getFirstElement(), $this->uri, $method, $this->baseHref);
+
+        if (null !== $values) {
+            $form->setValues($values);
+        }
+
+        return $form;
     }
 
     public function getNode(int $position): ?\Dom\Node
@@ -687,6 +815,69 @@ class HtmlCrawler implements \Countable, \IteratorAggregate
     private function normalizeWhitespace(string $string): string
     {
         return trim(preg_replace("/(?:[ \n\r\t\x0C]{2,}+|[\n\r\t\x0C])/", ' ', $string), " \n\r\t\x0C");
+    }
+
+    /**
+     * Collapses whitespace the way the XPath normalize-space() function does, so
+     * that the selectors below match what the classic crawler matches. That set
+     * of characters is narrower than the HTML5 one: it leaves the form feed out.
+     */
+    private static function normalizeSpace(string $string): string
+    {
+        return trim(preg_replace("/[ \n\r\t]++/", ' ', $string), " \n\r\t");
+    }
+
+    /**
+     * Selects the nodes matching the selector, the current nodes included, that
+     * the given predicate accepts.
+     *
+     * @param callable(\Dom\Element): bool $accept
+     */
+    private function select(string $selector, callable $accept): static
+    {
+        $crawler = $this->createSubCrawler(null);
+
+        foreach ($this->nodes as $node) {
+            if ($node instanceof \Dom\Element && $node->matches($selector) && $accept($node)) {
+                $crawler->addNode($node);
+            }
+
+            if (!$node instanceof \Dom\ParentNode) {
+                continue;
+            }
+
+            foreach ($node->querySelectorAll($selector) as $candidate) {
+                if ($accept($candidate)) {
+                    $crawler->addNode($candidate);
+                }
+            }
+        }
+
+        return $crawler;
+    }
+
+    /**
+     * @throws \InvalidArgumentException If the current node list is empty or the node is not an element
+     */
+    private function getFirstElement(): \Dom\Element
+    {
+        if (!$this->nodes) {
+            throw new \InvalidArgumentException('The current node list is empty.');
+        }
+
+        return $this->assertElement($this->nodes[0]);
+    }
+
+    /**
+     * @throws \InvalidArgumentException If the node is not an element
+     */
+    private function assertElement(\Dom\Node $node): \Dom\Element
+    {
+        if (!$node instanceof \Dom\Element) {
+            throw new \InvalidArgumentException(\sprintf('The current node list should contain only Dom\Element instances, "%s" found.', get_debug_type($node)));
+        }
+
+        return $node;
     }
 
     /**

--- a/src/Symfony/Component/DomCrawler/HtmlCrawler.php
+++ b/src/Symfony/Component/DomCrawler/HtmlCrawler.php
@@ -1,0 +1,793 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DomCrawler;
+
+/**
+ * HtmlCrawler eases navigation of a list of \Dom\Node objects.
+ *
+ * Unlike Crawler, it holds the document parsed by the native HTML5 parser and
+ * selects with the selector engine of that same parser. CSS selectors are
+ * therefore handled by the engine itself instead of being translated to XPath,
+ * which supports the whole selector syntax the engine knows.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ *
+ * @implements \IteratorAggregate<int, \Dom\Node>
+ */
+class HtmlCrawler implements \Countable, \IteratorAggregate
+{
+    /**
+     * The namespace the HTML parser puts elements in. XPath 1.0 has no notion
+     * of a default namespace, so unprefixed name tests never match those
+     * elements; expressions are rewritten to use self::XPATH_PREFIX instead.
+     */
+    private const HTML_NAMESPACE = 'http://www.w3.org/1999/xhtml';
+    private const XPATH_PREFIX = 'html';
+
+    protected ?string $baseHref;
+    private ?\Dom\Document $document = null;
+
+    /**
+     * @var list<\Dom\Node>
+     */
+    private array $nodes = [];
+
+    /**
+     * @param \Dom\NodeList<\Dom\Node>|\Dom\Node|\Dom\Node[]|string|null $node A Node to use as the base for the crawling
+     */
+    public function __construct(
+        \Dom\NodeList|\Dom\Node|array|string|null $node = null,
+        protected ?string $uri = null,
+        ?string $baseHref = null,
+    ) {
+        $this->baseHref = $baseHref ?: $uri;
+
+        $this->add($node);
+    }
+
+    public function getUri(): ?string
+    {
+        return $this->uri;
+    }
+
+    public function getBaseHref(): ?string
+    {
+        return $this->baseHref;
+    }
+
+    /**
+     * Removes all the nodes.
+     */
+    public function clear(): void
+    {
+        $this->nodes = [];
+        $this->document = null;
+    }
+
+    /**
+     * Adds a node to the current list of nodes.
+     *
+     * This method uses the appropriate specialized add*() method based
+     * on the type of the argument.
+     *
+     * @param \Dom\NodeList<\Dom\Node>|\Dom\Node|\Dom\Node[]|string|null $node
+     */
+    public function add(\Dom\NodeList|\Dom\Node|array|string|null $node): void
+    {
+        if ($node instanceof \Dom\NodeList) {
+            $this->addNodeList($node);
+        } elseif ($node instanceof \Dom\Node) {
+            $this->addNode($node);
+        } elseif (\is_array($node)) {
+            $this->addNodes($node);
+        } elseif (\is_string($node)) {
+            $this->addHtmlContent($node);
+        }
+    }
+
+    /**
+     * Adds an HTML document.
+     */
+    public function addHtmlContent(string $content, string $charset = 'UTF-8'): void
+    {
+        $this->addDocument($this->parseHtml($content, $charset));
+    }
+
+    /**
+     * Adds a \Dom\Document to the list of nodes.
+     */
+    public function addDocument(\Dom\Document $dom): void
+    {
+        if ($dom->documentElement) {
+            $this->addNode($dom->documentElement);
+        }
+    }
+
+    /**
+     * @param \Dom\NodeList<\Dom\Node> $nodes
+     */
+    public function addNodeList(\Dom\NodeList $nodes): void
+    {
+        foreach ($nodes as $node) {
+            if ($node instanceof \Dom\Node) {
+                $this->addNode($node);
+            }
+        }
+    }
+
+    /**
+     * @param \Dom\Node[] $nodes
+     */
+    public function addNodes(array $nodes): void
+    {
+        foreach ($nodes as $node) {
+            $this->add($node);
+        }
+    }
+
+    public function addNode(\Dom\Node $node): void
+    {
+        if ($node instanceof \Dom\Document) {
+            $node = $node->documentElement;
+
+            if (null === $node) {
+                return;
+            }
+        }
+
+        if (null !== $this->document && $this->document !== $node->ownerDocument) {
+            throw new \InvalidArgumentException('Attaching DOM nodes from multiple documents in the same crawler is forbidden.');
+        }
+
+        $this->document ??= $node->ownerDocument;
+
+        // Don't add duplicate nodes in the Crawler
+        if (\in_array($node, $this->nodes, true)) {
+            return;
+        }
+
+        $this->nodes[] = $node;
+    }
+
+    /**
+     * Returns a node given its position in the node list.
+     */
+    public function eq(int $position): static
+    {
+        if (isset($this->nodes[$position])) {
+            return $this->createSubCrawler($this->nodes[$position]);
+        }
+
+        return $this->createSubCrawler(null);
+    }
+
+    /**
+     * Calls an anonymous function on each node of the list.
+     *
+     * The anonymous function receives the position and the node wrapped
+     * in an HtmlCrawler instance as arguments.
+     *
+     * @template T
+     *
+     * @param \Closure(static, int): T $closure
+     *
+     * @return list<T>
+     */
+    public function each(\Closure $closure): array
+    {
+        $data = [];
+        foreach ($this->nodes as $i => $node) {
+            $data[] = $closure($this->createSubCrawler($node), $i);
+        }
+
+        return $data;
+    }
+
+    /**
+     * Slices the list of nodes by $offset and $length.
+     */
+    public function slice(int $offset = 0, ?int $length = null): static
+    {
+        return $this->createSubCrawler(\array_slice($this->nodes, $offset, $length));
+    }
+
+    /**
+     * Reduces the list of nodes by calling an anonymous function.
+     *
+     * To remove a node from the list, the anonymous function must return false.
+     *
+     * @param \Closure(static, int):bool $closure
+     */
+    public function reduce(\Closure $closure): static
+    {
+        $nodes = [];
+        foreach ($this->nodes as $i => $node) {
+            if (false !== $closure($this->createSubCrawler($node), $i)) {
+                $nodes[] = $node;
+            }
+        }
+
+        return $this->createSubCrawler($nodes);
+    }
+
+    /**
+     * Returns the first node of the current selection.
+     */
+    public function first(): static
+    {
+        return $this->eq(0);
+    }
+
+    /**
+     * Returns the last node of the current selection.
+     */
+    public function last(): static
+    {
+        return $this->eq(\count($this->nodes) - 1);
+    }
+
+    /**
+     * Returns the siblings nodes of the current selection.
+     *
+     * @throws \InvalidArgumentException When current node is empty
+     */
+    public function siblings(): static
+    {
+        if (!$this->nodes) {
+            throw new \InvalidArgumentException('The current node list is empty.');
+        }
+
+        return $this->createSubCrawler($this->sibling($this->getNode(0)->parentNode->firstChild));
+    }
+
+    /**
+     * Checks whether the first node of the list matches the given selector.
+     */
+    public function matches(string $selector): bool
+    {
+        if (!$this->nodes) {
+            return false;
+        }
+
+        $node = $this->getNode(0);
+
+        return $node instanceof \Dom\Element && $node->matches($selector);
+    }
+
+    /**
+     * Return first parents (heading toward the document root) of the Element that matches the provided selector.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/Element/closest
+     *
+     * @throws \InvalidArgumentException When current node is empty
+     */
+    public function closest(string $selector): ?static
+    {
+        if (!$this->nodes) {
+            throw new \InvalidArgumentException('The current node list is empty.');
+        }
+
+        $node = $this->getNode(0);
+
+        if (!$node instanceof \Dom\Element) {
+            return null;
+        }
+
+        return ($node = $node->closest($selector)) ? $this->createSubCrawler($node) : null;
+    }
+
+    /**
+     * Returns the next siblings nodes of the current selection.
+     *
+     * @throws \InvalidArgumentException When current node is empty
+     */
+    public function nextAll(): static
+    {
+        if (!$this->nodes) {
+            throw new \InvalidArgumentException('The current node list is empty.');
+        }
+
+        return $this->createSubCrawler($this->sibling($this->getNode(0)));
+    }
+
+    /**
+     * Returns the previous sibling nodes of the current selection.
+     *
+     * @throws \InvalidArgumentException When current node is empty
+     */
+    public function previousAll(): static
+    {
+        if (!$this->nodes) {
+            throw new \InvalidArgumentException('The current node list is empty.');
+        }
+
+        return $this->createSubCrawler($this->sibling($this->getNode(0), 'previousSibling'));
+    }
+
+    /**
+     * Returns the ancestors of the current selection.
+     *
+     * @throws \InvalidArgumentException When the current node is empty
+     */
+    public function ancestors(): static
+    {
+        if (!$this->nodes) {
+            throw new \InvalidArgumentException('The current node list is empty.');
+        }
+
+        $node = $this->getNode(0);
+        $nodes = [];
+
+        while ($node = $node->parentNode) {
+            if ($node instanceof \Dom\Element) {
+                $nodes[] = $node;
+            }
+        }
+
+        return $this->createSubCrawler($nodes);
+    }
+
+    /**
+     * Returns the children nodes of the current selection.
+     *
+     * @throws \InvalidArgumentException When the current node is empty
+     */
+    public function children(?string $selector = null): static
+    {
+        if (!$this->nodes) {
+            throw new \InvalidArgumentException('The current node list is empty.');
+        }
+
+        $node = $this->getNode(0)->firstChild;
+        $nodes = $node ? $this->sibling($node) : [];
+
+        if (null !== $selector) {
+            $nodes = array_values(array_filter($nodes, static fn (\Dom\Node $n) => $n instanceof \Dom\Element && $n->matches($selector)));
+        }
+
+        return $this->createSubCrawler($nodes);
+    }
+
+    /**
+     * Returns the attribute value of the first node of the list.
+     *
+     * @param string|null $default When not null: the value to return when the node or attribute is empty
+     *
+     * @throws \InvalidArgumentException When current node is empty
+     */
+    public function attr(string $attribute, ?string $default = null): ?string
+    {
+        if (!$this->nodes) {
+            if (null !== $default) {
+                return $default;
+            }
+
+            throw new \InvalidArgumentException('The current node list is empty.');
+        }
+
+        $node = $this->getNode(0);
+
+        return $node instanceof \Dom\Element && $node->hasAttribute($attribute) ? $node->getAttribute($attribute) : $default;
+    }
+
+    /**
+     * Returns the node name of the first node of the list.
+     *
+     * @throws \InvalidArgumentException When the current node is empty
+     */
+    public function nodeName(): string
+    {
+        if (!$this->nodes) {
+            throw new \InvalidArgumentException('The current node list is empty.');
+        }
+
+        $node = $this->getNode(0);
+
+        return $node instanceof \Dom\Element ? $node->localName : $node->nodeName;
+    }
+
+    /**
+     * Returns the text of the first node of the list.
+     *
+     * Pass true as the second argument to normalize whitespaces.
+     *
+     * @param string|null $default             When not null: the value to return when the current node is empty
+     * @param bool        $normalizeWhitespace Whether whitespaces should be trimmed and normalized to single spaces
+     *
+     * @throws \InvalidArgumentException When current node is empty
+     */
+    public function text(?string $default = null, bool $normalizeWhitespace = true): string
+    {
+        if (!$this->nodes) {
+            if (null !== $default) {
+                return $default;
+            }
+
+            throw new \InvalidArgumentException('The current node list is empty.');
+        }
+
+        $text = $this->getNode(0)->textContent;
+
+        if ($normalizeWhitespace) {
+            return $this->normalizeWhitespace($text);
+        }
+
+        return $text;
+    }
+
+    /**
+     * Returns only the inner text that is the direct descendent of the current node, excluding any child nodes.
+     *
+     * @param bool $normalizeWhitespace Whether whitespaces should be trimmed and normalized to single spaces
+     */
+    public function innerText(bool $normalizeWhitespace = true): string
+    {
+        foreach ($this->getNode(0)->childNodes as $childNode) {
+            if (!$childNode instanceof \Dom\Text && !$childNode instanceof \Dom\CDATASection) {
+                continue;
+            }
+            if (!$normalizeWhitespace) {
+                return $childNode->data;
+            }
+            if ('' !== trim($childNode->data)) {
+                return $this->normalizeWhitespace($childNode->data);
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * Returns the first node of the list as HTML.
+     *
+     * @param string|null $default When not null: the value to return when the current node is empty
+     *
+     * @throws \InvalidArgumentException When the current node is empty
+     */
+    public function html(?string $default = null): string
+    {
+        if (!$this->nodes || !$this->getNode(0) instanceof \Dom\Element) {
+            if (null !== $default) {
+                return $default;
+            }
+
+            throw new \InvalidArgumentException('The current node list is empty.');
+        }
+
+        return $this->getNode(0)->innerHTML;
+    }
+
+    /**
+     * Returns the first node of the list as an HTML string, including the node itself.
+     *
+     * @throws \InvalidArgumentException When the current node is empty
+     */
+    public function outerHtml(): string
+    {
+        if (!$this->nodes || !$this->getNode(0) instanceof \Dom\Element) {
+            throw new \InvalidArgumentException('The current node list is empty.');
+        }
+
+        return $this->getNode(0)->outerHTML;
+    }
+
+    /**
+     * Evaluates an XPath expression.
+     *
+     * Since an XPath expression might evaluate to either a simple type or a \Dom\NodeList,
+     * this method will return either an array of simple types or a new HtmlCrawler instance.
+     *
+     * @throws \LogicException when the crawler is uninitialized
+     */
+    public function evaluate(string $xpath): array|static
+    {
+        if (null === $this->document) {
+            throw new \LogicException('Cannot evaluate the expression on an uninitialized crawler.');
+        }
+
+        $xpath = $this->prefixXPath($xpath);
+        $domxpath = $this->createXPath();
+
+        $data = [];
+        foreach ($this->nodes as $node) {
+            $data[] = $domxpath->evaluate($xpath, $node);
+        }
+
+        if (isset($data[0]) && $data[0] instanceof \Dom\NodeList) {
+            return $this->createSubCrawler($data);
+        }
+
+        return $data;
+    }
+
+    /**
+     * Extracts information from the list of nodes.
+     *
+     * You can extract attributes or/and the node value (_text).
+     *
+     * Example:
+     *
+     *     $crawler->filter('h1 a')->extract(['_text', 'href']);
+     */
+    public function extract(array $attributes): array
+    {
+        $count = \count($attributes);
+
+        $data = [];
+        foreach ($this->nodes as $node) {
+            $elements = [];
+            foreach ($attributes as $attribute) {
+                if ('_text' === $attribute) {
+                    $elements[] = $node->textContent;
+                } elseif ('_name' === $attribute) {
+                    $elements[] = $node instanceof \Dom\Element ? $node->localName : $node->nodeName;
+                } else {
+                    $elements[] = $node instanceof \Dom\Element && $node->hasAttribute($attribute) ? $node->getAttribute($attribute) : null;
+                }
+            }
+
+            $data[] = 1 === $count ? $elements[0] : $elements;
+        }
+
+        return $data;
+    }
+
+    /**
+     * Filters the list of nodes with an XPath expression.
+     *
+     * The XPath expression is evaluated in the context of the crawler, which
+     * is considered as a fake parent of the elements inside it.
+     * This means that a child selector "div" or "./div" will match only
+     * the div elements of the current crawler, not their children.
+     *
+     * Unprefixed element name tests are matched against the HTML namespace the
+     * parser puts elements in, so "//div" selects div elements as expected.
+     */
+    public function filterXPath(string $xpath): static
+    {
+        $xpath = $this->relativize($xpath);
+
+        // If we dropped all expressions in the XPath while preparing it, there would be no match
+        if ('' === $xpath) {
+            return $this->createSubCrawler(null);
+        }
+
+        return $this->filterRelativeXPath($xpath);
+    }
+
+    /**
+     * Filters the list of nodes with a CSS selector.
+     *
+     * The selector is handled by the selector engine of the HTML parser, so
+     * every selector that engine supports can be used.
+     */
+    public function filter(string $selector): static
+    {
+        $crawler = $this->createSubCrawler(null);
+
+        foreach ($this->nodes as $node) {
+            if ($node instanceof \Dom\ParentNode) {
+                $crawler->addNodeList($node->querySelectorAll($selector));
+            }
+        }
+
+        return $crawler;
+    }
+
+    public function getNode(int $position): ?\Dom\Node
+    {
+        return $this->nodes[$position] ?? null;
+    }
+
+    public function count(): int
+    {
+        return \count($this->nodes);
+    }
+
+    /**
+     * @return \ArrayIterator<int, \Dom\Node>
+     */
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->nodes);
+    }
+
+    private function parseHtml(string $htmlContent, string $charset = 'UTF-8'): \Dom\HTMLDocument
+    {
+        // Elements are put in the HTML namespace on purpose: the selector engine
+        // only applies HTML semantics, such as case-insensitive tag names and the
+        // pseudo-classes that depend on the kind of an element, to elements that
+        // are in it.
+        try {
+            return \Dom\HTMLDocument::createFromString($htmlContent, 0, $charset);
+        } catch (\ValueError) {
+            return \Dom\HTMLDocument::createFromString($htmlContent, 0);
+        }
+    }
+
+    private function createXPath(): \Dom\XPath
+    {
+        $xpath = new \Dom\XPath($this->document);
+        $xpath->registerNamespace(self::XPATH_PREFIX, self::HTML_NAMESPACE);
+
+        return $xpath;
+    }
+
+    private function filterRelativeXPath(string $xpath): static
+    {
+        $crawler = $this->createSubCrawler(null);
+
+        if (null === $this->document) {
+            return $crawler;
+        }
+
+        $xpath = $this->prefixXPath($xpath);
+        $domxpath = $this->createXPath();
+
+        foreach ($this->nodes as $node) {
+            $crawler->addNodeList($domxpath->query($xpath, $node));
+        }
+
+        return $crawler;
+    }
+
+    /**
+     * Prefixes unprefixed element name tests with the HTML namespace prefix.
+     *
+     * XPath 1.0 resolves an unprefixed name test against no namespace at all,
+     * so "//div" cannot match an element the parser put in the HTML namespace.
+     * Names that are already prefixed, node type tests, function calls,
+     * wildcards, attributes, variables and string literals are left alone.
+     */
+    private function prefixXPath(string $xpath): string
+    {
+        return preg_replace_callback(
+            <<<'REGEXP'
+                /
+                    "[^"]*+" | '[^']*+'         (*SKIP)(*FAIL)  # skip string literals
+                  | \$[\w.-]++                  (*SKIP)(*FAIL)  # skip variable references
+                  | @[\w.:-]++                  (*SKIP)(*FAIL)  # skip attribute name tests
+                  | (?<![\w.-])                                 # not in the middle of a name
+                    (?<!(?<!:):)                                # not after a namespace separator, but "::" is an axis
+                    (?P<name>[A-Za-z_][\w.-]*+)
+                    (?![\w.-]*+ \s*+ [(:])                      # neither a function call nor a prefix itself
+                /x
+                REGEXP,
+            static fn (array $m) => isset($m['name']) && '' !== $m['name'] ? self::XPATH_PREFIX.':'.$m['name'] : $m[0],
+            $xpath
+        );
+    }
+
+    /**
+     * @return list<\Dom\Node>
+     */
+    private function sibling(\Dom\Node $node, string $siblingDir = 'nextSibling'): array
+    {
+        $nodes = [];
+
+        $currentNode = $this->getNode(0);
+        do {
+            if ($node !== $currentNode && $node instanceof \Dom\Element) {
+                $nodes[] = $node;
+            }
+        } while ($node = $node->$siblingDir);
+
+        return $nodes;
+    }
+
+    private function normalizeWhitespace(string $string): string
+    {
+        return trim(preg_replace("/(?:[ \n\r\t\x0C]{2,}+|[\n\r\t\x0C])/", ' ', $string), " \n\r\t\x0C");
+    }
+
+    /**
+     * Make the XPath relative to the current context.
+     *
+     * The returned XPath will match elements matching the XPath inside the current crawler
+     * when running in the context of a node of the crawler.
+     */
+    private function relativize(string $xpath): string
+    {
+        $expressions = [];
+
+        // An expression which will never match to replace expressions which cannot match in the crawler
+        $nonMatchingExpression = 'a[name() = "b"]';
+
+        $xpathLen = \strlen($xpath);
+        $openedBrackets = 0;
+        $startPosition = strspn($xpath, " \t\n\r\0\x0B");
+
+        for ($i = $startPosition; $i <= $xpathLen; ++$i) {
+            $i += strcspn($xpath, '"\'[]|', $i);
+
+            if ($i < $xpathLen) {
+                switch ($xpath[$i]) {
+                    case '"':
+                    case "'":
+                        if (false === $i = strpos($xpath, $xpath[$i], $i + 1)) {
+                            return $xpath; // The XPath expression is invalid
+                        }
+                        continue 2;
+                    case '[':
+                        ++$openedBrackets;
+                        continue 2;
+                    case ']':
+                        --$openedBrackets;
+                        continue 2;
+                }
+            }
+            if ($openedBrackets) {
+                continue;
+            }
+
+            if ($startPosition < $xpathLen && '(' === $xpath[$startPosition]) {
+                // If the union is inside some braces, we need to preserve the opening braces and apply
+                // the change only inside it.
+                $j = 1 + strspn($xpath, "( \t\n\r\0\x0B", $startPosition + 1);
+                $parenthesis = substr($xpath, $startPosition, $j);
+                $startPosition += $j;
+            } else {
+                $parenthesis = '';
+            }
+            $expression = rtrim(substr($xpath, $startPosition, $i - $startPosition));
+
+            if (str_starts_with($expression, 'self::*/')) {
+                $expression = './'.substr($expression, 8);
+            }
+
+            // add prefix before absolute element selector
+            if ('' === $expression) {
+                $expression = $nonMatchingExpression;
+            } elseif (str_starts_with($expression, '//')) {
+                $expression = 'descendant-or-self::'.substr($expression, 2);
+            } elseif (str_starts_with($expression, './/')) {
+                $expression = 'descendant-or-self::'.substr($expression, 3);
+            } elseif (str_starts_with($expression, './')) {
+                $expression = 'self::'.substr($expression, 2);
+            } elseif (str_starts_with($expression, 'child::')) {
+                $expression = 'self::'.substr($expression, 7);
+            } elseif ('/' === $expression[0] || '.' === $expression[0] || str_starts_with($expression, 'self::')) {
+                $expression = $nonMatchingExpression;
+            } elseif (str_starts_with($expression, 'descendant::')) {
+                $expression = 'descendant-or-self::'.substr($expression, 12);
+            } elseif (preg_match('/^(ancestor|ancestor-or-self|attribute|following|following-sibling|namespace|parent|preceding|preceding-sibling)::/', $expression)) {
+                // the fake root has no parent, preceding or following nodes and also no attributes (even no namespace attributes)
+                $expression = $nonMatchingExpression;
+            } elseif (!str_starts_with($expression, 'descendant-or-self::')) {
+                $expression = 'self::'.$expression;
+            }
+            $expressions[] = $parenthesis.$expression;
+
+            if ($i === $xpathLen) {
+                return implode(' | ', $expressions);
+            }
+
+            $i += strspn($xpath, " \t\n\r\0\x0B", $i + 1);
+            $startPosition = $i + 1;
+        }
+
+        return $xpath; // The XPath expression is invalid
+    }
+
+    /**
+     * Creates a crawler for some subnodes.
+     *
+     * @param \Dom\NodeList<\Dom\Node>|\Dom\Node|\Dom\Node[]|string|null $nodes
+     */
+    private function createSubCrawler(\Dom\NodeList|\Dom\Node|array|string|null $nodes): static
+    {
+        $crawler = new static($nodes, $this->uri, $this->baseHref);
+        $crawler->document = $this->document;
+
+        return $crawler;
+    }
+}

--- a/src/Symfony/Component/DomCrawler/HtmlForm.php
+++ b/src/Symfony/Component/DomCrawler/HtmlForm.php
@@ -11,31 +11,31 @@
 
 namespace Symfony\Component\DomCrawler;
 
-use Symfony\Component\DomCrawler\Field\ChoiceFormField;
-use Symfony\Component\DomCrawler\Field\FormField;
+use Symfony\Component\DomCrawler\Field\HtmlChoiceFormField;
+use Symfony\Component\DomCrawler\Field\HtmlFormField;
 
 /**
- * Form represents an HTML form.
+ * HtmlForm represents an HTML form, backed by the native HTML parser.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class Form extends Link implements \ArrayAccess
+class HtmlForm extends HtmlLink implements \ArrayAccess
 {
     use FormTrait;
 
-    private \DOMElement $button;
-    private FormFieldRegistry $fields;
+    private \Dom\Element $button;
+    private HtmlFormFieldRegistry $fields;
 
     /**
-     * @param \DOMElement $node       A \DOMElement instance
-     * @param string|null $currentUri The URI of the page where the form is embedded
-     * @param string|null $method     The method to use for the link (if null, it defaults to the method defined by the form)
-     * @param string|null $baseHref   The URI of the <base> used for relative links, but not for empty action
+     * @param \Dom\Element $node       A \Dom\Element instance
+     * @param string|null  $currentUri The URI of the page where the form is embedded
+     * @param string|null  $method     The method to use for the link (if null, it defaults to the method defined by the form)
+     * @param string|null  $baseHref   The URI of the <base> used for relative links, but not for empty action
      *
      * @throws \LogicException if the node is not a button inside a form tag
      */
     public function __construct(
-        \DOMElement $node,
+        \Dom\Element $node,
         ?string $currentUri = null,
         ?string $method = null,
         private ?string $baseHref = null,
@@ -48,7 +48,7 @@ class Form extends Link implements \ArrayAccess
     /**
      * Gets the form node associated with this form.
      */
-    public function getFormNode(): \DOMElement
+    public function getFormNode(): \Dom\Element
     {
         return $this->node;
     }
@@ -66,7 +66,7 @@ class Form extends Link implements \ArrayAccess
                 continue;
             }
 
-            if (!$field instanceof Field\FileFormField && $field->hasValue()) {
+            if (!$field instanceof Field\HtmlFileFormField && $field->hasValue()) {
                 $values[$name] = $field->getValue();
             }
         }
@@ -90,7 +90,7 @@ class Form extends Link implements \ArrayAccess
                 continue;
             }
 
-            if ($field instanceof Field\FileFormField) {
+            if ($field instanceof Field\HtmlFileFormField) {
                 $files[$name] = $field->getValue();
             }
         }
@@ -101,11 +101,11 @@ class Form extends Link implements \ArrayAccess
     /**
      * Gets a named field.
      *
-     * @return FormField|FormField[]|FormField[][]
+     * @return HtmlFormField|HtmlFormField[]|HtmlFormField[][]
      *
      * @throws \InvalidArgumentException When field is not present in this form
      */
-    public function get(string $name): FormField|array
+    public function get(string $name): HtmlFormField|array
     {
         return $this->fields->get($name);
     }
@@ -113,7 +113,7 @@ class Form extends Link implements \ArrayAccess
     /**
      * Sets a named field.
      */
-    public function set(FormField $field): void
+    public function set(HtmlFormField $field): void
     {
         $this->fields->add($field);
     }
@@ -121,7 +121,7 @@ class Form extends Link implements \ArrayAccess
     /**
      * Gets all fields.
      *
-     * @return FormField[]
+     * @return HtmlFormField[]
      */
     public function all(): array
     {
@@ -133,11 +133,11 @@ class Form extends Link implements \ArrayAccess
      *
      * @param string $name The field name
      *
-     * @return FormField|FormField[]|FormField[][]
+     * @return HtmlFormField|HtmlFormField[]|HtmlFormField[][]
      *
      * @throws \InvalidArgumentException if the field does not exist
      */
-    public function offsetGet(mixed $name): FormField|array
+    public function offsetGet(mixed $name): HtmlFormField|array
     {
         return $this->fields->get($name);
     }
@@ -150,7 +150,7 @@ class Form extends Link implements \ArrayAccess
     public function disableValidation(): static
     {
         foreach ($this->fields->all() as $field) {
-            if ($field instanceof ChoiceFormField) {
+            if ($field instanceof HtmlChoiceFormField) {
                 $field->disableValidation();
             }
         }
@@ -161,14 +161,14 @@ class Form extends Link implements \ArrayAccess
     /**
      * Sets the node for the form.
      *
-     * Expects a 'submit' button \DOMElement and finds the corresponding form element, or the form element itself.
+     * Expects a 'submit' button \Dom\Element and finds the corresponding form element, or the form element itself.
      *
      * @throws \LogicException If given node is not a button or input or does not have a form ancestor
      */
-    protected function setNode(\DOMElement $node): void
+    protected function setNode(\Dom\Element $node): void
     {
         $this->button = $node;
-        if ('button' === $node->localName || ('input' === $node->localName && \in_array(strtolower($node->getAttribute('type')), ['submit', 'button', 'image'], true))) {
+        if ('button' === $node->localName || ('input' === $node->localName && \in_array(strtolower($node->getAttribute('type') ?? ''), ['submit', 'button', 'image'], true))) {
             if ($node->hasAttribute('form')) {
                 // if the node has the HTML5-compliant 'form' attribute, use it
                 $formId = $node->getAttribute('form');
@@ -185,7 +185,7 @@ class Form extends Link implements \ArrayAccess
                 if (null === $node = $node->parentNode) {
                     throw new \LogicException('The selected node does not have a form ancestor.');
                 }
-            } while ('form' !== $node->localName);
+            } while (!$node instanceof \Dom\Element || 'form' !== $node->localName);
         } elseif ('form' !== $node->localName) {
             throw new \LogicException(\sprintf('Unable to submit on a "%s" tag.', $node->localName));
         }
@@ -202,26 +202,26 @@ class Form extends Link implements \ArrayAccess
      */
     private function initialize(): void
     {
-        $this->fields = new FormFieldRegistry();
+        $this->fields = new HtmlFormFieldRegistry();
 
         // add submitted button if it has a valid name
         if ('form' !== $this->button->localName && $this->button->hasAttribute('name') && $this->button->getAttribute('name')) {
-            if ('input' == $this->button->localName && 'image' == strtolower($this->button->getAttribute('type'))) {
+            if ('input' === $this->button->localName && 'image' === strtolower($this->button->getAttribute('type') ?? '')) {
                 $name = $this->button->getAttribute('name');
                 $this->button->setAttribute('value', '0');
 
                 // temporarily change the name of the input node for the x coordinate
                 $this->button->setAttribute('name', $name.'.x');
-                $this->set(new Field\InputFormField($this->button));
+                $this->set(new Field\HtmlInputFormField($this->button));
 
                 // temporarily change the name of the input node for the y coordinate
                 $this->button->setAttribute('name', $name.'.y');
-                $this->set(new Field\InputFormField($this->button));
+                $this->set(new Field\HtmlInputFormField($this->button));
 
                 // restore the original name of the input node
                 $this->button->setAttribute('name', $name);
             } else {
-                $this->set(new Field\InputFormField($this->button));
+                $this->set(new Field\HtmlInputFormField($this->button));
             }
         }
 
@@ -229,34 +229,36 @@ class Form extends Link implements \ArrayAccess
             $this->addField($node);
         }
 
-        if ($this->baseHref && '' !== $this->node->getAttribute('action')) {
+        if ($this->baseHref && '' !== ($this->node->getAttribute('action') ?? '')) {
             $this->currentUri = $this->baseHref;
         }
     }
 
-    private function addField(\DOMElement $node): void
+    private function addField(\Dom\Element $node): void
     {
         if (!$node->hasAttribute('name') || !$node->getAttribute('name')) {
             return;
         }
 
         $localName = $node->localName;
-        if ('select' == $localName || 'input' == $localName && 'checkbox' == strtolower($node->getAttribute('type'))) {
-            $this->set(new ChoiceFormField($node));
-        } elseif ('input' == $localName && 'radio' == strtolower($node->getAttribute('type'))) {
+        $type = strtolower($node->getAttribute('type') ?? '');
+
+        if ('select' === $localName || 'input' === $localName && 'checkbox' === $type) {
+            $this->set(new HtmlChoiceFormField($node));
+        } elseif ('input' === $localName && 'radio' === $type) {
             // there may be other fields with the same name that are no choice
-            // fields already registered (see https://github.com/symfony/symfony/issues/11689)
-            if ($this->has($node->getAttribute('name')) && $this->get($node->getAttribute('name')) instanceof ChoiceFormField) {
+            // fields already registered
+            if ($this->has($node->getAttribute('name')) && $this->get($node->getAttribute('name')) instanceof HtmlChoiceFormField) {
                 $this->get($node->getAttribute('name'))->addChoice($node);
             } else {
-                $this->set(new ChoiceFormField($node));
+                $this->set(new HtmlChoiceFormField($node));
             }
-        } elseif ('input' == $localName && 'file' == strtolower($node->getAttribute('type'))) {
-            $this->set(new Field\FileFormField($node));
-        } elseif ('input' == $localName && !\in_array(strtolower($node->getAttribute('type')), ['submit', 'button', 'image'], true)) {
-            $this->set(new Field\InputFormField($node));
-        } elseif ('textarea' == $localName) {
-            $this->set(new Field\TextareaFormField($node));
+        } elseif ('input' === $localName && 'file' === $type) {
+            $this->set(new Field\HtmlFileFormField($node));
+        } elseif ('input' === $localName && !\in_array($type, ['submit', 'button', 'image'], true)) {
+            $this->set(new Field\HtmlInputFormField($node));
+        } elseif ('textarea' === $localName) {
+            $this->set(new Field\HtmlTextareaFormField($node));
         }
     }
 }

--- a/src/Symfony/Component/DomCrawler/HtmlForm.php
+++ b/src/Symfony/Component/DomCrawler/HtmlForm.php
@@ -18,6 +18,8 @@ use Symfony\Component\DomCrawler\Field\HtmlFormField;
  * HtmlForm represents an HTML form, backed by the native HTML parser.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @implements \ArrayAccess<string, HtmlFormField|array<HtmlFormField>>
  */
 class HtmlForm extends HtmlLink implements \ArrayAccess
 {
@@ -248,8 +250,10 @@ class HtmlForm extends HtmlLink implements \ArrayAccess
         } elseif ('input' === $localName && 'radio' === $type) {
             // there may be other fields with the same name that are no choice
             // fields already registered
-            if ($this->has($node->getAttribute('name')) && $this->get($node->getAttribute('name')) instanceof HtmlChoiceFormField) {
-                $this->get($node->getAttribute('name'))->addChoice($node);
+            $field = $this->has($node->getAttribute('name')) ? $this->get($node->getAttribute('name')) : null;
+
+            if ($field instanceof HtmlChoiceFormField) {
+                $field->addChoice($node);
             } else {
                 $this->set(new HtmlChoiceFormField($node));
             }

--- a/src/Symfony/Component/DomCrawler/HtmlFormFieldRegistry.php
+++ b/src/Symfony/Component/DomCrawler/HtmlFormFieldRegistry.php
@@ -24,6 +24,8 @@ class HtmlFormFieldRegistry
 
     /**
      * Adds a field to the registry.
+     *
+     * @psalm-suppress UnsupportedPropertyReferenceUsage the property is declared in FormFieldRegistryTrait
      */
     public function add(HtmlFormField $field): void
     {
@@ -50,6 +52,8 @@ class HtmlFormFieldRegistry
      * @return HtmlFormField|HtmlFormField[]|HtmlFormField[][]
      *
      * @throws \InvalidArgumentException if the field does not exist
+     *
+     * @psalm-suppress UnsupportedPropertyReferenceUsage the property is declared in FormFieldRegistryTrait
      */
     public function &get(string $name): HtmlFormField|array
     {
@@ -77,7 +81,7 @@ class HtmlFormFieldRegistry
         if ((!\is_array($value) && $target instanceof HtmlFormField) || $target instanceof Field\HtmlChoiceFormField) {
             $target->setValue($value);
         } elseif (\is_array($value)) {
-            $registry = new static();
+            $registry = new self();
             $registry->base = $name;
             $registry->fields = $value;
             foreach ($registry->all() as $k => $v) {

--- a/src/Symfony/Component/DomCrawler/HtmlFormFieldRegistry.php
+++ b/src/Symfony/Component/DomCrawler/HtmlFormFieldRegistry.php
@@ -11,21 +11,21 @@
 
 namespace Symfony\Component\DomCrawler;
 
-use Symfony\Component\DomCrawler\Field\FormField;
+use Symfony\Component\DomCrawler\Field\HtmlFormField;
 
 /**
  * This is an internal class that must not be used directly.
  *
  * @internal
  */
-class FormFieldRegistry
+class HtmlFormFieldRegistry
 {
     use FormFieldRegistryTrait;
 
     /**
      * Adds a field to the registry.
      */
-    public function add(FormField $field): void
+    public function add(HtmlFormField $field): void
     {
         $segments = $this->getSegments($field->getName());
 
@@ -47,11 +47,11 @@ class FormFieldRegistry
     /**
      * Returns the value of the field based on the fully qualified name and its children.
      *
-     * @return FormField|FormField[]|FormField[][]
+     * @return HtmlFormField|HtmlFormField[]|HtmlFormField[][]
      *
      * @throws \InvalidArgumentException if the field does not exist
      */
-    public function &get(string $name): FormField|array
+    public function &get(string $name): HtmlFormField|array
     {
         $segments = $this->getSegments($name);
         $target = &$this->fields;
@@ -74,7 +74,7 @@ class FormFieldRegistry
     public function set(string $name, mixed $value): void
     {
         $target = &$this->get($name);
-        if ((!\is_array($value) && $target instanceof FormField) || $target instanceof Field\ChoiceFormField) {
+        if ((!\is_array($value) && $target instanceof HtmlFormField) || $target instanceof Field\HtmlChoiceFormField) {
             $target->setValue($value);
         } elseif (\is_array($value)) {
             $registry = new static();

--- a/src/Symfony/Component/DomCrawler/HtmlImage.php
+++ b/src/Symfony/Component/DomCrawler/HtmlImage.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DomCrawler;
+
+/**
+ * HtmlImage represents an HTML image (an HTML img tag).
+ */
+class HtmlImage extends AbstractHtmlUriElement
+{
+    public function __construct(\Dom\Element $node, ?string $currentUri = null)
+    {
+        parent::__construct($node, $currentUri, 'GET');
+    }
+
+    protected function getRawUri(): string
+    {
+        return $this->node->getAttribute('src') ?? '';
+    }
+
+    protected function setNode(\Dom\Element $node): void
+    {
+        if ('img' !== $node->localName) {
+            throw new \LogicException(\sprintf('Unable to visualize a "%s" tag.', $node->localName));
+        }
+
+        $this->node = $node;
+    }
+}

--- a/src/Symfony/Component/DomCrawler/HtmlLink.php
+++ b/src/Symfony/Component/DomCrawler/HtmlLink.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DomCrawler;
+
+/**
+ * HtmlLink represents an HTML link (an HTML a, area or link tag).
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class HtmlLink extends AbstractHtmlUriElement
+{
+    protected function getRawUri(): string
+    {
+        return $this->node->getAttribute('href') ?? '';
+    }
+
+    protected function setNode(\Dom\Element $node): void
+    {
+        if ('a' !== $node->localName && 'area' !== $node->localName && 'link' !== $node->localName) {
+            throw new \LogicException(\sprintf('Unable to navigate from a "%s" tag.', $node->localName));
+        }
+
+        $this->node = $node;
+    }
+}

--- a/src/Symfony/Component/DomCrawler/Tests/Field/FormFieldTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/Field/FormFieldTest.php
@@ -58,6 +58,18 @@ class FormFieldTest extends FormFieldTestCase
         $this->assertEquals('Foo label', $field->getLabel()->textContent, '->getLabel() returns the associated label');
     }
 
+    public function testLabelIsAssignedByForAttributeContainingAQuote()
+    {
+        $dom = new \DOMDocument();
+        $dom->loadHTML('<html><form>
+            <label for=\'a"b\'>Foo label</label>
+            <input type="text" id=\'a"b\' name="foo" value="foo" />
+        </form></html>');
+
+        $field = new InputFormField($dom->getElementById('a"b'));
+        $this->assertEquals('Foo label', $field->getLabel()->textContent, '->getLabel() returns the associated label');
+    }
+
     public function testLabelIsAssignedByParentingRelation()
     {
         $dom = new \DOMDocument();

--- a/src/Symfony/Component/DomCrawler/Tests/Field/FormFieldTestCase.php
+++ b/src/Symfony/Component/DomCrawler/Tests/Field/FormFieldTestCase.php
@@ -26,4 +26,22 @@ class FormFieldTestCase extends TestCase
 
         return $node;
     }
+
+    /**
+     * The native parser has no way to build an element out of a document, so the
+     * node is parsed instead of created, then given its attributes. The closing
+     * tag is left out because the parser rejects one on a void element such as
+     * input, and closes every other element on its own.
+     */
+    protected function createHtmlNode(string $tag, string $value = '', array $attributes = []): \Dom\Element
+    {
+        $document = \Dom\HTMLDocument::createFromString(\sprintf('<!doctype html><body><%s>%s', $tag, $value), 0);
+        $node = $document->querySelector($tag);
+
+        foreach ($attributes as $name => $attributeValue) {
+            $node->setAttribute($name, $attributeValue);
+        }
+
+        return $node;
+    }
 }

--- a/src/Symfony/Component/DomCrawler/Tests/Field/HtmlChoiceFormFieldTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/Field/HtmlChoiceFormFieldTest.php
@@ -47,7 +47,6 @@ class HtmlChoiceFormFieldTest extends FormFieldTestCase
         yield 'options without a value attribute' => ['<select name="n"><option>Foo</option><option>Bar</option></select>', 'select'];
         yield 'option with an empty text' => ['<select name="n"><option></option><option>Bar</option></select>', 'select'];
         yield 'options in an optgroup' => ['<select name="n"><optgroup label="G"><option value="foo">Foo</option></optgroup></select>', 'select'];
-        yield 'option holding markup' => ['<select name="n"><option value="foo"><b>bold</b> tail</option></select>', 'select'];
         yield 'option text needing normalization' => ['<select name="n"><option value="foo">  Foo   bar  </option></select>', 'select'];
         yield 'unchecked checkbox' => ['<input type="checkbox" name="n" value="foo">', 'input'];
         yield 'checked checkbox' => ['<input type="checkbox" name="n" value="foo" checked>', 'input'];
@@ -72,13 +71,13 @@ class HtmlChoiceFormFieldTest extends FormFieldTestCase
      */
     public function testOptionTextIsReadFromTheTextContent()
     {
-        $html = '<select name="n"><option value="foo"><b>bold</b> tail</option><option value="bar">Tom &amp; Jerry</option></select>';
+        $html = '<select name="n"><option value="foo">  Tom &amp;   Jerry  </option><option value="bar">Plain</option></select>';
         $field = new HtmlChoiceFormField($this->nativeNode($html, 'select'));
 
-        $field->selectByText('bold tail');
+        $field->selectByText('Tom & Jerry');
         $this->assertSame('foo', $field->getValue());
 
-        $field->selectByText('Tom & Jerry');
+        $field->selectByText('Plain');
         $this->assertSame('bar', $field->getValue());
     }
 

--- a/src/Symfony/Component/DomCrawler/Tests/Field/HtmlChoiceFormFieldTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/Field/HtmlChoiceFormFieldTest.php
@@ -1,0 +1,332 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DomCrawler\Tests\Field;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Component\DomCrawler\Field\ChoiceFormField;
+use Symfony\Component\DomCrawler\Field\HtmlChoiceFormField;
+
+class HtmlChoiceFormFieldTest extends FormFieldTestCase
+{
+    /**
+     * The native and the classic fields must read the same document the same way.
+     */
+    #[DataProvider('provideFields')]
+    public function testMatchesClassic(string $html, string $selector)
+    {
+        $native = new HtmlChoiceFormField($this->nativeNode($html, $selector));
+        $classic = new ChoiceFormField($this->classicNode($html, $selector));
+
+        $this->assertSame($classic->getType(), $native->getType());
+        $this->assertSame($classic->isMultiple(), $native->isMultiple());
+        $this->assertSame($classic->getValue(), $native->getValue());
+        $this->assertSame($classic->hasValue(), $native->hasValue());
+        $this->assertSame($classic->isDisabled(), $native->isDisabled());
+        $this->assertSame($classic->availableOptionValues(), $native->availableOptionValues());
+    }
+
+    public static function provideFields(): iterable
+    {
+        yield 'select, no option selected' => ['<select name="n"><option value="foo">foo</option><option value="bar">bar</option></select>', 'select'];
+        yield 'select, second option selected' => ['<select name="n"><option value="foo">foo</option><option value="bar" selected>bar</option></select>', 'select'];
+        yield 'select with an empty selected attribute' => ['<select name="n"><option value="foo">foo</option><option value="bar" selected="">bar</option></select>', 'select'];
+        yield 'select without options' => ['<select name="n"></select>', 'select'];
+        yield 'select with a disabled attribute' => ['<select name="n" disabled><option value="foo">foo</option></select>', 'select'];
+        yield 'select with a disabled option selected' => ['<select name="n"><option value="foo" disabled selected>foo</option><option value="bar">bar</option></select>', 'select'];
+        yield 'multiple select' => ['<select name="n[]" multiple><option value="foo" selected>foo</option><option value="bar">bar</option></select>', 'select'];
+        yield 'multiple select, nothing selected' => ['<select name="n[]" multiple><option value="foo">foo</option></select>', 'select'];
+        yield 'options without a value attribute' => ['<select name="n"><option>Foo</option><option>Bar</option></select>', 'select'];
+        yield 'option with an empty text' => ['<select name="n"><option></option><option>Bar</option></select>', 'select'];
+        yield 'options in an optgroup' => ['<select name="n"><optgroup label="G"><option value="foo">Foo</option></optgroup></select>', 'select'];
+        yield 'option holding markup' => ['<select name="n"><option value="foo"><b>bold</b> tail</option></select>', 'select'];
+        yield 'option text needing normalization' => ['<select name="n"><option value="foo">  Foo   bar  </option></select>', 'select'];
+        yield 'unchecked checkbox' => ['<input type="checkbox" name="n" value="foo">', 'input'];
+        yield 'checked checkbox' => ['<input type="checkbox" name="n" value="foo" checked>', 'input'];
+        yield 'checkbox without a value attribute' => ['<input type="checkbox" name="n" checked>', 'input'];
+        yield 'disabled checkbox' => ['<input type="checkbox" name="n" value="foo" disabled>', 'input'];
+        yield 'uppercased checkbox type' => ['<input type="CHECKBOX" name="n" value="foo">', 'input'];
+        yield 'unchecked radio' => ['<input type="radio" name="n" value="foo">', 'input'];
+        yield 'checked radio' => ['<input type="radio" name="n" value="foo" checked>', 'input'];
+        yield 'disabled radio' => ['<input type="radio" name="n" value="foo" disabled checked>', 'input'];
+    }
+
+    public function testMultipleSelectDropsTheBracketsFromTheName()
+    {
+        $field = new HtmlChoiceFormField($this->nativeNode('<select name="n[]" multiple><option value="foo">foo</option></select>', 'select'));
+
+        $this->assertSame('n', $field->getName());
+    }
+
+    /**
+     * The option text is read from the text content, because the native DOM
+     * reports a null nodeValue for an element.
+     */
+    public function testOptionTextIsReadFromTheTextContent()
+    {
+        $html = '<select name="n"><option value="foo"><b>bold</b> tail</option><option value="bar">Tom &amp; Jerry</option></select>';
+        $field = new HtmlChoiceFormField($this->nativeNode($html, 'select'));
+
+        $field->selectByText('bold tail');
+        $this->assertSame('foo', $field->getValue());
+
+        $field->selectByText('Tom & Jerry');
+        $this->assertSame('bar', $field->getValue());
+    }
+
+    public function testOptionWithoutAValueAttributeFallsBackToItsText()
+    {
+        $field = new HtmlChoiceFormField($this->nativeNode('<select name="n"><option>Foo</option><option>Bar</option></select>', 'select'));
+
+        $field->select('Bar');
+        $this->assertSame('Bar', $field->getValue());
+    }
+
+    public function testOptionWithoutAValueOrATextHasAnEmptyValue()
+    {
+        $field = new HtmlChoiceFormField($this->nativeNode('<select name="n"><option></option><option>Bar</option></select>', 'select'));
+
+        $this->assertSame(['', 'Bar'], $field->availableOptionValues());
+        $this->assertSame('', $field->getValue());
+    }
+
+    public function testCheckboxWithoutAValueDefaultsToOn()
+    {
+        $field = new HtmlChoiceFormField($this->nativeNode('<input type="checkbox" name="n">', 'input'));
+
+        $this->assertSame(['on'], $field->availableOptionValues());
+    }
+
+    public function testIsDisabledWhenTheSelectedOptionIsDisabled()
+    {
+        $field = new HtmlChoiceFormField($this->nativeNode('<select name="n"><option value="foo" disabled selected>foo</option><option value="bar">bar</option></select>', 'select'));
+
+        $this->assertTrue($field->isDisabled());
+
+        $field->setValue('bar');
+        $this->assertFalse($field->isDisabled());
+    }
+
+    public function testSetValue()
+    {
+        $field = new HtmlChoiceFormField($this->nativeNode('<select name="n"><option value="foo">foo</option><option value="bar">bar</option></select>', 'select'));
+
+        $this->assertSame('foo', $field->getValue());
+
+        $field->setValue('bar');
+        $this->assertSame('bar', $field->getValue());
+    }
+
+    public function testSetValueRejectsAnUnknownValue()
+    {
+        $field = new HtmlChoiceFormField($this->nativeNode('<select name="n"><option value="foo">foo</option></select>', 'select'));
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Input "n" cannot take "bar" as a value (possible values: "foo").');
+
+        $field->setValue('bar');
+    }
+
+    public function testSetValueRejectsAnArrayOnASingleSelect()
+    {
+        $field = new HtmlChoiceFormField($this->nativeNode('<select name="n"><option value="foo">foo</option></select>', 'select'));
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The value for "n" cannot be an array.');
+
+        $field->setValue(['foo']);
+    }
+
+    public function testSetValueOnAMultipleSelect()
+    {
+        $field = new HtmlChoiceFormField($this->nativeNode('<select name="n[]" multiple><option value="foo">foo</option><option value="bar">bar</option></select>', 'select'));
+
+        $field->setValue(['foo', 'bar']);
+        $this->assertSame(['foo', 'bar'], $field->getValue());
+
+        $field->setValue('bar');
+        $this->assertSame(['bar'], $field->getValue());
+    }
+
+    public function testTickAndUntick()
+    {
+        $field = new HtmlChoiceFormField($this->nativeNode('<input type="checkbox" name="n">', 'input'));
+
+        $this->assertNull($field->getValue());
+        $this->assertFalse($field->hasValue());
+
+        $field->tick();
+        $this->assertSame('on', $field->getValue());
+        $this->assertTrue($field->hasValue());
+
+        $field->untick();
+        $this->assertNull($field->getValue());
+        $this->assertFalse($field->hasValue());
+    }
+
+    public function testTickUsesTheValueAttribute()
+    {
+        $field = new HtmlChoiceFormField($this->nativeNode('<input type="checkbox" name="n" value="yes">', 'input'));
+        $field->tick();
+
+        $this->assertSame('yes', $field->getValue());
+    }
+
+    public function testTickRejectsANonCheckbox()
+    {
+        $field = new HtmlChoiceFormField($this->nativeNode('<input type="radio" name="n" value="foo">', 'input'));
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('You cannot tick "n" as it is not a checkbox (radio).');
+
+        $field->tick();
+    }
+
+    public function testUntickRejectsANonCheckbox()
+    {
+        $field = new HtmlChoiceFormField($this->nativeNode('<select name="n"><option value="foo">foo</option></select>', 'select'));
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('You cannot untick "n" as it is not a checkbox (select).');
+
+        $field->untick();
+    }
+
+    public function testAddChoiceToASelect()
+    {
+        $document = \Dom\HTMLDocument::createFromString('<!doctype html><body><select name="n"><option value="foo">foo</option></select><select><option value="baz" selected>baz</option></select>', 0);
+        $field = new HtmlChoiceFormField($document->querySelector('select'));
+
+        $field->addChoice($document->querySelectorAll('option')[1]);
+
+        $this->assertSame(['foo', 'baz'], $field->availableOptionValues());
+        $this->assertSame('baz', $field->getValue());
+    }
+
+    public function testAddChoiceToARadio()
+    {
+        $document = \Dom\HTMLDocument::createFromString('<!doctype html><body><input type="radio" name="n" value="foo"><input type="radio" name="n" value="bar" checked>', 0);
+        $field = new HtmlChoiceFormField($document->querySelector('input'));
+
+        $field->addChoice($document->querySelectorAll('input')[1]);
+
+        $this->assertSame(['foo', 'bar'], $field->availableOptionValues());
+        $this->assertSame('bar', $field->getValue());
+    }
+
+    public function testAddChoiceRejectsAMismatchedTag()
+    {
+        $document = \Dom\HTMLDocument::createFromString('<!doctype html><body><select name="n"><option value="foo">foo</option></select><input value="bar">', 0);
+        $field = new HtmlChoiceFormField($document->querySelector('select'));
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Unable to add a choice for "n": expected an "option" tag, got "input".');
+
+        $field->addChoice($document->querySelector('input'));
+    }
+
+    public function testAddChoiceRejectsACheckbox()
+    {
+        $document = \Dom\HTMLDocument::createFromString('<!doctype html><body><input type="checkbox" name="n" value="foo"><input type="checkbox" value="bar">', 0);
+        $field = new HtmlChoiceFormField($document->querySelector('input'));
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Unable to add a choice for "n" as it is neither multiple, a radio button nor a select field (type is "checkbox").');
+
+        $field->addChoice($document->querySelectorAll('input')[1]);
+    }
+
+    public function testSelectByText()
+    {
+        $field = new HtmlChoiceFormField($this->nativeNode('<select name="n"><option value="ok">  This  is ok  </option><option value="ko">This is ko</option></select>', 'select'));
+
+        $field->selectByText('This is ok');
+        $this->assertSame('ok', $field->getValue());
+
+        $field->selectByText('This is ko');
+        $this->assertSame('ko', $field->getValue());
+
+        $field->selectByText("\tThis\nis  ok\n");
+        $this->assertSame('ok', $field->getValue());
+    }
+
+    public function testSelectByTextRejectsAnUnknownText()
+    {
+        $field = new HtmlChoiceFormField($this->nativeNode('<select name="n"><option value="ok">Visible</option></select>', 'select'));
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Input "n" has no option with text "Unknown" (possible texts: "Visible").');
+
+        $field->selectByText('Unknown');
+    }
+
+    public function testSelectByTextRejectsANonSelect()
+    {
+        $field = new HtmlChoiceFormField($this->nativeNode('<input type="checkbox" name="n" value="foo">', 'input'));
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('You cannot call selectByText() on "n" as it is not a select (checkbox).');
+
+        $field->selectByText('foo');
+    }
+
+    public function testDisableValidation()
+    {
+        $field = new HtmlChoiceFormField($this->nativeNode('<select name="n"><option value="foo">foo</option></select>', 'select'));
+        $field->disableValidation();
+        $field->setValue('unknown');
+
+        $this->assertSame('unknown', $field->getValue());
+    }
+
+    public function testInitializeRejectsAnUnsupportedTag()
+    {
+        $node = $this->createHtmlNode('textarea');
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('An HtmlChoiceFormField can only be created from an input or select tag (textarea given).');
+
+        new HtmlChoiceFormField($node);
+    }
+
+    public function testInitializeRejectsAnInputWithAnotherType()
+    {
+        $node = $this->createHtmlNode('input', '', ['type' => 'text']);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('An HtmlChoiceFormField can only be created from an input tag with a type of checkbox or radio (given type is "text").');
+
+        new HtmlChoiceFormField($node);
+    }
+
+    public function testInitializeRejectsAnInputWithoutAType()
+    {
+        $node = $this->createHtmlNode('input');
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('An HtmlChoiceFormField can only be created from an input tag with a type of checkbox or radio (given type is "").');
+
+        new HtmlChoiceFormField($node);
+    }
+
+    private function nativeNode(string $html, string $selector): \Dom\Element
+    {
+        return \Dom\HTMLDocument::createFromString('<!doctype html><body>'.$html, 0)->querySelector($selector);
+    }
+
+    private function classicNode(string $html, string $selector): \DOMElement
+    {
+        $document = new \DOMDocument();
+        $document->loadHTML('<!doctype html><body>'.$html, \LIBXML_NOERROR);
+
+        return $document->getElementsByTagName($selector)->item(0);
+    }
+}

--- a/src/Symfony/Component/DomCrawler/Tests/Field/HtmlFileFormFieldTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/Field/HtmlFileFormFieldTest.php
@@ -1,0 +1,111 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DomCrawler\Tests\Field;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Component\DomCrawler\Field\HtmlFileFormField;
+
+class HtmlFileFormFieldTest extends FormFieldTestCase
+{
+    public function testInitialize()
+    {
+        $node = $this->createHtmlNode('input', '', ['type' => 'file', 'name' => 'name']);
+        $field = new HtmlFileFormField($node);
+
+        $this->assertSame(['name' => '', 'type' => '', 'tmp_name' => '', 'error' => \UPLOAD_ERR_NO_FILE, 'size' => 0], $field->getValue());
+    }
+
+    public function testInitializeRejectsANonInputNode()
+    {
+        $node = $this->createHtmlNode('textarea');
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('An HtmlFileFormField can only be created from an input tag (textarea given).');
+
+        new HtmlFileFormField($node);
+    }
+
+    public function testInitializeRejectsAnInputWithAnotherType()
+    {
+        $node = $this->createHtmlNode('input', '', ['type' => 'text']);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('An HtmlFileFormField can only be created from an input tag with a type of file (given type is "text").');
+
+        new HtmlFileFormField($node);
+    }
+
+    public function testInitializeRejectsAnInputWithoutAType()
+    {
+        $node = $this->createHtmlNode('input');
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('An HtmlFileFormField can only be created from an input tag with a type of file (given type is "").');
+
+        new HtmlFileFormField($node);
+    }
+
+    #[DataProvider('provideSetValueMethods')]
+    public function testSetValue(string $method)
+    {
+        $node = $this->createHtmlNode('input', '', ['type' => 'file', 'name' => 'name']);
+        $field = new HtmlFileFormField($node);
+
+        $field->$method(null);
+        $this->assertSame(['name' => '', 'type' => '', 'tmp_name' => '', 'error' => \UPLOAD_ERR_NO_FILE, 'size' => 0], $field->getValue());
+
+        $field->$method(__FILE__);
+        $value = $field->getValue();
+
+        $this->assertSame(basename(__FILE__), $value['name']);
+        $this->assertSame('', $value['type']);
+        $this->assertFileExists($value['tmp_name']);
+        $this->assertSame(\UPLOAD_ERR_OK, $value['error']);
+        $this->assertSame(filesize(__FILE__), $value['size']);
+        $this->assertSame('php', pathinfo($value['tmp_name'], \PATHINFO_EXTENSION));
+    }
+
+    public static function provideSetValueMethods(): iterable
+    {
+        yield 'setValue' => ['setValue'];
+        yield 'upload' => ['upload'];
+    }
+
+    public function testSetErrorCode()
+    {
+        $node = $this->createHtmlNode('input', '', ['type' => 'file', 'name' => 'name']);
+        $field = new HtmlFileFormField($node);
+
+        $field->setErrorCode(\UPLOAD_ERR_FORM_SIZE);
+        $this->assertSame(\UPLOAD_ERR_FORM_SIZE, $field->getValue()['error']);
+    }
+
+    public function testSetErrorCodeRejectsAnUnknownCode()
+    {
+        $node = $this->createHtmlNode('input', '', ['type' => 'file', 'name' => 'name']);
+        $field = new HtmlFileFormField($node);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The error code "12345" is not valid.');
+
+        $field->setErrorCode(12345);
+    }
+
+    public function testSetFilePath()
+    {
+        $node = $this->createHtmlNode('input', '', ['type' => 'file', 'name' => 'name']);
+        $field = new HtmlFileFormField($node);
+        $field->setFilePath(__FILE__);
+
+        $this->assertSame(__FILE__, $field->getValue());
+    }
+}

--- a/src/Symfony/Component/DomCrawler/Tests/Field/HtmlFormFieldTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/Field/HtmlFormFieldTest.php
@@ -1,0 +1,109 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DomCrawler\Tests\Field;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Component\DomCrawler\Field\HtmlInputFormField;
+use Symfony\Component\DomCrawler\Field\InputFormField;
+
+class HtmlFormFieldTest extends FormFieldTestCase
+{
+    public function testGetName()
+    {
+        $node = $this->createHtmlNode('input', '', ['type' => 'text', 'name' => 'name', 'value' => 'value']);
+        $field = new HtmlInputFormField($node);
+
+        $this->assertSame('name', $field->getName());
+    }
+
+    public function testGetNameIsEmptyWhenTheAttributeIsMissing()
+    {
+        $node = $this->createHtmlNode('input', '', ['type' => 'text']);
+        $field = new HtmlInputFormField($node);
+
+        $this->assertSame('', $field->getName());
+    }
+
+    public function testGetSetHasValue()
+    {
+        $node = $this->createHtmlNode('input', '', ['type' => 'text', 'name' => 'name', 'value' => 'value']);
+        $field = new HtmlInputFormField($node);
+
+        $this->assertSame('value', $field->getValue());
+
+        $field->setValue('foo');
+        $this->assertSame('foo', $field->getValue());
+
+        $field->setValue(null);
+        $this->assertSame('', $field->getValue());
+
+        $this->assertTrue($field->hasValue());
+    }
+
+    public function testIsDisabled()
+    {
+        $node = $this->createHtmlNode('input', '', ['type' => 'text', 'name' => 'name', 'disabled' => 'disabled']);
+        $this->assertTrue((new HtmlInputFormField($node))->isDisabled());
+
+        $node = $this->createHtmlNode('input', '', ['type' => 'text', 'name' => 'name']);
+        $this->assertFalse((new HtmlInputFormField($node))->isDisabled());
+    }
+
+    public function testGetLabelReturnsTheNativeElement()
+    {
+        $field = new HtmlInputFormField($this->nativeInput('<label for="foo">Foo label</label><input id="foo" name="foo">'));
+        $label = $field->getLabel();
+
+        $this->assertInstanceOf(\Dom\Element::class, $label);
+        $this->assertSame('label', $label->localName);
+    }
+
+    /**
+     * The native and the classic fields must find the same label.
+     */
+    #[DataProvider('provideLabelCases')]
+    public function testGetLabelMatchesClassic(string $html, ?string $expected)
+    {
+        $native = new HtmlInputFormField($this->nativeInput($html));
+        $classic = new InputFormField($this->classicInput($html));
+
+        $this->assertSame($expected, $native->getLabel()?->textContent);
+        $this->assertSame($classic->getLabel()?->textContent, $native->getLabel()?->textContent);
+    }
+
+    public static function provideLabelCases(): iterable
+    {
+        yield 'none' => ['<input id="foo" name="foo">', null];
+        yield 'for attribute' => ['<label for="foo">L</label><input id="foo" name="foo">', 'L'];
+        yield 'label after the input' => ['<input id="foo" name="foo"><label for="foo">L</label>', 'L'];
+        yield 'parenting relation' => ['<label>L<input id="foo" name="foo"></label>', 'L'];
+        yield 'for attribute wins over parenting' => ['<label for="foo">L</label><label>P<input id="foo" name="foo"></label>', 'L'];
+        yield 'first matching label wins' => ['<label for="foo">L</label><label for="foo">O</label><input id="foo" name="foo">', 'L'];
+        yield 'closest ancestor label wins' => ['<label>O<label>L<input name="foo"></label></label>', 'L'];
+        yield 'unmatched for falls back to parenting' => ['<label for="bar">B</label><label>L<input id="foo" name="foo"></label>', 'L'];
+        yield 'label outside the form' => ['<label for="foo">L</label><form><input id="foo" name="foo"></form>', 'L'];
+        yield 'quote in the id' => ['<label for=\'a"b\'>L</label><input id=\'a"b\' name="foo">', 'L'];
+    }
+
+    private function nativeInput(string $html): \Dom\Element
+    {
+        return \Dom\HTMLDocument::createFromString('<!doctype html><body>'.$html.'</body>', 0)->querySelector('input');
+    }
+
+    private function classicInput(string $html): \DOMElement
+    {
+        $document = new \DOMDocument();
+        $document->loadHTML('<!doctype html><body>'.$html.'</body>', \LIBXML_NOERROR);
+
+        return $document->getElementsByTagName('input')->item(0);
+    }
+}

--- a/src/Symfony/Component/DomCrawler/Tests/Field/HtmlInputFormFieldTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/Field/HtmlInputFormFieldTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DomCrawler\Tests\Field;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Component\DomCrawler\Field\HtmlInputFormField;
+
+class HtmlInputFormFieldTest extends FormFieldTestCase
+{
+    public function testInitialize()
+    {
+        $node = $this->createHtmlNode('input', '', ['type' => 'text', 'name' => 'name', 'value' => 'value']);
+        $field = new HtmlInputFormField($node);
+
+        $this->assertSame('value', $field->getValue());
+    }
+
+    public function testInitializeWithoutAValueAttribute()
+    {
+        $node = $this->createHtmlNode('input', '', ['type' => 'text', 'name' => 'name']);
+        $field = new HtmlInputFormField($node);
+
+        $this->assertSame('', $field->getValue());
+    }
+
+    public function testInitializeFromAButton()
+    {
+        $node = $this->createHtmlNode('button', 'text', ['name' => 'name', 'value' => 'value']);
+        $field = new HtmlInputFormField($node);
+
+        $this->assertSame('value', $field->getValue());
+    }
+
+    #[DataProvider('provideRejectedNodes')]
+    public function testInitializeRejectsUnsupportedNodes(string $tag, array $attributes, string $message)
+    {
+        $node = $this->createHtmlNode($tag, '', $attributes);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage($message);
+
+        new HtmlInputFormField($node);
+    }
+
+    public static function provideRejectedNodes(): iterable
+    {
+        yield 'textarea' => ['textarea', [], 'An HtmlInputFormField can only be created from an input or button tag (textarea given).'];
+        yield 'checkbox' => ['input', ['type' => 'checkbox'], 'Checkboxes should be instances of HtmlChoiceFormField.'];
+        yield 'uppercased checkbox' => ['input', ['type' => 'CHECKBOX'], 'Checkboxes should be instances of HtmlChoiceFormField.'];
+        yield 'file' => ['input', ['type' => 'file'], 'File inputs should be instances of HtmlFileFormField.'];
+        yield 'uppercased file' => ['input', ['type' => 'FILE'], 'File inputs should be instances of HtmlFileFormField.'];
+    }
+}

--- a/src/Symfony/Component/DomCrawler/Tests/Field/HtmlTextareaFormFieldTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/Field/HtmlTextareaFormFieldTest.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DomCrawler\Tests\Field;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Component\DomCrawler\Field\HtmlTextareaFormField;
+
+class HtmlTextareaFormFieldTest extends FormFieldTestCase
+{
+    #[DataProvider('provideContents')]
+    public function testInitialize(string $content)
+    {
+        $node = $this->createHtmlNode('textarea', $content, ['name' => 'name']);
+        $field = new HtmlTextareaFormField($node);
+
+        $this->assertSame($content, $field->getValue());
+    }
+
+    public static function provideContents(): iterable
+    {
+        yield 'text' => ['foo bar'];
+        yield 'empty' => [''];
+        yield 'markup is raw text' => ['foo bar <h1>Baz</h1>'];
+        yield 'unbalanced markup is raw text' => ['foo bar <h1>Baz</h2>'];
+        yield 'newlines' => ["first\nsecond"];
+    }
+
+    public function testEntitiesAreDecoded()
+    {
+        $node = $this->createHtmlNode('textarea', 'a&amp;b&lt;c', ['name' => 'name']);
+        $field = new HtmlTextareaFormField($node);
+
+        $this->assertSame('a&b<c', $field->getValue());
+    }
+
+    public function testInitializeRejectsANonTextareaNode()
+    {
+        $node = $this->createHtmlNode('input');
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('An HtmlTextareaFormField can only be created from a textarea tag (input given).');
+
+        new HtmlTextareaFormField($node);
+    }
+
+    /**
+     * The HTML parser reads the content of a textarea as raw text, so markup that
+     * looks like a comment is part of the value. loadHTML() parses it as markup
+     * instead and drops it, which is why the two fields report different values.
+     */
+    public function testCommentsBelongToTheValue()
+    {
+        $html = '<!doctype html><body><textarea name="name">a<!--c-->b</textarea></body>';
+
+        $node = \Dom\HTMLDocument::createFromString($html, 0)->querySelector('textarea');
+        $this->assertSame('a<!--c-->b', (new HtmlTextareaFormField($node))->getValue());
+
+        $document = new \DOMDocument();
+        $document->loadHTML($html, \LIBXML_NOERROR);
+        $this->assertSame('ab', $document->getElementsByTagName('textarea')->item(0)->textContent);
+    }
+}

--- a/src/Symfony/Component/DomCrawler/Tests/FormFieldOrderTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/FormFieldOrderTest.php
@@ -1,0 +1,122 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DomCrawler\Tests;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DomCrawler\Form;
+
+/**
+ * Pins which fields a form collects and in which order.
+ *
+ * Field order decides how same-named fields overwrite each other in the
+ * registry, so it is part of the behavior and not an implementation detail.
+ */
+class FormFieldOrderTest extends TestCase
+{
+    private function form(string $html, string $buttonSelector = 'form'): Form
+    {
+        $dom = new \DOMDocument();
+        $dom->loadHTML('<!doctype html><html><body>'.$html.'</body></html>', \LIBXML_NOERROR);
+
+        $node = 'form' === $buttonSelector
+            ? $dom->getElementsByTagName('form')->item(0)
+            : $dom->getElementById($buttonSelector);
+
+        return new Form($node, 'http://localhost/');
+    }
+
+    #[DataProvider('provideForms')]
+    public function testCollectedFieldsAndOrder(string $html, array $expected)
+    {
+        $this->assertSame($expected, array_keys($this->form($html)->all()));
+    }
+
+    public static function provideForms(): iterable
+    {
+        yield 'document order is preserved' => [
+            '<form><input name="a"><select name="b"></select><textarea name="c"></textarea><input name="d"></form>',
+            ['a', 'b', 'c', 'd'],
+        ];
+
+        yield 'nested markup does not reorder' => [
+            '<form><div><input name="a"></div><input name="b"><fieldset><div><input name="c"></div></fieldset></form>',
+            ['a', 'b', 'c'],
+        ];
+
+        yield 'a descendant pointing at another form is excluded' => [
+            '<form id="f"><input name="in"><input name="out" form="other"></form>',
+            ['in'],
+        ];
+
+        yield 'an external field pointing at this form is collected' => [
+            '<form id="f"><input name="in"></form><input name="ext" form="f">',
+            ['in', 'ext'],
+        ];
+
+        yield 'fields inside a template are excluded' => [
+            '<form><input name="a"><template><input name="tpl"></template><input name="b"></form>',
+            ['a', 'b'],
+        ];
+
+        yield 'a turbo-stream inside a template is collected again' => [
+            '<form><input name="a"><template><turbo-stream><input name="ts"></turbo-stream></template></form>',
+            ['a', 'ts'],
+        ];
+
+        yield 'a later same-named field wins' => [
+            '<form><input name="a" value="first"><input name="a" value="second"></form>',
+            ['a'],
+        ];
+
+        yield 'unnamed fields are skipped' => [
+            '<form><input><input name="a"></form>',
+            ['a'],
+        ];
+    }
+
+    public function testLaterSameNamedFieldOverwritesTheEarlierOne()
+    {
+        $form = $this->form('<form><input name="a" value="first"><input name="a" value="second"></form>');
+
+        $this->assertSame('second', $form->get('a')->getValue());
+    }
+
+    public function testSubmitButtonIsCollectedBeforeTheFormFields()
+    {
+        $html = '<form id="f"><input name="a"><button id="btn" name="go" value="1">go</button></form>';
+
+        $this->assertSame(['go', 'a'], array_keys($this->form($html, 'btn')->all()));
+    }
+
+    public function testImageButtonContributesCoordinatePairs()
+    {
+        $html = '<form id="f"><input name="a"><input id="btn" type="image" name="pic"></form>';
+
+        $this->assertSame(['pic.x', 'pic.y', 'a'], array_keys($this->form($html, 'btn')->all()));
+    }
+
+    public function testFormAttributeOnTheButtonSelectsThatForm()
+    {
+        $html = '<form id="one"><input name="in_one"></form><form id="two"><input name="in_two"></form>'
+            .'<button id="btn" form="two" name="go" value="1">go</button>';
+
+        $this->assertSame(['go', 'in_two'], array_keys($this->form($html, 'btn')->all()));
+    }
+
+    public function testValuesReflectCollectionOrder()
+    {
+        $form = $this->form('<form><input name="a" value="1"><input name="b" value="2"></form>');
+
+        $this->assertSame(['a' => '1', 'b' => '2'], $form->getValues());
+    }
+}

--- a/src/Symfony/Component/DomCrawler/Tests/HtmlCrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/HtmlCrawlerTest.php
@@ -49,10 +49,10 @@ class HtmlCrawlerTest extends TestCase
                 <a href="/foo">Fabien"s Foo</a>
                 <a href="/foo">' Fabien"s Foo</a>
 
-                <a href="/bar"><img alt="Bar"/></a>
-                <a href="/bar"><img alt="   Fabien's Bar   "/></a>
-                <a href="/bar"><img alt="Fabien&quot;s Bar"/></a>
-                <a href="/bar"><img alt="' Fabien&quot;s Bar"/></a>
+                <a href="/bar"><img alt="Bar"></a>
+                <a href="/bar"><img alt="   Fabien's Bar   "></a>
+                <a href="/bar"><img alt="Fabien&quot;s Bar"></a>
+                <a href="/bar"><img alt="' Fabien&quot;s Bar"></a>
 
                 <a href="/example">Klausi|Claudiu</a>
                 <a href="/deep"><span><img alt="Deep"></span></a>
@@ -258,9 +258,14 @@ class HtmlCrawlerTest extends TestCase
     {
         $crawler = new HtmlCrawler(self::HTML);
 
+        $this->assertSame(2, $crawler->filter('p')->count());
+
+        if (2 !== \Dom\HTMLDocument::createFromString('<!doctype html><body><p>a</p><p>b</p>', 0)->querySelectorAll('P')->length) {
+            $this->markTestSkipped('The selector engine of this PHP version does not fold tag names to lower case.');
+        }
+
         // tag names are matched case-insensitively in HTML
         $this->assertSame(2, $crawler->filter('P')->count());
-        $this->assertSame(2, $crawler->filter('p')->count());
     }
 
     public function testFilterIsScopedToTheCurrentNodes()
@@ -343,6 +348,14 @@ class HtmlCrawlerTest extends TestCase
             $this->assertSame($c->html(), $n->html(), $selector);
             $this->assertSame($c->outerHtml(), $n->outerHtml(), $selector);
         }
+    }
+
+    public function testOuterHtmlOfAnXmlDocument()
+    {
+        $crawler = new HtmlCrawler();
+        $crawler->addDocument(\Dom\XMLDocument::createFromString('<r><p class="i">a<b>b</b></p></r>'));
+
+        $this->assertSame('<p class="i">a<b>b</b></p>', $crawler->filter('p')->outerHtml());
     }
 
     public function testExtractMatchesCrawler()

--- a/src/Symfony/Component/DomCrawler/Tests/HtmlCrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/HtmlCrawlerTest.php
@@ -11,9 +11,12 @@
 
 namespace Symfony\Component\DomCrawler\Tests;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\DomCrawler\HtmlCrawler;
+use Symfony\Component\DomCrawler\HtmlImage;
+use Symfony\Component\DomCrawler\HtmlLink;
 
 class HtmlCrawlerTest extends TestCase
 {
@@ -36,6 +39,209 @@ class HtmlCrawlerTest extends TestCase
             </body>
         </html>
         HTML;
+
+    private const SELECTION_HTML = <<<'HTML'
+        <!doctype html>
+        <html>
+            <body>
+                <a href="foo">Foo</a>
+                <a href="/foo">   Fabien's Foo   </a>
+                <a href="/foo">Fabien"s Foo</a>
+                <a href="/foo">' Fabien"s Foo</a>
+
+                <a href="/bar"><img alt="Bar"/></a>
+                <a href="/bar"><img alt="   Fabien's Bar   "/></a>
+                <a href="/bar"><img alt="Fabien&quot;s Bar"/></a>
+                <a href="/bar"><img alt="' Fabien&quot;s Bar"/></a>
+
+                <a href="/example">Klausi|Claudiu</a>
+                <a href="/deep"><span><img alt="Deep"></span></a>
+
+                <form action="foo" id="FooFormId">
+                    <input type="text" value="TextValue" name="TextName">
+                    <input type="submit" value="FooValue" name="FooName" id="FooId">
+                    <input type="button" value="BarValue" name="BarName" id="BarId">
+                    <button value="ButtonValue" name="ButtonName" id="ButtonId"></button>
+                    <button type="submit" name="Click 'Here'">Quoted</button>
+                    <input type="SUBMIT" value="UpperValue" name="UpperName">
+                    <input type="submit image" value="BothValue" alt="BothAlt">
+                </form>
+
+                <input type="image" alt="ImageAlt" form="FooFormId">
+                <button form="FooFormId">ButtonText</button>
+                <img src="/pic.png" alt="  A   picture  ">
+            </body>
+        </html>
+        HTML;
+
+    #[DataProvider('provideSelectLinkValues')]
+    public function testSelectLinkMatchesCrawler(string $value, int $expectedCount)
+    {
+        $native = new HtmlCrawler(self::SELECTION_HTML, 'http://localhost/');
+        $classic = new Crawler(self::SELECTION_HTML, 'http://localhost/');
+
+        $this->assertCount($expectedCount, $native->selectLink($value));
+        $this->assertSame($classic->selectLink($value)->extract(['href', '_text']), $native->selectLink($value)->extract(['href', '_text']));
+    }
+
+    public static function provideSelectLinkValues(): iterable
+    {
+        yield 'by text' => ['Foo', 4];
+        yield 'text with a single quote' => ["Fabien's Foo", 1];
+        yield 'text with a double quote' => ['Fabien"s Foo', 2];
+        yield 'text with both quotes' => ['\' Fabien"s Foo', 1];
+        yield 'by the alt of a child image' => ['Bar', 4];
+        yield 'image alt with a single quote' => ["Fabien's Bar", 1];
+        yield 'image alt with a double quote' => ['Fabien"s Bar', 2];
+        yield 'text with a pipe' => ['Klausi|Claudiu', 1];
+        yield 'a deeper image is not a direct child' => ['Deep', 0];
+        yield 'partial words do not match' => ['Fabie', 0];
+        yield 'unknown text' => ['Nothing', 0];
+    }
+
+    #[DataProvider('provideSelectImageValues')]
+    public function testSelectImageMatchesCrawler(string $value, int $expectedCount)
+    {
+        $native = new HtmlCrawler(self::SELECTION_HTML, 'http://localhost/');
+        $classic = new Crawler(self::SELECTION_HTML, 'http://localhost/');
+
+        $this->assertCount($expectedCount, $native->selectImage($value));
+        $this->assertSame($classic->selectImage($value)->extract(['alt', 'src']), $native->selectImage($value)->extract(['alt', 'src']));
+    }
+
+    public static function provideSelectImageValues(): iterable
+    {
+        yield 'by alt' => ['Bar', 4];
+        yield 'whitespace in the alt is normalized' => ['A picture', 1];
+        yield 'a substring of the alt matches' => ['pictur', 1];
+        yield 'alt with a single quote' => ["Fabien's Bar", 1];
+        yield 'alt with a double quote' => ['Fabien"s Bar', 2];
+        yield 'unknown alt' => ['Nothing', 0];
+    }
+
+    #[DataProvider('provideSelectButtonValues')]
+    public function testSelectButtonMatchesCrawler(string $value, int $expectedCount)
+    {
+        $native = new HtmlCrawler(self::SELECTION_HTML, 'http://localhost/');
+        $classic = new Crawler(self::SELECTION_HTML, 'http://localhost/');
+
+        $this->assertCount($expectedCount, $native->selectButton($value));
+        $this->assertSame($classic->selectButton($value)->extract(['_name', 'name', 'id', 'value']), $native->selectButton($value)->extract(['_name', 'name', 'id', 'value']));
+    }
+
+    public static function provideSelectButtonValues(): iterable
+    {
+        yield 'submit input by value' => ['FooValue', 1];
+        yield 'submit input by name' => ['FooName', 1];
+        yield 'submit input by id' => ['FooId', 1];
+        yield 'button input by value' => ['BarValue', 1];
+        yield 'button input by name' => ['BarName', 1];
+        yield 'button input by id' => ['BarId', 1];
+        yield 'image input by alt' => ['ImageAlt', 1];
+        yield 'button tag by value' => ['ButtonValue', 1];
+        yield 'button tag by name' => ['ButtonName', 1];
+        yield 'button tag by id' => ['ButtonId', 1];
+        yield 'button tag by text' => ['ButtonText', 1];
+        yield 'name holding a single quote' => ["Click 'Here'", 1];
+        yield 'an uppercased type is a button too' => ['UpperValue', 1];
+        yield 'a type naming both kinds matches on the value' => ['BothValue', 1];
+        yield 'a type naming both kinds matches on the alt too' => ['BothAlt', 1];
+        yield 'a text input is not a button' => ['TextValue', 0];
+        yield 'unknown value' => ['Nothing', 0];
+    }
+
+    public function testSelectIncludesTheContextNodeItself()
+    {
+        $native = new HtmlCrawler(self::SELECTION_HTML, 'http://localhost/');
+        $classic = new Crawler(self::SELECTION_HTML, 'http://localhost/');
+
+        $this->assertCount(1, $native->filter('a')->eq(1)->selectLink("Fabien's Foo"));
+        $this->assertSame(
+            $classic->filter('a')->eq(1)->selectLink("Fabien's Foo")->extract(['href']),
+            $native->filter('a')->eq(1)->selectLink("Fabien's Foo")->extract(['href']),
+        );
+    }
+
+    public function testSelectIsScopedToTheCurrentNodes()
+    {
+        $crawler = new HtmlCrawler(self::SELECTION_HTML, 'http://localhost/');
+
+        $this->assertCount(1, $crawler->filter('form')->selectButton('FooValue'));
+        $this->assertCount(0, $crawler->filter('form')->selectButton('ImageAlt'));
+        $this->assertCount(0, $crawler->filter('form')->selectButton('ButtonText'));
+        $this->assertCount(0, $crawler->filter('ul')->selectLink('Foo'));
+    }
+
+    public function testLink()
+    {
+        $crawler = new HtmlCrawler(self::SELECTION_HTML, 'http://localhost/bar/');
+        $link = $crawler->selectLink('Foo')->link();
+
+        $this->assertInstanceOf(HtmlLink::class, $link);
+        $this->assertSame('http://localhost/bar/foo', $link->getUri());
+        $this->assertSame('GET', $link->getMethod());
+        $this->assertSame('POST', $crawler->selectLink('Foo')->link('post')->getMethod());
+    }
+
+    public function testLinks()
+    {
+        $crawler = new HtmlCrawler(self::SELECTION_HTML, 'http://localhost/bar/');
+        $links = $crawler->selectLink('Foo')->links();
+
+        $this->assertContainsOnlyInstancesOf(HtmlLink::class, $links);
+        $this->assertSame(
+            ['http://localhost/bar/foo', 'http://localhost/foo', 'http://localhost/foo', 'http://localhost/foo'],
+            array_map(static fn (HtmlLink $link) => $link->getUri(), $links),
+        );
+    }
+
+    public function testLinkOnAnEmptyNodeListThrows()
+    {
+        $crawler = new HtmlCrawler(self::SELECTION_HTML, 'http://localhost/');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The current node list is empty.');
+
+        $crawler->filter('nothing')->link();
+    }
+
+    public function testLinkOnANonLinkTagThrows()
+    {
+        $crawler = new HtmlCrawler(self::SELECTION_HTML, 'http://localhost/');
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Unable to navigate from a "form" tag.');
+
+        $crawler->filter('form')->link();
+    }
+
+    public function testImage()
+    {
+        $crawler = new HtmlCrawler(self::SELECTION_HTML, 'http://localhost/bar/');
+        $image = $crawler->selectImage('A picture')->image();
+
+        $this->assertInstanceOf(HtmlImage::class, $image);
+        $this->assertSame('http://localhost/pic.png', $image->getUri());
+    }
+
+    public function testImages()
+    {
+        $crawler = new HtmlCrawler(self::SELECTION_HTML, 'http://localhost/bar/');
+        $images = $crawler->selectImage('Bar')->images();
+
+        $this->assertContainsOnlyInstancesOf(HtmlImage::class, $images);
+        $this->assertCount(4, $images);
+    }
+
+    public function testImageOnAnEmptyNodeListThrows()
+    {
+        $crawler = new HtmlCrawler(self::SELECTION_HTML, 'http://localhost/');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The current node list is empty.');
+
+        $crawler->filter('nothing')->image();
+    }
 
     public function testFilterSupportsSelectorsCssSelectorCannotTranslate()
     {
@@ -148,6 +354,15 @@ class HtmlCrawlerTest extends TestCase
             $classic->filter('li')->extract(['_text', '_name']),
             $native->filter('li')->extract(['_text', '_name']),
         );
+    }
+
+    public function testExtractReportsAMissingAttributeAsAnEmptyString()
+    {
+        $native = new HtmlCrawler(self::HTML);
+        $classic = new Crawler(self::HTML);
+
+        $this->assertSame(['', 'x', ''], $native->filter('input')->extract(['value']));
+        $this->assertSame($classic->filter('input')->extract(['value']), $native->filter('input')->extract(['value']));
     }
 
     public function testAttr()

--- a/src/Symfony/Component/DomCrawler/Tests/HtmlCrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/HtmlCrawlerTest.php
@@ -1,0 +1,211 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DomCrawler\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DomCrawler\Crawler;
+use Symfony\Component\DomCrawler\HtmlCrawler;
+
+class HtmlCrawlerTest extends TestCase
+{
+    private const HTML = <<<'HTML'
+        <!doctype html>
+        <html>
+            <body>
+                <div id="wrap" class="Box">
+                    <p class="intro" data-tag="FOO">  hello   <b>world</b>  </p>
+                    <p>second</p>
+                </div>
+                <form>
+                    <input name="a" required>
+                    <input name="b" readonly value="x">
+                    <input name="c">
+                </form>
+                <a href="/x">link</a>
+                <a>no href</a>
+                <ul><li>one</li><li>two</li><li>three</li></ul>
+            </body>
+        </html>
+        HTML;
+
+    public function testFilterSupportsSelectorsCssSelectorCannotTranslate()
+    {
+        $crawler = new HtmlCrawler(self::HTML);
+
+        $this->assertSame(1, $crawler->filter('input:required')->count());
+        $this->assertSame(1, $crawler->filter('input:read-only')->count());
+        $this->assertSame(1, $crawler->filter('a:any-link')->count());
+        $this->assertSame(1, $crawler->filter('[data-tag="foo" i]')->count());
+        $this->assertSame(1, $crawler->filter('li:nth-child(2 of .none), li:nth-child(2)')->count());
+    }
+
+    public function testFilterAppliesHtmlSemantics()
+    {
+        $crawler = new HtmlCrawler(self::HTML);
+
+        // tag names are matched case-insensitively in HTML
+        $this->assertSame(2, $crawler->filter('P')->count());
+        $this->assertSame(2, $crawler->filter('p')->count());
+    }
+
+    public function testFilterIsScopedToTheCurrentNodes()
+    {
+        $crawler = new HtmlCrawler(self::HTML);
+
+        $this->assertSame(2, $crawler->filter('#wrap')->filter('p')->count());
+        $this->assertSame(0, $crawler->filter('ul')->filter('p')->count());
+    }
+
+    public function testFilterXPathAcceptsUnprefixedNames()
+    {
+        $crawler = new HtmlCrawler(self::HTML);
+
+        $this->assertSame(2, $crawler->filterXPath('//p')->count());
+        $this->assertSame(1, $crawler->filterXPath('//a[@href]')->count());
+        $this->assertSame(3, $crawler->filterXPath('//li')->count());
+    }
+
+    public function testFilterXPathIsRelativeToTheCurrentNodes()
+    {
+        $crawler = new HtmlCrawler(self::HTML);
+
+        $this->assertSame(2, $crawler->filter('#wrap')->filterXPath('.//p')->count());
+        $this->assertSame(0, $crawler->filter('ul')->filterXPath('.//p')->count());
+    }
+
+    public function testEvaluateReturnsScalars()
+    {
+        $crawler = new HtmlCrawler(self::HTML);
+
+        $this->assertSame([3.0], $crawler->evaluate('count(//li)'));
+    }
+
+    public function testMatchesAndClosest()
+    {
+        $crawler = new HtmlCrawler(self::HTML);
+        $intro = $crawler->filter('p.intro');
+
+        $this->assertTrue($intro->matches('.intro'));
+        $this->assertTrue($intro->matches('div > p'));
+        $this->assertFalse($intro->matches('ul'));
+
+        $this->assertSame('wrap', $intro->closest('#wrap')->attr('id'));
+        $this->assertNull($intro->closest('table'));
+    }
+
+    public function testChildrenWithAndWithoutSelector()
+    {
+        $crawler = new HtmlCrawler(self::HTML);
+
+        $this->assertSame(2, $crawler->filter('#wrap')->children()->count());
+        $this->assertSame(1, $crawler->filter('#wrap')->children('.intro')->count());
+    }
+
+    public function testTraversal()
+    {
+        $crawler = new HtmlCrawler(self::HTML);
+        $second = $crawler->filter('li')->eq(1);
+
+        $this->assertSame('two', $second->text());
+        $this->assertSame(1, $second->nextAll()->count());
+        $this->assertSame(1, $second->previousAll()->count());
+        $this->assertSame(2, $second->siblings()->count());
+        $this->assertContains('ul', $second->ancestors()->each(static fn (HtmlCrawler $n) => $n->nodeName()));
+    }
+
+    public function testContentAccessorsMatchCrawler()
+    {
+        $native = new HtmlCrawler(self::HTML);
+        $classic = new Crawler(self::HTML);
+
+        foreach (['#wrap', 'p.intro', 'ul'] as $selector) {
+            $n = $native->filter($selector);
+            $c = $classic->filter($selector);
+
+            $this->assertSame($c->nodeName(), $n->nodeName(), $selector);
+            $this->assertSame($c->text(), $n->text(), $selector);
+            $this->assertSame($c->innerText(), $n->innerText(), $selector);
+            $this->assertSame($c->html(), $n->html(), $selector);
+            $this->assertSame($c->outerHtml(), $n->outerHtml(), $selector);
+        }
+    }
+
+    public function testExtractMatchesCrawler()
+    {
+        $native = new HtmlCrawler(self::HTML);
+        $classic = new Crawler(self::HTML);
+
+        $this->assertSame(
+            $classic->filter('li')->extract(['_text', '_name']),
+            $native->filter('li')->extract(['_text', '_name']),
+        );
+    }
+
+    public function testAttr()
+    {
+        $crawler = new HtmlCrawler(self::HTML);
+
+        $this->assertSame('/x', $crawler->filter('a')->attr('href'));
+        $this->assertNull($crawler->filter('ul')->attr('href'));
+        $this->assertSame('fallback', $crawler->filter('ul')->attr('href', 'fallback'));
+        $this->assertSame('fallback', $crawler->filter('nothing')->attr('href', 'fallback'));
+    }
+
+    public function testEmptyNodeListThrows()
+    {
+        $crawler = new HtmlCrawler(self::HTML);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The current node list is empty.');
+
+        $crawler->filter('nothing')->text();
+    }
+
+    public function testNodesFromDistinctDocumentsAreRejected()
+    {
+        $crawler = new HtmlCrawler(self::HTML);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Attaching DOM nodes from multiple documents in the same crawler is forbidden.');
+
+        $crawler->addNode((new HtmlCrawler(self::HTML))->filter('ul')->getNode(0));
+    }
+
+    public function testSliceReduceFirstLastAndCount()
+    {
+        $crawler = new HtmlCrawler(self::HTML);
+        $items = $crawler->filter('li');
+
+        $this->assertSame(3, $items->count());
+        $this->assertCount(3, iterator_to_array($items));
+        $this->assertSame('one', $items->first()->text());
+        $this->assertSame('three', $items->last()->text());
+        $this->assertSame(2, $items->slice(1)->count());
+        $this->assertSame('two', $items->reduce(static fn (HtmlCrawler $n) => 'two' === $n->text())->text());
+    }
+
+    public function testGetNodeReturnsNativeNodes()
+    {
+        $crawler = new HtmlCrawler(self::HTML);
+
+        $this->assertInstanceOf(\Dom\Element::class, $crawler->filter('ul')->getNode(0));
+        $this->assertNull($crawler->filter('ul')->getNode(9));
+    }
+
+    public function testClear()
+    {
+        $crawler = new HtmlCrawler(self::HTML);
+        $crawler->clear();
+
+        $this->assertSame(0, $crawler->count());
+    }
+}

--- a/src/Symfony/Component/DomCrawler/Tests/HtmlFormFieldRegistryTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/HtmlFormFieldRegistryTest.php
@@ -1,0 +1,166 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DomCrawler\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DomCrawler\Field\HtmlChoiceFormField;
+use Symfony\Component\DomCrawler\Field\HtmlInputFormField;
+use Symfony\Component\DomCrawler\Field\InputFormField;
+use Symfony\Component\DomCrawler\HtmlFormFieldRegistry;
+
+class HtmlFormFieldRegistryTest extends TestCase
+{
+    public function testAcceptsAnyName()
+    {
+        $registry = new HtmlFormFieldRegistry();
+        $registry->add($field = $this->input('[t:dbt%3adate;]data_daterange_enddate_value'));
+
+        $this->assertSame($field, $registry->get('[t:dbt%3adate;]data_daterange_enddate_value'));
+
+        $registry->remove('[t:dbt%3adate;]data_daterange_enddate_value');
+        $this->assertFalse($registry->has('[t:dbt%3adate;]data_daterange_enddate_value'));
+    }
+
+    public function testGetRejectsAnUnknownField()
+    {
+        $registry = new HtmlFormFieldRegistry();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unreachable field "foo".');
+
+        $registry->get('foo');
+    }
+
+    public function testSetRejectsAnUnknownField()
+    {
+        $registry = new HtmlFormFieldRegistry();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unreachable field "foo".');
+
+        $registry->set('foo', null);
+    }
+
+    public function testHas()
+    {
+        $registry = new HtmlFormFieldRegistry();
+        $registry->add($this->input('foo[bar]'));
+
+        $this->assertTrue($registry->has('foo'));
+        $this->assertTrue($registry->has('foo[bar]'));
+        $this->assertFalse($registry->has('bar'));
+        $this->assertFalse($registry->has('foo[foo]'));
+    }
+
+    public function testRemove()
+    {
+        $registry = new HtmlFormFieldRegistry();
+        $registry->add($this->input('foo'));
+        $registry->remove('foo');
+
+        $this->assertFalse($registry->has('foo'));
+    }
+
+    public function testRemoveLeavesAnUnknownPathAlone()
+    {
+        $registry = new HtmlFormFieldRegistry();
+        $registry->remove('foo[bar]');
+
+        $this->assertFalse($registry->has('foo'));
+        $this->assertSame([], $registry->all());
+    }
+
+    public function testKeepsTheSpacesOfASegment()
+    {
+        $registry = new HtmlFormFieldRegistry();
+        $registry->add($this->input('foo[ bar ]'));
+
+        $this->assertTrue($registry->has('foo[ bar ]'));
+        $this->assertSame(['foo[ bar ]'], array_keys($registry->all()));
+    }
+
+    public function testSupportsMultivaluedFields()
+    {
+        $registry = new HtmlFormFieldRegistry();
+        $registry->add($this->input('foo[]'));
+        $registry->add($this->input('foo[]'));
+        $registry->add($this->input('bar[5]'));
+        $registry->add($this->input('bar[]'));
+        $registry->add($this->input('bar[baz]'));
+
+        $this->assertSame(['foo[0]', 'foo[1]', 'bar[5]', 'bar[6]', 'bar[baz]'], array_keys($registry->all()));
+    }
+
+    public function testSetValues()
+    {
+        $registry = new HtmlFormFieldRegistry();
+        $registry->add($this->input('foo[2]'));
+        $registry->add($this->input('foo[bar][baz]'));
+
+        $registry->set('foo', [2 => 'two', 'bar' => ['baz' => 'fbb']]);
+
+        $this->assertSame('two', $registry->get('foo[2]')->getValue());
+        $this->assertSame('fbb', $registry->get('foo[bar][baz]')->getValue());
+    }
+
+    public function testSetRejectsAValueOnACompoundField()
+    {
+        $registry = new HtmlFormFieldRegistry();
+        $registry->add($this->input('foo[bar][baz]'));
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot set value on a compound field "foo[bar]".');
+
+        $registry->set('foo[bar]', 'fbb');
+    }
+
+    public function testSetRejectsAnArrayOnASingleField()
+    {
+        $registry = new HtmlFormFieldRegistry();
+        $registry->add($this->input('bar'));
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unreachable field "0".');
+
+        $registry->set('bar', ['baz']);
+    }
+
+    public function testSetPassesAnArrayToAChoiceField()
+    {
+        $node = \Dom\HTMLDocument::createFromString('<!doctype html><body><select name="foo[]" multiple><option value="a">A</option><option value="b">B</option></select>', 0)->querySelector('select');
+
+        $registry = new HtmlFormFieldRegistry();
+        $registry->add(new HtmlChoiceFormField($node));
+
+        $registry->set('foo', ['a', 'b']);
+        $this->assertSame(['a', 'b'], $registry->get('foo')->getValue());
+    }
+
+    public function testAddRejectsAClassicField()
+    {
+        $document = new \DOMDocument();
+        $document->loadHTML('<!doctype html><body><input name="foo" value="v">', \LIBXML_NOERROR);
+
+        $registry = new HtmlFormFieldRegistry();
+
+        $this->expectException(\TypeError::class);
+
+        $registry->add(new InputFormField($document->getElementsByTagName('input')->item(0)));
+    }
+
+    private function input(string $name): HtmlInputFormField
+    {
+        $html = \sprintf('<!doctype html><body><input name="%s" value="v">', $name);
+
+        return new HtmlInputFormField(\Dom\HTMLDocument::createFromString($html, 0)->querySelector('input'));
+    }
+}

--- a/src/Symfony/Component/DomCrawler/Tests/HtmlFormTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/HtmlFormTest.php
@@ -1,0 +1,261 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DomCrawler\Tests;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DomCrawler\Crawler;
+use Symfony\Component\DomCrawler\Field\ChoiceFormField;
+use Symfony\Component\DomCrawler\Field\HtmlChoiceFormField;
+use Symfony\Component\DomCrawler\Field\HtmlFormField;
+use Symfony\Component\DomCrawler\Form;
+use Symfony\Component\DomCrawler\HtmlCrawler;
+use Symfony\Component\DomCrawler\HtmlForm;
+
+class HtmlFormTest extends TestCase
+{
+    /**
+     * The native and the classic form must read the same document the same way.
+     */
+    #[DataProvider('provideForms')]
+    public function testMatchesClassic(string $html, string $selector)
+    {
+        $native = $this->nativeForm($html, $selector);
+        $classic = $this->classicForm($html, $selector);
+
+        $this->assertSame($classic->getMethod(), $native->getMethod());
+        $this->assertSame($classic->getName(), $native->getName());
+        $this->assertSame($classic->getUri(), $native->getUri());
+        $this->assertSame($classic->getValues(), $native->getValues());
+        $this->assertSame($classic->getPhpValues(), $native->getPhpValues());
+        $this->assertSame($classic->getFiles(), $native->getFiles());
+        $this->assertSame($classic->getPhpFiles(), $native->getPhpFiles());
+        $this->assertSame(array_keys($classic->all()), array_keys($native->all()));
+        $this->assertSame($this->fieldKinds($classic), $this->fieldKinds($native));
+    }
+
+    public static function provideForms(): iterable
+    {
+        yield 'text input' => ['<form action="/x"><input type="text" name="t" value="v"></form>', 'form'];
+        yield 'method is uppercased' => ['<form action="/x" method="post"><input name="t" value="v"></form>', 'form'];
+        yield 'named form' => ['<form action="/x" name="myform"><input name="t" value="v"></form>', 'form'];
+        yield 'get method merges the values into the query' => ['<form action="/x?a=b"><input name="t" value="v"></form>', 'form'];
+        yield 'every field kind' => ['<form action="/x" method="post"><input name="t" value="v"><textarea name="ta">hello</textarea><select name="s"><option value="a">A</option><option value="b" selected>B</option></select><input type="checkbox" name="c" value="1" checked><input type="radio" name="r" value="1"><input type="radio" name="r" value="2" checked><input type="file" name="f"></form>', 'form'];
+        yield 'unchecked checkbox is left out' => ['<form action="/x" method="post"><input type="checkbox" name="c" value="1"></form>', 'form'];
+        yield 'disabled fields are left out' => ['<form action="/x" method="post"><input name="a" value="1" disabled><input name="b" value="2"></form>', 'form'];
+        yield 'fields without a name are left out' => ['<form action="/x" method="post"><input value="1"><input name="" value="2"><input name="c" value="3"></form>', 'form'];
+        yield 'submit buttons are left out' => ['<form action="/x" method="post"><input type="submit" name="s" value="go"><input type="button" name="b" value="go"><input name="t" value="v"></form>', 'form'];
+        yield 'array notation' => ['<form action="/x" method="post"><input name="a[b][c]" value="1"><input name="a[b][d]" value="2"><input name="l[]" value="3"><input name="l[]" value="4"></form>', 'form'];
+        yield 'multiple select' => ['<form action="/x" method="post"><select name="s[]" multiple><option value="a" selected>A</option><option value="b" selected>B</option></select></form>', 'form'];
+        yield 'nested form tags are collected once' => ['<form action="/x" method="post"><div><input name="t" value="v"></div></form>', 'form'];
+        yield 'fields in a template are inert' => ['<form action="/x" method="post"><template><input name="hidden" value="x"></template><input name="shown" value="y"></form>', 'form'];
+        yield 'a turbo-stream outside a template is live' => ['<form action="/x" method="post"><turbo-stream><input name="streamed" value="x"></turbo-stream><input name="shown" value="y"></form>', 'form'];
+        yield 'form attribute pulls an outside field in' => ['<form action="/x" method="post" id="f1"><input name="in" value="1"></form><input name="out" value="2" form="f1">', 'form'];
+        yield 'form attribute pushes a descendant out' => ['<form action="/x" method="post" id="f1"><input name="in" value="1"><input name="other" value="2" form="f2"></form>', 'form'];
+        yield 'built from a submit button' => ['<form action="/x" method="post"><input name="t" value="v"><input type="submit" name="s" value="go"></form>', 'input[type=submit]'];
+        yield 'built from a button tag' => ['<form action="/x" method="post"><input name="t" value="v"><button name="b" value="go">go</button></form>', 'button'];
+        yield 'formaction overrides the action' => ['<form action="/x" method="post"><input type="submit" name="s" value="go" formaction="/y"></form>', 'input[type=submit]'];
+        yield 'formmethod overrides the method' => ['<form action="/x" method="post"><input type="submit" name="s" value="go" formmethod="put"></form>', 'input[type=submit]'];
+        yield 'image input becomes x and y' => ['<form action="/x" method="post"><input type="image" name="i" alt="go"></form>', 'input[type=image]'];
+        yield 'button with a form attribute' => ['<form action="/x" method="post" id="f1"><input name="t" value="v"></form><button name="b" value="go" form="f1">go</button>', 'button'];
+        yield 'no action' => ['<form method="post"><input name="t" value="v"></form>', 'form'];
+    }
+
+    /**
+     * The HTML parser keeps the content of a template out of the tree, and PHP
+     * exposes no way to reach it, so a field inside a template stays out of the
+     * form even when a turbo-stream wraps it. loadHTML() knows nothing about
+     * templates, so the classic form can bring such a field back.
+     */
+    public function testATurboStreamInsideATemplateDoesNotBringFieldsBack()
+    {
+        $html = '<form action="/x" method="post"><template><turbo-stream><input name="back" value="x"></turbo-stream></template><input name="shown" value="y"></form>';
+
+        $this->assertSame(['shown' => 'y'], $this->nativeForm($html, 'form')->getValues());
+        $this->assertSame(['back' => 'x', 'shown' => 'y'], $this->classicForm($html, 'form')->getValues());
+    }
+
+    public function testGetFormNodeReturnsTheNativeElement()
+    {
+        $form = $this->nativeForm('<form action="/x"><input name="t" value="v"></form>', 'form');
+
+        $this->assertInstanceOf(\Dom\Element::class, $form->getFormNode());
+        $this->assertSame('form', $form->getFormNode()->localName);
+    }
+
+    public function testSetValues()
+    {
+        $form = $this->nativeForm('<form action="/x" method="post"><input name="a" value="1"><input name="b" value="2"></form>', 'form');
+        $form->setValues(['a' => 'x', 'b' => 'y']);
+
+        $this->assertSame(['a' => 'x', 'b' => 'y'], $form->getValues());
+    }
+
+    public function testArrayAccess()
+    {
+        $form = $this->nativeForm('<form action="/x" method="post"><input name="a" value="1"></form>', 'form');
+
+        $this->assertTrue(isset($form['a']));
+        $this->assertFalse(isset($form['b']));
+        $this->assertInstanceOf(HtmlFormField::class, $form['a']);
+
+        $form['a'] = 'x';
+        $this->assertSame('x', $form['a']->getValue());
+
+        unset($form['a']);
+        $this->assertFalse($form->has('a'));
+    }
+
+    public function testGetAndSetAField()
+    {
+        $form = $this->nativeForm('<form action="/x" method="post"><input name="a" value="1"></form>', 'form');
+        $field = $form->get('a');
+
+        $this->assertInstanceOf(HtmlFormField::class, $field);
+
+        $form->remove('a');
+        $this->assertFalse($form->has('a'));
+
+        $form->set($field);
+        $this->assertTrue($form->has('a'));
+    }
+
+    public function testARadioGroupCollectsEveryOption()
+    {
+        $form = $this->nativeForm('<form action="/x" method="post"><input type="radio" name="r" value="1"><input type="radio" name="r" value="2" checked></form>', 'form');
+
+        $this->assertSame(['1', '2'], $form->get('r')->availableOptionValues());
+
+        $form['r'] = '1';
+        $this->assertSame(['r' => '1'], $form->getValues());
+    }
+
+    public function testGetRejectsAnUnknownField()
+    {
+        $form = $this->nativeForm('<form action="/x"><input name="a" value="1"></form>', 'form');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unreachable field "b".');
+
+        $form->get('b');
+    }
+
+    public function testDisableValidation()
+    {
+        $form = $this->nativeForm('<form action="/x" method="post"><select name="s"><option value="a">A</option></select></form>', 'form');
+        $form->disableValidation();
+        $form['s'] = 'unknown';
+
+        $this->assertSame(['s' => 'unknown'], $form->getValues());
+    }
+
+    public function testFilesAreOnlySentByAWritingMethod()
+    {
+        $html = '<form action="/x" method="%s"><input type="file" name="f"></form>';
+
+        $this->assertSame([], $this->nativeForm(\sprintf($html, 'get'), 'form')->getFiles());
+        $this->assertArrayHasKey('f', $this->nativeForm(\sprintf($html, 'post'), 'form')->getFiles());
+    }
+
+    public function testBaseHrefIsUsedWhenTheActionIsNotEmpty()
+    {
+        $crawler = new HtmlCrawler('<!doctype html><body><form action="foo"><input name="t" value="v"></form>', 'http://localhost/bar/', 'http://example.com/base/');
+
+        $this->assertSame('http://example.com/base/foo?t=v', $crawler->filter('form')->form()->getUri());
+    }
+
+    public function testBaseHrefIsIgnoredWhenTheActionIsEmpty()
+    {
+        $crawler = new HtmlCrawler('<!doctype html><body><form><input name="t" value="v"></form>', 'http://localhost/bar/', 'http://example.com/base/');
+
+        $this->assertSame('http://localhost/bar/?t=v', $crawler->filter('form')->form()->getUri());
+    }
+
+    public function testSetNodeRejectsANonFormTag()
+    {
+        $node = \Dom\HTMLDocument::createFromString('<!doctype html><body><div></div>', 0)->querySelector('div');
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Unable to submit on a "div" tag.');
+
+        new HtmlForm($node, 'http://localhost/');
+    }
+
+    public function testSetNodeRejectsAButtonWithoutAFormAncestor()
+    {
+        $node = \Dom\HTMLDocument::createFromString('<!doctype html><body><button></button>', 0)->querySelector('button');
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('The selected node does not have a form ancestor.');
+
+        new HtmlForm($node, 'http://localhost/');
+    }
+
+    public function testSetNodeRejectsAnInvalidFormAttribute()
+    {
+        $node = \Dom\HTMLDocument::createFromString('<!doctype html><body><button form="nope"></button>', 0)->querySelector('button');
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('The selected node has an invalid form attribute (nope).');
+
+        new HtmlForm($node, 'http://localhost/');
+    }
+
+    public function testCrawlerFormPassesTheValues()
+    {
+        $crawler = new HtmlCrawler('<!doctype html><body><form action="/x" method="post"><input name="a" value="1"></form>', 'http://localhost/');
+        $form = $crawler->filter('form')->form(['a' => 'x'], 'PUT');
+
+        $this->assertInstanceOf(HtmlForm::class, $form);
+        $this->assertSame(['a' => 'x'], $form->getValues());
+        $this->assertSame('PUT', $form->getMethod());
+    }
+
+    public function testCrawlerFormOnAnEmptyNodeListThrows()
+    {
+        $crawler = new HtmlCrawler('<!doctype html><body><p>x</p>', 'http://localhost/');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The current node list is empty.');
+
+        $crawler->filter('form')->form();
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function fieldKinds(Form|HtmlForm $form): array
+    {
+        $kinds = [];
+        foreach ($form->all() as $name => $field) {
+            $kind = str_replace('Html', '', (new \ReflectionClass($field))->getShortName());
+
+            if ($field instanceof HtmlChoiceFormField || $field instanceof ChoiceFormField) {
+                $kind .= ':'.$field->getType();
+            }
+
+            $kinds[$name] = $kind;
+        }
+
+        return $kinds;
+    }
+
+    private function nativeForm(string $html, string $selector): HtmlForm
+    {
+        return (new HtmlCrawler('<!doctype html><body>'.$html, 'http://localhost/base/'))->filter($selector)->form();
+    }
+
+    private function classicForm(string $html, string $selector): Form
+    {
+        return (new Crawler('<!doctype html><body>'.$html, 'http://localhost/base/'))->filter($selector)->form();
+    }
+}

--- a/src/Symfony/Component/DomCrawler/Tests/HtmlUriElementTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/HtmlUriElementTest.php
@@ -1,0 +1,140 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DomCrawler\Tests;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DomCrawler\HtmlImage;
+use Symfony\Component\DomCrawler\HtmlLink;
+use Symfony\Component\DomCrawler\Image;
+use Symfony\Component\DomCrawler\Link;
+
+class HtmlUriElementTest extends TestCase
+{
+    private function nativeElement(string $html, string $selector): \Dom\Element
+    {
+        return \Dom\HTMLDocument::createFromString('<!doctype html><body>'.$html.'</body>', 0)->querySelector($selector);
+    }
+
+    private function classicElement(string $html, string $selector): \DOMElement
+    {
+        $dom = new \DOMDocument();
+        $dom->loadHTML('<!doctype html><body>'.$html.'</body>', \LIBXML_NOERROR);
+
+        return $dom->getElementsByTagName($selector)->item(0);
+    }
+
+    public function testGetUriAndMethod()
+    {
+        $link = new HtmlLink($this->nativeElement('<a href="/foo">f</a>', 'a'), 'http://localhost/bar/');
+
+        $this->assertSame('http://localhost/foo', $link->getUri());
+        $this->assertSame('GET', $link->getMethod());
+    }
+
+    public function testMethodIsUppercased()
+    {
+        $link = new HtmlLink($this->nativeElement('<a href="/foo">f</a>', 'a'), 'http://localhost/', 'post');
+
+        $this->assertSame('POST', $link->getMethod());
+    }
+
+    public function testGetNodeReturnsTheNativeElement()
+    {
+        $node = $this->nativeElement('<a href="/foo">f</a>', 'a');
+
+        $this->assertSame($node, (new HtmlLink($node, 'http://localhost/'))->getNode());
+    }
+
+    #[DataProvider('provideLinkTags')]
+    public function testAcceptsEveryLinkTag(string $html, string $selector)
+    {
+        $link = new HtmlLink($this->nativeElement($html, $selector), 'http://localhost/');
+
+        $this->assertSame('http://localhost/foo', $link->getUri());
+    }
+
+    public static function provideLinkTags(): iterable
+    {
+        yield 'a' => ['<a href="/foo">f</a>', 'a'];
+        yield 'area' => ['<map><area href="/foo"></map>', 'area'];
+        yield 'link' => ['<link href="/foo">', 'link'];
+    }
+
+    public function testRejectsANonLinkTag()
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Unable to navigate from a "div" tag.');
+
+        new HtmlLink($this->nativeElement('<div></div>', 'div'), 'http://localhost/');
+    }
+
+    public function testRejectsANonImageTag()
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Unable to visualize a "div" tag.');
+
+        new HtmlImage($this->nativeElement('<div></div>', 'div'), 'http://localhost/');
+    }
+
+    public function testRelativeUriWithoutAnAbsoluteBaseIsRejected()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Symfony\Component\DomCrawler\AbstractHtmlUriElement');
+
+        new HtmlLink($this->nativeElement('<a href="/foo">f</a>', 'a'), 'not-absolute');
+    }
+
+    public function testImageGetUri()
+    {
+        $image = new HtmlImage($this->nativeElement('<img src="/pic.png">', 'img'), 'http://localhost/bar/');
+
+        $this->assertSame('http://localhost/pic.png', $image->getUri());
+    }
+
+    /**
+     * The native and the classic elements must resolve URIs the same way.
+     */
+    #[DataProvider('provideUriCases')]
+    public function testNativeMatchesClassic(string $href, ?string $currentUri)
+    {
+        $html = \sprintf('<a href="%s">f</a>', $href);
+
+        $native = new HtmlLink($this->nativeElement($html, 'a'), $currentUri);
+        $classic = new Link($this->classicElement($html, 'a'), $currentUri);
+
+        $this->assertSame($classic->getUri(), $native->getUri());
+        $this->assertSame($classic->getMethod(), $native->getMethod());
+    }
+
+    public static function provideUriCases(): iterable
+    {
+        yield 'absolute path' => ['/foo', 'http://localhost/bar/baz'];
+        yield 'relative path' => ['foo', 'http://localhost/bar/baz'];
+        yield 'parent path' => ['../foo', 'http://localhost/bar/baz/'];
+        yield 'same directory' => ['./foo', 'http://localhost/bar/'];
+        yield 'absolute url' => ['http://example.com/foo', 'http://localhost/'];
+        yield 'query only' => ['?a=b', 'http://localhost/bar'];
+        yield 'fragment only' => ['#frag', 'http://localhost/bar'];
+        yield 'empty href' => ['', 'http://localhost/bar'];
+    }
+
+    public function testImageNativeMatchesClassic()
+    {
+        $html = '<img src="../pic.png">';
+
+        $native = new HtmlImage($this->nativeElement($html, 'img'), 'http://localhost/a/b/');
+        $classic = new Image($this->classicElement($html, 'img'), 'http://localhost/a/b/');
+
+        $this->assertSame($classic->getUri(), $native->getUri());
+    }
+}

--- a/src/Symfony/Component/DomCrawler/UriElementTrait.php
+++ b/src/Symfony/Component/DomCrawler/UriElementTrait.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DomCrawler;
+
+/**
+ * Holds the URI logic shared by the classic and the native URI elements.
+ *
+ * The using class declares the $node property with the element type it accepts,
+ * so that each of them keeps an exact signature.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @internal
+ */
+trait UriElementTrait
+{
+    /**
+     * Gets the method associated with this link.
+     */
+    public function getMethod(): string
+    {
+        return $this->method ?? 'GET';
+    }
+
+    /**
+     * Gets the URI associated with this link.
+     */
+    public function getUri(): string
+    {
+        return UriResolver::resolve($this->getRawUri(), $this->currentUri);
+    }
+
+    /**
+     * Returns raw URI data.
+     */
+    abstract protected function getRawUri(): string;
+
+    /**
+     * Returns the canonicalized URI path (see RFC 3986, section 5.2.4).
+     *
+     * @param string $path URI path
+     */
+    protected function canonicalizePath(string $path): string
+    {
+        if ('' === $path || '/' === $path) {
+            return $path;
+        }
+
+        if (str_ends_with($path, '.')) {
+            $path .= '/';
+        }
+
+        $output = [];
+
+        foreach (explode('/', $path) as $segment) {
+            if ('..' === $segment) {
+                array_pop($output);
+            } elseif ('.' !== $segment) {
+                $output[] = $segment;
+            }
+        }
+
+        return implode('/', $output);
+    }
+
+    /**
+     * @throws \InvalidArgumentException if the URI is relative and no absolute base URI is available
+     */
+    private function assertUriIsResolvable(): void
+    {
+        $elementUriIsRelative = !parse_url(trim($this->getRawUri()), \PHP_URL_SCHEME);
+        $baseUriIsAbsolute = null !== $this->currentUri && \in_array(strtolower(substr($this->currentUri, 0, 4)), ['http', 'file'], true);
+
+        if ($elementUriIsRelative && !$baseUriIsAbsolute) {
+            throw new \InvalidArgumentException(\sprintf('The URL of the element is relative, so you must define its base URI passing an absolute URL to the constructor of the "%s" class ("%s" was passed).', __CLASS__, $this->currentUri));
+        }
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Issues        | Fix #57605
| License       | MIT

PHP 8.4 ships a spec-compliant HTML parser with its own selector engine. This adds a crawler that uses it, so that `querySelectorAll()`, `matches()` and `closest()` do the selecting instead of translating CSS to XPath.

```php
use Symfony\Component\DomCrawler\HtmlCrawler;

$crawler = new HtmlCrawler($html, 'http://localhost/');

// selectors CssSelector cannot translate now work
$crawler->filter('input:required');
$crawler->filter('[data-tag="foo" i]');
$crawler->filter('li:nth-child(2 of .highlighted)');

// same API as Crawler for the rest
$crawler->filter('#wrap')->children('.intro')->text();
$crawler->selectButton('Save')->form(['name' => 'Fabien'])->getPhpValues();
```

### Why a parallel set of classes

`Dom\*` and `DOM*` are disjoint class hierarchies with no interop: `importNode()` raises a `TypeError` in both directions, and `Dom\Element instanceof DOMNode` is false. So this cannot be a mode on `Crawler`, and a shared interface would have to be typed on one of the two node types. The native side is therefore a parallel set of classes, and only `@internal` traits are shared:

| classic | native |
| --- | --- |
| `Crawler` | `HtmlCrawler` |
| `Form` | `HtmlForm` |
| `Link`, `Image` | `HtmlLink`, `HtmlImage` |
| `FormField` and subclasses | `HtmlFormField` and subclasses |
| `FormFieldRegistry` | `HtmlFormFieldRegistry` |

No public API was added to enable that sharing. The native classes expose no method the classic ones do not already have, and no shipped class gains a public or protected member: a reflection dump of every public and protected member of `Crawler`, `Form`, `Link`, `Image`, `AbstractUriElement`, `FormFieldRegistry`, `FormField` and the four field classes is byte-identical to 8.2.

`HtmlCrawler` deliberately leaves out `addContent()`, `addXmlContent()`, `registerNamespace()`, `setDefaultNamespacePrefix()` and `xpathLiteral()`: it is HTML-only, and the selector engine needs no namespace plumbing.

### Two parsing decisions

**The document is parsed with the default HTML namespace, not with `Dom\HTML_NO_DEFAULT_NS`.** lexbor only applies HTML semantics to elements that are in the HTML namespace, so the flag changes what the selector engine matches, measured on one document:

| selector | `HTML_NO_DEFAULT_NS` | default namespace |
| --- | --- | --- |
| `DIV` | 0 | 1 |
| `input:required` | 0 | 1 |
| `input:read-only` | 2, wrong nodes | 1 |
| `a:any-link` | 0 | 1 |

**Because of that, `filterXPath()` rewrites unprefixed element name tests to a registered `html:` prefix**, since XPath 1.0 has no notion of a default namespace and `registerNodeNS=false` does not help. The rewrite leaves `//x:div`, `local-name()`, `text()`, `node()`, `@attr`, axis names and quoted strings alone, and handles unions and predicates.

### Selection uses the engine, comparison stays in PHP

`selectLink()`, `selectImage()` and `selectButton()` pass a CSS selector to the engine and compare the text in PHP, because CSS has no text predicate. That removes the XPath string building and its `xpathLiteral()` quoting, and the results match `Crawler` for values holding single quotes, double quotes, both, and pipes.

### Behaviour that differs from `Crawler`, on purpose

**`<textarea>` content.** For `<textarea>a<!--c-->b</textarea>`, `loadHTML()` parses the content as markup and drops the comment, giving `ab`. The native parser treats a textarea as raw text, as the HTML standard requires, and gives `a<!--c-->b`. Entities are still decoded. This was not unified: the native value is the correct one.

**`<template>` content cannot be walked, so the turbo-stream carve-out does not apply.** The native parser keeps template content in a separate `DocumentFragment`, which the HTML standard requires, and PHP exposes no accessor for it: there is no `Dom\HTMLTemplateElement`, `->content` is undefined, and `childNodes`, `firstChild`, `getElementsByTagName()`, `querySelectorAll()`, `Dom\XPath` and a full tree walk all see nothing, although `innerHTML` still serializes the markup. A field inside a `<template>` is therefore inert on the native side by construction, which is the intended behaviour, but a `<turbo-stream>` inside a template cannot bring it back, where `Form` does bring it back. `HtmlFormTest::testATurboStreamInsideATemplateDoesNotBringFieldsBack` pins both sides.

The fragment does exist and is linked to its template, so the only way in today is `getElementById()` on a descendant that happens to carry an `id`, which is not general enough to build on. Reported upstream as [php/php-src#23334](https://github.com/php/php-src/issues/23334); if `content` lands, the carve-out can be restored.

### Changes to existing classes

`Form` and the form fields no longer use `\DOMXPath`. Those lookups are expressed with the members both DOM APIs share, so the classic and the native side run the same code:

- tags are identified by `localName`, because the native DOM uppercases `nodeName` and `tagName` for HTML elements
- option text is read from `textContent`, because the native DOM reports a null `nodeValue` for an element, as the standard requires

Two consequences worth reviewing:

- **`ChoiceFormField` now identifies tags by local name**, so a namespaced node such as `<xhtml:select>` in an XML document is accepted where it used to be rejected, and the tag named in the `LogicException` loses its prefix. This matches how `Form` already collects field nodes.
- **`FormField::getLabel()` gains a fix.** It used to interpolate the `id` into an XPath string literal, so an id holding a double quote produced `Warning: DOMXPath::query(): Invalid predicate`, then `Warning: Attempt to read property "length" on false`, and a null label. Asking the document for its `label` elements fixes it, and drops a full tree walk. The same defect is on the maintained branches and goes there as [#65392](https://github.com/symfony/symfony/pull/65392).

`FormField::$document` and `FormField::$xpath` are **kept and deprecated** rather than removed. Removing them would fatal any userland subclass, since protected members of a shipped abstract class are part of the extension contract. `$xpath` is still populated.

### What the oldest supported PHP can and cannot do

The component declares `php >=8.4.1`, and the native DOM has moved since that release, in both directions:

- `Dom\Element::$outerHTML` and `Dom\Element::$children` were added in **8.5**, so neither is used. `outerHtml()` asks the document to serialize the node, and `selectLink()` walks `childNodes`.
- The selector engine of **8.4.1** does not fold tag names to lower case, so `filter('P')` finds nothing there while `Crawler::filter('P')` finds the `<p>` elements. Nothing else differs: `:required`, `:read-only`, `:any-link`, case-insensitive attribute matching and `:nth-child(n of S)` all behave on 8.4.1. The one test that depends on tag folding detects the behaviour first and skips when it is absent, rather than pinning a patch version.
- Its parser also reports a tree error for a self-closing void element, fixed upstream in **8.4.4**. No fixture relies on that spelling.

Raising the requirement past 8.4.1 would remove the first of these, but that is a decision for the root constraint rather than this pull request.

### Checks

- DomCrawler 689, BrowserKit 249, CssSelector 604, green on **PHP 8.4.23 and 8.5.8**, and the Windows job exercises 8.4.1.
- php-cs-fixer exit 0.
- A `Form` snapshot over 20 documents (values, PHP values, files, field classes, disabled and `hasValue` flags) is byte-identical to 8.2, so the trait extractions changed no behaviour.
- 35 source mutations were applied one at a time; every one is caught by a test.
- `FormFieldOrderTest` was written before the `Form` rewrite and pins which fields a form collects and in what order, because document order decides how same-named fields overwrite each other.

Not covered: BrowserKit still builds a classic `Crawler`, so nothing wires `HtmlCrawler` into `AbstractBrowser` yet. That belongs in its own pull request.

### For the documentation

- `HtmlCrawler` selects with the parser's own engine, so the full selector syntax that engine supports is available, including `:required`, `:read-only`, `:any-link`, case-insensitive attribute matching and `:nth-child(n of S)`.
- It is HTML-only: no `addXmlContent()`, no namespace registration.
- `Dom\*` and `DOM*` nodes cannot be mixed, so a `Crawler` and an `HtmlCrawler` cannot exchange nodes, and the field, link, image and form classes come in two families.
- The two behaviour differences above: textarea raw text, and template content being invisible.
