### PR TITLE
[DomCrawler] Read the whole content of a textarea

### DIFF
--- a/src/Symfony/Component/DomCrawler/Field/TextareaFormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/TextareaFormField.php
@@ -31,9 +31,6 @@ class TextareaFormField extends FormField
             throw new \LogicException(\sprintf('A TextareaFormField can only be created from a textarea tag (%s given).', $this->node->nodeName));
         }
 
-        $this->value = '';
-        foreach ($this->node->childNodes as $node) {
-            $this->value .= $node->wholeText;
-        }
+        $this->value = $this->node->textContent;
     }
 }

--- a/src/Symfony/Component/DomCrawler/Tests/Field/TextareaFormFieldTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/Field/TextareaFormFieldTest.php
@@ -43,4 +43,49 @@ class TextareaFormFieldTest extends FormFieldTestCase
 
         $this->assertEquals('foo bar <h1>Baz</h2>', $field->getValue(), '->initialize() sets the value of the field to the textarea node value');
     }
+
+    /**
+     * @dataProvider provideParsedContents
+     */
+    public function testInitializeWithParsedContent(string $content, string $expected)
+    {
+        $field = new TextareaFormField($this->parseTextarea($content));
+
+        $this->assertSame($expected, $field->getValue());
+    }
+
+    public static function provideParsedContents(): iterable
+    {
+        yield 'text' => ['foo bar', 'foo bar'];
+        yield 'empty' => ['', ''];
+        yield 'entity' => ['a&amp;b', 'a&b'];
+        yield 'escaped markup' => ['foo bar &lt;h1&gt;Baz&lt;/h1&gt;', 'foo bar <h1>Baz</h1>'];
+        yield 'comment' => ['a<!--c-->b', 'ab'];
+        yield 'element' => ['foo bar <h1>Baz</h1>', 'foo bar Baz'];
+        yield 'inline element' => ['a<b>c</b>', 'ac'];
+        yield 'nested elements' => ['a<div><p>b</p></div>c', 'abc'];
+    }
+
+    public function testInitializeDoesNotRepeatAdjacentTextNodes()
+    {
+        $document = new \DOMDocument();
+        $document->loadXML('<form><textarea name="name">a<![CDATA[x]]>b</textarea></form>');
+
+        $field = new TextareaFormField($document->getElementsByTagName('textarea')->item(0));
+
+        $this->assertSame('axb', $field->getValue());
+    }
+
+    /**
+     * The content has to be parsed instead of passed to createElement(), which
+     * always builds a single text child and never the other node types the
+     * parser produces for markup inside a textarea.
+     */
+    private function parseTextarea(string $content): \DOMElement
+    {
+        $document = new \DOMDocument();
+        $document->loadHTML('<html><body><form><textarea name="name">'.$content.'</textarea></form></body></html>', \LIBXML_NOERROR);
+
+        return $document->getElementsByTagName('textarea')->item(0);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`TextareaFormField::initialize()` reads `wholeText` on every child node of the textarea:

```php
$this->value = '';
foreach ($this->node->childNodes as $node) {
    $this->value .= $node->wholeText;
}
```

`wholeText` is a property of `DOMText`, not of `DOMNode`, and libxml's HTML parser does not treat the content of a textarea as raw text. So a comment or an element inside it becomes a `DOMComment` or a `DOMElement` child, and reading `wholeText` on that child raises a warning and contributes nothing, which also drops everything after it:

| textarea content | before | after |
| --- | --- | --- |
| `a<!--c-->b` | `'ab'` plus `Undefined property: DOMComment::$wholeText` | `'ab'` |
| `foo bar <h1>Baz</h1>` | `'foo bar '` plus `Undefined property: DOMElement::$wholeText` | `'foo bar Baz'` |
| `a<b>c</b>` | `'a'` plus `Undefined property: DOMElement::$wholeText` | `'ac'` |

`wholeText` also spans every text node adjacent to the one it is read on, so a run of adjacent text nodes is added once per node. A CDATA section produces such a run, and this one is silent:

```php
$crawler = new Crawler(null, 'http://example.com/');
$crawler->addXmlContent('<html><body><form action="/x" method="post"><textarea name="t">a<![CDATA[x]]>b</textarea></form></body></html>');

$crawler->filterXPath('//form')->form()->getValues();
```

Before: `['t' => 'axbaxbaxb']`. After: `['t' => 'axb']`.

`textContent` cannot exhibit either failure: it is a `DOMNode` property, so no child type is wrong, and it visits each descendant exactly once.

Reproduced identically on 6.4, 7.4, 8.1 and 8.2, so this targets 6.4.

### Checks

- DomCrawler 564 tests, BrowserKit 242 tests, green on PHP 8.4 and 8.5. php-cs-fixer exit 0.
- Revert-verified: with the fix reverted and the tests kept, the four parsed-markup data sets error with the `Undefined property` warnings pointing at the loop, and the CDATA test fails with `'axbaxbaxb'` against `'axb'`. The `text`, `empty`, `entity` and `escaped markup` sets pass on the old code, so those protect existing behaviour.
- Behaviour was compared value by value between the old and the new code over 44 node shapes. 32 are byte-identical, including a textarea whose only child is a text node holding literal markup, an empty textarea, entity references and a lone CDATA section. The 12 that differ are the cases above plus a `DOMProcessingInstruction` child, which loses its warning without changing the value, and a `DOMEntityReference` child under `substituteEntities = false`, which recovers `'aMIDb'` from `'ab'`.
- The existing tests build nodes with `DOMDocument::createElement($tag, $value)`, which always makes a single text child and therefore never reached this. The new tests parse a document.

### Who this affects

The value only changes for HTML that carries unescaped markup inside a textarea, and every such case also emitted a PHP warning before, which the phpunit bridge turns into an error. Forms rendered by Symfony are unaffected: `form_div_layout.html.twig` writes the value escaped, so it reaches libxml as a single text node.

One honest limitation: a spec-compliant parser treats textarea content as raw text, so a browser would submit `'a<!--c-->b'` and `'foo bar <h1>Baz</h1>'`. `loadHTML` has already discarded the tags before the field sees the node, so `'ab'` and `'foo bar Baz'` are the best this parser can do. Full fidelity needs the native HTML parser, which is what `HtmlTextareaFormField` provides in [#65389](https://github.com/symfony/symfony/pull/65389) on 8.2.

### Note for the merge up

No conflict on 7.4, 8.1 or 8.2, and none with [#65389](https://github.com/symfony/symfony/pull/65389). Take both sides. The native twin there already reads `textContent`, and the test that pins the difference between the two parsers asserts on the DOM directly rather than through this class, so it is unaffected.
