### PR TITLE
[DomCrawler] Fix FormField::getLabel() when the field id contains a quote

### DIFF
--- a/src/Symfony/Component/DomCrawler/Field/FormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/FormField.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\DomCrawler\Field;
 
+use Symfony\Component\DomCrawler\Crawler;
+
 /**
  * FormField is the abstract class for all form fields.
  *
@@ -63,7 +65,7 @@ abstract class FormField
         $xpath = new \DOMXPath($this->node->ownerDocument);
 
         if ($this->node->hasAttribute('id')) {
-            $labels = $xpath->query(\sprintf('descendant::label[@for="%s"]', $this->node->getAttribute('id')));
+            $labels = $xpath->query(\sprintf('descendant::label[@for=%s]', Crawler::xpathLiteral($this->node->getAttribute('id'))));
             if ($labels->length > 0) {
                 return $labels->item(0);
             }

--- a/src/Symfony/Component/DomCrawler/Tests/Field/FormFieldTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/Field/FormFieldTest.php
@@ -58,6 +58,22 @@ class FormFieldTest extends FormFieldTestCase
         $this->assertEquals('Foo label', $field->getLabel()->textContent, '->getLabel() returns the associated label');
     }
 
+    /**
+     * @dataProvider getIdsWithQuotes
+     */
+    public function testLabelIsAssignedByForAttributeWithQuotesInId(string $id)
+    {
+        $dom = new \DOMDocument();
+        $dom->loadHTML(\sprintf('<html><form>
+            <label for="%1$s">Foo label</label>
+            <input type="text" id="%1$s" name="foo" value="foo" />
+            <input type="submit" />
+        </form></html>', htmlspecialchars($id, \ENT_QUOTES)));
+
+        $field = new InputFormField($dom->getElementById($id));
+        $this->assertEquals('Foo label', $field->getLabel()->textContent, '->getLabel() returns the associated label');
+    }
+
     public function testLabelIsAssignedByParentingRelation()
     {
         $dom = new \DOMDocument();
@@ -68,5 +84,12 @@ class FormFieldTest extends FormFieldTestCase
 
         $field = new InputFormField($dom->getElementById('foo'));
         $this->assertEquals('Foo label', $field->getLabel()->textContent, '->getLabel() returns the parent label');
+    }
+
+    public static function getIdsWithQuotes()
+    {
+        yield 'double quote' => ['a"b'];
+        yield 'single quote' => ["a'b"];
+        yield 'both quotes' => ['a\'b"c'];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`FormField::getLabel()` interpolates the field's `id` into a double-quoted XPath string literal:

```php
$labels = $xpath->query(\sprintf('descendant::label[@for="%s"]', $this->node->getAttribute('id')));
```

An `id` holding a double quote therefore produces a malformed expression. `DOMXPath::query()` returns `false` and the next line reads a property on it:

```php
$html = '<html><form><label for=\'a"b\'>Foo label</label><input type="text" id=\'a"b\' name="foo"></form></html>';
$dom = new \DOMDocument();
$dom->loadHTML($html);

(new InputFormField($dom->getElementById('a"b')))->getLabel();
```

Before:

```
Warning: DOMXPath::query(): Invalid predicate
Warning: Attempt to read property "length" on false
NULL
```

After: the `<label>` element.

The label is also lost when the field has a wrapping `<label>` that the ancestor lookup would have found, because the warning fires before that branch is reached.

`Crawler::xpathLiteral()` exists for exactly this quoting problem and already handles a value with single quotes, double quotes or both. `Form::initialize()` in the same component uses it for the form `id`.

Reproduced identically on 6.4, 7.4, 8.1 and 8.2, so this targets 6.4. The interpolation dates back to Symfony 3.2, where `getLabel()` was introduced.

### Checks

- DomCrawler 558 tests, BrowserKit 242 tests, green on PHP 8.4 and 8.5. php-cs-fixer exit 0.
- Revert-verified: with the fix reverted and the test kept, the `double quote` and `both quotes` data sets error with `DOMXPath::query(): Invalid predicate` pointing at the interpolated line. The `single quote` set passes on the old code, so it protects existing behaviour rather than proving the fix.
- Edge cases run: single quote, double quote, both kinds, `]`, `[`, `(`, `)`, `/`, `*`, an empty `id`, an absent `id`, and the wrapping-label fallback. Only the two quoted cases change, and only from a warning plus `null` to the label.

### Note for the merge up

On 8.2, [#65389](https://github.com/symfony/symfony/pull/65389) replaces this XPath query with a tree walk in PHP, which fixes the same defect there. When this reaches 8.2, keep 8.2's `FormField.php` and drop both hunks of this commit from that file, the query line and the `Crawler` import. Keep the test: it is implementation independent.

The one remaining raw interpolation in the component, `Crawler::discoverNamespace()`, is left alone: its callers derive the prefix from a regex that cannot capture a quote.
