### PR TITLE
[Serializer] Support extensible discriminator map via child attribute

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -2135,6 +2135,10 @@ class FrameworkExtension extends Extension
             });
         }
 
+        $container->registerAttributeForAutoconfiguration(SerializerMapping\DiscriminatorMapType::class, static function (ChildDefinition $definition, SerializerMapping\DiscriminatorMapType $attribute) {
+            $definition->addTag('serializer.attribute_metadata', ['for' => $attribute->class, 'type' => $attribute->type, 'discriminator_map_type' => true]);
+        });
+
         $serializerLoaders[] = new Reference('serializer.mapping.attribute_loader');
 
         $container->getDefinition('serializer.mapping.attribute_loader')

--- a/src/Symfony/Component/Serializer/Attribute/DiscriminatorMap.php
+++ b/src/Symfony/Component/Serializer/Attribute/DiscriminatorMap.php
@@ -28,19 +28,11 @@ class DiscriminatorMap
      */
     public function __construct(
         public readonly string $typeProperty,
-        public readonly array $mapping,
+        public readonly array $mapping = [],
         public readonly ?string $defaultType = null,
     ) {
         if (!$typeProperty) {
             throw new InvalidArgumentException(\sprintf('Parameter "typeProperty" given to "%s" cannot be empty.', static::class));
-        }
-
-        if (!$mapping) {
-            throw new InvalidArgumentException(\sprintf('Parameter "mapping" given to "%s" cannot be empty.', static::class));
-        }
-
-        if (null !== $this->defaultType && !\array_key_exists($this->defaultType, $this->mapping)) {
-            throw new InvalidArgumentException(\sprintf('Default type "%s" given to "%s" must be present in "mapping" types.', $this->defaultType, static::class));
         }
     }
 }

--- a/src/Symfony/Component/Serializer/Attribute/DiscriminatorMapType.php
+++ b/src/Symfony/Component/Serializer/Attribute/DiscriminatorMapType.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Attribute;
+
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+
+/**
+ * Adds the attributed class to a {@see DiscriminatorMap} declared by a parent class or implemented interface.
+ *
+ * @author Matthias Schmidt <matthias@mttsch.dev>
+ */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
+final class DiscriminatorMapType
+{
+    /**
+     * @param string       $type  The value that identifies the attributed class in the discriminator map
+     * @param class-string $class The class or interface declaring the discriminator map
+     *
+     * @throws InvalidArgumentException
+     */
+    public function __construct(
+        public readonly string $type,
+        public readonly string $class,
+    ) {
+        if (!$type) {
+            throw new InvalidArgumentException(\sprintf('Parameter "type" given to "%s" cannot be empty.', static::class));
+        }
+
+        if (!$class) {
+            throw new InvalidArgumentException(\sprintf('Parameter "class" given to "%s" cannot be empty.', static::class));
+        }
+    }
+}

--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -15,6 +15,9 @@ CHANGELOG
  * Add support for configuring serialized names and paths per group, with repeatable `#[SerializedName]` and `#[SerializedPath]` attributes, a `serialized` key in YAML and a `<serialized>` element in XML
  * Enable using `#[WithAccessors]` from the PropertyInfo component with the serializer
  * Add `AbstractNormalizer::ENABLE_DEFAULT_GROUPS` context option to opt into implicit `Default` and class-short-name groups for attributes without explicit `#[Groups]`, mirroring Validator group conventions
+ * Add `DiscriminatorMapType` to extend discriminator maps from mapped child classes
+ * Make the `mapping` argument of `DiscriminatorMap` optional and validate it together with `defaultType` at metadata loading time
+ * Add `LoaderChainAwareInterface` so that loaders in a `LoaderChain` can defer work until all loaders have run; `LoaderChain` then validates discriminator maps declared in any format
 
 8.1
 ---

--- a/src/Symfony/Component/Serializer/DependencyInjection/AttributeMetadataPass.php
+++ b/src/Symfony/Component/Serializer/DependencyInjection/AttributeMetadataPass.php
@@ -28,13 +28,27 @@ final class AttributeMetadataPass implements CompilerPassInterface
 
         $resolve = $container->getParameterBag()->resolveValue(...);
         $taggedClasses = [];
+        $discriminatorMapTypes = [];
         foreach ($container->getDefinitions() as $id => $definition) {
             if (!$definition->hasTag('serializer.attribute_metadata')) {
                 continue;
             }
             $class = $resolve($definition->getClass());
             foreach ($definition->getTag('serializer.attribute_metadata') as $attributes) {
-                if ($class !== $for = $attributes['for'] ?? $class) {
+                $for = $attributes['for'] ?? $class;
+
+                if ($attributes['discriminator_map_type'] ?? false) {
+                    $this->checkDiscriminatorMapType($container, $class, $for);
+                    $type = $attributes['type'];
+                    if (isset($discriminatorMapTypes[$for][$type]) && $class !== $discriminatorMapTypes[$for][$type]) {
+                        throw new MappingException(\sprintf('Discriminator map type "%s" for "%s" is already mapped to "%s".', $type, $for, $discriminatorMapTypes[$for][$type]));
+                    }
+                    $discriminatorMapTypes[$for][$type] = $class;
+
+                    continue;
+                }
+
+                if ($class !== $for) {
                     $this->checkSourceMapsToTarget($container, $class, $for);
                 }
 
@@ -42,20 +56,28 @@ final class AttributeMetadataPass implements CompilerPassInterface
             }
         }
 
+        ksort($discriminatorMapTypes);
+        $loader = $container->getDefinition('serializer.mapping.attribute_loader')
+            ->setArgument(2, $discriminatorMapTypes);
+
         if (!$taggedClasses) {
             return;
         }
 
         ksort($taggedClasses);
-
-        $container->getDefinition('serializer.mapping.attribute_loader')
-            ->replaceArgument(1, array_map('array_keys', $taggedClasses));
+        $loader->replaceArgument(1, array_map('array_keys', $taggedClasses));
     }
 
     private function checkSourceMapsToTarget(ContainerBuilder $container, string $source, string $target): void
     {
-        $source = $container->getReflectionClass($source);
-        $target = $container->getReflectionClass($target);
+        if (!$r = $container->getReflectionClass($source)) {
+            throw new MappingException(\sprintf('Class "%s" cannot extend serialization for "%s" because it cannot be found.', $source, $target));
+        }
+        $source = $r;
+        if (!$r = $container->getReflectionClass($target)) {
+            throw new MappingException(\sprintf('Class "%s" cannot extend serialization for "%s" because the target class cannot be found.', $source->name, $target));
+        }
+        $target = $r;
 
         foreach ($source->getProperties() as $p) {
             if ($p->class === $source->name && !($target->hasProperty($p->name) && $target->getProperty($p->name)->class === $target->name)) {
@@ -67,6 +89,22 @@ final class AttributeMetadataPass implements CompilerPassInterface
             if ($m->class === $source->name && !($target->hasMethod($m->name) && $target->getMethod($m->name)->class === $target->name)) {
                 throw new MappingException(\sprintf('The method "%s" on "%s" is not present on "%s".', $m->name, $source->name, $target->name));
             }
+        }
+    }
+
+    private function checkDiscriminatorMapType(ContainerBuilder $container, string $source, string $target): void
+    {
+        if (!$r = $container->getReflectionClass($source)) {
+            throw new MappingException(\sprintf('Class "%s" cannot add a discriminator map type for "%s" because it cannot be found.', $source, $target));
+        }
+        $source = $r;
+        if (!$r = $container->getReflectionClass($target)) {
+            throw new MappingException(\sprintf('Class "%s" cannot add a discriminator map type for "%s" because the target class cannot be found.', $source->name, $target));
+        }
+        $target = $r;
+
+        if (!is_a($source->name, $target->name, true)) {
+            throw new MappingException(\sprintf('Class "%s" cannot add a discriminator map type for "%s" because it is not a subtype of it.', $source->name, $target->name));
         }
     }
 }

--- a/src/Symfony/Component/Serializer/Mapping/Loader/AttributeLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/AttributeLoader.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Serializer\Mapping\Loader;
 
 use Symfony\Component\Serializer\Attribute\Context;
 use Symfony\Component\Serializer\Attribute\DiscriminatorMap;
+use Symfony\Component\Serializer\Attribute\DiscriminatorMapType;
 use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Serializer\Attribute\Ignore;
 use Symfony\Component\Serializer\Attribute\MaxDepth;
@@ -31,12 +32,13 @@ use Symfony\Component\Serializer\Mapping\ClassMetadataInterface;
  * @author Alexander M. Turek <me@derrabus.de>
  * @author Alexandre Daubois <alex.daubois@gmail.com>
  */
-class AttributeLoader implements LoaderInterface
+class AttributeLoader implements LoaderChainAwareInterface
 {
     use AccessorCollisionResolverTrait;
 
     private const KNOWN_ATTRIBUTES = [
         DiscriminatorMap::class,
+        DiscriminatorMapType::class,
         Groups::class,
         Ignore::class,
         MaxDepth::class,
@@ -45,12 +47,19 @@ class AttributeLoader implements LoaderInterface
         Context::class,
     ];
 
+    private bool $deferDiscriminatorMapValidation = false;
+
+    private array $deferredDiscriminatorMapTypes = [];
+
     /**
-     * @param array<class-string, class-string[]> $mappedClasses
+     * @param array<class-string, class-string[]>                   $mappedClasses
+     * @param array<class-string, array<string, class-string>>|null $discriminatorMapTypes The registry of classes contributed to discriminator
+     *                                                                                     maps, or null when contributions are not wired at all
      */
     public function __construct(
         private bool $allowAnyClass = true,
         private array $mappedClasses = [],
+        private ?array $discriminatorMapTypes = null,
     ) {
     }
 
@@ -59,14 +68,36 @@ class AttributeLoader implements LoaderInterface
      */
     public function getMappedClasses(): array
     {
-        return array_keys($this->mappedClasses);
+        return array_keys($this->mappedClasses + ($this->discriminatorMapTypes ?? []));
+    }
+
+    public function prepareLoading(ClassMetadataInterface $metadata): void
+    {
+        $this->deferDiscriminatorMapValidation = true;
+        unset($this->deferredDiscriminatorMapTypes[$metadata->getName()]);
+    }
+
+    public function finalizeLoading(ClassMetadataInterface $metadata): void
+    {
+        $this->deferDiscriminatorMapValidation = false;
+        $deferred = $this->deferredDiscriminatorMapTypes[$metadata->getName()] ?? [];
+        unset($this->deferredDiscriminatorMapTypes[$metadata->getName()]);
+
+        foreach ($deferred as [$type, $mappedClass]) {
+            $this->addDiscriminatorMapType($type, $mappedClass, $metadata);
+        }
+
+        $this->validateDiscriminatorMap($metadata);
     }
 
     public function loadClassMetadata(ClassMetadataInterface $classMetadata): bool
     {
         $className = $classMetadata->getName();
 
-        if (!$sourceClasses = $this->mappedClasses[$className] ??= $this->allowAnyClass ? [$className] : []) {
+        $sourceClasses = $this->mappedClasses[$className] ??= $this->allowAnyClass ? [$className] : [];
+        $discriminatorMapTypes = $this->discriminatorMapTypes[$className] ?? [];
+
+        if (!$sourceClasses && !$discriminatorMapTypes) {
             return false;
         }
 
@@ -83,7 +114,28 @@ class AttributeLoader implements LoaderInterface
             $success = $this->doLoadClassMetadata($reflectionClass, $classMetadata) || $success;
         }
 
+        foreach ($discriminatorMapTypes as $type => $mappedClass) {
+            $this->addDiscriminatorMapType($type, $mappedClass, $classMetadata);
+        }
+
+        if (!$this->deferDiscriminatorMapValidation) {
+            $this->validateDiscriminatorMap($classMetadata);
+        }
+
         return $success;
+    }
+
+    private function validateDiscriminatorMap(ClassMetadataInterface $classMetadata): void
+    {
+        if (null !== $mapping = $classMetadata->getClassDiscriminatorMapping()) {
+            if (!$mapping->getTypesMapping()) {
+                throw new MappingException(\sprintf('Discriminator map for "%s" cannot be empty.', $classMetadata->getName()));
+            }
+
+            if (null !== $mapping->getDefaultType() && null === $mapping->getClassForType($mapping->getDefaultType())) {
+                throw new MappingException(\sprintf('Default type "%s" for discriminator map of "%s" must be present in mapping types.', $mapping->getDefaultType(), $classMetadata->getName()));
+            }
+        }
     }
 
     private function doLoadClassMetadata(\ReflectionClass $reflectionClass, ClassMetadataInterface $classMetadata): bool
@@ -96,8 +148,10 @@ class AttributeLoader implements LoaderInterface
         $attributesMetadata = $classMetadata->getAttributesMetadata();
 
         foreach ($this->loadAttributes($reflectionClass) as $attribute) {
+            $loaded = true;
             match (true) {
                 $attribute instanceof DiscriminatorMap => $classMetadata->setClassDiscriminatorMapping(new ClassDiscriminatorMapping($attribute->typeProperty, $attribute->mapping, $attribute->defaultType)),
+                $attribute instanceof DiscriminatorMapType => $this->checkDiscriminatorMapTypeIsRegistered($attribute, $className),
                 $attribute instanceof Groups => $classGroups = $attribute->groups,
                 $attribute instanceof Context => $classContextAttribute = $attribute,
                 default => null,
@@ -215,6 +269,43 @@ class AttributeLoader implements LoaderInterface
         }
 
         return $loaded;
+    }
+
+    /**
+     * @param class-string $mappedClass
+     */
+    private function addDiscriminatorMapType(string $type, string $mappedClass, ClassMetadataInterface $classMetadata): void
+    {
+        if (!is_a($mappedClass, $classMetadata->getName(), true)) {
+            throw new MappingException(\sprintf('Class "%s" cannot add discriminator map type "%s" for "%s" because it is not a subtype of it.', $mappedClass, $type, $classMetadata->getName()));
+        }
+
+        if ($this->deferDiscriminatorMapValidation) {
+            // wait for the whole loader chain to run, so that types are added to the
+            // final discriminator map, no matter which loader declares it
+            $this->deferredDiscriminatorMapTypes[$classMetadata->getName()][] = [$type, $mappedClass];
+
+            return;
+        }
+
+        if (null === $mapping = $classMetadata->getClassDiscriminatorMapping()) {
+            throw new MappingException(\sprintf('Class "%s" cannot add discriminator map type "%s" for "%s" because the target does not declare a discriminator map.', $mappedClass, $type, $classMetadata->getName()));
+        }
+
+        $typesMapping = $mapping->getTypesMapping();
+        if (isset($typesMapping[$type]) && $typesMapping[$type] !== $mappedClass) {
+            throw new MappingException(\sprintf('Discriminator map type "%s" for "%s" is already mapped to "%s".', $type, $classMetadata->getName(), $typesMapping[$type]));
+        }
+
+        $typesMapping[$type] = $mappedClass;
+        $classMetadata->setClassDiscriminatorMapping(new ClassDiscriminatorMapping($mapping->getTypeProperty(), $typesMapping, $mapping->getDefaultType()));
+    }
+
+    private function checkDiscriminatorMapTypeIsRegistered(DiscriminatorMapType $attribute, string $className): void
+    {
+        if (null !== $this->discriminatorMapTypes && $className !== ($this->discriminatorMapTypes[$attribute->class][$attribute->type] ?? null)) {
+            throw new MappingException(\sprintf('Class "%s" cannot add discriminator map type "%s" for "%s" because it is not registered with the loader. Make sure the class is in a path scanned for services and not in an excluded one, or register it with the "discriminatorMapTypes" argument of the loader.', $className, $attribute->type, $attribute->class));
+        }
     }
 
     private function loadAttributes(\ReflectionMethod|\ReflectionClass|\ReflectionProperty $reflector): iterable

--- a/src/Symfony/Component/Serializer/Mapping/Loader/LoaderChain.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/LoaderChain.php
@@ -48,7 +48,19 @@ class LoaderChain implements LoaderInterface
         $success = false;
 
         foreach ($this->loaders as $loader) {
+            if ($loader instanceof LoaderChainAwareInterface) {
+                $loader->prepareLoading($metadata);
+            }
+        }
+
+        foreach ($this->loaders as $loader) {
             $success = $loader->loadClassMetadata($metadata) || $success;
+        }
+
+        foreach ($this->loaders as $loader) {
+            if ($loader instanceof LoaderChainAwareInterface) {
+                $loader->finalizeLoading($metadata);
+            }
         }
 
         return $success;

--- a/src/Symfony/Component/Serializer/Mapping/Loader/LoaderChainAwareInterface.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/LoaderChainAwareInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Mapping\Loader;
+
+use Symfony\Component\Serializer\Mapping\ClassMetadataInterface;
+
+/**
+ * Allows a loader to defer work until all loaders in a chain have run.
+ *
+ * This is useful when a loader contributes metadata that another loader may
+ * provide later in the chain. Loaders that are used directly can keep their
+ * immediate validation behavior.
+ *
+ * @author Matthias Schmidt <matthias@mttsch.dev>
+ */
+interface LoaderChainAwareInterface extends LoaderInterface
+{
+    public function prepareLoading(ClassMetadataInterface $metadata): void;
+
+    public function finalizeLoading(ClassMetadataInterface $metadata): void;
+}

--- a/src/Symfony/Component/Serializer/Tests/Attribute/DiscriminatorMapTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Attribute/DiscriminatorMapTest.php
@@ -40,16 +40,17 @@ class DiscriminatorMapTest extends TestCase
         new DiscriminatorMap(typeProperty: '', mapping: ['foo' => 'FooClass']);
     }
 
-    public function testExceptionWithEmptyMappingProperty()
+    public function testEmptyMappingCanBeExtendedByMappedClasses()
     {
-        $this->expectException(InvalidArgumentException::class);
-        new DiscriminatorMap(typeProperty: 'type', mapping: []);
+        $attribute = new DiscriminatorMap(typeProperty: 'type');
+
+        $this->assertSame([], $attribute->mapping);
     }
 
-    public function testExceptionWithMissingDefaultTypeInMapping()
+    public function testDefaultTypeCanReferenceAContributedType()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(\sprintf('Default type "bar" given to "%s" must be present in "mapping" types.', DiscriminatorMap::class));
-        new DiscriminatorMap(typeProperty: 'type', mapping: ['foo' => 'FooClass'], defaultType: 'bar');
+        $attribute = new DiscriminatorMap(typeProperty: 'type', mapping: ['foo' => 'FooClass'], defaultType: 'bar');
+
+        $this->assertSame('bar', $attribute->defaultType);
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Attribute/DiscriminatorMapTypeTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Attribute/DiscriminatorMapTypeTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Attribute;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Attribute\DiscriminatorMapType;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+
+class DiscriminatorMapTypeTest extends TestCase
+{
+    public function testProperties()
+    {
+        $attribute = new DiscriminatorMapType('email', self::class);
+
+        $this->assertSame('email', $attribute->type);
+        $this->assertSame(self::class, $attribute->class);
+    }
+
+    public function testRejectsEmptyType()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new DiscriminatorMapType('', self::class);
+    }
+
+    public function testRejectsEmptyClass()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Parameter "class"');
+        new DiscriminatorMapType('email', '');
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/DependencyInjection/AttributeMetadataPassTest.php
+++ b/src/Symfony/Component/Serializer/Tests/DependencyInjection/AttributeMetadataPassTest.php
@@ -39,7 +39,7 @@ class AttributeMetadataPassTest extends TestCase
         (new AttributeMetadataPass())->process($container);
 
         $arguments = $container->getDefinition('serializer.mapping.attribute_loader')->getArguments();
-        $this->assertSame([false, []], $arguments);
+        $this->assertSame([false, [], []], $arguments, 'An empty discriminator map type registry should still be wired.');
     }
 
     public function testProcessWithTaggedServices()
@@ -70,7 +70,7 @@ class AttributeMetadataPassTest extends TestCase
             'App\Entity\Product' => ['App\Entity\Product'],
             'App\Entity\User' => ['App\Entity\User'],
         ];
-        $this->assertSame([false, $expectedClasses], $arguments);
+        $this->assertSame([false, $expectedClasses, []], $arguments);
     }
 
     public function testProcessWithForOptionAndMatchingMembers()
@@ -88,7 +88,7 @@ class AttributeMetadataPassTest extends TestCase
         (new AttributeMetadataPass())->process($container);
 
         $arguments = $container->getDefinition('serializer.mapping.attribute_loader')->getArguments();
-        $this->assertSame([false, [$targetClass => [$sourceClass]]], $arguments);
+        $this->assertSame([false, [$targetClass => [$sourceClass]], []], $arguments);
     }
 
     public function testProcessWithForOptionAndMissingMemberThrows()
@@ -104,6 +104,103 @@ class AttributeMetadataPassTest extends TestCase
             ->addTag('serializer.attribute_metadata', ['for' => $targetClass]);
 
         $this->expectException(MappingException::class);
+        (new AttributeMetadataPass())->process($container);
+    }
+
+    public function testProcessWithDiscriminatorMapType()
+    {
+        $container = new ContainerBuilder();
+        $container->register('serializer.mapping.attribute_loader', AttributeLoader::class)
+            ->setArguments([false, []]);
+        $container->register('service.source', _AttrMeta_DiscriminatorChild::class)
+            ->addTag('serializer.attribute_metadata', ['for' => _AttrMeta_DiscriminatorParent::class, 'type' => 'child', 'discriminator_map_type' => true]);
+        $container->register('service.same_source', _AttrMeta_DiscriminatorChild::class)
+            ->addTag('serializer.attribute_metadata', ['for' => _AttrMeta_DiscriminatorParent::class, 'type' => 'child', 'discriminator_map_type' => true]);
+
+        (new AttributeMetadataPass())->process($container);
+
+        $arguments = $container->getDefinition('serializer.mapping.attribute_loader')->getArguments();
+        $this->assertSame([false, [], [_AttrMeta_DiscriminatorParent::class => ['child' => _AttrMeta_DiscriminatorChild::class]]], $arguments);
+    }
+
+    public function testProcessCollectsSelfContributedDiscriminatorMapType()
+    {
+        $container = new ContainerBuilder();
+        $container->register('serializer.mapping.attribute_loader', AttributeLoader::class)
+            ->setArguments([false, []]);
+        $container->register('service.self', _AttrMeta_DiscriminatorParent::class)
+            ->addTag('serializer.attribute_metadata', ['for' => _AttrMeta_DiscriminatorParent::class, 'type' => 'parent', 'discriminator_map_type' => true]);
+
+        (new AttributeMetadataPass())->process($container);
+
+        $arguments = $container->getDefinition('serializer.mapping.attribute_loader')->getArguments();
+        $this->assertSame([false, [], [_AttrMeta_DiscriminatorParent::class => ['parent' => _AttrMeta_DiscriminatorParent::class]]], $arguments);
+    }
+
+    public function testProcessRejectsDiscriminatorMapTypeOnUnknownClass()
+    {
+        $container = new ContainerBuilder();
+        $container->register('serializer.mapping.attribute_loader', AttributeLoader::class)
+            ->setArguments([false, []]);
+        $container->register('service.source', 'App\MissingChild')
+            ->addTag('serializer.attribute_metadata', ['for' => _AttrMeta_DiscriminatorParent::class, 'type' => 'child', 'discriminator_map_type' => true]);
+
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage(\sprintf('Class "App\MissingChild" cannot add a discriminator map type for "%s" because it cannot be found.', _AttrMeta_DiscriminatorParent::class));
+        (new AttributeMetadataPass())->process($container);
+    }
+
+    public function testProcessRejectsDiscriminatorMapTypeForUnknownTargetClass()
+    {
+        $container = new ContainerBuilder();
+        $container->register('serializer.mapping.attribute_loader', AttributeLoader::class)
+            ->setArguments([false, []]);
+        $container->register('service.source', _AttrMeta_DiscriminatorChild::class)
+            ->addTag('serializer.attribute_metadata', ['for' => 'App\MissingParent', 'type' => 'child', 'discriminator_map_type' => true]);
+
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage(\sprintf('Class "%s" cannot add a discriminator map type for "App\MissingParent" because the target class cannot be found.', _AttrMeta_DiscriminatorChild::class));
+        (new AttributeMetadataPass())->process($container);
+    }
+
+    public function testProcessRejectsUnknownTargetClass()
+    {
+        $container = new ContainerBuilder();
+        $container->register('serializer.mapping.attribute_loader', AttributeLoader::class)
+            ->setArguments([false, []]);
+        $container->register('service.source', _AttrMeta_Source::class)
+            ->addTag('serializer.attribute_metadata', ['for' => 'App\MissingTarget']);
+
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage(\sprintf('Class "%s" cannot extend serialization for "App\MissingTarget" because the target class cannot be found.', _AttrMeta_Source::class));
+        (new AttributeMetadataPass())->process($container);
+    }
+
+    public function testProcessRejectsDiscriminatorMapTypeThatIsNotASubtype()
+    {
+        $container = new ContainerBuilder();
+        $container->register('serializer.mapping.attribute_loader', AttributeLoader::class)
+            ->setArguments([false, []]);
+        $container->register('service.source', _AttrMeta_Source::class)
+            ->addTag('serializer.attribute_metadata', ['for' => _AttrMeta_DiscriminatorParent::class, 'type' => 'source', 'discriminator_map_type' => true]);
+
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage('is not a subtype');
+        (new AttributeMetadataPass())->process($container);
+    }
+
+    public function testProcessRejectsDuplicateDiscriminatorMapTypes()
+    {
+        $container = new ContainerBuilder();
+        $container->register('serializer.mapping.attribute_loader', AttributeLoader::class)
+            ->setArguments([false, []]);
+        $container->register('service.first', _AttrMeta_DiscriminatorChild::class)
+            ->addTag('serializer.attribute_metadata', ['for' => _AttrMeta_DiscriminatorParent::class, 'type' => 'child', 'discriminator_map_type' => true]);
+        $container->register('service.second', _AttrMeta_SecondDiscriminatorChild::class)
+            ->addTag('serializer.attribute_metadata', ['for' => _AttrMeta_DiscriminatorParent::class, 'type' => 'child', 'discriminator_map_type' => true]);
+
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage(\sprintf('Discriminator map type "child" for "%s" is already mapped to "%s".', _AttrMeta_DiscriminatorParent::class, _AttrMeta_DiscriminatorChild::class));
         (new AttributeMetadataPass())->process($container);
     }
 }
@@ -129,4 +226,16 @@ class _AttrMeta_Target
 class _AttrMeta_BadSource
 {
     public string $extra;
+}
+
+class _AttrMeta_DiscriminatorParent
+{
+}
+
+class _AttrMeta_DiscriminatorChild extends _AttrMeta_DiscriminatorParent
+{
+}
+
+class _AttrMeta_SecondDiscriminatorChild extends _AttrMeta_DiscriminatorParent
+{
 }

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Loader/AttributeLoaderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Loader/AttributeLoaderTest.php
@@ -17,7 +17,10 @@ use Symfony\Component\Serializer\Exception\MappingException;
 use Symfony\Component\Serializer\Mapping\AttributeMetadata;
 use Symfony\Component\Serializer\Mapping\ClassDiscriminatorMapping;
 use Symfony\Component\Serializer\Mapping\ClassMetadata;
+use Symfony\Component\Serializer\Mapping\ClassMetadataInterface;
 use Symfony\Component\Serializer\Mapping\Loader\AttributeLoader;
+use Symfony\Component\Serializer\Mapping\Loader\LoaderChain;
+use Symfony\Component\Serializer\Mapping\Loader\LoaderChainAwareInterface;
 use Symfony\Component\Serializer\Mapping\Loader\LoaderInterface;
 use Symfony\Component\Serializer\Tests\Fixtures\Attributes\AbstractDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\Attributes\AbstractDummyFirstChild;
@@ -91,6 +94,305 @@ class AttributeLoaderTest extends TestCase
         $expected->getReflectionClass();
 
         $this->assertEquals($expected, $classMetadata);
+    }
+
+    public function testLoadDiscriminatorMapTypesFromMappedChildClasses()
+    {
+        $loader = new AttributeLoader(false, [], [
+            _DiscriminatorMapParent::class => [
+                'first' => _DiscriminatorMapFirstChild::class,
+                'second' => _DiscriminatorMapSecondChild::class,
+            ],
+        ]);
+        $classMetadata = new ClassMetadata(_DiscriminatorMapParent::class);
+
+        $this->assertTrue($loader->loadClassMetadata($classMetadata));
+        $this->assertEquals(new ClassDiscriminatorMapping('type', [
+            'first' => _DiscriminatorMapFirstChild::class,
+            'second' => _DiscriminatorMapSecondChild::class,
+        ]), $classMetadata->getClassDiscriminatorMapping());
+    }
+
+    public function testDiscriminatorMapTypeCanBeReconciledAfterAnotherLoaderProvidesTheMap()
+    {
+        $loader = new LoaderChain([
+            new AttributeLoader(false, [], [_DeferredDiscriminatorParent::class => ['child' => _DeferredDiscriminatorChild::class]]),
+            new class implements LoaderInterface {
+                public function loadClassMetadata(ClassMetadataInterface $metadata): bool
+                {
+                    $metadata->setClassDiscriminatorMapping(new ClassDiscriminatorMapping('type', ['parent' => _DeferredDiscriminatorParent::class]));
+
+                    return true;
+                }
+            },
+        ]);
+        $metadata = new ClassMetadata(_DeferredDiscriminatorParent::class);
+
+        $this->assertTrue($loader->loadClassMetadata($metadata));
+        $this->assertSame(['child' => _DeferredDiscriminatorChild::class, 'parent' => _DeferredDiscriminatorParent::class], $metadata->getClassDiscriminatorMapping()->getTypesMapping());
+    }
+
+    public function testLoaderChainAwareLifecycle()
+    {
+        $events = [];
+        $awareLoader = new class($events) implements LoaderInterface, LoaderChainAwareInterface {
+            public function __construct(private array &$events)
+            {
+            }
+
+            public function prepareLoading(ClassMetadataInterface $metadata): void
+            {
+                $this->events[] = 'prepare';
+            }
+
+            public function loadClassMetadata(ClassMetadataInterface $metadata): bool
+            {
+                $this->events[] = 'aware';
+
+                return true;
+            }
+
+            public function finalizeLoading(ClassMetadataInterface $metadata): void
+            {
+                $this->events[] = 'finalize';
+            }
+        };
+        $ordinaryLoader = new class($events) implements LoaderInterface {
+            public function __construct(private array &$events)
+            {
+            }
+
+            public function loadClassMetadata(ClassMetadataInterface $metadata): bool
+            {
+                $this->events[] = 'ordinary';
+
+                return false;
+            }
+        };
+
+        $this->assertTrue((new LoaderChain([$awareLoader, $ordinaryLoader]))->loadClassMetadata(new ClassMetadata(_DeferredDiscriminatorParent::class)));
+        $this->assertSame(['prepare', 'aware', 'ordinary', 'finalize'], $events);
+    }
+
+    public function testDiscriminatorMapTypeSurvivesALaterLoaderReplacingTheMap()
+    {
+        $loader = new LoaderChain([
+            new AttributeLoader(false, [], [_DiscriminatorMapParent::class => ['first' => _DiscriminatorMapFirstChild::class]]),
+            new class implements LoaderInterface {
+                public function loadClassMetadata(ClassMetadataInterface $metadata): bool
+                {
+                    $metadata->setClassDiscriminatorMapping(new ClassDiscriminatorMapping('kind', ['second' => _DiscriminatorMapSecondChild::class]));
+
+                    return true;
+                }
+            },
+        ]);
+        $metadata = new ClassMetadata(_DiscriminatorMapParent::class);
+
+        $loader->loadClassMetadata($metadata);
+
+        $mapping = $metadata->getClassDiscriminatorMapping();
+        $this->assertSame('kind', $mapping->getTypeProperty());
+        $this->assertSame(['second' => _DiscriminatorMapSecondChild::class, 'first' => _DiscriminatorMapFirstChild::class], $mapping->getTypesMapping());
+    }
+
+    public function testLoadDiscriminatorMapTypeThroughChainRejectsTargetWithoutDiscriminatorMap()
+    {
+        $loader = new LoaderChain([
+            new AttributeLoader(false, [], [_DeferredDiscriminatorParent::class => ['child' => _DeferredDiscriminatorChild::class]]),
+        ]);
+
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage(\sprintf('Class "%s" cannot add discriminator map type "child" for "%s" because the target does not declare a discriminator map.', _DeferredDiscriminatorChild::class, _DeferredDiscriminatorParent::class));
+
+        $loader->loadClassMetadata(new ClassMetadata(_DeferredDiscriminatorParent::class));
+    }
+
+    public function testLoadDiscriminatorMapTypeThroughChainAfterAFailedLoad()
+    {
+        $loader = new LoaderChain([
+            new AttributeLoader(false, [], [_DeferredDiscriminatorParent::class => ['child' => _DeferredDiscriminatorChild::class]]),
+            new class implements LoaderInterface {
+                private bool $failNext = true;
+
+                public function loadClassMetadata(ClassMetadataInterface $metadata): bool
+                {
+                    if ($this->failNext) {
+                        $this->failNext = false;
+
+                        throw new MappingException('Transient failure.');
+                    }
+                    $metadata->setClassDiscriminatorMapping(new ClassDiscriminatorMapping('type', []));
+
+                    return true;
+                }
+            },
+        ]);
+
+        try {
+            $loader->loadClassMetadata(new ClassMetadata(_DeferredDiscriminatorParent::class));
+            $this->fail('The first load should have failed.');
+        } catch (MappingException $e) {
+            $this->assertSame('Transient failure.', $e->getMessage());
+        }
+
+        $metadata = new ClassMetadata(_DeferredDiscriminatorParent::class);
+        $loader->loadClassMetadata($metadata);
+
+        $this->assertSame(['child' => _DeferredDiscriminatorChild::class], $metadata->getClassDiscriminatorMapping()->getTypesMapping());
+    }
+
+    public function testLoadDiscriminatorMapTypeRejectsContributorMissingFromTheLoaderRegistry()
+    {
+        $loader = new AttributeLoader(true, [], []);
+
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage(\sprintf('Class "%s" cannot add discriminator map type "first" for "%s" because it is not registered with the loader.', _DiscriminatorMapFirstChild::class, _DiscriminatorMapParent::class));
+
+        $loader->loadClassMetadata(new ClassMetadata(_DiscriminatorMapFirstChild::class));
+    }
+
+    public function testLoadDiscriminatorMapTypeIsIgnoredWithoutALoaderRegistry()
+    {
+        $loader = new AttributeLoader();
+
+        $this->assertTrue($loader->loadClassMetadata(new ClassMetadata(_DiscriminatorMapFirstChild::class)));
+    }
+
+    public function testLoadDiscriminatorMapTypeForInterface()
+    {
+        $loader = new AttributeLoader(false, [], [
+            _DiscriminatorMapInterface::class => ['implementation' => _DiscriminatorMapImplementation::class],
+        ]);
+        $classMetadata = new ClassMetadata(_DiscriminatorMapInterface::class);
+
+        $loader->loadClassMetadata($classMetadata);
+
+        $this->assertEquals(new ClassDiscriminatorMapping('type', [
+            'implementation' => _DiscriminatorMapImplementation::class,
+        ]), $classMetadata->getClassDiscriminatorMapping());
+    }
+
+    public function testMappedDiscriminatorMapTypeDoesNotLoadChildAttributeMetadata()
+    {
+        $loader = new AttributeLoader(false, [], [
+            _DiscriminatorMapParent::class => ['with_metadata' => _DiscriminatorMapChildWithPropertyMetadata::class],
+        ]);
+        $classMetadata = new ClassMetadata(_DiscriminatorMapParent::class);
+
+        $loader->loadClassMetadata($classMetadata);
+
+        $this->assertSame([], $classMetadata->getAttributesMetadata());
+    }
+
+    public function testLoadMultipleDiscriminatorMapTypesFromOneMappedChildClass()
+    {
+        $loader = new AttributeLoader(false, [], [
+            _DiscriminatorMapParent::class => [
+                'first_alias' => _DiscriminatorMapMultipleTypesChild::class,
+                'second_alias' => _DiscriminatorMapMultipleTypesChild::class,
+            ],
+        ]);
+        $classMetadata = new ClassMetadata(_DiscriminatorMapParent::class);
+
+        $loader->loadClassMetadata($classMetadata);
+
+        $this->assertEquals(new ClassDiscriminatorMapping('type', [
+            'first_alias' => _DiscriminatorMapMultipleTypesChild::class,
+            'second_alias' => _DiscriminatorMapMultipleTypesChild::class,
+        ]), $classMetadata->getClassDiscriminatorMapping());
+    }
+
+    public function testLoadEmptyDiscriminatorMapWithoutMappedChildClassesThrows()
+    {
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage(\sprintf('Discriminator map for "%s" cannot be empty.', _DiscriminatorMapParent::class));
+
+        (new AttributeLoader())->loadClassMetadata(new ClassMetadata(_DiscriminatorMapParent::class));
+    }
+
+    public function testLoadDiscriminatorMapRequiresContributedDefaultTypeToExist()
+    {
+        $loader = new AttributeLoader(false, [], [
+            _DiscriminatorMapWithContributedDefault::class => ['first' => _DiscriminatorMapFirstDefaultChild::class],
+        ]);
+
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage('Default type "second"');
+        $loader->loadClassMetadata(new ClassMetadata(_DiscriminatorMapWithContributedDefault::class));
+    }
+
+    public function testLoadDiscriminatorMapAllowsContributedDefaultTypeWithInlineMapping()
+    {
+        $loader = new AttributeLoader(false, [], [
+            _DiscriminatorMapWithInlineMappingAndContributedDefault::class => ['second' => _DiscriminatorMapContributedDefaultChild::class],
+        ]);
+        $classMetadata = new ClassMetadata(_DiscriminatorMapWithInlineMappingAndContributedDefault::class);
+
+        $loader->loadClassMetadata($classMetadata);
+
+        $mapping = $classMetadata->getClassDiscriminatorMapping();
+        $this->assertSame('second', $mapping->getDefaultType());
+        $this->assertSame(_DiscriminatorMapContributedDefaultChild::class, $mapping->getClassForType('second'));
+    }
+
+    public function testChildDiscriminatorMapDoesNotReplaceTheMapItContributesTo()
+    {
+        $loader = new AttributeLoader(false, [], [
+            _DiscriminatorMapParent::class => ['nested' => _NestedDiscriminatorMapChild::class],
+        ]);
+        $classMetadata = new ClassMetadata(_DiscriminatorMapParent::class);
+
+        $loader->loadClassMetadata($classMetadata);
+
+        $mapping = $classMetadata->getClassDiscriminatorMapping();
+        $this->assertSame('type', $mapping->getTypeProperty());
+        $this->assertSame(_NestedDiscriminatorMapChild::class, $mapping->getClassForType('nested'));
+    }
+
+    public function testLoadDiscriminatorMapTypeRejectsConflictingDuplicateTypes()
+    {
+        $loader = new AttributeLoader(false, [], [
+            AbstractDummy::class => ['first' => AbstractDummySecondChild::class],
+        ]);
+
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage(\sprintf('Discriminator map type "first" for "%s" is already mapped to "%s".', AbstractDummy::class, AbstractDummyFirstChild::class));
+        $loader->loadClassMetadata(new ClassMetadata(AbstractDummy::class));
+    }
+
+    public function testLoadDiscriminatorMapTypeToleratesAContributionMatchingTheInlineMapping()
+    {
+        $loader = new AttributeLoader(false, [], [
+            AbstractDummy::class => ['first' => AbstractDummyFirstChild::class],
+        ]);
+        $classMetadata = new ClassMetadata(AbstractDummy::class);
+
+        $loader->loadClassMetadata($classMetadata);
+
+        $this->assertSame(AbstractDummyFirstChild::class, $classMetadata->getClassDiscriminatorMapping()->getClassForType('first'));
+    }
+
+    public function testLoadDiscriminatorMapTypeRejectsClassThatIsNotASubtype()
+    {
+        $loader = new AttributeLoader(false, [], [
+            _DiscriminatorMapParent::class => ['unrelated' => _UnrelatedDiscriminatorMapType::class],
+        ]);
+
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage(\sprintf('Class "%s" cannot add discriminator map type "unrelated" for "%s" because it is not a subtype of it.', _UnrelatedDiscriminatorMapType::class, _DiscriminatorMapParent::class));
+        $loader->loadClassMetadata(new ClassMetadata(_DiscriminatorMapParent::class));
+    }
+
+    public function testLoadDiscriminatorMapTypeRejectsTargetWithoutDiscriminatorMap()
+    {
+        $loader = new AttributeLoader(false, [], [
+            _ParentWithoutDiscriminatorMap::class => ['child' => _ChildOfParentWithoutDiscriminatorMap::class],
+        ]);
+
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage(\sprintf('Class "%s" cannot add discriminator map type "child" for "%s" because the target does not declare a discriminator map.', _ChildOfParentWithoutDiscriminatorMap::class, _ParentWithoutDiscriminatorMap::class));
+        $loader->loadClassMetadata(new ClassMetadata(_ParentWithoutDiscriminatorMap::class));
     }
 
     public function testLoadMaxDepth()
@@ -264,6 +566,15 @@ class AttributeLoaderTest extends TestCase
         $this->assertSame(['App\Entity\User', 'App\Entity\Product'], $loader->getMappedClasses());
     }
 
+    public function testGetMappedClassesIncludesDiscriminatorMapTargets()
+    {
+        $loader = new AttributeLoader(false, [], [
+            _DiscriminatorMapParent::class => ['first' => _DiscriminatorMapFirstChild::class],
+        ]);
+
+        $this->assertSame([_DiscriminatorMapParent::class], $loader->getMappedClasses());
+    }
+
     public function testLoadClassMetadataReturnsFalseForUnmappedClass()
     {
         $loader = new AttributeLoader(false, ['App\Entity\User' => ['App\Entity\User']]);
@@ -338,6 +649,8 @@ class _AttrMap_Target
     }
 }
 
+use Symfony\Component\Serializer\Attribute\DiscriminatorMap;
+use Symfony\Component\Serializer\Attribute\DiscriminatorMapType;
 use Symfony\Component\Serializer\Attribute\ExtendsSerializationFor;
 use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Serializer\Attribute\SerializedName;
@@ -368,4 +681,94 @@ class _AttrMap_ExtensionForTargetWithOwnAttributes
 {
     #[SerializedName('extended_value')]
     public string $value = '';
+}
+
+#[DiscriminatorMap('type')]
+abstract class _DiscriminatorMapParent
+{
+}
+
+#[DiscriminatorMap('type')]
+interface _DiscriminatorMapInterface
+{
+}
+
+#[DiscriminatorMapType('implementation', class: _DiscriminatorMapInterface::class)]
+class _DiscriminatorMapImplementation implements _DiscriminatorMapInterface
+{
+}
+
+#[DiscriminatorMapType('first', class: _DiscriminatorMapParent::class)]
+class _DiscriminatorMapFirstChild extends _DiscriminatorMapParent
+{
+}
+
+#[DiscriminatorMapType('second', class: _DiscriminatorMapParent::class)]
+class _DiscriminatorMapSecondChild extends _DiscriminatorMapParent
+{
+}
+
+#[DiscriminatorMapType('with_metadata', class: _DiscriminatorMapParent::class)]
+class _DiscriminatorMapChildWithPropertyMetadata extends _DiscriminatorMapParent
+{
+    #[SerializedName('subject_line')]
+    public string $subject;
+}
+
+#[DiscriminatorMapType('first_alias', class: _DiscriminatorMapParent::class)]
+#[DiscriminatorMapType('second_alias', class: _DiscriminatorMapParent::class)]
+class _DiscriminatorMapMultipleTypesChild extends _DiscriminatorMapParent
+{
+}
+
+class _DeferredDiscriminatorParent
+{
+}
+
+class _DeferredDiscriminatorChild extends _DeferredDiscriminatorParent
+{
+}
+
+#[DiscriminatorMapType('unrelated', class: _DiscriminatorMapParent::class)]
+class _UnrelatedDiscriminatorMapType
+{
+}
+
+abstract class _ParentWithoutDiscriminatorMap
+{
+}
+
+#[DiscriminatorMapType('child', class: _ParentWithoutDiscriminatorMap::class)]
+class _ChildOfParentWithoutDiscriminatorMap extends _ParentWithoutDiscriminatorMap
+{
+}
+
+#[DiscriminatorMap('nested_type', ['leaf' => _DiscriminatorMapFirstChild::class])]
+#[DiscriminatorMapType('nested', class: _DiscriminatorMapParent::class)]
+class _NestedDiscriminatorMapChild extends _DiscriminatorMapParent
+{
+}
+
+#[DiscriminatorMap('type', defaultType: 'second')]
+abstract class _DiscriminatorMapWithContributedDefault
+{
+}
+
+#[DiscriminatorMapType('first', class: _DiscriminatorMapWithContributedDefault::class)]
+class _DiscriminatorMapFirstDefaultChild extends _DiscriminatorMapWithContributedDefault
+{
+}
+
+#[DiscriminatorMap('type', ['first' => _DiscriminatorMapInlineDefaultChild::class], defaultType: 'second')]
+abstract class _DiscriminatorMapWithInlineMappingAndContributedDefault
+{
+}
+
+class _DiscriminatorMapInlineDefaultChild extends _DiscriminatorMapWithInlineMappingAndContributedDefault
+{
+}
+
+#[DiscriminatorMapType('second', class: _DiscriminatorMapWithInlineMappingAndContributedDefault::class)]
+class _DiscriminatorMapContributedDefaultChild extends _DiscriminatorMapWithInlineMappingAndContributedDefault
+{
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

This PR adds the `#[DiscriminatorMapType]` attribute. It lets a class add itself to a discriminator map declared by one of its parent classes or interfaces, so a map can be extended without modifying the class that declares it.

```php
#[DiscriminatorMap(typeProperty: 'type')]
abstract class Message
{
}

#[DiscriminatorMapType('email', class: Message::class)]
final class EmailMessage extends Message
{
}
```

The attribute is repeatable, so one class can register several type names.

Inline mappings keep working and are merged with contributed types. The `mapping` argument of `DiscriminatorMap` is now optional; the merged map is validated after metadata loading: it must not be empty, every contributed class must be a subtype of the declaring class, a type name cannot map to two different classes, and `defaultType` must be present in the merged map. `defaultType` can therefore reference a contributed type. Registering a type both inline and through the attribute is accepted when both point to the same class.

The map does not have to be declared as an attribute. `AttributeLoader` defers merging and validating contributed types until every loader in a `LoaderChain` has run, through the new `LoaderChainAwareInterface` (`prepareLoading()` / `finalizeLoading()`). A map declared in a YAML or XML mapping file can therefore be extended with the attribute, and contributed types end up in the final map whichever loader declared it. As a side effect, the chain now validates maps declared in any format: an empty map or a `default_type` missing from the map fails at metadata loading time instead of when the type is used.

In a full-stack application, contributed types are collected at container compile time through autoconfiguration, which also reports duplicate type names and invalid target classes during the build. Standalone users can pass the contributed types to `AttributeLoader`'s third constructor argument.

Discovery has a boundary: the contributing classes must live inside the paths scanned for service discovery. They do not need to be instantiable services, abstract classes and interfaces in scanned paths work, but classes under an `exclude:`d path (such as `src/Entity/` in the default recipe) are not seen by autoconfiguration. A class that carries the attribute without having been discovered fails with a `MappingException` explaining what to do when its metadata is first loaded.

For the documentation:
- declaring a map and contributing types from child classes (`class:` targets the class that declares the map, which can be an interface)
- the repeatable attribute form
- the validation rules above and when they are reported (compile time vs metadata loading)
- `defaultType` can name a contributed type
- maps declared in YAML/XML can be extended with the attribute
- the discovery boundary: contributing classes must be inside scanned service-discovery paths; with the default recipe, `src/Entity/` is excluded, and the attribute fails loudly there
- registering the same type inline and with the attribute is allowed when it maps to the same class
