### PR TITLE
[Yaml][FrameworkBundle] Add JSON Schema validation to the `lint:yaml` command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -152,6 +152,7 @@
         "monolog/monolog": "^3.0",
         "nikic/php-parser": "^5.0",
         "nyholm/psr7": "^1.0",
+        "opis/json-schema": "^2.6",
         "pda/pheanstalk": "^5.1|^7.0|^8.0",
         "php-http/discovery": "^1.15",
         "php-http/httplug": "^1.0|^2.0",

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * Add the `framework.mailer.tracking` option to set default open/click tracking for every outgoing message
  * Add the `doctrine.orm.entity` tag to auto-excluded `#[Entity]` and `#[MappedSuperclass]` classes to allow discovering them
  * Add `framework.rate_limiter.builder` option
+ * Add JSON Schema validation to the `lint:yaml` command, resolved from the `--check-schema` option, an in-file schema header, the component schema for well-known config files (`config/routes`, `config/services`, `config/serializer`, `config/validator`), or `config/schema.json` for `config/packages` by default
  * Add the `cache.adapter.pdo_tag_aware` cache pool adapter
  * Register the `web_link.json_linkset_serializer`, `web_link.json_linkset_parser`, `web_link.link_template_header_serializer` and `web_link.link_template_header_parser` services
  * Add `framework.asset_mapper.importmap_integrity_algorithms` option to add integrity metadata to importmaps

--- a/src/Symfony/Bundle/FrameworkBundle/Command/YamlLintCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/YamlLintCommand.php
@@ -13,6 +13,8 @@ namespace Symfony\Bundle\FrameworkBundle\Command;
 
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Yaml\Command\LintCommand as BaseLintCommand;
+use Symfony\Component\Yaml\Schema\SchemaResolverInterface;
+use Symfony\Component\Yaml\Schema\SchemaValidatorInterface;
 
 /**
  * Validates YAML files syntax and outputs encountered errors.
@@ -25,7 +27,7 @@ use Symfony\Component\Yaml\Command\LintCommand as BaseLintCommand;
 #[AsCommand(name: 'lint:yaml', description: 'Lint a YAML file and outputs encountered errors')]
 class YamlLintCommand extends BaseLintCommand
 {
-    public function __construct()
+    public function __construct(?SchemaResolverInterface $schemaResolver = null, ?SchemaValidatorInterface $schemaValidator = null, ?string $projectDir = null)
     {
         $directoryIteratorProvider = function ($directory, $default) {
             if (!is_dir($directory)) {
@@ -37,7 +39,7 @@ class YamlLintCommand extends BaseLintCommand
 
         $isReadableProvider = static fn ($fileOrDirectory, $default) => str_starts_with($fileOrDirectory, '@') || $default($fileOrDirectory);
 
-        parent::__construct(null, $directoryIteratorProvider, $isReadableProvider);
+        parent::__construct(null, $directoryIteratorProvider, $isReadableProvider, $schemaResolver, $schemaValidator, $projectDir);
     }
 
     protected function configure(): void

--- a/src/Symfony/Bundle/FrameworkBundle/Command/YamlLintSchemaResolver.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/YamlLintSchemaResolver.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Command;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Serializer\Serializer;
+use Symfony\Component\Validator\Validation;
+use Symfony\Component\Yaml\Schema\SchemaResolverInterface;
+
+/**
+ * Resolves the default JSON Schema of a YAML file, based on Symfony conventions.
+ *
+ * A schema declared by the document itself, through the decorated resolver, comes first.
+ * Then well-known config files (routes, services, serializer and validator mappings) validate
+ * against their component schema, wherever they live, since the naming convention also applies
+ * inside bundles. Finally, the bundle configuration files of this project (the packages directory
+ * of its config directory) fall back to the generated schema.json when it exists. Any other file
+ * has no schema.
+ *
+ * Without a config directory, the generated schema is never applied.
+ *
+ * @author Jérôme Tamarelle <jerome@tamarelle.net>
+ */
+final class YamlLintSchemaResolver implements SchemaResolverInterface
+{
+    public function __construct(
+        private readonly ?string $configDir = null,
+        private readonly ?SchemaResolverInterface $schemaResolver = null,
+    ) {
+    }
+
+    public function resolve(string $content, ?string $file = null): ?string
+    {
+        if ($schema = $this->schemaResolver?->resolve($content, $file)) {
+            return $schema;
+        }
+
+        if (!$file) {
+            return null;
+        }
+
+        $file = self::canonicalize($file);
+        foreach (self::getComponentSchemas() as [$pattern, $class, $schema]) {
+            if (preg_match($pattern, $file) && class_exists($class)) {
+                return \dirname((new \ReflectionClass($class))->getFileName()).$schema;
+            }
+        }
+
+        if ($this->configDir && preg_match('#\.ya?ml$#', $file) && is_file($schema = $this->configDir.'/schema.json')) {
+            return str_starts_with($file, self::canonicalize($this->configDir).'/packages/') ? $schema : null;
+        }
+
+        return null;
+    }
+
+    private static function canonicalize(string $path): string
+    {
+        return str_replace('\\', '/', realpath($path) ?: $path);
+    }
+
+    /**
+     * @return iterable<array{0: string, 1: class-string, 2: string}> A pattern, a component class and the schema path relative to it
+     */
+    private static function getComponentSchemas(): iterable
+    {
+        yield ['#(^|/)config/routes(\.ya?ml|/.+\.ya?ml)$#', Route::class, '/Loader/schema/routing.schema.json'];
+        yield ['#(^|/)config/services(\.ya?ml|_[^/]+\.ya?ml)$#', ContainerBuilder::class, '/Loader/schema/services.schema.json'];
+        yield ['#(^|/)config/serializer/.+\.ya?ml$#', Serializer::class, '/Mapping/Loader/schema/serialization.schema.json'];
+        yield ['#(^|/)config/validator/.+\.ya?ml$#', Validation::class, '/Mapping/Loader/schema/validation.schema.json'];
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/JsonSchemaConfigDumpPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/JsonSchemaConfigDumpPass.php
@@ -120,7 +120,7 @@ class JsonSchemaConfigDumpPass implements CompilerPassInterface
             }
             ksort($whenProperties);
             $rootProperties['when@'.$env] = [
-                'type' => 'object',
+                '$ref' => '#/$defs/types/object_null',
                 'properties' => $whenProperties,
                 'additionalProperties' => false,
             ];
@@ -134,7 +134,7 @@ class JsonSchemaConfigDumpPass implements CompilerPassInterface
             'properties' => $rootProperties,
             'patternProperties' => [
                 '^when@[a-zA-Z0-9]+$' => [
-                    'type' => 'object',
+                    '$ref' => '#/$defs/types/object_null',
                     'properties' => $allProperties,
                 ],
             ],

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -229,6 +229,7 @@ use Symfony\Component\Workflow;
 use Symfony\Component\Workflow\Arc;
 use Symfony\Component\Workflow\WorkflowInterface;
 use Symfony\Component\Yaml\Command\LintCommand as BaseYamlLintCommand;
+use Symfony\Component\Yaml\Schema\SchemaResolverInterface;
 use Symfony\Component\Yaml\Yaml;
 use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Cache\CallbackInterface;
@@ -299,6 +300,10 @@ class FrameworkExtension extends Extension
             }
             if (!class_exists(BaseYamlLintCommand::class)) {
                 $container->removeDefinition('console.command.yaml_lint');
+            } elseif (!ContainerBuilder::willBeAvailable('symfony/yaml', SchemaResolverInterface::class, ['symfony/framework-bundle'])) {
+                $container->getDefinition('console.command.yaml_lint')->setArguments([]);
+            } elseif ($container->hasParameter('.kernel.config_dir')) {
+                $container->getDefinition('console.command.yaml_lint')->getArgument(0)->replaceArgument(0, $container->getParameter('.kernel.config_dir'));
             }
 
             if (!class_exists(BaseTranslationLintCommand::class)) {

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.php
@@ -38,6 +38,7 @@ use Symfony\Bundle\FrameworkBundle\Command\SecretsSetCommand;
 use Symfony\Bundle\FrameworkBundle\Command\TranslationDebugCommand;
 use Symfony\Bundle\FrameworkBundle\Command\TranslationExtractCommand;
 use Symfony\Bundle\FrameworkBundle\Command\YamlLintCommand;
+use Symfony\Bundle\FrameworkBundle\Command\YamlLintSchemaResolver;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\EventListener\SuggestMissingPackageSubscriber;
 use Symfony\Component\Console\EventListener\ValidateQuestionInputListener;
@@ -61,6 +62,8 @@ use Symfony\Component\Translation\Command\TranslationPushCommand;
 use Symfony\Component\Translation\Command\XliffLintCommand;
 use Symfony\Component\Validator\Command\DebugCommand as ValidatorDebugCommand;
 use Symfony\Component\Workflow\Command\WorkflowDumpCommand;
+use Symfony\Component\Yaml\Schema\FileHeaderSchemaResolver;
+use Symfony\Component\Yaml\Schema\SchemaValidator;
 use Symfony\WebpackEncoreBundle\Asset\EntrypointLookupInterface;
 
 return static function (ContainerConfigurator $container) {
@@ -324,6 +327,12 @@ return static function (ContainerConfigurator $container) {
             ->tag('console.command')
 
         ->set('console.command.yaml_lint', YamlLintCommand::class)
+            ->args([
+                inline_service(YamlLintSchemaResolver::class)
+                    ->args([null, inline_service(FileHeaderSchemaResolver::class)]),
+                inline_service(SchemaValidator::class),
+                param('kernel.project_dir'),
+            ])
             ->tag('console.command')
 
         ->set('console.command.translation_lint', TranslationLintCommand::class)

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/YamlLintCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/YamlLintCommandTest.php
@@ -11,8 +11,10 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\Command;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\FrameworkBundle\Command\YamlLintCommand;
+use Symfony\Bundle\FrameworkBundle\Command\YamlLintSchemaResolver;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Application as BaseApplication;
 use Symfony\Component\Console\Helper\HelperSet;
@@ -20,6 +22,8 @@ use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\Yaml\Schema\FileHeaderSchemaResolver;
+use Symfony\Component\Yaml\Schema\SchemaResolverInterface;
 
 /**
  * Tests the YamlLintCommand.
@@ -91,6 +95,180 @@ bar';
 
         $tester->assertCommandIsSuccessful('Returns 0 in case of success');
         $this->assertStringContainsString('[OK] All 0 YAML files contain valid syntax', trim($tester->getDisplay()));
+    }
+
+    public function testLintValidatesAgainstSchemaOption()
+    {
+        $this->skipIfJsonSchemaMissing();
+
+        $schema = $this->createSchema();
+
+        $tester = $this->createCommandTester();
+        $filename = $this->createFile('version: not-an-integer');
+
+        $tester->execute(['filename' => $filename, '--check-schema' => $schema], ['decorated' => false]);
+
+        $this->assertSame(1, $tester->getStatusCode(), 'lint:yaml validates against the schema given with --check-schema');
+    }
+
+    public function testLintValidatesAgainstSchemaHeader()
+    {
+        $this->skipIfJsonSchemaMissing();
+
+        $schema = $this->createSchema();
+
+        $tester = $this->createCommandTester();
+        $filename = $this->createFile(\sprintf("# \$schema=%s\nversion: not-an-integer", basename($schema)));
+
+        $tester->execute(['filename' => $filename, '--check-schema' => null], ['decorated' => false]);
+
+        $this->assertSame(1, $tester->getStatusCode(), 'lint:yaml validates against the in-file schema header');
+    }
+
+    public function testLintValidatesPackageConfigAgainstDefaultConfigSchema()
+    {
+        $this->skipIfJsonSchemaMissing();
+
+        $projectDir = sys_get_temp_dir().'/yml-lint-test';
+        @mkdir($projectDir.'/config/packages', 0o777, true);
+        file_put_contents($projectDir.'/config/schema.json', json_encode([
+            'type' => 'object',
+            'properties' => ['version' => ['type' => 'integer']],
+        ]));
+        $file = $projectDir.'/config/packages/framework.yaml';
+        file_put_contents($file, 'version: not-an-integer');
+        $this->files[] = $file;
+        $this->files[] = $projectDir.'/config/schema.json';
+
+        try {
+            $tester = $this->createFrameworkCommandTester($projectDir);
+
+            $tester->execute(['filename' => $file, '--check-schema' => null], ['decorated' => false]);
+
+            $this->assertSame(1, $tester->getStatusCode(), 'config/packages files are validated against config/schema.json by default');
+        } finally {
+            @unlink($file);
+            @unlink($projectDir.'/config/schema.json');
+            @rmdir($projectDir.'/config/packages');
+            @rmdir($projectDir.'/config');
+        }
+    }
+
+    #[DataProvider('provideComponentSchemaFiles')]
+    public function testLintValidatesWellKnownFilesAgainstComponentSchema(string $relativePath, string $schemaFile, ?string $requiredClass = null)
+    {
+        $this->skipIfJsonSchemaMissing();
+
+        if (null !== $requiredClass && !class_exists($requiredClass)) {
+            $this->markTestSkipped(\sprintf('The "%s" class is required.', $requiredClass));
+        }
+
+        $projectDir = sys_get_temp_dir().'/yml-lint-test';
+        $file = $projectDir.'/'.$relativePath;
+        @mkdir(\dirname($file), 0o777, true);
+        // A sequence is not an object, which every component schema requires at the root.
+        file_put_contents($file, '- invalid');
+        $this->files[] = $file;
+
+        try {
+            $tester = $this->createFrameworkCommandTester($projectDir);
+
+            $tester->execute(['filename' => $file, '--check-schema' => null], ['verbosity' => OutputInterface::VERBOSITY_VERBOSE, 'decorated' => false]);
+
+            $this->assertSame(1, $tester->getStatusCode(), \sprintf('%s is validated against the %s schema', $relativePath, $schemaFile));
+            // Strip the wrap prefix and every whitespace so the wrapped absolute schema path stays searchable.
+            $this->assertStringContainsString($schemaFile, preg_replace('/\s+/', '', preg_replace('~\n\s*// ~', '', $tester->getDisplay())));
+        } finally {
+            @unlink($file);
+            @rmdir(\dirname($file));
+            @rmdir($projectDir.'/config');
+        }
+    }
+
+    public static function provideComponentSchemaFiles(): iterable
+    {
+        yield 'routes' => ['config/routes/app.yaml', 'routing.schema.json'];
+        yield 'services' => ['config/services.yaml', 'services.schema.json'];
+        yield 'serializer' => ['config/serializer/app.yaml', 'serialization.schema.json', \Symfony\Component\Serializer\Serializer::class];
+        yield 'validator' => ['config/validator/app.yaml', 'validation.schema.json', \Symfony\Component\Validator\Validation::class];
+    }
+
+    public function testLintDoesNotApplyGeneratedSchemaOutsideConfigPackages()
+    {
+        $this->skipIfJsonSchemaMissing();
+
+        $projectDir = sys_get_temp_dir().'/yml-lint-test';
+        @mkdir($projectDir.'/config', 0o777, true);
+        file_put_contents($projectDir.'/config/schema.json', json_encode(['type' => 'object']));
+        $this->files[] = $projectDir.'/config/schema.json';
+        // A file outside config/packages, which config/schema.json does not describe.
+        $file = $this->createFile('- invalid');
+
+        try {
+            $tester = $this->createFrameworkCommandTester($projectDir);
+
+            $tester->execute(['filename' => $file, '--check-schema' => null], ['decorated' => false]);
+
+            $this->assertSame(0, $tester->getStatusCode(), 'config/schema.json is not applied outside config/packages');
+        } finally {
+            @unlink($projectDir.'/config/schema.json');
+            @rmdir($projectDir.'/config');
+        }
+    }
+
+    public function testLintDisplaysSchemaRelativeToProjectDir()
+    {
+        $this->skipIfJsonSchemaMissing();
+
+        $projectDir = sys_get_temp_dir().'/yml-lint-test';
+        @mkdir($projectDir.'/config', 0o777, true);
+        $schema = $projectDir.'/config/schema.json';
+        file_put_contents($schema, json_encode(['type' => 'object']));
+
+        try {
+            $tester = $this->createFrameworkCommandTester($projectDir);
+            $filename = $this->createFile('foo: bar');
+
+            $tester->execute(
+                ['filename' => $filename, '--check-schema' => $schema],
+                ['verbosity' => OutputInterface::VERBOSITY_VERBOSE, 'decorated' => false]
+            );
+
+            // The comment style wraps at 80 columns and prefixes every line with "//",
+            // so collapse line breaks and the prefix before asserting on the label.
+            $display = preg_replace('~\s*\n\s*(// )?~', ' ', $tester->getDisplay());
+            $this->assertStringContainsString('validated against config/schema.json', $display);
+        } finally {
+            @unlink($schema);
+            @rmdir($projectDir.'/config');
+        }
+    }
+
+    private function skipIfJsonSchemaMissing(): void
+    {
+        if (!interface_exists(SchemaResolverInterface::class)) {
+            $this->markTestSkipped('symfony/yaml 8.2 or higher is required.');
+        }
+
+        if (!class_exists(\Opis\JsonSchema\Validator::class)) {
+            $this->markTestSkipped('The "opis/json-schema" package is required.');
+        }
+    }
+
+    private function createSchema(): string
+    {
+        return $this->createFile(json_encode([
+            'type' => 'object',
+            'properties' => ['version' => ['type' => 'integer']],
+        ]));
+    }
+
+    private function createFrameworkCommandTester(string $projectDir): CommandTester
+    {
+        $application = new BaseApplication();
+        $application->addCommand(new YamlLintCommand(new YamlLintSchemaResolver($projectDir.'/config', new FileHeaderSchemaResolver()), null, $projectDir));
+
+        return $this->createCommandTester($application);
     }
 
     private function createFile($content): string

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/YamlLintSchemaResolverTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/YamlLintSchemaResolverTest.php
@@ -1,0 +1,164 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Command;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\Command\YamlLintSchemaResolver;
+use Symfony\Component\Serializer\Serializer;
+use Symfony\Component\Validator\Validation;
+use Symfony\Component\Yaml\Schema\SchemaResolverInterface;
+
+class YamlLintSchemaResolverTest extends TestCase
+{
+    private string $projectDir;
+    private string $configDir;
+
+    protected function setUp(): void
+    {
+        $projectDir = sys_get_temp_dir().'/yaml-lint-schema-resolver';
+        @mkdir($projectDir.'/config/packages', 0o777, true);
+
+        // Canonicalize, since the resolver compares the file with the resolved config directory.
+        $this->projectDir = realpath($projectDir);
+        $this->configDir = $this->projectDir.'/config';
+
+        // Skip last: tearDown() runs for skipped tests too, so the properties must be set.
+        if (!interface_exists(SchemaResolverInterface::class)) {
+            $this->markTestSkipped('symfony/yaml 8.2 or higher is required.');
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->configDir.'/schema.json');
+        @rmdir($this->configDir.'/packages');
+        @rmdir($this->configDir);
+        @rmdir($this->projectDir);
+    }
+
+    public function testStdinHasNoSchema()
+    {
+        $resolver = new YamlLintSchemaResolver($this->configDir);
+
+        $this->assertNull($resolver->resolve(''));
+    }
+
+    public function testTheDecoratedResolverComesFirst()
+    {
+        $header = $this->createStub(SchemaResolverInterface::class);
+        $header->method('resolve')->willReturn('/from-the-document.json');
+
+        $resolver = new YamlLintSchemaResolver($this->configDir, $header);
+
+        // A file that would otherwise resolve to the routing schema.
+        $this->assertSame('/from-the-document.json', $resolver->resolve('# $schema=/from-the-document.json', $this->projectDir.'/config/routes.yaml'));
+    }
+
+    public function testConventionsApplyWhenTheDecoratedResolverFindsNothing()
+    {
+        $header = $this->createStub(SchemaResolverInterface::class);
+        $header->method('resolve')->willReturn(null);
+
+        $resolver = new YamlLintSchemaResolver($this->configDir, $header);
+
+        $this->assertSame('routing.schema.json', basename($resolver->resolve('version: 8', $this->projectDir.'/config/routes.yaml')));
+    }
+
+    #[DataProvider('provideWellKnownFiles')]
+    public function testWellKnownFilesUseTheComponentSchema(string $relativePath, string $schemaFile, ?string $requiredClass = null)
+    {
+        if (null !== $requiredClass && !class_exists($requiredClass)) {
+            $this->markTestSkipped(\sprintf('The "%s" class is required.', $requiredClass));
+        }
+
+        $resolver = new YamlLintSchemaResolver($this->configDir);
+
+        $schema = $resolver->resolve('', $this->projectDir.'/'.$relativePath);
+
+        $this->assertNotNull($schema, \sprintf('"%s" resolves to a schema.', $relativePath));
+        $this->assertSame($schemaFile, basename($schema));
+        $this->assertFileExists($schema);
+    }
+
+    public static function provideWellKnownFiles(): iterable
+    {
+        yield 'routes' => ['config/routes.yaml', 'routing.schema.json'];
+        yield 'routes in a subdirectory' => ['config/routes/app.yaml', 'routing.schema.json'];
+        yield 'services' => ['config/services.yaml', 'services.schema.json'];
+        yield 'services per environment' => ['config/services_test.yaml', 'services.schema.json'];
+        yield 'serializer' => ['config/serializer/app.yaml', 'serialization.schema.json', Serializer::class];
+        yield 'validator' => ['config/validator/app.yaml', 'validation.schema.json', Validation::class];
+        yield 'the .yml extension' => ['config/routes.yml', 'routing.schema.json'];
+        yield 'services with the .yml extension' => ['config/services_test.yml', 'services.schema.json'];
+    }
+
+    #[DataProvider('provideUnknownFiles')]
+    public function testUnknownFilesHaveNoSchema(string $relativePath)
+    {
+        $resolver = new YamlLintSchemaResolver($this->configDir);
+
+        $this->assertNull($resolver->resolve('', $this->projectDir.'/'.$relativePath));
+    }
+
+    public static function provideUnknownFiles(): iterable
+    {
+        yield 'an arbitrary file' => ['translations/messages.en.yaml'];
+        yield 'another extension' => ['config/routes.xml'];
+        yield 'a file outside the config directory' => ['src/routes.yaml'];
+        yield 'a subdirectory of config' => ['config/other/app.yaml'];
+        // "config/services_test.yaml" matches, but the pattern must not cross directories.
+        yield 'a nested services file' => ['config/services/app.yaml'];
+    }
+
+    public function testWindowsPathsAreNormalized()
+    {
+        $resolver = new YamlLintSchemaResolver($this->configDir);
+
+        $schema = $resolver->resolve('', 'C:\\project\\config\\routes.yaml');
+
+        $this->assertNotNull($schema);
+        $this->assertSame('routing.schema.json', basename($schema));
+    }
+
+    public function testPackageConfigUsesTheGeneratedSchema()
+    {
+        touch($this->configDir.'/schema.json');
+
+        $resolver = new YamlLintSchemaResolver($this->configDir);
+
+        $this->assertSame($this->configDir.'/schema.json', $resolver->resolve('', $this->configDir.'/packages/framework.yaml'));
+        $this->assertSame($this->configDir.'/schema.json', $resolver->resolve('', $this->configDir.'/packages/dev/monolog.yaml'));
+        $this->assertSame($this->configDir.'/schema.json', $resolver->resolve('', $this->configDir.'/packages/twig.yml'));
+    }
+
+    public function testPackageConfigHasNoSchemaWithoutTheGeneratedFile()
+    {
+        $resolver = new YamlLintSchemaResolver($this->configDir);
+
+        $this->assertNull($resolver->resolve('', $this->configDir.'/packages/framework.yaml'));
+    }
+
+    public function testTheGeneratedSchemaOnlyAppliesToPackageConfig()
+    {
+        touch($this->configDir.'/schema.json');
+
+        $resolver = new YamlLintSchemaResolver($this->configDir);
+
+        $this->assertNull($resolver->resolve('', $this->configDir.'/packages.yaml'));
+        $this->assertNull($resolver->resolve('', $this->projectDir.'/other.yaml'));
+        // A packages directory of another project, or of a bundle, is not described by this schema.
+        $this->assertNull($resolver->resolve('', '/elsewhere/config/packages/framework.yaml'));
+        // A file explicitly passed to the command may have any extension.
+        $this->assertNull($resolver->resolve('', $this->configDir.'/packages/framework.xml'));
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -3930,6 +3930,25 @@ abstract class FrameworkExtensionTestCase extends TestCase
         });
     }
 
+    public function testYamlLintCommandUsesTheKernelConfigDir()
+    {
+        $container = $this->createContainerFromFile('default_config', ['.kernel.config_dir' => '/project/config']);
+
+        $resolver = $container->getDefinition('console.command.yaml_lint')->getArgument(0);
+
+        $this->assertSame('/project/config', $resolver->getArgument(0));
+    }
+
+    public function testYamlLintCommandWithoutKernelConfigDir()
+    {
+        $container = $this->createContainerFromFile('default_config');
+
+        $resolver = $container->getDefinition('console.command.yaml_lint')->getArgument(0);
+
+        // Without a config directory, the generated schema.json is never applied.
+        $this->assertNull($resolver->getArgument(0));
+    }
+
     protected function createContainer(array $data = [])
     {
         $container = new ContainerBuilder(new EnvPlaceholderParameterBag(array_merge([

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/config/schema.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/config/schema.json
@@ -163,7 +163,7 @@
                         "description": "Set true to enable support for the '_method' request parameter to determine the intended HTTP method on POST requests."
                     },
                     "allowed_http_method_override": {
-                        "$ref": "#/$defs/types/array",
+                        "$ref": "#/$defs/types/array_null",
                         "items": {
                             "$ref": "#/$defs/types/string_null"
                         },
@@ -325,10 +325,20 @@
                                                         "default": "_token"
                                                     },
                                                     "field_attr": {
-                                                        "$ref": "#/$defs/types/object_null",
-                                                        "additionalProperties": {
-                                                            "$ref": "#/$defs/types/scalar"
-                                                        },
+                                                        "anyOf": [
+                                                            {
+                                                                "$ref": "#/$defs/types/object_null",
+                                                                "additionalProperties": {
+                                                                    "$ref": "#/$defs/types/scalar"
+                                                                }
+                                                            },
+                                                            {
+                                                                "$ref": "#/$defs/types/array_null",
+                                                                "items": {
+                                                                    "$ref": "#/$defs/types/scalar"
+                                                                }
+                                                            }
+                                                        ],
                                                         "default": {
                                                             "data-controller": "csrf-protection"
                                                         }
@@ -541,7 +551,7 @@
                         "$ref": "#/$defs/types/object_null",
                         "properties": {
                             "expiration": {
-                                "$ref": "#/$defs/types/integer",
+                                "$ref": "#/$defs/types/integer_null",
                                 "default": null,
                                 "description": "Default expiration of signed URIs, in seconds."
                             }
@@ -794,7 +804,7 @@
                                                     ]
                                                 },
                                                 "events_to_dispatch": {
-                                                    "$ref": "#/$defs/types/array",
+                                                    "$ref": "#/$defs/types/array_null",
                                                     "items": {
                                                         "$ref": "#/$defs/types/string_null"
                                                     },
@@ -818,10 +828,20 @@
                                                                         "$ref": "#/$defs/types/scalar"
                                                                     },
                                                                     "metadata": {
-                                                                        "$ref": "#/$defs/types/object_null",
-                                                                        "additionalProperties": {
-                                                                            "$ref": "#/$defs/types/variable"
-                                                                        },
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "$ref": "#/$defs/types/object_null",
+                                                                                "additionalProperties": {
+                                                                                    "$ref": "#/$defs/types/variable"
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "$ref": "#/$defs/types/array_null",
+                                                                                "items": {
+                                                                                    "$ref": "#/$defs/types/variable"
+                                                                                }
+                                                                            }
+                                                                        ],
                                                                         "examples": [
                                                                             {
                                                                                 "color": "blue",
@@ -923,10 +943,20 @@
                                                                 "default": 1
                                                             },
                                                             "metadata": {
-                                                                "$ref": "#/$defs/types/object_null",
-                                                                "additionalProperties": {
-                                                                    "$ref": "#/$defs/types/variable"
-                                                                },
+                                                                "anyOf": [
+                                                                    {
+                                                                        "$ref": "#/$defs/types/object_null",
+                                                                        "additionalProperties": {
+                                                                            "$ref": "#/$defs/types/variable"
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "$ref": "#/$defs/types/array_null",
+                                                                        "items": {
+                                                                            "$ref": "#/$defs/types/variable"
+                                                                        }
+                                                                    }
+                                                                ],
                                                                 "examples": [
                                                                     {
                                                                         "color": "blue",
@@ -943,10 +973,20 @@
                                                     "minItems": 1
                                                 },
                                                 "metadata": {
-                                                    "$ref": "#/$defs/types/object_null",
-                                                    "additionalProperties": {
-                                                        "$ref": "#/$defs/types/variable"
-                                                    },
+                                                    "anyOf": [
+                                                        {
+                                                            "$ref": "#/$defs/types/object_null",
+                                                            "additionalProperties": {
+                                                                "$ref": "#/$defs/types/variable"
+                                                            }
+                                                        },
+                                                        {
+                                                            "$ref": "#/$defs/types/array_null",
+                                                            "items": {
+                                                                "$ref": "#/$defs/types/variable"
+                                                            }
+                                                        }
+                                                    ],
                                                     "examples": [
                                                         {
                                                             "color": "blue",
@@ -1319,6 +1359,12 @@
                                                 }
                                             },
                                             {
+                                                "$ref": "#/$defs/types/array_null",
+                                                "items": {
+                                                    "$ref": "#/$defs/types/scalar"
+                                                }
+                                            },
+                                            {
                                                 "type": [
                                                     "string"
                                                 ]
@@ -1376,10 +1422,20 @@
                                         "description": "Behavior if an asset cannot be found when imported from JavaScript or CSS files - e.g. \"import './non-existent.js'\". \"strict\" means an exception is thrown, \"warn\" means a warning is logged, \"ignore\" means the import is left as-is."
                                     },
                                     "extensions": {
-                                        "$ref": "#/$defs/types/object_null",
-                                        "additionalProperties": {
-                                            "$ref": "#/$defs/types/scalar"
-                                        },
+                                        "anyOf": [
+                                            {
+                                                "$ref": "#/$defs/types/object_null",
+                                                "additionalProperties": {
+                                                    "$ref": "#/$defs/types/scalar"
+                                                }
+                                            },
+                                            {
+                                                "$ref": "#/$defs/types/array_null",
+                                                "items": {
+                                                    "$ref": "#/$defs/types/scalar"
+                                                }
+                                            }
+                                        ],
                                         "description": "Key-value pair of file extensions set to their mime type.",
                                         "examples": [
                                             {
@@ -1413,10 +1469,20 @@
                                         "description": "Which entries end up in the rendered importmap: \"all\" of them, or only the ones \"reachable\" from the rendered entrypoints (their eager and lazy import chains) plus the polyfill."
                                     },
                                     "importmap_script_attributes": {
-                                        "$ref": "#/$defs/types/object_null",
-                                        "additionalProperties": {
-                                            "$ref": "#/$defs/types/scalar"
-                                        },
+                                        "anyOf": [
+                                            {
+                                                "$ref": "#/$defs/types/object_null",
+                                                "additionalProperties": {
+                                                    "$ref": "#/$defs/types/scalar"
+                                                }
+                                            },
+                                            {
+                                                "$ref": "#/$defs/types/array_null",
+                                                "items": {
+                                                    "$ref": "#/$defs/types/scalar"
+                                                }
+                                            }
+                                        ],
                                         "description": "Key-value pair of attributes to add to script tags output for the importmap.",
                                         "examples": [
                                             {
@@ -1690,10 +1756,20 @@
                                                     "$ref": "#/$defs/types/scalar"
                                                 },
                                                 "domains": {
-                                                    "$ref": "#/$defs/types/object_null",
-                                                    "additionalProperties": {
-                                                        "$ref": "#/$defs/types/scalar"
-                                                    }
+                                                    "anyOf": [
+                                                        {
+                                                            "$ref": "#/$defs/types/object_null",
+                                                            "additionalProperties": {
+                                                                "$ref": "#/$defs/types/scalar"
+                                                            }
+                                                        },
+                                                        {
+                                                            "$ref": "#/$defs/types/array_null",
+                                                            "items": {
+                                                                "$ref": "#/$defs/types/scalar"
+                                                            }
+                                                        }
+                                                    ]
                                                 },
                                                 "locales": {
                                                     "$ref": "#/$defs/types/array_null",
@@ -1721,10 +1797,20 @@
                                                             "$ref": "#/$defs/types/string_null"
                                                         },
                                                         "parameters": {
-                                                            "$ref": "#/$defs/types/object_null",
-                                                            "additionalProperties": {
-                                                                "$ref": "#/$defs/types/scalar"
-                                                            }
+                                                            "anyOf": [
+                                                                {
+                                                                    "$ref": "#/$defs/types/object_null",
+                                                                    "additionalProperties": {
+                                                                        "$ref": "#/$defs/types/scalar"
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "$ref": "#/$defs/types/array_null",
+                                                                    "items": {
+                                                                        "$ref": "#/$defs/types/scalar"
+                                                                    }
+                                                                }
+                                                            ]
                                                         },
                                                         "domain": {
                                                             "$ref": "#/$defs/types/string_null"
@@ -1971,10 +2057,20 @@
                                         }
                                     },
                                     "default_context": {
-                                        "$ref": "#/$defs/types/object_null",
-                                        "additionalProperties": {
-                                            "$ref": "#/$defs/types/variable"
-                                        }
+                                        "anyOf": [
+                                            {
+                                                "$ref": "#/$defs/types/object_null",
+                                                "additionalProperties": {
+                                                    "$ref": "#/$defs/types/variable"
+                                                }
+                                            },
+                                            {
+                                                "$ref": "#/$defs/types/array_null",
+                                                "items": {
+                                                    "$ref": "#/$defs/types/variable"
+                                                }
+                                            }
+                                        ]
                                     },
                                     "named_serializers": {
                                         "$ref": "#/$defs/types/object_null",
@@ -1985,10 +2081,20 @@
                                                     "$ref": "#/$defs/types/scalar"
                                                 },
                                                 "default_context": {
-                                                    "$ref": "#/$defs/types/object_null",
-                                                    "additionalProperties": {
-                                                        "$ref": "#/$defs/types/variable"
-                                                    }
+                                                    "anyOf": [
+                                                        {
+                                                            "$ref": "#/$defs/types/object_null",
+                                                            "additionalProperties": {
+                                                                "$ref": "#/$defs/types/variable"
+                                                            }
+                                                        },
+                                                        {
+                                                            "$ref": "#/$defs/types/array_null",
+                                                            "items": {
+                                                                "$ref": "#/$defs/types/variable"
+                                                            }
+                                                        }
+                                                    ]
                                                 },
                                                 "include_built_in_normalizers": {
                                                     "$ref": "#/$defs/types/boolean",
@@ -2082,10 +2188,20 @@
                                         "default": false
                                     },
                                     "aliases": {
-                                        "$ref": "#/$defs/types/object_null",
-                                        "additionalProperties": {
-                                            "$ref": "#/$defs/types/scalar"
-                                        },
+                                        "anyOf": [
+                                            {
+                                                "$ref": "#/$defs/types/object_null",
+                                                "additionalProperties": {
+                                                    "$ref": "#/$defs/types/scalar"
+                                                }
+                                            },
+                                            {
+                                                "$ref": "#/$defs/types/array_null",
+                                                "items": {
+                                                    "$ref": "#/$defs/types/scalar"
+                                                }
+                                            }
+                                        ],
                                         "description": "Additional type aliases to be used during type context creation."
                                     }
                                 },
@@ -2413,6 +2529,13 @@
                                                 "minProperties": 1
                                             },
                                             {
+                                                "$ref": "#/$defs/types/array_null",
+                                                "items": {
+                                                    "$ref": "#/$defs/types/scalar"
+                                                },
+                                                "minItems": 1
+                                            },
+                                            {
                                                 "type": [
                                                     "string"
                                                 ]
@@ -2480,10 +2603,20 @@
                                                         "description": "Serialization format for the messenger.transport.symfony_serializer service (which is not the serializer used by default)."
                                                     },
                                                     "context": {
-                                                        "$ref": "#/$defs/types/object_null",
-                                                        "additionalProperties": {
-                                                            "$ref": "#/$defs/types/variable"
-                                                        },
+                                                        "anyOf": [
+                                                            {
+                                                                "$ref": "#/$defs/types/object_null",
+                                                                "additionalProperties": {
+                                                                    "$ref": "#/$defs/types/variable"
+                                                                }
+                                                            },
+                                                            {
+                                                                "$ref": "#/$defs/types/array_null",
+                                                                "items": {
+                                                                    "$ref": "#/$defs/types/variable"
+                                                                }
+                                                            }
+                                                        ],
                                                         "description": "Context array for the messenger.transport.symfony_serializer service (which is not the serializer used by default)."
                                                     }
                                                 },
@@ -2519,10 +2652,20 @@
                                                             "description": "Service id of a custom serializer to use."
                                                         },
                                                         "options": {
-                                                            "$ref": "#/$defs/types/object_null",
-                                                            "additionalProperties": {
-                                                                "$ref": "#/$defs/types/variable"
-                                                            }
+                                                            "anyOf": [
+                                                                {
+                                                                    "$ref": "#/$defs/types/object_null",
+                                                                    "additionalProperties": {
+                                                                        "$ref": "#/$defs/types/variable"
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "$ref": "#/$defs/types/array_null",
+                                                                    "items": {
+                                                                        "$ref": "#/$defs/types/variable"
+                                                                    }
+                                                                }
+                                                            ]
                                                         },
                                                         "failure_transport": {
                                                             "$ref": "#/$defs/types/scalar",
@@ -2820,17 +2963,37 @@
                                         "$ref": "#/$defs/types/object_null",
                                         "properties": {
                                             "vars": {
-                                                "$ref": "#/$defs/types/object_null",
-                                                "additionalProperties": {
-                                                    "$ref": "#/$defs/types/variable"
-                                                },
+                                                "anyOf": [
+                                                    {
+                                                        "$ref": "#/$defs/types/object_null",
+                                                        "additionalProperties": {
+                                                            "$ref": "#/$defs/types/variable"
+                                                        }
+                                                    },
+                                                    {
+                                                        "$ref": "#/$defs/types/array_null",
+                                                        "items": {
+                                                            "$ref": "#/$defs/types/variable"
+                                                        }
+                                                    }
+                                                ],
                                                 "description": "Associative array: the default vars used to expand the templated URI."
                                             },
                                             "headers": {
-                                                "$ref": "#/$defs/types/object_null",
-                                                "additionalProperties": {
-                                                    "$ref": "#/$defs/types/variable"
-                                                },
+                                                "anyOf": [
+                                                    {
+                                                        "$ref": "#/$defs/types/object_null",
+                                                        "additionalProperties": {
+                                                            "$ref": "#/$defs/types/variable"
+                                                        }
+                                                    },
+                                                    {
+                                                        "$ref": "#/$defs/types/array_null",
+                                                        "items": {
+                                                            "$ref": "#/$defs/types/variable"
+                                                        }
+                                                    }
+                                                ],
                                                 "description": "Associative array: header => value(s)."
                                             },
                                             "max_redirects": {
@@ -2842,10 +3005,20 @@
                                                 "description": "The default HTTP version, typically 1.1 or 2.0, leave to null for the best version."
                                             },
                                             "resolve": {
-                                                "$ref": "#/$defs/types/object_null",
-                                                "additionalProperties": {
-                                                    "$ref": "#/$defs/types/scalar"
-                                                },
+                                                "anyOf": [
+                                                    {
+                                                        "$ref": "#/$defs/types/object_null",
+                                                        "additionalProperties": {
+                                                            "$ref": "#/$defs/types/scalar"
+                                                        }
+                                                    },
+                                                    {
+                                                        "$ref": "#/$defs/types/array_null",
+                                                        "items": {
+                                                            "$ref": "#/$defs/types/scalar"
+                                                        }
+                                                    }
+                                                ],
                                                 "description": "Associative array: domain => IP."
                                             },
                                             "proxy": {
@@ -2925,10 +3098,20 @@
                                                 "description": "The minimum version of TLS to accept; must be one of STREAM_CRYPTO_METHOD_TLSv*_CLIENT constants."
                                             },
                                             "extra": {
-                                                "$ref": "#/$defs/types/object_null",
-                                                "additionalProperties": {
-                                                    "$ref": "#/$defs/types/variable"
-                                                },
+                                                "anyOf": [
+                                                    {
+                                                        "$ref": "#/$defs/types/object_null",
+                                                        "additionalProperties": {
+                                                            "$ref": "#/$defs/types/variable"
+                                                        }
+                                                    },
+                                                    {
+                                                        "$ref": "#/$defs/types/array_null",
+                                                        "items": {
+                                                            "$ref": "#/$defs/types/variable"
+                                                        }
+                                                    }
+                                                ],
                                                 "description": "Extra options for specific HTTP client."
                                             },
                                             "rate_limiter": {
@@ -3133,10 +3316,20 @@
                                                             "description": "A \"username:password\" pair to use Microsoft NTLM authentication (requires the cURL extension)."
                                                         },
                                                         "query": {
-                                                            "$ref": "#/$defs/types/object_null",
-                                                            "additionalProperties": {
-                                                                "$ref": "#/$defs/types/scalar"
-                                                            },
+                                                            "anyOf": [
+                                                                {
+                                                                    "$ref": "#/$defs/types/object_null",
+                                                                    "additionalProperties": {
+                                                                        "$ref": "#/$defs/types/scalar"
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "$ref": "#/$defs/types/array_null",
+                                                                    "items": {
+                                                                        "$ref": "#/$defs/types/scalar"
+                                                                    }
+                                                                }
+                                                            ],
                                                             "description": "Associative array of query string values merged with the base URI."
                                                         },
                                                         "mock_response_factory": {
@@ -3144,10 +3337,20 @@
                                                             "description": "`true` to always return empty 200 responses, `false` to disable mocking, or the id of the service to use to generate mock responses (invokable or iterable)."
                                                         },
                                                         "headers": {
-                                                            "$ref": "#/$defs/types/object_null",
-                                                            "additionalProperties": {
-                                                                "$ref": "#/$defs/types/variable"
-                                                            },
+                                                            "anyOf": [
+                                                                {
+                                                                    "$ref": "#/$defs/types/object_null",
+                                                                    "additionalProperties": {
+                                                                        "$ref": "#/$defs/types/variable"
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "$ref": "#/$defs/types/array_null",
+                                                                    "items": {
+                                                                        "$ref": "#/$defs/types/variable"
+                                                                    }
+                                                                }
+                                                            ],
                                                             "description": "Associative array: header => value(s)."
                                                         },
                                                         "max_redirects": {
@@ -3159,10 +3362,20 @@
                                                             "description": "The default HTTP version, typically 1.1 or 2.0, leave to null for the best version."
                                                         },
                                                         "resolve": {
-                                                            "$ref": "#/$defs/types/object_null",
-                                                            "additionalProperties": {
-                                                                "$ref": "#/$defs/types/scalar"
-                                                            },
+                                                            "anyOf": [
+                                                                {
+                                                                    "$ref": "#/$defs/types/object_null",
+                                                                    "additionalProperties": {
+                                                                        "$ref": "#/$defs/types/scalar"
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "$ref": "#/$defs/types/array_null",
+                                                                    "items": {
+                                                                        "$ref": "#/$defs/types/scalar"
+                                                                    }
+                                                                }
+                                                            ],
                                                             "description": "Associative array: domain => IP."
                                                         },
                                                         "proxy": {
@@ -3242,10 +3455,20 @@
                                                             "description": "The minimum version of TLS to accept; must be one of STREAM_CRYPTO_METHOD_TLSv*_CLIENT constants."
                                                         },
                                                         "extra": {
-                                                            "$ref": "#/$defs/types/object_null",
-                                                            "additionalProperties": {
-                                                                "$ref": "#/$defs/types/variable"
-                                                            },
+                                                            "anyOf": [
+                                                                {
+                                                                    "$ref": "#/$defs/types/object_null",
+                                                                    "additionalProperties": {
+                                                                        "$ref": "#/$defs/types/variable"
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "$ref": "#/$defs/types/array_null",
+                                                                    "items": {
+                                                                        "$ref": "#/$defs/types/variable"
+                                                                    }
+                                                                }
+                                                            ],
                                                             "description": "Extra options for specific HTTP client."
                                                         },
                                                         "rate_limiter": {
@@ -3621,10 +3844,20 @@
                                                         "description": "The private key passphrase"
                                                     },
                                                     "options": {
-                                                        "$ref": "#/$defs/types/object_null",
-                                                        "additionalProperties": {
-                                                            "$ref": "#/$defs/types/variable"
-                                                        }
+                                                        "anyOf": [
+                                                            {
+                                                                "$ref": "#/$defs/types/object_null",
+                                                                "additionalProperties": {
+                                                                    "$ref": "#/$defs/types/variable"
+                                                                }
+                                                            },
+                                                            {
+                                                                "$ref": "#/$defs/types/array_null",
+                                                                "items": {
+                                                                    "$ref": "#/$defs/types/variable"
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 },
                                                 "additionalProperties": false
@@ -3674,7 +3907,7 @@
                                                         "default": null
                                                     },
                                                     "sign_options": {
-                                                        "$ref": "#/$defs/types/integer",
+                                                        "$ref": "#/$defs/types/integer_null",
                                                         "default": null
                                                     }
                                                 },
@@ -3711,10 +3944,20 @@
                                                         "description": "S/MIME certificate repository service. This service shall implement the `Symfony\\Component\\Mailer\\EventListener\\SmimeCertificateRepositoryInterface`."
                                                     },
                                                     "certificates": {
-                                                        "$ref": "#/$defs/types/object_null",
-                                                        "additionalProperties": {
-                                                            "$ref": "#/$defs/types/scalar"
-                                                        },
+                                                        "anyOf": [
+                                                            {
+                                                                "$ref": "#/$defs/types/object_null",
+                                                                "additionalProperties": {
+                                                                    "$ref": "#/$defs/types/scalar"
+                                                                }
+                                                            },
+                                                            {
+                                                                "$ref": "#/$defs/types/array_null",
+                                                                "items": {
+                                                                    "$ref": "#/$defs/types/scalar"
+                                                                }
+                                                            }
+                                                        ],
                                                         "description": "Recipient S/MIME certificates, as a map of email address to certificate file path. Cannot be used together with \"repository\"."
                                                     },
                                                     "on_missing_certificate": {
@@ -3740,7 +3983,7 @@
                                                         "description": "Also encrypt for the sender, when a certificate is available for its address, so that the sender can read the messages it sent."
                                                     },
                                                     "cipher": {
-                                                        "$ref": "#/$defs/types/integer",
+                                                        "$ref": "#/$defs/types/integer_null",
                                                         "default": null,
                                                         "description": "A set of algorithms used to encrypt the message"
                                                     }
@@ -3843,10 +4086,20 @@
                                                         "description": "Service or class implementing `Symfony\\Component\\Mailer\\EventListener\\PgpPublicKeyRepositoryInterface` to provide recipient PGP public keys."
                                                     },
                                                     "keys": {
-                                                        "$ref": "#/$defs/types/object_null",
-                                                        "additionalProperties": {
-                                                            "$ref": "#/$defs/types/scalar"
-                                                        },
+                                                        "anyOf": [
+                                                            {
+                                                                "$ref": "#/$defs/types/object_null",
+                                                                "additionalProperties": {
+                                                                    "$ref": "#/$defs/types/scalar"
+                                                                }
+                                                            },
+                                                            {
+                                                                "$ref": "#/$defs/types/array_null",
+                                                                "items": {
+                                                                    "$ref": "#/$defs/types/scalar"
+                                                                }
+                                                            }
+                                                        ],
                                                         "description": "Recipient PGP public keys, as a map of email address to public key file path. Cannot be used together with \"repository\"."
                                                     },
                                                     "binary": {
@@ -4044,16 +4297,36 @@
                                         "description": "The message bus to use. Defaults to the default bus if the Messenger component is installed."
                                     },
                                     "chatter_transports": {
-                                        "$ref": "#/$defs/types/object_null",
-                                        "additionalProperties": {
-                                            "$ref": "#/$defs/types/scalar"
-                                        }
+                                        "anyOf": [
+                                            {
+                                                "$ref": "#/$defs/types/object_null",
+                                                "additionalProperties": {
+                                                    "$ref": "#/$defs/types/scalar"
+                                                }
+                                            },
+                                            {
+                                                "$ref": "#/$defs/types/array_null",
+                                                "items": {
+                                                    "$ref": "#/$defs/types/scalar"
+                                                }
+                                            }
+                                        ]
                                     },
                                     "texter_transports": {
-                                        "$ref": "#/$defs/types/object_null",
-                                        "additionalProperties": {
-                                            "$ref": "#/$defs/types/scalar"
-                                        }
+                                        "anyOf": [
+                                            {
+                                                "$ref": "#/$defs/types/object_null",
+                                                "additionalProperties": {
+                                                    "$ref": "#/$defs/types/scalar"
+                                                }
+                                            },
+                                            {
+                                                "$ref": "#/$defs/types/array_null",
+                                                "items": {
+                                                    "$ref": "#/$defs/types/scalar"
+                                                }
+                                            }
+                                        ]
                                     },
                                     "notification_on_failed_messages": {
                                         "$ref": "#/$defs/types/boolean",
@@ -4381,10 +4654,20 @@
                                                     "description": "Allows all static elements and attributes from the W3C Sanitizer API standard."
                                                 },
                                                 "allow_elements": {
-                                                    "$ref": "#/$defs/types/object_null",
-                                                    "additionalProperties": {
-                                                        "$ref": "#/$defs/types/variable"
-                                                    },
+                                                    "anyOf": [
+                                                        {
+                                                            "$ref": "#/$defs/types/object_null",
+                                                            "additionalProperties": {
+                                                                "$ref": "#/$defs/types/variable"
+                                                            }
+                                                        },
+                                                        {
+                                                            "$ref": "#/$defs/types/array_null",
+                                                            "items": {
+                                                                "$ref": "#/$defs/types/variable"
+                                                            }
+                                                        }
+                                                    ],
                                                     "description": "Configures the elements that the sanitizer should retain from the input. The element name is the key, the value is either a list of allowed attributes for this element or \"*\" to allow the default set of attributes (https://wicg.github.io/sanitizer-api/#default-configuration).",
                                                     "examples": [
                                                         {
@@ -4429,26 +4712,56 @@
                                                     "description": "Configures elements as dropped. Dropped elements are elements the sanitizer should remove from the input, including their children."
                                                 },
                                                 "allow_attributes": {
-                                                    "$ref": "#/$defs/types/object_null",
-                                                    "additionalProperties": {
-                                                        "$ref": "#/$defs/types/variable"
-                                                    },
+                                                    "anyOf": [
+                                                        {
+                                                            "$ref": "#/$defs/types/object_null",
+                                                            "additionalProperties": {
+                                                                "$ref": "#/$defs/types/variable"
+                                                            }
+                                                        },
+                                                        {
+                                                            "$ref": "#/$defs/types/array_null",
+                                                            "items": {
+                                                                "$ref": "#/$defs/types/variable"
+                                                            }
+                                                        }
+                                                    ],
                                                     "description": "Configures attributes as allowed. Allowed attributes are attributes the sanitizer should retain from the input."
                                                 },
                                                 "drop_attributes": {
-                                                    "$ref": "#/$defs/types/object_null",
-                                                    "additionalProperties": {
-                                                        "$ref": "#/$defs/types/variable"
-                                                    },
+                                                    "anyOf": [
+                                                        {
+                                                            "$ref": "#/$defs/types/object_null",
+                                                            "additionalProperties": {
+                                                                "$ref": "#/$defs/types/variable"
+                                                            }
+                                                        },
+                                                        {
+                                                            "$ref": "#/$defs/types/array_null",
+                                                            "items": {
+                                                                "$ref": "#/$defs/types/variable"
+                                                            }
+                                                        }
+                                                    ],
                                                     "description": "Configures attributes as dropped. Dropped attributes are attributes the sanitizer should remove from the input."
                                                 },
                                                 "force_attributes": {
                                                     "$ref": "#/$defs/types/object_null",
                                                     "additionalProperties": {
-                                                        "$ref": "#/$defs/types/object_null",
-                                                        "additionalProperties": {
-                                                            "$ref": "#/$defs/types/string_null"
-                                                        }
+                                                        "anyOf": [
+                                                            {
+                                                                "$ref": "#/$defs/types/object_null",
+                                                                "additionalProperties": {
+                                                                    "$ref": "#/$defs/types/string_null"
+                                                                }
+                                                            },
+                                                            {
+                                                                "$ref": "#/$defs/types/array_null",
+                                                                "items": {
+                                                                    "$ref": "#/$defs/types/string_null"
+                                                                }
+                                                            }
+                                                        ]
                                                     },
                                                     "description": "Forcefully set the values of certain attributes on certain elements."
                                                 },
@@ -4476,7 +4789,7 @@
                                                 "allowed_link_hosts": {
                                                     "anyOf": [
                                                         {
-                                                            "$ref": "#/$defs/types/array",
+                                                            "$ref": "#/$defs/types/array_null",
                                                             "items": {
                                                                 "$ref": "#/$defs/types/string_null"
                                                             }
@@ -4514,7 +4827,7 @@
                                                 "allowed_media_hosts": {
                                                     "anyOf": [
                                                         {
-                                                            "$ref": "#/$defs/types/array",
+                                                            "$ref": "#/$defs/types/array_null",
                                                             "items": {
                                                                 "$ref": "#/$defs/types/string_null"
                                                             }
@@ -4620,7 +4933,7 @@
                                                     "subnets": {
                                                         "anyOf": [
                                                             {
-                                                                "$ref": "#/$defs/types/array",
+                                                                "$ref": "#/$defs/types/array_null",
                                                                 "items": {
                                                                     "$ref": "#/$defs/types/scalar"
                                                                 }
@@ -4718,7 +5031,8 @@
                                                 },
                                                 "secret": {
                                                     "$ref": "#/$defs/types/scalar",
-                                                    "default": ""
+                                                    "default": "",
+                                                    "description": "The secret used to verify incoming request signatures. It must be set in production: with an empty value, requests from any sender are accepted."
                                                 }
                                             },
                                             "required": [
@@ -4822,6 +5136,153 @@
                 },
                 "additionalProperties": false
             },
+            "mercure": {
+                "$ref": "#/$defs/types/object_null",
+                "properties": {
+                    "hubs": {
+                        "$ref": "#/$defs/types/object_null",
+                        "additionalProperties": {
+                            "$ref": "#/$defs/types/object_null",
+                            "properties": {
+                                "url": {
+                                    "$ref": "#/$defs/types/scalar",
+                                    "description": "URL of the hub's publish endpoint",
+                                    "examples": [
+                                        "https://demo.mercure.rocks/.well-known/mercure"
+                                    ]
+                                },
+                                "public_url": {
+                                    "$ref": "#/$defs/types/scalar",
+                                    "default": null,
+                                    "description": "URL of the hub's public endpoint",
+                                    "examples": [
+                                        "https://demo.mercure.rocks/.well-known/mercure"
+                                    ]
+                                },
+                                "jwt": {
+                                    "anyOf": [
+                                        {
+                                            "$ref": "#/$defs/types/object_null",
+                                            "properties": {
+                                                "value": {
+                                                    "$ref": "#/$defs/types/scalar",
+                                                    "description": "JSON Web Token to use to publish to this hub."
+                                                },
+                                                "provider": {
+                                                    "$ref": "#/$defs/types/scalar",
+                                                    "description": "The ID of a service to call to provide the JSON Web Token."
+                                                },
+                                                "factory": {
+                                                    "$ref": "#/$defs/types/scalar",
+                                                    "description": "The ID of a service to call to create the JSON Web Token."
+                                                },
+                                                "publish": {
+                                                    "$ref": "#/$defs/types/array_null",
+                                                    "items": {
+                                                        "$ref": "#/$defs/types/scalar"
+                                                    },
+                                                    "description": "A list of topics to allow publishing to when using the given factory to generate the JWT."
+                                                },
+                                                "subscribe": {
+                                                    "$ref": "#/$defs/types/array_null",
+                                                    "items": {
+                                                        "$ref": "#/$defs/types/scalar"
+                                                    },
+                                                    "description": "A list of topics to allow subscribing to when using the given factory to generate the JWT."
+                                                },
+                                                "secret": {
+                                                    "$ref": "#/$defs/types/scalar",
+                                                    "description": "The JWT Secret to use.",
+                                                    "examples": [
+                                                        "!ChangeMe!"
+                                                    ]
+                                                },
+                                                "passphrase": {
+                                                    "$ref": "#/$defs/types/scalar",
+                                                    "default": "",
+                                                    "description": "The JWT secret passphrase."
+                                                },
+                                                "algorithm": {
+                                                    "$ref": "#/$defs/types/scalar",
+                                                    "default": "hmac.sha256",
+                                                    "description": "The algorithm to use to sign the JWT"
+                                                }
+                                            },
+                                            "additionalProperties": false
+                                        },
+                                        {
+                                            "type": [
+                                                "string"
+                                            ]
+                                        }
+                                    ],
+                                    "description": "JSON Web Token configuration."
+                                },
+                                "jwt_provider": {
+                                    "$ref": "#/$defs/types/scalar",
+                                    "description": "Deprecated since symfony/mercure-bundle 0.3: The child node \"jwt_provider\" at path \"mercure.hubs..jwt_provider\" is deprecated, use \"jwt.provider\" instead.\n\nThe ID of a service to call to generate the JSON Web Token.",
+                                    "deprecated": true
+                                },
+                                "bus": {
+                                    "$ref": "#/$defs/types/scalar",
+                                    "description": "Name of the Messenger bus where the handler for this hub must be registered. Default to the default bus if Messenger is enabled."
+                                }
+                            },
+                            "additionalProperties": false
+                        }
+                    },
+                    "default_hub": {
+                        "$ref": "#/$defs/types/scalar"
+                    },
+                    "default_cookie_lifetime": {
+                        "$ref": "#/$defs/types/integer_null",
+                        "default": null,
+                        "description": "Default lifetime of the cookie containing the JWT, in seconds. Defaults to the value of \"framework.session.cookie_lifetime\"."
+                    },
+                    "enable_profiler": {
+                        "$ref": "#/$defs/types/boolean",
+                        "description": "Deprecated since symfony/mercure-bundle 0.3: The child node \"enable_profiler\" at path \"mercure.enable_profiler\" is deprecated.\n\nEnable Symfony Web Profiler integration.",
+                        "deprecated": true
+                    }
+                },
+                "additionalProperties": false
+            },
+            "test": {
+                "$ref": "#/$defs/types/object_null",
+                "properties": {
+                    "custom": {
+                        "$ref": "#/$defs/types/scalar"
+                    },
+                    "array": {
+                        "$ref": "#/$defs/types/object_null",
+                        "properties": {
+                            "child1": {
+                                "$ref": "#/$defs/types/scalar"
+                            },
+                            "child2": {
+                                "$ref": "#/$defs/types/scalar"
+                            }
+                        },
+                        "additionalProperties": false
+                    },
+                    "options": {
+                        "$ref": "#/$defs/types/object_null",
+                        "additionalProperties": {
+                            "$ref": "#/$defs/types/object_null",
+                            "properties": {
+                                "key": {
+                                    "$ref": "#/$defs/types/scalar"
+                                },
+                                "data": {
+                                    "$ref": "#/$defs/types/scalar"
+                                }
+                            },
+                            "additionalProperties": false
+                        }
+                    }
+                },
+                "additionalProperties": false
+            },
             "test_dump": {
                 "$ref": "#/$defs/types/object_null",
                 "properties": {
@@ -4842,19 +5303,31 @@
         "framework": {
             "$ref": "#/$defs/nodes/framework"
         },
+        "mercure": {
+            "$ref": "#/$defs/nodes/mercure"
+        },
+        "test": {
+            "$ref": "#/$defs/nodes/test"
+        },
         "test_dump": {
             "$ref": "#/$defs/nodes/test_dump"
         }
     },
     "patternProperties": {
         "^when@[a-zA-Z0-9]+$": {
-            "type": "object",
+            "$ref": "#/$defs/types/object_null",
             "properties": {
                 "foo": {
                     "$ref": "#/$defs/nodes/foo"
                 },
                 "framework": {
                     "$ref": "#/$defs/nodes/framework"
+                },
+                "mercure": {
+                    "$ref": "#/$defs/nodes/mercure"
+                },
+                "test": {
+                    "$ref": "#/$defs/nodes/test"
                 },
                 "test_dump": {
                     "$ref": "#/$defs/nodes/test_dump"

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -38,6 +38,7 @@
     "require-dev": {
         "doctrine/persistence": "^1.3|^2|^3",
         "dragonmantank/cron-expression": "^3.1",
+        "opis/json-schema": "^2.6",
         "phpdocumentor/reflection-docblock": "^5.2|^6.0",
         "phpstan/phpdoc-parser": "^1.0|^2.0",
         "seld/jsonlint": "^1.10",

--- a/src/Symfony/Component/Config/Definition/BaseNode.php
+++ b/src/Symfony/Component/Config/Definition/BaseNode.php
@@ -174,6 +174,10 @@ abstract class BaseNode implements NodeInterface
      */
     public function isNullable(): bool
     {
+        if ($this->hasDefaultValue() && null === $this->getDefaultValue()) {
+            return true;
+        }
+
         foreach ($this->equivalentValues as [$from, $to]) {
             // the builder registers a null equivalence on every node; only a mapping that
             // replaces null makes it acceptable, as an identity mapping leaves it to be

--- a/src/Symfony/Component/Config/Definition/BooleanNode.php
+++ b/src/Symfony/Component/Config/Definition/BooleanNode.php
@@ -31,7 +31,7 @@ class BooleanNode extends ScalarNode
 
     public function isNullable(): bool
     {
-        return $this->nullable;
+        return $this->nullable || ($this->hasDefaultValue() && null === $this->getDefaultValue());
     }
 
     protected function validateType(mixed $value): void

--- a/src/Symfony/Component/Config/Definition/Dumper/JsonSchemaDumper.php
+++ b/src/Symfony/Component/Config/Definition/Dumper/JsonSchemaDumper.php
@@ -102,6 +102,22 @@ final class JsonSchemaDumper
                 if ($node->getMinNumberOfElements()) {
                     $schema['minProperties'] = $node->getMinNumberOfElements();
                 }
+
+                // A key-attribute map also accepts the equivalent list form, which the Config
+                // layer normalizes back into a map. Only scalar prototypes are exposed as a
+                // list, where each item is the attribute value.
+                if (!$node->getPrototype() instanceof ArrayNode) {
+                    $listSchema = [
+                        '$ref' => $node->isNullable() ? '#/$defs/types/array_null' : '#/$defs/types/array',
+                        'items' => $prototypeSchema,
+                    ];
+
+                    if ($node->getMinNumberOfElements()) {
+                        $listSchema['minItems'] = $node->getMinNumberOfElements();
+                    }
+
+                    $schema = ['anyOf' => [$schema, $listSchema]];
+                }
             } else {
                 $schema = [
                     '$ref' => $node->isNullable() ? '#/$defs/types/array_null' : '#/$defs/types/array',

--- a/src/Symfony/Component/Config/Tests/Definition/Dumper/JsonSchemaDumperTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Dumper/JsonSchemaDumperTest.php
@@ -121,9 +121,41 @@ class JsonSchemaDumperTest extends TestCase
         $prototype->setKeyAttribute('name');
         $root = new ArrayNode('root');
         $root->addChild($prototype);
-        yield [$prototype, [
-            '$ref' => '#/$defs/types/object',
-            'additionalProperties' => ['$ref' => '#/$defs/types/string'],
+        yield 'key-attribute map with scalar prototype also accepts a list' => [$prototype, [
+            'anyOf' => [
+                [
+                    '$ref' => '#/$defs/types/object',
+                    'additionalProperties' => ['$ref' => '#/$defs/types/string'],
+                ],
+                [
+                    '$ref' => '#/$defs/types/array',
+                    'items' => ['$ref' => '#/$defs/types/string'],
+                ],
+            ],
+        ]];
+
+        // A prototyped list with a null default is nullable, so it uses the array_null ref.
+        $listWithNullDefault = (new ArrayNodeDefinition('proto'))->defaultNull()->stringPrototype()->end()->getNode();
+        yield 'array list with null default uses the nullable ref' => [$listWithNullDefault, [
+            '$ref' => '#/$defs/types/array_null',
+            'items' => ['$ref' => '#/$defs/types/string_null'],
+            'default' => null,
+        ]];
+
+        // A prototyped map with a null default is nullable, so it uses the object_null ref.
+        $mapWithNullDefault = (new ArrayNodeDefinition('proto'))->defaultNull()->useAttributeAsKey('name')->stringPrototype()->end()->getNode();
+        yield 'array map with null default uses the nullable ref' => [$mapWithNullDefault, [
+            'anyOf' => [
+                [
+                    '$ref' => '#/$defs/types/object_null',
+                    'additionalProperties' => ['$ref' => '#/$defs/types/string_null'],
+                ],
+                [
+                    '$ref' => '#/$defs/types/array_null',
+                    'items' => ['$ref' => '#/$defs/types/string_null'],
+                ],
+            ],
+            'default' => null,
         ]];
 
         $child = new BooleanNode('node');

--- a/src/Symfony/Component/Config/Tests/Fixtures/Configuration/ExampleConfiguration.schema.json
+++ b/src/Symfony/Component/Config/Tests/Fixtures/Configuration/ExampleConfiguration.schema.json
@@ -190,7 +190,7 @@
                     }
                 },
                 "string_list_default_null": {
-                    "$ref": "#/$defs/types/array",
+                    "$ref": "#/$defs/types/array_null",
                     "items": {
                         "$ref": "#/$defs/types/string_null"
                     },
@@ -206,11 +206,22 @@
                     ]
                 },
                 "parameters": {
-                    "$ref": "#/$defs/types/object_null",
-                    "additionalProperties": {
-                        "$ref": "#/$defs/types/scalar",
-                        "description": "Parameter name"
-                    }
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/types/object_null",
+                            "additionalProperties": {
+                                "$ref": "#/$defs/types/scalar",
+                                "description": "Parameter name"
+                            }
+                        },
+                        {
+                            "$ref": "#/$defs/types/array_null",
+                            "items": {
+                                "$ref": "#/$defs/types/scalar",
+                                "description": "Parameter name"
+                            }
+                        }
+                    ]
                 },
                 "connections": {
                     "$ref": "#/$defs/types/array_null",

--- a/src/Symfony/Component/Yaml/CHANGELOG.md
+++ b/src/Symfony/Component/Yaml/CHANGELOG.md
@@ -7,6 +7,8 @@ CHANGELOG
  * Add support for the `!!null`, `!!bool` and `!!int` tags, and accept quoted values for them and for `!!float`
  * Throw a `ParseException` when the value of a `!!float` tag is not a valid float, instead of casting it to `0.0`
  * Add a `gitlab` output format to the `lint:yaml` command, producing a report in the GitLab Code Quality format
+ * Add a `Schema` namespace with a `SchemaValidatorInterface` to validate data against a JSON Schema, a `SchemaResolverInterface` to determine the schema of a document, and their `SchemaValidator` and `FileHeaderSchemaResolver` implementations
+ * Add JSON Schema validation to the `lint:yaml` command through the `--check-schema` option or a `# yaml-language-server: $schema=` / `# $schema=` file header
 
 8.0
 ---

--- a/src/Symfony/Component/Yaml/Command/LintCommand.php
+++ b/src/Symfony/Component/Yaml/Command/LintCommand.php
@@ -18,6 +18,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Completion\CompletionInput;
 use Symfony\Component\Console\Completion\CompletionSuggestions;
 use Symfony\Component\Console\Exception\InvalidArgumentException;
+use Symfony\Component\Console\Exception\LogicException;
 use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -25,7 +26,12 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Yaml\Exception\ParseException;
+use Symfony\Component\Yaml\Exception\RuntimeException as YamlRuntimeException;
 use Symfony\Component\Yaml\Parser;
+use Symfony\Component\Yaml\Schema\FileHeaderSchemaResolver;
+use Symfony\Component\Yaml\Schema\SchemaResolverInterface;
+use Symfony\Component\Yaml\Schema\SchemaValidator;
+use Symfony\Component\Yaml\Schema\SchemaValidatorInterface;
 use Symfony\Component\Yaml\Yaml;
 
 /**
@@ -42,13 +48,26 @@ class LintCommand extends Command
     private bool $displayCorrectFiles;
     private ?\Closure $directoryIteratorProvider;
     private ?\Closure $isReadableProvider;
+    private ?string $schema = null;
+    private bool $checkSchema = false;
+    private SchemaResolverInterface $schemaResolver;
+    private SchemaValidatorInterface $schemaValidator;
+    private string $baseDir;
 
-    public function __construct(?string $name = null, ?callable $directoryIteratorProvider = null, ?callable $isReadableProvider = null)
+    /**
+     * @param SchemaResolverInterface|null  $schemaResolver  Resolves the schema of the files that do not force one
+     * @param SchemaValidatorInterface|null $schemaValidator The validator used by the --check-schema option
+     * @param string|null                   $baseDir         The directory schema paths are displayed relative to
+     */
+    public function __construct(?string $name = null, ?callable $directoryIteratorProvider = null, ?callable $isReadableProvider = null, ?SchemaResolverInterface $schemaResolver = null, ?SchemaValidatorInterface $schemaValidator = null, ?string $baseDir = null)
     {
         parent::__construct($name);
 
         $this->directoryIteratorProvider = null === $directoryIteratorProvider ? null : $directoryIteratorProvider(...);
         $this->isReadableProvider = null === $isReadableProvider ? null : $isReadableProvider(...);
+        $this->schemaResolver = $schemaResolver ?? new FileHeaderSchemaResolver();
+        $this->schemaValidator = $schemaValidator ?? new SchemaValidator();
+        $this->baseDir = $baseDir ?? (getcwd() ?: '');
     }
 
     protected function configure(): void
@@ -58,6 +77,7 @@ class LintCommand extends Command
             ->addOption('format', null, InputOption::VALUE_REQUIRED, \sprintf('The output format ("%s")', implode('", "', $this->getAvailableFormatOptions())))
             ->addOption('exclude', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Path(s) to exclude')
             ->addOption('parse-tags', null, InputOption::VALUE_NEGATABLE, 'Parse custom tags', null)
+            ->addOption('check-schema', null, InputOption::VALUE_OPTIONAL, 'Validate the content against a JSON Schema, optionally given as a file', false)
             ->setHelp(<<<EOF
                 The <info>%command.name%</info> command lints a YAML file and outputs to STDOUT
                 the first encountered syntax error.
@@ -82,6 +102,22 @@ class LintCommand extends Command
 
                   <info>php %command.full_name% dirname --exclude="dirname/foo.yaml" --exclude="dirname/bar.yaml"</info>
 
+                The <info>--check-schema</info> option validates the content against a JSON Schema.
+                It accepts an optional schema file:
+
+                  <info>php %command.full_name% filename --check-schema=schema.json</info>
+
+                When used without a value, the schema is resolved from the file header or a
+                default schema:
+
+                  <info>php %command.full_name% dirname --check-schema</info>
+
+                A schema can be declared inside the file itself with a header, resolved
+                relative to the file location:
+
+                  <info># yaml-language-server: \$schema=schema.json</info>
+                  <info># \$schema=schema.json</info>
+
                 EOF
             )
         ;
@@ -94,6 +130,15 @@ class LintCommand extends Command
         $excludes = $input->getOption('exclude');
         $this->format = $input->getOption('format');
         $flags = $input->getOption('parse-tags');
+
+        // false when absent, null when passed without a value, a string when a schema file is given
+        $checkSchema = $input->getOption('check-schema');
+        $this->checkSchema = false !== $checkSchema;
+        $this->schema = \is_string($checkSchema) ? $checkSchema : null;
+
+        if ($this->checkSchema && !$this->schemaValidator->isSupported()) {
+            throw new LogicException('Validating against a JSON Schema requires the "opis/json-schema" package. Try running "composer require opis/json-schema".');
+        }
 
         if (null === $this->format) {
             // Autodetect format according to CI environment
@@ -139,14 +184,62 @@ class LintCommand extends Command
         });
 
         try {
-            $this->getParser()->parse($content, Yaml::PARSE_CONSTANT | $flags);
+            $data = $this->getParser()->parse($content, Yaml::PARSE_CONSTANT | $flags);
         } catch (ParseException $e) {
             return ['file' => $file, 'line' => $e->getParsedLine(), 'valid' => false, 'message' => $e->getMessage()];
         } finally {
             restore_error_handler();
         }
 
-        return ['file' => $file, 'valid' => true];
+        if (!$this->checkSchema) {
+            return ['file' => $file, 'valid' => true];
+        }
+
+        $schema = $this->schema ?? $this->schemaResolver->resolve($content, $file);
+        if (!$schema) {
+            return ['file' => $file, 'valid' => true, 'schema' => null];
+        }
+
+        try {
+            // The library availability is guarded in execute() when --check-schema is used.
+            $errors = $this->schemaValidator->validate($data, $schema, $content);
+        } catch (YamlRuntimeException $e) {
+            // An unresolvable or invalid schema fails this file only, not the whole run.
+            return ['file' => $file, 'line' => 0, 'valid' => false, 'message' => $e->getMessage(), 'schema' => $schema];
+        }
+
+        if ($errors) {
+            return [
+                'file' => $file,
+                'line' => $errors[0]['line'],
+                'valid' => false,
+                'message' => implode(\PHP_EOL, array_column($errors, 'message')),
+                'schema' => $schema,
+            ];
+        }
+
+        return ['file' => $file, 'valid' => true, 'schema' => $schema];
+    }
+
+    private function schemaComment(array $info): string
+    {
+        if (!$this->displayCorrectFiles || !\array_key_exists('schema', $info)) {
+            return '';
+        }
+
+        return $info['schema']
+            ? \sprintf(' (validated against %s)', $this->relativizeSchema($info['schema']))
+            : ' (no schema)';
+    }
+
+    /**
+     * Displays the schema path relative to the base directory when possible.
+     */
+    private function relativizeSchema(string $schema): string
+    {
+        $baseDir = str_replace('\\', '/', $this->baseDir);
+
+        return $baseDir && str_starts_with(str_replace('\\', '/', $schema), $baseDir.'/') ? substr($schema, \strlen($baseDir) + 1) : $schema;
     }
 
     private function display(SymfonyStyle $io, array $files): int
@@ -194,10 +287,10 @@ class LintCommand extends Command
 
         foreach ($filesInfo as $info) {
             if ($info['valid'] && $this->displayCorrectFiles) {
-                $io->comment('<info>OK</info>'.($info['file'] ? \sprintf(' in %s', $info['file']) : ''));
+                $io->comment('<info>OK</info>'.($info['file'] ? \sprintf(' in %s', $info['file']) : '').$this->schemaComment($info));
             } elseif (!$info['valid']) {
                 ++$erroredFiles;
-                $io->text('<error> ERROR </error>'.($info['file'] ? \sprintf(' in %s', $info['file']) : ''));
+                $io->text('<error> ERROR </error>'.($info['file'] ? \sprintf(' in %s', $info['file']) : '').$this->schemaComment($info));
                 $io->text(\sprintf('<error> >> %s</error>', $info['message']));
 
                 if (str_contains($info['message'], 'PARSE_CUSTOM_TAGS')) {
@@ -211,7 +304,7 @@ class LintCommand extends Command
         }
 
         if (0 === $erroredFiles) {
-            $io->success(\sprintf('All %d YAML files contain valid syntax.', $countFiles));
+            $io->success(\sprintf('All %d YAML files contain valid syntax%s.', $countFiles, $this->checkSchema ? ' and conform to the schema' : ''));
         } else {
             $io->warning(\sprintf('%d YAML files have valid syntax and %d contain errors.%s', $countFiles - $erroredFiles, $erroredFiles, $suggestTagOption ? ' Use the --parse-tags option if you want parse custom tags.' : ''));
         }

--- a/src/Symfony/Component/Yaml/Exception/LogicException.php
+++ b/src/Symfony/Component/Yaml/Exception/LogicException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Yaml\Exception;
+
+/**
+ * Exception class thrown when a programming error is detected, such as a missing dependency.
+ *
+ * @author Jérôme Tamarelle <jerome@tamarelle.net>
+ */
+class LogicException extends \LogicException implements ExceptionInterface
+{
+}

--- a/src/Symfony/Component/Yaml/Schema/FileHeaderSchemaResolver.php
+++ b/src/Symfony/Component/Yaml/Schema/FileHeaderSchemaResolver.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Yaml\Schema;
+
+/**
+ * Resolves the schema declared in the document header, before any YAML content.
+ *
+ * Both the "# yaml-language-server: $schema=" and the shorter "# $schema=" forms are
+ * supported. A relative location is resolved against the directory of the file.
+ *
+ * @author Jérôme Tamarelle <jerome@tamarelle.net>
+ */
+final class FileHeaderSchemaResolver implements SchemaResolverInterface
+{
+    public function resolve(string $content, ?string $file = null): ?string
+    {
+        if (null === $schema = self::matchHeader($content)) {
+            return null;
+        }
+
+        if (null !== $file && !str_contains($schema, '://') && !self::isAbsolutePath($schema)) {
+            $schema = \dirname($file).'/'.$schema;
+        }
+
+        return $schema;
+    }
+
+    /**
+     * Looks for a "$schema" declaration in the leading comment block, before any YAML content.
+     */
+    private static function matchHeader(string $content): ?string
+    {
+        foreach (preg_split('/\R/', $content) as $line) {
+            $line = ltrim($line);
+
+            if ('' === $line) {
+                continue;
+            }
+
+            // Stop at the first line that is not a comment: the header only applies at the top of the file.
+            if (!str_starts_with($line, '#')) {
+                return null;
+            }
+
+            if (preg_match('/^#\s*(?:yaml-language-server:\s*)?\$schema=(\S+)/', $line, $matches)) {
+                return $matches[1];
+            }
+        }
+
+        return null;
+    }
+
+    private static function isAbsolutePath(string $path): bool
+    {
+        // Unix ("/...") and Windows ("C:/..." or "C:\...") absolute paths.
+        return str_starts_with($path, '/') || 1 === preg_match('#^[A-Za-z]:[/\\\\]#', $path);
+    }
+}

--- a/src/Symfony/Component/Yaml/Schema/SchemaResolverInterface.php
+++ b/src/Symfony/Component/Yaml/Schema/SchemaResolverInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Yaml\Schema;
+
+/**
+ * Determines the JSON Schema a YAML document must validate against.
+ *
+ * @author Jérôme Tamarelle <jerome@tamarelle.net>
+ */
+interface SchemaResolverInterface
+{
+    /**
+     * @param string      $content The raw YAML content
+     * @param string|null $file    The file path, or null when the content comes from STDIN
+     *
+     * @return string|null The schema location, or null when no schema applies
+     */
+    public function resolve(string $content, ?string $file = null): ?string;
+}

--- a/src/Symfony/Component/Yaml/Schema/SchemaValidator.php
+++ b/src/Symfony/Component/Yaml/Schema/SchemaValidator.php
@@ -1,0 +1,153 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Yaml\Schema;
+
+use Opis\JsonSchema\Errors\ErrorFormatter;
+use Opis\JsonSchema\Parsers\SchemaParser;
+use Opis\JsonSchema\Resolvers\SchemaResolver;
+use Opis\JsonSchema\SchemaLoader;
+use Opis\JsonSchema\Validator;
+use Symfony\Component\Yaml\Exception\LogicException;
+use Symfony\Component\Yaml\Exception\RuntimeException;
+
+/**
+ * Validates data, typically parsed from a YAML document, against a JSON Schema.
+ *
+ * Relies on the "opis/json-schema" package.
+ *
+ * @author Jérôme Tamarelle <jerome@tamarelle.net>
+ */
+final class SchemaValidator implements SchemaValidatorInterface
+{
+    private ?Validator $validator = null;
+
+    /**
+     * @var array<string, string> Filesystem paths already registered on the validator, keyed by schema id
+     */
+    private array $registeredFiles = [];
+
+    public function isSupported(): bool
+    {
+        return class_exists(Validator::class);
+    }
+
+    /**
+     * @throws RuntimeException When the schema is remote, since only local schema files are supported
+     */
+    public function validate(mixed $data, string $schema, ?string $content = null): array
+    {
+        if (!$this->isSupported()) {
+            throw new LogicException('Validating against a JSON Schema requires the "opis/json-schema" package. Try running "composer require opis/json-schema".');
+        }
+
+        if (str_contains($schema, '://') && !str_starts_with($schema, 'file://')) {
+            throw new RuntimeException(\sprintf('Cannot validate against remote schema "%s": only local schema files are supported.', $schema));
+        }
+
+        try {
+            $data = json_decode(json_encode($data, \JSON_THROW_ON_ERROR), flags: \JSON_THROW_ON_ERROR);
+        } catch (\JsonException $e) {
+            // A silent failure would validate null instead, and report the file as valid.
+            throw new RuntimeException(\sprintf('Unable to convert the content to JSON before validating it against schema "%s": ', $schema).$e->getMessage(), 0, $e);
+        }
+
+        // Disable default value application: a linter validates the actual content and must
+        // not inject (then check) schema defaults, which may be null on non-nullable nodes.
+        // Keep validating after the first violation, so one run reports them all.
+        $validator = $this->validator ??= new Validator(new SchemaLoader(new SchemaParser([], ['allowDefaults' => false]), new SchemaResolver(), true), 100, false);
+
+        if (is_file($schema)) {
+            // Register the file so relative and internal "$ref" resolve against its location.
+            $path = realpath($schema) ?: $schema;
+            $id = self::toFileUri($path);
+
+            if (!isset($this->registeredFiles[$id])) {
+                $validator->resolver()->registerFile($id, $path);
+                $this->registeredFiles[$id] = $path;
+            }
+
+            $schema = $id;
+        }
+
+        try {
+            $result = $validator->validate($data, $schema);
+        } catch (\Exception $e) {
+            // A missing file, an unreachable URL or an invalid schema aborts a single file, not the whole run.
+            throw new RuntimeException(\sprintf('Unable to validate against schema "%s": ', $schema).$e->getMessage(), 0, $e);
+        }
+
+        if ($result->isValid()) {
+            return [];
+        }
+
+        $errors = [];
+        foreach ((new ErrorFormatter())->formatKeyed($result->error()) as $pointer => $messages) {
+            // The formatter percent-encodes pointer segments (for example "@" as "%40").
+            $pointer = rawurldecode($pointer);
+            $property = trim($pointer, '/');
+
+            foreach ($messages as $message) {
+                $errors[] = [
+                    'message' => ($property ? str_replace('/', '.', $property).': ' : '').$message,
+                    'line' => null === $content ? 0 : self::locateLine($content, $pointer),
+                ];
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * Builds a "file://" URI from a filesystem path, using forward slashes so Windows paths stay valid URIs.
+     */
+    private static function toFileUri(string $path): string
+    {
+        $path = str_replace('\\', '/', $path);
+
+        // Windows paths ("C:/...") need an extra leading slash to form "file:///C:/...".
+        return 'file://'.(str_starts_with($path, '/') ? '' : '/').$path;
+    }
+
+    /**
+     * Best-effort resolution of the YAML line for a JSON Schema error path.
+     *
+     * The path is a JSON Pointer (for example "/when@prod/framework") or a dotted
+     * property path. The line of the deepest matching key is returned, or 0 when
+     * it cannot be located.
+     */
+    private static function locateLine(string $content, string $path): int
+    {
+        $path = str_replace(['~1', '~0'], ['/', '~'], $path);
+        $segments = preg_split('#[/.]#', trim($path, '/.'), -1, \PREG_SPLIT_NO_EMPTY) ?: [];
+
+        $lines = explode("\n", $content);
+        $line = 0;
+        $offset = 0;
+
+        foreach ($segments as $segment) {
+            // Array indices in the path do not map to a key in the document.
+            if (ctype_digit($segment)) {
+                continue;
+            }
+
+            for ($i = $offset; $i < \count($lines); ++$i) {
+                if (preg_match('/^\s*'.preg_quote($segment, '/').'\s*:/', $lines[$i])) {
+                    $line = $i + 1;
+                    $offset = $i + 1;
+                    break;
+                }
+            }
+        }
+
+        return $line;
+    }
+}

--- a/src/Symfony/Component/Yaml/Schema/SchemaValidatorInterface.php
+++ b/src/Symfony/Component/Yaml/Schema/SchemaValidatorInterface.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Yaml\Schema;
+
+use Symfony\Component\Yaml\Exception\LogicException;
+use Symfony\Component\Yaml\Exception\RuntimeException;
+
+/**
+ * Validates data, typically parsed from a YAML document, against a JSON Schema.
+ *
+ * @author Jérôme Tamarelle <jerome@tamarelle.net>
+ */
+interface SchemaValidatorInterface
+{
+    /**
+     * Whether this validator can run, for example when the library it relies on is installed.
+     */
+    public function isSupported(): bool;
+
+    /**
+     * @param mixed       $data    The data to validate, typically the result of Yaml::parse()
+     * @param string      $schema  The schema location, as returned by a SchemaResolverInterface
+     * @param string|null $content The raw YAML content, used to locate the errors in the document
+     *
+     * @return list<array{message: string, line: int}> The validation errors, empty when the data is valid
+     *
+     * @throws LogicException   When this validator cannot run
+     * @throws RuntimeException When the schema cannot be loaded or is not a valid JSON Schema
+     */
+    public function validate(mixed $data, string $schema, ?string $content = null): array;
+}

--- a/src/Symfony/Component/Yaml/Tests/Command/LintCommandTest.php
+++ b/src/Symfony/Component/Yaml/Tests/Command/LintCommandTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Tester\CommandCompletionTester;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Yaml\Command\LintCommand;
+use Symfony\Component\Yaml\Schema\SchemaResolverInterface;
 
 /**
  * Tests the YamlLintCommand.
@@ -174,6 +175,189 @@ bar';
         $this->assertSame(1, $ret, 'lint:yaml exits with code 1 in case of error');
     }
 
+    public function testLintValidatesAgainstSchemaOption()
+    {
+        $this->skipIfJsonSchemaMissing();
+
+        $schema = $this->createSchemaFile();
+        $filename = $this->createFile("name: Symfony\nversion: 8");
+
+        $tester = $this->createCommandTester();
+        $ret = $tester->execute(['filename' => $filename, '--check-schema' => $schema], ['decorated' => false]);
+
+        $this->assertSame(0, $ret, 'lint:yaml exits with code 0 when the content matches the schema');
+        $this->assertStringContainsString('contain valid syntax and conform to the schema', $tester->getDisplay());
+    }
+
+    public function testLintReportsSchemaViolationWithOption()
+    {
+        $this->skipIfJsonSchemaMissing();
+
+        $schema = $this->createSchemaFile();
+        $filename = $this->createFile('version: not-an-integer');
+
+        $tester = $this->createCommandTester();
+        $ret = $tester->execute(['filename' => $filename, '--check-schema' => $schema], ['decorated' => false]);
+
+        $this->assertSame(1, $ret, 'lint:yaml exits with code 1 when the content violates the schema');
+        $this->assertStringContainsString('ERROR', $tester->getDisplay());
+    }
+
+    public function testLintReportsAllSchemaViolations()
+    {
+        $this->skipIfJsonSchemaMissing();
+
+        $schema = $this->createSchemaFile();
+        $filename = $this->createFile("name: 8\nversion: not-an-integer");
+
+        $tester = $this->createCommandTester();
+        $ret = $tester->execute(['filename' => $filename, '--check-schema' => $schema], ['decorated' => false]);
+
+        $this->assertSame(1, $ret);
+        $display = $tester->getDisplay();
+        $this->assertStringContainsString('name:', $display);
+        $this->assertStringContainsString('version:', $display);
+    }
+
+    public function testLintReportsUnresolvableSchemaAsError()
+    {
+        $this->skipIfJsonSchemaMissing();
+
+        $filename = $this->createFile("name: Symfony\nversion: 8");
+
+        $tester = $this->createCommandTester();
+        $ret = $tester->execute(['filename' => $filename, '--check-schema' => '/nonexistent/schema.json'], ['decorated' => false]);
+
+        // An unresolvable schema is reported as a file error, it does not abort the command with a stack trace.
+        $this->assertSame(1, $ret, 'lint:yaml exits with code 1 when the schema cannot be loaded');
+        $this->assertStringContainsString('ERROR', $tester->getDisplay());
+    }
+
+    public function testLintValidatesAgainstSchemaHeader()
+    {
+        $this->skipIfJsonSchemaMissing();
+
+        $schema = $this->createSchemaFile();
+        $filename = $this->createFile(\sprintf("# yaml-language-server: \$schema=%s\nversion: not-an-integer", basename($schema)));
+
+        $ret = $this->createCommandTester()->execute(['filename' => $filename, '--check-schema' => null], ['decorated' => false]);
+
+        $this->assertSame(1, $ret, 'lint:yaml uses the schema declared in the file header');
+    }
+
+    public function testLintValidatesAgainstShortSchemaHeader()
+    {
+        $this->skipIfJsonSchemaMissing();
+
+        $schema = $this->createSchemaFile();
+        $filename = $this->createFile(\sprintf("# \$schema=%s\nversion: not-an-integer", basename($schema)));
+
+        $ret = $this->createCommandTester()->execute(['filename' => $filename, '--check-schema' => null], ['decorated' => false]);
+
+        $this->assertSame(1, $ret, 'lint:yaml uses the short schema header');
+    }
+
+    public function testLintDisplaysSchemaPerFileInVerboseMode()
+    {
+        $this->skipIfJsonSchemaMissing();
+
+        $schema = $this->createSchemaFile();
+        $filename = $this->createFile("name: Symfony\nversion: 8");
+
+        $tester = $this->createCommandTester();
+        $tester->execute(['filename' => $filename, '--check-schema' => $schema], ['verbosity' => OutputInterface::VERBOSITY_VERBOSE, 'decorated' => false]);
+
+        // The comment style wraps at 80 columns and prefixes every line with "//",
+        // so collapse line breaks and the prefix before asserting on the label.
+        $display = preg_replace('~\s*\n\s*(// )?~', ' ', $tester->getDisplay());
+        $this->assertStringContainsString('validated against', $display);
+    }
+
+    public function testLintUsesTheInjectedSchemaResolver()
+    {
+        $this->skipIfJsonSchemaMissing();
+
+        $schema = $this->createSchemaFile();
+        $filename = $this->createFile('version: not-an-integer');
+
+        $application = new Application();
+        $resolver = $this->createStub(SchemaResolverInterface::class);
+        $resolver->method('resolve')->willReturn($schema);
+
+        $application->addCommand(new LintCommand(null, null, null, $resolver));
+        $tester = new CommandTester($application->find('lint:yaml'));
+
+        $ret = $tester->execute(['filename' => $filename, '--check-schema' => null], ['decorated' => false]);
+
+        $this->assertSame(1, $ret, 'lint:yaml validates against the schema returned by the injected resolver');
+    }
+
+    public function testLintDisplaysSchemaRelativeToTheBaseDir()
+    {
+        $this->skipIfJsonSchemaMissing();
+
+        $schema = $this->createSchemaFile();
+        $filename = $this->createFile("name: Symfony\nversion: 8");
+
+        $application = new Application();
+        $application->addCommand(new LintCommand(null, null, null, null, null, \dirname($schema)));
+        $tester = new CommandTester($application->find('lint:yaml'));
+
+        $tester->execute(['filename' => $filename, '--check-schema' => $schema], ['verbosity' => OutputInterface::VERBOSITY_VERBOSE, 'decorated' => false]);
+
+        $display = preg_replace('~\s*\n\s*(// )?~', ' ', $tester->getDisplay());
+        $this->assertStringContainsString('validated against '.basename($schema), $display);
+    }
+
+    public function testLintReportsSchemaViolationLineWithGithubFormat()
+    {
+        $this->skipIfJsonSchemaMissing();
+
+        $schema = $this->createSchemaFile();
+        $filename = $this->createFile("name: Symfony\nversion: not-an-integer");
+
+        $tester = $this->createCommandTester();
+        $tester->execute(['filename' => $filename, '--check-schema' => $schema, '--format' => 'github'], ['decorated' => false]);
+
+        self::assertSame(1, $tester->getStatusCode());
+        self::assertStringContainsString('line=2', $tester->getDisplay());
+    }
+
+    public function testLintDoesNotValidateSchemaWithoutOption()
+    {
+        $this->skipIfJsonSchemaMissing();
+
+        $schema = $this->createSchemaFile();
+        $filename = $this->createFile(\sprintf("# \$schema=%s\nversion: not-an-integer", basename($schema)));
+
+        $ret = $this->createCommandTester()->execute(['filename' => $filename], ['decorated' => false]);
+
+        $this->assertSame(0, $ret, 'lint:yaml only validates against a schema when --check-schema is used');
+    }
+
+    public function testLintWithoutSchemaOnlyChecksSyntax()
+    {
+        $filename = $this->createFile('version: not-an-integer');
+
+        $ret = $this->createCommandTester()->execute(['filename' => $filename], ['decorated' => false]);
+
+        $this->assertSame(0, $ret, 'lint:yaml only checks syntax when no schema is resolved');
+    }
+
+    public function testLintThrowsWhenSchemaOptionUsedWithoutLibrary()
+    {
+        if (class_exists(\Opis\JsonSchema\Validator::class)) {
+            $this->markTestSkipped('The "opis/json-schema" package is installed.');
+        }
+
+        $filename = $this->createFile('foo: bar');
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('opis/json-schema');
+
+        $this->createCommandTester()->execute(['filename' => $filename, '--check-schema' => 'schema.json'], ['decorated' => false]);
+    }
+
     public function testLintWithExclude()
     {
         $tester = $this->createCommandTester();
@@ -216,6 +400,24 @@ bar';
         $this->files[] = $filename;
 
         return $filename;
+    }
+
+    private function createSchemaFile(): string
+    {
+        return $this->createFile(json_encode([
+            'type' => 'object',
+            'properties' => [
+                'name' => ['type' => 'string'],
+                'version' => ['type' => 'integer'],
+            ],
+        ]));
+    }
+
+    private function skipIfJsonSchemaMissing(): void
+    {
+        if (!class_exists(\Opis\JsonSchema\Validator::class)) {
+            $this->markTestSkipped('The "opis/json-schema" package is required.');
+        }
     }
 
     protected function createCommand(): Command

--- a/src/Symfony/Component/Yaml/Tests/Schema/FileHeaderSchemaResolverTest.php
+++ b/src/Symfony/Component/Yaml/Tests/Schema/FileHeaderSchemaResolverTest.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Yaml\Tests\Schema;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Schema\FileHeaderSchemaResolver;
+
+class FileHeaderSchemaResolverTest extends TestCase
+{
+    #[DataProvider('provideHeaders')]
+    public function testHeaderIsMatched(string $content)
+    {
+        $resolver = new FileHeaderSchemaResolver();
+
+        $this->assertSame('/schema.json', $resolver->resolve($content));
+    }
+
+    public static function provideHeaders(): iterable
+    {
+        yield 'the language server form' => ["# yaml-language-server: \$schema=/schema.json\nversion: 8"];
+        yield 'the short form' => ["# \$schema=/schema.json\nversion: 8"];
+        yield 'without a space after the hash' => ["#\$schema=/schema.json\nversion: 8"];
+        yield 'below another comment' => ["# Some comment\n# \$schema=/schema.json\nversion: 8"];
+        yield 'below a blank line' => ["\n# \$schema=/schema.json\nversion: 8"];
+        yield 'an indented header' => ["    # \$schema=/schema.json\nversion: 8"];
+    }
+
+    #[DataProvider('provideContentWithoutHeader')]
+    public function testNoHeaderResolvesToNull(string $content)
+    {
+        $resolver = new FileHeaderSchemaResolver();
+
+        $this->assertNull($resolver->resolve($content));
+    }
+
+    public static function provideContentWithoutHeader(): iterable
+    {
+        yield 'no comment at all' => ['version: 8'];
+        yield 'an unrelated comment' => ["# Some comment\nversion: 8"];
+        // The header only applies at the top of the file, before any YAML content.
+        yield 'below the content' => ["version: 8\n# \$schema=/schema.json"];
+        yield 'an empty document' => [''];
+    }
+
+    public function testRelativeHeaderIsResolvedAgainstTheFile()
+    {
+        $resolver = new FileHeaderSchemaResolver();
+
+        $this->assertSame('/project/config/schema.json', $resolver->resolve('# $schema=schema.json', '/project/config/routes.yaml'));
+        $this->assertSame('/project/config/../schema.json', $resolver->resolve('# $schema=../schema.json', '/project/config/routes.yaml'));
+    }
+
+    #[DataProvider('provideNonRelativeHeaders')]
+    public function testNonRelativeHeaderIsKeptAsIs(string $schema)
+    {
+        $resolver = new FileHeaderSchemaResolver();
+
+        $this->assertSame($schema, $resolver->resolve('# $schema='.$schema, '/project/config/routes.yaml'));
+    }
+
+    public static function provideNonRelativeHeaders(): iterable
+    {
+        yield 'a unix absolute path' => ['/schema.json'];
+        yield 'a windows absolute path' => ['C:/project/schema.json'];
+        yield 'a windows absolute path with backslashes' => ['C:\\project\\schema.json'];
+        yield 'a url' => ['https://example.com/schema.json'];
+    }
+
+    public function testHeaderIsNotResolvedWithoutAFile()
+    {
+        $resolver = new FileHeaderSchemaResolver();
+
+        $this->assertSame('schema.json', $resolver->resolve('# $schema=schema.json'));
+    }
+}

--- a/src/Symfony/Component/Yaml/Tests/Schema/SchemaValidatorTest.php
+++ b/src/Symfony/Component/Yaml/Tests/Schema/SchemaValidatorTest.php
@@ -1,0 +1,148 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Yaml\Tests\Schema;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Exception\RuntimeException;
+use Symfony\Component\Yaml\Schema\SchemaValidator;
+use Symfony\Component\Yaml\Yaml;
+
+class SchemaValidatorTest extends TestCase
+{
+    private array $files = [];
+
+    protected function setUp(): void
+    {
+        if (!(new SchemaValidator())->isSupported()) {
+            $this->markTestSkipped('The "opis/json-schema" package is required.');
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->files as $file) {
+            @unlink($file);
+        }
+    }
+
+    public function testValidDataReturnsNoError()
+    {
+        $content = "name: Symfony\nversion: 8";
+        $validator = new SchemaValidator();
+
+        $this->assertSame([], $validator->validate(Yaml::parse($content), $this->createSchema(), $content));
+    }
+
+    public function testInvalidDataReturnsErrors()
+    {
+        $content = 'version: not-an-integer';
+        $validator = new SchemaValidator();
+
+        $errors = $validator->validate(Yaml::parse($content), $this->createSchema(), $content);
+
+        $this->assertNotEmpty($errors);
+        $this->assertIsString($errors[0]['message']);
+        $this->assertSame(1, $errors[0]['line']);
+    }
+
+    public function testErrorsHaveNoLineWithoutContent()
+    {
+        $content = 'version: not-an-integer';
+        $validator = new SchemaValidator();
+
+        $errors = $validator->validate(Yaml::parse($content), $this->createSchema());
+
+        $this->assertNotEmpty($errors);
+        $this->assertSame(0, $errors[0]['line']);
+    }
+
+    public function testErrorLineIsResolvedFromNestedKey()
+    {
+        $schema = $this->createFile(json_encode([
+            'type' => 'object',
+            'properties' => [
+                'parent' => [
+                    'type' => 'object',
+                    'properties' => ['child' => ['type' => 'integer']],
+                ],
+            ],
+        ]));
+
+        $content = "parent:\n    child: not-an-integer";
+        $validator = new SchemaValidator();
+
+        $errors = $validator->validate(Yaml::parse($content), $schema, $content);
+
+        $this->assertNotEmpty($errors);
+        $this->assertSame(2, $errors[0]['line']);
+    }
+
+    public function testInvalidUtf8ThrowsRuntimeException()
+    {
+        // Encoding such a value to JSON fails, and the data must not be silently validated as null.
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Unable to convert the content to JSON');
+
+        (new SchemaValidator())->validate(['name' => "\xB1\x31"], $this->createSchema());
+    }
+
+    public function testUnresolvableSchemaThrowsRuntimeException()
+    {
+        $content = 'version: 8';
+
+        $this->expectException(RuntimeException::class);
+        (new SchemaValidator())->validate(Yaml::parse($content), '/nonexistent/schema.json', $content);
+    }
+
+    public function testAllViolationsAreReported()
+    {
+        $content = "name: 8\nversion: not-an-integer";
+        $validator = new SchemaValidator();
+
+        $errors = $validator->validate(Yaml::parse($content), $this->createSchema(), $content);
+
+        $this->assertCount(2, $errors);
+        $this->assertSame(1, $errors[0]['line']);
+        $this->assertSame(2, $errors[1]['line']);
+    }
+
+    public function testRemoteSchemaIsRejected()
+    {
+        $content = 'version: 8';
+
+        // A remote schema is never fetched over the network while linting.
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('only local schema files are supported');
+        (new SchemaValidator())->validate(Yaml::parse($content), 'https://example.com/schema.json', $content);
+    }
+
+    private function createSchema(): string
+    {
+        return $this->createFile(json_encode([
+            'type' => 'object',
+            'properties' => [
+                'name' => ['type' => 'string'],
+                'version' => ['type' => 'integer'],
+            ],
+        ]));
+    }
+
+    private function createFile(string $content): string
+    {
+        $filename = tempnam(sys_get_temp_dir(), 'sf-schema-');
+        file_put_contents($filename, $content);
+
+        $this->files[] = $filename;
+
+        return $filename;
+    }
+}

--- a/src/Symfony/Component/Yaml/composer.json
+++ b/src/Symfony/Component/Yaml/composer.json
@@ -34,6 +34,7 @@
         "symfony/polyfill-ctype": "^1.8"
     },
     "require-dev": {
+        "opis/json-schema": "^2.6",
         "symfony/console": "^7.4|^8.0",
         "yaml/yaml-test-suite": "*"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

This adds JSON Schema validation to the `lint:yaml` command, on top of the existing syntax check.

The Yaml component gets a `Symfony\Component\Yaml\Schema` namespace:

* `SchemaResolverInterface::resolve($content, $file)` returns the schema a document must validate against, or null.
* `FileHeaderSchemaResolver` reads the `# yaml-language-server: $schema=` and `# $schema=` header from the leading comment block, resolving a relative location against the directory of the file.
* `SchemaValidatorInterface` exposes `isSupported()` and `validate($data, $schema, $content)`.
* `SchemaValidator` implements it on top of `opis/json-schema` and is the only class that depends on the library. All violations are reported in one run, each with the YAML line it occurs on. Only local schema files are supported: a remote schema fails with a clear per-file error, so linting never touches the network.

`LintCommand` receives a resolver, a validator and a base directory (used to shorten displayed schema paths) through optional constructor arguments, and gains the `--check-schema` option, which takes an optional value. Absent, no schema check runs. Present without a value, the schema comes from the resolver. Present with a value, that schema file is forced.

```
# validate against a given schema
php bin/console lint:yaml config/packages/ --check-schema=config/schema.json

# resolve the schema from each file header or the default conventions
php bin/console lint:yaml config/ --check-schema
```

In verbose mode the command prints the schema used for each file, and states `(no schema)` when none applies (this never fails the run). An unresolvable or invalid schema is reported as a per-file error and the lint keeps going.

FrameworkBundle ships `YamlLintSchemaResolver`, which decorates the header resolver and falls back to Symfony conventions, matching the JSON Schema Store catalog:

* `config/routes.yaml`, `config/routes/**/*.yaml` -> routing schema
* `config/services.yaml`, `config/services_*.yaml` -> services schema
* `config/serializer/**/*.yaml` -> serialization schema (when the Serializer component is installed)
* `config/validator/**/*.yaml` -> validation schema (when the Validator component is installed)
* the `.yml` extension is accepted everywhere

The generated `config/schema.json` applies to the `packages` directory of the project config directory only, since it describes the configuration of this application. The config directory comes from the `.kernel.config_dir` build parameter, the same one `JsonSchemaConfigDumpPass` uses to write the file; without it, the generated schema is never applied.

## Library choice

Validation relies on `opis/json-schema`, kept as an optional dependency: the command throws a `LogicException` with the `composer require` hint when the option is used without the package.

`justinrainbow/json-schema` was evaluated first but does not fit the schemas produced by the config schema dumper. Those schemas target draft 2019-09/2020-12 and rely on keywords declared next to `$ref` and on chained `$ref` (a property references a node definition that itself references a type definition with sibling keywords). `justinrainbow/json-schema` only applies the per-keyword draft engine in strict mode, and even then its `$ref` resolution drops the sibling keywords, so nested properties are never validated and invalid content passes as valid. `opis/json-schema` implements draft 2019-09/2020-12 fully, including `$ref` with siblings and chained `$ref`, and validates these schemas correctly.

Because a linter validates the actual file content, default value application is disabled in the validator, so schema defaults are not injected into the data and then checked.

## Config schema generator

Two fixes were made to the config schema generator so generated schemas match real configuration:

* `BaseNode::isNullable()` now returns true when the node default is null, so `$ref`-based nodes (array, object, and so on) use their nullable variant. This avoids a `null` default being reported as invalid against a non-nullable type. `isNullable()` is only consumed by the JSON Schema dumper.
* A prototyped map with a key attribute and a scalar prototype now also accepts the equivalent list form, since the Config layer accepts a list for these nodes.

Environment blocks (`when@<env>`) in the app config schema now use the nullable object type, so an empty environment block validates.

## Known limitations

Some valid Symfony configuration still reports schema errors because the generated schema cannot represent every runtime normalization. These are generator limitations, not linter bugs, and are out of scope here:

* Nodes that accept a list through a `beforeNormalization` closure (for example the Monolog handler `channels`, written as `["!event"]`) cannot be introspected, so the list form is missing from the schema.
* An empty YAML mapping `{}` is parsed to an empty PHP array and serialized as `[]`, so it fails against an `object` type (for example `framework.validation.auto_mapping`).
* Some nodes accept keys merged by normalization at a parent level (for example `doctrine.dbal` connection keys such as `url`), which `additionalProperties: false` then rejects.
* A key required in a node definition but provided by the bundle rather than the app (for example `framework.router.resource`) is reported as missing.

## Documentation

Points for the docs PR: the `--check-schema` option and its optional value, the two header forms and their relative resolution, the FrameworkBundle conventions above, the generated `config/schema.json` scope (`config/packages` only), the opis requirement, and the local-files-only rule.
