### PR TITLE
[Tui] Sanitize pasted text in InputWidget

### DIFF
--- a/src/Symfony/Component/Tui/Tests/Widget/InputTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/InputTest.php
@@ -499,6 +499,39 @@ class InputTest extends TestCase
         $this->assertLessThanOrEqual(15, AnsiUtils::visibleWidth($lines[0]));
     }
 
+    public function testPastedEscapeSequencesAreStripped()
+    {
+        $input = new InputWidget();
+        $input->handleInput("\x1b[200~before\x1b]0;title\x07\x1b[31mafter\x1b[201~");
+
+        $this->assertSame('before]0;title[31mafter', $input->getValue());
+        $this->assertStringNotContainsString("\x1b", $input->getValue());
+        $this->assertStringNotContainsString("\x07", $input->getValue());
+        $this->assertStringNotContainsString("\x1b", $input->render(new RenderContext(80, 24))[0]);
+    }
+
+    public function testPastedNewlinesAndControlBytesAreRemoved()
+    {
+        $input = new InputWidget();
+        $input->handleInput("\x1b[200~a\r\nb\x00c\x1b[201~");
+
+        $this->assertSame('abc', $input->getValue());
+    }
+
+    public function testPasteThatSanitizesToNothingIsIgnored()
+    {
+        $changes = 0;
+        $input = new InputWidget();
+        $input->onChange(static function () use (&$changes) {
+            ++$changes;
+        });
+        $input->handleInput("\x1b[200~\x1b[201~");
+        $input->handleInput("\x1b[200~\n\x1b[201~");
+
+        $this->assertSame('', $input->getValue());
+        $this->assertSame(0, $changes);
+    }
+
     private function assertValidUtf8(string $value, string $message = ''): void
     {
         $this->assertTrue(mb_check_encoding($value, 'UTF-8'), $message ?: 'Value should be valid UTF-8');

--- a/src/Symfony/Component/Tui/Widget/InputWidget.php
+++ b/src/Symfony/Component/Tui/Widget/InputWidget.php
@@ -442,8 +442,16 @@ class InputWidget extends AbstractWidget implements FocusableInterface
 
     private function handlePaste(string $text): void
     {
+        // Pasted bytes are untrusted: a paste can carry escape sequences that
+        // would be replayed verbatim to the terminal on the next render.
+        $cleanText = StringUtils::sanitizeUtf8($text);
         // Clean pasted text - remove newlines
-        $cleanText = str_replace(["\r\n", "\r", "\n"], '', $text);
+        $cleanText = str_replace(["\r\n", "\r", "\n"], '', $cleanText);
+        $cleanText = StringUtils::stripControlBytes($cleanText);
+
+        if ('' === $cleanText) {
+            return;
+        }
 
         $this->line->insert($cleanText);
         $this->notifyChange();

--- a/src/Symfony/Component/Tui/Widget/TextWidget.php
+++ b/src/Symfony/Component/Tui/Widget/TextWidget.php
@@ -58,9 +58,9 @@ use Symfony\Component\Tui\Widget\Figlet\FigletRenderer;
  *  - InputWidget::setPrompt()
  *
  * Sanitizing widgets (which call StringUtils::stripControlBytes on input):
- * InputWidget::setValue, EditorWidget/EditorDocument, MarkdownWidget,
- * SettingItem::$currentValue, ProgressBarWidget::setMessage,
- * LoaderWidget::setMessage.
+ * InputWidget::setValue and pasted content, EditorWidget/EditorDocument,
+ * MarkdownWidget, SettingItem::$currentValue,
+ * ProgressBarWidget::setMessage, LoaderWidget::setMessage.
  *
  * @experimental
  *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

A bracketed paste is the one input path into `InputWidget` that skips the control-character check guarding typed keys: `handleInput()` rejects anything with a control byte, but pasted content goes straight to `Line::insert()`. So the bytes the terminal hands over inside `ESC[200~ … ESC[201~` land in the value verbatim, and the next render replays them to the terminal.

```php
$input = new InputWidget();
$input->handleInput("\x1b[200~\x1b]0;pwned\x07\x1b[31mred\x1b[201~");

$input->getValue();                          // "\x1b]0;pwned\x07\x1b[31mred"
$input->render(new RenderContext(40, 1))[0]; // same bytes, on their way to the terminal
```

That sets the terminal title and leaves a dangling SGR bleeding colour into everything drawn after the input. It also breaks the width accounting: the escapes are zero-width, so the field pads itself to the full column count and the text overflows.

`EditorWidget` already runs pasted content through `StringUtils::sanitizeUtf8()` + `stripControlBytes()`, and `InputWidget::setValue()` does the same — only this path did not. The class docblock in `TextWidget` that lists the sanitizing surfaces is updated to match.

A paste that sanitizes down to nothing is now dropped instead of dispatching an empty `ChangeEvent`.
