### PR TITLE
[Tui] Keep the progress bar inside the available columns

### DIFF
--- a/src/Symfony/Component/Tui/Tests/Widget/ProgressBarTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/ProgressBarTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Tui\Tests\Widget;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Tui\Ansi\AnsiUtils;
 use Symfony\Component\Tui\Render\RenderContext;
 use Symfony\Component\Tui\Style\Style;
 use Symfony\Component\Tui\Style\StyleSheet;
@@ -449,6 +450,35 @@ class ProgressBarTest extends TestCase
         // Should not exceed 40 columns
         $visibleWidth = mb_strwidth(preg_replace('/\x1b\[[^m]*m/', '', $content));
         $this->assertLessThanOrEqual(40, $visibleWidth);
+    }
+
+    /**
+     * The bar can only give back as many columns as it owns; anything left
+     * over has to be cut off the line, or the Renderer rejects it.
+     */
+    public function testRenderNeverExceedsTheAvailableWidth()
+    {
+        foreach ([40, 20, 15, 14, 10, 5, 1] as $columns) {
+            $bar = new ProgressBarWidget(10);
+            $bar->setProgress(3);
+
+            $line = $bar->render(new RenderContext($columns, 24))[0];
+
+            $this->assertLessThanOrEqual($columns, AnsiUtils::visibleWidth($line), \sprintf('Line fits in %d columns.', $columns));
+        }
+    }
+
+    public function testRenderInATerminalTooNarrowForTheBar()
+    {
+        $terminal = new VirtualTerminal(12, 6);
+        $tui = new Tui(terminal: $terminal);
+        $bar = new ProgressBarWidget(10);
+        $tui->add($bar);
+        $bar->setProgress(3);
+
+        $tui->processRender();
+
+        $this->assertLessThanOrEqual(12, AnsiUtils::visibleWidth($bar->render(new RenderContext(12, 6))[0]));
     }
 
     public function testMemoryPlaceholder()

--- a/src/Symfony/Component/Tui/Widget/ProgressBarWidget.php
+++ b/src/Symfony/Component/Tui/Widget/ProgressBarWidget.php
@@ -507,17 +507,26 @@ class ProgressBarWidget extends AbstractWidget
 
         // If the line is too wide, shrink the bar to fit
         $lineWidth = AnsiUtils::visibleWidth($line);
-        if ($lineWidth > $availableWidth) {
-            $newBarWidth = $this->barWidth - ($lineWidth - $availableWidth);
-            if ($newBarWidth >= 1) {
-                $savedBarWidth = $this->barWidth;
-                $this->barWidth = $newBarWidth;
-                $line = $this->replacePlaceholders($format);
-                $this->barWidth = $savedBarWidth;
-            }
+        if ($lineWidth <= $availableWidth) {
+            return $line;
         }
 
-        return $line;
+        // Shrink as far as the bar goes, down to a single cell. Giving up
+        // when the overflow is larger than the bar would leave the line at
+        // its full width, so a terminal narrow enough to swallow the whole
+        // bar produced a wider line than a slightly wider one did.
+        $newBarWidth = max(1, $this->barWidth - ($lineWidth - $availableWidth));
+        if ($newBarWidth !== $this->barWidth) {
+            $savedBarWidth = $this->barWidth;
+            $this->barWidth = $newBarWidth;
+            $line = $this->replacePlaceholders($format);
+            $this->barWidth = $savedBarWidth;
+        }
+
+        // The rest of the format (counters, percentage, message) can still
+        // outgrow the available columns on its own; the Renderer rejects an
+        // over-wide line, so cut it instead of aborting the render.
+        return AnsiUtils::truncateToWidth($line, $availableWidth, '');
     }
 
     private function replacePlaceholders(string $format): string


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`ProgressBarWidget::buildLine()` shrinks the bar by exactly the overflow, but only applies the result when it stays at 1 or more:

```php
$newBarWidth = $this->barWidth - ($lineWidth - $availableWidth);
if ($newBarWidth >= 1) { /* re-render with the smaller bar */ }
```

Once the terminal is narrow enough that the overflow exceeds the bar width, the shrink is skipped entirely and the full-width line is returned — so the widget gets *wider* as the terminal gets narrower:

```
cols=20 -> width=20   3/10 [━━━━━━]  30%
cols=12 -> width=42   3/10 [━━━━━━━━━━━━━━━━━━━━━━━━━━━━]  30%
```

`Renderer::render()` rejects a line wider than its box, so this is not just a cosmetic overflow — the render aborts:

```
RenderException: Widget "…\ProgressBarWidget" rendered line 0 with width 42, exceeding the available 12 columns.
```

Clamp the shrink at a single cell, and truncate whatever is left over. The counters, percentage and message around the bar can outgrow the box on their own, and no bar width can give those columns back.
