### PR TITLE
[Tui] Budget the select list arrow in columns, not bytes

### DIFF
--- a/src/Symfony/Component/Tui/Tests/Widget/SelectListTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/SelectListTest.php
@@ -242,6 +242,43 @@ class SelectListTest extends TestCase
     }
 
     /**
+     * The selected row is prefixed with an arrow: three bytes, two columns.
+     * Budgeting in bytes cost that row two columns of description.
+     */
+    public function testSelectedRowGetsTheSameWidthBudgetAsTheOthers()
+    {
+        $description = str_repeat('D', 120);
+        $list = new SelectListWidget([
+            ['value' => 'alpha', 'label' => 'alpha', 'description' => $description],
+            ['value' => 'beta', 'label' => 'beta', 'description' => $description],
+        ]);
+
+        $lines = $list->render(new RenderContext(60, 24));
+
+        $this->assertSame(
+            AnsiUtils::visibleWidth($lines[1]),
+            AnsiUtils::visibleWidth($lines[0]),
+            'The selected row is truncated to the same width as the others.',
+        );
+    }
+
+    public function testSelectedRowWithoutDescriptionGetsTheSameWidthBudget()
+    {
+        $label = str_repeat('L', 120);
+        $list = new SelectListWidget([
+            ['value' => 'alpha', 'label' => $label],
+            ['value' => 'beta', 'label' => $label],
+        ]);
+
+        $lines = $list->render(new RenderContext(60, 24));
+
+        $this->assertSame(
+            AnsiUtils::visibleWidth($lines[1]),
+            AnsiUtils::visibleWidth($lines[0]),
+        );
+    }
+
+    /**
      * @return array{SelectListWidget, Tui}
      */
     private function createTestListWithTui(): array

--- a/src/Symfony/Component/Tui/Widget/SelectListWidget.php
+++ b/src/Symfony/Component/Tui/Widget/SelectListWidget.php
@@ -287,14 +287,17 @@ class SelectListWidget extends AbstractWidget implements FocusableInterface
 
         if ($isSelected) {
             $prefix = '→ ';
+            // The arrow is three bytes wide and one column wide; every
+            // budget here is in columns.
+            $prefixWidth = AnsiUtils::visibleWidth($prefix);
             $selectedStyle = $this->resolveElement('selected');
 
             if (null !== $description && $columns > 40) {
-                $maxValueColumns = min($labelColumnWidth, $columns - \strlen($prefix) - 4);
+                $maxValueColumns = min($labelColumnWidth, $columns - $prefixWidth - 4);
                 $truncatedValue = AnsiUtils::truncateToWidth($displayValue, $maxValueColumns, '');
                 $spacing = str_repeat(' ', max(1, $alignedWidth - AnsiUtils::visibleWidth($truncatedValue)));
 
-                $descriptionStart = \strlen($prefix) + AnsiUtils::visibleWidth($truncatedValue) + \strlen($spacing);
+                $descriptionStart = $prefixWidth + AnsiUtils::visibleWidth($truncatedValue) + \strlen($spacing);
                 $remainingColumns = $columns - $descriptionStart - 2;
 
                 if ($remainingColumns > 10) {
@@ -304,20 +307,21 @@ class SelectListWidget extends AbstractWidget implements FocusableInterface
                 }
             }
 
-            $maxColumns = $columns - \strlen($prefix) - 2;
+            $maxColumns = $columns - $prefixWidth - 2;
 
             return $selectedStyle->apply($prefix.AnsiUtils::truncateToWidth($displayValue, $maxColumns, ''));
         }
 
         // Non-selected item
         $prefix = '  ';
+        $prefixWidth = AnsiUtils::visibleWidth($prefix);
 
         if (null !== $description && $columns > 40) {
-            $maxValueColumns = min($labelColumnWidth, $columns - \strlen($prefix) - 4);
+            $maxValueColumns = min($labelColumnWidth, $columns - $prefixWidth - 4);
             $truncatedValue = AnsiUtils::truncateToWidth($displayValue, $maxValueColumns, '');
             $spacing = str_repeat(' ', max(1, $alignedWidth - AnsiUtils::visibleWidth($truncatedValue)));
 
-            $descriptionStart = \strlen($prefix) + AnsiUtils::visibleWidth($truncatedValue) + \strlen($spacing);
+            $descriptionStart = $prefixWidth + AnsiUtils::visibleWidth($truncatedValue) + \strlen($spacing);
             $remainingColumns = $columns - $descriptionStart - 2;
 
             if ($remainingColumns > 10) {
@@ -329,7 +333,7 @@ class SelectListWidget extends AbstractWidget implements FocusableInterface
             }
         }
 
-        $maxColumns = $columns - \strlen($prefix) - 2;
+        $maxColumns = $columns - $prefixWidth - 2;
 
         return $prefix.AnsiUtils::truncateToWidth($displayValue, $maxColumns, '');
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`SelectListWidget::renderItem()` measures its prefix with `strlen()`. For the unselected rows the prefix is `'  '`, where bytes and columns agree; the selected row is prefixed with `'→ '` — three bytes, two columns. Every budget derived from it (`$maxValueColumns`, `$descriptionStart`, `$maxColumns`) came out two columns short, so the highlighted row truncated its label and description two columns earlier than the rows around it:

```
w=56 → alpha  DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD
w=58   beta   DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD
```

Measure the prefix with `AnsiUtils::visibleWidth()`, like the rest of the line already does.
