### PR TITLE
[Tui] Make a pasted block one undo step in the editor

### DIFF
--- a/src/Symfony/Component/Tui/Tests/Widget/Editor/EditorDocumentTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/Editor/EditorDocumentTest.php
@@ -497,6 +497,41 @@ class EditorDocumentTest extends TestCase
         $this->assertSame([], $doc->getPasteMarkers());
     }
 
+    public function testMultiLinePasteIsASingleUndoStep()
+    {
+        $doc = new EditorDocument();
+        $doc->insertText('start');
+        $doc->handlePaste("line 1\nline 2\nline 3");
+        $this->assertSame("startline 1\nline 2\nline 3", $doc->getText());
+
+        $this->assertTrue($doc->undo());
+        $this->assertSame('start', $doc->getText());
+        $this->assertSame(0, $doc->getCursorLine());
+        $this->assertSame(5, $doc->getCursorCol());
+    }
+
+    public function testMultiLinePasteIsRedoneInOneStep()
+    {
+        $doc = new EditorDocument();
+        $doc->handlePaste("line 1\nline 2\nline 3");
+        $doc->undo();
+
+        $this->assertTrue($doc->redo());
+        $this->assertSame("line 1\nline 2\nline 3", $doc->getText());
+    }
+
+    public function testPasteInTheMiddleOfALine()
+    {
+        $doc = new EditorDocument();
+        $doc->setText('ab');
+        $doc->setCursorCol(1);
+        $doc->handlePaste("X\nY");
+
+        $this->assertSame("aX\nYb", $doc->getText());
+        $this->assertSame(1, $doc->getCursorLine());
+        $this->assertSame(1, $doc->getCursorCol());
+    }
+
     public function testPasteStripsControlBytesToPreventTerminalInjection()
     {
         $doc = new EditorDocument();

--- a/src/Symfony/Component/Tui/Widget/Editor/EditorDocument.php
+++ b/src/Symfony/Component/Tui/Widget/Editor/EditorDocument.php
@@ -483,8 +483,8 @@ final class EditorDocument
                     grapheme_extract($line, 1, \GRAPHEME_EXTR_COUNT, $nextByteOffset, $nextByteOffset);
                     $idx = strpos($line, $char, $nextByteOffset);
                 } else {
-                    $searchIn = 0 === $this->cursorCol ? false : substr($line, 0, $this->cursorCol);
-                    $idx = false !== $searchIn ? strrpos($searchIn, $char) : false;
+                    $haystack = 0 === $this->cursorCol ? false : substr($line, 0, $this->cursorCol);
+                    $idx = false !== $haystack ? strrpos($haystack, $char) : false;
                 }
             } else {
                 $idx = $isForward ? strpos($line, $char) : strrpos($line, $char);
@@ -619,14 +619,12 @@ final class EditorDocument
             return;
         }
 
-        // Insert first line at cursor
-        $this->insertText($lines[0]);
+        // One paste is one edit: take a single snapshot and insert the whole
+        // content in one go, so a later undo takes all of it back at once.
+        $this->pushUndoSnapshot();
+        $this->killRing->resetAction();
 
-        // Insert remaining lines
-        for ($i = 1; $i < \count($lines); ++$i) {
-            $this->insertNewLine();
-            $this->insertText($lines[$i]);
-        }
+        $this->insertTextAtCursor($content);
     }
 
     // --- Internal ---


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`EditorDocument::handlePaste()` replays a paste of ten lines or fewer as a sequence of `insertText()` / `insertNewLine()` calls, and each of those pushes its own undo snapshot. Undoing a three-line paste therefore takes five presses and walks back through half-pasted intermediate states:

```php
$doc->handlePaste("a\nb\nc");   // ["a", "b", "c"]
$doc->undo();                   // ["a", "b", ""]
$doc->undo();                   // ["a", "b"]
$doc->undo();                   // ["a", ""]
$doc->undo();                   // ["a"]
$doc->undo();                   // [""]
```

The large-paste path (>10 lines), which inserts a single marker, already undid in one step — so the two paste paths disagreed on what an undo unit is.

`insertTextAtCursor()` splits on newlines itself, so the whole block can go in under a single snapshot, which is also what a user means by "undo the paste".
