### PR TITLE
[Tui] Wrap ordered list items to their own marker width

### DIFF
--- a/src/Symfony/Component/Tui/Tests/Widget/MarkdownTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/MarkdownTest.php
@@ -220,6 +220,29 @@ class MarkdownTest extends TestCase
     }
 
     /**
+     * A two-digit marker is four columns wide, so the item's text has four
+     * fewer columns to wrap into and its continuation lines line up under it.
+     */
+    public function testOrderedListWithTwoDigitMarkers()
+    {
+        $markdown = '';
+        for ($i = 1; $i <= 11; ++$i) {
+            $markdown .= $i.". item text that is fairly long here\n";
+        }
+
+        $md = $this->createMarkdown($markdown);
+        $lines = array_map(AnsiUtils::stripAnsiCodes(...), $md->render(new RenderContext(20, 60)));
+
+        foreach ($lines as $line) {
+            $this->assertLessThanOrEqual(20, AnsiUtils::visibleWidth($line));
+        }
+
+        $tenth = array_search('10. item text that', $lines, true);
+        $this->assertNotFalse($tenth, 'The tenth item starts a line of its own: '.implode(' / ', $lines));
+        $this->assertStringStartsWith('    ', $lines[$tenth + 1], 'Continuation lines are indented under the text, not under the marker.');
+    }
+
+    /**
      * Render a widget through the Renderer pipeline to get full chrome applied.
      *
      * @return string[]

--- a/src/Symfony/Component/Tui/Widget/MarkdownWidget.php
+++ b/src/Symfony/Component/Tui/Widget/MarkdownWidget.php
@@ -309,7 +309,6 @@ class MarkdownWidget extends AbstractWidget
     private function renderList(ListBlock $list, int $columns): array
     {
         $lines = [];
-        $itemColumns = max(1, $columns - 2);
         $isOrdered = 'ordered' === $list->getListData()->type;
         $index = $list->getListData()->start ?? 1;
         $listBulletStyle = $this->resolveElement('list-bullet');
@@ -319,11 +318,17 @@ class MarkdownWidget extends AbstractWidget
                 continue;
             }
 
-            $bullet = $listBulletStyle->apply($isOrdered ? $index.'. ' : '• ').$this->restoreContext;
+            // The marker is not always two columns wide: an ordered list
+            // reaching 10 needs four, and the content has to be wrapped and
+            // indented to whatever this item's marker actually takes.
+            $marker = $isOrdered ? $index.'. ' : '• ';
+            $markerWidth = AnsiUtils::visibleWidth($marker);
+            $bullet = $listBulletStyle->apply($marker).$this->restoreContext;
+            $continuation = str_repeat(' ', $markerWidth);
 
-            $content = $this->renderListItemContent($item, $itemColumns);
+            $content = $this->renderListItemContent($item, max(1, $columns - $markerWidth));
             foreach ($content as $i => $line) {
-                $lines[] = (0 === $i ? $bullet : '  ').$line;
+                $lines[] = (0 === $i ? $bullet : $continuation).$line;
             }
 
             ++$index;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`MarkdownWidget::renderList()` wraps every item's content to `$columns - 2` and indents continuation lines by two spaces. That holds while the marker is `'• '` or `'1. '`, but from the tenth item on an ordered marker is four columns wide, so the item's first line runs two columns past the widget. The outer wrap in `renderMarkdown()` then breaks the tail onto a line of its own:

```
9. item text that is
  fairly long here
10. item text that
is
  fairly long here
```

Measure each item's own marker and wrap and indent its content to that width. Unordered lists are unaffected — `'• '` is still two columns.
