### PR TITLE
[Tui] Keep markdown table columns within the table width

### DIFF
--- a/src/Symfony/Component/Tui/Tests/Widget/MarkdownTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/MarkdownTest.php
@@ -220,6 +220,26 @@ class MarkdownTest extends TestCase
     }
 
     /**
+     * The borders are drawn from the computed column widths, so those widths
+     * have to add up to the space the table was given.
+     */
+    public function testTableWithOneVeryWideColumnStaysInsideTheWidth()
+    {
+        $wide = str_repeat('W', 60);
+        $markdown = "| $wide | b | c |\n|---|---|---|\n| ".str_repeat('X', 60)." | y | z |\n";
+
+        $md = $this->createMarkdown($markdown);
+
+        foreach ([14, 16, 20, 30] as $columns) {
+            $lines = $md->render(new RenderContext($columns, 60));
+            $this->assertStringStartsWith('┌', AnsiUtils::stripAnsiCodes($lines[0]));
+            foreach ($lines as $line) {
+                $this->assertSame($columns, AnsiUtils::visibleWidth($line), \sprintf('Every table row fills exactly %d columns.', $columns));
+            }
+        }
+    }
+
+    /**
      * Render a widget through the Renderer pipeline to get full chrome applied.
      *
      * @return string[]

--- a/src/Symfony/Component/Tui/Widget/MarkdownWidget.php
+++ b/src/Symfony/Component/Tui/Widget/MarkdownWidget.php
@@ -449,11 +449,29 @@ class MarkdownWidget extends AbstractWidget
                 $columnWidths[] = max(1, (int) floor($proportion * $availableForCells));
             }
 
-            $allocated = array_sum($columnWidths);
-            $remaining = $availableForCells - $allocated;
+            $remaining = $availableForCells - array_sum($columnWidths);
             for ($i = 0; $remaining > 0 && $i < $numCols; ++$i) {
                 ++$columnWidths[$i];
                 --$remaining;
+            }
+
+            // Flooring each share and then lifting the empty ones back to a
+            // single column can spend more than the budget, and the borders
+            // are sized from these widths: the row would run past the widget
+            // and get wrapped, breaking the table apart. Take the excess off
+            // the widest columns, which have the most to spare.
+            while ($remaining < 0) {
+                $widest = null;
+                foreach ($columnWidths as $i => $width) {
+                    if ($width > 1 && (null === $widest || $width > $columnWidths[$widest])) {
+                        $widest = $i;
+                    }
+                }
+                if (null === $widest) {
+                    break;
+                }
+                --$columnWidths[$widest];
+                ++$remaining;
             }
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

When a table does not fit, `MarkdownWidget::formatTable()` scales the columns proportionally, floors each share, then lifts anything that floored to zero back up to one column:

```php
$columnWidths[] = max(1, (int) floor($proportion * $availableForCells));
```

Nothing takes those extra columns back. There is a loop that hands out *leftover* space, but none that reclaims an overspend, so a table with one dominant column comes out wider than the space it was given. The borders are built from the same widths, so the outer wrap in `renderMarkdown()` folds every row and the table falls apart:

```
┌─────┬───┬───
┐
│ WWW │ b │ c
│
```

Reclaim the excess from the widest columns, which have the most to spare.
