### PR TITLE
[Tui] Ignore an empty input chunk in the text widgets

### DIFF
--- a/src/Symfony/Component/Tui/Tests/Widget/EditorTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/EditorTest.php
@@ -1476,4 +1476,27 @@ class EditorTest extends TestCase
 
         return implode("\n", $lines);
     }
+
+    public function testEmptyInputChunkWhileWaitingForAJumpTarget()
+    {
+        $editor = new EditorWidget();
+        $editor->setText('hello world');
+        $editor->handleInput("\x1d"); // ctrl+] starts character jump mode
+
+        $warnings = [];
+        set_error_handler(static function (int $level, string $message) use (&$warnings): bool {
+            $warnings[] = $message;
+
+            return true;
+        });
+
+        try {
+            $editor->handleInput('');
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertSame([], $warnings);
+        $this->assertSame('hello world', $editor->getText());
+    }
 }

--- a/src/Symfony/Component/Tui/Tests/Widget/InputTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/InputTest.php
@@ -499,6 +499,21 @@ class InputTest extends TestCase
         $this->assertLessThanOrEqual(15, AnsiUtils::visibleWidth($lines[0]));
     }
 
+    public function testEmptyInputChunkIsIgnored()
+    {
+        $changes = 0;
+        $input = new InputWidget();
+        $input->setValue('hello');
+        $input->onChange(static function () use (&$changes) {
+            ++$changes;
+        });
+
+        $input->handleInput('');
+
+        $this->assertSame('hello', $input->getValue());
+        $this->assertSame(0, $changes, 'An empty chunk is not a keystroke.');
+    }
+
     private function assertValidUtf8(string $value, string $message = ''): void
     {
         $this->assertTrue(mb_check_encoding($value, 'UTF-8'), $message ?: 'Value should be valid UTF-8');

--- a/src/Symfony/Component/Tui/Widget/EditorWidget.php
+++ b/src/Symfony/Component/Tui/Widget/EditorWidget.php
@@ -207,6 +207,12 @@ class EditorWidget extends AbstractWidget implements FocusableInterface, Vertica
             return;
         }
 
+        // Nothing left to route once the paste bytes are peeled off, and the
+        // handling below reads $data[0].
+        if ('' === $data) {
+            return;
+        }
+
         $kb = $this->getKeybindings();
 
         // Handle character jump mode (awaiting next character to jump to)

--- a/src/Symfony/Component/Tui/Widget/InputWidget.php
+++ b/src/Symfony/Component/Tui/Widget/InputWidget.php
@@ -159,6 +159,12 @@ class InputWidget extends AbstractWidget implements FocusableInterface
                 return;
             }
 
+            // Nothing left to route once the paste bytes are peeled off; an
+            // empty chunk is not a keystroke and not text to insert.
+            if ('' === $data) {
+                return;
+            }
+
             $kb = $this->getKeybindings();
 
             // Cancel


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Both text widgets peel the bracketed-paste bytes off the chunk they were handed and carry on with whatever is left — which can be nothing. They only return early on an empty remainder *while a paste is still buffering*, so an empty chunk with no paste in flight falls through into the key handling:

```php
$editor = new EditorWidget();
$editor->handleInput("\x1d"); // ctrl+], waits for a character-jump target
$editor->handleInput('');     // Warning: Uninitialized string offset 0
```

```php
$input = new InputWidget();
$input->onChange($listener);
$input->handleInput('');      // $listener fires; nothing changed
```

`EditorWidget` reads `$data[0]` while in jump mode, and `InputWidget` clears the control-character check, inserts nothing, and dispatches a `ChangeEvent` that reports no change.

An empty chunk is neither a keystroke nor text to insert — return.
