### PR TITLE
[Tui] Measure joined emoji the same way the wrapper breaks them

### DIFF
--- a/src/Symfony/Component/Tui/Ansi/AnsiUtils.php
+++ b/src/Symfony/Component/Tui/Ansi/AnsiUtils.php
@@ -170,9 +170,12 @@ final class AnsiUtils
         }
 
         // mb_strwidth() sums codepoints, so it counts a combining mark as its
-        // own column. Only text that carries marks needs the slower per
-        // grapheme walk.
-        if (preg_match('/\p{M}/u', $clean)) {
+        // own column and a zero-width joiner as one more. Only text that
+        // carries marks or joiners needs the slower per grapheme walk, which
+        // is also the measure the wrapper breaks lines by: the two have to
+        // agree or a wrapped chunk comes back wider than the width it was
+        // wrapped to.
+        if (preg_match('/[\p{M}\p{Cf}]/u', $clean)) {
             $width = 0;
             foreach (grapheme_str_split($clean) ?: [] as $grapheme) {
                 $width += self::graphemeWidth($grapheme);

--- a/src/Symfony/Component/Tui/Tests/Ansi/AnsiUtilsTest.php
+++ b/src/Symfony/Component/Tui/Tests/Ansi/AnsiUtilsTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Tui\Tests\Ansi;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Tui\Ansi\AnsiUtils;
+use Symfony\Component\Tui\Ansi\TextWrapper;
 
 class AnsiUtilsTest extends TestCase
 {
@@ -587,5 +588,38 @@ class AnsiUtilsTest extends TestCase
         // Truncating "東京 OK" to 4 columns keeps "東" and drops the rest;
         // the space at column 5 must not surface where "京" was dropped.
         $this->assertSame("\x1b[31m東\x1b[0m…", AnsiUtils::truncateToWidth("\x1b[31m東京\x1b[0m OK", 4, '…'));
+    }
+
+    /**
+     * The wrapper breaks lines by graphemeWidth() and every consumer measures
+     * the result with visibleWidth(); if the two disagree, a chunk comes back
+     * wider than the width it was wrapped to.
+     */
+    public function testVisibleWidthOfAJoinedSequenceMatchesItsGraphemeWidth()
+    {
+        $family = "\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}\u{200D}\u{1F466}";
+
+        $this->assertSame(AnsiUtils::graphemeWidth($family), AnsiUtils::visibleWidth($family));
+    }
+
+    public function testVisibleWidthIsAdditiveOverGraphemes()
+    {
+        $line = "a\u{1F44B}b\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}\u{200D}\u{1F466}c";
+
+        $sum = 0;
+        foreach (grapheme_str_split($line) as $grapheme) {
+            $sum += AnsiUtils::visibleWidth($grapheme);
+        }
+
+        $this->assertSame($sum, AnsiUtils::visibleWidth($line));
+    }
+
+    public function testWrappedChunksNeverExceedTheRequestedWidth()
+    {
+        $line = "a\u{1F44B}b\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}\u{200D}\u{1F466}c";
+
+        foreach (TextWrapper::wrapTextWithAnsi($line, 8) as $chunk) {
+            $this->assertLessThanOrEqual(8, AnsiUtils::visibleWidth($chunk));
+        }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`AnsiUtils::visibleWidth()` only walks graphemes when the text carries a combining mark:

```php
if (preg_match('/\p{M}/u', $clean)) { /* per-grapheme walk */ }

return mb_strwidth($clean, 'UTF-8');
```

A zero-width joiner is `Cf`, not `M`, so a ZWJ sequence falls through to `mb_strwidth()`, which sums the codepoints and charges a column for each joiner:

```php
$family = "👨‍👩‍👧‍👦";
AnsiUtils::visibleWidth($family);   // 11
AnsiUtils::graphemeWidth($family);  //  8
```

That matters because `TextWrapper` breaks lines by `graphemeWidth()` (`TextWrapper.php:425`) while every consumer measures the result with `visibleWidth()`. The two disagreeing means a wrapped chunk comes back wider than the width it was wrapped to, and `Renderer::render()` rejects an over-wide line — so a family emoji in a `TextWidget` or `MarkdownWidget` aborts the render:

```
wrapTextWithAnsi("a👋b👨‍👩‍👧‍👦c", 8)
  chunk 0 width=4
  chunk 1 width=11   <-- wrapped to 8
  chunk 2 width=1
```

Send text carrying joiners down the same per-grapheme walk. What a terminal actually draws for a ZWJ sequence is a separate question — `UnicodeString::width()` still sums the parts — this only makes the component agree with itself.
