### PR TITLE
[Tui] Truncate the select list rows to the widget width

### DIFF
--- a/src/Symfony/Component/Tui/Tests/Widget/SelectListTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/SelectListTest.php
@@ -241,6 +241,32 @@ class SelectListTest extends TestCase
         return new SelectListWidget($items, 5);
     }
 
+    public function testNoMatchLineIsTruncatedToTheWidth()
+    {
+        $list = new SelectListWidget([['value' => 'alpha', 'label' => 'alpha']]);
+        $list->setFilter('zzz');
+
+        foreach ([40, 19, 10, 5, 1] as $columns) {
+            $lines = $list->render(new RenderContext($columns, 24));
+
+            $this->assertLessThanOrEqual($columns, AnsiUtils::visibleWidth($lines[0]), \sprintf('The no-match line fits in %d columns.', $columns));
+        }
+    }
+
+    public function testItemsAreTruncatedToTheWidth()
+    {
+        $list = new SelectListWidget([
+            ['value' => 'a', 'label' => 'alpha', 'description' => 'the first one'],
+            ['value' => 'b', 'label' => 'beta', 'description' => 'the second one'],
+        ]);
+
+        foreach ([60, 40, 20, 6, 4, 2, 1] as $columns) {
+            foreach ($list->render(new RenderContext($columns, 24)) as $line) {
+                $this->assertLessThanOrEqual($columns, AnsiUtils::visibleWidth($line), \sprintf('Every row fits in %d columns.', $columns));
+            }
+        }
+    }
+
     /**
      * @return array{SelectListWidget, Tui}
      */

--- a/src/Symfony/Component/Tui/Widget/SelectListWidget.php
+++ b/src/Symfony/Component/Tui/Widget/SelectListWidget.php
@@ -219,7 +219,7 @@ class SelectListWidget extends AbstractWidget implements FocusableInterface
         // No items match filter
         if (!$this->filteredItems) {
             $line = $this->applyElement('no-match', '  No matching items');
-            $lines[] = $line;
+            $lines[] = AnsiUtils::truncateToWidth($line, $columns, '');
 
             return $lines;
         }
@@ -247,7 +247,10 @@ class SelectListWidget extends AbstractWidget implements FocusableInterface
             $isSelected = $i === $this->selectedIndex;
             $description = isset($item['description']) ? $this->normalizeDescription($item['description']) : null;
             $line = $this->renderItem($item, $isSelected, $description, $columns, $labelColumnWidth);
-            $lines[] = $line;
+            // renderItem() budgets the label against the columns left after
+            // its prefix, but the prefix itself is emitted unconditionally
+            // and is wider than the widget once the pane gets narrow enough.
+            $lines[] = AnsiUtils::truncateToWidth($line, $columns, '');
         }
 
         // Add scroll indicator if needed


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Two rows in `SelectListWidget` escape the width the widget was given.

**The empty-filter line is emitted raw.** Every other line in `render()` goes through `truncateToWidth()`; this one does not, so it stays 19 columns wide whatever the pane is:

```
cols=40  width=19  "  No matching items"
cols=10  width=19  "  No matching items"
cols=1   width=19  "  No matching items"
```

**The item prefix is emitted unconditionally.** `renderItem()` budgets the label against the columns left after the prefix, but the prefix (`'  '` or the arrow) is prepended regardless, so a one-column pane still gets a two-column row.

`Renderer::render()` rejects a line wider than its box, so both cases abort the render rather than merely looking wrong. Run them through `truncateToWidth()` like the rest.
