### PR TITLE
[Tui] Cut an editor row at the box when one character will not fit

### DIFF
--- a/src/Symfony/Component/Tui/Tests/Widget/Editor/EditorRendererTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/Editor/EditorRendererTest.php
@@ -127,6 +127,23 @@ class EditorRendererTest extends TestCase
     }
 
     /**
+     * A grapheme cannot be split, so the wrapper hands back a chunk wider
+     * than the width whenever one character does not fit in the whole box.
+     */
+    public function testACharacterWiderThanTheBoxDoesNotOverflowTheLine()
+    {
+        $family = "\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}\u{200D}\u{1F466}";
+
+        foreach ([['日本'], ['x'.$family.'y'], [$family]] as $docLines) {
+            foreach ([1, 2, 3, 4] as $columns) {
+                foreach ($this->renderSimple($docLines, 0, 0, $columns, 10) as $line) {
+                    $this->assertLessThanOrEqual($columns, AnsiUtils::visibleWidth($line), \sprintf('Every rendered row fits in %d columns.', $columns));
+                }
+            }
+        }
+    }
+
+    /**
      * @param string[] $docLines
      *
      * @return string[]

--- a/src/Symfony/Component/Tui/Widget/Editor/EditorRenderer.php
+++ b/src/Symfony/Component/Tui/Widget/Editor/EditorRenderer.php
@@ -130,8 +130,17 @@ final class EditorRenderer
                 $displayLine = $this->renderCursorInChunk($chunkText, $cursorPosInChunk, $columns, $cursorShape, $focused);
             }
 
-            // Pad to width
+            // A grapheme cannot be split, so a chunk still overflows when one
+            // character is wider than the whole box (a CJK glyph in a
+            // one-column pane, a joined emoji in four). The Renderer rejects
+            // an over-wide line, so cut what does not fit.
             $visibleWidth = AnsiUtils::visibleWidth($displayLine);
+            if ($visibleWidth > $columns) {
+                $displayLine = AnsiUtils::truncateToWidth($displayLine, $columns, '');
+                $visibleWidth = AnsiUtils::visibleWidth($displayLine);
+            }
+
+            // Pad to width
             $padding = max(0, $columns - $visibleWidth);
 
             $result[] = $displayLine.str_repeat(' ', $padding);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

A grapheme cannot be split, so `TextWrapper::wrapLineIntoChunks()` hands back a chunk wider than the width it was asked for whenever a single character does not fit in the whole box:

```php
TextWrapper::wrapLineIntoChunks('日本', 1);
//  w=2 "日"
//  w=2 "本"
```

`EditorRenderer::renderLine()` pads that chunk out and emits it as a row, so the editor produces lines wider than its own frame:

```
editor '日本' at cols=1
  line 0 w=1 "─"
  line 1 w=2 "日"     <-- wider than the frame
  line 2 w=2 "本"
  line 3 w=1 "─"
```

`Renderer::render()` rejects an over-wide line, so this aborts the render rather than just looking wrong. Same for a joined emoji in a four-column pane.

Cut what does not fit — the character cannot be drawn in a box that narrow either way, and losing it beats losing the frame. Keeping the chunk intact in the wrapper is deliberate: `EditorViewport` and the cursor mapping rely on `start_index`/`end_index` covering the whole line.
