### PR TITLE
[Tui] Stop scheduled intervals drifting behind the loop

### DIFF
--- a/src/Symfony/Component/Tui/Loop/TickScheduler.php
+++ b/src/Symfony/Component/Tui/Loop/TickScheduler.php
@@ -82,7 +82,21 @@ final class TickScheduler
                 continue;
             }
 
-            $this->intervals[$id]['next_run_at'] = $now + $interval['interval'];
+            // Advance from the time this run was due, not from the moment the
+            // loop got round to it. The loop polls on its own cadence, so
+            // restarting the period at $now hands every late wake-up to the
+            // next one and the callback falls further behind for good.
+            $nextRunAt = $interval['next_run_at'] + $interval['interval'];
+
+            if ($nextRunAt <= $now) {
+                // Whole periods went by unserved (a stalled loop, a suspended
+                // process). Skip them and line up on the next one instead of
+                // firing a burst to catch up.
+                $missed = (int) floor(($now - $interval['next_run_at']) / $interval['interval']);
+                $nextRunAt = $interval['next_run_at'] + ($missed + 1) * $interval['interval'];
+            }
+
+            $this->intervals[$id]['next_run_at'] = $nextRunAt;
             ($interval['callback'])();
         }
     }

--- a/src/Symfony/Component/Tui/Tests/Loop/TickSchedulerTest.php
+++ b/src/Symfony/Component/Tui/Tests/Loop/TickSchedulerTest.php
@@ -38,13 +38,59 @@ class TickSchedulerTest extends TestCase
         $scheduler->runDue($start + 0.10);
         $this->assertSame(0, $calls);
 
+        // Due at 0.50 but the loop only came back at 1.00, so this run is
+        // late; the period it belongs to still ends at 1.00.
         $scheduler->runDue($start + 1.00);
         $this->assertSame(1, $calls);
 
+        // Being served late does not push the following period back.
         $scheduler->runDue($start + 1.20);
-        $this->assertSame(1, $calls);
+        $this->assertSame(2, $calls);
 
         $scheduler->runDue($start + 1.60);
+        $this->assertSame(3, $calls);
+    }
+
+    public function testRunDueDoesNotDriftBehindTheInterval()
+    {
+        $scheduler = new TickScheduler();
+        $calls = 0;
+        $start = microtime(true);
+
+        $scheduler->schedule(static function () use (&$calls): void {
+            ++$calls;
+        }, 0.100);
+
+        // A loop polling every 30 ms cannot land on the 100 ms boundary, but
+        // the rate it serves must still be one call per 100 ms.
+        for ($i = 1; $i <= 200; ++$i) {
+            $scheduler->runDue($start + $i * 0.030);
+        }
+
+        $this->assertSame(60, $calls);
+    }
+
+    public function testRunDueSkipsPeriodsMissedWhileTheLoopWasStalled()
+    {
+        $scheduler = new TickScheduler();
+        $calls = 0;
+        $start = microtime(true);
+
+        $scheduler->schedule(static function () use (&$calls): void {
+            ++$calls;
+        }, 0.100);
+
+        // Ten periods went by unserved while the loop was away.
+        $scheduler->runDue($start + 1.0);
+        $this->assertSame(1, $calls);
+
+        // The loop is back and polling every 10 ms. The missed periods are
+        // dropped, so the next 90 ms hold at most one more call rather than
+        // replaying the backlog one poll at a time.
+        for ($i = 1; $i <= 9; ++$i) {
+            $scheduler->runDue($start + 1.0 + $i * 0.010);
+        }
+
         $this->assertSame(2, $calls);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`TickScheduler::runDue()` reschedules from the moment the loop got round to the callback rather than from the time the run was due:

```php
$this->intervals[$id]['next_run_at'] = $now + $interval['interval'];
```

The loop polls on its own cadence and can never land exactly on an interval boundary, so that error is paid on every single run and the callback settles at the poll period rounded up to the interval:

```
interval 100 ms, loop polling every 30 ms
  -> fires every 120 ms; 50 calls in 6 s instead of 60
```

`Tui::scheduleInterval()` is public API, so "run this every 100 ms" quietly becomes "every 120 ms" — and worse as the loop gets busier.

Advance from the scheduled time instead. When whole periods went by unserved — a stalled loop, a suspended process — skip them and line up on the next boundary rather than firing a burst to catch up.

**One existing test changes expectations.** `testRunDueExecutesAndReschedulesCallbacks` asserted that a run served 0.5 s late pushed the following period 0.5 s back; it now asserts the following period keeps its place. That assertion *is* the behaviour under discussion, so if you would rather keep the interval anchored to the last invocation, this PR is the wrong change and I will close it.
