### PR TITLE
[Tui] Read a zero cursor-move count as one in ScreenBuffer

### DIFF
--- a/src/Symfony/Component/Tui/Terminal/ScreenBuffer.php
+++ b/src/Symfony/Component/Tui/Terminal/ScreenBuffer.php
@@ -471,23 +471,26 @@ final class ScreenBuffer
         $nums = '' !== $paramStr ? array_map('intval', explode(';', $paramStr)) : [];
 
         switch ($finalByte) {
+            // The cursor moves take a repeat count whose default is 1, and a
+            // count of 0 is read as 1 rather than as "stay put" — an omitted
+            // and an explicit zero parameter mean the same thing.
             case 'A': // Cursor Up
-                $n = $nums[0] ?? 1;
+                $n = max(1, $nums[0] ?? 1);
                 $this->cursorRow = max(0, $this->cursorRow - $n);
                 break;
 
             case 'B': // Cursor Down
-                $n = $nums[0] ?? 1;
+                $n = max(1, $nums[0] ?? 1);
                 $this->cursorRow = min($this->height - 1, $this->cursorRow + $n);
                 break;
 
             case 'C': // Cursor Forward
-                $n = $nums[0] ?? 1;
+                $n = max(1, $nums[0] ?? 1);
                 $this->cursorCol = min($this->width - 1, $this->cursorCol + $n);
                 break;
 
             case 'D': // Cursor Back
-                $n = $nums[0] ?? 1;
+                $n = max(1, $nums[0] ?? 1);
                 $this->cursorCol = max(0, $this->cursorCol - $n);
                 break;
 

--- a/src/Symfony/Component/Tui/Tests/Terminal/ScreenBufferTest.php
+++ b/src/Symfony/Component/Tui/Tests/Terminal/ScreenBufferTest.php
@@ -587,4 +587,40 @@ class ScreenBufferTest extends TestCase
         yield 'private mode set/reset' => ["Hello\x1b[?25h\x1b[?25l World", 'Hello World'];
         yield 'standard mode set/reset' => ["Hello\x1b[25h\x1b[25l World", 'Hello World'];
     }
+
+    /**
+     * A repeat count of 0 means the same as an omitted one, so both move a
+     * single position.
+     */
+    #[DataProvider('zeroRepeatCountProvider')]
+    public function testAZeroRepeatCountMovesOnePosition(string $sequence, int $expectedRow, int $expectedCol)
+    {
+        $buffer = new ScreenBuffer(20, 6);
+        $buffer->write("\x1b[3;5H");
+        $buffer->write($sequence);
+        $buffer->write('X');
+
+        foreach ($buffer->getLines() as $row => $line) {
+            if (false !== $col = strpos($line, 'X')) {
+                $this->assertSame([$expectedRow, $expectedCol], [$row, $col]);
+
+                return;
+            }
+        }
+
+        $this->fail('The written character was not found on the screen.');
+    }
+
+    /**
+     * @return iterable<string, array{string, int, int}>
+     */
+    public static function zeroRepeatCountProvider(): iterable
+    {
+        yield 'no move' => ['', 2, 4];
+        yield 'up, default count' => ["\x1b[A", 1, 4];
+        yield 'up, zero count' => ["\x1b[0A", 1, 4];
+        yield 'down, zero count' => ["\x1b[0B", 3, 4];
+        yield 'forward, zero count' => ["\x1b[0C", 2, 5];
+        yield 'back, zero count' => ["\x1b[0D", 2, 3];
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`CUU`/`CUD`/`CUF`/`CUB` take a repeat count whose default is 1, and an explicit `0` means the same as an omitted parameter — xterm and every other terminal clamp it up. `ScreenBuffer::parseCsiSequence()` takes the parameter at face value:

```php
case 'C': // Cursor Forward
    $n = $nums[0] ?? 1;
```

so the cursor does not move at all:

```
start at row 2, col 4
CSI A    (default 1 up)   row=1 col=4
CSI 0 A  (should be 1 up) row=2 col=4   <-- did not move
CSI 0 C  (1 right)        row=2 col=4   <-- did not move
```

`ScreenBuffer` replays output produced by other programs (`TeeTerminal`, `ScreenBufferHtmlRenderer`), so the divergence is not academic: everything the program draws after a `CSI 0 C` lands one position off from where the same bytes would land in a real terminal.

`CHA` and `CUP` already come out right — they subtract 1 and clamp at 0, which lands a zero parameter on the same cell as a 1 — so only the four relative moves change.
