### PR TITLE
[Tui] Fill only the columns a row is actually missing

### DIFF
--- a/src/Symfony/Component/Tui/Terminal/ScreenBuffer.php
+++ b/src/Symfony/Component/Tui/Terminal/ScreenBuffer.php
@@ -307,9 +307,14 @@ final class ScreenBuffer
             $this->cells[$this->cursorRow] = [];
         }
 
-        // Fill any gaps with spaces
-        for ($col = \count($this->cells[$this->cursorRow]); $col < $this->cursorCol; ++$col) {
-            $this->cells[$this->cursorRow][$col] = ['char' => ' ', 'style' => ''];
+        // Fill any gaps with spaces. Which columns are missing has to be
+        // asked column by column: an erase unsets cells in the middle of the
+        // row, so the number of cells stops matching the columns they sit in
+        // and counting them walks the fill straight over live characters.
+        for ($col = 0; $col < $this->cursorCol; ++$col) {
+            if (!isset($this->cells[$this->cursorRow][$col])) {
+                $this->cells[$this->cursorRow][$col] = ['char' => ' ', 'style' => ''];
+            }
         }
 
         $style = $this->styleTracker->getActiveCodes();

--- a/src/Symfony/Component/Tui/Tests/Terminal/ScreenBufferTest.php
+++ b/src/Symfony/Component/Tui/Tests/Terminal/ScreenBufferTest.php
@@ -587,4 +587,30 @@ class ScreenBufferTest extends TestCase
         yield 'private mode set/reset' => ["Hello\x1b[?25h\x1b[?25l World", 'Hello World'];
         yield 'standard mode set/reset' => ["Hello\x1b[25h\x1b[25l World", 'Hello World'];
     }
+
+    /**
+     * An erase unsets cells in the middle of a row, so the number of cells in
+     * that row no longer matches the columns they sit in.
+     */
+    public function testWritingRightOfAnErasedRangeKeepsTheCharactersInBetween()
+    {
+        $buffer = new ScreenBuffer(20, 3);
+        $buffer->write('abcdefghij');
+        $buffer->write("\x1b[1;5H");  // row 1, column 5
+        $buffer->write("\x1b[1K");    // erase from the start of the line to the cursor
+        $buffer->write("\x1b[1;13H"); // row 1, column 13
+        $buffer->write('X');
+
+        $this->assertSame('     fghij  X', $buffer->getLines()[0]);
+    }
+
+    public function testWritingRightOfAnErasedRangeKeepsTheirStyles()
+    {
+        $buffer = new ScreenBuffer(20, 3);
+        $buffer->write("\x1b[31mabcdefghij\x1b[0m");
+        $buffer->write("\x1b[1;5H\x1b[1K");
+        $buffer->write("\x1b[1;13HX");
+
+        $this->assertStringContainsString("\x1b[31mfghij", $buffer->getStyledScreen());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`ScreenBuffer::putChar()` starts its gap fill at the *number* of cells in the row:

```php
for ($col = \count($this->cells[$this->cursorRow]); $col < $this->cursorCol; ++$col) {
    $this->cells[$this->cursorRow][$col] = ['char' => ' ', 'style' => ''];
}
```

That only equals the first missing column while the row is dense. An erase unsets cells in the middle of it (`eraseInLine()` uses `unset()`), and from then on the count trails the columns the surviving cells actually sit in — so writing anywhere to the right of the hole walks the fill straight over live characters and blanks them:

```php
$buffer->write('abcdefghij');
$buffer->write("\x1b[1;5H\x1b[1K"); // erase from the start of the line to column 5
$buffer->write("\x1b[1;13HX");

// expected "     fghij  X"
// got      "            X"
```

Ask column by column instead. Cells that were never written stay absent for the same reason they do today — `getLineText()` already reads a missing cell as a space.
