### PR TITLE
[Tui] Match every modifier in the modifyOtherKeys form of enter

### DIFF
--- a/src/Symfony/Component/Tui/Input/KeyParser.php
+++ b/src/Symfony/Component/Tui/Input/KeyParser.php
@@ -626,11 +626,13 @@ final class KeyParser
                         || (!$this->kittyProtocolActive && "\n" === $data)
                         || "\x1bOM" === $data
                         || $this->matchesKittySequence($data, self::CODEPOINTS['enter'], 0)
-                        || $this->matchesKittySequence($data, self::CODEPOINTS['kp_enter'], 0);
+                        || $this->matchesKittySequence($data, self::CODEPOINTS['kp_enter'], 0)
+                        || $this->matchesModifyOtherKeys($data, self::CODEPOINTS['enter'], 0);
                 }
 
                 return $this->matchesKittySequence($data, self::CODEPOINTS['enter'], $modifier)
-                    || $this->matchesKittySequence($data, self::CODEPOINTS['kp_enter'], $modifier);
+                    || $this->matchesKittySequence($data, self::CODEPOINTS['kp_enter'], $modifier)
+                    || $this->matchesModifyOtherKeys($data, self::CODEPOINTS['enter'], $modifier);
 
             case 'backspace':
                 if ($alt && !$ctrl && !$shift) {

--- a/src/Symfony/Component/Tui/Tests/Input/KeyParserTest.php
+++ b/src/Symfony/Component/Tui/Tests/Input/KeyParserTest.php
@@ -302,4 +302,33 @@ class KeyParserTest extends TestCase
         $this->assertFalse($this->parser->matches("\x1b[98;7u", 'ctrl+alt+a'));
         $this->assertFalse($this->parser->matches("\x1b[97;5u", 'ctrl+alt+a'));
     }
+
+    /**
+     * xterm's modifyOtherKeys form reports every modifier through the same
+     * `CSI 27 ; mods ; keycode ~` shape, not just shift and alt.
+     */
+    #[DataProvider('modifyOtherKeysEnterProvider')]
+    public function testModifyOtherKeysEnter(string $sequence, string $keyId)
+    {
+        $this->assertTrue($this->parser->matches($sequence, $keyId));
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function modifyOtherKeysEnterProvider(): iterable
+    {
+        yield 'enter' => ["\x1b[27;1;13~", 'enter'];
+        yield 'shift+enter' => ["\x1b[27;2;13~", 'shift+enter'];
+        yield 'alt+enter' => ["\x1b[27;3;13~", 'alt+enter'];
+        yield 'ctrl+enter' => ["\x1b[27;5;13~", 'ctrl+enter'];
+        yield 'ctrl+shift+enter' => ["\x1b[27;6;13~", 'ctrl+shift+enter'];
+        yield 'ctrl+alt+enter' => ["\x1b[27;7;13~", 'ctrl+alt+enter'];
+    }
+
+    public function testModifyOtherKeysEnterDoesNotMatchAnotherModifier()
+    {
+        $this->assertFalse($this->parser->matches("\x1b[27;5;13~", 'shift+enter'));
+        $this->assertFalse($this->parser->matches("\x1b[27;5;9~", 'ctrl+enter'));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

xterm's `modifyOtherKeys` reports every modifier through the same `CSI 27 ; mods ; keycode ~` shape, but `KeyParser` only consults it from the shift-only and alt-only branches of the `enter` case. Every other combination falls through to the kitty check alone:

```php
$parser->matches("\x1b[27;2;13~", 'shift+enter');  // true
$parser->matches("\x1b[27;3;13~", 'alt+enter');    // true
$parser->matches("\x1b[27;5;13~", 'ctrl+enter');   // false
```

So with `modifyOtherKeys` on, `ctrl+enter` — the key `EditorWidget`'s own docblock names for submit — is dead, while `shift+enter` right next to it works. Consult it from the remaining branches too.
