### PR TITLE
[Tui] Size the composite canvas from the whole base layer

### DIFF
--- a/src/Symfony/Component/Tui/Render/Compositor.php
+++ b/src/Symfony/Component/Tui/Render/Compositor.php
@@ -54,7 +54,14 @@ final class Compositor
 
         $base = $layers[0];
         $height = $base->height ?? \count($base->lines);
-        $width = $base->width ?? (!$base->lines ? 0 : AnsiUtils::visibleWidth($base->lines[0]));
+        $width = $base->width ?? self::widestLine($base->lines);
+
+        if ($width < 1 || $height < 1) {
+            // Nothing to draw on. CellBuffer rejects an empty canvas, and a
+            // base layer with no lines is degenerate input in the same way an
+            // empty layer list is.
+            return [];
+        }
 
         $buffer = new CellBuffer($width, $height);
 
@@ -68,5 +75,18 @@ final class Compositor
         }
 
         return $buffer->toLines();
+    }
+
+    /**
+     * @param string[] $lines
+     */
+    private static function widestLine(array $lines): int
+    {
+        $width = 0;
+        foreach ($lines as $line) {
+            $width = max($width, AnsiUtils::visibleWidth($line));
+        }
+
+        return $width;
     }
 }

--- a/src/Symfony/Component/Tui/Tests/Render/CompositorTest.php
+++ b/src/Symfony/Component/Tui/Tests/Render/CompositorTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Tests\Render;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Tui\Ansi\AnsiUtils;
+use Symfony\Component\Tui\Render\Compositor;
+use Symfony\Component\Tui\Render\Layer;
+
+class CompositorTest extends TestCase
+{
+    public function testCanvasIsAsWideAsTheWidestBaseLine()
+    {
+        $lines = Compositor::composite(new Layer(['ab', 'a longer line here', 'abc']));
+
+        $this->assertSame(['ab                ', 'a longer line here', 'abc               '], $lines);
+    }
+
+    public function testAnExplicitCanvasWidthStillWins()
+    {
+        $lines = Compositor::composite(new Layer(['ab', 'a longer line here'], width: 4));
+
+        $this->assertSame(['ab  ', 'a lo'], $lines);
+    }
+
+    public function testAnOverlayLandsOnTheRowsBelowTheFirst()
+    {
+        $lines = Compositor::composite(
+            new Layer(['..', '..................']),
+            new Layer(['XX'], row: 1, col: 16),
+        );
+
+        $this->assertSame(18, AnsiUtils::visibleWidth($lines[1]));
+        $this->assertSame('................XX', $lines[1]);
+    }
+
+    public function testAnEmptyBaseComposesToNothing()
+    {
+        $this->assertSame([], Compositor::composite(new Layer([])));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`Compositor::composite()` takes the canvas width from the base layer's **first** line:

```php
$width = $base->width ?? (!$base->lines ? 0 : AnsiUtils::visibleWidth($base->lines[0]));
```

so every line below it is cut to that width:

```php
Compositor::composite(new Layer(['ab', 'a longer line here', 'abc']));
// ['ab', 'a ', 'ab']
```

Nothing asks a base layer to be rectangular — `Layer::$width` is documented as an *optional* explicit canvas size, inferred when absent — and ragged input is normal here: `FigletRenderer` rtrims every line it produces precisely so the result composites cleanly against lower layers. Measure them all.

While in there: a base layer with no lines asked `CellBuffer` for a 0×0 canvas and got `InvalidArgumentException: CellBuffer dimensions must be at least 1x1`. An empty base is degenerate input in the same way an empty layer list is, which `composite()` already answers with an empty result.
