### PR TITLE
[Tui] Skip an out-of-range extended color instead of failing the page

### DIFF
--- a/src/Symfony/Component/Tui/Ansi/ScreenBufferHtmlRenderer.php
+++ b/src/Symfony/Component/Tui/Ansi/ScreenBufferHtmlRenderer.php
@@ -177,11 +177,22 @@ final class ScreenBufferHtmlRenderer
                     48 => 'background-color',
                     58 => 'text-decoration-color',
                 };
+                // Color and its factories reject a value out of range. The
+                // sequences here come from whatever program's output is being
+                // replayed, so an out-of-range component is input to skip like
+                // any other code this method does not understand — not a
+                // reason to fail the whole conversion. Either way the
+                // parameters are consumed, or they would be read back as
+                // codes of their own.
                 if (isset($params[$i + 1]) && 5 === $params[$i + 1] && isset($params[$i + 2])) {
-                    $css[$cssProp] = Color::palette($params[$i + 2])->toHex();
+                    if (self::isColorComponent($params[$i + 2])) {
+                        $css[$cssProp] = Color::palette($params[$i + 2])->toHex();
+                    }
                     $i += 2;
                 } elseif (isset($params[$i + 1]) && 2 === $params[$i + 1] && isset($params[$i + 4])) {
-                    $css[$cssProp] = Color::rgb($params[$i + 2], $params[$i + 3], $params[$i + 4])->toHex();
+                    if (self::isColorComponent($params[$i + 2]) && self::isColorComponent($params[$i + 3]) && self::isColorComponent($params[$i + 4])) {
+                        $css[$cssProp] = Color::rgb($params[$i + 2], $params[$i + 3], $params[$i + 4])->toHex();
+                    }
                     $i += 4;
                 }
             } elseif (59 === $code) {
@@ -218,5 +229,10 @@ final class ScreenBufferHtmlRenderer
         }
 
         return rtrim($cssStr);
+    }
+
+    private static function isColorComponent(int $value): bool
+    {
+        return $value >= 0 && $value <= 255;
     }
 }

--- a/src/Symfony/Component/Tui/Tests/Ansi/ScreenBufferHtmlRendererTest.php
+++ b/src/Symfony/Component/Tui/Tests/Ansi/ScreenBufferHtmlRendererTest.php
@@ -270,4 +270,36 @@ class ScreenBufferHtmlRendererTest extends TestCase
 
         return new ScreenBufferHtmlRenderer()->convert($screen);
     }
+
+    /**
+     * The sequences come from whatever program's output is being replayed, so
+     * a parameter Color would reject must not fail the conversion.
+     */
+    #[DataProvider('outOfRangeColorProvider')]
+    public function testAnOutOfRangeExtendedColorIsSkipped(string $sequence)
+    {
+        $screen = new ScreenBuffer(10, 2);
+        $screen->write($sequence.'X');
+
+        $this->assertSame('X', (new ScreenBufferHtmlRenderer())->convert($screen));
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function outOfRangeColorProvider(): iterable
+    {
+        yield 'palette index above 255' => ["\x1b[38;5;999m"];
+        yield 'background palette index above 255' => ["\x1b[48;5;300m"];
+        yield 'rgb component above 255' => ["\x1b[38;2;300;0;0m"];
+        yield 'underline color out of range' => ["\x1b[58;5;300m"];
+    }
+
+    public function testAnInRangeExtendedColorStillRenders()
+    {
+        $screen = new ScreenBuffer(10, 2);
+        $screen->write("\x1b[38;5;120mX");
+
+        $this->assertSame('<span style="color: #87ff87;">X</span>', (new ScreenBufferHtmlRenderer())->convert($screen));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`ScreenBufferHtmlRenderer::ansiToCss()` hands the parameters of a `38`/`48`/`58` sequence straight to `Color::palette()` and `Color::rgb()`:

```php
$css[$cssProp] = Color::palette($params[$i + 2])->toHex();
```

Both reject a value outside 0–255. The sequences come from whatever program's output the `ScreenBuffer` is replaying, so one bad parameter anywhere on the screen takes the whole conversion down:

```php
$screen->write("\x1b[38;5;999mX");
(new ScreenBufferHtmlRenderer())->convert($screen);
// InvalidArgumentException: Color palette index must be 0-255, got: 999
```

Every other code `ansiToCss()` does not understand is skipped; do the same here. The parameters are consumed either way, or they would be read back as SGR codes of their own (`5` would land as "blink").
