### PR TITLE
[Tui] Draw the progress bar in columns, not in characters

### DIFF
--- a/src/Symfony/Component/Tui/Tests/Widget/ProgressBarTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/ProgressBarTest.php
@@ -11,7 +11,9 @@
 
 namespace Symfony\Component\Tui\Tests\Widget;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Tui\Ansi\AnsiUtils;
 use Symfony\Component\Tui\Render\RenderContext;
 use Symfony\Component\Tui\Style\Style;
 use Symfony\Component\Tui\Style\StyleSheet;
@@ -449,6 +451,44 @@ class ProgressBarTest extends TestCase
         // Should not exceed 40 columns
         $visibleWidth = mb_strwidth(preg_replace('/\x1b\[[^m]*m/', '', $content));
         $this->assertLessThanOrEqual(40, $visibleWidth);
+    }
+
+    /**
+     * setBarWidth() is a number of columns, so it has to hold whatever the
+     * bar is drawn with.
+     */
+    #[DataProvider('barCharacterProvider')]
+    public function testTheBarIsAsWideAsItWasAskedToBe(?string $bar, ?string $empty, ?string $progress)
+    {
+        $widget = new ProgressBarWidget(10);
+        $widget->setBarWidth(10);
+        $widget->setProgress(5);
+        if (null !== $bar) {
+            $widget->setBarCharacter($bar);
+        }
+        if (null !== $empty) {
+            $widget->setEmptyBarCharacter($empty);
+        }
+        if (null !== $progress) {
+            $widget->setProgressCharacter($progress);
+        }
+
+        $plain = AnsiUtils::stripAnsiCodes($widget->render(new RenderContext(200, 4))[0]);
+        $this->assertSame(1, preg_match('/\[(.*)\]/u', $plain, $matches));
+        $this->assertSame(10, AnsiUtils::visibleWidth($matches[1]));
+    }
+
+    /**
+     * @return iterable<string, array{?string, ?string, ?string}>
+     */
+    public static function barCharacterProvider(): iterable
+    {
+        yield 'defaults' => [null, null, null];
+        yield 'ascii' => ['=', '-', null];
+        yield 'wide bar characters' => ['日', '本', null];
+        yield 'wide progress character' => [null, null, '👉'];
+        yield 'two-character progress' => [null, null, '=>'];
+        yield 'wide everything' => ['日', '本', '👉'];
     }
 
     public function testMemoryPlaceholder()

--- a/src/Symfony/Component/Tui/Widget/ProgressBarWidget.php
+++ b/src/Symfony/Component/Tui/Widget/ProgressBarWidget.php
@@ -558,19 +558,49 @@ class ProgressBarWidget extends AbstractWidget
 
     private function renderBar(): string
     {
-        $completeBars = $this->getBarOffset();
-        $styledComplete = $this->applyElement('bar-fill', str_repeat($this->barChar, $completeBars));
+        // The bar width is a number of columns, so how many times a character
+        // goes into it depends on how wide that character draws. Counting
+        // characters instead makes a bar of wide glyphs twice the width that
+        // was asked for.
+        $completeColumns = $this->getBarOffset();
+        $styledComplete = $this->applyElement('bar-fill', self::repeatToWidth($this->barChar, $completeColumns));
 
-        if ($completeBars < $this->barWidth) {
-            $progressCharLen = mb_strlen($this->progressChar);
-            $emptyBars = $this->barWidth - $completeBars - $progressCharLen;
-            $styledProgress = '' !== $this->progressChar ? $this->applyElement('bar-progress', $this->progressChar) : '';
-            $styledEmpty = $this->applyElement('bar-empty', str_repeat($this->emptyBarChar, max(0, $emptyBars)));
+        if ($completeColumns < $this->barWidth) {
+            $remainingColumns = $this->barWidth - $completeColumns;
+
+            $styledProgress = '';
+            $progressColumns = AnsiUtils::visibleWidth($this->progressChar);
+            if ('' !== $this->progressChar && $progressColumns <= $remainingColumns) {
+                $styledProgress = $this->applyElement('bar-progress', $this->progressChar);
+                $remainingColumns -= $progressColumns;
+            }
+
+            $styledEmpty = $this->applyElement('bar-empty', self::repeatToWidth($this->emptyBarChar, $remainingColumns));
 
             return $styledComplete.$styledProgress.$styledEmpty;
         }
 
         return $styledComplete;
+    }
+
+    /**
+     * Repeat a character to fill exactly the given number of columns, padding
+     * with spaces when it does not divide evenly.
+     */
+    private static function repeatToWidth(string $char, int $columns): string
+    {
+        if ($columns <= 0) {
+            return '';
+        }
+
+        $charColumns = AnsiUtils::visibleWidth($char);
+        if ($charColumns < 1) {
+            return str_repeat(' ', $columns);
+        }
+
+        $count = intdiv($columns, $charColumns);
+
+        return str_repeat($char, $count).str_repeat(' ', $columns - $count * $charColumns);
     }
 
     private static function formatTime(int $secs): string


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`setBarWidth()` is a number of columns, but `renderBar()` repeats the bar character that many *times* and measures the progress character with `mb_strlen()`. Both count characters, so anything that does not draw one column per character comes out the wrong size:

```php
$bar->setBarWidth(10);
$bar->setBarCharacter('日');
$bar->setEmptyBarCharacter('本');   // renders 20 columns

$bar->setBarWidth(10);
$bar->setProgressCharacter('👉');   // renders 11 columns
```

The intent was already there — a two-*character* ASCII marker like `'=>'` is accounted for correctly — it is only the measure that is wrong. `buildLine()` also derives its shrink from `$this->barWidth` on the assumption that one bar cell is one column, so an oversized bar takes the whole line with it.

Fill the requested columns instead, padding when the character does not divide into them evenly, and drop the progress marker when what is left of the bar cannot hold it.
