### PR TITLE
[Tui] Drop the time a stall missed instead of replaying it

### DIFF
--- a/src/Symfony/Component/Tui/Loop/FixedStepAccumulator.php
+++ b/src/Symfony/Component/Tui/Loop/FixedStepAccumulator.php
@@ -31,7 +31,7 @@ final class FixedStepAccumulator
         private int $maxStepsPerUpdate = 5,
     ) {
         if ($stepsPerSecond <= 0.0) {
-            throw new InvalidArgumentException(\sprintf('Steps per second must be greater than 0, got %d.', $stepsPerSecond));
+            throw new InvalidArgumentException(\sprintf('Steps per second must be greater than 0, got "%s".', $stepsPerSecond));
         }
 
         if ($maxStepsPerUpdate < 1) {
@@ -46,8 +46,15 @@ final class FixedStepAccumulator
     {
         $this->accumulator += max(0.0, $deltaTime) * $this->stepsPerSecond;
 
-        if (0 < $steps = min($this->maxStepsPerUpdate, (int) floor($this->accumulator))) {
+        if (0 < $steps = (int) floor($this->accumulator)) {
+            // Take every whole step out of the accumulator, keeping only the
+            // fraction. Capping the count without clearing the rest turns a
+            // stall into a backlog that is paid back at cap speed over the
+            // following updates -- ten idle seconds run the animation at
+            // full tilt for the next two -- when the point of the cap is to
+            // drop the time that was missed.
             $this->accumulator -= $steps;
+            $steps = min($this->maxStepsPerUpdate, $steps);
         }
 
         return $steps;
@@ -56,7 +63,7 @@ final class FixedStepAccumulator
     public function setStepsPerSecond(float $stepsPerSecond): void
     {
         if ($stepsPerSecond <= 0.0) {
-            throw new InvalidArgumentException(\sprintf('Steps per second must be greater than 0, got %d.', $stepsPerSecond));
+            throw new InvalidArgumentException(\sprintf('Steps per second must be greater than 0, got "%s".', $stepsPerSecond));
         }
 
         $this->stepsPerSecond = $stepsPerSecond;

--- a/src/Symfony/Component/Tui/Loop/PeriodicStepper.php
+++ b/src/Symfony/Component/Tui/Loop/PeriodicStepper.php
@@ -32,7 +32,7 @@ final class PeriodicStepper
         int $maxStepsPerUpdate = 8,
     ) {
         if ($intervalSeconds <= 0.0) {
-            throw new InvalidArgumentException(\sprintf('Interval must be greater than 0, got %d.', $intervalSeconds));
+            throw new InvalidArgumentException(\sprintf('Interval must be greater than 0, got "%s".', $intervalSeconds));
         }
 
         $this->accumulator = new FixedStepAccumulator(1.0 / $intervalSeconds, $maxStepsPerUpdate);
@@ -62,7 +62,7 @@ final class PeriodicStepper
     public function setIntervalSeconds(float $intervalSeconds): void
     {
         if ($intervalSeconds <= 0.0) {
-            throw new InvalidArgumentException(\sprintf('Interval must be greater than 0, got %d.', $intervalSeconds));
+            throw new InvalidArgumentException(\sprintf('Interval must be greater than 0, got "%s".', $intervalSeconds));
         }
 
         $this->intervalSeconds = $intervalSeconds;

--- a/src/Symfony/Component/Tui/Tests/Loop/FixedStepAccumulatorTest.php
+++ b/src/Symfony/Component/Tui/Tests/Loop/FixedStepAccumulatorTest.php
@@ -56,4 +56,38 @@ class FixedStepAccumulatorTest extends TestCase
 
         $this->assertSame(0, $accumulator->computeSteps(1.0 / 120.0));
     }
+
+    /**
+     * The cap bounds the work one update may do; the time above it is time
+     * that was missed, not work owed.
+     */
+    public function testTimeAboveTheCapIsDroppedRatherThanQueued()
+    {
+        $accumulator = new FixedStepAccumulator(10.0, 5);
+
+        // Ten seconds went by in one update: a hundred steps' worth.
+        $this->assertSame(5, $accumulator->computeSteps(10.0));
+
+        // The updates that follow run at their own rate again.
+        for ($i = 0; $i < 20; ++$i) {
+            $this->assertSame(1, $accumulator->computeSteps(0.1), 'Update '.$i.' is not paying back the stall.');
+        }
+    }
+
+    public function testTheFractionSurvivesADroppedBacklog()
+    {
+        $accumulator = new FixedStepAccumulator(10.0, 5);
+
+        $accumulator->computeSteps(10.05);
+
+        // 0.5 of a step was left over, so the next half step completes it.
+        $this->assertSame(1, $accumulator->computeSteps(0.05));
+    }
+
+    public function testTheRejectedStepRateIsReported()
+    {
+        $this->expectExceptionMessage('Steps per second must be greater than 0, got "-0.5".');
+
+        new FixedStepAccumulator(-0.5);
+    }
 }

--- a/src/Symfony/Component/Tui/Tests/Loop/PeriodicStepperTest.php
+++ b/src/Symfony/Component/Tui/Tests/Loop/PeriodicStepperTest.php
@@ -54,4 +54,11 @@ class PeriodicStepperTest extends TestCase
         $this->assertSame(0, $stepper->advance(0.1));
         $this->assertSame(1, $stepper->advance(0.1));
     }
+
+    public function testTheRejectedIntervalIsReported()
+    {
+        $this->expectExceptionMessage('Interval must be greater than 0, got "-0.25".');
+
+        new PeriodicStepper(-0.25);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`FixedStepAccumulator::computeSteps()` caps how many steps one update returns, but subtracts only the *capped* number from the accumulator:

```php
if (0 < $steps = min($this->maxStepsPerUpdate, (int) floor($this->accumulator))) {
    $this->accumulator -= $steps;
}
```

The rest stays owed and comes back at cap speed on every following update:

```
10 steps/sec, cap 5, one 10-second stall
-> 5, then 5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5
   across the next two seconds of normal 100 ms frames
```

So the spinner runs at five times its rate for two seconds after any hiccup — which is the thing the cap exists to prevent; today it only spreads the burst instead of dropping it. Take every whole step out of the accumulator, keep the fraction so the phase stays smooth, and return at most the cap.

**This is a behaviour change**, so it is worth saying plainly: after a stall the missed frames are gone rather than fast-forwarded. That is what an animation wants and what "bounded fixed-step counts" in the class docblock reads as; if you would rather the backlog be honoured, this is the wrong change.

Also, both classes format a float with `%d` when rejecting it, so `new PeriodicStepper(-0.25)` reports "got 0" — the one number in the message is the one thing the caller needs.
