### PR TITLE
[Tui] Cycle onto the list when the setting holds a value it does not offer

### DIFF
--- a/src/Symfony/Component/Tui/Tests/Widget/SettingsListTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/SettingsListTest.php
@@ -318,4 +318,37 @@ class SettingsListTest extends TestCase
 
         return [$widget, $tui];
     }
+
+    /**
+     * A setting can hold a value that is not one of the ones it offers --
+     * SettingItem takes the current value independently of the list, and
+     * updateValue() accepts anything.
+     */
+    public function testCyclingFromAValueThatIsNotInTheList()
+    {
+        $this->assertSame('light', $this->cycleFromCustomValue("\x1b[C"), 'Right steps onto the first value.');
+        $this->assertSame('dark', $this->cycleFromCustomValue("\x1b[D"), 'Left steps onto the last value.');
+        $this->assertSame('light', $this->cycleFromCustomValue("\r"), 'Enter agrees with Right.');
+    }
+
+    public function testCyclingFromTheFirstValueIsUnchanged()
+    {
+        $item = new SettingItem('theme', 'Theme', 'light', null, ['light', 'dark']);
+        $widget = new SettingsListWidget([$item]);
+
+        $widget->handleInput("\x1b[C");
+        $this->assertSame('dark', $widget->getValue('theme'));
+
+        $widget->handleInput("\x1b[D");
+        $this->assertSame('light', $widget->getValue('theme'));
+    }
+
+    private function cycleFromCustomValue(string $key): string
+    {
+        $item = new SettingItem('theme', 'Theme', 'custom', null, ['light', 'dark']);
+        $widget = new SettingsListWidget([$item]);
+        $widget->handleInput($key);
+
+        return $widget->getValue('theme');
+    }
 }

--- a/src/Symfony/Component/Tui/Widget/SettingsListWidget.php
+++ b/src/Symfony/Component/Tui/Widget/SettingsListWidget.php
@@ -289,10 +289,19 @@ class SettingsListWidget extends AbstractWidget implements FocusableInterface, P
 
         $values = $item->getValues();
         $valueCount = \count($values);
-        $currentIndex = array_search($item->getCurrentValue(), $values, true) ?: 0;
+        $currentIndex = array_search($item->getCurrentValue(), $values, true);
 
-        // Calculate next index with wrapping
-        $nextIndex = ($currentIndex + $direction + $valueCount) % $valueCount;
+        if (false === $currentIndex) {
+            // The value is not one of the offered ones, so there is no
+            // position to step from: step onto the list instead. Reading the
+            // miss as index 0 sent both directions to the same value and
+            // disagreed with what activating the item does.
+            $nextIndex = $direction > 0 ? 0 : $valueCount - 1;
+        } else {
+            // Calculate next index with wrapping
+            $nextIndex = ($currentIndex + $direction + $valueCount) % $valueCount;
+        }
+
         $newValue = $values[$nextIndex];
 
         $item->setCurrentValue($newValue);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

A `SettingItem` takes its current value independently of the values it offers, and `updateValue()` accepts anything, so the value can be one `array_search()` does not find. `cycleValue()` reads that miss as index 0:

```php
$currentIndex = array_search($item->getCurrentValue(), $values, true) ?: 0;
```

(the `?:` also swallows a genuine hit at index 0 — harmless today only because 0 and "not found" currently mean the same thing here).

With a value the list does not contain, both arrows then land on the same place, and activating the item gives a third answer:

```
current value "custom", values ["light", "dark"]
right -> dark
left  -> dark
enter -> light
```

There is no position to step from, so step *onto* the list: forward takes the first value, backward the last — which is what `activateCurrentItem()` already does for forward.
