### PR TITLE
[Tui] Keep a widget's own listeners when it leaves the tree

### DIFF
--- a/src/Symfony/Component/Tui/Tests/Widget/WidgetTreeTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/WidgetTreeTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\Tui\Render\RenderRequestorInterface;
 use Symfony\Component\Tui\Terminal\VirtualTerminal;
 use Symfony\Component\Tui\Tui;
 use Symfony\Component\Tui\Widget\ContainerWidget;
+use Symfony\Component\Tui\Widget\InputWidget;
 use Symfony\Component\Tui\Widget\TextWidget;
 use Symfony\Component\Tui\Widget\WidgetContext;
 use Symfony\Component\Tui\Widget\WidgetTree;
@@ -108,5 +109,31 @@ class WidgetTreeTest extends TestCase
         $this->tree->detach($child);
 
         $this->assertNull($child->getParent());
+    }
+
+    /**
+     * The listeners live on the widget and are dispatched from it, so taking
+     * it out of the tree and putting it back must not unhook them.
+     */
+    public function testListenersSurviveBeingRemovedFromTheTree()
+    {
+        $terminal = new VirtualTerminal(40, 10);
+        $tui = new Tui(terminal: $terminal);
+        $input = new InputWidget();
+
+        $submits = 0;
+        $input->onSubmit(static function () use (&$submits) {
+            ++$submits;
+        });
+
+        $tui->add($input);
+        $input->handleInput("\r");
+        $this->assertSame(1, $submits);
+
+        $tui->remove($input);
+        $tui->add($input);
+        $input->handleInput("\r");
+
+        $this->assertSame(2, $submits);
     }
 }

--- a/src/Symfony/Component/Tui/Widget/AbstractWidget.php
+++ b/src/Symfony/Component/Tui/Widget/AbstractWidget.php
@@ -229,8 +229,10 @@ abstract class AbstractWidget
             $context->getFocusManager()->remove($this);
         }
 
-        $this->listeners = [];
-
+        // The listeners stay. They live on this widget and are dispatched
+        // from it, so there is nothing registered elsewhere to unwind, and
+        // dropping them silently unhooks the callbacks a caller registered
+        // on a widget it still holds and may add back.
         $this->onDetach();
         $this->parent = null;
         $this->context = null;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`AbstractWidget::detach()` empties `$this->listeners`, so taking a widget out of the tree unhooks every callback registered on it through `onSubmit()`, `onChange()`, `onCancel()` and the rest. Put the same widget back and it looks and behaves normally while none of its callbacks fire again:

```php
$input->onSubmit($listener);

$tui->add($input);
$input->handleInput("\r");   // $listener fires

$tui->remove($input);
$tui->add($input);
$input->handleInput("\r");   // silence
```

There is nothing to unwind. These listeners live on the widget and `dispatch()` reads them straight off it — unlike the ones `SettingsListWidget` registers on the shared event dispatcher, which it still removes on detach. Swapping a widget out of a container and back (a modal, a switched pane) is ordinary, so leave them alone.
