### PR TITLE
[Tui] Batch of bug fixes

### DIFF
--- a/src/Symfony/Component/Tui/Ansi/AnsiUtils.php
+++ b/src/Symfony/Component/Tui/Ansi/AnsiUtils.php
@@ -170,9 +170,12 @@ final class AnsiUtils
         }
 
         // mb_strwidth() sums codepoints, so it counts a combining mark as its
-        // own column. Only text that carries marks needs the slower per
-        // grapheme walk.
-        if (preg_match('/\p{M}/u', $clean)) {
+        // own column and a zero-width joiner as one more. Only text that
+        // carries marks or joiners needs the slower per grapheme walk, which
+        // is also the measure the wrapper breaks lines by: the two have to
+        // agree or a wrapped chunk comes back wider than the width it was
+        // wrapped to.
+        if (preg_match('/[\p{M}\p{Cf}]/u', $clean)) {
             $width = 0;
             foreach (grapheme_str_split($clean) ?: [] as $grapheme) {
                 $width += self::graphemeWidth($grapheme);

--- a/src/Symfony/Component/Tui/Ansi/ScreenBufferHtmlRenderer.php
+++ b/src/Symfony/Component/Tui/Ansi/ScreenBufferHtmlRenderer.php
@@ -177,11 +177,22 @@ final class ScreenBufferHtmlRenderer
                     48 => 'background-color',
                     58 => 'text-decoration-color',
                 };
+                // Color and its factories reject a value out of range. The
+                // sequences here come from whatever program's output is being
+                // replayed, so an out-of-range component is input to skip like
+                // any other code this method does not understand, not a
+                // reason to fail the whole conversion. Either way the
+                // parameters are consumed, or they would be read back as
+                // codes of their own.
                 if (isset($params[$i + 1]) && 5 === $params[$i + 1] && isset($params[$i + 2])) {
-                    $css[$cssProp] = Color::palette($params[$i + 2])->toHex();
+                    if (self::isColorComponent($params[$i + 2])) {
+                        $css[$cssProp] = Color::palette($params[$i + 2])->toHex();
+                    }
                     $i += 2;
                 } elseif (isset($params[$i + 1]) && 2 === $params[$i + 1] && isset($params[$i + 4])) {
-                    $css[$cssProp] = Color::rgb($params[$i + 2], $params[$i + 3], $params[$i + 4])->toHex();
+                    if (self::isColorComponent($params[$i + 2]) && self::isColorComponent($params[$i + 3]) && self::isColorComponent($params[$i + 4])) {
+                        $css[$cssProp] = Color::rgb($params[$i + 2], $params[$i + 3], $params[$i + 4])->toHex();
+                    }
                     $i += 4;
                 }
             } elseif (59 === $code) {
@@ -218,5 +229,10 @@ final class ScreenBufferHtmlRenderer
         }
 
         return rtrim($cssStr);
+    }
+
+    private static function isColorComponent(int $value): bool
+    {
+        return $value >= 0 && $value <= 255;
     }
 }

--- a/src/Symfony/Component/Tui/Input/KeyParser.php
+++ b/src/Symfony/Component/Tui/Input/KeyParser.php
@@ -626,11 +626,13 @@ final class KeyParser
                         || (!$this->kittyProtocolActive && "\n" === $data)
                         || "\x1bOM" === $data
                         || $this->matchesKittySequence($data, self::CODEPOINTS['enter'], 0)
-                        || $this->matchesKittySequence($data, self::CODEPOINTS['kp_enter'], 0);
+                        || $this->matchesKittySequence($data, self::CODEPOINTS['kp_enter'], 0)
+                        || $this->matchesModifyOtherKeys($data, self::CODEPOINTS['enter'], 0);
                 }
 
                 return $this->matchesKittySequence($data, self::CODEPOINTS['enter'], $modifier)
-                    || $this->matchesKittySequence($data, self::CODEPOINTS['kp_enter'], $modifier);
+                    || $this->matchesKittySequence($data, self::CODEPOINTS['kp_enter'], $modifier)
+                    || $this->matchesModifyOtherKeys($data, self::CODEPOINTS['enter'], $modifier);
 
             case 'backspace':
                 if ($alt && !$ctrl && !$shift) {

--- a/src/Symfony/Component/Tui/Loop/FixedStepAccumulator.php
+++ b/src/Symfony/Component/Tui/Loop/FixedStepAccumulator.php
@@ -31,7 +31,7 @@ final class FixedStepAccumulator
         private int $maxStepsPerUpdate = 5,
     ) {
         if ($stepsPerSecond <= 0.0) {
-            throw new InvalidArgumentException(\sprintf('Steps per second must be greater than 0, got %d.', $stepsPerSecond));
+            throw new InvalidArgumentException(\sprintf('Steps per second must be greater than 0, got "%s".', $stepsPerSecond));
         }
 
         if ($maxStepsPerUpdate < 1) {
@@ -46,8 +46,15 @@ final class FixedStepAccumulator
     {
         $this->accumulator += max(0.0, $deltaTime) * $this->stepsPerSecond;
 
-        if (0 < $steps = min($this->maxStepsPerUpdate, (int) floor($this->accumulator))) {
+        if (0 < $steps = (int) floor($this->accumulator)) {
+            // Take every whole step out of the accumulator, keeping only the
+            // fraction. Capping the count without clearing the rest turns a
+            // stall into a backlog that is paid back at cap speed over the
+            // following updates -- ten idle seconds run the animation at
+            // full tilt for the next two -- when the point of the cap is to
+            // drop the time that was missed.
             $this->accumulator -= $steps;
+            $steps = min($this->maxStepsPerUpdate, $steps);
         }
 
         return $steps;
@@ -56,7 +63,7 @@ final class FixedStepAccumulator
     public function setStepsPerSecond(float $stepsPerSecond): void
     {
         if ($stepsPerSecond <= 0.0) {
-            throw new InvalidArgumentException(\sprintf('Steps per second must be greater than 0, got %d.', $stepsPerSecond));
+            throw new InvalidArgumentException(\sprintf('Steps per second must be greater than 0, got "%s".', $stepsPerSecond));
         }
 
         $this->stepsPerSecond = $stepsPerSecond;

--- a/src/Symfony/Component/Tui/Loop/PeriodicStepper.php
+++ b/src/Symfony/Component/Tui/Loop/PeriodicStepper.php
@@ -32,7 +32,7 @@ final class PeriodicStepper
         int $maxStepsPerUpdate = 8,
     ) {
         if ($intervalSeconds <= 0.0) {
-            throw new InvalidArgumentException(\sprintf('Interval must be greater than 0, got %d.', $intervalSeconds));
+            throw new InvalidArgumentException(\sprintf('Interval must be greater than 0, got "%s".', $intervalSeconds));
         }
 
         $this->accumulator = new FixedStepAccumulator(1.0 / $intervalSeconds, $maxStepsPerUpdate);
@@ -62,7 +62,7 @@ final class PeriodicStepper
     public function setIntervalSeconds(float $intervalSeconds): void
     {
         if ($intervalSeconds <= 0.0) {
-            throw new InvalidArgumentException(\sprintf('Interval must be greater than 0, got %d.', $intervalSeconds));
+            throw new InvalidArgumentException(\sprintf('Interval must be greater than 0, got "%s".', $intervalSeconds));
         }
 
         $this->intervalSeconds = $intervalSeconds;

--- a/src/Symfony/Component/Tui/Loop/TickScheduler.php
+++ b/src/Symfony/Component/Tui/Loop/TickScheduler.php
@@ -41,7 +41,7 @@ final class TickScheduler
     public function schedule(callable $callback, float $intervalSeconds): string
     {
         if ($intervalSeconds <= 0) {
-            throw new InvalidArgumentException(\sprintf('Interval must be greater than 0, got %f.', $intervalSeconds));
+            throw new InvalidArgumentException(\sprintf('Interval must be greater than 0, got "%s".', $intervalSeconds));
         }
 
         $id = 'interval-'.(++$this->counter);

--- a/src/Symfony/Component/Tui/Loop/TickScheduler.php
+++ b/src/Symfony/Component/Tui/Loop/TickScheduler.php
@@ -82,7 +82,21 @@ final class TickScheduler
                 continue;
             }
 
-            $this->intervals[$id]['next_run_at'] = $now + $interval['interval'];
+            // Advance from the time this run was due, not from the moment the
+            // loop got round to it. The loop polls on its own cadence, so
+            // restarting the period at $now hands every late wake-up to the
+            // next one and the callback falls further behind for good.
+            $nextRunAt = $interval['next_run_at'] + $interval['interval'];
+
+            if ($nextRunAt <= $now) {
+                // Whole periods went by unserved (a stalled loop, a suspended
+                // process). Skip them and line up on the next one instead of
+                // firing a burst to catch up.
+                $missed = (int) floor(($now - $interval['next_run_at']) / $interval['interval']);
+                $nextRunAt = $interval['next_run_at'] + ($missed + 1) * $interval['interval'];
+            }
+
+            $this->intervals[$id]['next_run_at'] = $nextRunAt;
             ($interval['callback'])();
         }
     }

--- a/src/Symfony/Component/Tui/Render/Compositor.php
+++ b/src/Symfony/Component/Tui/Render/Compositor.php
@@ -54,7 +54,14 @@ final class Compositor
 
         $base = $layers[0];
         $height = $base->height ?? \count($base->lines);
-        $width = $base->width ?? (!$base->lines ? 0 : AnsiUtils::visibleWidth($base->lines[0]));
+        $width = $base->width ?? self::widestLine($base->lines);
+
+        if ($width < 1 || $height < 1) {
+            // Nothing to draw on. CellBuffer rejects an empty canvas, and a
+            // base layer with no lines is degenerate input in the same way an
+            // empty layer list is.
+            return [];
+        }
 
         $buffer = new CellBuffer($width, $height);
 
@@ -68,5 +75,18 @@ final class Compositor
         }
 
         return $buffer->toLines();
+    }
+
+    /**
+     * @param string[] $lines
+     */
+    private static function widestLine(array $lines): int
+    {
+        $width = 0;
+        foreach ($lines as $line) {
+            $width = max($width, AnsiUtils::visibleWidth($line));
+        }
+
+        return $width;
     }
 }

--- a/src/Symfony/Component/Tui/Terminal/ScreenBuffer.php
+++ b/src/Symfony/Component/Tui/Terminal/ScreenBuffer.php
@@ -471,23 +471,26 @@ final class ScreenBuffer
         $nums = '' !== $paramStr ? array_map('intval', explode(';', $paramStr)) : [];
 
         switch ($finalByte) {
+            // The cursor moves take a repeat count whose default is 1, and a
+            // count of 0 is read as 1 rather than as "stay put": an omitted
+            // and an explicit zero parameter mean the same thing.
             case 'A': // Cursor Up
-                $n = $nums[0] ?? 1;
+                $n = max(1, $nums[0] ?? 1);
                 $this->cursorRow = max(0, $this->cursorRow - $n);
                 break;
 
             case 'B': // Cursor Down
-                $n = $nums[0] ?? 1;
+                $n = max(1, $nums[0] ?? 1);
                 $this->cursorRow = min($this->height - 1, $this->cursorRow + $n);
                 break;
 
             case 'C': // Cursor Forward
-                $n = $nums[0] ?? 1;
+                $n = max(1, $nums[0] ?? 1);
                 $this->cursorCol = min($this->width - 1, $this->cursorCol + $n);
                 break;
 
             case 'D': // Cursor Back
-                $n = $nums[0] ?? 1;
+                $n = max(1, $nums[0] ?? 1);
                 $this->cursorCol = max(0, $this->cursorCol - $n);
                 break;
 

--- a/src/Symfony/Component/Tui/Terminal/ScreenBuffer.php
+++ b/src/Symfony/Component/Tui/Terminal/ScreenBuffer.php
@@ -307,13 +307,17 @@ final class ScreenBuffer
             $this->cells[$this->cursorRow] = [];
         }
 
-        // Fill any gaps with spaces. Which columns are missing has to be
-        // asked column by column: an erase unsets cells in the middle of the
-        // row, so the number of cells stops matching the columns they sit in
-        // and counting them walks the fill straight over live characters.
-        for ($col = 0; $col < $this->cursorCol; ++$col) {
-            if (!isset($this->cells[$this->cursorRow][$col])) {
-                $this->cells[$this->cursorRow][$col] = ['char' => ' ', 'style' => ''];
+        // Fill any gaps with spaces. A row that has as many cells as the
+        // cursor has columns to its left is contiguous, and the common case
+        // of appending to it needs no fill at all. Once the counts disagree
+        // -- an erase unsets cells in the middle of the row -- the missing
+        // columns have to be asked for one by one, because counting them
+        // walks the fill straight over live characters.
+        if (\count($this->cells[$this->cursorRow]) !== $this->cursorCol) {
+            for ($col = 0; $col < $this->cursorCol; ++$col) {
+                if (!isset($this->cells[$this->cursorRow][$col])) {
+                    $this->cells[$this->cursorRow][$col] = ['char' => ' ', 'style' => ''];
+                }
             }
         }
 

--- a/src/Symfony/Component/Tui/Terminal/ScreenBuffer.php
+++ b/src/Symfony/Component/Tui/Terminal/ScreenBuffer.php
@@ -307,9 +307,14 @@ final class ScreenBuffer
             $this->cells[$this->cursorRow] = [];
         }
 
-        // Fill any gaps with spaces
-        for ($col = \count($this->cells[$this->cursorRow]); $col < $this->cursorCol; ++$col) {
-            $this->cells[$this->cursorRow][$col] = ['char' => ' ', 'style' => ''];
+        // Fill any gaps with spaces. Which columns are missing has to be
+        // asked column by column: an erase unsets cells in the middle of the
+        // row, so the number of cells stops matching the columns they sit in
+        // and counting them walks the fill straight over live characters.
+        for ($col = 0; $col < $this->cursorCol; ++$col) {
+            if (!isset($this->cells[$this->cursorRow][$col])) {
+                $this->cells[$this->cursorRow][$col] = ['char' => ' ', 'style' => ''];
+            }
         }
 
         $style = $this->styleTracker->getActiveCodes();

--- a/src/Symfony/Component/Tui/Tests/Ansi/AnsiUtilsTest.php
+++ b/src/Symfony/Component/Tui/Tests/Ansi/AnsiUtilsTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Tui\Tests\Ansi;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Tui\Ansi\AnsiUtils;
+use Symfony\Component\Tui\Ansi\TextWrapper;
 
 class AnsiUtilsTest extends TestCase
 {
@@ -587,5 +588,38 @@ class AnsiUtilsTest extends TestCase
         // Truncating "東京 OK" to 4 columns keeps "東" and drops the rest;
         // the space at column 5 must not surface where "京" was dropped.
         $this->assertSame("\x1b[31m東\x1b[0m…", AnsiUtils::truncateToWidth("\x1b[31m東京\x1b[0m OK", 4, '…'));
+    }
+
+    /**
+     * The wrapper breaks lines by graphemeWidth() and every consumer measures
+     * the result with visibleWidth(); if the two disagree, a chunk comes back
+     * wider than the width it was wrapped to.
+     */
+    public function testVisibleWidthOfAJoinedSequenceMatchesItsGraphemeWidth()
+    {
+        $family = "\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}\u{200D}\u{1F466}";
+
+        $this->assertSame(AnsiUtils::graphemeWidth($family), AnsiUtils::visibleWidth($family));
+    }
+
+    public function testVisibleWidthIsAdditiveOverGraphemes()
+    {
+        $line = "a\u{1F44B}b\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}\u{200D}\u{1F466}c";
+
+        $sum = 0;
+        foreach (grapheme_str_split($line) as $grapheme) {
+            $sum += AnsiUtils::visibleWidth($grapheme);
+        }
+
+        $this->assertSame($sum, AnsiUtils::visibleWidth($line));
+    }
+
+    public function testWrappedChunksNeverExceedTheRequestedWidth()
+    {
+        $line = "a\u{1F44B}b\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}\u{200D}\u{1F466}c";
+
+        foreach (TextWrapper::wrapTextWithAnsi($line, 8) as $chunk) {
+            $this->assertLessThanOrEqual(8, AnsiUtils::visibleWidth($chunk));
+        }
     }
 }

--- a/src/Symfony/Component/Tui/Tests/Ansi/ScreenBufferHtmlRendererTest.php
+++ b/src/Symfony/Component/Tui/Tests/Ansi/ScreenBufferHtmlRendererTest.php
@@ -270,4 +270,36 @@ class ScreenBufferHtmlRendererTest extends TestCase
 
         return new ScreenBufferHtmlRenderer()->convert($screen);
     }
+
+    /**
+     * The sequences come from whatever program's output is being replayed, so
+     * a parameter Color would reject must not fail the conversion.
+     */
+    #[DataProvider('outOfRangeColorProvider')]
+    public function testAnOutOfRangeExtendedColorIsSkipped(string $sequence)
+    {
+        $screen = new ScreenBuffer(10, 2);
+        $screen->write($sequence.'X');
+
+        $this->assertSame('X', (new ScreenBufferHtmlRenderer())->convert($screen));
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function outOfRangeColorProvider(): iterable
+    {
+        yield 'palette index above 255' => ["\x1b[38;5;999m"];
+        yield 'background palette index above 255' => ["\x1b[48;5;300m"];
+        yield 'rgb component above 255' => ["\x1b[38;2;300;0;0m"];
+        yield 'underline color out of range' => ["\x1b[58;5;300m"];
+    }
+
+    public function testAnInRangeExtendedColorStillRenders()
+    {
+        $screen = new ScreenBuffer(10, 2);
+        $screen->write("\x1b[38;5;120mX");
+
+        $this->assertSame('<span style="color: #87ff87;">X</span>', (new ScreenBufferHtmlRenderer())->convert($screen));
+    }
 }

--- a/src/Symfony/Component/Tui/Tests/Input/KeyParserTest.php
+++ b/src/Symfony/Component/Tui/Tests/Input/KeyParserTest.php
@@ -302,4 +302,33 @@ class KeyParserTest extends TestCase
         $this->assertFalse($this->parser->matches("\x1b[98;7u", 'ctrl+alt+a'));
         $this->assertFalse($this->parser->matches("\x1b[97;5u", 'ctrl+alt+a'));
     }
+
+    /**
+     * xterm's modifyOtherKeys form reports every modifier through the same
+     * `CSI 27 ; mods ; keycode ~` shape, not just shift and alt.
+     */
+    #[DataProvider('modifyOtherKeysEnterProvider')]
+    public function testModifyOtherKeysEnter(string $sequence, string $keyId)
+    {
+        $this->assertTrue($this->parser->matches($sequence, $keyId));
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function modifyOtherKeysEnterProvider(): iterable
+    {
+        yield 'enter' => ["\x1b[27;1;13~", 'enter'];
+        yield 'shift+enter' => ["\x1b[27;2;13~", 'shift+enter'];
+        yield 'alt+enter' => ["\x1b[27;3;13~", 'alt+enter'];
+        yield 'ctrl+enter' => ["\x1b[27;5;13~", 'ctrl+enter'];
+        yield 'ctrl+shift+enter' => ["\x1b[27;6;13~", 'ctrl+shift+enter'];
+        yield 'ctrl+alt+enter' => ["\x1b[27;7;13~", 'ctrl+alt+enter'];
+    }
+
+    public function testModifyOtherKeysEnterDoesNotMatchAnotherModifier()
+    {
+        $this->assertFalse($this->parser->matches("\x1b[27;5;13~", 'shift+enter'));
+        $this->assertFalse($this->parser->matches("\x1b[27;5;9~", 'ctrl+enter'));
+    }
 }

--- a/src/Symfony/Component/Tui/Tests/Loop/FixedStepAccumulatorTest.php
+++ b/src/Symfony/Component/Tui/Tests/Loop/FixedStepAccumulatorTest.php
@@ -56,4 +56,38 @@ class FixedStepAccumulatorTest extends TestCase
 
         $this->assertSame(0, $accumulator->computeSteps(1.0 / 120.0));
     }
+
+    /**
+     * The cap bounds the work one update may do; the time above it is time
+     * that was missed, not work owed.
+     */
+    public function testTimeAboveTheCapIsDroppedRatherThanQueued()
+    {
+        $accumulator = new FixedStepAccumulator(10.0, 5);
+
+        // Ten seconds went by in one update: a hundred steps' worth.
+        $this->assertSame(5, $accumulator->computeSteps(10.0));
+
+        // The updates that follow run at their own rate again.
+        for ($i = 0; $i < 20; ++$i) {
+            $this->assertSame(1, $accumulator->computeSteps(0.1), 'Update '.$i.' is not paying back the stall.');
+        }
+    }
+
+    public function testTheFractionSurvivesADroppedBacklog()
+    {
+        $accumulator = new FixedStepAccumulator(10.0, 5);
+
+        $accumulator->computeSteps(10.05);
+
+        // 0.5 of a step was left over, so the next half step completes it.
+        $this->assertSame(1, $accumulator->computeSteps(0.05));
+    }
+
+    public function testTheRejectedStepRateIsReported()
+    {
+        $this->expectExceptionMessage('Steps per second must be greater than 0, got "-0.5".');
+
+        new FixedStepAccumulator(-0.5);
+    }
 }

--- a/src/Symfony/Component/Tui/Tests/Loop/PeriodicStepperTest.php
+++ b/src/Symfony/Component/Tui/Tests/Loop/PeriodicStepperTest.php
@@ -54,4 +54,11 @@ class PeriodicStepperTest extends TestCase
         $this->assertSame(0, $stepper->advance(0.1));
         $this->assertSame(1, $stepper->advance(0.1));
     }
+
+    public function testTheRejectedIntervalIsReported()
+    {
+        $this->expectExceptionMessage('Interval must be greater than 0, got "-0.25".');
+
+        new PeriodicStepper(-0.25);
+    }
 }

--- a/src/Symfony/Component/Tui/Tests/Loop/TickSchedulerTest.php
+++ b/src/Symfony/Component/Tui/Tests/Loop/TickSchedulerTest.php
@@ -38,13 +38,59 @@ class TickSchedulerTest extends TestCase
         $scheduler->runDue($start + 0.10);
         $this->assertSame(0, $calls);
 
+        // Due at 0.50 but the loop only came back at 1.00, so this run is
+        // late; the period it belongs to still ends at 1.00.
         $scheduler->runDue($start + 1.00);
         $this->assertSame(1, $calls);
 
+        // Being served late does not push the following period back.
         $scheduler->runDue($start + 1.20);
-        $this->assertSame(1, $calls);
+        $this->assertSame(2, $calls);
 
         $scheduler->runDue($start + 1.60);
+        $this->assertSame(3, $calls);
+    }
+
+    public function testRunDueDoesNotDriftBehindTheInterval()
+    {
+        $scheduler = new TickScheduler();
+        $calls = 0;
+        $start = microtime(true);
+
+        $scheduler->schedule(static function () use (&$calls): void {
+            ++$calls;
+        }, 0.100);
+
+        // A loop polling every 30 ms cannot land on the 100 ms boundary, but
+        // the rate it serves must still be one call per 100 ms.
+        for ($i = 1; $i <= 200; ++$i) {
+            $scheduler->runDue($start + $i * 0.030);
+        }
+
+        $this->assertSame(60, $calls);
+    }
+
+    public function testRunDueSkipsPeriodsMissedWhileTheLoopWasStalled()
+    {
+        $scheduler = new TickScheduler();
+        $calls = 0;
+        $start = microtime(true);
+
+        $scheduler->schedule(static function () use (&$calls): void {
+            ++$calls;
+        }, 0.100);
+
+        // Ten periods went by unserved while the loop was away.
+        $scheduler->runDue($start + 1.0);
+        $this->assertSame(1, $calls);
+
+        // The loop is back and polling every 10 ms. The missed periods are
+        // dropped, so the next 90 ms hold at most one more call rather than
+        // replaying the backlog one poll at a time.
+        for ($i = 1; $i <= 9; ++$i) {
+            $scheduler->runDue($start + 1.0 + $i * 0.010);
+        }
+
         $this->assertSame(2, $calls);
     }
 

--- a/src/Symfony/Component/Tui/Tests/Render/CompositorTest.php
+++ b/src/Symfony/Component/Tui/Tests/Render/CompositorTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Tui\Tests\Render;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Tui\Ansi\AnsiUtils;
+use Symfony\Component\Tui\Render\Compositor;
+use Symfony\Component\Tui\Render\Layer;
+
+class CompositorTest extends TestCase
+{
+    public function testCanvasIsAsWideAsTheWidestBaseLine()
+    {
+        $lines = Compositor::composite(new Layer(['ab', 'a longer line here', 'abc']));
+
+        $this->assertSame(['ab                ', 'a longer line here', 'abc               '], $lines);
+    }
+
+    public function testAnExplicitCanvasWidthStillWins()
+    {
+        $lines = Compositor::composite(new Layer(['ab', 'a longer line here'], width: 4));
+
+        $this->assertSame(['ab  ', 'a lo'], $lines);
+    }
+
+    public function testAnOverlayLandsOnTheRowsBelowTheFirst()
+    {
+        $lines = Compositor::composite(
+            new Layer(['..', '..................']),
+            new Layer(['XX'], row: 1, col: 16),
+        );
+
+        $this->assertSame(18, AnsiUtils::visibleWidth($lines[1]));
+        $this->assertSame('................XX', $lines[1]);
+    }
+
+    public function testAnEmptyBaseComposesToNothing()
+    {
+        $this->assertSame([], Compositor::composite(new Layer([])));
+    }
+}

--- a/src/Symfony/Component/Tui/Tests/Terminal/ScreenBufferTest.php
+++ b/src/Symfony/Component/Tui/Tests/Terminal/ScreenBufferTest.php
@@ -623,4 +623,30 @@ class ScreenBufferTest extends TestCase
         yield 'forward, zero count' => ["\x1b[0C", 2, 5];
         yield 'back, zero count' => ["\x1b[0D", 2, 3];
     }
+
+    /**
+     * An erase unsets cells in the middle of a row, so the number of cells in
+     * that row no longer matches the columns they sit in.
+     */
+    public function testWritingRightOfAnErasedRangeKeepsTheCharactersInBetween()
+    {
+        $buffer = new ScreenBuffer(20, 3);
+        $buffer->write('abcdefghij');
+        $buffer->write("\x1b[1;5H");  // row 1, column 5
+        $buffer->write("\x1b[1K");    // erase from the start of the line to the cursor
+        $buffer->write("\x1b[1;13H"); // row 1, column 13
+        $buffer->write('X');
+
+        $this->assertSame('     fghij  X', $buffer->getLines()[0]);
+    }
+
+    public function testWritingRightOfAnErasedRangeKeepsTheirStyles()
+    {
+        $buffer = new ScreenBuffer(20, 3);
+        $buffer->write("\x1b[31mabcdefghij\x1b[0m");
+        $buffer->write("\x1b[1;5H\x1b[1K");
+        $buffer->write("\x1b[1;13HX");
+
+        $this->assertStringContainsString("\x1b[31mfghij", $buffer->getStyledScreen());
+    }
 }

--- a/src/Symfony/Component/Tui/Tests/Terminal/ScreenBufferTest.php
+++ b/src/Symfony/Component/Tui/Tests/Terminal/ScreenBufferTest.php
@@ -587,4 +587,40 @@ class ScreenBufferTest extends TestCase
         yield 'private mode set/reset' => ["Hello\x1b[?25h\x1b[?25l World", 'Hello World'];
         yield 'standard mode set/reset' => ["Hello\x1b[25h\x1b[25l World", 'Hello World'];
     }
+
+    /**
+     * A repeat count of 0 means the same as an omitted one, so both move a
+     * single position.
+     */
+    #[DataProvider('zeroRepeatCountProvider')]
+    public function testAZeroRepeatCountMovesOnePosition(string $sequence, int $expectedRow, int $expectedCol)
+    {
+        $buffer = new ScreenBuffer(20, 6);
+        $buffer->write("\x1b[3;5H");
+        $buffer->write($sequence);
+        $buffer->write('X');
+
+        foreach ($buffer->getLines() as $row => $line) {
+            if (false !== $col = strpos($line, 'X')) {
+                $this->assertSame([$expectedRow, $expectedCol], [$row, $col]);
+
+                return;
+            }
+        }
+
+        $this->fail('The written character was not found on the screen.');
+    }
+
+    /**
+     * @return iterable<string, array{string, int, int}>
+     */
+    public static function zeroRepeatCountProvider(): iterable
+    {
+        yield 'no move' => ['', 2, 4];
+        yield 'up, default count' => ["\x1b[A", 1, 4];
+        yield 'up, zero count' => ["\x1b[0A", 1, 4];
+        yield 'down, zero count' => ["\x1b[0B", 3, 4];
+        yield 'forward, zero count' => ["\x1b[0C", 2, 5];
+        yield 'back, zero count' => ["\x1b[0D", 2, 3];
+    }
 }

--- a/src/Symfony/Component/Tui/Tests/Widget/Editor/EditorDocumentTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/Editor/EditorDocumentTest.php
@@ -603,4 +603,61 @@ class EditorDocumentTest extends TestCase
         yield 'Japanese' => ['日本', '日'];
         yield 'CJK' => ['中文', '中'];
     }
+
+    /**
+     * The cursor is a byte offset into one line. Carrying it to another line
+     * clamps it to that line's length, and a length is not a character
+     * boundary.
+     */
+    public function testMovingDownOntoAShorterLineOfWideCharactersKeepsTheDocumentValid()
+    {
+        $doc = new EditorDocument();
+        $doc->setText("abcde\n日本");
+        $doc->setCursorLine(0);
+        $doc->setCursorCol(4);
+
+        $doc->moveCursorDown();
+        $this->assertSame(3, $doc->getCursorCol(), 'The cursor sits between the two characters, not inside the second.');
+
+        $doc->insertText('x');
+        $this->assertSame("abcde\n日x本", $doc->getText());
+        $this->assertTrue(mb_check_encoding($doc->getText(), 'UTF-8'));
+    }
+
+    public function testMovingUpOntoALineOfWideCharactersKeepsTheDocumentValid()
+    {
+        $doc = new EditorDocument();
+        $doc->setText("日本\nabcde");
+        $doc->setCursorLine(1);
+        $doc->setCursorCol(4);
+
+        $doc->moveCursorUp();
+        $this->assertSame(3, $doc->getCursorCol());
+
+        $doc->insertText('x');
+        $this->assertTrue(mb_check_encoding($doc->getText(), 'UTF-8'));
+    }
+
+    public function testSetCursorColLandsOnACharacterBoundary()
+    {
+        $doc = new EditorDocument();
+        $doc->setText('日本語');
+
+        foreach ([0 => 0, 1 => 0, 2 => 0, 3 => 3, 4 => 3, 5 => 3, 6 => 6, 99 => 9] as $asked => $expected) {
+            $doc->setCursorCol($asked);
+            $this->assertSame($expected, $doc->getCursorCol(), \sprintf('Column %d snaps to %d.', $asked, $expected));
+        }
+    }
+
+    public function testDeletingALineLandsTheCursorOnACharacterBoundary()
+    {
+        $doc = new EditorDocument();
+        $doc->setText("abcde\n日本\nlast");
+        $doc->setCursorLine(0);
+        $doc->setCursorCol(4);
+
+        $doc->deleteLine();
+
+        $this->assertSame(3, $doc->getCursorCol());
+    }
 }

--- a/src/Symfony/Component/Tui/Tests/Widget/Editor/EditorDocumentTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/Editor/EditorDocumentTest.php
@@ -497,6 +497,41 @@ class EditorDocumentTest extends TestCase
         $this->assertSame([], $doc->getPasteMarkers());
     }
 
+    public function testMultiLinePasteIsASingleUndoStep()
+    {
+        $doc = new EditorDocument();
+        $doc->insertText('start');
+        $doc->handlePaste("line 1\nline 2\nline 3");
+        $this->assertSame("startline 1\nline 2\nline 3", $doc->getText());
+
+        $this->assertTrue($doc->undo());
+        $this->assertSame('start', $doc->getText());
+        $this->assertSame(0, $doc->getCursorLine());
+        $this->assertSame(5, $doc->getCursorCol());
+    }
+
+    public function testMultiLinePasteIsRedoneInOneStep()
+    {
+        $doc = new EditorDocument();
+        $doc->handlePaste("line 1\nline 2\nline 3");
+        $doc->undo();
+
+        $this->assertTrue($doc->redo());
+        $this->assertSame("line 1\nline 2\nline 3", $doc->getText());
+    }
+
+    public function testPasteInTheMiddleOfALine()
+    {
+        $doc = new EditorDocument();
+        $doc->setText('ab');
+        $doc->setCursorCol(1);
+        $doc->handlePaste("X\nY");
+
+        $this->assertSame("aX\nYb", $doc->getText());
+        $this->assertSame(1, $doc->getCursorLine());
+        $this->assertSame(1, $doc->getCursorCol());
+    }
+
     public function testPasteStripsControlBytesToPreventTerminalInjection()
     {
         $doc = new EditorDocument();

--- a/src/Symfony/Component/Tui/Tests/Widget/Editor/EditorRendererTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/Editor/EditorRendererTest.php
@@ -127,6 +127,23 @@ class EditorRendererTest extends TestCase
     }
 
     /**
+     * A grapheme cannot be split, so the wrapper hands back a chunk wider
+     * than the width whenever one character does not fit in the whole box.
+     */
+    public function testACharacterWiderThanTheBoxDoesNotOverflowTheLine()
+    {
+        $family = "\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}\u{200D}\u{1F466}";
+
+        foreach ([['日本'], ['x'.$family.'y'], [$family]] as $docLines) {
+            foreach ([1, 2, 3, 4] as $columns) {
+                foreach ($this->renderSimple($docLines, 0, 0, $columns, 10) as $line) {
+                    $this->assertLessThanOrEqual($columns, AnsiUtils::visibleWidth($line), \sprintf('Every rendered row fits in %d columns.', $columns));
+                }
+            }
+        }
+    }
+
+    /**
      * @param string[] $docLines
      *
      * @return string[]

--- a/src/Symfony/Component/Tui/Tests/Widget/Editor/EditorRendererTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/Editor/EditorRendererTest.php
@@ -181,6 +181,49 @@ class EditorRendererTest extends TestCase
     }
 
     /**
+     * The viewport measures in logical lines and keeps at least one so the
+     * cursor line is drawn; a single line can wrap to more rows than the
+     * editor has.
+     */
+    public function testAWrappedLineDoesNotRenderMoreRowsThanTheEditorHas()
+    {
+        $docLines = [str_repeat('word ', 40), 'second line', 'third line'];
+
+        foreach ([40, 20, 10, 6] as $columns) {
+            foreach ([1, 3, 5] as $maxDisplayRows) {
+                $viewport = [
+                    'scroll_offset' => 0,
+                    'visible_line_count' => 1,
+                    'lines_above' => 0,
+                    'lines_below' => 2,
+                ];
+
+                $lines = $this->renderWithViewport($docLines, $viewport, 0, 0, $columns, $maxDisplayRows);
+
+                // Two frame rows on top of the content.
+                $this->assertLessThanOrEqual($maxDisplayRows + 2, \count($lines), \sprintf('%d columns, %d rows allowed.', $columns, $maxDisplayRows));
+            }
+        }
+    }
+
+    public function testTheCursorStaysOnScreenWhenItsLineIsCutDown()
+    {
+        $docLines = [str_repeat('word ', 40)];
+        $viewport = [
+            'scroll_offset' => 0,
+            'visible_line_count' => 1,
+            'lines_above' => 0,
+            'lines_below' => 0,
+        ];
+
+        // The cursor sits at the very end, which wraps far past the third row.
+        $lines = $this->renderWithViewport($docLines, $viewport, 0, \strlen($docLines[0]) - 1, 10, 3, false, true);
+
+        $this->assertCount(5, $lines);
+        $this->assertStringContainsString(AnsiUtils::CURSOR_MARKER_PREFIX, implode('', $lines), 'The window follows the cursor instead of showing the top of the line.');
+    }
+
+    /**
      * @param string[] $docLines
      *
      * @return string[]

--- a/src/Symfony/Component/Tui/Tests/Widget/Editor/EditorRendererTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/Editor/EditorRendererTest.php
@@ -144,6 +144,43 @@ class EditorRendererTest extends TestCase
     }
 
     /**
+     * The scroll indicator is thirteen columns of its own before any frame is
+     * drawn around it, and a pane can be narrower than that.
+     */
+    public function testTheScrollIndicatorIsCutToTheWidth()
+    {
+        $docLines = ['one', 'two', 'three', 'four', 'five', 'six'];
+        $viewport = [
+            'scroll_offset' => 2,
+            'visible_line_count' => 2,
+            'lines_above' => 2,
+            'lines_below' => 2,
+        ];
+
+        foreach ([40, 14, 13, 12, 8, 5, 1] as $columns) {
+            foreach ($this->renderWithViewport($docLines, $viewport, 2, 0, $columns, 10) as $line) {
+                $this->assertLessThanOrEqual($columns, AnsiUtils::visibleWidth($line), \sprintf('Every row fits in %d columns.', $columns));
+            }
+        }
+    }
+
+    public function testTheScrollIndicatorStillFillsTheFrameWhenItFits()
+    {
+        $docLines = ['one', 'two', 'three', 'four'];
+        $viewport = [
+            'scroll_offset' => 1,
+            'visible_line_count' => 1,
+            'lines_above' => 1,
+            'lines_below' => 2,
+        ];
+
+        $lines = $this->renderWithViewport($docLines, $viewport, 1, 0, 20, 10);
+
+        $this->assertSame('─── ↑ 1 more ───────', AnsiUtils::stripAnsiCodes($lines[0]));
+        $this->assertSame('─── ↓ 2 more ───────', AnsiUtils::stripAnsiCodes($lines[\count($lines) - 1]));
+    }
+
+    /**
      * @param string[] $docLines
      *
      * @return string[]

--- a/src/Symfony/Component/Tui/Tests/Widget/EditorTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/EditorTest.php
@@ -1476,4 +1476,27 @@ class EditorTest extends TestCase
 
         return implode("\n", $lines);
     }
+
+    public function testEmptyInputChunkWhileWaitingForAJumpTarget()
+    {
+        $editor = new EditorWidget();
+        $editor->setText('hello world');
+        $editor->handleInput("\x1d"); // ctrl+] starts character jump mode
+
+        $warnings = [];
+        set_error_handler(static function (int $level, string $message) use (&$warnings): bool {
+            $warnings[] = $message;
+
+            return true;
+        });
+
+        try {
+            $editor->handleInput('');
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertSame([], $warnings);
+        $this->assertSame('hello world', $editor->getText());
+    }
 }

--- a/src/Symfony/Component/Tui/Tests/Widget/InputTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/InputTest.php
@@ -532,6 +532,21 @@ class InputTest extends TestCase
         $this->assertSame(0, $changes);
     }
 
+    public function testEmptyInputChunkIsIgnored()
+    {
+        $changes = 0;
+        $input = new InputWidget();
+        $input->setValue('hello');
+        $input->onChange(static function () use (&$changes) {
+            ++$changes;
+        });
+
+        $input->handleInput('');
+
+        $this->assertSame('hello', $input->getValue());
+        $this->assertSame(0, $changes, 'An empty chunk is not a keystroke.');
+    }
+
     private function assertValidUtf8(string $value, string $message = ''): void
     {
         $this->assertTrue(mb_check_encoding($value, 'UTF-8'), $message ?: 'Value should be valid UTF-8');

--- a/src/Symfony/Component/Tui/Tests/Widget/InputTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/InputTest.php
@@ -499,6 +499,39 @@ class InputTest extends TestCase
         $this->assertLessThanOrEqual(15, AnsiUtils::visibleWidth($lines[0]));
     }
 
+    public function testPastedEscapeSequencesAreStripped()
+    {
+        $input = new InputWidget();
+        $input->handleInput("\x1b[200~before\x1b]0;title\x07\x1b[31mafter\x1b[201~");
+
+        $this->assertSame('before]0;title[31mafter', $input->getValue());
+        $this->assertStringNotContainsString("\x1b", $input->getValue());
+        $this->assertStringNotContainsString("\x07", $input->getValue());
+        $this->assertStringNotContainsString("\x1b", $input->render(new RenderContext(80, 24))[0]);
+    }
+
+    public function testPastedNewlinesAndControlBytesAreRemoved()
+    {
+        $input = new InputWidget();
+        $input->handleInput("\x1b[200~a\r\nb\x00c\x1b[201~");
+
+        $this->assertSame('abc', $input->getValue());
+    }
+
+    public function testPasteThatSanitizesToNothingIsIgnored()
+    {
+        $changes = 0;
+        $input = new InputWidget();
+        $input->onChange(static function () use (&$changes) {
+            ++$changes;
+        });
+        $input->handleInput("\x1b[200~\x1b[201~");
+        $input->handleInput("\x1b[200~\n\x1b[201~");
+
+        $this->assertSame('', $input->getValue());
+        $this->assertSame(0, $changes);
+    }
+
     private function assertValidUtf8(string $value, string $message = ''): void
     {
         $this->assertTrue(mb_check_encoding($value, 'UTF-8'), $message ?: 'Value should be valid UTF-8');

--- a/src/Symfony/Component/Tui/Tests/Widget/MarkdownTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/MarkdownTest.php
@@ -243,6 +243,26 @@ class MarkdownTest extends TestCase
     }
 
     /**
+     * The borders are drawn from the computed column widths, so those widths
+     * have to add up to the space the table was given.
+     */
+    public function testTableWithOneVeryWideColumnStaysInsideTheWidth()
+    {
+        $wide = str_repeat('W', 60);
+        $markdown = "| $wide | b | c |\n|---|---|---|\n| ".str_repeat('X', 60)." | y | z |\n";
+
+        $md = $this->createMarkdown($markdown);
+
+        foreach ([14, 16, 20, 30] as $columns) {
+            $lines = $md->render(new RenderContext($columns, 60));
+            $this->assertStringStartsWith('┌', AnsiUtils::stripAnsiCodes($lines[0]));
+            foreach ($lines as $line) {
+                $this->assertSame($columns, AnsiUtils::visibleWidth($line), \sprintf('Every table row fills exactly %d columns.', $columns));
+            }
+        }
+    }
+
+    /**
      * Render a widget through the Renderer pipeline to get full chrome applied.
      *
      * @return string[]

--- a/src/Symfony/Component/Tui/Tests/Widget/MarkdownTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/MarkdownTest.php
@@ -220,6 +220,29 @@ class MarkdownTest extends TestCase
     }
 
     /**
+     * A two-digit marker is four columns wide, so the item's text has four
+     * fewer columns to wrap into and its continuation lines line up under it.
+     */
+    public function testOrderedListWithTwoDigitMarkers()
+    {
+        $markdown = '';
+        for ($i = 1; $i <= 11; ++$i) {
+            $markdown .= $i.". item text that is fairly long here\n";
+        }
+
+        $md = $this->createMarkdown($markdown);
+        $lines = array_map(AnsiUtils::stripAnsiCodes(...), $md->render(new RenderContext(20, 60)));
+
+        foreach ($lines as $line) {
+            $this->assertLessThanOrEqual(20, AnsiUtils::visibleWidth($line));
+        }
+
+        $tenth = array_search('10. item text that', $lines, true);
+        $this->assertNotFalse($tenth, 'The tenth item starts a line of its own: '.implode(' / ', $lines));
+        $this->assertStringStartsWith('    ', $lines[$tenth + 1], 'Continuation lines are indented under the text, not under the marker.');
+    }
+
+    /**
      * Render a widget through the Renderer pipeline to get full chrome applied.
      *
      * @return string[]

--- a/src/Symfony/Component/Tui/Tests/Widget/ProgressBarTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/ProgressBarTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Tui\Tests\Widget;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Tui\Ansi\AnsiUtils;
 use Symfony\Component\Tui\Render\RenderContext;
 use Symfony\Component\Tui\Style\Style;
 use Symfony\Component\Tui\Style\StyleSheet;
@@ -449,6 +450,35 @@ class ProgressBarTest extends TestCase
         // Should not exceed 40 columns
         $visibleWidth = mb_strwidth(preg_replace('/\x1b\[[^m]*m/', '', $content));
         $this->assertLessThanOrEqual(40, $visibleWidth);
+    }
+
+    /**
+     * The bar can only give back as many columns as it owns; anything left
+     * over has to be cut off the line, or the Renderer rejects it.
+     */
+    public function testRenderNeverExceedsTheAvailableWidth()
+    {
+        foreach ([40, 20, 15, 14, 10, 5, 1] as $columns) {
+            $bar = new ProgressBarWidget(10);
+            $bar->setProgress(3);
+
+            $line = $bar->render(new RenderContext($columns, 24))[0];
+
+            $this->assertLessThanOrEqual($columns, AnsiUtils::visibleWidth($line), \sprintf('Line fits in %d columns.', $columns));
+        }
+    }
+
+    public function testRenderInATerminalTooNarrowForTheBar()
+    {
+        $terminal = new VirtualTerminal(12, 6);
+        $tui = new Tui(terminal: $terminal);
+        $bar = new ProgressBarWidget(10);
+        $tui->add($bar);
+        $bar->setProgress(3);
+
+        $tui->processRender();
+
+        $this->assertLessThanOrEqual(12, AnsiUtils::visibleWidth($bar->render(new RenderContext(12, 6))[0]));
     }
 
     public function testMemoryPlaceholder()

--- a/src/Symfony/Component/Tui/Tests/Widget/ProgressBarTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/ProgressBarTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Tui\Tests\Widget;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Tui\Ansi\AnsiUtils;
 use Symfony\Component\Tui\Render\RenderContext;
@@ -479,6 +480,44 @@ class ProgressBarTest extends TestCase
         $tui->processRender();
 
         $this->assertLessThanOrEqual(12, AnsiUtils::visibleWidth($bar->render(new RenderContext(12, 6))[0]));
+    }
+
+    /**
+     * setBarWidth() is a number of columns, so it has to hold whatever the
+     * bar is drawn with.
+     */
+    #[DataProvider('barCharacterProvider')]
+    public function testTheBarIsAsWideAsItWasAskedToBe(?string $bar, ?string $empty, ?string $progress)
+    {
+        $widget = new ProgressBarWidget(10);
+        $widget->setBarWidth(10);
+        $widget->setProgress(5);
+        if (null !== $bar) {
+            $widget->setBarCharacter($bar);
+        }
+        if (null !== $empty) {
+            $widget->setEmptyBarCharacter($empty);
+        }
+        if (null !== $progress) {
+            $widget->setProgressCharacter($progress);
+        }
+
+        $plain = AnsiUtils::stripAnsiCodes($widget->render(new RenderContext(200, 4))[0]);
+        $this->assertSame(1, preg_match('/\[(.*)\]/u', $plain, $matches));
+        $this->assertSame(10, AnsiUtils::visibleWidth($matches[1]));
+    }
+
+    /**
+     * @return iterable<string, array{?string, ?string, ?string}>
+     */
+    public static function barCharacterProvider(): iterable
+    {
+        yield 'defaults' => [null, null, null];
+        yield 'ascii' => ['=', '-', null];
+        yield 'wide bar characters' => ['日', '本', null];
+        yield 'wide progress character' => [null, null, '👉'];
+        yield 'two-character progress' => [null, null, '=>'];
+        yield 'wide everything' => ['日', '本', '👉'];
     }
 
     public function testMemoryPlaceholder()

--- a/src/Symfony/Component/Tui/Tests/Widget/SelectListTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/SelectListTest.php
@@ -242,6 +242,43 @@ class SelectListTest extends TestCase
     }
 
     /**
+     * The selected row is prefixed with an arrow: three bytes, two columns.
+     * Budgeting in bytes cost that row two columns of description.
+     */
+    public function testSelectedRowGetsTheSameWidthBudgetAsTheOthers()
+    {
+        $description = str_repeat('D', 120);
+        $list = new SelectListWidget([
+            ['value' => 'alpha', 'label' => 'alpha', 'description' => $description],
+            ['value' => 'beta', 'label' => 'beta', 'description' => $description],
+        ]);
+
+        $lines = $list->render(new RenderContext(60, 24));
+
+        $this->assertSame(
+            AnsiUtils::visibleWidth($lines[1]),
+            AnsiUtils::visibleWidth($lines[0]),
+            'The selected row is truncated to the same width as the others.',
+        );
+    }
+
+    public function testSelectedRowWithoutDescriptionGetsTheSameWidthBudget()
+    {
+        $label = str_repeat('L', 120);
+        $list = new SelectListWidget([
+            ['value' => 'alpha', 'label' => $label],
+            ['value' => 'beta', 'label' => $label],
+        ]);
+
+        $lines = $list->render(new RenderContext(60, 24));
+
+        $this->assertSame(
+            AnsiUtils::visibleWidth($lines[1]),
+            AnsiUtils::visibleWidth($lines[0]),
+        );
+    }
+
+    /**
      * @return array{SelectListWidget, Tui}
      */
     private function createTestListWithTui(): array

--- a/src/Symfony/Component/Tui/Tests/Widget/SelectListTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/SelectListTest.php
@@ -241,6 +241,32 @@ class SelectListTest extends TestCase
         return new SelectListWidget($items, 5);
     }
 
+    public function testNoMatchLineIsTruncatedToTheWidth()
+    {
+        $list = new SelectListWidget([['value' => 'alpha', 'label' => 'alpha']]);
+        $list->setFilter('zzz');
+
+        foreach ([40, 19, 10, 5, 1] as $columns) {
+            $lines = $list->render(new RenderContext($columns, 24));
+
+            $this->assertLessThanOrEqual($columns, AnsiUtils::visibleWidth($lines[0]), \sprintf('The no-match line fits in %d columns.', $columns));
+        }
+    }
+
+    public function testItemsAreTruncatedToTheWidth()
+    {
+        $list = new SelectListWidget([
+            ['value' => 'a', 'label' => 'alpha', 'description' => 'the first one'],
+            ['value' => 'b', 'label' => 'beta', 'description' => 'the second one'],
+        ]);
+
+        foreach ([60, 40, 20, 6, 4, 2, 1] as $columns) {
+            foreach ($list->render(new RenderContext($columns, 24)) as $line) {
+                $this->assertLessThanOrEqual($columns, AnsiUtils::visibleWidth($line), \sprintf('Every row fits in %d columns.', $columns));
+            }
+        }
+    }
+
     /**
      * The selected row is prefixed with an arrow: three bytes, two columns.
      * Budgeting in bytes cost that row two columns of description.

--- a/src/Symfony/Component/Tui/Tests/Widget/SettingsListTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/SettingsListTest.php
@@ -318,4 +318,37 @@ class SettingsListTest extends TestCase
 
         return [$widget, $tui];
     }
+
+    /**
+     * A setting can hold a value that is not one of the ones it offers --
+     * SettingItem takes the current value independently of the list, and
+     * updateValue() accepts anything.
+     */
+    public function testCyclingFromAValueThatIsNotInTheList()
+    {
+        $this->assertSame('light', $this->cycleFromCustomValue("\x1b[C"), 'Right steps onto the first value.');
+        $this->assertSame('dark', $this->cycleFromCustomValue("\x1b[D"), 'Left steps onto the last value.');
+        $this->assertSame('light', $this->cycleFromCustomValue("\r"), 'Enter agrees with Right.');
+    }
+
+    public function testCyclingFromTheFirstValueIsUnchanged()
+    {
+        $item = new SettingItem('theme', 'Theme', 'light', null, ['light', 'dark']);
+        $widget = new SettingsListWidget([$item]);
+
+        $widget->handleInput("\x1b[C");
+        $this->assertSame('dark', $widget->getValue('theme'));
+
+        $widget->handleInput("\x1b[D");
+        $this->assertSame('light', $widget->getValue('theme'));
+    }
+
+    private function cycleFromCustomValue(string $key): string
+    {
+        $item = new SettingItem('theme', 'Theme', 'custom', null, ['light', 'dark']);
+        $widget = new SettingsListWidget([$item]);
+        $widget->handleInput($key);
+
+        return $widget->getValue('theme');
+    }
 }

--- a/src/Symfony/Component/Tui/Widget/Editor/EditorDocument.php
+++ b/src/Symfony/Component/Tui/Widget/Editor/EditorDocument.php
@@ -483,8 +483,8 @@ final class EditorDocument
                     grapheme_extract($line, 1, \GRAPHEME_EXTR_COUNT, $nextByteOffset, $nextByteOffset);
                     $idx = strpos($line, $char, $nextByteOffset);
                 } else {
-                    $searchIn = 0 === $this->cursorCol ? false : substr($line, 0, $this->cursorCol);
-                    $idx = false !== $searchIn ? strrpos($searchIn, $char) : false;
+                    $haystack = 0 === $this->cursorCol ? false : substr($line, 0, $this->cursorCol);
+                    $idx = false !== $haystack ? strrpos($haystack, $char) : false;
                 }
             } else {
                 $idx = $isForward ? strpos($line, $char) : strrpos($line, $char);
@@ -619,14 +619,12 @@ final class EditorDocument
             return;
         }
 
-        // Insert first line at cursor
-        $this->insertText($lines[0]);
+        // One paste is one edit: take a single snapshot and insert the whole
+        // content in one go, so a later undo takes all of it back at once.
+        $this->pushUndoSnapshot();
+        $this->killRing->resetAction();
 
-        // Insert remaining lines
-        for ($i = 1; $i < \count($lines); ++$i) {
-            $this->insertNewLine();
-            $this->insertText($lines[$i]);
-        }
+        $this->insertTextAtCursor($content);
     }
 
     // --- Internal ---

--- a/src/Symfony/Component/Tui/Widget/Editor/EditorDocument.php
+++ b/src/Symfony/Component/Tui/Widget/Editor/EditorDocument.php
@@ -85,7 +85,7 @@ final class EditorDocument
 
     public function setCursorCol(int $col): void
     {
-        $this->cursorCol = $col;
+        $this->cursorCol = $this->columnOnCurrentLine($col);
     }
 
     public function getKillRing(): KillRing
@@ -253,7 +253,7 @@ final class EditorDocument
             $this->lines = [''];
         }
 
-        $this->cursorCol = min($this->cursorCol, \strlen($this->lines[$this->cursorLine]));
+        $this->cursorCol = $this->columnOnCurrentLine($this->cursorCol);
 
         return true;
     }
@@ -358,7 +358,7 @@ final class EditorDocument
     {
         if ($this->cursorLine > 0) {
             --$this->cursorLine;
-            $this->cursorCol = min($this->cursorCol, \strlen($this->lines[$this->cursorLine]));
+            $this->cursorCol = $this->columnOnCurrentLine($this->cursorCol);
 
             return true;
         }
@@ -370,7 +370,7 @@ final class EditorDocument
     {
         if ($this->cursorLine < \count($this->lines) - 1) {
             ++$this->cursorLine;
-            $this->cursorCol = min($this->cursorCol, \strlen($this->lines[$this->cursorLine]));
+            $this->cursorCol = $this->columnOnCurrentLine($this->cursorCol);
 
             return true;
         }
@@ -659,6 +659,39 @@ final class EditorDocument
 
         $this->cursorLine = $lastLineIndex;
         $this->cursorCol = \strlen($lines[\count($lines) - 1] ?? '');
+    }
+
+    /**
+     * Bring a byte offset onto the current line, and onto a character
+     * boundary within it.
+     *
+     * The cursor is a byte offset into one line, so carrying it to another
+     * line means clamping it to that line's length -- and a length is not a
+     * boundary. Landing between the bytes of a character leaves the next
+     * insert or delete free to cut it in half, which takes the whole document
+     * out of UTF-8.
+     */
+    private function columnOnCurrentLine(int $col): int
+    {
+        $line = $this->lines[$this->cursorLine] ?? '';
+
+        if ($col <= 0) {
+            return 0;
+        }
+
+        if ($col >= $length = \strlen($line)) {
+            return $length;
+        }
+
+        $offset = 0;
+        foreach (grapheme_str_split($line) ?: [] as $grapheme) {
+            if ($offset + \strlen($grapheme) > $col) {
+                return $offset;
+            }
+            $offset += \strlen($grapheme);
+        }
+
+        return $offset;
     }
 
     private function currentLine(): Line

--- a/src/Symfony/Component/Tui/Widget/Editor/EditorRenderer.php
+++ b/src/Symfony/Component/Tui/Widget/Editor/EditorRenderer.php
@@ -51,13 +51,7 @@ final class EditorRenderer
         $result = [];
 
         // Top border (with scroll indicator if scrolled down)
-        if ($viewport['lines_above'] > 0) {
-            $indicator = "─── ↑ {$viewport['lines_above']} more ";
-            $remaining = $columns - AnsiUtils::visibleWidth($indicator);
-            $result[] = $frameStyle->apply($indicator.str_repeat('─', max(0, $remaining)));
-        } else {
-            $result[] = $frameStyle->apply(str_repeat('─', $columns));
-        }
+        $result[] = $this->renderFrameRow($viewport['lines_above'], '↑', $columns, $frameStyle);
 
         // Render visible lines
         $displayRowsRendered = 0;
@@ -82,15 +76,33 @@ final class EditorRenderer
         }
 
         // Bottom border (with scroll indicator if more content below)
-        if ($viewport['lines_below'] > 0) {
-            $indicator = "─── ↓ {$viewport['lines_below']} more ";
-            $remaining = $columns - AnsiUtils::visibleWidth($indicator);
-            $result[] = $frameStyle->apply($indicator.str_repeat('─', max(0, $remaining)));
-        } else {
-            $result[] = $frameStyle->apply(str_repeat('─', $columns));
-        }
+        $result[] = $this->renderFrameRow($viewport['lines_below'], '↓', $columns, $frameStyle);
 
         return $result;
+    }
+
+    /**
+     * Render one frame row, carrying the count of lines hidden in that
+     * direction when there are any.
+     */
+    private function renderFrameRow(int $hiddenLines, string $arrow, int $columns, Style $frameStyle): string
+    {
+        if ($hiddenLines < 1) {
+            return $frameStyle->apply(str_repeat('─', max(0, $columns)));
+        }
+
+        // The indicator has a width of its own, and a pane can be narrower
+        // than that. Padding it out to the frame is only half the job: what
+        // does not fit has to come off, or the row runs past the box and the
+        // Renderer rejects it.
+        $indicator = \sprintf('─── %s %d more ', $arrow, $hiddenLines);
+        $indicatorWidth = AnsiUtils::visibleWidth($indicator);
+
+        if ($indicatorWidth > $columns) {
+            return $frameStyle->apply(AnsiUtils::truncateToWidth($indicator, $columns, ''));
+        }
+
+        return $frameStyle->apply($indicator.str_repeat('─', $columns - $indicatorWidth));
     }
 
     /**

--- a/src/Symfony/Component/Tui/Widget/Editor/EditorRenderer.php
+++ b/src/Symfony/Component/Tui/Widget/Editor/EditorRenderer.php
@@ -54,17 +54,38 @@ final class EditorRenderer
         $result[] = $this->renderFrameRow($viewport['lines_above'], '↑', $columns, $frameStyle);
 
         // Render visible lines
-        $displayRowsRendered = 0;
+        $contentRows = [];
+        $cursorRow = null;
         for ($i = 0; $i < $viewport['visible_line_count']; ++$i) {
             $lineIndex = $viewport['scroll_offset'] + $i;
             $line = $lines[$lineIndex] ?? '';
             $isCursorLine = $lineIndex === $cursorLine;
 
-            $renderedLines = $this->renderLine($line, $isCursorLine, $cursorCol, $columns, $cursorShape, $focused);
-            foreach ($renderedLines as $renderedLine) {
-                $result[] = $renderedLine;
+            $rendered = $this->renderLine($line, $isCursorLine, $cursorCol, $columns, $cursorShape, $focused);
+            if (null !== $rendered['cursor_row']) {
+                $cursorRow = \count($contentRows) + $rendered['cursor_row'];
             }
-            $displayRowsRendered += \count($renderedLines);
+            foreach ($rendered['lines'] as $renderedLine) {
+                $contentRows[] = $renderedLine;
+            }
+        }
+
+        // The viewport hands back whole logical lines and always keeps at
+        // least one, so the cursor line is drawn even when it wraps to more
+        // rows than the editor was given. Show the window of rows the cursor
+        // is in rather than every one of them, which would run the editor
+        // past its own frame and push whatever is laid out below off screen.
+        if (\count($contentRows) > $maxDisplayRows) {
+            $start = 0;
+            if (null !== $cursorRow && $cursorRow >= $maxDisplayRows) {
+                $start = min($cursorRow - $maxDisplayRows + 1, \count($contentRows) - $maxDisplayRows);
+            }
+            $contentRows = \array_slice($contentRows, $start, $maxDisplayRows);
+        }
+
+        $displayRowsRendered = \count($contentRows);
+        foreach ($contentRows as $contentRow) {
+            $result[] = $contentRow;
         }
 
         // In fill mode, pad with empty rows to fill the allocated space
@@ -108,13 +129,16 @@ final class EditorRenderer
     /**
      * Render a logical line, possibly wrapped into multiple display lines.
      *
-     * @return string[] Array of display lines (one or more if wrapped)
+     * @return array{lines: string[], cursor_row: int|null} The display lines
+     *                                                      (one or more if wrapped), and which of
+     *                                                      them carries the cursor
      */
     private function renderLine(string $line, bool $isCursorLine, int $cursorCol, int $columns, CursorShape $cursorShape, bool $focused): array
     {
         $chunks = TextWrapper::wrapLineIntoChunks($line, $columns);
 
         $result = [];
+        $cursorRow = null;
         $chunkCount = \count($chunks);
 
         foreach ($chunks as $i => $chunk) {
@@ -139,6 +163,7 @@ final class EditorRenderer
             }
 
             if ($hasCursor) {
+                $cursorRow ??= \count($result);
                 $displayLine = $this->renderCursorInChunk($chunkText, $cursorPosInChunk, $columns, $cursorShape, $focused);
             }
 
@@ -158,7 +183,7 @@ final class EditorRenderer
             $result[] = $displayLine.str_repeat(' ', $padding);
         }
 
-        return $result;
+        return ['lines' => $result, 'cursor_row' => $cursorRow];
     }
 
     /**

--- a/src/Symfony/Component/Tui/Widget/Editor/EditorRenderer.php
+++ b/src/Symfony/Component/Tui/Widget/Editor/EditorRenderer.php
@@ -130,8 +130,17 @@ final class EditorRenderer
                 $displayLine = $this->renderCursorInChunk($chunkText, $cursorPosInChunk, $columns, $cursorShape, $focused);
             }
 
-            // Pad to width
+            // A grapheme cannot be split, so a chunk still overflows when one
+            // character is wider than the whole box (a CJK glyph in a
+            // one-column pane, a joined emoji in four). The Renderer rejects
+            // an over-wide line, so cut what does not fit.
             $visibleWidth = AnsiUtils::visibleWidth($displayLine);
+            if ($visibleWidth > $columns) {
+                $displayLine = AnsiUtils::truncateToWidth($displayLine, $columns, '');
+                $visibleWidth = AnsiUtils::visibleWidth($displayLine);
+            }
+
+            // Pad to width
             $padding = max(0, $columns - $visibleWidth);
 
             $result[] = $displayLine.str_repeat(' ', $padding);

--- a/src/Symfony/Component/Tui/Widget/EditorWidget.php
+++ b/src/Symfony/Component/Tui/Widget/EditorWidget.php
@@ -200,11 +200,6 @@ class EditorWidget extends AbstractWidget implements FocusableInterface, Vertica
         if (null !== $pastedText = $this->processBracketedPaste($data)) {
             $this->document->handlePaste($pastedText);
             $this->notifyChange();
-            if ('' === $data) {
-                return;
-            }
-        } elseif ('' === $data && $this->isBufferingPaste()) {
-            return;
         }
 
         // Nothing left to route once the paste bytes are peeled off, and the

--- a/src/Symfony/Component/Tui/Widget/EditorWidget.php
+++ b/src/Symfony/Component/Tui/Widget/EditorWidget.php
@@ -207,6 +207,12 @@ class EditorWidget extends AbstractWidget implements FocusableInterface, Vertica
             return;
         }
 
+        // Nothing left to route once the paste bytes are peeled off, and the
+        // handling below reads $data[0].
+        if ('' === $data) {
+            return;
+        }
+
         $kb = $this->getKeybindings();
 
         // Handle character jump mode (awaiting next character to jump to)

--- a/src/Symfony/Component/Tui/Widget/InputWidget.php
+++ b/src/Symfony/Component/Tui/Widget/InputWidget.php
@@ -149,14 +149,8 @@ class InputWidget extends AbstractWidget implements FocusableInterface
 
         try {
             // Handle bracketed paste mode
-            $pastedText = $this->processBracketedPaste($data);
-            if (null !== $pastedText) {
+            if (null !== $pastedText = $this->processBracketedPaste($data)) {
                 $this->handlePaste($pastedText);
-                if ('' === $data) {
-                    return;
-                }
-            } elseif ('' === $data && $this->isBufferingPaste()) {
-                return;
             }
 
             // Nothing left to route once the paste bytes are peeled off; an

--- a/src/Symfony/Component/Tui/Widget/InputWidget.php
+++ b/src/Symfony/Component/Tui/Widget/InputWidget.php
@@ -442,8 +442,16 @@ class InputWidget extends AbstractWidget implements FocusableInterface
 
     private function handlePaste(string $text): void
     {
+        // Pasted bytes are untrusted: a paste can carry escape sequences that
+        // would be replayed verbatim to the terminal on the next render.
+        $cleanText = StringUtils::sanitizeUtf8($text);
         // Clean pasted text - remove newlines
-        $cleanText = str_replace(["\r\n", "\r", "\n"], '', $text);
+        $cleanText = str_replace(["\r\n", "\r", "\n"], '', $cleanText);
+        $cleanText = StringUtils::stripControlBytes($cleanText);
+
+        if ('' === $cleanText) {
+            return;
+        }
 
         $this->line->insert($cleanText);
         $this->notifyChange();

--- a/src/Symfony/Component/Tui/Widget/InputWidget.php
+++ b/src/Symfony/Component/Tui/Widget/InputWidget.php
@@ -159,6 +159,12 @@ class InputWidget extends AbstractWidget implements FocusableInterface
                 return;
             }
 
+            // Nothing left to route once the paste bytes are peeled off; an
+            // empty chunk is not a keystroke and not text to insert.
+            if ('' === $data) {
+                return;
+            }
+
             $kb = $this->getKeybindings();
 
             // Cancel

--- a/src/Symfony/Component/Tui/Widget/MarkdownWidget.php
+++ b/src/Symfony/Component/Tui/Widget/MarkdownWidget.php
@@ -454,11 +454,29 @@ class MarkdownWidget extends AbstractWidget
                 $columnWidths[] = max(1, (int) floor($proportion * $availableForCells));
             }
 
-            $allocated = array_sum($columnWidths);
-            $remaining = $availableForCells - $allocated;
+            $remaining = $availableForCells - array_sum($columnWidths);
             for ($i = 0; $remaining > 0 && $i < $numCols; ++$i) {
                 ++$columnWidths[$i];
                 --$remaining;
+            }
+
+            // Flooring each share and then lifting the empty ones back to a
+            // single column can spend more than the budget, and the borders
+            // are sized from these widths: the row would run past the widget
+            // and get wrapped, breaking the table apart. Take the excess off
+            // the widest columns, which have the most to spare.
+            while ($remaining < 0) {
+                $widest = null;
+                foreach ($columnWidths as $i => $width) {
+                    if ($width > 1 && (null === $widest || $width > $columnWidths[$widest])) {
+                        $widest = $i;
+                    }
+                }
+                if (null === $widest) {
+                    break;
+                }
+                --$columnWidths[$widest];
+                ++$remaining;
             }
         }
 

--- a/src/Symfony/Component/Tui/Widget/MarkdownWidget.php
+++ b/src/Symfony/Component/Tui/Widget/MarkdownWidget.php
@@ -309,7 +309,6 @@ class MarkdownWidget extends AbstractWidget
     private function renderList(ListBlock $list, int $columns): array
     {
         $lines = [];
-        $itemColumns = max(1, $columns - 2);
         $isOrdered = 'ordered' === $list->getListData()->type;
         $index = $list->getListData()->start ?? 1;
         $listBulletStyle = $this->resolveElement('list-bullet');
@@ -319,11 +318,17 @@ class MarkdownWidget extends AbstractWidget
                 continue;
             }
 
-            $bullet = $listBulletStyle->apply($isOrdered ? $index.'. ' : '• ').$this->restoreContext;
+            // The marker is not always two columns wide: an ordered list
+            // reaching 10 needs four, and the content has to be wrapped and
+            // indented to whatever this item's marker actually takes.
+            $marker = $isOrdered ? $index.'. ' : '• ';
+            $markerWidth = AnsiUtils::visibleWidth($marker);
+            $bullet = $listBulletStyle->apply($marker).$this->restoreContext;
+            $continuation = str_repeat(' ', $markerWidth);
 
-            $content = $this->renderListItemContent($item, $itemColumns);
+            $content = $this->renderListItemContent($item, max(1, $columns - $markerWidth));
             foreach ($content as $i => $line) {
-                $lines[] = (0 === $i ? $bullet : '  ').$line;
+                $lines[] = (0 === $i ? $bullet : $continuation).$line;
             }
 
             ++$index;

--- a/src/Symfony/Component/Tui/Widget/ProgressBarWidget.php
+++ b/src/Symfony/Component/Tui/Widget/ProgressBarWidget.php
@@ -507,17 +507,26 @@ class ProgressBarWidget extends AbstractWidget
 
         // If the line is too wide, shrink the bar to fit
         $lineWidth = AnsiUtils::visibleWidth($line);
-        if ($lineWidth > $availableWidth) {
-            $newBarWidth = $this->barWidth - ($lineWidth - $availableWidth);
-            if ($newBarWidth >= 1) {
-                $savedBarWidth = $this->barWidth;
-                $this->barWidth = $newBarWidth;
-                $line = $this->replacePlaceholders($format);
-                $this->barWidth = $savedBarWidth;
-            }
+        if ($lineWidth <= $availableWidth) {
+            return $line;
         }
 
-        return $line;
+        // Shrink as far as the bar goes, down to a single cell. Giving up
+        // when the overflow is larger than the bar would leave the line at
+        // its full width, so a terminal narrow enough to swallow the whole
+        // bar produced a wider line than a slightly wider one did.
+        $newBarWidth = max(1, $this->barWidth - ($lineWidth - $availableWidth));
+        if ($newBarWidth !== $this->barWidth) {
+            $savedBarWidth = $this->barWidth;
+            $this->barWidth = $newBarWidth;
+            $line = $this->replacePlaceholders($format);
+            $this->barWidth = $savedBarWidth;
+        }
+
+        // The rest of the format (counters, percentage, message) can still
+        // outgrow the available columns on its own; the Renderer rejects an
+        // over-wide line, so cut it instead of aborting the render.
+        return AnsiUtils::truncateToWidth($line, $availableWidth, '');
     }
 
     private function replacePlaceholders(string $format): string

--- a/src/Symfony/Component/Tui/Widget/ProgressBarWidget.php
+++ b/src/Symfony/Component/Tui/Widget/ProgressBarWidget.php
@@ -567,19 +567,49 @@ class ProgressBarWidget extends AbstractWidget
 
     private function renderBar(): string
     {
-        $completeBars = $this->getBarOffset();
-        $styledComplete = $this->applyElement('bar-fill', str_repeat($this->barChar, $completeBars));
+        // The bar width is a number of columns, so how many times a character
+        // goes into it depends on how wide that character draws. Counting
+        // characters instead makes a bar of wide glyphs twice the width that
+        // was asked for.
+        $completeColumns = $this->getBarOffset();
+        $styledComplete = $this->applyElement('bar-fill', self::repeatToWidth($this->barChar, $completeColumns));
 
-        if ($completeBars < $this->barWidth) {
-            $progressCharLen = mb_strlen($this->progressChar);
-            $emptyBars = $this->barWidth - $completeBars - $progressCharLen;
-            $styledProgress = '' !== $this->progressChar ? $this->applyElement('bar-progress', $this->progressChar) : '';
-            $styledEmpty = $this->applyElement('bar-empty', str_repeat($this->emptyBarChar, max(0, $emptyBars)));
+        if ($completeColumns < $this->barWidth) {
+            $remainingColumns = $this->barWidth - $completeColumns;
+
+            $styledProgress = '';
+            $progressColumns = AnsiUtils::visibleWidth($this->progressChar);
+            if ('' !== $this->progressChar && $progressColumns <= $remainingColumns) {
+                $styledProgress = $this->applyElement('bar-progress', $this->progressChar);
+                $remainingColumns -= $progressColumns;
+            }
+
+            $styledEmpty = $this->applyElement('bar-empty', self::repeatToWidth($this->emptyBarChar, $remainingColumns));
 
             return $styledComplete.$styledProgress.$styledEmpty;
         }
 
         return $styledComplete;
+    }
+
+    /**
+     * Repeat a character to fill exactly the given number of columns, padding
+     * with spaces when it does not divide evenly.
+     */
+    private static function repeatToWidth(string $char, int $columns): string
+    {
+        if ($columns <= 0) {
+            return '';
+        }
+
+        $charColumns = AnsiUtils::visibleWidth($char);
+        if ($charColumns < 1) {
+            return str_repeat(' ', $columns);
+        }
+
+        $count = intdiv($columns, $charColumns);
+
+        return str_repeat($char, $count).str_repeat(' ', $columns - $count * $charColumns);
     }
 
     private static function formatTime(int $secs): string

--- a/src/Symfony/Component/Tui/Widget/SelectListWidget.php
+++ b/src/Symfony/Component/Tui/Widget/SelectListWidget.php
@@ -219,7 +219,7 @@ class SelectListWidget extends AbstractWidget implements FocusableInterface
         // No items match filter
         if (!$this->filteredItems) {
             $line = $this->applyElement('no-match', '  No matching items');
-            $lines[] = $line;
+            $lines[] = AnsiUtils::truncateToWidth($line, $columns, '');
 
             return $lines;
         }
@@ -247,7 +247,10 @@ class SelectListWidget extends AbstractWidget implements FocusableInterface
             $isSelected = $i === $this->selectedIndex;
             $description = isset($item['description']) ? $this->normalizeDescription($item['description']) : null;
             $line = $this->renderItem($item, $isSelected, $description, $columns, $labelColumnWidth);
-            $lines[] = $line;
+            // renderItem() budgets the label against the columns left after
+            // its prefix, but the prefix itself is emitted unconditionally
+            // and is wider than the widget once the pane gets narrow enough.
+            $lines[] = AnsiUtils::truncateToWidth($line, $columns, '');
         }
 
         // Add scroll indicator if needed

--- a/src/Symfony/Component/Tui/Widget/SelectListWidget.php
+++ b/src/Symfony/Component/Tui/Widget/SelectListWidget.php
@@ -287,14 +287,17 @@ class SelectListWidget extends AbstractWidget implements FocusableInterface
 
         if ($isSelected) {
             $prefix = '→ ';
+            // The arrow is three bytes wide and one column wide; every
+            // budget here is in columns.
+            $prefixWidth = AnsiUtils::visibleWidth($prefix);
             $selectedStyle = $this->resolveElement('selected');
 
             if (null !== $description && $columns > 40) {
-                $maxValueColumns = min($labelColumnWidth, $columns - \strlen($prefix) - 4);
+                $maxValueColumns = min($labelColumnWidth, $columns - $prefixWidth - 4);
                 $truncatedValue = AnsiUtils::truncateToWidth($displayValue, $maxValueColumns, '');
                 $spacing = str_repeat(' ', max(1, $alignedWidth - AnsiUtils::visibleWidth($truncatedValue)));
 
-                $descriptionStart = \strlen($prefix) + AnsiUtils::visibleWidth($truncatedValue) + \strlen($spacing);
+                $descriptionStart = $prefixWidth + AnsiUtils::visibleWidth($truncatedValue) + \strlen($spacing);
                 $remainingColumns = $columns - $descriptionStart - 2;
 
                 if ($remainingColumns > 10) {
@@ -304,20 +307,21 @@ class SelectListWidget extends AbstractWidget implements FocusableInterface
                 }
             }
 
-            $maxColumns = $columns - \strlen($prefix) - 2;
+            $maxColumns = $columns - $prefixWidth - 2;
 
             return $selectedStyle->apply($prefix.AnsiUtils::truncateToWidth($displayValue, $maxColumns, ''));
         }
 
         // Non-selected item
         $prefix = '  ';
+        $prefixWidth = AnsiUtils::visibleWidth($prefix);
 
         if (null !== $description && $columns > 40) {
-            $maxValueColumns = min($labelColumnWidth, $columns - \strlen($prefix) - 4);
+            $maxValueColumns = min($labelColumnWidth, $columns - $prefixWidth - 4);
             $truncatedValue = AnsiUtils::truncateToWidth($displayValue, $maxValueColumns, '');
             $spacing = str_repeat(' ', max(1, $alignedWidth - AnsiUtils::visibleWidth($truncatedValue)));
 
-            $descriptionStart = \strlen($prefix) + AnsiUtils::visibleWidth($truncatedValue) + \strlen($spacing);
+            $descriptionStart = $prefixWidth + AnsiUtils::visibleWidth($truncatedValue) + \strlen($spacing);
             $remainingColumns = $columns - $descriptionStart - 2;
 
             if ($remainingColumns > 10) {
@@ -329,7 +333,7 @@ class SelectListWidget extends AbstractWidget implements FocusableInterface
             }
         }
 
-        $maxColumns = $columns - \strlen($prefix) - 2;
+        $maxColumns = $columns - $prefixWidth - 2;
 
         return $prefix.AnsiUtils::truncateToWidth($displayValue, $maxColumns, '');
     }

--- a/src/Symfony/Component/Tui/Widget/SettingsListWidget.php
+++ b/src/Symfony/Component/Tui/Widget/SettingsListWidget.php
@@ -289,10 +289,19 @@ class SettingsListWidget extends AbstractWidget implements FocusableInterface, P
 
         $values = $item->getValues();
         $valueCount = \count($values);
-        $currentIndex = array_search($item->getCurrentValue(), $values, true) ?: 0;
+        $currentIndex = array_search($item->getCurrentValue(), $values, true);
 
-        // Calculate next index with wrapping
-        $nextIndex = ($currentIndex + $direction + $valueCount) % $valueCount;
+        if (false === $currentIndex) {
+            // The value is not one of the offered ones, so there is no
+            // position to step from: step onto the list instead. Reading the
+            // miss as index 0 sent both directions to the same value and
+            // disagreed with what activating the item does.
+            $nextIndex = $direction > 0 ? 0 : $valueCount - 1;
+        } else {
+            // Calculate next index with wrapping
+            $nextIndex = ($currentIndex + $direction + $valueCount) % $valueCount;
+        }
+
         $newValue = $values[$nextIndex];
 
         $item->setCurrentValue($newValue);

--- a/src/Symfony/Component/Tui/Widget/TextWidget.php
+++ b/src/Symfony/Component/Tui/Widget/TextWidget.php
@@ -58,9 +58,9 @@ use Symfony\Component\Tui\Widget\Figlet\FigletRenderer;
  *  - InputWidget::setPrompt()
  *
  * Sanitizing widgets (which call StringUtils::stripControlBytes on input):
- * InputWidget::setValue, EditorWidget/EditorDocument, MarkdownWidget,
- * SettingItem::$currentValue, ProgressBarWidget::setMessage,
- * LoaderWidget::setMessage.
+ * InputWidget::setValue and pasted content, EditorWidget/EditorDocument,
+ * MarkdownWidget, SettingItem::$currentValue,
+ * ProgressBarWidget::setMessage, LoaderWidget::setMessage.
  *
  * @experimental
  *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Gathers twenty-two Tui bug fixes @sadiqk2 opened separately into one branch, one commit each, so the
component can be reviewed and merged as a whole instead of the pull requests racing each other over the
same files. Replaces #65396, #65397, #65398, #65399, #65400, #65401, #65402, #65403, #65404, #65405,
#65406, #65407, #65408, #65409, #65410, #65411, #65412, #65413, #65414 and #65417.

Each commit keeps its author and fixes one defect: column-width accounting in the progress bar, select
list, markdown widget and editor renderer, grapheme width for joined emoji, cursor and erase handling in
`ScreenBuffer`, out-of-range colors in the HTML renderer, the modifyOtherKeys form of enter, canvas
sizing in `Compositor`, interval drift and stall handling in the loop classes, paste sanitizing and undo
grouping in the text widgets, value cycling in the settings list, and from the second batch: the editor
scroll indicator cut to the pane width, the cursor snapped to a character boundary when it changes line,
and a wrapped line kept inside the editor's row budget.

#65415 was part of the first batch and was pulled out: it changes a documented contract rather than
fixing an oversight, so it moved to 8.2 as #65418.

Checks run: full `Tui` suite on the merged branch, 1773 tests green. Every fix was revert-verified by
running the branch's tests against unpatched 8.1 source: 41 of the 49 added test methods fail there, and
each of the twenty-two commits has at least one that does. The remaining eight pass on base by design,
being control tests that assert unchanged behavior. `Unit Tests (8.6)` is red on
`VarDumper\FFICasterTest` and the Twig bridge under PHP 8.6-dev, on components this branch does not
touch, and it fails the same way before these commits.
