### PR TITLE
[Tui] Second batch of bug fixes

### DIFF
--- a/src/Symfony/Component/Tui/Tests/Widget/Editor/EditorDocumentTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/Editor/EditorDocumentTest.php
@@ -568,4 +568,61 @@ class EditorDocumentTest extends TestCase
         yield 'Japanese' => ['日本', '日'];
         yield 'CJK' => ['中文', '中'];
     }
+
+    /**
+     * The cursor is a byte offset into one line. Carrying it to another line
+     * clamps it to that line's length, and a length is not a character
+     * boundary.
+     */
+    public function testMovingDownOntoAShorterLineOfWideCharactersKeepsTheDocumentValid()
+    {
+        $doc = new EditorDocument();
+        $doc->setText("abcde\n日本");
+        $doc->setCursorLine(0);
+        $doc->setCursorCol(4);
+
+        $doc->moveCursorDown();
+        $this->assertSame(3, $doc->getCursorCol(), 'The cursor sits between the two characters, not inside the second.');
+
+        $doc->insertText('x');
+        $this->assertSame("abcde\n日x本", $doc->getText());
+        $this->assertTrue(mb_check_encoding($doc->getText(), 'UTF-8'));
+    }
+
+    public function testMovingUpOntoALineOfWideCharactersKeepsTheDocumentValid()
+    {
+        $doc = new EditorDocument();
+        $doc->setText("日本\nabcde");
+        $doc->setCursorLine(1);
+        $doc->setCursorCol(4);
+
+        $doc->moveCursorUp();
+        $this->assertSame(3, $doc->getCursorCol());
+
+        $doc->insertText('x');
+        $this->assertTrue(mb_check_encoding($doc->getText(), 'UTF-8'));
+    }
+
+    public function testSetCursorColLandsOnACharacterBoundary()
+    {
+        $doc = new EditorDocument();
+        $doc->setText('日本語');
+
+        foreach ([0 => 0, 1 => 0, 2 => 0, 3 => 3, 4 => 3, 5 => 3, 6 => 6, 99 => 9] as $asked => $expected) {
+            $doc->setCursorCol($asked);
+            $this->assertSame($expected, $doc->getCursorCol(), \sprintf('Column %d snaps to %d.', $asked, $expected));
+        }
+    }
+
+    public function testDeletingALineLandsTheCursorOnACharacterBoundary()
+    {
+        $doc = new EditorDocument();
+        $doc->setText("abcde\n日本\nlast");
+        $doc->setCursorLine(0);
+        $doc->setCursorCol(4);
+
+        $doc->deleteLine();
+
+        $this->assertSame(3, $doc->getCursorCol());
+    }
 }

--- a/src/Symfony/Component/Tui/Tests/Widget/Editor/EditorRendererTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/Editor/EditorRendererTest.php
@@ -164,6 +164,49 @@ class EditorRendererTest extends TestCase
     }
 
     /**
+     * The viewport measures in logical lines and keeps at least one so the
+     * cursor line is drawn; a single line can wrap to more rows than the
+     * editor has.
+     */
+    public function testAWrappedLineDoesNotRenderMoreRowsThanTheEditorHas()
+    {
+        $docLines = [str_repeat('word ', 40), 'second line', 'third line'];
+
+        foreach ([40, 20, 10, 6] as $columns) {
+            foreach ([1, 3, 5] as $maxDisplayRows) {
+                $viewport = [
+                    'scroll_offset' => 0,
+                    'visible_line_count' => 1,
+                    'lines_above' => 0,
+                    'lines_below' => 2,
+                ];
+
+                $lines = $this->renderWithViewport($docLines, $viewport, 0, 0, $columns, $maxDisplayRows);
+
+                // Two frame rows on top of the content.
+                $this->assertLessThanOrEqual($maxDisplayRows + 2, \count($lines), \sprintf('%d columns, %d rows allowed.', $columns, $maxDisplayRows));
+            }
+        }
+    }
+
+    public function testTheCursorStaysOnScreenWhenItsLineIsCutDown()
+    {
+        $docLines = [str_repeat('word ', 40)];
+        $viewport = [
+            'scroll_offset' => 0,
+            'visible_line_count' => 1,
+            'lines_above' => 0,
+            'lines_below' => 0,
+        ];
+
+        // The cursor sits at the very end, which wraps far past the third row.
+        $lines = $this->renderWithViewport($docLines, $viewport, 0, \strlen($docLines[0]) - 1, 10, 3, false, true);
+
+        $this->assertCount(5, $lines);
+        $this->assertStringContainsString(AnsiUtils::CURSOR_MARKER_PREFIX, implode('', $lines), 'The window follows the cursor instead of showing the top of the line.');
+    }
+
+    /**
      * @param string[] $docLines
      *
      * @return string[]

--- a/src/Symfony/Component/Tui/Tests/Widget/Editor/EditorRendererTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/Editor/EditorRendererTest.php
@@ -127,6 +127,43 @@ class EditorRendererTest extends TestCase
     }
 
     /**
+     * The scroll indicator is thirteen columns of its own before any frame is
+     * drawn around it, and a pane can be narrower than that.
+     */
+    public function testTheScrollIndicatorIsCutToTheWidth()
+    {
+        $docLines = ['one', 'two', 'three', 'four', 'five', 'six'];
+        $viewport = [
+            'scroll_offset' => 2,
+            'visible_line_count' => 2,
+            'lines_above' => 2,
+            'lines_below' => 2,
+        ];
+
+        foreach ([40, 14, 13, 12, 8, 5, 1] as $columns) {
+            foreach ($this->renderWithViewport($docLines, $viewport, 2, 0, $columns, 10) as $line) {
+                $this->assertLessThanOrEqual($columns, AnsiUtils::visibleWidth($line), \sprintf('Every row fits in %d columns.', $columns));
+            }
+        }
+    }
+
+    public function testTheScrollIndicatorStillFillsTheFrameWhenItFits()
+    {
+        $docLines = ['one', 'two', 'three', 'four'];
+        $viewport = [
+            'scroll_offset' => 1,
+            'visible_line_count' => 1,
+            'lines_above' => 1,
+            'lines_below' => 2,
+        ];
+
+        $lines = $this->renderWithViewport($docLines, $viewport, 1, 0, 20, 10);
+
+        $this->assertSame('─── ↑ 1 more ───────', AnsiUtils::stripAnsiCodes($lines[0]));
+        $this->assertSame('─── ↓ 2 more ───────', AnsiUtils::stripAnsiCodes($lines[\count($lines) - 1]));
+    }
+
+    /**
      * @param string[] $docLines
      *
      * @return string[]

--- a/src/Symfony/Component/Tui/Widget/Editor/EditorDocument.php
+++ b/src/Symfony/Component/Tui/Widget/Editor/EditorDocument.php
@@ -85,7 +85,7 @@ final class EditorDocument
 
     public function setCursorCol(int $col): void
     {
-        $this->cursorCol = $col;
+        $this->cursorCol = $this->columnOnCurrentLine($col);
     }
 
     public function getKillRing(): KillRing
@@ -253,7 +253,7 @@ final class EditorDocument
             $this->lines = [''];
         }
 
-        $this->cursorCol = min($this->cursorCol, \strlen($this->lines[$this->cursorLine]));
+        $this->cursorCol = $this->columnOnCurrentLine($this->cursorCol);
 
         return true;
     }
@@ -358,7 +358,7 @@ final class EditorDocument
     {
         if ($this->cursorLine > 0) {
             --$this->cursorLine;
-            $this->cursorCol = min($this->cursorCol, \strlen($this->lines[$this->cursorLine]));
+            $this->cursorCol = $this->columnOnCurrentLine($this->cursorCol);
 
             return true;
         }
@@ -370,7 +370,7 @@ final class EditorDocument
     {
         if ($this->cursorLine < \count($this->lines) - 1) {
             ++$this->cursorLine;
-            $this->cursorCol = min($this->cursorCol, \strlen($this->lines[$this->cursorLine]));
+            $this->cursorCol = $this->columnOnCurrentLine($this->cursorCol);
 
             return true;
         }
@@ -661,6 +661,39 @@ final class EditorDocument
 
         $this->cursorLine = $lastLineIndex;
         $this->cursorCol = \strlen($lines[\count($lines) - 1] ?? '');
+    }
+
+    /**
+     * Bring a byte offset onto the current line, and onto a character
+     * boundary within it.
+     *
+     * The cursor is a byte offset into one line, so carrying it to another
+     * line means clamping it to that line's length -- and a length is not a
+     * boundary. Landing between the bytes of a character leaves the next
+     * insert or delete free to cut it in half, which takes the whole document
+     * out of UTF-8.
+     */
+    private function columnOnCurrentLine(int $col): int
+    {
+        $line = $this->lines[$this->cursorLine] ?? '';
+
+        if ($col <= 0) {
+            return 0;
+        }
+
+        if ($col >= $length = \strlen($line)) {
+            return $length;
+        }
+
+        $offset = 0;
+        foreach (grapheme_str_split($line) ?: [] as $grapheme) {
+            if ($offset + \strlen($grapheme) > $col) {
+                return $offset;
+            }
+            $offset += \strlen($grapheme);
+        }
+
+        return $offset;
     }
 
     private function currentLine(): Line

--- a/src/Symfony/Component/Tui/Widget/Editor/EditorDocument.php
+++ b/src/Symfony/Component/Tui/Widget/Editor/EditorDocument.php
@@ -483,8 +483,8 @@ final class EditorDocument
                     grapheme_extract($line, 1, \GRAPHEME_EXTR_COUNT, $nextByteOffset, $nextByteOffset);
                     $idx = strpos($line, $char, $nextByteOffset);
                 } else {
-                    $searchIn = 0 === $this->cursorCol ? false : substr($line, 0, $this->cursorCol);
-                    $idx = false !== $searchIn ? strrpos($searchIn, $char) : false;
+                    $haystack = 0 === $this->cursorCol ? false : substr($line, 0, $this->cursorCol);
+                    $idx = false !== $haystack ? strrpos($haystack, $char) : false;
                 }
             } else {
                 $idx = $isForward ? strpos($line, $char) : strrpos($line, $char);

--- a/src/Symfony/Component/Tui/Widget/Editor/EditorRenderer.php
+++ b/src/Symfony/Component/Tui/Widget/Editor/EditorRenderer.php
@@ -51,13 +51,7 @@ final class EditorRenderer
         $result = [];
 
         // Top border (with scroll indicator if scrolled down)
-        if ($viewport['lines_above'] > 0) {
-            $indicator = "─── ↑ {$viewport['lines_above']} more ";
-            $remaining = $columns - AnsiUtils::visibleWidth($indicator);
-            $result[] = $frameStyle->apply($indicator.str_repeat('─', max(0, $remaining)));
-        } else {
-            $result[] = $frameStyle->apply(str_repeat('─', $columns));
-        }
+        $result[] = $this->renderFrameRow($viewport['lines_above'], '↑', $columns, $frameStyle);
 
         // Render visible lines
         $displayRowsRendered = 0;
@@ -82,15 +76,33 @@ final class EditorRenderer
         }
 
         // Bottom border (with scroll indicator if more content below)
-        if ($viewport['lines_below'] > 0) {
-            $indicator = "─── ↓ {$viewport['lines_below']} more ";
-            $remaining = $columns - AnsiUtils::visibleWidth($indicator);
-            $result[] = $frameStyle->apply($indicator.str_repeat('─', max(0, $remaining)));
-        } else {
-            $result[] = $frameStyle->apply(str_repeat('─', $columns));
-        }
+        $result[] = $this->renderFrameRow($viewport['lines_below'], '↓', $columns, $frameStyle);
 
         return $result;
+    }
+
+    /**
+     * Render one frame row, carrying the count of lines hidden in that
+     * direction when there are any.
+     */
+    private function renderFrameRow(int $hiddenLines, string $arrow, int $columns, Style $frameStyle): string
+    {
+        if ($hiddenLines < 1) {
+            return $frameStyle->apply(str_repeat('─', max(0, $columns)));
+        }
+
+        // The indicator has a width of its own, and a pane can be narrower
+        // than that. Padding it out to the frame is only half the job: what
+        // does not fit has to come off, or the row runs past the box and the
+        // Renderer rejects it.
+        $indicator = \sprintf('─── %s %d more ', $arrow, $hiddenLines);
+        $indicatorWidth = AnsiUtils::visibleWidth($indicator);
+
+        if ($indicatorWidth > $columns) {
+            return $frameStyle->apply(AnsiUtils::truncateToWidth($indicator, $columns, ''));
+        }
+
+        return $frameStyle->apply($indicator.str_repeat('─', $columns - $indicatorWidth));
     }
 
     /**

--- a/src/Symfony/Component/Tui/Widget/Editor/EditorRenderer.php
+++ b/src/Symfony/Component/Tui/Widget/Editor/EditorRenderer.php
@@ -54,17 +54,38 @@ final class EditorRenderer
         $result[] = $this->renderFrameRow($viewport['lines_above'], '↑', $columns, $frameStyle);
 
         // Render visible lines
-        $displayRowsRendered = 0;
+        $contentRows = [];
+        $cursorRow = null;
         for ($i = 0; $i < $viewport['visible_line_count']; ++$i) {
             $lineIndex = $viewport['scroll_offset'] + $i;
             $line = $lines[$lineIndex] ?? '';
             $isCursorLine = $lineIndex === $cursorLine;
 
-            $renderedLines = $this->renderLine($line, $isCursorLine, $cursorCol, $columns, $cursorShape, $focused);
-            foreach ($renderedLines as $renderedLine) {
-                $result[] = $renderedLine;
+            $rendered = $this->renderLine($line, $isCursorLine, $cursorCol, $columns, $cursorShape, $focused);
+            if (null !== $rendered['cursor_row']) {
+                $cursorRow = \count($contentRows) + $rendered['cursor_row'];
             }
-            $displayRowsRendered += \count($renderedLines);
+            foreach ($rendered['lines'] as $renderedLine) {
+                $contentRows[] = $renderedLine;
+            }
+        }
+
+        // The viewport hands back whole logical lines and always keeps at
+        // least one, so the cursor line is drawn even when it wraps to more
+        // rows than the editor was given. Show the window of rows the cursor
+        // is in rather than every one of them, which would run the editor
+        // past its own frame and push whatever is laid out below off screen.
+        if (\count($contentRows) > $maxDisplayRows) {
+            $start = 0;
+            if (null !== $cursorRow && $cursorRow >= $maxDisplayRows) {
+                $start = min($cursorRow - $maxDisplayRows + 1, \count($contentRows) - $maxDisplayRows);
+            }
+            $contentRows = \array_slice($contentRows, $start, $maxDisplayRows);
+        }
+
+        $displayRowsRendered = \count($contentRows);
+        foreach ($contentRows as $contentRow) {
+            $result[] = $contentRow;
         }
 
         // In fill mode, pad with empty rows to fill the allocated space
@@ -108,13 +129,16 @@ final class EditorRenderer
     /**
      * Render a logical line, possibly wrapped into multiple display lines.
      *
-     * @return string[] Array of display lines (one or more if wrapped)
+     * @return array{lines: string[], cursor_row: int|null} The display lines
+     *                                                      (one or more if wrapped), and which of
+     *                                                      them carries the cursor
      */
     private function renderLine(string $line, bool $isCursorLine, int $cursorCol, int $columns, CursorShape $cursorShape, bool $focused): array
     {
         $chunks = TextWrapper::wrapLineIntoChunks($line, $columns);
 
         $result = [];
+        $cursorRow = null;
         $chunkCount = \count($chunks);
 
         foreach ($chunks as $i => $chunk) {
@@ -139,6 +163,7 @@ final class EditorRenderer
             }
 
             if ($hasCursor) {
+                $cursorRow ??= \count($result);
                 $displayLine = $this->renderCursorInChunk($chunkText, $cursorPosInChunk, $columns, $cursorShape, $focused);
             }
 
@@ -149,7 +174,7 @@ final class EditorRenderer
             $result[] = $displayLine.str_repeat(' ', $padding);
         }
 
-        return $result;
+        return ['lines' => $result, 'cursor_row' => $cursorRow];
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

A second batch, found by carrying on with the property fuzzing that produced the first one — one commit per bug, each with a test that fails without its fix. All three are in the editor; the first two are the kind that only show up once the terminal gets narrow, the third corrupts the document.

**Follow-up to #65416**, not a replacement: no commit here touches a line that one changes. The three cherry-pick onto it with a single trivial conflict in `EditorRendererTest.php`, where both batches add tests at the same anchor — keep both. Happy to rebase onto that branch instead if you would rather have them together.

---

**1. The scroll indicator is not cut to the pane width**

The frame row carrying `─── ↓ N more ───` is padded out to the columns the editor was given but never cut down to them. The indicator is thirteen columns before any frame is drawn around it:

```
RenderException: Widget "…\EditorWidget" rendered line 8 with width 13,
exceeding the available 5 columns.
```

An editor beside anything else in a horizontal layout reaches those widths as soon as the terminal is resized down.

**2. The cursor lands between the bytes of a character when it changes line**

The cursor is a byte offset into one line, so carrying it to another means clamping it to that line's length — and a length is not a character boundary:

```php
$doc->setText("abcde\n日本");
$doc->setCursorLine(0);
$doc->setCursorCol(4);
$doc->moveCursorDown();   // line 1, column 4 — inside 本 (bytes 3..5)
$doc->insertText('x');    // the document is no longer UTF-8
```

Everything downstream assumes the text is well formed: `grapheme_str_split()` stops returning the real characters, the width measurements go with it, and the corruption is saved out with the document. `moveCursorUp()`, `moveCursorDown()`, `deleteLine()` and the page-scroll path all went through the same raw clamp, so they now share one that snaps to the start of the character the offset falls in.

**3. A wrapped line ignores the editor's row budget**

The viewport counts whole logical lines against the rows available and always keeps at least one, so the cursor line is drawn even when it does not fit. The renderer then emits every row that line wraps to and nothing weighs them against the budget again:

```
setMaxVisibleLines(5) at 10 columns -> 20 content rows
setMaxVisibleLines(3) at 40 columns ->  5 content rows
```

Rows are not validated the way columns are, so this does not raise — the editor just grows past its own frame and pushes whatever is laid out below it off the screen. The rows are now cut to the budget, taking the window the cursor is in so it stays visible instead of always showing the top of the line.
