### PR TITLE
[Tui] Keep a widget's listeners across detach, and add off() to release them

### DIFF
--- a/src/Symfony/Component/Tui/CHANGELOG.md
+++ b/src/Symfony/Component/Tui/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add `CollapsibleWidget` for collapsible detail/summary panels
+ * Add `AbstractWidget::off()` to remove listeners registered with `AbstractWidget::on()`
  * Add `AnsiUtils::walkCells()` to iterate the cells and escape sequences of a rendered line
  * Add `AnsiUtils::sliceToWidth()` to extract a fixed-width range of columns from a line
  * Add `AbstractWidget::postRender()` to post-process a widget's finished lines, chrome included

--- a/src/Symfony/Component/Tui/Tests/Widget/WidgetTreeTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/WidgetTreeTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Tui\Tests\Widget;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Tui\Event\SubmitEvent;
 use Symfony\Component\Tui\Focus\FocusManager;
 use Symfony\Component\Tui\Input\Keybindings;
 use Symfony\Component\Tui\Render\Renderer;
@@ -154,5 +155,80 @@ class WidgetTreeTest extends TestCase
         $input->handleInput("\r");
 
         $this->assertSame(1, $submits);
+    }
+
+    public function testOffRemovesASingleListener()
+    {
+        $tui = new Tui(terminal: new VirtualTerminal(40, 10));
+        $input = new InputWidget();
+
+        $first = 0;
+        $second = 0;
+        $one = static function () use (&$first) { ++$first; };
+        $two = static function () use (&$second) { ++$second; };
+        $input->on(SubmitEvent::class, $one);
+        $input->on(SubmitEvent::class, $two);
+
+        $tui->add($input);
+        $input->handleInput("\r");
+        $this->assertSame([1, 1], [$first, $second]);
+
+        $input->off(SubmitEvent::class, $one);
+        $input->handleInput("\r");
+
+        $this->assertSame([1, 2], [$first, $second], 'Only the listener that was passed is released.');
+    }
+
+    public function testOffRemovesAFirstClassCallable()
+    {
+        $tui = new Tui(terminal: new VirtualTerminal(40, 10));
+        $input = new InputWidget();
+
+        $counter = new class {
+            public int $count = 0;
+
+            public function increment(): void
+            {
+                ++$this->count;
+            }
+        };
+        $input->on(SubmitEvent::class, $counter->increment(...));
+
+        $tui->add($input);
+        $input->handleInput("\r");
+        $this->assertSame(1, $counter->count);
+
+        $input->off(SubmitEvent::class, $counter->increment(...));
+        $input->handleInput("\r");
+
+        $this->assertSame(1, $counter->count);
+        $this->assertFalse($input->hasListeners(SubmitEvent::class));
+    }
+
+    public function testOffWithoutAListenerRemovesThemAll()
+    {
+        $tui = new Tui(terminal: new VirtualTerminal(40, 10));
+        $input = new InputWidget();
+
+        $submits = 0;
+        $input->onSubmit(static function () use (&$submits) { ++$submits; });
+        $input->onSubmit(static function () use (&$submits) { ++$submits; });
+
+        $tui->add($input);
+        $input->handleInput("\r");
+        $this->assertSame(2, $submits);
+
+        $input->off(SubmitEvent::class);
+        $input->handleInput("\r");
+
+        $this->assertSame(2, $submits);
+    }
+
+    public function testOffIsAcceptedForAnEventTypeThatWasNeverListenedTo()
+    {
+        $input = new InputWidget();
+
+        $this->assertSame($input, $input->off(SubmitEvent::class));
+        $this->assertSame($input, $input->off(SubmitEvent::class, static function () {}));
     }
 }

--- a/src/Symfony/Component/Tui/Tests/Widget/WidgetTreeTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/WidgetTreeTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\Tui\Render\RenderRequestorInterface;
 use Symfony\Component\Tui\Terminal\VirtualTerminal;
 use Symfony\Component\Tui\Tui;
 use Symfony\Component\Tui\Widget\ContainerWidget;
+use Symfony\Component\Tui\Widget\InputWidget;
 use Symfony\Component\Tui\Widget\TextWidget;
 use Symfony\Component\Tui\Widget\WidgetContext;
 use Symfony\Component\Tui\Widget\WidgetTree;
@@ -108,5 +109,50 @@ class WidgetTreeTest extends TestCase
         $this->tree->detach($child);
 
         $this->assertNull($child->getParent());
+    }
+
+    /**
+     * The listeners live on the widget and are dispatched from it, so taking
+     * it out of the tree and putting it back must not unhook them.
+     */
+    public function testListenersSurviveBeingRemovedFromTheTree()
+    {
+        $terminal = new VirtualTerminal(40, 10);
+        $tui = new Tui(terminal: $terminal);
+        $input = new InputWidget();
+
+        $submits = 0;
+        $input->onSubmit(static function () use (&$submits) {
+            ++$submits;
+        });
+
+        $tui->add($input);
+        $input->handleInput("\r");
+        $this->assertSame(1, $submits);
+
+        $tui->remove($input);
+        $tui->add($input);
+        $input->handleInput("\r");
+
+        $this->assertSame(2, $submits);
+    }
+
+    public function testAWidgetOutOfTheTreeStillFiresItsListeners()
+    {
+        $tui = new Tui(terminal: new VirtualTerminal(40, 10));
+        $input = new InputWidget();
+
+        $submits = 0;
+        $input->onSubmit(static function () use (&$submits) {
+            ++$submits;
+        });
+
+        $tui->add($input);
+        $tui->remove($input);
+        $this->assertNull($input->getContext());
+
+        $input->handleInput("\r");
+
+        $this->assertSame(1, $submits);
     }
 }

--- a/src/Symfony/Component/Tui/Widget/AbstractWidget.php
+++ b/src/Symfony/Component/Tui/Widget/AbstractWidget.php
@@ -229,8 +229,10 @@ abstract class AbstractWidget
             $context->getFocusManager()->remove($this);
         }
 
-        $this->listeners = [];
-
+        // The listeners stay. They live on this widget and are dispatched
+        // from it, so there is nothing registered elsewhere to unwind, and
+        // dropping them silently unhooks the callbacks a caller registered
+        // on a widget it still holds and may add back.
         $this->onDetach();
         $this->parent = null;
         $this->context = null;

--- a/src/Symfony/Component/Tui/Widget/AbstractWidget.php
+++ b/src/Symfony/Component/Tui/Widget/AbstractWidget.php
@@ -232,7 +232,8 @@ abstract class AbstractWidget
         // The listeners stay. They live on this widget and are dispatched
         // from it, so there is nothing registered elsewhere to unwind, and
         // dropping them silently unhooks the callbacks a caller registered
-        // on a widget it still holds and may add back.
+        // on a widget it still holds and may add back. Releasing one is the
+        // caller's call to make, through off().
         $this->onDetach();
         $this->parent = null;
         $this->context = null;
@@ -288,7 +289,9 @@ abstract class AbstractWidget
      * Register a listener for a specific event type on this widget.
      *
      * The listener is only called when this specific widget dispatches the event.
-     * Listeners are stored locally on the widget and automatically cleared on detach.
+     * Listeners are stored locally on the widget and live as long as it does:
+     * taking the widget out of the tree and adding it back keeps them. Use
+     * {@see off()} to release one.
      *
      * @param class-string<AbstractEvent> $eventClass The event class to listen for
      * @param callable                    $listener   The listener to invoke
@@ -298,6 +301,44 @@ abstract class AbstractWidget
     final public function on(string $eventClass, callable $listener): static
     {
         $this->listeners[$eventClass][] = $listener;
+
+        return $this;
+    }
+
+    /**
+     * Remove listeners registered on this widget for a specific event type.
+     *
+     * Passing a listener removes every registration of it, comparing by
+     * identity: the callable has to be the one that was passed to {@see on()},
+     * which for an inline closure means the same instance. First-class
+     * callables of the same method on the same object do match. Passing no
+     * listener removes every listener the widget holds for the event class.
+     *
+     * @param class-string<AbstractEvent> $eventClass The event class to stop listening for
+     * @param callable|null               $listener   The listener to remove, or null for all of them
+     *
+     * @return $this
+     */
+    final public function off(string $eventClass, ?callable $listener = null): static
+    {
+        if (null === $listener) {
+            unset($this->listeners[$eventClass]);
+
+            return $this;
+        }
+
+        $remaining = [];
+        foreach ($this->listeners[$eventClass] ?? [] as $registered) {
+            if ($registered !== $listener && !($listener instanceof \Closure && $registered == $listener)) {
+                $remaining[] = $registered;
+            }
+        }
+
+        if ($remaining) {
+            $this->listeners[$eventClass] = $remaining;
+        } else {
+            unset($this->listeners[$eventClass]);
+        }
 
         return $this;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Takes over #65415 by @sadiqk2, whose commit is kept here as it was.

A widget's listeners now belong to whoever registered them, for as long as they want them.

Two changes make that true. Taking a widget out of the tree no longer drops the callbacks registered on
it, so a caller that removes a widget and adds it back keeps its handlers. And `off()` gives the caller
a way to release one, which `on()` never had.

```php
$widget->on(SubmitEvent::class, $listener);

$widget->off(SubmitEvent::class, $listener); // drops that one registration
$widget->off(SubmitEvent::class);            // drops every listener for the event
```

The listener argument is compared the same way as `EventDispatcher::removeListener()`. A first-class
callable of the same method matches even when created twice, so `off(Event::class, $service->handle(...))`
releases what `on(Event::class, $service->handle(...))` registered. An inline closure is only matched by
the same instance: it cannot be removed by passing an identical-looking one, so keep a reference when you
intend to release it later. When the same callable was registered more than once, `off()` removes every
registration of it.
Calling `off()` for an event class that was never listened to does nothing and returns the widget, so it
is safe to call unconditionally.

`off()` only touches the widget's own listeners, the ones registered through `on()` and its typed
wrappers such as `onChange()` and `onSubmit()`. Listeners registered globally through `Tui::on()` live
on the event dispatcher and are unaffected.

Checks run: full `Tui` suite on 8.2 (1773 tests, green), PHP-CS-Fixer clean.

Points for the documentation: `off()` alongside `on()`, the identity comparison and what it means for
inline closures, the no-argument form that drops every listener for an event class, and the fact that
listeners survive a detach so a widget can be moved in the tree without losing its handlers.

