### PR TITLE
[Console] Consume the whole escape sequence when reading autocomplete input

### DIFF
--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -298,6 +298,18 @@ class QuestionHelper extends Helper
                 // Did we read an escape sequence?
                 $c .= fread($inputStream, 2);
 
+                // A CSI sequence ends with a byte in the 0x40-0x7E range, preceded by any number of
+                // parameter and intermediate bytes; consume them all so that none leaks into the answer
+                if ('[' === ($c[1] ?? '')) {
+                    while (($o = \ord($c[\strlen($c) - 1])) >= 0x20 && $o <= 0x3F) {
+                        if (!$next = fread($inputStream, 1)) {
+                            break;
+                        }
+
+                        $c .= $next;
+                    }
+                }
+
                 // A = Up Arrow. B = Down Arrow
                 if (isset($c[2]) && ('A' === $c[2] || 'B' === $c[2])) {
                     if ('A' === $c[2] && -1 === $ofs) {

--- a/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
@@ -223,6 +223,28 @@ class QuestionHelperTest extends AbstractQuestionHelperTestCase
         $this->assertEquals('F⭐Y', $dialog->ask($this->createStreamableInputInterfaceMock($inputStream), $this->createOutputInterface(), $question));
     }
 
+    public function testAskWithAutocompleteIgnoresParameterizedEscapeSequences()
+    {
+        if (!Terminal::hasSttyAvailable()) {
+            $this->markTestSkipped('`stty` is required to test autocomplete functionality');
+        }
+
+        // Zzz<DELETE><NEWLINE>
+        // Zzz<PAGE UP><NEWLINE>
+        // Zzz<CTRL+LEFT><NEWLINE>
+        $inputStream = $this->getInputStream("Zzz\033[3~\nZzz\033[5~\nZzz\033[1;5D\n");
+
+        $dialog = new QuestionHelper();
+        $dialog->setHelperSet(new HelperSet([new FormatterHelper()]));
+
+        $question = new Question('Please select a bundle', 'FrameworkBundle');
+        $question->setAutocompleterValues(['AcmeDemoBundle', 'AsseticBundle', 'SecurityBundle', 'FooBundle']);
+
+        $this->assertSame('Zzz', $dialog->ask($this->createStreamableInputInterfaceMock($inputStream), $this->createOutputInterface(), $question));
+        $this->assertSame('Zzz', $dialog->ask($this->createStreamableInputInterfaceMock($inputStream), $this->createOutputInterface(), $question));
+        $this->assertSame('Zzz', $dialog->ask($this->createStreamableInputInterfaceMock($inputStream), $this->createOutputInterface(), $question));
+    }
+
     public function testAskWithAutocompleteTrimmable()
     {
         if (!Terminal::hasSttyAvailable()) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

When reading input for a question with autocomplete, an escape sequence is read as exactly three bytes:

```php
} elseif ("\033" === $c) {
    $c .= fread($inputStream, 2);
```

That covers arrows (`\e[A`), but not any sequence carrying parameters. Pressing Delete sends `\e[3~`, so `[3` is consumed and `~` stays in the stream, where the next iteration reads it as a normal character and appends it to the answer:

```
input:  Acme<DELETE><ENTER>
answer: "Acme~"
```

The same happens with Page Up and Page Down (`\e[5~`, `\e[6~`) and with modified arrows such as Ctrl+Left (`\e[1;5D`), which leaks `;5D`.

A CSI sequence is `ESC [`, then any number of parameter bytes (0x30-0x3F) and intermediate bytes (0x20-0x2F), terminated by a final byte in the 0x40-0x7E range. This reads to that final byte, so nothing is left behind. Arrow handling is unchanged, since `\e[A` already ends on its final byte.

Spotted while reviewing #64867, which rewrites this loop for other reasons.

Note that the added test only runs where a TTY is available. `Terminal::hasSttyAvailable()` is false on the CI runners, so this test and the 15 other autocomplete tests are skipped there. I verified it under a pty: it fails with `'Zzz~'` before the patch and passes after, and the full `QuestionHelperTest` is green (58 tests, 125 assertions).