### PR TITLE
[Mailer] Add DSN param `timeout` to configure the SMTP connect/read/write timeout

### DIFF
--- a/src/Symfony/Component/Mailer/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add a `rate_limiter` option to mailer transports
+ * Add DSN param `timeout` to configure the connect/read/write timeout of SMTP transports
  * Reorder EsmtpTransport authenticators to prefer PLAIN over obsolete LOGIN
 
 8.0

--- a/src/Symfony/Component/Mailer/Tests/Transport/Smtp/EsmtpTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/Smtp/EsmtpTransportFactoryTest.php
@@ -11,8 +11,10 @@
 
 namespace Symfony\Component\Mailer\Tests\Transport\Smtp;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use Psr\Log\NullLogger;
 use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\Mailer\Exception\InvalidArgumentException;
 use Symfony\Component\Mailer\Test\AbstractTransportFactoryTestCase;
 use Symfony\Component\Mailer\Transport\Dsn;
 use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport;
@@ -158,6 +160,22 @@ class EsmtpTransportFactoryTest extends AbstractTransportFactoryTestCase
             $transport,
         ];
 
+        $transport = new EsmtpTransport('example.com', 465, true, null, $logger);
+        $transport->getStream()->setTimeout(10.0);
+
+        yield [
+            Dsn::fromString('smtps://:@example.com:465?timeout=10'),
+            $transport,
+        ];
+
+        $transport = new EsmtpTransport('example.com', 25, false, null, $logger);
+        $transport->getStream()->setTimeout(2.5);
+
+        yield [
+            Dsn::fromString('smtp://:@example.com:25?timeout=2.5'),
+            $transport,
+        ];
+
         $transport = new EsmtpTransport('example.com', 25, false, null, $logger);
         $transport->setAutoTls(false);
 
@@ -211,5 +229,21 @@ class EsmtpTransportFactoryTest extends AbstractTransportFactoryTestCase
     public static function unsupportedSchemeProvider(): iterable
     {
         yield [new Dsn('null', '')];
+    }
+
+    #[DataProvider('invalidTimeoutProvider')]
+    public function testInvalidTimeout(string $timeout)
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(\sprintf('The "timeout" option is not valid: it must be a positive number of seconds, "%s" given.', $timeout));
+
+        $this->getFactory()->create(Dsn::fromString('smtp://example.com?timeout='.$timeout));
+    }
+
+    public static function invalidTimeoutProvider(): iterable
+    {
+        yield ['0'];
+        yield ['-1'];
+        yield ['abc'];
     }
 }

--- a/src/Symfony/Component/Mailer/Transport/Smtp/EsmtpTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/EsmtpTransportFactory.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Mailer\Transport\Smtp;
 
+use Symfony\Component\Mailer\Exception\InvalidArgumentException;
 use Symfony\Component\Mailer\Exception\UnsupportedSchemeException;
 use Symfony\Component\Mailer\Transport\AbstractTransportFactory;
 use Symfony\Component\Mailer\Transport\Dsn;
@@ -41,6 +42,13 @@ final class EsmtpTransportFactory extends AbstractTransportFactory
         $stream = $transport->getStream();
         if ('' !== $sourceIp = $dsn->getOption('source_ip', '')) {
             $stream->setSourceIp($sourceIp);
+        }
+
+        if (null !== ($timeout = $dsn->getOption('timeout'))) {
+            if (!is_numeric($timeout) || (float) $timeout <= 0) {
+                throw new InvalidArgumentException(\sprintf('The "timeout" option is not valid: it must be a positive number of seconds, "%s" given.', $timeout));
+            }
+            $stream->setTimeout((float) $timeout);
         }
         $streamOptions = $stream->getStreamOptions();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

The SMTP transport currently has no DSN option to configure its timeout: `EsmtpTransportFactory` ignores a `timeout` query param, and `SocketStream` falls back to the `default_socket_timeout` ini value (60s by default). As a result, a consumer hitting a stalled relay can block far longer than intended, with no way to tune it from configuration short of registering a custom transport factory.

This adds a `timeout` DSN param to `smtp://` and `smtps://` transports:

```
smtp://user:pass@relay.example:587?timeout=10
```

The value (a positive number of seconds, fractional values allowed) is passed to `SocketStream::setTimeout()` and thus covers the TCP connect as well as the subsequent read/write operations on the socket. An invalid value (non-numeric, zero or negative) throws an `InvalidArgumentException` with an explicit message instead of silently casting to `0` (which would disable the timeout entirely).
