### PR TITLE
[Cache] Fix Predis ignoring the "auth" parameter set in the DSN or in the options

### DIFF
--- a/src/Symfony/Component/Cache/Tests/Adapter/PredisAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PredisAdapterTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Cache\Tests\Adapter;
 
 use Predis\Connection\StreamConnection;
 use Symfony\Component\Cache\Adapter\RedisAdapter;
+use Symfony\Component\Cache\Exception\InvalidArgumentException;
 
 /**
  * @group integration
@@ -54,6 +55,35 @@ class PredisAdapterTest extends AbstractRedisAdapterTestCase
         }
 
         $this->assertSame($params, $connectionParameters);
+    }
+
+    public function testCreateConnectionWithAuthFromQueryString()
+    {
+        $redisHost = getenv('REDIS_HOST');
+
+        $redis = RedisAdapter::createConnection('redis://'.$redisHost.'/1?auth=p4ssw0rd', ['class' => \Predis\Client::class]);
+
+        $this->assertSame('p4ssw0rd', $redis->getConnection()->getParameters()->toArray()['password'] ?? null);
+    }
+
+    public function testCreateConnectionWithAclAuthFromOptions()
+    {
+        $redisHost = getenv('REDIS_HOST');
+
+        $redis = RedisAdapter::createConnection('redis://'.$redisHost.'/1', ['class' => \Predis\Client::class, 'auth' => ['user', 'p4ssw0rd']]);
+
+        $parameters = $redis->getConnection()->getParameters()->toArray();
+
+        $this->assertSame('user', $parameters['username'] ?? null);
+        $this->assertSame('p4ssw0rd', $parameters['password'] ?? null);
+    }
+
+    public function testCreateConnectionWithAnInvalidAuthShape()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid Redis DSN: the "auth" parameter must be a string, or a list of exactly two elements for ACL, "[username, password]".');
+
+        RedisAdapter::createConnection('redis://'.getenv('REDIS_HOST').'/1?auth[user]=u&auth[pass]=p', ['class' => \Predis\Client::class]);
     }
 
     public function testCreateSslConnection()

--- a/src/Symfony/Component/Cache/Traits/RedisTrait.php
+++ b/src/Symfony/Component/Cache/Traits/RedisTrait.php
@@ -194,6 +194,10 @@ trait RedisTrait
 
         if (!isset($params['redis_sentinel'])) {
             $params['auth'] ??= $auth;
+        }
+
+        if (\is_array($params['auth']) && (!array_is_list($params['auth']) || 2 !== \count($params['auth']))) {
+            throw new InvalidArgumentException('Invalid Redis DSN: the "auth" parameter must be a string, or a list of exactly two elements for ACL, "[username, password]".');
         } elseif (!class_exists(\Predis\Client::class) && !class_exists(\RedisSentinel::class) && !class_exists(Sentinel::class)) {
             throw new CacheException('Redis Sentinel support requires one of: "predis/predis", "ext-redis >= 5.2", "ext-relay".');
         }
@@ -230,7 +234,7 @@ trait RedisTrait
         if ($isRedisExt || $isRelayExt) {
             $connect = $params['persistent'] || $params['persistent_id'] ? 'pconnect' : 'connect';
 
-            $initializer = static function () use ($class, $isRedisExt, $connect, $params, $auth, $hosts, $tls) {
+            $initializer = static function () use ($class, $isRedisExt, $connect, $params, $hosts, $tls) {
                 $sentinelClass = $isRedisExt ? \RedisSentinel::class : Sentinel::class;
                 $redis = new $class();
                 $hostIndex = 0;
@@ -310,7 +314,7 @@ trait RedisTrait
                         $redis->setOption($isRedisExt ? \Redis::OPT_TCP_KEEPALIVE : Relay::OPT_TCP_KEEPALIVE, $params['tcp_keepalive']);
                     }
 
-                    if ((!\defined('Redis::SCAN_PREFIX') && null !== $auth && $isRedisExt && !$redis->auth($auth)) || !$redis->select($params['dbindex'])) {
+                    if ((!\defined('Redis::SCAN_PREFIX') && null !== $params['auth'] && $isRedisExt && !$redis->auth($params['auth'])) || !$redis->select($params['dbindex'])) {
                         $e = preg_replace('/^ERR /', '', $redis->getLastError());
                         throw new InvalidArgumentException('Redis connection failed: '.$e.'.');
                     }
@@ -393,12 +397,12 @@ trait RedisTrait
             if ($params['dbindex']) {
                 $params['parameters']['database'] = $params['dbindex'];
             }
-            if (\is_array($auth)) {
+            if (\is_array($params['auth'])) {
                 // ACL
-                $params['parameters']['username'] = $auth[0];
-                $params['parameters']['password'] = $auth[1];
-            } elseif (null !== $auth) {
-                $params['parameters']['password'] = $auth;
+                $params['parameters']['username'] = $params['auth'][0];
+                $params['parameters']['password'] = $params['auth'][1];
+            } elseif (null !== $params['auth']) {
+                $params['parameters']['password'] = $params['auth'];
             }
 
             if (isset($params['ssl'])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`RedisTrait` resolves credentials into `$params['auth']`, which is filled from the DSN userinfo, from the `auth` query parameter and from the `auth` option. Two code paths ignored that and read the local `$auth` variable instead, which only ever holds the userinfo part:

* the Predis branch, so `?auth=` and the documented `'auth' => ['user', 'password']` option were both silently dropped
* the ext-redis branch for phpredis below 6, where `Redis::SCAN_PREFIX` is not defined and credentials are applied with an explicit `$redis->auth()` call

Both now read `$params['auth']`, so the same DSN authenticates the same way with ext-redis, Relay and Predis, on old and new phpredis alike.

```php
RedisAdapter::createConnection('redis://cache:6379?auth=p4ssw0rd', ['class' => \Predis\Client::class]);
// before: no password set, connection attempted unauthenticated

RedisAdapter::createConnection('redis://cache:6379', ['class' => \Predis\Client::class, 'auth' => ['user', 'p4ssw0rd']]);
// before: neither username nor password set
```

The local `$auth` is now confined to parsing the userinfo, and the connection closure no longer captures it.

While doing that, an `auth` value that is an array of an unexpected shape used to emit `Undefined array key 0` and `Undefined array key 1`, then connect with no credentials at all. It now throws:

```
Invalid Redis DSN: the "auth" parameter must be a string, or a list of exactly two elements for ACL, "[username, password]".
```

The check sits where `auth` is resolved rather than in one branch, so it applies to every client implementation. It is reachable today by writing `?auth[user]=u&auth[pass]=p`, which is the phpredis `session.save_path` spelling, so people do try it.