### PR TITLE
[Security] Reject malformed login link parameters instead of throwing a TypeError

### DIFF
--- a/src/Symfony/Component/Security/Http/LoginLink/LoginLinkHandler.php
+++ b/src/Symfony/Component/Security/Http/LoginLink/LoginLinkHandler.php
@@ -82,6 +82,12 @@ final class LoginLinkHandler implements LoginLinkHandlerInterface
     public function consumeLoginLink(Request $request): UserInterface
     {
         $userIdentifier = $request->get('user');
+        if (null === $userIdentifier || '' === $userIdentifier) {
+            throw new InvalidLoginLinkException('Missing "user" parameter.');
+        }
+        if (!\is_string($userIdentifier)) {
+            throw new InvalidLoginLinkException('Invalid "user" parameter.');
+        }
 
         if (!$hash = $request->get('hash')) {
             throw new InvalidLoginLinkException('Missing "hash" parameter.');
@@ -93,7 +99,7 @@ final class LoginLinkHandler implements LoginLinkHandlerInterface
         if (!$expires = $request->get('expires')) {
             throw new InvalidLoginLinkException('Missing "expires" parameter.');
         }
-        if (!preg_match('/^\d+$/', $expires)) {
+        if (!\is_string($expires) || !preg_match('/^\d+$/', $expires)) {
             throw new InvalidLoginLinkException('Invalid "expires" parameter.');
         }
 

--- a/src/Symfony/Component/Security/Http/Tests/LoginLink/LoginLinkHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/LoginLink/LoginLinkHandlerTest.php
@@ -240,6 +240,36 @@ class LoginLinkHandlerTest extends TestCase
         $linker->consumeLoginLink($request);
     }
 
+    public function testConsumeLoginLinkWithMissingUser()
+    {
+        $this->expectException(InvalidLoginLinkException::class);
+        $this->expectExceptionMessage('Missing "user" parameter.');
+        $request = Request::create('/login/verify?hash=thehash&expires='.(time() + 500));
+
+        $linker = $this->createLinker();
+        $linker->consumeLoginLink($request);
+    }
+
+    public function testConsumeLoginLinkWithArrayUser()
+    {
+        $this->expectException(InvalidLoginLinkException::class);
+        $this->expectExceptionMessage('Invalid "user" parameter.');
+        $request = Request::create('/login/verify?user[]=weaverryan&hash=thehash&expires='.(time() + 500));
+
+        $linker = $this->createLinker();
+        $linker->consumeLoginLink($request);
+    }
+
+    public function testConsumeLoginLinkWithArrayExpiration()
+    {
+        $this->expectException(InvalidLoginLinkException::class);
+        $this->expectExceptionMessage('Invalid "expires" parameter.');
+        $request = Request::create('/login/verify?user=weaverryan&hash=thehash&expires[]=1000000000');
+
+        $linker = $this->createLinker();
+        $linker->consumeLoginLink($request);
+    }
+
     public function testConsumeLoginLinkWithInvalidExpiration()
     {
         $user = new TestLoginLinkHandlerUser('weaverryan', 'ryan@symfonycasts.com', 'pwhash');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`consumeLoginLink()` crashes with a `TypeError` instead of rejecting the link when the request carries malformed parameters:

- `/login/check?user=x&expires[]=1&hash=h` crashes in `preg_match()`; this one is reachable through the standard `check_route` flow, since the authenticator only validates `user` itself, and turns into a 500 response.
- a missing or array `user` parameter crashes in `SignatureHasher::acceptSignatureHash()` for apps that call `consumeLoginLink()` directly, as the docs show.

`Request::get()` returns arrays as-is when the query parameter uses the `foo[]=` syntax, so the existing truthiness checks let them through. This adds the same kind of guards the `hash` parameter already has, throwing `InvalidLoginLinkException` so these requests get the regular invalid-link handling instead of a 500.