### PR TITLE
[WebProfilerBundle] Fix wrongly disabled tabs and toggles that cannot be focused

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
@@ -271,7 +271,7 @@
             </div>
         </div>
 
-        <div class="tab {{ collector.sessionmetadata is empty ? 'disabled' }}">
+        <div class="tab {{ collector.sessionmetadata is empty and collector.sessionusages is empty ? 'disabled' }}">
             <h3 class="tab-title">Session{% if collector.sessionusages is not empty %} <span class="badge">{{ collector.sessionusages|length }}</span>{% endif %}</h3>
 
             <div class="tab-content">

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
@@ -331,7 +331,7 @@
                                     {%- if link %}</a>{% else %}</span>{% endif %}
                                     <div class="text-small font-normal">
                                         {% set usage_id = 'session-usage-trace-' ~ key %}
-                                        <a class="btn btn-link text-small sf-toggle" data-toggle-selector="#{{ usage_id }}" data-toggle-alt-content="Hide trace">Show trace</a>
+                                        <button type="button" class="btn btn-link text-small sf-toggle" data-toggle-selector="#{{ usage_id }}" data-toggle-alt-content="Hide trace">Show trace</button>
                                     </div>
                                     <div id="{{ usage_id }}" class="context sf-toggle-content sf-toggle-hidden">
                                         {{ profiler_dump(usage.trace, maxDepth=2) }}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/serializer.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/serializer.html.twig
@@ -183,7 +183,7 @@
             {% else %}
                 {{ caller.name }}
             {% endif %}
-            line <a class="text-small sf-toggle" data-toggle-selector="#sf-trace-{{ method }}-{{ index }}">{{ caller.line }}</a>
+            line <button type="button" class="btn-link text-small sf-toggle" data-toggle-selector="#sf-trace-{{ method }}-{{ index }}">{{ caller.line }}</button>
         </span>
 
         <div class="sf-serializer-compact hidden" id="sf-trace-{{ method }}-{{ index }}">
@@ -283,7 +283,7 @@
     <span class="nowrap">{{ item.dataType }}</span>
 
     <div>
-        <a class="btn btn-link text-small sf-toggle" data-toggle-selector="#{{ data_id }}" data-toggle-alt-content="Hide contents">Show contents</a>
+        <button type="button" class="btn btn-link text-small sf-toggle" data-toggle-selector="#{{ data_id }}" data-toggle-alt-content="Hide contents">Show contents</button>
         <div id="{{ data_id }}" class="context sf-toggle-content sf-toggle-hidden">
             {{ profiler_dump(item.data) }}
         </div>
@@ -301,7 +301,7 @@
     {% endif %}
 
     <div>
-        <a class="btn btn-link text-small sf-toggle" data-toggle-selector="#{{ context_id }}" data-toggle-alt-content="Hide context">Show context</a>
+        <button type="button" class="btn btn-link text-small sf-toggle" data-toggle-selector="#{{ context_id }}" data-toggle-alt-content="Hide context">Show context</button>
         <div id="{{ context_id }}" class="context sf-toggle-content sf-toggle-hidden">
             {{ profiler_dump(item.context) }}
         </div>
@@ -317,7 +317,7 @@
 
     {% if item.normalization|length > 1 %}
         <div>
-            <a class="btn btn-link text-small sf-toggle" data-toggle-selector="#{{ nested_normalizers_id }}" data-toggle-alt-content="Hide nested normalizers">Show nested normalizers</a>
+            <button type="button" class="btn btn-link text-small sf-toggle" data-toggle-selector="#{{ nested_normalizers_id }}" data-toggle-alt-content="Hide nested normalizers">Show nested normalizers</button>
             <div id="{{ nested_normalizers_id }}" class="context sf-toggle-content sf-toggle-hidden">
                 <ul class="text-small" style="line-height:80%;margin-top:10px">
                     {% for normalizer in item.normalization %}
@@ -338,7 +338,7 @@
 
     {% if item.encoding|length > 1 %}
         <div>
-            <a class="btn btn-link text-small sf-toggle" data-toggle-selector="#{{ nested_encoders_id }}" data-toggle-alt-content="Hide nested encoders">Show nested encoders</a>
+            <button type="button" class="btn btn-link text-small sf-toggle" data-toggle-selector="#{{ nested_encoders_id }}" data-toggle-alt-content="Hide nested encoders">Show nested encoders</button>
             <div id="{{ nested_encoders_id }}" class="context sf-toggle-content sf-toggle-hidden">
                 <ul class="text-small" style="line-height:80%;margin-top:10px">
                     {% for encoder in item.encoding %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -29,7 +29,8 @@
                 tabNavigation.classList.add('tab-navigation');
                 tabNavigation.setAttribute('role', 'tablist');
 
-                let selectedTabId = `tab-${i}-0`; /* select the first tab by default */
+                let selectedTabId = null;
+                let firstEnabledTabId = null;
                 tabs.forEach((tab, j) => {
                     const tabId = `tab-${i}-${j}`;
                     const tabTitle = tab.querySelector('.tab-title').innerHTML;
@@ -42,6 +43,8 @@
                     if (tab.classList.contains('active')) { selectedTabId = tabId; }
                     if (tab.classList.contains('disabled')) {
                         tabNavigationItem.classList.add('disabled');
+                    } else if (null === firstEnabledTabId) {
+                        firstEnabledTabId = tabId;
                     }
                     tabNavigationItem.innerHTML = tabTitle;
                     tabNavigation.appendChild(tabNavigationItem);
@@ -51,6 +54,7 @@
                 });
 
                 tabGroup.insertBefore(tabNavigation, tabGroup.firstChild);
+                selectedTabId = selectedTabId || firstEnabledTabId || `tab-${i}-0`;
                 document.querySelector('[data-tab-id="' + selectedTabId + '"]').classList.add('active');
             });
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Three profiler defects, extracted from #64853 where they sat on top of accessibility work targeting 8.2. The commits are @Nitram1123's, unchanged apart from the resolution against 6.4.

**The Session tab is disabled when the session was used but never started.** `session_metadata` is only collected when `$session->isStarted()`, while session usages are recorded as soon as the session is touched. A visitor with no session cookie, or a stateless route, therefore produces a Session tab that shows a usage badge and cannot be opened:

```
metadata / usages      | before     | after
0 / 0                  | disabled   | disabled
0 / 1                  | disabled   | (clickable)
1 / 0                  | (clickable)| (clickable)
1 / 1                  | (clickable)| (clickable)
```

**A panel can open on a disabled tab.** The default selection was hardcoded to `tab-${i}-0` and only moved when a tab carried the `active` class. The HTTP Client panel builds one tab per client and disables the ones with no traces, so an app whose first configured client made no request opens on a greyed-out tab reading "No requests were made". The Cache and Serializer panels have the same shape. The default now falls back to the first tab that is not disabled, and keeps `tab-${i}-0` when every tab is disabled.

**Six toggles are not reachable by keyboard.** `<a class="sf-toggle">` without an `href` is not focusable and is not announced as a control, so "Show trace" in the Request panel and five toggles in the Serializer panel can only be used with a mouse. They become `<button type="button">`, which the existing `.btn-link` rule already styles the same way.

No test covers these: WebProfilerBundle has no harness that renders collector templates, and `base_js.html.twig` has no JavaScript tests at all. The full bundle suite passes (137 tests, 392 assertions), and the Twig expression change was verified with the table above.
