### PR TITLE
[Tui] Add AnsiUtils::walkCells(), AnsiUtils::sliceToWidth() and AbstractWidget::postRender()

### DIFF
--- a/src/Symfony/Component/Tui/Ansi/AnsiUtils.php
+++ b/src/Symfony/Component/Tui/Ansi/AnsiUtils.php
@@ -509,6 +509,150 @@ final class AnsiUtils
     }
 
     /**
+     * Split a rendered line into escape sequences and visible cells.
+     *
+     * Walks the line in one pass and yields one token per escape sequence
+     * and per grapheme cluster. Concatenating the "text" of every token
+     * gives back the original line, so a caller can rebuild a line while
+     * changing only the cells it cares about: mask a region, recolor a
+     * column, overlay another line cell by cell.
+     *
+     * Each token carries:
+     *
+     *   - "text": the grapheme, or the escape sequence
+     *   - "col": the column the token starts at
+     *   - "width": the display width of the cell, 0 for escape sequences
+     *   - "bg": whether an SGR background is active at this point
+     *
+     * Escape sequences that are not SGR (cursor moves, erase, OSC
+     * hyperlinks, APC markers) never affect "bg" and pass through like any
+     * other zero-width token.
+     *
+     * @return \Generator<int, array{text: string, col: int, width: int, bg: bool}>
+     */
+    public static function walkCells(string $line): \Generator
+    {
+        $i = 0;
+        $col = 0;
+        $len = \strlen($line);
+        $bg = false;
+
+        while ($i < $len) {
+            if ("\x1b" === $line[$i]) {
+                if (null !== $ansi = self::extractAnsiCode($line, $i)) {
+                    $bg = self::sgrSetsBackground($ansi['code'], $bg);
+                    yield ['text' => $ansi['code'], 'col' => $col, 'width' => 0, 'bg' => $bg];
+                    $i += $ansi['length'];
+                    continue;
+                }
+
+                // ESC byte that opens no complete sequence: pass it through
+                yield ['text' => "\x1b", 'col' => $col, 'width' => 0, 'bg' => $bg];
+                ++$i;
+                continue;
+            }
+
+            if (false === $textEnd = strpos($line, "\x1b", $i)) {
+                $textEnd = $len;
+            }
+            $segment = substr($line, $i, $textEnd - $i);
+
+            if (preg_match('/^[\x20-\x7E]*+$/', $segment)) {
+                // ASCII fast path: every byte is one cell of one column
+                for ($j = 0, $segLen = \strlen($segment); $j < $segLen; ++$j) {
+                    yield ['text' => $segment[$j], 'col' => $col, 'width' => 1, 'bg' => $bg];
+                    ++$col;
+                }
+            } elseif (false !== $graphemes = grapheme_str_split($segment)) {
+                foreach ($graphemes as $grapheme) {
+                    $width = "\t" === $grapheme ? self::TAB_WIDTH : self::graphemeWidth($grapheme);
+                    yield ['text' => $grapheme, 'col' => $col, 'width' => $width, 'bg' => $bg];
+                    $col += $width;
+                }
+            } else {
+                // Invalid UTF-8: emit the bytes one by one so the line still rebuilds
+                for ($j = 0, $segLen = \strlen($segment); $j < $segLen; ++$j) {
+                    yield ['text' => $segment[$j], 'col' => $col, 'width' => 1, 'bg' => $bg];
+                    ++$col;
+                }
+            }
+
+            $i = $textEnd;
+        }
+    }
+
+    /**
+     * Extract a range of columns from a line, exactly $length columns wide.
+     *
+     * Unlike sliceByColumn(), the result always measures exactly $length
+     * columns: a wide character cut by a boundary becomes spaces for the
+     * columns that fall inside the range, and a line shorter than the range
+     * is padded with spaces. Adjacent slices of the same line therefore
+     * cover every column exactly once, which is what composing fixed-width
+     * regions out of slices requires.
+     *
+     * Escape sequences before the range are carried into the slice so the
+     * active style is preserved; sequences past the range are dropped.
+     */
+    public static function sliceToWidth(string $line, int $startCol, int $length): string
+    {
+        if ($length <= 0) {
+            return '';
+        }
+
+        // Fast path: pure printable ASCII maps one byte to one column
+        if (!str_contains($line, "\x1b") && preg_match('/^[\x20-\x7E]*+$/', $line)) {
+            return str_pad(substr($line, $startCol, $length), $length);
+        }
+
+        $endCol = $startCol + $length;
+        $result = '';
+        $resultWidth = 0;
+        $pendingAnsi = '';
+
+        foreach (self::walkCells($line) as $token) {
+            if ($token['col'] >= $endCol) {
+                break;
+            }
+
+            if (0 === $token['width']) {
+                if ($token['col'] >= $startCol) {
+                    $result .= $pendingAnsi.$token['text'];
+                    $pendingAnsi = '';
+                } else {
+                    $pendingAnsi .= $token['text'];
+                }
+                continue;
+            }
+
+            $cellEnd = $token['col'] + $token['width'];
+            if ($cellEnd <= $startCol) {
+                continue;
+            }
+
+            $result .= $pendingAnsi;
+            $pendingAnsi = '';
+
+            if ($token['col'] >= $startCol && $cellEnd <= $endCol) {
+                $result .= $token['text'];
+                $resultWidth += $token['width'];
+            } else {
+                // The cell straddles a boundary of the range: it cannot be
+                // split, so its columns inside the range become spaces
+                $overlap = min($cellEnd, $endCol) - max($token['col'], $startCol);
+                $result .= str_repeat(' ', $overlap);
+                $resultWidth += $overlap;
+            }
+        }
+
+        if ($resultWidth < $length) {
+            $result .= str_repeat(' ', $length - $resultWidth);
+        }
+
+        return $result;
+    }
+
+    /**
      * Calculate the display width of a single grapheme in terminal columns.
      *
      * Uses mb_strwidth() for single-codepoint graphemes (fast C-level call),
@@ -654,5 +798,59 @@ final class AnsiUtils
         }
 
         return $result;
+    }
+
+    /**
+     * Parse an SGR sequence to determine the new background-active state.
+     *
+     * Returns true when the sequence sets a background color, false when it
+     * resets it, and $current unchanged for anything that is not an SGR
+     * sequence or does not touch the background.
+     */
+    private static function sgrSetsBackground(string $seq, bool $current): bool
+    {
+        // Only SGR sequences (CSI ... m) touch colors
+        if (\strlen($seq) < 3 || "\x1b[" !== substr($seq, 0, 2) || !str_ends_with($seq, 'm')) {
+            return $current;
+        }
+
+        if ('' === $params = substr($seq, 2, -1)) {
+            return false; // bare ESC [ m is SGR 0, a full reset
+        }
+
+        $state = $current;
+        $parts = explode(';', $params);
+        $count = \count($parts);
+        $idx = 0;
+
+        while ($idx < $count) {
+            $n = (int) $parts[$idx];
+
+            if (38 === $n || 48 === $n || 58 === $n) {
+                // Extended color: N;5;I (256-color) or N;2;R;G;B (truecolor).
+                // Only 48 sets a background, but the payload of 38 (foreground)
+                // and 58 (underline) has to be skipped just the same: a zero
+                // channel would otherwise be read as SGR 0
+                if (48 === $n) {
+                    $state = true;
+                }
+                if ($idx + 1 < $count) {
+                    if ('5' === $parts[$idx + 1]) {
+                        $idx += 2; // skip N and 5; ++$idx below advances past I
+                    } elseif ('2' === $parts[$idx + 1]) {
+                        $idx += 4; // skip N, 2, R and G; ++$idx below advances past B
+                    }
+                }
+            } elseif (0 === $n || 49 === $n) {
+                // SGR 0 (full reset) or SGR 49 (default background)
+                $state = false;
+            } elseif (($n >= 40 && $n <= 47) || ($n >= 100 && $n <= 107)) {
+                // Standard (40-47) and bright (100-107) background colors
+                $state = true;
+            }
+            ++$idx;
+        }
+
+        return $state;
     }
 }

--- a/src/Symfony/Component/Tui/CHANGELOG.md
+++ b/src/Symfony/Component/Tui/CHANGELOG.md
@@ -4,6 +4,10 @@ CHANGELOG
 8.2
 ---
 
+ * Add `AnsiUtils::walkCells()` to iterate the cells and escape sequences of a rendered line
+ * Add `AnsiUtils::sliceToWidth()` to extract a fixed-width range of columns from a line
+ * Add `AbstractWidget::postRender()` to post-process a widget's finished lines, chrome included
+ * Make `LoopClock` part of the public API
  * Reuse unchanged rendered line segments during differential updates
  * Add `AbstractWidget::attachChild()` and `AbstractWidget::detachChild()` to wire child widgets
  * Add multi-select support to `SelectListWidget`

--- a/src/Symfony/Component/Tui/Loop/LoopClock.php
+++ b/src/Symfony/Component/Tui/Loop/LoopClock.php
@@ -16,8 +16,6 @@ namespace Symfony\Component\Tui\Loop;
  *
  * @experimental
  *
- * @internal
- *
  * @author Fabien Potencier <fabien@symfony.com>
  */
 final class LoopClock

--- a/src/Symfony/Component/Tui/Render/Renderer.php
+++ b/src/Symfony/Component/Tui/Render/Renderer.php
@@ -48,6 +48,9 @@ final class Renderer implements WidgetRendererInterface
     private LayoutEngine $layoutEngine;
     private ChromeApplier $chromeApplier;
 
+    /** @var array<class-string, bool> */
+    private array $postRenderOverridden = [];
+
     /** Current terminal columns, set during render() for breakpoint resolution */
     private ?int $currentColumns = null;
 
@@ -154,6 +157,12 @@ final class Renderer implements WidgetRendererInterface
         } else {
             $innerContext = $this->chromeApplier->computeInnerContext($styledContext, $resolvedStyle);
             $lines = $this->chromeApplier->apply(new ArrayLineBuffer($widget->render($innerContext)), $context->getColumns(), $resolvedStyle, $widget);
+        }
+
+        // Reflection once per class: the hook costs nothing to widgets that
+        // do not override it, since only then do the lines need materializing
+        if ($this->postRenderOverridden[$widget::class] ??= AbstractWidget::class !== new \ReflectionMethod($widget, 'postRender')->getDeclaringClass()->name) {
+            $lines = new ArrayLineBuffer($widget->postRender($lines->toArray(), $context));
         }
 
         $this->validateLines($widget, $lines, $context->getColumns());

--- a/src/Symfony/Component/Tui/Tests/Ansi/AnsiUtilsTest.php
+++ b/src/Symfony/Component/Tui/Tests/Ansi/AnsiUtilsTest.php
@@ -588,4 +588,181 @@ class AnsiUtilsTest extends TestCase
         // the space at column 5 must not surface where "京" was dropped.
         $this->assertSame("\x1b[31m東\x1b[0m…", AnsiUtils::truncateToWidth("\x1b[31m東京\x1b[0m OK", 4, '…'));
     }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function walkCellsLosslessProvider(): iterable
+    {
+        yield 'plain ascii' => ['hello world'];
+        yield 'empty string' => [''];
+        yield 'csi colors' => ["\x1b[1;31mred\x1b[0m plain"];
+        yield 'wide characters' => ['日本語テキスト'];
+        yield 'mixed widths' => ["a\x1b[42m日b本\x1b[49mc"];
+        yield 'combining mark' => ["e\u{0301}cole"];
+        yield 'osc 8 hyperlink' => ["\x1b]8;;https://symfony.com\x07link\x1b]8;;\x07 after"];
+        yield 'apc cursor marker' => [AnsiUtils::cursorMarker().'ab'];
+        yield 'tab' => ["a\tb"];
+        yield 'emoji' => ['😀x'];
+        yield 'trailing escape' => ["ab\x1b[0m"];
+        yield 'lone trailing esc byte' => ["ab\x1b"];
+        yield 'charset designation' => ["\x1b(Bab"];
+    }
+
+    #[DataProvider('walkCellsLosslessProvider')]
+    public function testWalkCellsRebuildsTheLine(string $line)
+    {
+        $rebuilt = '';
+        foreach (AnsiUtils::walkCells($line) as $token) {
+            $rebuilt .= $token['text'];
+        }
+
+        $this->assertSame($line, $rebuilt);
+    }
+
+    public function testWalkCellsReportsColumnsAndWidths()
+    {
+        $tokens = iterator_to_array(AnsiUtils::walkCells('a日b'), false);
+
+        $this->assertSame([
+            ['text' => 'a', 'col' => 0, 'width' => 1, 'bg' => false],
+            ['text' => '日', 'col' => 1, 'width' => 2, 'bg' => false],
+            ['text' => 'b', 'col' => 3, 'width' => 1, 'bg' => false],
+        ], $tokens);
+    }
+
+    public function testWalkCellsKeepsACombiningMarkWithItsBase()
+    {
+        $tokens = iterator_to_array(AnsiUtils::walkCells("e\u{0301}c"), false);
+
+        $this->assertSame([
+            ['text' => "e\u{0301}", 'col' => 0, 'width' => 1, 'bg' => false],
+            ['text' => 'c', 'col' => 1, 'width' => 1, 'bg' => false],
+        ], $tokens);
+    }
+
+    public function testWalkCellsYieldsEscapeSequencesAsZeroWidthTokens()
+    {
+        $line = "\x1b]8;;https://symfony.com\x07li\x1b]8;;\x07".AnsiUtils::cursorMarker().'nk';
+        $cells = [];
+        $escapes = 0;
+        foreach (AnsiUtils::walkCells($line) as $token) {
+            if (0 === $token['width']) {
+                ++$escapes;
+                continue;
+            }
+            $cells[] = [$token['text'], $token['col']];
+        }
+
+        $this->assertSame(3, $escapes);
+        $this->assertSame([['l', 0], ['i', 1], ['n', 2], ['k', 3]], $cells);
+    }
+
+    public function testWalkCellsCountsATabAsTabWidthColumns()
+    {
+        $tokens = iterator_to_array(AnsiUtils::walkCells("a\tb"), false);
+
+        $this->assertSame([
+            ['text' => 'a', 'col' => 0, 'width' => 1, 'bg' => false],
+            ['text' => "\t", 'col' => 1, 'width' => AnsiUtils::TAB_WIDTH, 'bg' => false],
+            ['text' => 'b', 'col' => 1 + AnsiUtils::TAB_WIDTH, 'width' => 1, 'bg' => false],
+        ], $tokens);
+    }
+
+    public function testWalkCellsTracksTheActiveBackground()
+    {
+        $line = "a\x1b[41mb\x1b[49mc\x1b[48;2;10;20;30md\x1b[0me\x1b[38;2;0;0;0mf\x1b[107mg\x1b[mh";
+        $bgByCell = [];
+        foreach (AnsiUtils::walkCells($line) as $token) {
+            if (0 !== $token['width']) {
+                $bgByCell[$token['text']] = $token['bg'];
+            }
+        }
+
+        $this->assertSame([
+            'a' => false, // nothing set yet
+            'b' => true,  // standard bg color
+            'c' => false, // SGR 49 resets the background
+            'd' => true,  // truecolor bg
+            'e' => false, // SGR 0 full reset
+            'f' => false, // truecolor fg: the 0 channels are payload, not SGR 0
+            'g' => true,  // bright bg color
+            'h' => false, // bare ESC[m is SGR 0
+        ], $bgByCell);
+    }
+
+    public function testWalkCellsLeavesTheBackgroundUntouchedForNonSgrSequences()
+    {
+        // ESC[2K and ESC[0K are erase sequences, not SGR: their parameters
+        // must not be read as color codes even though 0 would mean a reset
+        $line = "\x1b[41ma\x1b[2Kb\x1b[0Kc\x1b]8;;x\x07d";
+        $bgByCell = [];
+        foreach (AnsiUtils::walkCells($line) as $token) {
+            if (0 !== $token['width']) {
+                $bgByCell[$token['text']] = $token['bg'];
+            }
+        }
+
+        $this->assertSame(['a' => true, 'b' => true, 'c' => true, 'd' => true], $bgByCell);
+    }
+
+    /**
+     * @return iterable<string, array{string, int, int, string}>
+     */
+    public static function sliceToWidthProvider(): iterable
+    {
+        yield 'ascii inner range' => ['abcdef', 1, 3, 'bcd'];
+        yield 'ascii full line' => ['abc', 0, 3, 'abc'];
+        yield 'short line is padded' => ['ab', 0, 5, 'ab   '];
+        yield 'range past the end is spaces' => ['ab', 4, 3, '   '];
+        yield 'zero length' => ['abc', 0, 0, ''];
+        yield 'wide char fully inside' => ['a日b', 1, 2, '日'];
+        yield 'wide char cut at the right edge' => ['a日b', 0, 2, 'a '];
+        yield 'wide char cut at the left edge' => ['a日b', 2, 2, ' b'];
+        yield 'wide char cut on both sides' => ['日本語', 1, 2, '  '];
+        yield 'ansi codes before the range still apply' => ["\x1b[31mabc\x1b[0mdef", 1, 2, "\x1b[31mbc"];
+        yield 'ansi codes inside the range are kept' => ["ab\x1b[31mcd", 1, 2, "b\x1b[31mc"];
+        yield 'tab cut at the right edge' => ["\tx", 0, 2, '  '];
+    }
+
+    #[DataProvider('sliceToWidthProvider')]
+    public function testSliceToWidth(string $line, int $startCol, int $length, string $expected)
+    {
+        $this->assertSame($expected, AnsiUtils::sliceToWidth($line, $startCol, $length));
+    }
+
+    public function testSliceToWidthAlwaysReturnsTheRequestedWidth()
+    {
+        $lines = [
+            '日本語テキスト',
+            'a日b本c語d',
+            "\x1b[31m日本\x1b[42m語テ\x1b[0mキ",
+            '😀😀😀',
+            "e\u{0301}日e\u{0301}本",
+            "ab\tcd日",
+        ];
+
+        foreach ($lines as $line) {
+            $lineWidth = AnsiUtils::visibleWidth($line);
+            for ($startCol = 0; $startCol <= $lineWidth + 2; ++$startCol) {
+                for ($length = 1; $length <= 6; ++$length) {
+                    $slice = AnsiUtils::sliceToWidth($line, $startCol, $length);
+                    $this->assertSame($length, AnsiUtils::visibleWidth($slice), \sprintf('sliceToWidth(%s, %d, %d) returned %s', json_encode($line), $startCol, $length, json_encode($slice)));
+                }
+            }
+        }
+    }
+
+    public function testSlicesToWidthComposeIntoTheFullLine()
+    {
+        // Cutting a line into adjacent fixed-width slices must cover every
+        // column exactly once: this is what a transition or a split-screen
+        // widget relies on to keep neighbouring regions aligned.
+        $line = 'a日b本c';
+        foreach ([1, 2, 3, 4] as $split) {
+            $left = AnsiUtils::sliceToWidth($line, 0, $split);
+            $right = AnsiUtils::sliceToWidth($line, $split, 7 - $split);
+            $this->assertSame(7, AnsiUtils::visibleWidth($left.$right), \sprintf('split at %d', $split));
+        }
+    }
 }

--- a/src/Symfony/Component/Tui/Tests/Render/RendererTest.php
+++ b/src/Symfony/Component/Tui/Tests/Render/RendererTest.php
@@ -1356,6 +1356,88 @@ class RendererTest extends TestCase
         $this->assertSame('        hi', $lines[0]);
         $this->assertTrue($widget->beforeRenderRan);
     }
+    // ---------------------------------------------------------------
+    // postRender hook
+    // ---------------------------------------------------------------
+
+    private static function newPostRenderWidget(): AbstractWidget
+    {
+        return new class extends AbstractWidget {
+            public array $seenLines = [];
+            public int $calls = 0;
+
+            public function render(RenderContext $context): array
+            {
+                return ['ab'];
+            }
+
+            public function postRender(array $lines, RenderContext $context): array
+            {
+                ++$this->calls;
+                $this->seenLines = $lines;
+
+                return array_map(strtoupper(...), $lines);
+            }
+        };
+    }
+
+    public function testPostRenderReceivesTheFinishedBoxAndItsResultIsRendered()
+    {
+        $renderer = new Renderer();
+        $widget = self::newPostRenderWidget();
+        $widget->setStyle(new Style(border: Border::all(1, 'none')));
+        $root = new ContainerWidget();
+        $root->add($widget);
+
+        $frame = implode("\n", $renderer->renderFrame($root, 10, 5)->toArray());
+
+        // The hook saw the box with its border already drawn, not the raw content
+        $this->assertCount(3, $widget->seenLines);
+        $this->assertStringContainsString('ab', $widget->seenLines[1]);
+        $this->assertStringNotContainsString('ab', $widget->seenLines[0]);
+
+        // What the hook returned is what the frame carries
+        $this->assertStringContainsString('AB', $frame);
+        $this->assertStringNotContainsString('ab', $frame);
+    }
+
+    public function testPostRenderResultIsCachedUntilTheWidgetIsInvalidated()
+    {
+        $renderer = new Renderer();
+        $widget = self::newPostRenderWidget();
+        $root = new ContainerWidget();
+        $root->add($widget);
+
+        $renderer->renderFrame($root, 10, 5);
+        $renderer->renderFrame($root, 10, 5);
+        $this->assertSame(1, $widget->calls);
+
+        $widget->invalidate();
+        $renderer->renderFrame($root, 10, 5);
+        $this->assertSame(2, $widget->calls);
+    }
+
+    public function testPostRenderLinesKeepTheWidthContract()
+    {
+        $renderer = new Renderer();
+        $widget = new class extends AbstractWidget {
+            public function render(RenderContext $context): array
+            {
+                return ['ab'];
+            }
+
+            public function postRender(array $lines, RenderContext $context): array
+            {
+                return [str_repeat('x', 100)];
+            }
+        };
+        $root = new ContainerWidget();
+        $root->add($widget);
+
+        $this->expectException(RenderException::class);
+
+        $renderer->renderFrame($root, 10, 5);
+    }
 }
 
 /**

--- a/src/Symfony/Component/Tui/Widget/AbstractWidget.php
+++ b/src/Symfony/Component/Tui/Widget/AbstractWidget.php
@@ -390,6 +390,28 @@ abstract class AbstractWidget
     abstract public function render(RenderContext $context): array;
 
     /**
+     * Post-process the widget's finished lines, chrome included.
+     *
+     * The Renderer calls this with the fully rendered box: content, padding,
+     * border and background are already applied. Override it to rewrite the
+     * box as a whole, e.g. to paint a layer under it, dim it or mask it,
+     * something render() cannot do because chrome is applied after it.
+     *
+     * The result is cached with the render, so a widget that animates its
+     * post-processing must call invalidate() to produce a new frame.
+     *
+     * The width contract of render() applies to the returned lines too.
+     *
+     * @param list<string> $lines One element per terminal row
+     *
+     * @return list<string>
+     */
+    public function postRender(array $lines, RenderContext $context): array
+    {
+        return $lines;
+    }
+
+    /**
      * Makes a widget a child of this one, so it takes part in the render tree.
      *
      * Call it from a widget that owns other widgets, once the child is stored.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

#65130 (transitions) and #65328 (gradients) both hand-roll the same walk over a rendered ANSI line, and both get it wrong in different places: cutting a double-width character loses or gains a column in every transition, and the gradient pass treats OSC 8 hyperlinks and the APC cursor marker as printable text. Discussion in https://github.com/symfony/symfony/pull/65130#issuecomment-5330079668 concluded that the transitions can live outside the component entirely once a small set of primitives exists in core. This PR is that set.

## `AnsiUtils::walkCells()`

One public cell walk, written and tested once. It splits a rendered line into tokens, one per escape sequence and one per grapheme cluster:

```php
foreach (AnsiUtils::walkCells($line) as $token) {
    // $token = ['text' => ..., 'col' => ..., 'width' => ..., 'bg' => ...]
}
```

`width` is 0 for escape sequences. `bg` says whether an SGR background is active at that point, so a compositing pass can let a widget's own background win over a painted layer. Non-SGR sequences (cursor moves, erase, OSC 8, APC) pass through untouched and never affect `bg`. Concatenating the `text` of every token gives back the original line, so a caller can rebuild a line while changing only the cells it cares about.

## `AnsiUtils::sliceToWidth()`

`sliceByColumn()` cannot return exactly the requested number of columns when a wide character straddles a boundary, which is where the width drift in #65130 comes from. `sliceToWidth($line, $startCol, $length)` always returns exactly `$length` columns: a straddled wide character becomes spaces for the columns inside the range, and a short line is padded. Adjacent slices of the same line therefore cover every column exactly once, which is what composing fixed-width regions requires. Escape sequences before the range are carried into the slice so the active style is preserved.

## `AbstractWidget::postRender()`

`render()` cannot touch the widget's own chrome, because padding, border and background are applied after it returns. `postRender(array $lines, RenderContext $context)` is called with the finished box and its result is what the parent receives, so an out-of-tree widget can paint a layer under its own border, dim itself, or mask a region. The result is cached with the render; the Renderer detects the override once per class, so widgets that do not override it pay nothing.

## `LoopClock`

Now public API (the `@internal` annotation is removed). It is the piece that lets an animated widget advance by wall-clock time in production and by an injected `$deltaTime` in tests; without it, every out-of-tree animated widget reimplements the same three lines around `hrtime()`.

With these four, a `tui-transitions` package needs nothing internal: the transitions are pure functions from ANSI lines to ANSI lines over `walkCells()`/`sliceToWidth()`, and `TransitionWidget` is `AbstractWidget` + `ScheduledTickTrait` + `LoopClock`. #65328 will be rebased to build `paintBackground()` on `walkCells()`, which fixes its OSC/APC handling as a side effect.

Checks run: full Tui suite green (1767 tests), php-cs-fixer clean on touched files, and each new test verified to fail against the base source.

## For the documentation

- `walkCells()`: token shape, the lossless-rebuild guarantee, `bg` semantics, escape sequences as zero-width tokens.
- `sliceToWidth()`: exact-width guarantee, spaces for straddled wide characters, style carry-over from before the range.
- `postRender()`: runs on the finished box, result is cached, width contract still applies.
