### PR TITLE
[Yaml] Fix parsing an alias followed by a comment

### DIFF
--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -646,10 +646,11 @@ class Inline
         $scalar = trim($scalar);
 
         if (str_starts_with($scalar, '*')) {
-            if (false !== $pos = strpos($scalar, '#')) {
-                $value = substr($scalar, 1, $pos - 2);
-            } else {
-                $value = substr($scalar, 1);
+            $value = substr($scalar, 1);
+
+            // remove comments
+            if (Parser::preg_match('/[ \t]+#/', $value, $match, \PREG_OFFSET_CAPTURE)) {
+                $value = substr($value, 0, $match[0][1]);
             }
 
             // an unquoted *

--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -259,6 +259,12 @@ class Parser
                     $allowOverwrite = true;
                     if (isset($values['value'][0]) && '*' === $values['value'][0]) {
                         $refName = substr(rtrim($values['value']), 1);
+
+                        // remove comments
+                        if (self::preg_match('/[ \t]+#/', $refName, $match, \PREG_OFFSET_CAPTURE)) {
+                            $refName = substr($refName, 0, $match[0][1]);
+                        }
+
                         if (!\array_key_exists($refName, $this->refs)) {
                             if (false !== $pos = array_search($refName, $this->refsBeingParsed, true)) {
                                 throw new ParseException(\sprintf('Circular reference [%s] detected for reference "%s".', implode(', ', array_merge(\array_slice($this->refsBeingParsed, $pos), [$refName])), $refName), $this->currentLineNb + 1, $this->currentLine, $this->filename);
@@ -738,10 +744,11 @@ class Parser
     private function parseValue(string $value, int $flags, string $context): mixed
     {
         if (str_starts_with($value, '*')) {
-            if (false !== $pos = strpos($value, '#')) {
-                $value = substr($value, 1, $pos - 2);
-            } else {
-                $value = substr($value, 1);
+            $value = substr($value, 1);
+
+            // remove comments
+            if (self::preg_match('/[ \t]+#/', $value, $match, \PREG_OFFSET_CAPTURE)) {
+                $value = substr($value, 0, $match[0][1]);
             }
 
             if (!\array_key_exists($value, $this->refs)) {

--- a/src/Symfony/Component/Yaml/Tests/InlineTest.php
+++ b/src/Symfony/Component/Yaml/Tests/InlineTest.php
@@ -261,6 +261,7 @@ class InlineTest extends TestCase
             'map' => ['{ key: *var }', ['key' => 'var-value']],
             'list-in-map' => ['{ key: [*var] }', ['key' => ['var-value']]],
             'map-in-map' => ['{ foo: { bar: *var } }', ['foo' => ['bar' => 'var-value']]],
+            'map-followed-by-a-comment' => ['{ key: *var  # comment }', ['key' => 'var-value']],
         ];
     }
 

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -1192,6 +1192,24 @@ class ParserTest extends TestCase
         ));
     }
 
+    public function testParseAliasFollowedByAComment()
+    {
+        $this->assertSame([
+            'var' => 'var-value',
+            'scalar' => 'var-value',
+            'list' => ['var-value'],
+            'map' => ['key' => 'var-value', 'other' => 'plain'],
+        ], $this->parser->parse(<<<'EOF'
+            var: &var var-value
+            scalar: *var  # a comment
+            list:
+              - *var   # another comment
+            map: { key: *var,  # a comment inside a flow collection
+              other: plain }
+            EOF
+        ));
+    }
+
     public function testYamlDirective()
     {
         $yaml = <<<'EOF'
@@ -2390,6 +2408,22 @@ class ParserTest extends TestCase
                     param: "some"
                     YAML,
             ],
+            'mixed mapping with inline notation having separated lines with comments' => [
+                [
+                    'map' => [
+                        'key' => 'value',
+                        'a' => 'b',
+                    ],
+                    'param' => 'some',
+                ],
+                <<<YAML
+                    map: {  # a comment
+                        key: "value",  # another comment
+                        a: "b"
+                    }
+                    param: "some"
+                    YAML,
+            ],
             'mixed mapping with compact inline notation on one line' => [
                 [
                     'map' => [
@@ -2910,6 +2944,21 @@ class ParserTest extends TestCase
         ];
 
         $this->assertSame($expected, $this->parser->parse($yaml));
+    }
+
+    public function testParseMergeKeyAliasFollowedByAComment()
+    {
+        $this->assertSame([
+            'base' => ['a' => 'foo'],
+            'derived' => ['a' => 'foo', 'b' => 'bar'],
+        ], $this->parser->parse(<<<'EOF'
+            base: &base
+                a: foo
+            derived:
+                <<: *base # a comment
+                b: bar
+            EOF
+        ));
     }
 
     public function testParseReferencesOnMergeKeysWithMappingsParsedAsObjects()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`Yaml::parse()` throws on an alias followed by a comment when more than one space sits between them.

```yaml
defaults: &defaults
    a: 1
config: *defaults  # two spaces here
```

That gives `Reference "defaults " does not exist`. The alias name is cut at `strpos($value, '#') - 2`, which assumes exactly one whitespace character before the comment. A single space or a single tab work by accident. Two or more spaces fail.

`<<: *defaults # comment` never handled comments at all, so the comment text became part of the reference name. That one fails with a single space too.

Both sites now cut the name at the same whitespace-then-`#` scan that `Inline::parseScalar()` already uses. `Inline::evaluateScalar()` has a copy of the same expression, reached through `Inline::parse()`, and gets the same fix.

Two behavior notes:

- A `#` that is not preceded by whitespace is now part of the reference name, as the spec defines: `*some#name` resolves the anchor `&some#name` instead of failing on a truncated name.
- On a single line, `map: { key: *v  # c }` keeps failing with `Malformed inline YAML string`: the comment runs to the end of the line and swallows the closing brace, so the mapping is unterminated. This is invalid YAML and rejecting it is correct. Comments inside flow collections that close on a later line keep working; tests now pin that behavior.
