### PR TITLE
[Cache] Require cache/integration-tests ^0.18 instead of a pinned commit

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -61,8 +61,9 @@ jobs:
           # update dependencies when the PR changes composer.json so that packages it adds are resolvable
           if ! git diff --quiet "$base_sha" HEAD -- composer.json; then
             export COMPOSER_ROOT_VERSION=$(grep ' VERSION = ' src/Symfony/Component/HttpKernel/Kernel.php | grep -P -o '[0-9]+\.[0-9]+').x-dev
+            rm composer.lock
             composer remove --dev --no-update --no-interaction symfony/phpunit-bridge
-            composer require --no-progress --ansi --no-plugins psalm/phar:@stable phpunit/phpunit:^11.5 php-http/discovery psr/event-dispatcher mongodb/mongodb jetbrains/phpstorm-stubs
+            composer require --no-progress --ansi --no-plugins psalm/phar:@stable phpunit/phpunit:^9.5 php-http/discovery psr/event-dispatcher mongodb/mongodb jetbrains/phpstorm-stubs
           fi
 
       - name: Psalm
@@ -114,8 +115,9 @@ jobs:
           # update dependencies when the PR changes composer.json so that packages it adds are resolvable
           if ! git diff --quiet "$base_sha" HEAD -- composer.json; then
             export COMPOSER_ROOT_VERSION=$(grep ' VERSION = ' src/Symfony/Component/HttpKernel/Kernel.php | grep -P -o '[0-9]+\.[0-9]+').x-dev
+            rm composer.lock
             composer remove --dev --no-update --no-interaction symfony/phpunit-bridge
-            composer require --no-progress --ansi --no-plugins phpstan/phpstan:@stable phpstan/phpstan-deprecation-rules:@stable phpunit/phpunit:^11.5 php-http/discovery psr/event-dispatcher mongodb/mongodb
+            composer require --no-progress --ansi --no-plugins phpstan/phpstan:@stable phpstan/phpstan-deprecation-rules:@stable phpunit/phpunit:^9.5 php-http/discovery psr/event-dispatcher mongodb/mongodb
           fi
 
       - name: PHPStan

--- a/composer.json
+++ b/composer.json
@@ -129,7 +129,7 @@
         "async-aws/ses": "^1.0",
         "async-aws/sqs": "^1.0|^2.0",
         "async-aws/sns": "^1.0",
-        "cache/integration-tests": "2024.09.17",
+        "cache/integration-tests": "^0.18@stable",
         "doctrine/annotations": "^1.13.1|^2",
         "doctrine/collections": "^1.0|^2.0",
         "doctrine/data-fixtures": "^1.1|^2",
@@ -223,21 +223,6 @@
         {
             "type": "path",
             "url": "src/Symfony/Component/Runtime"
-        },
-        {
-            "type": "package",
-            "package": {
-                "name": "cache/integration-tests",
-                "version": "2024.09.17",
-                "source": {
-                    "type": "git",
-                    "url": "https://github.com/php-cache/integration-tests.git",
-                    "reference": "fb7d78718f1e5bbfd7c63e5c5734000999ac7366"
-                },
-                "autoload": {
-                    "psr-4": { "Cache\\IntegrationTests\\": "src/" }
-                }
-            }
         }
     ],
     "minimum-stability": "dev"

--- a/src/Symfony/Component/Cache/composer.json
+++ b/src/Symfony/Component/Cache/composer.json
@@ -29,7 +29,7 @@
         "symfony/var-exporter": "^6.3.6|^7.0"
     },
     "require-dev": {
-        "cache/integration-tests": "2024.09.17",
+        "cache/integration-tests": "^0.18@stable",
         "doctrine/dbal": "^2.13.1|^3|^4",
         "predis/predis": "^1.1|^2.0",
         "psr/simple-cache": "^1.0|^2.0|^3.0",
@@ -55,22 +55,5 @@
             "/Tests/"
         ]
     },
-    "repositories": [
-        {
-            "type": "package",
-            "package": {
-                "name": "cache/integration-tests",
-                "version": "2024.09.17",
-                "source": {
-                    "type": "git",
-                    "url": "https://github.com/php-cache/integration-tests.git",
-                    "reference": "fb7d78718f1e5bbfd7c63e5c5734000999ac7366"
-                },
-                "autoload": {
-                    "psr-4": { "Cache\\IntegrationTests\\": "src/" }
-                }
-            }
-        }
-    ],
     "minimum-stability": "dev"
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues       | -
| License       | MIT

Follow-up to 12821b67cc9, which pinned `cache/integration-tests` to commit `fb7d787` behind a fake `2024.09.17` version after `dev-master` moved to 1.0 and broke our CI (php-cache/integration-tests#123).

Upstream has since tagged `0.18.0` at that exact commit (the compare between the tag and our pinned reference is empty), so the inline package repositories are no longer needed and a regular constraint does the job.

The constraint is `^0.18@stable` rather than `^0.18`: with `minimum-stability: dev` and no `prefer-stable`, plain `^0.18` resolves to `0.18.x-dev` and would track a moving branch again, which is what broke us in the first place. Verified with a dry run: `^0.18` locks `0.18.x-dev fb7d787`, `^0.18@stable` locks `0.18.0`.

6.4 stays on the 0.18 line permanently, for two reasons that no upstream release can lift here:

- 1.x requires PHP 8.2. Five 6.4 jobs resolve dependencies on PHP 8.1: the three static-analysis jobs, the integration-tests job, and the 8.1 unit job, whose `--ignore-platform-req=php+` waives upper bounds only, so the lower bound still fails the solver.
- 1.x initialises its fixtures with `#[Before]` and `#[After]` hooks, which PHPUnit 9.6, pinned on this branch, does not support. Running the suite against 1.0.3 there fails 51 of 56 tests with "Typed property `Cache\IntegrationTests\SimpleCacheTest::$cache` must not be accessed before initialization", whatever the PHP version.

A constraint that splits by platform, `^0.18@stable|^1.0.3@stable`, resolves as intended (0.18.0 on 8.1, 1.0.3 on 8.2 and above) but does not help: these tests are not in the `integration` group, so the jobs on 8.2 and above would run them under PHPUnit 9.6 and fail.

7.4 has neither limitation, and #65431 moves it to `^1.0.3`, without `@stable`, so that branch follows upstream and catches their mistakes early. It will conflict when this one is merged up; the resolution is to keep 7.4's constraint.

Note that the earlier reason given here, the `: void` return types 1.x added to the test methods, no longer applies: upstream reverted them in 1.0.2, and only two private helpers keep them.

---

The first CI run surfaced two latent bugs in the `Switch to PR` path of the static-analysis workflow, which only runs when a PR changes `composer.json` (rare on 6.4, so they went unnoticed). Fixed in the second commit:

- it requires `phpunit/phpunit:^11.5`, which cannot install on the jobs' PHP 8.1; the base install on the same jobs uses `^9.5`. Aligned on `^9.5`.
- `composer require` performs a partial update against the lock file created by the base install, so a *changed* constraint on an already-locked package is rejected ("fixed to 2024.09.17 (lock file version) by a partial update"). The lock is now removed first so the PR's `composer.json` is fully re-resolved; this is what the comment above that block already promises.

Both verified locally by simulating the jobs' resolution with `config.platform.php=8.1.34`: `^11.5` reproduces the CI failure, `^9.5` without a lock resolves and locks `cache/integration-tests 0.18.0`.
