### PR TITLE
[FrameworkBundle][HttpKernel] Allow excluding requests from being profiled

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -30,6 +30,7 @@ CHANGELOG
  * Generate JSON schema for YAML configuration of bundles
  * Add support for rate limited transports
  * Register the security functions `is_granted()`, `is_authenticated()`, `is_fully_authenticated()` and `is_remember_me()` in the validator expression language
+ * Add `framework.profiler.excluded_paths` and `framework.profiler.excluded_http_codes` to skip profiling requests matching a path or answered with a given HTTP status code
 
 8.1
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -390,6 +390,59 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('collect_parameter')->defaultNull()->info('The name of the parameter to use to enable or disable collection on a per request basis.')->end()
                         ->booleanNode('only_exceptions')->defaultFalse()->end()
                         ->booleanNode('only_main_requests')->defaultFalse()->end()
+                        ->arrayNode('excluded_paths', 'excluded_path')
+                            ->info('Regular expressions matched against the url-decoded path info of the requests that must not be profiled. Patterns are case-sensitive and must not contain delimiters.')
+                            ->example(['^/\.well-known/', '^/favicon\.ico$'])
+                            ->acceptAndWrap(['string'])
+                            ->scalarPrototype()->cannotBeEmpty()->end()
+                            ->validate()
+                                ->ifTrue(static fn ($v) => $v && false === @preg_match('{('.implode('|', $v).')}', ''))
+                                ->thenInvalid('Invalid regular expression in the "excluded_paths" option: %s.')
+                            ->end()
+                        ->end()
+                        ->arrayNode('excluded_http_codes', 'excluded_http_code')
+                            ->info('Maps HTTP status codes whose responses must not be profiled to regular expressions restricting each exclusion to matching path infos.')
+                            ->example([404 => null, 400 => ['^/foo', '^/bar']])
+                            ->performNoDeepMerging()
+                            ->acceptAndWrap(['int', 'string'])
+                            ->beforeNormalization()
+                                ->ifArray()
+                                ->then(static function ($v) {
+                                    $map = [];
+                                    foreach ($v as $key => $val) {
+                                        if (\is_int($val) || \is_string($val) && is_numeric($val)) {
+                                            $map[$val] = [];
+                                        } elseif (null === $val || true === $val) {
+                                            $map[$key] = [];
+                                        } elseif (false !== $val) {
+                                            $map[$key] = $val;
+                                        }
+                                    }
+
+                                    return $map;
+                                })
+                            ->end()
+                            ->validate()
+                                ->always(static function ($v) {
+                                    foreach (array_keys($v) as $code) {
+                                        if (!\is_int($code) || 100 > $code || 599 < $code) {
+                                            throw new InvalidConfigurationException(\sprintf('The "excluded_http_codes" option only accepts HTTP status codes between 100 and 599, "%s" given.', $code));
+                                        }
+                                    }
+
+                                    return $v;
+                                })
+                            ->end()
+                            ->arrayPrototype()
+                                ->info('Regular expressions matched against the url-decoded path info that restrict the exclusion of this status code. When empty, every response having that status code is excluded.')
+                                ->acceptAndWrap(['string'])
+                                ->scalarPrototype()->cannotBeEmpty()->end()
+                                ->validate()
+                                    ->ifTrue(static fn ($v) => $v && false === @preg_match('{('.implode('|', $v).')}', ''))
+                                    ->thenInvalid('Invalid regular expression in the "excluded_http_codes" option: %s.')
+                                ->end()
+                            ->end()
+                        ->end()
                         ->scalarNode('dsn')->defaultValue('file:%kernel.cache_dir%/profiler')->end()
                         ->enumNode('collect_serializer_data')
                             ->values([true])

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -97,6 +97,7 @@ use Symfony\Component\HttpKernel\Controller\ArgumentResolver\RequestHeaderValueR
 use Symfony\Component\HttpKernel\Controller\ValueResolverInterface;
 use Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface;
 use Symfony\Component\HttpKernel\EventListener\ControllerAttributesListener;
+use Symfony\Component\HttpKernel\EventListener\ProfilerListener;
 use Symfony\Component\HttpKernel\Log\DebugLoggerConfigurator;
 use Symfony\Component\JsonPath\Attribute\AsJsonPathFunction;
 use Symfony\Component\JsonPath\JsonPathCrawler;
@@ -1018,8 +1019,14 @@ class FrameworkExtension extends Extension
             ->addArgument($config['collect'])
             ->addTag('kernel.reset', ['method' => 'reset']);
 
+        if (($config['excluded_paths'] || $config['excluded_http_codes']) && 8 > (new \ReflectionMethod(ProfilerListener::class, '__construct'))->getNumberOfParameters()) {
+            throw new LogicException('Excluding requests from the profiler cannot be enabled as this version of the HttpKernel component does not support it. Try upgrading "symfony/http-kernel".');
+        }
+
         $container->getDefinition('profiler_listener')
-            ->addArgument($config['collect_parameter']);
+            ->addArgument($config['collect_parameter'])
+            ->addArgument($config['excluded_paths'])
+            ->addArgument($config['excluded_http_codes']);
 
         if (!$container->getParameter('kernel.debug') || !$this->hasConsole() || !$container->has('debug.stopwatch')) {
             $container->removeDefinition('console_profiler_listener');

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -83,6 +83,129 @@ class ConfigurationTest extends TestCase
         ];
     }
 
+    #[DataProvider('provideEquivalentProfilerExclusions')]
+    public function testProfilerExcludedHttpCodesAreNormalized(array $excludedHttpCodes)
+    {
+        $config = (new Processor())->processConfiguration(new Configuration(true), [[
+            'profiler' => ['excluded_http_codes' => $excludedHttpCodes],
+        ]]);
+
+        $this->assertSame([
+            404 => [],
+            400 => ['^/foo', '^/bar'],
+        ], $config['profiler']['excluded_http_codes']);
+    }
+
+    public static function provideEquivalentProfilerExclusions(): iterable
+    {
+        yield 'mapping' => [[404 => null, 400 => ['^/foo', '^/bar']]];
+        yield 'mapping with an explicit empty list' => [[404 => [], 400 => ['^/foo', '^/bar']]];
+        yield 'mapping with true' => [[404 => true, 400 => ['^/foo', '^/bar']]];
+        yield 'mixed forms' => [[404, 400 => ['^/foo', '^/bar']]];
+    }
+
+    public function testProfilerExcludedHttpCodesAcceptsABareStatusCode()
+    {
+        $config = (new Processor())->processConfiguration(new Configuration(true), [[
+            'profiler' => ['excluded_http_codes' => 404],
+        ]]);
+
+        $this->assertSame([404 => []], $config['profiler']['excluded_http_codes']);
+    }
+
+    public function testProfilerExcludedHttpCodesAcceptsASinglePathAsAString()
+    {
+        $config = (new Processor())->processConfiguration(new Configuration(true), [[
+            'profiler' => ['excluded_http_codes' => [404 => '^/foo']],
+        ]]);
+
+        $this->assertSame([404 => ['^/foo']], $config['profiler']['excluded_http_codes']);
+    }
+
+    public function testProfilerExcludedHttpCodesSkipsCodesDisabledWithFalse()
+    {
+        $config = (new Processor())->processConfiguration(new Configuration(true), [[
+            'profiler' => ['excluded_http_codes' => [404 => false, 400 => null]],
+        ]]);
+
+        $this->assertSame([400 => []], $config['profiler']['excluded_http_codes']);
+    }
+
+    public function testProfilerExcludedHttpCodesAreOverriddenAcrossFiles()
+    {
+        $config = (new Processor())->processConfiguration(new Configuration(true), [
+            ['profiler' => ['excluded_http_codes' => [404]]],
+            ['profiler' => ['excluded_http_codes' => [404 => ['^/api']]]],
+        ]);
+
+        $this->assertSame([404 => ['^/api']], $config['profiler']['excluded_http_codes']);
+    }
+
+    public function testProfilerExcludedPathsAcceptsABareRegularExpression()
+    {
+        $config = (new Processor())->processConfiguration(new Configuration(true), [[
+            'profiler' => ['excluded_paths' => '^/\.well-known/'],
+        ]]);
+
+        $this->assertSame(['^/\.well-known/'], $config['profiler']['excluded_paths']);
+    }
+
+    #[DataProvider('provideOutOfRangeHttpCodes')]
+    public function testProfilerExcludedHttpCodesRejectsCodesOutOfRange(int $code, string $message)
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage($message);
+
+        (new Processor())->processConfiguration(new Configuration(true), [[
+            'profiler' => ['excluded_http_codes' => [$code]],
+        ]]);
+    }
+
+    public static function provideOutOfRangeHttpCodes(): iterable
+    {
+        yield 'below the lower bound' => [99, 'only accepts HTTP status codes between 100 and 599, "99" given'];
+        yield 'above the upper bound' => [600, 'only accepts HTTP status codes between 100 and 599, "600" given'];
+        yield 'negative' => [-1, 'only accepts HTTP status codes between 100 and 599, "-1" given'];
+    }
+
+    public function testProfilerExcludedPathsRejectsEmptyPatterns()
+    {
+        $this->expectException(InvalidConfigurationException::class);
+
+        (new Processor())->processConfiguration(new Configuration(true), [[
+            'profiler' => ['excluded_paths' => ['']],
+        ]]);
+    }
+
+    public function testProfilerExcludedHttpCodesRejectsEmptyPathPatterns()
+    {
+        $this->expectException(InvalidConfigurationException::class);
+
+        (new Processor())->processConfiguration(new Configuration(true), [[
+            'profiler' => ['excluded_http_codes' => [404 => ['']]],
+        ]]);
+    }
+
+    public function testProfilerExcludedPathsRejectsInvalidRegularExpressions()
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('Invalid regular expression in the "excluded_paths" option');
+
+        (new Processor())->processConfiguration(new Configuration(true), [[
+            'profiler' => ['excluded_paths' => ['^/foo(']],
+        ]]);
+    }
+
+    public function testProfilerExcludedHttpCodesRejectsInvalidRegularExpressions()
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('Invalid regular expression in the "excluded_http_codes" option');
+
+        (new Processor())->processConfiguration(new Configuration(true), [[
+            'profiler' => ['excluded_http_codes' => [404 => ['^/foo(']]],
+        ]]);
+    }
+
     public function testCacheAppAndDefaultProviderCannotBeCombined()
     {
         $this->expectException(InvalidConfigurationException::class);
@@ -960,6 +1083,8 @@ class ConfigurationTest extends TestCase
                 'enabled' => false,
                 'only_exceptions' => false,
                 'only_main_requests' => false,
+                'excluded_paths' => [],
+                'excluded_http_codes' => [],
                 'dsn' => 'file:%kernel.cache_dir%/profiler',
                 'collect' => true,
                 'collect_parameter' => null,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/profiler_exclusions.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/profiler_exclusions.php
@@ -1,0 +1,12 @@
+<?php
+
+$container->loadFromExtension('framework', [
+    'profiler' => [
+        'enabled' => true,
+        'excluded_paths' => ['^/\.well-known/'],
+        'excluded_http_codes' => [
+            404 => null,
+            400 => ['^/foo', '^/bar'],
+        ],
+    ],
+]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/profiler_exclusions.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/profiler_exclusions.yml
@@ -1,0 +1,8 @@
+framework:
+    profiler:
+        enabled: true
+        excluded_paths:
+            - '^/\.well-known/'
+        excluded_http_codes:
+            404: ~
+            400: ['^/foo', '^/bar']

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -70,6 +70,7 @@ use Symfony\Component\HttpClient\RetryableHttpClient;
 use Symfony\Component\HttpClient\ThrottlingHttpClient;
 use Symfony\Component\HttpFoundation\IpUtils;
 use Symfony\Component\HttpKernel\DependencyInjection\LoggerPass;
+use Symfony\Component\HttpKernel\EventListener\ProfilerListener;
 use Symfony\Component\HttpKernel\EventListener\RateLimitAttributeListener;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
@@ -387,6 +388,20 @@ abstract class FrameworkExtensionTestCase extends TestCase
         $this->assertTrue($container->hasDefinition('profiler'));
         $this->assertTrue($container->hasDefinition('serializer.data_collector'));
         $this->assertTrue($container->hasDefinition('debug.serializer'));
+    }
+
+    public function testProfilerExclusions()
+    {
+        if (8 > (new \ReflectionMethod(ProfilerListener::class, '__construct'))->getNumberOfParameters()) {
+            $this->markTestSkipped('This test requires symfony/http-kernel 8.2 or higher.');
+        }
+
+        $container = $this->createContainerFromFile('profiler_exclusions');
+
+        $definition = $container->getDefinition('profiler_listener');
+
+        $this->assertSame(['^/\.well-known/'], $definition->getArgument(6));
+        $this->assertSame([404 => [], 400 => ['^/foo', '^/bar']], $definition->getArgument(7));
     }
 
     public function testWorkflows()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ProfilerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ProfilerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Component\HttpKernel\EventListener\ProfilerListener;
 
 class ProfilerTest extends AbstractWebTestCase
 {
@@ -53,6 +54,33 @@ class ProfilerTest extends AbstractWebTestCase
 
         $client->request('GET', '/profiler');
         $this->assertNull($client->getProfile());
+    }
+
+    #[DataProvider('getConfigs')]
+    public function testProfilerExclusions($insulate)
+    {
+        if (8 > (new \ReflectionMethod(ProfilerListener::class, '__construct'))->getNumberOfParameters()) {
+            $this->markTestSkipped('This test requires symfony/http-kernel 8.2 or higher.');
+        }
+
+        $client = $this->createClient(['test_case' => 'ProfilerExclusions', 'root_config' => 'config.yml']);
+        if ($insulate) {
+            $client->insulate();
+        }
+
+        // a request whose path matches "excluded_paths" is not profiled and gets no debug token
+        $client->request('GET', '/session');
+        $this->assertNull($client->getProfile());
+        $this->assertFalse($client->getResponse()->headers->has('X-Debug-Token'));
+
+        // a response whose status code matches "excluded_http_codes" is not profiled either
+        $client->request('GET', '/not-found');
+        $this->assertSame(404, $client->getResponse()->getStatusCode());
+        $this->assertNull($client->getProfile());
+
+        // any other request is still profiled
+        $client->request('GET', '/profiler');
+        $this->assertIsObject($client->getProfile());
     }
 
     public static function getConfigs()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ProfilerExclusions/bundles.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ProfilerExclusions/bundles.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\TestBundle;
+
+return [
+    new FrameworkBundle(),
+    new TestBundle(),
+];

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ProfilerExclusions/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ProfilerExclusions/config.yml
@@ -1,0 +1,9 @@
+imports:
+    - { resource: ../config/default.yml }
+
+framework:
+    profiler:
+        enabled: true
+        excluded_paths: ['^/session']
+        excluded_http_codes:
+            404: ~

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ProfilerExclusions/routing.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ProfilerExclusions/routing.yml
@@ -1,0 +1,2 @@
+_sessiontest_bundle:
+    resource: '@TestBundle/Resources/config/routing.yml'

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/config/schema.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/config/schema.json
@@ -574,6 +574,67 @@
                                         "$ref": "#/$defs/types/boolean",
                                         "default": false
                                     },
+                                    "excluded_paths": {
+                                        "anyOf": [
+                                            {
+                                                "$ref": "#/$defs/types/array_null",
+                                                "items": {
+                                                    "$ref": "#/$defs/types/scalar"
+                                                }
+                                            },
+                                            {
+                                                "type": [
+                                                    "string"
+                                                ]
+                                            }
+                                        ],
+                                        "description": "Regular expressions matched against the url-decoded path info of the requests that must not be profiled. Patterns are case-sensitive and must not contain delimiters.",
+                                        "examples": [
+                                            [
+                                                "^/\\.well-known/",
+                                                "^/favicon\\.ico$"
+                                            ]
+                                        ]
+                                    },
+                                    "excluded_http_codes": {
+                                        "anyOf": [
+                                            {
+                                                "$ref": "#/$defs/types/array_null",
+                                                "items": {
+                                                    "anyOf": [
+                                                        {
+                                                            "$ref": "#/$defs/types/array_null",
+                                                            "items": {
+                                                                "$ref": "#/$defs/types/scalar"
+                                                            }
+                                                        },
+                                                        {
+                                                            "type": [
+                                                                "string"
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "description": "Regular expressions matched against the url-decoded path info that restrict the exclusion of this status code. When empty, every response having that status code is excluded."
+                                                }
+                                            },
+                                            {
+                                                "type": [
+                                                    "integer",
+                                                    "string"
+                                                ]
+                                            }
+                                        ],
+                                        "description": "Maps HTTP status codes whose responses must not be profiled to regular expressions restricting each exclusion to matching path infos.",
+                                        "examples": [
+                                            {
+                                                "404": null,
+                                                "400": [
+                                                    "^/foo",
+                                                    "^/bar"
+                                                ]
+                                            }
+                                        ]
+                                    },
                                     "dsn": {
                                         "$ref": "#/$defs/types/scalar",
                                         "default": "file:%kernel.cache_dir%/profiler"
@@ -608,6 +669,8 @@
                             "collect_parameter": null,
                             "only_exceptions": false,
                             "only_main_requests": false,
+                            "excluded_paths": [],
+                            "excluded_http_codes": [],
                             "dsn": "file:%kernel.cache_dir%/profiler",
                             "collect_serializer_data": true
                         },
@@ -1365,6 +1428,12 @@
                                         "default": "%kernel.project_dir%/assets/vendor",
                                         "description": "The directory to store JavaScript vendors."
                                     },
+                                    "minimum_release_age": {
+                                        "$ref": "#/$defs/types/integer",
+                                        "minimum": 0,
+                                        "default": 0,
+                                        "description": "Minimum age in seconds a package version must have to be considered when checking for updates (0 disables the check). Enabling it makes update checks download the full npm metadata document, which is larger than the abbreviated one."
+                                    },
                                     "precompress": {
                                         "anyOf": [
                                             {
@@ -1466,6 +1535,7 @@
                             "importmap_script_attributes": [],
                             "importmap_integrity_algorithms": [],
                             "vendor_dir": "%kernel.project_dir%/assets/vendor",
+                            "minimum_release_age": 0,
                             "precompress": {
                                 "enabled": false,
                                 "formats": [],

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -14,6 +14,7 @@ CHANGELOG
  * Add `SourceValueResolverInterface` to let a value resolver stage a raw value for the resolvers that follow it, so `#[MapQueryParameter]` accepts any type another resolver can build
  * Deprecate the `HIncludeFragmentRenderer` class, use the `EsiFragmentRenderer` or `InlineFragmentRenderer`, or Symfony UX Turbo, instead
  * Allow union and intersection type-hints when autowiring controller arguments
+ * Add the `$excludedPaths` and `$excludedHttpCodes` arguments to `ProfilerListener::__construct()` to skip profiling some requests
 
 8.1
 ---

--- a/src/Symfony/Component/HttpKernel/EventListener/ProfilerListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ProfilerListener.php
@@ -15,6 +15,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestMatcherInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
@@ -37,10 +38,15 @@ class ProfilerListener implements EventSubscriberInterface
     private \SplObjectStorage $profiles;
     /** @var \SplObjectStorage<Request, Request|null> */
     private \SplObjectStorage $parents;
+    private ?string $excludedPathsPattern = null;
+    /** @var array<int, string|null> */
+    private array $excludedHttpCodePatterns = [];
 
     /**
-     * @param bool $onlyException    True if the profiler only collects data when an exception occurs, false otherwise
-     * @param bool $onlyMainRequests True if the profiler only collects data when the request is the main request, false otherwise
+     * @param bool                     $onlyException     True if the profiler only collects data when an exception occurs, false otherwise
+     * @param bool                     $onlyMainRequests  True if the profiler only collects data when the request is the main request, false otherwise
+     * @param list<string>             $excludedPaths     Regular expressions matched against the url-decoded path info of the requests that must not be profiled
+     * @param array<int, list<string>> $excludedHttpCodes Maps HTTP status codes to regular expressions restricting each exclusion to matching path infos; an empty list excludes every response having that status code
      */
     public function __construct(
         private Profiler $profiler,
@@ -49,9 +55,19 @@ class ProfilerListener implements EventSubscriberInterface
         private bool $onlyException = false,
         private bool $onlyMainRequests = false,
         private ?string $collectParameter = null,
+        array $excludedPaths = [],
+        array $excludedHttpCodes = [],
     ) {
         $this->profiles = new \SplObjectStorage();
         $this->parents = new \SplObjectStorage();
+
+        if ($excludedPaths) {
+            $this->excludedPathsPattern = self::compilePattern($excludedPaths, 'excludedPaths');
+        }
+
+        foreach ($excludedHttpCodes as $code => $paths) {
+            $this->excludedHttpCodePatterns[$code] = $paths ? self::compilePattern($paths, 'excludedHttpCodes') : null;
+        }
     }
 
     /**
@@ -80,12 +96,17 @@ class ProfilerListener implements EventSubscriberInterface
         }
 
         $request = $event->getRequest();
-        if (null !== $this->collectParameter && null !== $collectParameterValue = $request->attributes->get($this->collectParameter) ?? $request->query->get($this->collectParameter) ?? $request->request->get($this->collectParameter)) {
-            filter_var($collectParameterValue, \FILTER_VALIDATE_BOOL) ? $this->profiler->enable() : $this->profiler->disable();
-        }
 
         $exception = $this->exception;
         $this->exception = null;
+
+        if ($this->isExcluded($request, $event->getResponse())) {
+            return;
+        }
+
+        if (null !== $this->collectParameter && null !== $collectParameterValue = $request->attributes->get($this->collectParameter) ?? $request->query->get($this->collectParameter) ?? $request->request->get($this->collectParameter)) {
+            filter_var($collectParameterValue, \FILTER_VALIDATE_BOOL) ? $this->profiler->enable() : $this->profiler->disable();
+        }
 
         if (null !== $this->matcher && !$this->matcher->matches($request)) {
             return;
@@ -147,5 +168,40 @@ class ProfilerListener implements EventSubscriberInterface
             KernelEvents::EXCEPTION => ['onKernelException', 0],
             KernelEvents::TERMINATE => ['onKernelTerminate', -1024],
         ];
+    }
+
+    private function isExcluded(Request $request, Response $response): bool
+    {
+        if (null === $this->excludedPathsPattern && !$this->excludedHttpCodePatterns) {
+            return false;
+        }
+
+        $pathInfo = rawurldecode($request->getPathInfo());
+
+        if (null !== $this->excludedPathsPattern && preg_match($this->excludedPathsPattern, $pathInfo)) {
+            return true;
+        }
+
+        if (!\array_key_exists($code = $response->getStatusCode(), $this->excludedHttpCodePatterns)) {
+            return false;
+        }
+
+        $pattern = $this->excludedHttpCodePatterns[$code];
+
+        return null === $pattern || preg_match($pattern, $pathInfo);
+    }
+
+    /**
+     * @param list<string> $regexps
+     */
+    private static function compilePattern(array $regexps, string $argument): string
+    {
+        $pattern = '{('.implode('|', $regexps).')}';
+
+        if (false === @preg_match($pattern, '')) {
+            throw new \LogicException(\sprintf('Invalid regular expression in the "$%s" argument of "%s": "%s".', $argument, self::class, implode('", "', $regexps)));
+        }
+
+        return $pattern;
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/ProfilerListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/ProfilerListenerTest.php
@@ -96,4 +96,184 @@ class ProfilerListenerTest extends TestCase
         $request->attributes->set('profile', true);
         yield [$request, true];
     }
+
+    #[DataProvider('excludedPathsProvider')]
+    public function testExcludedPaths(string $pathInfo, array $excludedPaths, bool $collected)
+    {
+        $this->assertProfileCollected($collected, Request::create($pathInfo), new Response(), $excludedPaths);
+    }
+
+    public static function excludedPathsProvider(): iterable
+    {
+        yield 'no exclusion configured' => ['/', [], true];
+        yield 'the Chrome DevTools probe' => ['/.well-known/appspecific/com.chrome.devtools.json', ['^/\.well-known/'], false];
+        yield 'non-matching path' => ['/api/foo', ['^/\.well-known/'], true];
+        yield 'patterns are case-sensitive' => ['/.WELL-KNOWN/x', ['^/\.well-known/'], true];
+        yield 'patterns are alternated' => ['/bar', ['^/foo', '^/bar'], false];
+        yield 'patterns are not anchored' => ['/a/.well-known/b', ['\.well-known'], false];
+        yield 'the path info is url-decoded' => ['/étape', ['^/étape'], false];
+    }
+
+    #[DataProvider('excludedHttpCodesProvider')]
+    public function testExcludedHttpCodes(int $statusCode, string $pathInfo, array $excludedHttpCodes, bool $collected)
+    {
+        $this->assertProfileCollected($collected, Request::create($pathInfo), new Response('', $statusCode), [], $excludedHttpCodes);
+    }
+
+    public static function excludedHttpCodesProvider(): iterable
+    {
+        yield 'no exclusion configured' => [200, '/', [], true];
+        yield 'matching code' => [404, '/', [404 => []], false];
+        yield 'non-matching code' => [200, '/', [404 => []], true];
+        yield 'other error code' => [500, '/', [404 => []], true];
+        yield 'matching code, non-matching path' => [404, '/foo', [404 => ['^/bar']], true];
+        yield 'matching code and path' => [404, '/bar', [404 => ['^/bar']], false];
+        yield 'paths are case-sensitive' => [404, '/FOO', [404 => ['^/foo']], true];
+        yield 'the second code matches' => [400, '/foo', [404 => [], 400 => ['^/foo']], false];
+    }
+
+    #[DataProvider('exclusionsOfTheDevToolsProbeProvider')]
+    public function testExcludedRequestDoesNotLeakItsExceptionToTheNextRequest(array $excludedPaths, array $excludedHttpCodes)
+    {
+        $profiler = $this->createMock(Profiler::class);
+        $profiler->expects($this->once())
+            ->method('collect')
+            ->with($this->anything(), $this->anything(), $this->isNull())
+            ->willReturn(new Profile('token'));
+
+        $kernel = $this->createStub(HttpKernelInterface::class);
+
+        $excluded = Request::create('/.well-known/appspecific/com.chrome.devtools.json');
+        $next = Request::create('/');
+
+        $requestStack = new RequestStack();
+        $requestStack->push($excluded);
+
+        $listener = new ProfilerListener($profiler, $requestStack, null, false, false, null, $excludedPaths, $excludedHttpCodes);
+
+        $listener->onKernelException(new ExceptionEvent($kernel, $excluded, Kernel::MAIN_REQUEST, new HttpException(404)));
+        $listener->onKernelResponse(new ResponseEvent($kernel, $excluded, Kernel::MAIN_REQUEST, new Response('', 404)));
+
+        $requestStack->pop();
+        $requestStack->push($next);
+        $listener->onKernelResponse(new ResponseEvent($kernel, $next, Kernel::MAIN_REQUEST, new Response()));
+    }
+
+    public static function exclusionsOfTheDevToolsProbeProvider(): iterable
+    {
+        yield 'by path' => [['^/\.well-known/'], []];
+        yield 'by HTTP status code' => [[], [404 => []]];
+    }
+
+    #[DataProvider('collectParameterValueProvider')]
+    public function testExcludedRequestIsNotForcedByTheCollectParameter(string $collectParameterValue)
+    {
+        $profiler = $this->createMock(Profiler::class);
+        $profiler->expects($this->never())->method('collect');
+        $profiler->expects($this->never())->method('enable');
+        $profiler->expects($this->never())->method('disable');
+
+        $request = Request::create('/.well-known/appspecific/com.chrome.devtools.json', 'GET', ['profile' => $collectParameterValue]);
+
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        $listener = new ProfilerListener($profiler, $requestStack, null, false, false, 'profile', ['^/\.well-known/']);
+        $listener->onKernelResponse(new ResponseEvent($this->createStub(HttpKernelInterface::class), $request, Kernel::MAIN_REQUEST, new Response()));
+    }
+
+    public static function collectParameterValueProvider(): iterable
+    {
+        yield 'the parameter cannot enable collection' => ['1'];
+        yield 'the parameter cannot disable the profiler for the next requests' => ['0'];
+    }
+
+    public function testSubRequestsAreExcludedOnTheirOwnPathInfo()
+    {
+        $profiler = $this->createMock(Profiler::class);
+        $profiler->expects($this->once())
+            ->method('collect')
+            ->with($this->callback(static fn (Request $request) => '/' === $request->getPathInfo()))
+            ->willReturn(new Profile('token'));
+
+        $kernel = $this->createStub(HttpKernelInterface::class);
+        $response = new Response();
+
+        $mainRequest = Request::create('/');
+        $subRequest = Request::create('/.well-known/appspecific/com.chrome.devtools.json');
+
+        $requestStack = new RequestStack();
+        $requestStack->push($mainRequest);
+
+        $listener = new ProfilerListener($profiler, $requestStack, null, false, false, null, ['^/\.well-known/']);
+
+        $requestStack->push($subRequest);
+        $listener->onKernelResponse(new ResponseEvent($kernel, $subRequest, Kernel::SUB_REQUEST, $response));
+        $requestStack->pop();
+
+        $listener->onKernelResponse(new ResponseEvent($kernel, $mainRequest, Kernel::MAIN_REQUEST, $response));
+        $listener->onKernelTerminate(new TerminateEvent($kernel, $mainRequest, $response));
+    }
+
+    public function testExcludingTheMainRequestKeepsTheProfilesOfItsSubRequests()
+    {
+        $profile = new Profile('token');
+
+        $profiler = $this->createMock(Profiler::class);
+        $profiler->expects($this->once())
+            ->method('collect')
+            ->with($this->callback(static fn (Request $request) => '/inner' === $request->getPathInfo()))
+            ->willReturn($profile);
+        $profiler->expects($this->once())
+            ->method('saveProfile')
+            ->with($profile);
+
+        $kernel = $this->createStub(HttpKernelInterface::class);
+        $response = new Response();
+
+        $mainRequest = Request::create('/.well-known/appspecific/com.chrome.devtools.json');
+        $subRequest = Request::create('/inner');
+
+        $requestStack = new RequestStack();
+        $requestStack->push($mainRequest);
+
+        $listener = new ProfilerListener($profiler, $requestStack, null, false, false, null, ['^/\.well-known/']);
+
+        $requestStack->push($subRequest);
+        $listener->onKernelResponse(new ResponseEvent($kernel, $subRequest, Kernel::SUB_REQUEST, $response));
+        $requestStack->pop();
+
+        $listener->onKernelResponse(new ResponseEvent($kernel, $mainRequest, Kernel::MAIN_REQUEST, $response));
+        $listener->onKernelTerminate(new TerminateEvent($kernel, $mainRequest, $response));
+    }
+
+    public function testExcludedPathsRejectInvalidRegularExpressions()
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage(\sprintf('Invalid regular expression in the "$excludedPaths" argument of "%s": "^/foo(".', ProfilerListener::class));
+
+        new ProfilerListener($this->createStub(Profiler::class), new RequestStack(), null, false, false, null, ['^/foo(']);
+    }
+
+    public function testExcludedHttpCodesRejectInvalidRegularExpressions()
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage(\sprintf('Invalid regular expression in the "$excludedHttpCodes" argument of "%s": "^/foo(".', ProfilerListener::class));
+
+        new ProfilerListener($this->createStub(Profiler::class), new RequestStack(), null, false, false, null, [], [404 => ['^/foo(']]);
+    }
+
+    private function assertProfileCollected(bool $expected, Request $request, Response $response, array $excludedPaths = [], array $excludedHttpCodes = []): void
+    {
+        $profiler = $this->createMock(Profiler::class);
+        $profiler->expects($expected ? $this->once() : $this->never())
+            ->method('collect')
+            ->willReturn(new Profile('token'));
+
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        $listener = new ProfilerListener($profiler, $requestStack, null, false, false, null, $excludedPaths, $excludedHttpCodes);
+        $listener->onKernelResponse(new ResponseEvent($this->createStub(HttpKernelInterface::class), $request, Kernel::MAIN_REQUEST, $response));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #63795
| License       | MIT

Some requests are noise in the profiler. The one that motivated #63795 is Chrome DevTools polling `/.well-known/appspecific/com.chrome.devtools.json`, which fills the profiler with 404s, but the pattern is general: health checks, `favicon.ico`, monitoring probes.

A previous attempt (#63942) hard-coded the DevTools path in WebProfilerBundle and was rejected: @MatTheCat pointed out that silently hiding 404s stops people from noticing that Symfony handles requests it should not, and @GromNaN preferred not to special-case one client. This PR takes the opposite approach and adds no default exclusion at all. Nothing changes unless the developer opts in explicitly, so the 404s stay visible by default.

Two new options on `framework.profiler`:

```yaml
framework:
    profiler:
        excluded_paths:
            - '^/\.well-known/'
            - '^/favicon\.ico$'
        excluded_http_codes:
            404: ~                      # every 404, whatever the path
            400: ['^/foo', '^/bar']     # only 400s under these paths
            405: '^/api'                # a single path can be given as a string
```

`excluded_paths` holds regular expressions matched against the url-decoded path info. Patterns are case-sensitive and must not contain delimiters. `excluded_http_codes` maps HTTP status codes to an optional list of path patterns: an empty or null list excludes every response carrying that code, and `false` disables an entry. Each option is compiled into a single pattern once in the constructor, so the runtime cost is one `preg_match` per request.

Under the hood this adds the `$excludedPaths` and `$excludedHttpCodes` arguments to `ProfilerListener::__construct()`. `$excludedHttpCodes` is a plain map, so a listener wired by hand takes the same shape as the config: `[404 => [], 400 => ['^/foo']]`. Both arguments are optional and appended last, so no BC break.

An excluded request is dropped before the `collect_parameter` handling, which means an exclusion cannot be overridden by `?collect=1`. Excluding a main request keeps the profiles of its sub-requests, and sub-requests are matched on their own path info. A pending exception on an excluded request is cleared rather than leaked to the next one.

Invalid regular expressions are rejected at config compile time and in the listener constructor, so a typo fails fast instead of silently disabling the profiler.

FrameworkBundle accepts `symfony/http-kernel` down to 6.4, and an older `ProfilerListener` would silently ignore the new arguments. Configuring one of the two options with such a version therefore throws a compile-time exception asking to upgrade `symfony/http-kernel`, following the pattern used by the PGP mailer options.

Documentation PR to follow once the API is agreed.
