### PR TITLE
[FrameworkBundle][WebLink] Add RFC 9264 link sets and the RFC 9652 Link-Template header

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add the `cache.adapter.pdo_tag_aware` cache pool adapter
+ * Register the `web_link.json_linkset_serializer`, `web_link.json_linkset_parser`, `web_link.link_template_header_serializer` and `web_link.link_template_header_parser` services
  * Add `framework.asset_mapper.importmap_integrity_algorithms` option to add integrity metadata to importmaps
  * Add `framework.asset_mapper.minimum_release_age` option to delay JavaScript package updates until a version reaches a minimum age
  * Add `framework.mailer.smime_encrypter.certificates`, `on_missing_certificate` and `encrypt_for_sender` options

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
@@ -410,7 +410,7 @@ abstract class AbstractController implements ServiceSubscriberInterface
     /**
      * Adds a Link HTTP header to the current response.
      *
-     * @see https://tools.ietf.org/html/rfc5988
+     * @see https://www.rfc-editor.org/rfc/rfc8288.html
      */
     protected function addLink(Request $request, LinkInterface $link): void
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerHelper.php
@@ -403,7 +403,7 @@ class ControllerHelper implements ServiceSubscriberInterface
     /**
      * Adds a Link HTTP header to the current response.
      *
-     * @see https://tools.ietf.org/html/rfc5988
+     * @see https://www.rfc-editor.org/rfc/rfc8288.html
      */
     public function addLink(Request $request, LinkInterface $link): void
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/web_link.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/web_link.php
@@ -14,6 +14,10 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 use Symfony\Component\WebLink\EventListener\AddLinkHeaderListener;
 use Symfony\Component\WebLink\HttpHeaderParser;
 use Symfony\Component\WebLink\HttpHeaderSerializer;
+use Symfony\Component\WebLink\JsonLinksetParser;
+use Symfony\Component\WebLink\JsonLinksetSerializer;
+use Symfony\Component\WebLink\LinkTemplateHeaderParser;
+use Symfony\Component\WebLink\LinkTemplateHeaderSerializer;
 
 return static function (ContainerConfigurator $container) {
     $container->services()
@@ -24,9 +28,22 @@ return static function (ContainerConfigurator $container) {
         ->set('web_link.http_header_parser', HttpHeaderParser::class)
         ->alias(HttpHeaderParser::class, 'web_link.http_header_parser')
 
+        ->set('web_link.link_template_header_serializer', LinkTemplateHeaderSerializer::class)
+        ->alias(LinkTemplateHeaderSerializer::class, 'web_link.link_template_header_serializer')
+
+        ->set('web_link.link_template_header_parser', LinkTemplateHeaderParser::class)
+        ->alias(LinkTemplateHeaderParser::class, 'web_link.link_template_header_parser')
+
+        ->set('web_link.json_linkset_serializer', JsonLinksetSerializer::class)
+        ->alias(JsonLinksetSerializer::class, 'web_link.json_linkset_serializer')
+
+        ->set('web_link.json_linkset_parser', JsonLinksetParser::class)
+        ->alias(JsonLinksetParser::class, 'web_link.json_linkset_parser')
+
         ->set('web_link.add_link_header_listener', AddLinkHeaderListener::class)
             ->args([
                 service('web_link.http_header_serializer'),
+                service('web_link.link_template_header_serializer'),
             ])
             ->tag('kernel.event_subscriber')
     ;

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -1066,6 +1066,16 @@ abstract class FrameworkExtensionTestCase extends TestCase
     {
         $container = $this->createContainerFromFile('web_link');
         $this->assertTrue($container->hasDefinition('web_link.add_link_header_listener'));
+        $this->assertTrue($container->hasDefinition('web_link.http_header_serializer'));
+        $this->assertTrue($container->hasDefinition('web_link.http_header_parser'));
+        $this->assertTrue($container->hasDefinition('web_link.link_template_header_serializer'));
+        $this->assertTrue($container->hasDefinition('web_link.link_template_header_parser'));
+        $this->assertTrue($container->hasDefinition('web_link.json_linkset_serializer'));
+        $this->assertTrue($container->hasDefinition('web_link.json_linkset_parser'));
+
+        $listener = $container->getDefinition('web_link.add_link_header_listener');
+        $this->assertSame('web_link.http_header_serializer', (string) $listener->getArgument(0));
+        $this->assertSame('web_link.link_template_header_serializer', (string) $listener->getArgument(1));
     }
 
     public function testMessengerServicesRemovedWhenDisabled()

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -77,7 +77,7 @@
         "symfony/uid": "^7.4|^8.0",
         "symfony/validator": "^7.4|^8.0",
         "symfony/workflow": "^7.4|^8.0",
-        "symfony/web-link": "^7.4|^8.0",
+        "symfony/web-link": "^8.2",
         "symfony/webhook": "^7.4|^8.0",
         "symfony/yaml": "^7.4|^8.0"
     },
@@ -94,6 +94,7 @@
         "symfony/messenger": "<7.4.10|>=8.0,<8.0.10",
         "symfony/mime": "<7.4.9|>=8.0,<8.0.9",
         "symfony/translation": "<7.4",
+        "symfony/web-link": "<8.2",
         "symfony/webhook": "<7.4",
         "symfony/workflow": "<8.2"
     },

--- a/src/Symfony/Component/WebLink/CHANGELOG.md
+++ b/src/Symfony/Component/WebLink/CHANGELOG.md
@@ -1,6 +1,13 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add `JsonLinksetSerializer` and `JsonLinksetParser` to write and read `application/linkset+json` documents (RFC 9264)
+ * Add `LinkTemplateHeaderSerializer` and `LinkTemplateHeaderParser` to write and read `Link-Template` headers (RFC 9652)
+ * Make `AddLinkHeaderListener` send templated links in a `Link-Template` header instead of dropping them
+
 8.1
 ---
 

--- a/src/Symfony/Component/WebLink/EventListener/AddLinkHeaderListener.php
+++ b/src/Symfony/Component/WebLink/EventListener/AddLinkHeaderListener.php
@@ -16,12 +16,14 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\WebLink\HttpHeaderSerializer;
+use Symfony\Component\WebLink\LinkTemplateHeaderSerializer;
 
 // Help opcache.preload discover always-needed symbols
 class_exists(HttpHeaderSerializer::class);
+class_exists(LinkTemplateHeaderSerializer::class);
 
 /**
- * Adds the Link HTTP header to the response.
+ * Adds the Link and Link-Template HTTP headers to the response.
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  *
@@ -31,6 +33,7 @@ class AddLinkHeaderListener implements EventSubscriberInterface
 {
     public function __construct(
         private readonly HttpHeaderSerializer $serializer = new HttpHeaderSerializer(),
+        private readonly LinkTemplateHeaderSerializer $templateSerializer = new LinkTemplateHeaderSerializer(),
     ) {
     }
 
@@ -45,7 +48,15 @@ class AddLinkHeaderListener implements EventSubscriberInterface
             return;
         }
 
-        $event->getResponse()->headers->set('Link', $this->serializer->serialize($links), false);
+        $headers = $event->getResponse()->headers;
+
+        if (null !== $header = $this->serializer->serialize($links)) {
+            $headers->set('Link', $header, false);
+        }
+
+        if (null !== $header = $this->templateSerializer->serialize($links)) {
+            $headers->set('Link-Template', $header, false);
+        }
     }
 
     public static function getSubscribedEvents(): array

--- a/src/Symfony/Component/WebLink/Exception/ExceptionInterface.php
+++ b/src/Symfony/Component/WebLink/Exception/ExceptionInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\WebLink\Exception;
+
+/**
+ * Base interface for all exceptions thrown by the WebLink component.
+ *
+ * @author Florent Morselli <florent.morselli@spomky-labs.com>
+ */
+interface ExceptionInterface extends \Throwable
+{
+}

--- a/src/Symfony/Component/WebLink/Exception/InvalidArgumentException.php
+++ b/src/Symfony/Component/WebLink/Exception/InvalidArgumentException.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\WebLink\Exception;
+
+/**
+ * @author Florent Morselli <florent.morselli@spomky-labs.com>
+ */
+class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface
+{
+}

--- a/src/Symfony/Component/WebLink/HttpHeaderParser.php
+++ b/src/Symfony/Component/WebLink/HttpHeaderParser.php
@@ -16,7 +16,7 @@ use Psr\Link\EvolvableLinkProviderInterface;
 /**
  * Parse a list of HTTP Link headers into a list of Link instances.
  *
- * @see https://tools.ietf.org/html/rfc5988
+ * @see https://www.rfc-editor.org/rfc/rfc8288.html
  *
  * @author Jérôme Tamarelle <jerome@tamarelle.net>
  */

--- a/src/Symfony/Component/WebLink/HttpHeaderSerializer.php
+++ b/src/Symfony/Component/WebLink/HttpHeaderSerializer.php
@@ -16,7 +16,7 @@ use Psr\Link\LinkInterface;
 /**
  * Serializes a list of Link instances to an HTTP Link header.
  *
- * @see https://tools.ietf.org/html/rfc5988
+ * @see https://www.rfc-editor.org/rfc/rfc8288.html
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  */

--- a/src/Symfony/Component/WebLink/JsonLinksetParser.php
+++ b/src/Symfony/Component/WebLink/JsonLinksetParser.php
@@ -1,0 +1,133 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\WebLink;
+
+use Psr\Link\EvolvableLinkProviderInterface;
+use Symfony\Component\WebLink\Exception\InvalidArgumentException;
+
+/**
+ * Parses an "application/linkset+json" document into a list of Link instances.
+ *
+ * The link context of each link context object is carried over to its links as
+ * an "anchor" attribute.
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc9264.html
+ *
+ * @author Florent Morselli <florent.morselli@spomky-labs.com>
+ */
+class JsonLinksetParser
+{
+    /**
+     * @throws InvalidArgumentException When the document does not follow the "application/linkset+json" format
+     */
+    public function parse(string $document): EvolvableLinkProviderInterface
+    {
+        try {
+            $data = json_decode($document, true, 512, \JSON_THROW_ON_ERROR);
+        } catch (\JsonException $e) {
+            throw new InvalidArgumentException('The link set is not a valid JSON document.', previous: $e);
+        }
+
+        if (!\is_array($data) || !\is_array($data['linkset'] ?? null)) {
+            throw new InvalidArgumentException('The link set must be a JSON object holding a "linkset" member.');
+        }
+
+        $links = new GenericLinkProvider();
+
+        foreach ($data['linkset'] as $context) {
+            if (!\is_array($context)) {
+                throw new InvalidArgumentException('Each member of the "linkset" array must be a link context object.');
+            }
+
+            $anchor = $context['anchor'] ?? null;
+            unset($context['anchor']);
+
+            if (null !== $anchor && !\is_string($anchor)) {
+                throw new InvalidArgumentException('The "anchor" member of a link context object must be a string.');
+            }
+
+            foreach ($context as $rel => $targets) {
+                if (!\is_array($targets)) {
+                    throw new InvalidArgumentException(\sprintf('The "%s" member of a link context object must be an array of link target objects.', $rel));
+                }
+
+                foreach ($targets as $target) {
+                    $links = $links->withLink(self::parseTarget((string) $rel, $anchor, $target));
+                }
+            }
+        }
+
+        return $links;
+    }
+
+    private static function parseTarget(string $rel, ?string $anchor, mixed $target): Link
+    {
+        if (!\is_array($target) || !\is_string($target['href'] ?? null)) {
+            throw new InvalidArgumentException(\sprintf('Each link target object of the "%s" relation type must hold an "href" member.', $rel));
+        }
+
+        $link = new Link($rel, $target['href']);
+        unset($target['href']);
+
+        if (null !== $anchor) {
+            $link = $link->withAttribute('anchor', $anchor);
+        }
+
+        foreach ($target as $key => $value) {
+            $link = $link->withAttribute((string) $key, self::parseAttribute((string) $key, $value));
+        }
+
+        return $link;
+    }
+
+    private static function parseAttribute(string $key, mixed $value): string|array
+    {
+        if (!\is_array($value)) {
+            return self::stringify($key, $value);
+        }
+
+        if (str_ends_with($key, '*')) {
+            $values = array_map(static fn ($item) => self::encodeExtendedValue($key, $item), array_is_list($value) ? $value : [$value]);
+        } else {
+            $values = array_map(static fn ($item) => self::stringify($key, $item), array_values($value));
+        }
+
+        return 1 === \count($values) ? $values[0] : $values;
+    }
+
+    /**
+     * Encodes the content and the language tag of an internationalized attribute back to RFC 8187.
+     */
+    private static function encodeExtendedValue(string $key, mixed $item): string
+    {
+        if (!\is_array($item) || !\is_string($item['value'] ?? null)) {
+            throw new InvalidArgumentException(\sprintf('The "%s" target attribute must hold objects with a "value" member.', $key));
+        }
+
+        $language = $item['language'] ?? '';
+
+        if (!\is_string($language)) {
+            throw new InvalidArgumentException(\sprintf('The "language" member of the "%s" target attribute must be a string.', $key));
+        }
+
+        return \sprintf("UTF-8'%s'%s", $language, rawurlencode($item['value']));
+    }
+
+    private static function stringify(string $key, mixed $value): string
+    {
+        if (!\is_scalar($value)) {
+            throw new InvalidArgumentException(\sprintf('The "%s" target attribute must hold string values.', $key));
+        }
+
+        return \is_bool($value) ? ($value ? '1' : '0') : (string) $value;
+    }
+}

--- a/src/Symfony/Component/WebLink/JsonLinksetSerializer.php
+++ b/src/Symfony/Component/WebLink/JsonLinksetSerializer.php
@@ -1,0 +1,141 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\WebLink;
+
+use Psr\Link\LinkInterface;
+use Symfony\Component\WebLink\Exception\InvalidArgumentException;
+
+/**
+ * Serializes a list of Link instances to an "application/linkset+json" document.
+ *
+ * Links are grouped by link context ("anchor" attribute), then by relation type.
+ * Templated links and links without a relation type are skipped, as the format
+ * conveys URI references grouped by relation type.
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc9264.html
+ *
+ * @author Florent Morselli <florent.morselli@spomky-labs.com>
+ */
+class JsonLinksetSerializer
+{
+    /**
+     * Target attributes that RFC 8288 defines as non-repeatable strings.
+     */
+    private const SINGLE_VALUED_ATTRIBUTES = ['media', 'title', 'type'];
+
+    /**
+     * Builds an "application/linkset+json" document.
+     *
+     * @param LinkInterface[]|\Traversable $links
+     * @param int                          $flags Bitmask of json_encode() options
+     *
+     * @throws InvalidArgumentException When a link has the "anchor" relation type or when the links cannot be encoded to JSON
+     */
+    public function serialize(iterable $links, int $flags = 0): string
+    {
+        $contexts = [];
+
+        foreach ($links as $link) {
+            if ($link->isTemplated()) {
+                continue;
+            }
+
+            $attributes = $link->getAttributes();
+            $anchor = $attributes['anchor'] ?? null;
+            unset($attributes['anchor']);
+
+            if (\is_array($anchor)) {
+                $anchor = [] === $anchor ? null : $anchor[array_key_first($anchor)];
+            }
+            $anchor = null === $anchor || false === $anchor ? null : self::stringify($anchor);
+
+            $target = ['href' => $link->getHref()] + self::serializeAttributes($attributes);
+
+            $context = null === $anchor ? '' : "\0".$anchor;
+
+            foreach ($link->getRels() as $rel) {
+                if ('anchor' === $rel) {
+                    throw new InvalidArgumentException('A link with the "anchor" relation type cannot be represented in an "application/linkset+json" document.');
+                }
+
+                $contexts[$context]['anchor'] = $anchor;
+                $contexts[$context]['rels'][$rel][] = $target;
+            }
+        }
+
+        $linkset = [];
+        foreach ($contexts as $context) {
+            $linkset[] = (null === $context['anchor'] ? [] : ['anchor' => $context['anchor']]) + $context['rels'];
+        }
+
+        try {
+            return json_encode(['linkset' => $linkset], \JSON_THROW_ON_ERROR | $flags);
+        } catch (\JsonException $e) {
+            throw new InvalidArgumentException(\sprintf('The link set cannot be serialized to JSON: "%s".', $e->getMessage()), previous: $e);
+        }
+    }
+
+    /**
+     * @param array<string, scalar|\Stringable|list<scalar|\Stringable>> $attributes
+     */
+    private static function serializeAttributes(array $attributes): array
+    {
+        $target = [];
+
+        foreach ($attributes as $key => $value) {
+            if (false === $value) {
+                continue;
+            }
+
+            $values = \is_array($value) ? array_values($value) : [$value];
+
+            if (str_ends_with($key, '*')) {
+                $target[$key] = array_map(self::decodeExtendedValue(...), $values);
+
+                continue;
+            }
+
+            if (\in_array($key, self::SINGLE_VALUED_ATTRIBUTES, true)) {
+                $target[$key] = self::stringify($values[0] ?? '');
+
+                continue;
+            }
+
+            $target[$key] = array_map(self::stringify(...), $values);
+        }
+
+        return $target;
+    }
+
+    /**
+     * Splits an RFC 8187 encoded value into its unescaped content and its language tag.
+     */
+    private static function decodeExtendedValue(mixed $value): array
+    {
+        $value = self::stringify($value);
+        $parts = explode("'", $value, 3);
+
+        if (3 !== \count($parts)) {
+            return ['value' => $value];
+        }
+
+        [, $language, $encoded] = $parts;
+        $decoded = rawurldecode($encoded);
+
+        return '' === $language ? ['value' => $decoded] : ['value' => $decoded, 'language' => $language];
+    }
+
+    private static function stringify(mixed $value): string
+    {
+        return true === $value ? '' : (string) $value;
+    }
+}

--- a/src/Symfony/Component/WebLink/LinkTemplateHeaderParser.php
+++ b/src/Symfony/Component/WebLink/LinkTemplateHeaderParser.php
@@ -1,0 +1,266 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\WebLink;
+
+use Psr\Link\EvolvableLinkProviderInterface;
+use Symfony\Component\WebLink\Exception\InvalidArgumentException;
+
+/**
+ * Parses a list of HTTP Link-Template headers into a list of Link instances.
+ *
+ * As mandated by RFC 9651 for structured fields, a header value that cannot be
+ * parsed is ignored as a whole and yields an empty list of links.
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc9652.html
+ *
+ * @author Florent Morselli <florent.morselli@spomky-labs.com>
+ */
+class LinkTemplateHeaderParser
+{
+    /**
+     * @param string|string[] $headers Value of the "Link-Template" HTTP header
+     */
+    public function parse(string|array $headers): EvolvableLinkProviderInterface
+    {
+        if (\is_array($headers)) {
+            $headers = implode(', ', $headers);
+        }
+
+        try {
+            return self::parseList($headers);
+        } catch (InvalidArgumentException) {
+            return new GenericLinkProvider();
+        }
+    }
+
+    private static function parseList(string $input): GenericLinkProvider
+    {
+        $links = new GenericLinkProvider();
+        $offset = 0;
+        self::skipSp($input, $offset);
+
+        if ($offset >= \strlen($input)) {
+            return $links;
+        }
+
+        while (true) {
+            $href = match ($input[$offset] ?? null) {
+                '"' => self::parseString($input, $offset),
+                '%' => self::parseDisplayString($input, $offset),
+                default => throw new InvalidArgumentException('A Link-Template member must be a structured field string.'),
+            };
+
+            $link = new Link(null, $href);
+
+            foreach (self::parseParameters($input, $offset) as $key => $value) {
+                if ('rel' === $key) {
+                    if (\is_string($value)) {
+                        foreach (preg_split('/\s+/', $value, 0, \PREG_SPLIT_NO_EMPTY) as $rel) {
+                            $link = $link->withRel($rel);
+                        }
+                    }
+
+                    continue;
+                }
+
+                $link = $link->withAttribute($key, $value);
+            }
+
+            $links = $links->withLink($link);
+
+            self::skipOws($input, $offset);
+
+            if ($offset >= \strlen($input)) {
+                return $links;
+            }
+
+            if (',' !== $input[$offset]) {
+                throw new InvalidArgumentException('Expected a comma between Link-Template members.');
+            }
+
+            ++$offset;
+            self::skipOws($input, $offset);
+
+            if ($offset >= \strlen($input)) {
+                throw new InvalidArgumentException('The Link-Template header must not end with a trailing comma.');
+            }
+        }
+    }
+
+    /**
+     * @return array<string, string|int|float|bool>
+     */
+    private static function parseParameters(string $input, int &$offset): array
+    {
+        $parameters = [];
+
+        while (';' === ($input[$offset] ?? null)) {
+            ++$offset;
+            self::skipSp($input, $offset);
+
+            if (!preg_match('/[a-z*][a-z0-9_.*-]*/A', $input, $matches, 0, $offset)) {
+                throw new InvalidArgumentException('Expected a structured field parameter key.');
+            }
+
+            $offset += \strlen($matches[0]);
+            $value = true;
+
+            if ('=' === ($input[$offset] ?? null)) {
+                ++$offset;
+                $value = self::parseBareItem($input, $offset);
+            }
+
+            $parameters[$matches[0]] = $value;
+        }
+
+        return $parameters;
+    }
+
+    private static function parseBareItem(string $input, int &$offset): string|int|float|bool
+    {
+        return match (true) {
+            !isset($input[$offset]) => throw new InvalidArgumentException('Unexpected end of the Link-Template header.'),
+            '"' === $input[$offset] => self::parseString($input, $offset),
+            '%' === $input[$offset] => self::parseDisplayString($input, $offset),
+            '?' === $input[$offset] => self::parseBoolean($input, $offset),
+            '-' === $input[$offset] || ctype_digit($input[$offset]) => self::parseNumber($input, $offset),
+            '*' === $input[$offset] || ctype_alpha($input[$offset]) => self::parseToken($input, $offset),
+            default => throw new InvalidArgumentException(\sprintf('Unexpected "%s" character in the Link-Template header.', $input[$offset])),
+        };
+    }
+
+    private static function parseString(string $input, int &$offset): string
+    {
+        ++$offset;
+        $output = '';
+
+        while (isset($input[$offset])) {
+            $char = $input[$offset++];
+
+            if ('\\' === $char) {
+                if (!isset($input[$offset])) {
+                    throw new InvalidArgumentException('Unterminated escape sequence in the Link-Template header.');
+                }
+
+                $next = $input[$offset++];
+
+                if ('"' !== $next && '\\' !== $next) {
+                    throw new InvalidArgumentException('Invalid escape sequence in the Link-Template header.');
+                }
+
+                $output .= $next;
+
+                continue;
+            }
+
+            if ('"' === $char) {
+                return $output;
+            }
+
+            if (0x20 > \ord($char) || 0x7E < \ord($char)) {
+                throw new InvalidArgumentException('A structured field string must hold printable ASCII characters only.');
+            }
+
+            $output .= $char;
+        }
+
+        throw new InvalidArgumentException('Unterminated string in the Link-Template header.');
+    }
+
+    private static function parseDisplayString(string $input, int &$offset): string
+    {
+        if ('%"' !== substr($input, $offset, 2)) {
+            throw new InvalidArgumentException('Expected a structured field display string.');
+        }
+
+        $offset += 2;
+        $output = '';
+
+        while (isset($input[$offset])) {
+            $char = $input[$offset++];
+
+            if (0x20 > \ord($char) || 0x7E < \ord($char)) {
+                throw new InvalidArgumentException('A structured field display string must hold printable ASCII characters only.');
+            }
+
+            if ('%' === $char) {
+                if (!preg_match('/[0-9a-f]{2}/A', $input, $matches, 0, $offset)) {
+                    throw new InvalidArgumentException('Invalid percent-encoded byte in the Link-Template header.');
+                }
+
+                $offset += 2;
+                $output .= \chr(hexdec($matches[0]));
+
+                continue;
+            }
+
+            if ('"' === $char) {
+                if (!preg_match('//u', $output)) {
+                    throw new InvalidArgumentException('A structured field display string must be encoded in UTF-8.');
+                }
+
+                return $output;
+            }
+
+            $output .= $char;
+        }
+
+        throw new InvalidArgumentException('Unterminated display string in the Link-Template header.');
+    }
+
+    private static function parseBoolean(string $input, int &$offset): bool
+    {
+        if (!preg_match('/\?[01]/A', $input, $matches, 0, $offset)) {
+            throw new InvalidArgumentException('Expected a structured field boolean.');
+        }
+
+        $offset += 2;
+
+        return '?1' === $matches[0];
+    }
+
+    private static function parseNumber(string $input, int &$offset): int|float
+    {
+        if (!preg_match('/-?(?:\d{1,12}\.\d{1,3}|\d{1,15})(?![\d.])/A', $input, $matches, 0, $offset)) {
+            throw new InvalidArgumentException('Expected a structured field number.');
+        }
+
+        $offset += \strlen($matches[0]);
+
+        return str_contains($matches[0], '.') ? (float) $matches[0] : (int) $matches[0];
+    }
+
+    private static function parseToken(string $input, int &$offset): string
+    {
+        if (!preg_match('/[a-zA-Z*][a-zA-Z0-9:\/!#$%&\'*+.^_`|~-]*/A', $input, $matches, 0, $offset)) {
+            throw new InvalidArgumentException('Expected a structured field token.');
+        }
+
+        $offset += \strlen($matches[0]);
+
+        return $matches[0];
+    }
+
+    private static function skipSp(string $input, int &$offset): void
+    {
+        while (' ' === ($input[$offset] ?? null)) {
+            ++$offset;
+        }
+    }
+
+    private static function skipOws(string $input, int &$offset): void
+    {
+        while (' ' === ($input[$offset] ?? null) || "\t" === ($input[$offset] ?? null)) {
+            ++$offset;
+        }
+    }
+}

--- a/src/Symfony/Component/WebLink/LinkTemplateHeaderSerializer.php
+++ b/src/Symfony/Component/WebLink/LinkTemplateHeaderSerializer.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\WebLink;
+
+use Psr\Link\LinkInterface;
+use Symfony\Component\WebLink\Exception\InvalidArgumentException;
+
+/**
+ * Serializes a list of Link instances to an HTTP Link-Template header.
+ *
+ * Only templated links are serialized: the others belong to the Link header.
+ * Repeated target attributes are serialized as repeated structured field
+ * parameters, of which only the last one is significant.
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc9652.html
+ *
+ * @author Florent Morselli <florent.morselli@spomky-labs.com>
+ */
+class LinkTemplateHeaderSerializer
+{
+    /**
+     * Structured field parameter key, as defined by RFC 9651.
+     */
+    private const KEY_PATTERN = '/^[a-z*][a-z0-9_.*-]*$/';
+
+    /**
+     * Builds the value of the "Link-Template" HTTP header.
+     *
+     * @param LinkInterface[]|\Traversable $links
+     *
+     * @throws InvalidArgumentException When a target attribute cannot be serialized as a structured field parameter key
+     *                                  or when a non-ASCII value is not encoded in UTF-8
+     */
+    public function serialize(iterable $links): ?string
+    {
+        $elements = [];
+
+        foreach ($links as $link) {
+            if (!$link->isTemplated()) {
+                continue;
+            }
+
+            $parts = [self::serializeString($link->getHref())];
+
+            if ($rels = $link->getRels()) {
+                $parts[] = 'rel='.self::serializeString(implode(' ', $rels));
+            }
+
+            foreach ($link->getAttributes() as $key => $value) {
+                $key = strtolower($key);
+
+                if (!preg_match(self::KEY_PATTERN, $key)) {
+                    throw new InvalidArgumentException(\sprintf('The "%s" target attribute cannot be serialized as a structured field parameter key.', $key));
+                }
+
+                foreach (\is_array($value) ? $value : [$value] as $item) {
+                    if (false === $item) {
+                        continue;
+                    }
+
+                    $parts[] = true === $item ? $key : $key.'='.self::serializeString((string) $item);
+                }
+            }
+
+            $elements[] = implode('; ', $parts);
+        }
+
+        return $elements ? implode(', ', $elements) : null;
+    }
+
+    /**
+     * Serializes a string as a structured field String, or as a Display String when it holds non-ASCII characters.
+     */
+    private static function serializeString(string $value): string
+    {
+        if (preg_match('/^[\x20-\x7E]*$/D', $value)) {
+            return '"'.addcslashes($value, '"\\').'"';
+        }
+
+        if (!preg_match('//u', $value)) {
+            throw new InvalidArgumentException('Non-ASCII strings must be encoded in UTF-8 to be serialized as structured field display strings.');
+        }
+
+        return '%"'.preg_replace_callback('/[%"\x00-\x1F\x7F-\xFF]/', static fn (array $m) => \sprintf('%%%02x', \ord($m[0])), $value).'"';
+    }
+}

--- a/src/Symfony/Component/WebLink/README.md
+++ b/src/Symfony/Component/WebLink/README.md
@@ -12,6 +12,12 @@ Hints](https://www.w3.org/TR/resource-hints/) W3C's specifications. It can also
 be used with extensions defined in the [HTML5 link type extensions
 wiki](http://microformats.org/wiki/existing-rel-values#HTML5_link_type_extensions).
 
+It also implements [Web Linking](https://www.rfc-editor.org/rfc/rfc8288.html)
+(RFC 8288), the two link set document formats defined by
+[Linkset](https://www.rfc-editor.org/rfc/rfc9264.html) (RFC 9264) and the
+[Link-Template](https://www.rfc-editor.org/rfc/rfc9652.html) HTTP header field
+(RFC 9652).
+
 Getting Started
 ---------------
 

--- a/src/Symfony/Component/WebLink/Tests/EventListener/AddLinkHeaderListenerTest.php
+++ b/src/Symfony/Component/WebLink/Tests/EventListener/AddLinkHeaderListenerTest.php
@@ -46,10 +46,61 @@ class AddLinkHeaderListenerTest extends TestCase
         ];
 
         $this->assertEquals($expected, $response->headers->all()['link']);
+        $this->assertFalse($response->headers->has('Link-Template'));
+    }
+
+    public function testOnKernelResponseSendsTemplatedLinksInTheLinkTemplateHeader()
+    {
+        $links = new GenericLinkProvider([
+            new Link('preload', '/foo'),
+            new Link('item', '/users/{id}'),
+        ]);
+        $response = $this->dispatch($links);
+
+        $this->assertSame('</foo>; rel="preload"', $response->headers->get('Link'));
+        $this->assertSame('"/users/{id}"; rel="item"', $response->headers->get('Link-Template'));
+    }
+
+    public function testOnKernelResponseDoesNotSendAnEmptyLinkHeader()
+    {
+        $response = $this->dispatch(new GenericLinkProvider([new Link('item', '/users/{id}')]));
+
+        $this->assertFalse($response->headers->has('Link'));
+        $this->assertSame('"/users/{id}"; rel="item"', $response->headers->get('Link-Template'));
+    }
+
+    public function testOnKernelResponseWithoutLinks()
+    {
+        $response = $this->dispatch(new GenericLinkProvider());
+
+        $this->assertFalse($response->headers->has('Link'));
+        $this->assertFalse($response->headers->has('Link-Template'));
+    }
+
+    public function testOnKernelResponseIgnoresSubRequests()
+    {
+        $request = new Request([], [], ['_links' => new GenericLinkProvider([new Link('preload', '/foo')])]);
+        $response = new Response();
+
+        $event = new ResponseEvent($this->createStub(HttpKernelInterface::class), $request, HttpKernelInterface::SUB_REQUEST, $response);
+        (new AddLinkHeaderListener())->onKernelResponse($event);
+
+        $this->assertFalse($response->headers->has('Link'));
     }
 
     public function testSubscribedEvents()
     {
         $this->assertEquals([KernelEvents::RESPONSE => 'onKernelResponse'], AddLinkHeaderListener::getSubscribedEvents());
+    }
+
+    private function dispatch(GenericLinkProvider $links): Response
+    {
+        $request = new Request([], [], ['_links' => $links]);
+        $response = new Response();
+
+        $event = new ResponseEvent($this->createStub(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST, $response);
+        (new AddLinkHeaderListener())->onKernelResponse($event);
+
+        return $response;
     }
 }

--- a/src/Symfony/Component/WebLink/Tests/JsonLinksetParserTest.php
+++ b/src/Symfony/Component/WebLink/Tests/JsonLinksetParserTest.php
@@ -1,0 +1,188 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\WebLink\Tests;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\WebLink\Exception\InvalidArgumentException;
+use Symfony\Component\WebLink\JsonLinksetParser;
+use Symfony\Component\WebLink\JsonLinksetSerializer;
+use Symfony\Component\WebLink\Link;
+
+class JsonLinksetParserTest extends TestCase
+{
+    private JsonLinksetParser $parser;
+
+    protected function setUp(): void
+    {
+        $this->parser = new JsonLinksetParser();
+    }
+
+    public function testParseEmptyLinkset()
+    {
+        self::assertSame([], $this->parser->parse('{"linkset": []}')->getLinks());
+    }
+
+    public function testParseSingleLink()
+    {
+        $links = $this->parser->parse(<<<'JSON'
+            {"linkset": [
+                {"anchor": "https://example.net/bar", "next": [{"href": "https://example.com/foo"}]}
+            ]}
+            JSON)->getLinks();
+
+        self::assertCount(1, $links);
+        self::assertSame(['next'], $links[0]->getRels());
+        self::assertSame('https://example.com/foo', $links[0]->getHref());
+        self::assertSame(['anchor' => 'https://example.net/bar'], $links[0]->getAttributes());
+    }
+
+    public function testParseWithoutAnchor()
+    {
+        $links = $this->parser->parse('{"linkset": [{"next": [{"href": "https://example.com/foo"}]}]}')->getLinks();
+
+        self::assertCount(1, $links);
+        self::assertSame([], $links[0]->getAttributes());
+    }
+
+    public function testParseSeveralContextsAndTargets()
+    {
+        $links = $this->parser->parse(<<<'JSON'
+            {"linkset": [
+                {"anchor": "https://example.net/bar", "item": [
+                    {"href": "https://example.com/foo1"},
+                    {"href": "https://example.com/foo2"}
+                ]},
+                {"anchor": "https://example.net/boo", "https://example.com/relations/baz": [
+                    {"href": "https://example.com/foo3"}
+                ]}
+            ]}
+            JSON)->getLinks();
+
+        self::assertCount(3, $links);
+        self::assertSame(['item'], $links[0]->getRels());
+        self::assertSame('https://example.com/foo1', $links[0]->getHref());
+        self::assertSame(['item'], $links[1]->getRels());
+        self::assertSame('https://example.com/foo2', $links[1]->getHref());
+        self::assertSame(['https://example.com/relations/baz'], $links[2]->getRels());
+        self::assertSame(['anchor' => 'https://example.net/boo'], $links[2]->getAttributes());
+    }
+
+    public function testParseTargetAttributesDefinedByWebLinking()
+    {
+        $links = $this->parser->parse(<<<'JSON'
+            {"linkset": [
+                {"next": [{
+                    "href": "https://example.com/foo",
+                    "type": "text/html",
+                    "media": "screen",
+                    "hreflang": ["en", "de"]
+                }]}
+            ]}
+            JSON)->getLinks();
+
+        self::assertSame([
+            'type' => 'text/html',
+            'media' => 'screen',
+            'hreflang' => ['en', 'de'],
+        ], $links[0]->getAttributes());
+    }
+
+    public function testParseUnwrapsSingleValuedArrays()
+    {
+        $links = $this->parser->parse('{"linkset": [{"next": [{"href": "/foo", "hreflang": ["en"], "foo": ["foovalue"]}]}]}')->getLinks();
+
+        self::assertSame(['hreflang' => 'en', 'foo' => 'foovalue'], $links[0]->getAttributes());
+    }
+
+    public function testParseInternationalizedTargetAttributes()
+    {
+        $links = $this->parser->parse(<<<'JSON'
+            {"linkset": [
+                {"next": [{
+                    "href": "https://example.com/foo",
+                    "title": "Next chapter",
+                    "title*": [{"value": "nächstes Kapitel", "language": "de"}],
+                    "baz*": [{"value": "bazvalue"}]
+                }]}
+            ]}
+            JSON)->getLinks();
+
+        self::assertSame([
+            'title' => 'Next chapter',
+            'title*' => "UTF-8'de'n%C3%A4chstes%20Kapitel",
+            'baz*' => "UTF-8''bazvalue",
+        ], $links[0]->getAttributes());
+    }
+
+    public function testParseRepeatedInternationalizedTargetAttributes()
+    {
+        $links = $this->parser->parse('{"linkset": [{"next": [{"href": "/foo", "title*": [{"value": "a", "language": "en"}, {"value": "b", "language": "fr"}]}]}]}')->getLinks();
+
+        self::assertSame(['title*' => ["UTF-8'en'a", "UTF-8'fr'b"]], $links[0]->getAttributes());
+    }
+
+    public function testParseCastsScalarAttributesToStrings()
+    {
+        $links = $this->parser->parse('{"linkset": [{"next": [{"href": "/foo", "pr": [0.7], "nopush": [true]}]}]}')->getLinks();
+
+        self::assertSame(['pr' => '0.7', 'nopush' => '1'], $links[0]->getAttributes());
+    }
+
+    public function testParseIgnoresExtensionsThatAreNotTargetAttributes()
+    {
+        $links = $this->parser->parse('{"linkset": [{"next": [{"href": "/foo"}]}], "meta": {"generated": "today"}}')->getLinks();
+
+        self::assertCount(1, $links);
+        self::assertSame('/foo', $links[0]->getHref());
+    }
+
+    public function testRoundTrip()
+    {
+        $links = [
+            (new Link('next', 'https://example.com/foo'))
+                ->withAttribute('anchor', 'https://example.net/bar')
+                ->withAttribute('type', 'text/html')
+                ->withAttribute('hreflang', ['en', 'de'])
+                ->withAttribute('title', 'Next chapter')
+                ->withAttribute('bar', ['barone', 'bartwo']),
+        ];
+
+        $document = (new JsonLinksetSerializer())->serialize($links);
+
+        self::assertEquals($links, $this->parser->parse($document)->getLinks());
+    }
+
+    #[DataProvider('provideInvalidDocuments')]
+    public function testParseInvalidDocument(string $document, string $expectedMessage)
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage($expectedMessage);
+
+        $this->parser->parse($document);
+    }
+
+    public static function provideInvalidDocuments(): iterable
+    {
+        yield 'not json' => ['{', 'The link set is not a valid JSON document.'];
+        yield 'not an object' => ['[]', 'The link set must be a JSON object holding a "linkset" member.'];
+        yield 'no linkset member' => ['{"links": []}', 'The link set must be a JSON object holding a "linkset" member.'];
+        yield 'context is not an object' => ['{"linkset": ["nope"]}', 'Each member of the "linkset" array must be a link context object.'];
+        yield 'anchor is not a string' => ['{"linkset": [{"anchor": 42}]}', 'The "anchor" member of a link context object must be a string.'];
+        yield 'targets are not an array' => ['{"linkset": [{"next": "/foo"}]}', 'The "next" member of a link context object must be an array of link target objects.'];
+        yield 'target without href' => ['{"linkset": [{"next": [{"type": "text/html"}]}]}', 'Each link target object of the "next" relation type must hold an "href" member.'];
+        yield 'href is not a string' => ['{"linkset": [{"next": [{"href": 42}]}]}', 'Each link target object of the "next" relation type must hold an "href" member.'];
+        yield 'internationalized attribute without value' => ['{"linkset": [{"next": [{"href": "/foo", "title*": [{"language": "de"}]}]}]}', 'The "title*" target attribute must hold objects with a "value" member.'];
+        yield 'internationalized attribute with an invalid language' => ['{"linkset": [{"next": [{"href": "/foo", "title*": [{"value": "a", "language": 42}]}]}]}', 'The "language" member of the "title*" target attribute must be a string.'];
+        yield 'attribute holding an object' => ['{"linkset": [{"next": [{"href": "/foo", "foo": [{"bar": "baz"}]}]}]}', 'The "foo" target attribute must hold string values.'];
+    }
+}

--- a/src/Symfony/Component/WebLink/Tests/JsonLinksetSerializerTest.php
+++ b/src/Symfony/Component/WebLink/Tests/JsonLinksetSerializerTest.php
@@ -1,0 +1,278 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\WebLink\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\WebLink\Exception\InvalidArgumentException;
+use Symfony\Component\WebLink\JsonLinksetSerializer;
+use Symfony\Component\WebLink\Link;
+
+class JsonLinksetSerializerTest extends TestCase
+{
+    private JsonLinksetSerializer $serializer;
+
+    protected function setUp(): void
+    {
+        $this->serializer = new JsonLinksetSerializer();
+    }
+
+    public function testSerializeEmpty()
+    {
+        self::assertSame('{"linkset":[]}', $this->serializer->serialize([]));
+    }
+
+    public function testSerializeSingleLink()
+    {
+        $links = [
+            (new Link('next', 'https://example.com/foo'))->withAttribute('anchor', 'https://example.net/bar'),
+        ];
+
+        self::assertJsonStringEqualsJsonString(<<<'JSON'
+            {"linkset": [
+                {"anchor": "https://example.net/bar", "next": [{"href": "https://example.com/foo"}]}
+            ]}
+            JSON, $this->serializer->serialize($links));
+    }
+
+    public function testSerializeGroupsLinksSharingTheSameContextAndRelation()
+    {
+        $links = [
+            (new Link('item', 'https://example.com/foo1'))->withAttribute('anchor', 'https://example.net/bar'),
+            (new Link('item', 'https://example.com/foo2'))->withAttribute('anchor', 'https://example.net/bar'),
+        ];
+
+        self::assertJsonStringEqualsJsonString(<<<'JSON'
+            {"linkset": [
+                {"anchor": "https://example.net/bar", "item": [
+                    {"href": "https://example.com/foo1"},
+                    {"href": "https://example.com/foo2"}
+                ]}
+            ]}
+            JSON, $this->serializer->serialize($links));
+    }
+
+    public function testSerializeSplitsDistinctContexts()
+    {
+        $links = [
+            (new Link('next', 'https://example.com/foo1'))->withAttribute('anchor', 'https://example.net/bar'),
+            (new Link('https://example.com/relations/baz', 'https://example.com/foo2'))->withAttribute('anchor', 'https://example.net/boo'),
+        ];
+
+        self::assertJsonStringEqualsJsonString(<<<'JSON'
+            {"linkset": [
+                {"anchor": "https://example.net/bar", "next": [{"href": "https://example.com/foo1"}]},
+                {"anchor": "https://example.net/boo", "https://example.com/relations/baz": [{"href": "https://example.com/foo2"}]}
+            ]}
+            JSON, $this->serializer->serialize($links));
+    }
+
+    public function testSerializeWithoutAnchorOmitsTheContext()
+    {
+        self::assertJsonStringEqualsJsonString(<<<'JSON'
+            {"linkset": [
+                {"next": [{"href": "https://example.com/foo"}]}
+            ]}
+            JSON, $this->serializer->serialize([new Link('next', 'https://example.com/foo')]));
+    }
+
+    public function testSerializeDistinguishesAnEmptyAnchorFromNoAnchor()
+    {
+        $links = [
+            (new Link('next', 'https://example.com/foo'))->withAttribute('anchor', ''),
+            new Link('next', 'https://example.com/bar'),
+        ];
+
+        self::assertJsonStringEqualsJsonString(<<<'JSON'
+            {"linkset": [
+                {"anchor": "", "next": [{"href": "https://example.com/foo"}]},
+                {"next": [{"href": "https://example.com/bar"}]}
+            ]}
+            JSON, $this->serializer->serialize($links));
+    }
+
+    public function testSerializeNumericAnchor()
+    {
+        $links = [(new Link('next', 'https://example.com/foo'))->withAttribute('anchor', '123')];
+
+        self::assertJsonStringEqualsJsonString('{"linkset":[{"anchor":"123","next":[{"href":"https://example.com/foo"}]}]}', $this->serializer->serialize($links));
+    }
+
+    public function testSerializeRepeatsMultipleRelations()
+    {
+        $links = [(new Link('alternate', 'https://example.com/foo'))->withRel('next')];
+
+        self::assertJsonStringEqualsJsonString(<<<'JSON'
+            {"linkset": [
+                {
+                    "alternate": [{"href": "https://example.com/foo"}],
+                    "next": [{"href": "https://example.com/foo"}]
+                }
+            ]}
+            JSON, $this->serializer->serialize($links));
+    }
+
+    public function testSerializeTargetAttributesDefinedByWebLinking()
+    {
+        $links = [
+            (new Link('next', 'https://example.com/foo'))
+                ->withAttribute('anchor', 'https://example.net/bar')
+                ->withAttribute('type', 'text/html')
+                ->withAttribute('hreflang', ['en', 'de'])
+                ->withAttribute('media', 'screen'),
+        ];
+
+        self::assertJsonStringEqualsJsonString(<<<'JSON'
+            {"linkset": [
+                {"anchor": "https://example.net/bar", "next": [{
+                    "href": "https://example.com/foo",
+                    "type": "text/html",
+                    "hreflang": ["en", "de"],
+                    "media": "screen"
+                }]}
+            ]}
+            JSON, $this->serializer->serialize($links));
+    }
+
+    public function testSerializeWrapsSingleValuedHreflangInAnArray()
+    {
+        $links = [(new Link('next', 'https://example.com/foo'))->withAttribute('hreflang', 'en')];
+
+        self::assertJsonStringEqualsJsonString('{"linkset":[{"next":[{"href":"https://example.com/foo","hreflang":["en"]}]}]}', $this->serializer->serialize($links));
+    }
+
+    public function testSerializeKeepsOnlyTheFirstValueOfNonRepeatableAttributes()
+    {
+        $links = [(new Link('next', 'https://example.com/foo'))->withAttribute('type', ['text/html', 'text/plain'])];
+
+        self::assertJsonStringEqualsJsonString('{"linkset":[{"next":[{"href":"https://example.com/foo","type":"text/html"}]}]}', $this->serializer->serialize($links));
+    }
+
+    public function testSerializeInternationalizedTargetAttributes()
+    {
+        $links = [
+            (new Link('next', 'https://example.com/foo'))
+                ->withAttribute('anchor', 'https://example.net/bar')
+                ->withAttribute('title', 'Next chapter')
+                ->withAttribute('title*', "UTF-8'de'n%c3%a4chstes%20Kapitel"),
+        ];
+
+        self::assertJsonStringEqualsJsonString(<<<'JSON'
+            {"linkset": [
+                {"anchor": "https://example.net/bar", "next": [{
+                    "href": "https://example.com/foo",
+                    "title": "Next chapter",
+                    "title*": [{"value": "nächstes Kapitel", "language": "de"}]
+                }]}
+            ]}
+            JSON, $this->serializer->serialize($links));
+    }
+
+    public function testSerializeInternationalizedTargetAttributeWithoutLanguage()
+    {
+        $links = [(new Link('next', 'https://example.com/foo'))->withAttribute('title*', "UTF-8''Next%20chapter")];
+
+        self::assertJsonStringEqualsJsonString('{"linkset":[{"next":[{"href":"https://example.com/foo","title*":[{"value":"Next chapter"}]}]}]}', $this->serializer->serialize($links));
+    }
+
+    public function testSerializeExtensionTargetAttributesAsArrays()
+    {
+        $links = [
+            (new Link('next', 'https://example.com/foo'))
+                ->withAttribute('anchor', 'https://example.net/bar')
+                ->withAttribute('type', 'text/html')
+                ->withAttribute('foo', 'foovalue')
+                ->withAttribute('bar', ['barone', 'bartwo'])
+                ->withAttribute('baz*', "UTF-8'en'bazvalue"),
+        ];
+
+        self::assertJsonStringEqualsJsonString(<<<'JSON'
+            {"linkset": [
+                {"anchor": "https://example.net/bar", "next": [{
+                    "href": "https://example.com/foo",
+                    "type": "text/html",
+                    "foo": ["foovalue"],
+                    "bar": ["barone", "bartwo"],
+                    "baz*": [{"value": "bazvalue", "language": "en"}]
+                }]}
+            ]}
+            JSON, $this->serializer->serialize($links));
+    }
+
+    public function testSerializeBooleanAttributes()
+    {
+        $links = [
+            (new Link('preload', 'https://example.com/foo'))
+                ->withAttribute('nopush', true)
+                ->withAttribute('nofollow', false),
+        ];
+
+        self::assertJsonStringEqualsJsonString('{"linkset":[{"preload":[{"href":"https://example.com/foo","nopush":[""]}]}]}', $this->serializer->serialize($links));
+    }
+
+    public function testSerializeSkipsTemplatedLinks()
+    {
+        $links = [
+            new Link('item', 'https://example.com/users/{id}'),
+            new Link('next', 'https://example.com/foo'),
+        ];
+
+        self::assertJsonStringEqualsJsonString('{"linkset":[{"next":[{"href":"https://example.com/foo"}]}]}', $this->serializer->serialize($links));
+    }
+
+    public function testSerializeSkipsLinksWithoutARelationType()
+    {
+        $links = [
+            new Link(null, 'https://example.com/foo'),
+            new Link('next', 'https://example.com/bar'),
+        ];
+
+        self::assertJsonStringEqualsJsonString('{"linkset":[{"next":[{"href":"https://example.com/bar"}]}]}', $this->serializer->serialize($links));
+    }
+
+    public function testSerializeTreatsAFalseAnchorAsAbsent()
+    {
+        $links = [(new Link('next', 'https://example.com/foo'))->withAttribute('anchor', false)];
+
+        self::assertJsonStringEqualsJsonString('{"linkset":[{"next":[{"href":"https://example.com/foo"}]}]}', $this->serializer->serialize($links));
+    }
+
+    public function testSerializeThrowsOnTheAnchorRelationType()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('A link with the "anchor" relation type cannot be represented in an "application/linkset+json" document.');
+
+        $this->serializer->serialize([(new Link('anchor', 'https://example.com/foo'))->withAttribute('anchor', 'https://example.net/bar')]);
+    }
+
+    public function testSerializeThrowsWhenTheLinksCannotBeEncoded()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The link set cannot be serialized to JSON: "Malformed UTF-8 characters, possibly incorrectly encoded".');
+
+        $this->serializer->serialize([(new Link('next', '/foo'))->withAttribute('title', "\xB1\x31")]);
+    }
+
+    public function testSerializeThrowsWhenTheLinksCannotBeEncodedWhateverTheFlags()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->serializer->serialize([(new Link('next', '/foo'))->withAttribute('title', "\xB1\x31")], \JSON_THROW_ON_ERROR);
+    }
+
+    public function testSerializeForwardsJsonEncodeFlags()
+    {
+        $links = [new Link('next', 'https://example.com/foo')];
+
+        self::assertStringContainsString('https://example.com/foo', $this->serializer->serialize($links, \JSON_UNESCAPED_SLASHES));
+        self::assertStringContainsString('https:\/\/example.com\/foo', $this->serializer->serialize($links));
+    }
+}

--- a/src/Symfony/Component/WebLink/Tests/LinkTemplateHeaderParserTest.php
+++ b/src/Symfony/Component/WebLink/Tests/LinkTemplateHeaderParserTest.php
@@ -1,0 +1,156 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\WebLink\Tests;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\WebLink\Link;
+use Symfony\Component\WebLink\LinkTemplateHeaderParser;
+use Symfony\Component\WebLink\LinkTemplateHeaderSerializer;
+
+class LinkTemplateHeaderParserTest extends TestCase
+{
+    private LinkTemplateHeaderParser $parser;
+
+    protected function setUp(): void
+    {
+        $this->parser = new LinkTemplateHeaderParser();
+    }
+
+    public function testParseEmpty()
+    {
+        self::assertSame([], $this->parser->parse('')->getLinks());
+        self::assertSame([], $this->parser->parse('   ')->getLinks());
+    }
+
+    public function testParse()
+    {
+        $links = $this->parser->parse('"/{username}"; rel="item"')->getLinks();
+
+        self::assertCount(1, $links);
+        self::assertSame('/{username}', $links[0]->getHref());
+        self::assertTrue($links[0]->isTemplated());
+        self::assertSame(['item'], $links[0]->getRels());
+        self::assertSame([], $links[0]->getAttributes());
+    }
+
+    public function testParseSeveralHeaders()
+    {
+        $links = $this->parser->parse([
+            '"/{username}"; rel="item"',
+            '"/books/{book_id}/author"; rel="author"; anchor="#{book_id}"',
+        ])->getLinks();
+
+        self::assertCount(2, $links);
+        self::assertSame(['item'], $links[0]->getRels());
+        self::assertSame('/books/{book_id}/author', $links[1]->getHref());
+        self::assertSame(['author'], $links[1]->getRels());
+        self::assertSame(['anchor' => '#{book_id}'], $links[1]->getAttributes());
+    }
+
+    public function testParseSeveralRelations()
+    {
+        $links = $this->parser->parse('"/{username}"; rel="alternate  next"')->getLinks();
+
+        self::assertSame(['alternate', 'next'], $links[0]->getRels());
+    }
+
+    public function testParseWithoutRelation()
+    {
+        $links = $this->parser->parse('"/{username}"')->getLinks();
+
+        self::assertCount(1, $links);
+        self::assertSame([], $links[0]->getRels());
+    }
+
+    public function testParseVarBase()
+    {
+        $links = $this->parser->parse('"/widgets/{widget_id}"; rel="https://example.org/rel/widget"; var-base="https://example.org/vars/"')->getLinks();
+
+        self::assertSame(['https://example.org/rel/widget'], $links[0]->getRels());
+        self::assertSame(['var-base' => 'https://example.org/vars/'], $links[0]->getAttributes());
+    }
+
+    #[DataProvider('provideParameterCases')]
+    public function testParseParameterTypes(string $header, array $expectedAttributes)
+    {
+        $links = $this->parser->parse($header)->getLinks();
+
+        self::assertCount(1, $links);
+        self::assertSame($expectedAttributes, $links[0]->getAttributes());
+    }
+
+    public static function provideParameterCases(): iterable
+    {
+        yield 'string' => ['"/{id}"; title="Hello"', ['title' => 'Hello']];
+        yield 'escaped string' => ['"/{id}"; title="a \"quoted\" \\\\ value"', ['title' => 'a "quoted" \\ value']];
+        yield 'display string' => ['"/{id}"; title=%"Bj%c3%b6rn J%c3%a4rnsida"', ['title' => 'Björn Järnsida']];
+        yield 'token' => ['"/{id}"; type=text/html', ['type' => 'text/html']];
+        yield 'true boolean' => ['"/{id}"; nopush', ['nopush' => true]];
+        yield 'explicit boolean' => ['"/{id}"; nopush=?1; nofollow=?0', ['nopush' => true, 'nofollow' => false]];
+        yield 'integer' => ['"/{id}"; weight=42', ['weight' => 42]];
+        yield 'decimal' => ['"/{id}"; pr=0.7', ['pr' => 0.7]];
+        yield 'negative integer' => ['"/{id}"; weight=-42', ['weight' => -42]];
+        yield 'spaces after the semicolon' => ['"/{id}";   title="Hello"', ['title' => 'Hello']];
+        yield 'last occurrence wins' => ['"/{id}"; title="a"; title="b"', ['title' => 'b']];
+    }
+
+    #[DataProvider('provideInvalidHeaders')]
+    public function testParseInvalidHeaderIsIgnored(string $header)
+    {
+        self::assertSame([], $this->parser->parse($header)->getLinks());
+    }
+
+    public static function provideInvalidHeaders(): iterable
+    {
+        yield 'unterminated string' => ['"/{id}'];
+        yield 'unterminated display string' => ['%"/{id}'];
+        yield 'invalid percent-encoded byte' => ['%"%zz"'];
+        yield 'invalid utf-8 display string' => ['%"%ff"'];
+        yield 'member is not a string' => ['/{id}; rel="item"'];
+        yield 'trailing comma' => ['"/{id}"; rel="item",'];
+        yield 'missing comma' => ['"/{id}" "/{name}"'];
+        yield 'uppercase parameter key' => ['"/{id}"; REL="item"'];
+        yield 'missing parameter key' => ['"/{id}"; ="item"'];
+        yield 'invalid escape sequence' => ['"/{id}"; title="a\\nb"'];
+        yield 'byte sequence parameter' => ['"/{id}"; sig=:cHJldGVuZCB0aGlzIGlzIGJpbmFyeQ==:'];
+        yield 'decimal with a 13-digit integer part' => ['"/{id}"; pr=1234567890123.5'];
+        yield 'decimal with a 4-digit fraction' => ['"/{id}"; pr=2.5000'];
+        yield '16-digit integer' => ['"/{id}"; weight=1234567890123456'];
+    }
+
+    public function testParseIgnoresTheWholeHeaderWhenOneMemberIsInvalid()
+    {
+        self::assertSame([], $this->parser->parse('"/{id}"; rel="item", nope')->getLinks());
+    }
+
+    public function testParseIgnoresARelParameterThatIsNotAString()
+    {
+        $links = $this->parser->parse('"/{id}"; rel=42; title="Hello"')->getLinks();
+
+        self::assertCount(1, $links);
+        self::assertSame([], $links[0]->getRels());
+        self::assertSame(['title' => 'Hello'], $links[0]->getAttributes());
+    }
+
+    public function testRoundTrip()
+    {
+        $links = [
+            (new Link('item', '/{username}'))->withAttribute('title', 'Björn Järnsida'),
+            (new Link('author', '/books/{book_id}/author'))->withAttribute('anchor', '#{book_id}'),
+        ];
+
+        $header = (new LinkTemplateHeaderSerializer())->serialize($links);
+
+        self::assertEquals($links, $this->parser->parse($header)->getLinks());
+    }
+}

--- a/src/Symfony/Component/WebLink/Tests/LinkTemplateHeaderSerializerTest.php
+++ b/src/Symfony/Component/WebLink/Tests/LinkTemplateHeaderSerializerTest.php
@@ -1,0 +1,141 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\WebLink\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\WebLink\Exception\InvalidArgumentException;
+use Symfony\Component\WebLink\Link;
+use Symfony\Component\WebLink\LinkTemplateHeaderSerializer;
+
+class LinkTemplateHeaderSerializerTest extends TestCase
+{
+    private LinkTemplateHeaderSerializer $serializer;
+
+    protected function setUp(): void
+    {
+        $this->serializer = new LinkTemplateHeaderSerializer();
+    }
+
+    public function testSerializeEmpty()
+    {
+        self::assertNull($this->serializer->serialize([]));
+    }
+
+    public function testSerialize()
+    {
+        self::assertSame('"/{username}"; rel="item"', $this->serializer->serialize([new Link('item', '/{username}')]));
+    }
+
+    public function testSerializeSeveralTemplates()
+    {
+        $links = [
+            new Link('item', '/{username}'),
+            (new Link('alternate', '/{username}{?format}'))->withRel('next'),
+        ];
+
+        self::assertSame('"/{username}"; rel="item", "/{username}{?format}"; rel="alternate next"', $this->serializer->serialize($links));
+    }
+
+    public function testSerializeTemplatedAnchor()
+    {
+        $links = [(new Link('author', '/books/{book_id}/author'))->withAttribute('anchor', '#{book_id}')];
+
+        self::assertSame('"/books/{book_id}/author"; rel="author"; anchor="#{book_id}"', $this->serializer->serialize($links));
+    }
+
+    public function testSerializeVarBase()
+    {
+        $links = [
+            (new Link('https://example.org/rel/widget', '/widgets/{widget_id}'))
+                ->withAttribute('var-base', 'https://example.org/vars/'),
+        ];
+
+        self::assertSame('"/widgets/{widget_id}"; rel="https://example.org/rel/widget"; var-base="https://example.org/vars/"', $this->serializer->serialize($links));
+    }
+
+    public function testSerializeNonAsciiAttributeAsADisplayString()
+    {
+        $links = [(new Link('author', '/authors/{id}'))->withAttribute('title', 'Björn Järnsida')];
+
+        self::assertSame('"/authors/{id}"; rel="author"; title=%"Bj%c3%b6rn J%c3%a4rnsida"', $this->serializer->serialize($links));
+    }
+
+    public function testSerializeEscapesStrings()
+    {
+        $links = [(new Link('item', '/{id}'))->withAttribute('title', 'a "quoted" \\ value')];
+
+        self::assertSame('"/{id}"; rel="item"; title="a \"quoted\" \\\\ value"', $this->serializer->serialize($links));
+    }
+
+    public function testSerializeNonPrintableAttributeAsADisplayString()
+    {
+        $links = [(new Link('item', '/{id}'))->withAttribute('title', "Hello\n")];
+
+        self::assertSame('"/{id}"; rel="item"; title=%"Hello%0a"', $this->serializer->serialize($links));
+    }
+
+    public function testSerializeBooleanAttributes()
+    {
+        $links = [
+            (new Link('item', '/{id}'))
+                ->withAttribute('nopush', true)
+                ->withAttribute('nofollow', false),
+        ];
+
+        self::assertSame('"/{id}"; rel="item"; nopush', $this->serializer->serialize($links));
+    }
+
+    public function testSerializeRepeatedAttributes()
+    {
+        $links = [(new Link('item', '/{id}'))->withAttribute('hreflang', ['fr', 'de'])];
+
+        self::assertSame('"/{id}"; rel="item"; hreflang="fr"; hreflang="de"', $this->serializer->serialize($links));
+    }
+
+    public function testSerializeLowercasesAttributeNames()
+    {
+        $links = [(new Link('item', '/{id}'))->withAttribute('Title', 'Hello')];
+
+        self::assertSame('"/{id}"; rel="item"; title="Hello"', $this->serializer->serialize($links));
+    }
+
+    public function testSerializeWithoutRel()
+    {
+        self::assertSame('"/{id}"', $this->serializer->serialize([new Link(null, '/{id}')]));
+    }
+
+    public function testSerializeSkipsLinksThatAreNotTemplated()
+    {
+        $links = [
+            new Link('preload', '/style.css'),
+            new Link('item', '/{id}'),
+        ];
+
+        self::assertSame('"/{id}"; rel="item"', $this->serializer->serialize($links));
+    }
+
+    public function testSerializeThrowsOnAnInvalidParameterKey()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "0invalid" target attribute cannot be serialized as a structured field parameter key.');
+
+        $this->serializer->serialize([(new Link('item', '/{id}'))->withAttribute('0invalid', 'value')]);
+    }
+
+    public function testSerializeThrowsOnANonUtf8Value()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Non-ASCII strings must be encoded in UTF-8 to be serialized as structured field display strings.');
+
+        $this->serializer->serialize([(new Link('item', '/{id}'))->withAttribute('title', "Bj\xF6rn")]);
+    }
+}

--- a/src/Symfony/Component/WebLink/composer.json
+++ b/src/Symfony/Component/WebLink/composer.json
@@ -2,7 +2,7 @@
     "name": "symfony/web-link",
     "type": "library",
     "description": "Manages links between resources",
-    "keywords": ["link", "psr13", "http", "http2", "preload", "prefetch", "prerender", "dns-prefetch", "push", "performance"],
+    "keywords": ["link", "linkset", "psr13", "http", "http2", "preload", "prefetch", "prerender", "dns-prefetch", "push", "performance"],
     "homepage": "https://symfony.com",
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

The WebLink component still points at [RFC 5988](https://tools.ietf.org/html/rfc5988), which [RFC 8288](https://www.rfc-editor.org/rfc/rfc8288.html) obsoleted in 2017. This PR fixes those references, and adds the two specifications that build on RFC 8288 and were missing from the component: [RFC 9264](https://www.rfc-editor.org/rfc/rfc9264.html) (link sets) and [RFC 9652](https://www.rfc-editor.org/rfc/rfc9652.html) (the `Link-Template` header field).

### RFC 8288

Four `@see` annotations, nothing else.

### RFC 9264: link sets

RFC 9264 defines two document formats conveying a set of links outside of an HTTP interaction, along with the `linkset` relation type that the component already exposes as `Link::REL_LINKSET`.

`application/linkset` needed no code at all: it is the `Link` field value with newlines allowed as separators, which `HttpHeaderParser` already accepts and `HttpHeaderSerializer` already produces.

`application/linkset+json` gets a `JsonLinksetSerializer` and a `JsonLinksetParser`:

```php
use Symfony\Component\WebLink\JsonLinksetSerializer;
use Symfony\Component\WebLink\Link;

echo (new JsonLinksetSerializer())->serialize([
    (new Link('next', 'https://example.com/foo'))
        ->withAttribute('anchor', 'https://example.net/bar')
        ->withAttribute('type', 'text/html')
        ->withAttribute('hreflang', ['en', 'de']),
]);
```

```json
{"linkset":[{"anchor":"https://example.net/bar","next":[{"href":"https://example.com/foo","type":"text/html","hreflang":["en","de"]}]}]}
```

Links are grouped by link context (the `anchor` attribute) then by relation type, `hreflang` and extension attributes are always arrays, `media`, `title` and `type` are single valued, and `title*` (like any attribute whose name ends with an asterisk) is transcoded between the RFC 8187 microsyntax and the `{"value": ..., "language": ...}` objects the JSON format mandates. Every example of the RFC round trips through the parser and back.

Values that cannot be represented make the serializer throw an `InvalidArgumentException`: strings that cannot be encoded to JSON, and links carrying the `anchor` relation type, which would collide with the `anchor` member of the format.

### RFC 9652: the Link-Template header field

`Link-Template` carries links whose target and anchor are URI templates. It is a structured field ([RFC 9651](https://www.rfc-editor.org/rfc/rfc9651.html)), a List of Strings with Parameters, so it has a different grammar from the `Link` header field. That is why it gets its own `LinkTemplateHeaderSerializer` and `LinkTemplateHeaderParser` rather than extra methods on the existing pair.

```php
use Symfony\Component\WebLink\Link;
use Symfony\Component\WebLink\LinkTemplateHeaderSerializer;

echo (new LinkTemplateHeaderSerializer())->serialize([
    (new Link('author', '/books/{book_id}/author'))->withAttribute('anchor', '#{book_id}'),
]);
// "/books/{book_id}/author"; rel="author"; anchor="#{book_id}"
```

Display Strings are supported, so non-ASCII target attributes are serialized the way the RFC shows:

```
Link-Template: "/authors/{id}"; rel="author"; title=%"Bj%c3%b6rn J%c3%a4rnsida"
```

Non-ASCII values that are not encoded in UTF-8 cannot be carried by a Display String: serializing them throws an `InvalidArgumentException` instead of emitting a header that conforming parsers must ignore.

As RFC 9651 mandates for structured fields, a header value that fails to parse is ignored as a whole and yields an empty link provider.

### AddLinkHeaderListener

The listener currently drops templated links on the floor, because `HttpHeaderSerializer` skips them: RFC 8288 has no room for a URI template. They now leave in a `Link-Template` header, so nothing is lost and no existing header changes.

```
Link: </style.css>; rel="preload"; as="style"
Link-Template: "/users/{id}"; rel="item"
```

Same change, side effect: the listener no longer sets an empty `Link:` header when every link in `_links` happens to be templated.

### Backward compatibility

`web_link.php` now wires classes that only exist from 8.2 on, so FrameworkBundle requires `symfony/web-link` `^8.2` and gets a matching `<8.2` conflict entry, like `symfony/workflow` and `symfony/http-client` already have.

---

Related: api-platform/core#6924 asks for `Link-Template` support in API Platform, and RFC 9264 link sets are the format [RFC 9727](https://www.rfc-editor.org/rfc/rfc9727.html) builds `/.well-known/api-catalog` on.

/cc @soyuka @dunglas

Documentation: symfony/symfony-docs#22740

