### PR TITLE
[Cache] Fix numeric string keys being cast to integers

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/TagAwareAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/TagAwareAdapter.php
@@ -195,7 +195,16 @@ class TagAwareAdapter implements TagAwareAdapterInterface, TagAwareCacheInterfac
         }
         $tagVersions = null;
 
-        return (self::$setCacheItemTags)($bufferedItems, $itemTags);
+        $items = (self::$setCacheItemTags)($bufferedItems, $itemTags);
+
+        foreach ($keys as $key) {
+            // PHP casts numeric strings to integers when they are used as array keys
+            if (\is_string($key) && $key === (string) (int) $key) {
+                return $this->yieldRequestedKeys($keys, $items);
+            }
+        }
+
+        return $items;
     }
 
     public function clear(string $prefix = ''): bool
@@ -372,5 +381,14 @@ class TagAwareAdapter implements TagAwareAdapterInterface, TagAwareCacheInterfac
         }
 
         return $tagVersions;
+    }
+
+    private function yieldRequestedKeys(array $keys, array $items): \Generator
+    {
+        $keys = array_combine($keys, $keys);
+
+        foreach ($items as $key => $item) {
+            yield ($keys[$key] ?? $key) => $item;
+        }
     }
 }

--- a/src/Symfony/Component/Cache/Psr16Cache.php
+++ b/src/Symfony/Component/Cache/Psr16Cache.php
@@ -157,14 +157,14 @@ class Psr16Cache implements CacheInterface, PruneableInterface, ResettableInterf
                 $values[$key] = $item->isHit() ? $item->get() : $default;
             }
 
-            return $values;
+            return $this->withRequestedKeys($keys, $values);
         }
 
         foreach ($items as $key => $item) {
             $values[$key] = $item->isHit() ? (self::$packCacheItem)($item) : $default;
         }
 
-        return $values;
+        return $this->withRequestedKeys($keys, $values);
     }
 
     public function setMultiple($values, $ttl = null): bool
@@ -240,6 +240,27 @@ class Psr16Cache implements CacheInterface, PruneableInterface, ResettableInterf
             throw $e;
         } catch (Psr6CacheException $e) {
             throw new InvalidArgumentException($e->getMessage(), $e->getCode(), $e);
+        }
+    }
+
+    private function withRequestedKeys(array $keys, array $values): iterable
+    {
+        foreach ($keys as $key) {
+            // PHP casts numeric strings to integers when they are used as array keys
+            if (\is_string($key) && $key === (string) (int) $key) {
+                return $this->yieldRequestedKeys($keys, $values);
+            }
+        }
+
+        return $values;
+    }
+
+    private function yieldRequestedKeys(array $keys, array $values): \Generator
+    {
+        $keys = array_combine($keys, $keys);
+
+        foreach ($values as $key => $value) {
+            yield ($keys[$key] ?? $key) => $value;
         }
     }
 }

--- a/src/Symfony/Component/Cache/Tests/Adapter/TagAwareAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/TagAwareAdapterTest.php
@@ -80,6 +80,23 @@ class TagAwareAdapterTest extends AdapterTestCase
         $this->assertFalse($pool->getItem('foo')->isHit()); // known tag version has expired
     }
 
+    public function testGetItemsWithNumericStringKeys()
+    {
+        $adapter = new TagAwareAdapter(new ArrayAdapter());
+
+        $item = $adapter->getItem('123');
+        $item->set('foo-val');
+        $adapter->save($item);
+
+        $keys = [];
+        foreach ($adapter->getItems(['123', '456']) as $key => $item) {
+            $keys[] = $key;
+            $this->assertSame($key, $item->getKey());
+        }
+
+        $this->assertSame(['123', '456'], $keys);
+    }
+
     public function testInvalidateTagsWithArrayAdapter()
     {
         $adapter = new TagAwareAdapter(new ArrayAdapter());

--- a/src/Symfony/Component/Cache/Tests/Psr16CacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Psr16CacheTest.php
@@ -12,12 +12,14 @@
 namespace Symfony\Component\Cache\Tests;
 
 use Cache\IntegrationTests\SimpleCacheTest;
+use Psr\Cache\CacheItemPoolInterface;
 use Psr\SimpleCache\CacheInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Cache\Adapter\TagAwareAdapter;
 use Symfony\Component\Cache\PruneableInterface;
 use Symfony\Component\Cache\Psr16Cache;
+use Symfony\Component\Cache\Tests\Fixtures\ExternalAdapter;
 
 /**
  * @group time-sensitive
@@ -199,6 +201,44 @@ class Psr16CacheTest extends SimpleCacheTest
         $this->assertSame('bar-val', $cache->get('bar'));
 
         $this->assertSame(['foo' => 'foo-val', 'bar' => 'bar-val'], $cache->getMultiple(['foo', 'bar']));
+    }
+
+    /**
+     * @dataProvider providePools
+     */
+    public function testGetMultipleWithNumericStringKeys(CacheItemPoolInterface $pool)
+    {
+        $cache = new Psr16Cache($pool);
+        $cache->set('123', 'foo-val');
+
+        $values = [];
+        foreach ($cache->getMultiple(['123', '456']) as $key => $value) {
+            $values[] = [$key, $value];
+        }
+
+        $this->assertSame([['123', 'foo-val'], ['456', null]], $values);
+    }
+
+    /**
+     * @dataProvider providePools
+     */
+    public function testGetMultipleReturnsUsableKeys(CacheItemPoolInterface $pool)
+    {
+        $cache = new Psr16Cache($pool);
+        $cache->set('123', 'foo-val');
+
+        $keys = [];
+        foreach ($cache->getMultiple(['123']) as $key => $value) {
+            $keys[] = $key;
+        }
+
+        $this->assertSame('foo-val', $cache->get($keys[0]));
+    }
+
+    public static function providePools(): iterable
+    {
+        yield 'adapter' => [new ArrayAdapter()];
+        yield 'external pool' => [new ExternalAdapter()];
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`Psr16Cache::getMultiple()` and `TagAwareAdapter::getItems()` collect their result into a PHP array. PHP casts numeric strings to integers when they are used as array keys, so a key like `'123'` comes back as `int(123)`:

```php
$cache = new Psr16Cache(new FilesystemAdapter());

foreach ($cache->getMultiple(['123']) as $key => $value) {
    var_dump($key); // int(123), expected string('123')
}
```

The keys are then unusable, because every other method of the component rejects a non-string key:

```php
foreach ($cache->getMultiple($ids) as $id => $value) {
    if (null === $value) {
        $cache->set($id, compute($id)); // InvalidArgumentException: Cache key must be string, "int" given.
    }
}
```

`get()`, `set()`, `has()` and `delete()` all throw the same way, so a read-then-write loop, the most common use of `getMultiple()`, breaks as soon as one key is a numeric string. PSR-16 documents the return as `iterable<string, mixed>` and PSR-6 as `iterable<string, CacheItemInterface>`, so the integer key is a spec violation too.

An array cannot carry `'123'` as a string key, so the results are returned as a generator that yields the requested keys. To keep the current return value for everyone who is not affected, this happens only when a requested key is one that PHP casts, which is exactly the case that is broken today. All other calls keep returning the same array as before, so array access, `count()` and repeated iteration are unchanged, including for the plain `['foo', 'bar']` keys asserted by the existing tests.

The detection is `\is_string($key) && $key === (string) (int) $key`. It was checked against PHP's own coercion for `'0'`, `'-0'`, `'-1'`, `'007'`, `'1e2'`, `'1.0'`, `' 1'`, `'1 '`, `'+1'`, `'0x1A'`, `''`, `'9223372036854775807'` and `'9223372036854775808'`, and it agrees on all of them.

Two classes are affected:

- `Psr16Cache::getMultiple()`, on both of its branches, the one for `AdapterInterface` pools and the one for foreign PSR-6 pools. The new tests cover both.
- `TagAwareAdapter::getItems()`, which buffers items in an array before returning them. It is the only PSR-6 adapter with the problem: the others build their result with a generator and already keep the key intact. The items themselves were always right, only the key they were yielded under was wrong.

`Psr16Adapter`, the reverse bridge inside the component, was already immune because it re-keys items by the ids it requested.

Checks: the new tests fail on 6.4 without the patch, with `int(123)` for the key and with the `InvalidArgumentException` above for the round trip. The full Cache suite passes with the patch (3007 tests). `php-cs-fixer` is clean on all four files.
