### PR TITLE
[Cache] Validate every key before deleting any in ArrayAdapter::deleteItems()

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/ArrayAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/ArrayAdapter.php
@@ -151,6 +151,10 @@ class ArrayAdapter implements AdapterInterface, CacheInterface, LoggerAwareInter
     public function deleteItems(array $keys): bool
     {
         foreach ($keys as $key) {
+            \assert('' !== CacheItem::validateKey($key));
+        }
+
+        foreach ($keys as $key) {
             $this->deleteItem($key);
         }
 

--- a/src/Symfony/Component/Cache/Tests/Adapter/ArrayAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/ArrayAdapterTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Cache\Tests\Adapter;
 
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\Exception\InvalidArgumentException;
 use Symfony\Component\Cache\Tests\Fixtures\TestEnum;
 
 /**
@@ -30,6 +31,21 @@ class ArrayAdapterTest extends AdapterTestCase
     public function createCachePool(int $defaultLifetime = 0): CacheItemPoolInterface
     {
         return new ArrayAdapter($defaultLifetime);
+    }
+
+    public function testDeleteItemsValidatesEveryKeyBeforeDeleting()
+    {
+        $cache = $this->createCachePool();
+        $item = $cache->getItem('key1');
+        $cache->save($item->set('value'));
+
+        try {
+            $cache->deleteItems(['key1', 'invalid{key']);
+            $this->fail(InvalidArgumentException::class.' expected.');
+        } catch (InvalidArgumentException) {
+        }
+
+        $this->assertTrue($cache->hasItem('key1'));
     }
 
     public function testGetValuesHitAndMiss()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`ArrayAdapter::deleteItems()` validates each key inside `deleteItem()`, as it goes, so an invalid key placed after valid ones throws only once the valid ones are already gone:

```php
$cache = new ArrayAdapter();
$cache->save($cache->getItem('key1')->set('value'));

try {
    $cache->deleteItems(['key1', 'invalid{key']);
} catch (InvalidArgumentException) {
}

$cache->hasItem('key1'); // false, the item was deleted by a call that threw
```

The call reports failure, yet part of it was applied, and the caller has no way to know how much. Every key is now validated before the first one is deleted, which is what `AbstractAdapterTrait::deleteItems()` already does by resolving all ids up front.

`ArrayAdapter` was the only adapter mutating before validation. `PhpArrayAdapter`, `ProxyAdapter`, `ChainAdapter` and `TagAwareAdapter` delegate to their inner pool, so they show the same symptom only when that pool is an `ArrayAdapter`, and this fixes them too. Validation stays under `assert()`, as everywhere else in the component, so nothing is added to the production path.

Checks: the new test fails on 6.4 without the patch (`key1` is gone after the throw) and passes with it. The full Cache suite passes (3008 tests). `php-cs-fixer` is clean.
