### PR TITLE
[Cache] Require cache/integration-tests ^1.0.3 instead of a pinned commit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -133,7 +133,7 @@
         "async-aws/ses": "^1.0",
         "async-aws/sqs": "^1.0|^2.0",
         "async-aws/sns": "^1.0",
-        "cache/integration-tests": "2024.09.17",
+        "cache/integration-tests": "^1.0.3",
         "doctrine/collections": "^1.8|^2.0",
         "doctrine/data-fixtures": "^1.1|^2",
         "doctrine/dbal": "^3.6|^4",
@@ -243,21 +243,6 @@
                     "type": "git",
                     "url": "https://github.com/jsonpath-standard/jsonpath-compliance-test-suite.git",
                     "reference": "b9d7153e58711ad38bb8e35ece69c13f4b2f7d63"
-                }
-            }
-        },
-        {
-            "type": "package",
-            "package": {
-                "name": "cache/integration-tests",
-                "version": "2024.09.17",
-                "source": {
-                    "type": "git",
-                    "url": "https://github.com/php-cache/integration-tests.git",
-                    "reference": "fb7d78718f1e5bbfd7c63e5c5734000999ac7366"
-                },
-                "autoload": {
-                    "psr-4": { "Cache\\IntegrationTests\\": "src/" }
                 }
             }
         }

--- a/src/Symfony/Component/Cache/Tests/Adapter/AbstractRedisAdapterTestCase.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/AbstractRedisAdapterTestCase.php
@@ -19,7 +19,7 @@ use Symfony\Component\Cache\Adapter\RedisAdapter;
 
 abstract class AbstractRedisAdapterTestCase extends AdapterTestCase
 {
-    protected $skippedTests = [
+    protected array $skippedTests = [
         'testExpiration' => 'Testing expiration slows down the test suite',
         'testHasItemReturnsFalseWhenDeferredItemIsExpired' => 'Testing expiration slows down the test suite',
         'testDefaultLifeTime' => 'Testing expiration slows down the test suite',

--- a/src/Symfony/Component/Cache/Tests/Adapter/ApcuAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/ApcuAdapterTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\Cache\Marshaller\MarshallerInterface;
 
 class ApcuAdapterTest extends AdapterTestCase
 {
-    protected $skippedTests = [
+    protected array $skippedTests = [
         'testExpiration' => 'Testing expiration slows down the test suite',
         'testHasItemReturnsFalseWhenDeferredItemIsExpired' => 'Testing expiration slows down the test suite',
         'testDefaultLifeTime' => 'Testing expiration slows down the test suite',

--- a/src/Symfony/Component/Cache/Tests/Adapter/ArrayAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/ArrayAdapterTest.php
@@ -20,7 +20,7 @@ use Symfony\Component\Clock\MockClock;
 #[Group('time-sensitive')]
 class ArrayAdapterTest extends AdapterTestCase
 {
-    protected $skippedTests = [
+    protected array $skippedTests = [
         'testGetMetadata' => 'ArrayAdapter does not keep metadata.',
         'testDeferredSaveWithoutCommit' => 'Assumes a shared cache which ArrayAdapter is not.',
         'testSaveWithoutExpire' => 'Assumes a shared cache which ArrayAdapter is not.',

--- a/src/Symfony/Component/Cache/Tests/Adapter/CouchbaseBucketAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/CouchbaseBucketAdapterTest.php
@@ -28,7 +28,7 @@ use Symfony\Component\Cache\Adapter\CouchbaseBucketAdapter;
 #[RequiresPhpExtension('couchbase', '>=2.6.0')]
 class CouchbaseBucketAdapterTest extends AdapterTestCase
 {
-    protected $skippedTests = [
+    protected array $skippedTests = [
         'testClearPrefix' => 'Couchbase cannot clear by prefix',
         'testClearPrefixWithUnderscore' => 'Couchbase cannot clear by prefix',
         'testClearWithInvalidPrefix' => 'Couchbase cannot clear by prefix',

--- a/src/Symfony/Component/Cache/Tests/Adapter/CouchbaseCollectionAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/CouchbaseCollectionAdapterTest.php
@@ -25,7 +25,7 @@ use Symfony\Component\Cache\Adapter\CouchbaseCollectionAdapter;
 #[Group('integration')]
 class CouchbaseCollectionAdapterTest extends AdapterTestCase
 {
-    protected $skippedTests = [
+    protected array $skippedTests = [
         'testClearPrefix' => 'Couchbase cannot clear by prefix',
         'testClearPrefixWithUnderscore' => 'Couchbase cannot clear by prefix',
         'testClearWithInvalidPrefix' => 'Couchbase cannot clear by prefix',

--- a/src/Symfony/Component/Cache/Tests/Adapter/MemcachedAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/MemcachedAdapterTest.php
@@ -22,7 +22,7 @@ use Symfony\Component\Cache\Exception\CacheException;
 #[Group('integration')]
 class MemcachedAdapterTest extends AdapterTestCase
 {
-    protected $skippedTests = [
+    protected array $skippedTests = [
         'testHasItemReturnsFalseWhenDeferredItemIsExpired' => 'Testing expiration slows down the test suite',
         'testDefaultLifeTime' => 'Testing expiration slows down the test suite',
         'testClearPrefix' => 'Memcached cannot clear by prefix',

--- a/src/Symfony/Component/Cache/Tests/Adapter/PhpArrayAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PhpArrayAdapterTest.php
@@ -23,7 +23,7 @@ use Symfony\Component\Filesystem\Filesystem;
 #[Group('time-sensitive')]
 class PhpArrayAdapterTest extends AdapterTestCase
 {
-    protected $skippedTests = [
+    protected array $skippedTests = [
         'testGet' => 'PhpArrayAdapter is read-only.',
         'testDontSaveWhenAskedNotTo' => 'PhpArrayAdapter is read-only.',
         'testRecursiveGet' => 'PhpArrayAdapter is read-only.',
@@ -86,6 +86,11 @@ class PhpArrayAdapterTest extends AdapterTestCase
         }
 
         return new PhpArrayAdapterWrapper(self::$file, new NullAdapter());
+    }
+
+    public function testDeleteItemsValidatesEveryKeyBeforeMutation()
+    {
+        $this->markTestSkipped('PhpArrayAdapter does not throw exceptions on invalid key.');
     }
 
     public function testStore()

--- a/src/Symfony/Component/Cache/Tests/Adapter/PhpArrayAdapterWithFallbackTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PhpArrayAdapterWithFallbackTest.php
@@ -20,7 +20,7 @@ use Symfony\Component\Filesystem\Filesystem;
 #[Group('time-sensitive')]
 class PhpArrayAdapterWithFallbackTest extends AdapterTestCase
 {
-    protected $skippedTests = [
+    protected array $skippedTests = [
         'testGetItemInvalidKeys' => 'PhpArrayAdapter does not throw exceptions on invalid key.',
         'testGetItemsInvalidKeys' => 'PhpArrayAdapter does not throw exceptions on invalid key.',
         'testHasItemInvalidKeys' => 'PhpArrayAdapter does not throw exceptions on invalid key.',

--- a/src/Symfony/Component/Cache/Tests/Adapter/PhpFilesAdapterAppendOnlyTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PhpFilesAdapterAppendOnlyTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\Cache\Adapter\PhpFilesAdapter;
 #[Group('time-sensitive')]
 class PhpFilesAdapterAppendOnlyTest extends PhpFilesAdapterTest
 {
-    protected $skippedTests = [
+    protected array $skippedTests = [
         'testDefaultLifeTime' => 'PhpFilesAdapter does not allow configuring a default lifetime.',
         'testExpiration' => 'PhpFilesAdapter in append-only mode does not expiration.',
     ];

--- a/src/Symfony/Component/Cache/Tests/Adapter/PhpFilesAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PhpFilesAdapterTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\Filesystem\Filesystem;
 #[Group('time-sensitive')]
 class PhpFilesAdapterTest extends AdapterTestCase
 {
-    protected $skippedTests = [
+    protected array $skippedTests = [
         'testDefaultLifeTime' => 'PhpFilesAdapter does not allow configuring a default lifetime.',
     ];
 

--- a/src/Symfony/Component/Cache/Tests/Adapter/ProxyAdapterAndRedisAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/ProxyAdapterAndRedisAdapterTest.php
@@ -21,7 +21,7 @@ use Symfony\Component\Cache\CacheItem;
 #[Group('integration')]
 class ProxyAdapterAndRedisAdapterTest extends AbstractRedisAdapterTestCase
 {
-    protected $skippedTests = [
+    protected array $skippedTests = [
         'testPrune' => 'RedisAdapter does not implement PruneableInterface.',
     ];
 

--- a/src/Symfony/Component/Cache/Tests/Adapter/ProxyAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/ProxyAdapterTest.php
@@ -22,7 +22,7 @@ use Symfony\Component\Cache\CacheItem;
 #[Group('time-sensitive')]
 class ProxyAdapterTest extends AdapterTestCase
 {
-    protected $skippedTests = [
+    protected array $skippedTests = [
         'testDeferredSaveWithoutCommit' => 'Assumes a shared cache which ArrayAdapter is not.',
         'testSaveWithoutExpire' => 'Assumes a shared cache which ArrayAdapter is not.',
         'testPrune' => 'ProxyAdapter just proxies',

--- a/src/Symfony/Component/Cache/Tests/Adapter/Psr16AdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/Psr16AdapterTest.php
@@ -21,7 +21,7 @@ use Symfony\Component\Cache\Psr16Cache;
 #[Group('time-sensitive')]
 class Psr16AdapterTest extends AdapterTestCase
 {
-    protected $skippedTests = [
+    protected array $skippedTests = [
         'testPrune' => 'Psr16adapter just proxies',
         'testClearPrefix' => 'SimpleCache cannot clear by prefix',
         'testClearPrefixWithUnderscore' => 'SimpleCache cannot clear by prefix',

--- a/src/Symfony/Component/Cache/Tests/Adapter/TraceableAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/TraceableAdapterTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\Cache\Adapter\TraceableAdapter;
 #[Group('time-sensitive')]
 class TraceableAdapterTest extends AdapterTestCase
 {
-    protected $skippedTests = [
+    protected array $skippedTests = [
         'testPrune' => 'TraceableAdapter just proxies',
     ];
 

--- a/src/Symfony/Component/Cache/composer.json
+++ b/src/Symfony/Component/Cache/composer.json
@@ -30,7 +30,7 @@
         "symfony/var-exporter": "^6.4|^7.0|^8.0"
     },
     "require-dev": {
-        "cache/integration-tests": "2024.09.17",
+        "cache/integration-tests": "^1.0.3",
         "doctrine/dbal": "^3.6|^4",
         "predis/predis": "^1.1|^2.0",
         "psr/simple-cache": "^1.0|^2.0|^3.0",
@@ -58,22 +58,5 @@
             "/Tests/"
         ]
     },
-    "repositories": [
-        {
-            "type": "package",
-            "package": {
-                "name": "cache/integration-tests",
-                "version": "2024.09.17",
-                "source": {
-                    "type": "git",
-                    "url": "https://github.com/php-cache/integration-tests.git",
-                    "reference": "fb7d78718f1e5bbfd7c63e5c5734000999ac7366"
-                },
-                "autoload": {
-                    "psr-4": { "Cache\\IntegrationTests\\": "src/" }
-                }
-            }
-        }
-    ],
     "minimum-stability": "dev"
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Depends on #65429 and #65430, which fix the bugs this upgrade uncovers. Both target 6.4 and have to be merged up before this one is green.

`cache/integration-tests` is currently declared through an inline package repository that pins commit `fb7d787` behind a made-up `2024.09.17` version, added in 12821b67cc9 when `dev-master` moved to 1.0 and broke our CI (php-cache/integration-tests#123). Upstream has released 1.0.3, which addresses what blocked us: the `: void` return types added on the test methods were reverted in 1.0.2, so our overrides are legal again, and `phpunit/phpunit` was moved out of `require` so it no longer pulls a second PHPUnit into consumers. A plain constraint replaces the pinned repository.

The constraint carries no `@stable` flag on purpose. The root `composer.json` sets `minimum-stability: dev` without `prefer-stable`, so `^1.0.3` resolves to `1.x-dev`, currently `d3c32b2`, which is the tree the `1.0.3` tag points at. Following the branch is what we want on a development branch: a mistake upstream then shows up in our CI while they can still fix it, instead of landing on us at their next release. The lower bound stays at `1.0.3` because that is the first release we can use. 6.4 makes the opposite choice in #65426 and pins to `@stable`, which is the right trade for a long-term branch.

Adopting 1.x needs three changes on our side:

- The base classes now declare `protected array $skippedTests`. A property type has to be identical in the child, so the fourteen test classes that redeclare it are typed the same way. This is why the change cannot be split from the constraint bump: typed and untyped only work against their matching version of the package.
- `PhpArrayAdapterTest` skips `testDeleteItemsValidatesEveryKeyBeforeMutation`. That adapter does not validate keys by design, which the class already records for the five sibling `*InvalidKeys` tests; this new one carries no `skippedTests` guard upstream, so it is skipped by overriding it.
- The three real bugs the new tests expose are fixed separately in #65429 and #65430, on 6.4, because they are present there too.

1.x cannot be used on 6.4: it requires PHP 8.2 while five 6.4 jobs still resolve dependencies on 8.1, and it initialises its fixtures through `#[Before]` hooks that PHPUnit 9.6, which 6.4 pins, does not support. 6.4 therefore stays on the 0.18 line, which #65426 moves to a regular `^0.18@stable` constraint. When that one is merged up it will conflict here; the resolution is to keep this branch's `^1.0.3` and the absence of the inline repository.

Checks: with #65429 and #65430 applied on top, the full Cache suite passes against the current 1.x tree on PHP 8.5 with PHPUnit 11.5 and `zend.assertions=1` (3125 tests, 338 skipped). Without them it fails six tests. `php-cs-fixer` is clean, and both `composer.json` files still parse.
