### PR TITLE
 Fix invalid interface naming in ObjectMapper changelog

### DIFF
--- a/src/Symfony/Component/ObjectMapper/CHANGELOG.md
+++ b/src/Symfony/Component/ObjectMapper/CHANGELOG.md
@@ -7,7 +7,7 @@ CHANGELOG
  * Add reverse class-map based on Map attribute
  * Merge nested properties when targeting the same class
  * Add a `targetClass` option to `MapCollection`
- * Add a `TransformObjectMapperAwareInterface` to inject the current object mapper instance to transformers
+ * Handle the `ObjectMapperAwareInterface` to inject the current object mapper instance to transformers
  * Add `SourceClass`, `ClassRule`, and `ClassRuleList` condition callables to match mapping rules based on source/target class
  * Allow `TargetClass` and `SourceClass` to accept arrays of class FQDNs
  * Add `IsNotNull` built-in condition to skip mapping when a source property value is null


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

But this PR could be closed in favor of a new one that will perform a full AI-driven review of all files referenced in the Changelog and Readme files of the SF components to detect similar inconsistencies or typos.
