### PR TITLE
[DependencyInjection] Allow computing resource tag attributes per tagged class

### DIFF
--- a/.github/patch-types.php
+++ b/.github/patch-types.php
@@ -39,8 +39,13 @@ foreach ($loader->getClassMap() as $class => $file) {
         case false !== strpos($file, '/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/compositetype_classes.php'):
         case false !== strpos($file, '/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/intersectiontype_classes.php'):
         case false !== strpos($file, '/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/MultipleArgumentsOptionalScalarNotReallyOptional.php'):
+        case false !== strpos($file, '/src/Symfony/Component/DependencyInjection/Tests/Fixtures/AbstractResourceTaggedWithClosure.php'):
+        case false !== strpos($file, '/src/Symfony/Component/DependencyInjection/Tests/Fixtures/BarResourceTaggedWithClosure.php'):
         case false !== strpos($file, '/src/Symfony/Component/DependencyInjection/Tests/Fixtures/BarTaggedWithClosure.php'):
+        case false !== strpos($file, '/src/Symfony/Component/DependencyInjection/Tests/Fixtures/FooResourceTaggedWithClosure.php'):
         case false !== strpos($file, '/src/Symfony/Component/DependencyInjection/Tests/Fixtures/FooTaggedWithClosure.php'):
+        case false !== strpos($file, '/src/Symfony/Component/DependencyInjection/Tests/Fixtures/PrivateConstructorResourceTaggedWithClosure.php'):
+        case false !== strpos($file, '/src/Symfony/Component/DependencyInjection/Tests/Fixtures/ResourceTaggedWithClosureInterface.php'):
         case false !== strpos($file, '/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TaggedWithClosureInterface.php'):
         case false !== strpos($file, '/src/Symfony/Component/DependencyInjection/Tests/Fixtures/ParentNotExists.php'):
         case false !== strpos($file, '/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Preload/'):

--- a/src/Symfony/Component/DependencyInjection/Attribute/Autoconfigure.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/Autoconfigure.php
@@ -30,7 +30,7 @@ class Autoconfigure
      * @param array<string, mixed>|null              $properties   The properties to define when creating the service
      * @param array{string, string}|string|null      $configurator A PHP function, reference or an array containing a class/reference and a method to call after the service is fully initialized
      * @param string|null                            $constructor  The public static method to use to instantiate the service
-     * @param array<array<mixed>>|string[]|null      $resourceTags The resource tags to add to the service
+     * @param array<array<mixed>>|string[]|null      $resourceTags The resource tags to add to the service; a tag's attributes may be a \Closure or a [class-string, method] callable that computes them from each tagged class's class-string
      * @param array{string|null, string}|string|null $factory      A reference, an expression, or an array containing a class/reference and a method to call to create the service
      */
     public function __construct(

--- a/src/Symfony/Component/DependencyInjection/Attribute/AutoconfigureResourceTag.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/AutoconfigureResourceTag.php
@@ -18,10 +18,13 @@ namespace Symfony\Component\DependencyInjection\Attribute;
 class AutoconfigureResourceTag extends Autoconfigure
 {
     /**
-     * @param string|null  $name       The resource tag name to add
-     * @param array<mixed> $attributes The attributes to attach to the resource tag
+     * @param string|null           $name       The resource tag name to add
+     * @param array<mixed>|\Closure $attributes The attributes to attach to the resource tag. To compute them per
+     *                                          tagged class, pass a closure receiving the concrete class-string
+     *                                          (requires PHP 8.5), or a [class-string, method] callable whose static
+     *                                          method is called on each concrete class (works on PHP 8.4)
      */
-    public function __construct(?string $name = null, array $attributes = [])
+    public function __construct(?string $name = null, array|\Closure $attributes = [])
     {
         parent::__construct(
             resourceTags: [

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * Write a `CACHEDIR.TAG` file in the cache and build directories so backup tools can skip them
  * Add a `factory` argument to the `#[Autoconfigure]` attribute, and support the `factory` key under `_instanceof`
  * Add `Preloader::ignore()` to exclude classes or namespace prefixes from preloading
+ * Allow computing resource tag attributes per tagged class when using `#[AutoconfigureResourceTag]`, `#[Autoconfigure]` or `_instanceof`, like for regular tags
 
 8.1
 ---

--- a/src/Symfony/Component/DependencyInjection/Compiler/RegisterAutoconfigureAttributesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/RegisterAutoconfigureAttributesPass.php
@@ -82,8 +82,8 @@ final class RegisterAutoconfigureAttributesPass implements CompilerPassInterface
                     // A closure attribute-set cannot be expressed in YAML and must not go
                     // through the loader below; it is resolved per concrete class later, in
                     // ResolveInstanceofConditionalsPass.
-                    if ('tags' === $type && \is_array($tag) && 1 === \count($tag) && current($tag) instanceof \Closure) {
-                        $closureTags[] = [key($tag), current($tag)];
+                    if (\is_array($tag) && 1 === \count($tag) && current($tag) instanceof \Closure) {
+                        $closureTags[] = [$type, key($tag), current($tag)];
                         unset($attribute[$type][$i]);
                     }
                 }
@@ -108,8 +108,12 @@ final class RegisterAutoconfigureAttributesPass implements CompilerPassInterface
 
             // The closure is wrapped in an array so addTag() keeps an array attribute-set;
             // ResolveInstanceofConditionalsPass unwraps and resolves it per concrete class.
-            foreach ($closureTags as [$name, $closure]) {
-                $container->registerForAutoconfiguration($class->name)->addTag($name, [$closure]);
+            foreach ($closureTags as [$type, $name, $closure]) {
+                $abstract = $container->registerForAutoconfiguration($class->name);
+                match ($type) {
+                    'tags' => $abstract->addTag($name, [$closure]),
+                    'resourceTags' => $abstract->addResourceTag($name, [$closure]),
+                };
             }
         };
 

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveInstanceofConditionalsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveInstanceofConditionalsPass.php
@@ -157,7 +157,7 @@ class ResolveInstanceofConditionalsPass implements CompilerPassInterface
                     if (null === $definition->getDecoratedService() || $interface === $definition->getClass() || \in_array($k, $tagsToKeep, true)) {
                         foreach ($v as $v) {
                             if (self::isLazyTagAttributes($v)) {
-                                if (!($r = $container->getReflectionClass($class, false)) || !$r->isInstantiable()) {
+                                if (!($r = $container->getReflectionClass($class, false)) || !self::canComputeTagAttributes($r, $v)) {
                                     continue;
                                 }
                                 $v = self::resolveTagAttributes($v, $class, $k, $interface);
@@ -297,5 +297,20 @@ class ResolveInstanceofConditionalsPass implements CompilerPassInterface
         }
 
         return $resolved;
+    }
+
+    /**
+     * Whether lazily-computed attributes can be resolved for a class: being instantiable is not required
+     * (private constructors and enums are fine), but a closure cannot run on an abstract class or an
+     * interface, and a [class-string, method] callable cannot when the method resolves to an abstract
+     * declaration there. Skipping beats throwing because base types legitimately match the instanceof rules.
+     */
+    private static function canComputeTagAttributes(\ReflectionClass $r, array $attributes): bool
+    {
+        if ($attributes[0] instanceof \Closure) {
+            return !$r->isAbstract();
+        }
+
+        return !$r->hasMethod($attributes[1]) || !$r->getMethod($attributes[1])->isAbstract();
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/IntegrationTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/IntegrationTest.php
@@ -31,6 +31,8 @@ use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\ServiceLocator;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\AbstractResourceTaggedWithCallable;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\AbstractResourceTaggedWithClosure;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\Attribute\CustomAnyAttribute;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\Attribute\CustomAutoconfiguration;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\Attribute\CustomMethodAttribute;
@@ -40,14 +42,24 @@ use Symfony\Component\DependencyInjection\Tests\Fixtures\AutoconfiguredInterface
 use Symfony\Component\DependencyInjection\Tests\Fixtures\AutoconfiguredService1;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\AutoconfiguredService2;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\AutowireLocatorConsumer;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\BarResourceTaggedWithCallable;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\BarResourceTaggedWithClosure;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\BarTagClass;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\BarTaggedWithCallable;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\BarTaggedWithClosure;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\EnumResourceTaggedWithCallable;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\FooBarTaggedClass;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\FooBarTaggedForDefaultPriorityClass;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\FooResourceTaggedWithCallable;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\FooResourceTaggedWithClosure;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\FooTagClass;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\FooTaggedWithCallable;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\FooTaggedWithClosure;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\PrivateConstructorResourceTaggedWithCallable;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\PrivateConstructorResourceTaggedWithClosure;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\PrivateConstructorTaggedWithCallable;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\ResourceTaggedWithCallableInterface;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\ResourceTaggedWithClosureInterface;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\StaticMethodTag;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\TaggedConsumerWithExclude;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\TaggedIteratorConsumer;
@@ -422,11 +434,66 @@ class IntegrationTest extends TestCase
             ->setPublic(true)
         ;
 
+        $container->register('private', PrivateConstructorTaggedWithCallable::class)->setAutoconfigured(true);
+
         (new RegisterAutoconfigureAttributesPass())->processClass($container, new \ReflectionClass(TaggedWithCallableInterface::class));
         (new ResolveInstanceofConditionalsPass())->process($container);
 
         $this->assertSame([['key' => 'foo']], $container->getDefinition('foo')->getTag('app.handler'));
         $this->assertSame([['key' => 'bar']], $container->getDefinition('bar')->getTag('app.handler'));
+        $this->assertSame([['key' => 'private']], $container->getDefinition('private')->getTag('app.handler'));
+    }
+
+    public function testAutoconfiguredResourceTagWithClosureAttributes()
+    {
+        if (\PHP_VERSION_ID < 80500) {
+            $this->markTestSkipped('Closures in constant expressions require PHP 8.5.');
+        }
+
+        $container = new ContainerBuilder();
+        $container->register('foo', FooResourceTaggedWithClosure::class)->setAutoconfigured(true);
+        $container->register('bar', BarResourceTaggedWithClosure::class)->setAutoconfigured(true);
+        $container->register('private', PrivateConstructorResourceTaggedWithClosure::class)->setAutoconfigured(true);
+        $container->register('abstract', AbstractResourceTaggedWithClosure::class)->setAutoconfigured(true);
+
+        (new RegisterAutoconfigureAttributesPass())->processClass($container, new \ReflectionClass(ResourceTaggedWithClosureInterface::class));
+        (new ResolveInstanceofConditionalsPass())->process($container);
+
+        $this->assertSame([['foo' => 'foo']], $container->getDefinition('foo')->getTag('foo_bar'));
+        $this->assertTrue($container->getDefinition('foo')->hasTag('container.excluded'));
+        $this->assertSame([['foo' => 'bar']], $container->getDefinition('bar')->getTag('foo_bar'));
+        $this->assertTrue($container->getDefinition('bar')->hasTag('container.excluded'));
+        $this->assertSame([['foo' => 'private']], $container->getDefinition('private')->getTag('foo_bar'));
+
+        // closures cannot be introspected: abstract classes are skipped, only the marker tag is added
+        $this->assertFalse($container->getDefinition('abstract')->hasTag('foo_bar'));
+        $this->assertTrue($container->getDefinition('abstract')->hasTag('container.excluded'));
+    }
+
+    public function testAutoconfiguredResourceTagWithCallableArrayAttributes()
+    {
+        $container = new ContainerBuilder();
+        $container->register('foo', FooResourceTaggedWithCallable::class)->setAutoconfigured(true);
+        $container->register('bar', BarResourceTaggedWithCallable::class)->setAutoconfigured(true);
+        $container->register('private', PrivateConstructorResourceTaggedWithCallable::class)->setAutoconfigured(true);
+        $container->register('enum', EnumResourceTaggedWithCallable::class)->setAutoconfigured(true);
+        $container->register('abstract', AbstractResourceTaggedWithCallable::class)->setAutoconfigured(true);
+        $container->register('interface', ResourceTaggedWithCallableInterface::class)->setAutoconfigured(true);
+
+        (new RegisterAutoconfigureAttributesPass())->processClass($container, new \ReflectionClass(ResourceTaggedWithCallableInterface::class));
+        (new ResolveInstanceofConditionalsPass())->process($container);
+
+        $this->assertSame([['foo' => 'foo']], $container->getDefinition('foo')->getTag('foo_bar'));
+        $this->assertTrue($container->getDefinition('foo')->hasTag('container.excluded'));
+        $this->assertSame([['foo' => 'bar']], $container->getDefinition('bar')->getTag('foo_bar'));
+        $this->assertTrue($container->getDefinition('bar')->hasTag('container.excluded'));
+        $this->assertSame([['foo' => 'private']], $container->getDefinition('private')->getTag('foo_bar'));
+        $this->assertSame([['foo' => 'enum']], $container->getDefinition('enum')->getTag('foo_bar'));
+        $this->assertSame([['foo' => 'abstract']], $container->getDefinition('abstract')->getTag('foo_bar'));
+
+        // on the interface itself the method is abstract: the tag is skipped, only the marker tag is added
+        $this->assertFalse($container->getDefinition('interface')->hasTag('foo_bar'));
+        $this->assertTrue($container->getDefinition('interface')->hasTag('container.excluded'));
     }
 
     public function testAutoconfiguredTagWithCallableArrayAttributesFromYaml()
@@ -439,6 +506,20 @@ class IntegrationTest extends TestCase
 
         $this->assertSame([['key' => 'foo']], $container->getDefinition('foo')->getTag('app.handler'));
         $this->assertSame([['key' => 'bar']], $container->getDefinition('bar')->getTag('app.handler'));
+    }
+
+    public function testAutoconfiguredResourceTagWithCallableArrayAttributesFromYaml()
+    {
+        $container = new ContainerBuilder();
+        $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Fixtures/yaml'));
+        $loader->load('services_with_callable_resource_tag_attributes.yml');
+
+        (new ResolveInstanceofConditionalsPass())->process($container);
+
+        $this->assertSame([['foo' => 'foo']], $container->getDefinition('foo')->getTag('foo_bar'));
+        $this->assertTrue($container->getDefinition('foo')->hasTag('container.excluded'));
+        $this->assertSame([['foo' => 'bar']], $container->getDefinition('bar')->getTag('foo_bar'));
+        $this->assertTrue($container->getDefinition('bar')->hasTag('container.excluded'));
     }
 
     public function testAutoconfiguredTagAttributesCanComputePriority()

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/AbstractResourceTaggedWithCallable.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/AbstractResourceTaggedWithCallable.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+abstract class AbstractResourceTaggedWithCallable implements ResourceTaggedWithCallableInterface
+{
+    public static function getTagAttributes(): array
+    {
+        return ['foo' => 'abstract'];
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/AbstractResourceTaggedWithClosure.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/AbstractResourceTaggedWithClosure.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+abstract class AbstractResourceTaggedWithClosure implements ResourceTaggedWithClosureInterface
+{
+    public static function getKey(): string
+    {
+        return 'abstract';
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/BarResourceTaggedWithCallable.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/BarResourceTaggedWithCallable.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+class BarResourceTaggedWithCallable implements ResourceTaggedWithCallableInterface
+{
+    public static function getTagAttributes(): array
+    {
+        return ['foo' => 'bar'];
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/BarResourceTaggedWithClosure.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/BarResourceTaggedWithClosure.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+class BarResourceTaggedWithClosure implements ResourceTaggedWithClosureInterface
+{
+    public static function getKey(): string
+    {
+        return 'bar';
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/EnumResourceTaggedWithCallable.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/EnumResourceTaggedWithCallable.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+enum EnumResourceTaggedWithCallable implements ResourceTaggedWithCallableInterface
+{
+    public static function getTagAttributes(): array
+    {
+        return ['foo' => 'enum'];
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/FooResourceTaggedWithCallable.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/FooResourceTaggedWithCallable.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+class FooResourceTaggedWithCallable implements ResourceTaggedWithCallableInterface
+{
+    public static function getTagAttributes(): array
+    {
+        return ['foo' => 'foo'];
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/FooResourceTaggedWithClosure.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/FooResourceTaggedWithClosure.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+class FooResourceTaggedWithClosure implements ResourceTaggedWithClosureInterface
+{
+    public static function getKey(): string
+    {
+        return 'foo';
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/PrivateConstructorResourceTaggedWithCallable.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/PrivateConstructorResourceTaggedWithCallable.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+class PrivateConstructorResourceTaggedWithCallable implements ResourceTaggedWithCallableInterface
+{
+    private function __construct()
+    {
+    }
+
+    public static function getTagAttributes(): array
+    {
+        return ['foo' => 'private'];
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/PrivateConstructorResourceTaggedWithClosure.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/PrivateConstructorResourceTaggedWithClosure.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+class PrivateConstructorResourceTaggedWithClosure implements ResourceTaggedWithClosureInterface
+{
+    private function __construct()
+    {
+    }
+
+    public static function getKey(): string
+    {
+        return 'private';
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/PrivateConstructorTaggedWithCallable.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/PrivateConstructorTaggedWithCallable.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+class PrivateConstructorTaggedWithCallable implements TaggedWithCallableInterface
+{
+    private function __construct()
+    {
+    }
+
+    public static function getTagAttributes(): array
+    {
+        return ['key' => 'private'];
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/ResourceTaggedWithCallableInterface.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/ResourceTaggedWithCallableInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureResourceTag;
+
+#[AutoconfigureResourceTag('foo_bar', attributes: [self::class, 'getTagAttributes'])]
+interface ResourceTaggedWithCallableInterface
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public static function getTagAttributes(): array;
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/ResourceTaggedWithClosureInterface.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/ResourceTaggedWithClosureInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureResourceTag;
+
+#[AutoconfigureResourceTag('foo_bar', attributes: static function (string $class): array {
+    return ['foo' => $class::getKey()];
+})]
+interface ResourceTaggedWithClosureInterface
+{
+    public static function getKey(): string;
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_with_callable_resource_tag_attributes.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_with_callable_resource_tag_attributes.yml
@@ -1,0 +1,11 @@
+services:
+    _instanceof:
+        Symfony\Component\DependencyInjection\Tests\Fixtures\ResourceTaggedWithCallableInterface:
+            resource_tags:
+                - foo_bar: [Symfony\Component\DependencyInjection\Tests\Fixtures\ResourceTaggedWithCallableInterface, getTagAttributes]
+
+    foo:
+        class: Symfony\Component\DependencyInjection\Tests\Fixtures\FooResourceTaggedWithCallable
+
+    bar:
+        class: Symfony\Component\DependencyInjection\Tests\Fixtures\BarResourceTaggedWithCallable


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Extracted from #65370, as I think this feature brings value on its own.

#64652 introduced computing tag attributes per tagged service using a closure or a `[class-string, method]` callable.

This PR extends the same capability to resource tags, so attributes can be computed per tagged class:

```php
#[AutoconfigureResourceTag('app.message', attributes: static function (string $class): array {
    return ['format' => $class::getFormat()];
})]
interface MessageInterface
{
    public static function getFormat(): string;
}
```

```yaml
services:
    _instanceof:
        App\MessageInterface:
            resource_tags:
                - app.message: [App\MessageInterface, getTagAttributes]
```

The `[class-string, method]` form already worked for resource tags on 8.2 because the resolution added by #64652 is shared by both tag flavors; this PR locks that in with tests. The closure form (PHP 8.5) is the new part.

The PR also refines when lazily-computed attributes are resolved, for regular and resource tags alike (both are new in 8.2, so this changes no released behavior): the computation now runs on any class it can run on, instead of only instantiable ones. Classes with a private constructor and enums get their attributes computed, and the `[class-string, method]` form also covers abstract classes that concretely implement the method. Closures cannot be introspected, so they keep skipping abstract classes and interfaces. This matches the set of classes a static attribute array tags, where nothing needs to be invoked.

For the documentation:
- resource tag attributes can be computed per tagged class, like for regular tags: pass a closure receiving the class-string (PHP 8.5) or a `[class-string, method]` callable whose static method is called on each tagged class (works on PHP 8.4);
- entry points: `#[AutoconfigureResourceTag]`, `#[Autoconfigure(resourceTags: ...)]`, and the `resource_tags` key under `_instanceof` (the callable form only, in config files);
- the computation also runs on classes the container cannot instantiate: private constructors, enums, and, for the callable form, abstract classes implementing the method.
