### PR TITLE
[Translation] Re-add the POEditor provider bridge

### DIFF
--- a/splitsh.json
+++ b/splitsh.json
@@ -190,6 +190,7 @@
         "loco-translation-provider": "src/Symfony/Component/Translation/Bridge/Loco",
         "lokalise-translation-provider": "src/Symfony/Component/Translation/Bridge/Lokalise",
         "phrase-translation-provider": "src/Symfony/Component/Translation/Bridge/Phrase",
+        "po-editor-translation-provider": "src/Symfony/Component/Translation/Bridge/PoEditor",
         "type-info": "src/Symfony/Component/TypeInfo",
         "uid": "src/Symfony/Component/Uid",
         "validator": "src/Symfony/Component/Validator",

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1750,6 +1750,7 @@ class FrameworkExtension extends Extension
             TranslationBridge\Loco\LocoProviderFactory::class => ['symfony/loco-translation-provider', ['translation.provider_factory.loco', 'translation.provider_factory.loco.http_client']],
             TranslationBridge\Lokalise\LokaliseProviderFactory::class => ['symfony/lokalise-translation-provider', ['translation.provider_factory.lokalise']],
             TranslationBridge\Phrase\PhraseProviderFactory::class => ['symfony/phrase-translation-provider', ['translation.provider_factory.phrase']],
+            TranslationBridge\PoEditor\PoEditorProviderFactory::class => ['symfony/po-editor-translation-provider', ['translation.provider_factory.poeditor']],
         ];
 
         $parentPackages = ['symfony/framework-bundle', 'symfony/translation', 'symfony/http-client'];

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation_providers.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation_providers.php
@@ -16,6 +16,7 @@ use Symfony\Component\Translation\Bridge\Crowdin\CrowdinProviderFactory;
 use Symfony\Component\Translation\Bridge\Loco\LocoProviderFactory;
 use Symfony\Component\Translation\Bridge\Lokalise\LokaliseProviderFactory;
 use Symfony\Component\Translation\Bridge\Phrase\PhraseProviderFactory;
+use Symfony\Component\Translation\Bridge\PoEditor\PoEditorProviderFactory;
 use Symfony\Component\Translation\Provider\NullProviderFactory;
 use Symfony\Component\Translation\Provider\TranslationProviderCollection;
 use Symfony\Component\Translation\Provider\TranslationProviderCollectionFactory;
@@ -95,6 +96,15 @@ return static function (ContainerConfigurator $container) {
                 service('translation.dumper.xliff'),
                 service('cache.app'),
                 param('kernel.default_locale'),
+            ])
+            ->tag('translation.provider_factory')
+
+        ->set('translation.provider_factory.poeditor', PoEditorProviderFactory::class)
+            ->args([
+                service('http_client'),
+                service('logger'),
+                param('kernel.default_locale'),
+                service('translation.loader.xliff'),
             ])
             ->tag('translation.provider_factory')
     ;

--- a/src/Symfony/Component/Translation/Bridge/PoEditor/.gitattributes
+++ b/src/Symfony/Component/Translation/Bridge/PoEditor/.gitattributes
@@ -1,0 +1,3 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Translation/Bridge/PoEditor/.gitignore
+++ b/src/Symfony/Component/Translation/Bridge/PoEditor/.gitignore
@@ -1,0 +1,5 @@
+vendor/
+composer.lock
+phpunit.xml
+.phpunit.cache
+.phpunit.result.cache

--- a/src/Symfony/Component/Translation/Bridge/PoEditor/CHANGELOG.md
+++ b/src/Symfony/Component/Translation/Bridge/PoEditor/CHANGELOG.md
@@ -1,0 +1,7 @@
+CHANGELOG
+=========
+
+8.2
+---
+
+ * Re-add the bridge

--- a/src/Symfony/Component/Translation/Bridge/PoEditor/LICENSE
+++ b/src/Symfony/Component/Translation/Bridge/PoEditor/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2026-present Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Symfony/Component/Translation/Bridge/PoEditor/PoEditorHttpClient.php
+++ b/src/Symfony/Component/Translation/Bridge/PoEditor/PoEditorHttpClient.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Bridge\PoEditor;
+
+use Symfony\Component\HttpClient\DecoratorTrait;
+use Symfony\Component\HttpClient\ScopingHttpClient;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+final class PoEditorHttpClient implements HttpClientInterface
+{
+    use DecoratorTrait;
+
+    public function request(string $method, string $url, array $options = []): ResponseInterface
+    {
+        if (isset($options['poeditor_credentials'])) {
+            if ('POST' === $method) {
+                $options['body'] = $options['poeditor_credentials'] + $options['body'];
+            }
+            unset($options['poeditor_credentials']);
+        }
+
+        return $this->client->request($method, $url, $options);
+    }
+
+    public static function create(HttpClientInterface $client, string $baseUri, string $apiToken, string $projectId): HttpClientInterface
+    {
+        return ScopingHttpClient::forBaseUri(new self($client), $baseUri, [
+            'poeditor_credentials' => [
+                'api_token' => $apiToken,
+                'id' => $projectId,
+            ],
+        ]);
+    }
+}

--- a/src/Symfony/Component/Translation/Bridge/PoEditor/PoEditorProvider.php
+++ b/src/Symfony/Component/Translation/Bridge/PoEditor/PoEditorProvider.php
@@ -1,0 +1,202 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Bridge\PoEditor;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Translation\Exception\ProviderException;
+use Symfony\Component\Translation\Loader\LoaderInterface;
+use Symfony\Component\Translation\Provider\ProviderInterface;
+use Symfony\Component\Translation\TranslatorBag;
+use Symfony\Component\Translation\TranslatorBagInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * @author Mathieu Santostefano <msantostefano@protonmail.com>
+ *
+ * In POEditor:
+ *  * Terms refer to Symfony's translation keys;
+ *  * Translations refer to Symfony's translated messages;
+ *  * Context fields refer to Symfony's translation domains.
+ *
+ * POEditor's API always returns 200 status code, even in case of failure.
+ */
+final class PoEditorProvider implements ProviderInterface
+{
+    public function __construct(
+        private readonly HttpClientInterface $client,
+        private readonly LoaderInterface $loader,
+        private readonly LoggerInterface $logger,
+        private readonly string $defaultLocale,
+        private readonly string $endpoint,
+    ) {
+    }
+
+    public function __toString(): string
+    {
+        return \sprintf('poeditor://%s', $this->endpoint);
+    }
+
+    public function write(TranslatorBagInterface $translatorBag): void
+    {
+        $defaultCatalogue = $translatorBag->getCatalogue($this->defaultLocale);
+
+        $terms = $translationsToAdd = [];
+        foreach ($defaultCatalogue->all() as $domain => $messages) {
+            foreach ($messages as $id => $message) {
+                $terms[] = [
+                    'term' => $id,
+                    'reference' => $id,
+                    // tags field is mandatory to export all translations in read method.
+                    'tags' => [$domain],
+                    'context' => $domain,
+                ];
+            }
+        }
+        $this->addTerms($terms);
+
+        foreach ($translatorBag->getCatalogues() as $catalogue) {
+            $locale = $catalogue->getLocale();
+            foreach ($catalogue->all() as $domain => $messages) {
+                foreach ($messages as $id => $message) {
+                    $translationsToAdd[$locale][] = [
+                        'term' => $id,
+                        'context' => $domain,
+                        'translation' => [
+                            'content' => $message,
+                        ],
+                    ];
+                }
+            }
+        }
+
+        $this->addTranslations($translationsToAdd);
+    }
+
+    public function read(array $domains, array $locales): TranslatorBag
+    {
+        $translatorBag = new TranslatorBag();
+        $exportResponses = $downloadResponses = [];
+
+        foreach ($locales as $locale) {
+            foreach ($domains as $domain) {
+                $response = $this->client->request('POST', 'projects/export', [
+                    'body' => [
+                        'language' => $locale,
+                        'type' => 'xlf',
+                        'filters' => json_encode(['translated']),
+                        'tags' => json_encode([$domain]),
+                    ],
+                ]);
+                $exportResponses[] = [$response, $locale, $domain];
+            }
+        }
+
+        foreach ($exportResponses as [$response, $locale, $domain]) {
+            $responseContent = $response->toArray(false);
+
+            if (200 !== $response->getStatusCode() || '200' !== (string) $responseContent['response']['code']) {
+                $this->logger->error('Unable to read the POEditor response: '.$response->getContent(false));
+                continue;
+            }
+
+            $fileUrl = $responseContent['result']['url'];
+            $downloadResponses[] = [$this->client->request('GET', $fileUrl), $locale, $domain, $fileUrl];
+        }
+
+        foreach ($downloadResponses as [$response, $locale, $domain, $fileUrl]) {
+            $responseContent = $response->getContent(false);
+
+            if (200 !== $response->getStatusCode()) {
+                $this->logger->error('Unable to download the POEditor exported file: '.$responseContent);
+                continue;
+            }
+
+            if (!$responseContent) {
+                $this->logger->error(\sprintf('The exported file "%s" from POEditor is empty.', $fileUrl));
+                continue;
+            }
+
+            $translatorBag->addCatalogue($this->loader->load($responseContent, $locale, $domain));
+        }
+
+        return $translatorBag;
+    }
+
+    public function delete(TranslatorBagInterface $translatorBag): void
+    {
+        $deletedIds = $termsToDelete = [];
+
+        foreach ($translatorBag->getCatalogues() as $catalogue) {
+            foreach ($catalogue->all() as $domain => $messages) {
+                foreach ($messages as $id => $message) {
+                    if (\in_array($id, $deletedIds[$domain] ?? [], true)) {
+                        continue;
+                    }
+
+                    $deletedIds[$domain][] = $id;
+                    $termsToDelete[] = [
+                        'term' => $id,
+                        'context' => $domain,
+                    ];
+                }
+            }
+        }
+
+        $this->deleteTerms($termsToDelete);
+    }
+
+    private function addTerms(array $terms): void
+    {
+        $response = $this->client->request('POST', 'terms/add', [
+            'body' => [
+                'data' => json_encode($terms),
+            ],
+        ]);
+
+        if (200 !== $response->getStatusCode() || '200' !== (string) $response->toArray(false)['response']['code']) {
+            throw new ProviderException(\sprintf('Unable to add new translation keys to POEditor: (status code: "%s") "%s".', $response->getStatusCode(), $response->getContent(false)), $response);
+        }
+    }
+
+    private function addTranslations(array $translationsPerLocale): void
+    {
+        $responses = [];
+
+        foreach ($translationsPerLocale as $locale => $translations) {
+            $responses[] = $this->client->request('POST', 'translations/add', [
+                'body' => [
+                    'language' => $locale,
+                    'data' => json_encode($translations),
+                ],
+            ]);
+        }
+
+        foreach ($responses as $response) {
+            if (200 !== $response->getStatusCode() || '200' !== (string) $response->toArray(false)['response']['code']) {
+                $this->logger->error(\sprintf('Unable to add translation messages to POEditor: "%s".', $response->getContent(false)));
+            }
+        }
+    }
+
+    private function deleteTerms(array $ids): void
+    {
+        $response = $this->client->request('POST', 'terms/delete', [
+            'body' => [
+                'data' => json_encode($ids),
+            ],
+        ]);
+
+        if (200 !== $response->getStatusCode() || '200' !== (string) $response->toArray(false)['response']['code']) {
+            throw new ProviderException(\sprintf('Unable to delete translation keys on POEditor: "%s".', $response->getContent(false)), $response);
+        }
+    }
+}

--- a/src/Symfony/Component/Translation/Bridge/PoEditor/PoEditorProviderFactory.php
+++ b/src/Symfony/Component/Translation/Bridge/PoEditor/PoEditorProviderFactory.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Bridge\PoEditor;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Translation\Exception\UnsupportedSchemeException;
+use Symfony\Component\Translation\Loader\LoaderInterface;
+use Symfony\Component\Translation\Provider\AbstractProviderFactory;
+use Symfony\Component\Translation\Provider\Dsn;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * @author Mathieu Santostefano <msantostefano@protonmail.com>
+ */
+final class PoEditorProviderFactory extends AbstractProviderFactory
+{
+    private const HOST = 'api.poeditor.com';
+
+    public function __construct(
+        private readonly HttpClientInterface $client,
+        private readonly LoggerInterface $logger,
+        private readonly string $defaultLocale,
+        private readonly LoaderInterface $loader,
+    ) {
+    }
+
+    public function create(Dsn $dsn): PoEditorProvider
+    {
+        if ('poeditor' !== $dsn->getScheme()) {
+            throw new UnsupportedSchemeException($dsn, 'poeditor', $this->getSupportedSchemes());
+        }
+
+        $endpoint = 'default' === $dsn->getHost() ? self::HOST : $dsn->getHost();
+        $endpoint .= $dsn->getPort() ? ':'.$dsn->getPort() : '';
+
+        $client = PoEditorHttpClient::create($this->client, 'https://'.$endpoint.'/v2/', $this->getPassword($dsn), $this->getUser($dsn));
+
+        return new PoEditorProvider($client, $this->loader, $this->logger, $this->defaultLocale, $endpoint);
+    }
+
+    protected function getSupportedSchemes(): array
+    {
+        return ['poeditor'];
+    }
+}

--- a/src/Symfony/Component/Translation/Bridge/PoEditor/README.md
+++ b/src/Symfony/Component/Translation/Bridge/PoEditor/README.md
@@ -1,0 +1,36 @@
+POEditor Translation Provider
+=============================
+
+Provides POEditor integration for Symfony Translation.
+
+DSN example
+-----------
+
+```
+// .env file
+POEDITOR_DSN=poeditor://PROJECT_ID:API_KEY@default
+```
+
+where:
+ - `PROJECT_ID` is your POEditor project ID
+ - `API_KEY` is your POEditor API key
+
+[more information on POEditor website](https://poeditor.com/docs/api)
+
+Sponsor
+-------
+
+This package is looking for a [backer][1].
+
+Help Symfony by [sponsoring][3] its development!
+
+Resources
+---------
+
+ * [Contributing](https://symfony.com/doc/current/contributing/index.html)
+ * [Report issues](https://github.com/symfony/symfony/issues) and
+   [send Pull Requests](https://github.com/symfony/symfony/pulls)
+   in the [main Symfony repository](https://github.com/symfony/symfony)
+
+[1]: https://symfony.com/backers
+[3]: https://symfony.com/sponsor

--- a/src/Symfony/Component/Translation/Bridge/PoEditor/Tests/PoEditorProviderFactoryTest.php
+++ b/src/Symfony/Component/Translation/Bridge/PoEditor/Tests/PoEditorProviderFactoryTest.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Bridge\PoEditor\Tests;
+
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\Translation\Bridge\PoEditor\PoEditorProviderFactory;
+use Symfony\Component\Translation\Loader\ArrayLoader;
+use Symfony\Component\Translation\Provider\ProviderFactoryInterface;
+use Symfony\Component\Translation\Test\AbstractProviderFactoryTestCase;
+use Symfony\Component\Translation\Test\IncompleteDsnTestTrait;
+
+class PoEditorProviderFactoryTest extends AbstractProviderFactoryTestCase
+{
+    use IncompleteDsnTestTrait;
+
+    public static function supportsProvider(): iterable
+    {
+        yield [true, 'poeditor://PROJECT_ID:API_KEY@default'];
+        yield [false, 'somethingElse://PROJECT_ID:API_KEY@default'];
+    }
+
+    public static function unsupportedSchemeProvider(): iterable
+    {
+        yield ['somethingElse://PROJECT_ID:API_KEY@default'];
+    }
+
+    public static function createProvider(): iterable
+    {
+        yield [
+            'poeditor://api.poeditor.com',
+            'poeditor://PROJECT_ID:API_KEY@default',
+        ];
+    }
+
+    public static function incompleteDsnProvider(): iterable
+    {
+        yield ['poeditor://default'];
+    }
+
+    public function createFactory(): ProviderFactoryInterface
+    {
+        return new PoEditorProviderFactory(new MockHttpClient(), new NullLogger(), 'en', new ArrayLoader());
+    }
+}

--- a/src/Symfony/Component/Translation/Bridge/PoEditor/Tests/PoEditorProviderTest.php
+++ b/src/Symfony/Component/Translation/Bridge/PoEditor/Tests/PoEditorProviderTest.php
@@ -1,0 +1,458 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Bridge\PoEditor\Tests;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\JsonMockResponse;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\Translation\Bridge\PoEditor\PoEditorHttpClient;
+use Symfony\Component\Translation\Bridge\PoEditor\PoEditorProvider;
+use Symfony\Component\Translation\Loader\ArrayLoader;
+use Symfony\Component\Translation\Loader\LoaderInterface;
+use Symfony\Component\Translation\Loader\XliffFileLoader;
+use Symfony\Component\Translation\MessageCatalogue;
+use Symfony\Component\Translation\Provider\ProviderInterface;
+use Symfony\Component\Translation\Test\ProviderTestCase;
+use Symfony\Component\Translation\TranslatorBag;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+class PoEditorProviderTest extends ProviderTestCase
+{
+    public static function createProvider(HttpClientInterface $client, LoaderInterface $loader, LoggerInterface $logger, string $defaultLocale, string $endpoint): ProviderInterface
+    {
+        return new PoEditorProvider(PoEditorHttpClient::create($client, 'https://'.$endpoint.'/v2/', 'API_KEY', 'PROJECT_ID'), $loader, $logger, $defaultLocale, $endpoint);
+    }
+
+    public static function toStringProvider(): iterable
+    {
+        $client = new MockHttpClient();
+        $loader = new ArrayLoader();
+        $logger = new NullLogger();
+
+        yield [
+            self::createProvider($client, $loader, $logger, 'en', 'api.poeditor.com'),
+            'poeditor://api.poeditor.com',
+        ];
+
+        yield [
+            self::createProvider($client, $loader, $logger, 'en', 'example.com'),
+            'poeditor://example.com',
+        ];
+
+        yield [
+            self::createProvider($client, $loader, $logger, 'en', 'example.com:99'),
+            'poeditor://example.com:99',
+        ];
+    }
+
+    public function testCompleteWriteProcess()
+    {
+        $successResponse = new JsonMockResponse([
+            'response' => [
+                'status' => 'success',
+                'code' => '200',
+                'message' => 'OK',
+            ],
+        ]);
+
+        $responses = [
+            'addTerms' => function (string $method, string $url, array $options = []) use ($successResponse): MockResponse {
+                $this->assertSame('POST', $method);
+                $this->assertSame(http_build_query([
+                    'api_token' => 'API_KEY',
+                    'id' => 'PROJECT_ID',
+                    'data' => json_encode([
+                        [
+                            'term' => 'a',
+                            'reference' => 'a',
+                            'tags' => ['messages'],
+                            'context' => 'messages',
+                        ],
+                        [
+                            'term' => 'post.num_comments',
+                            'reference' => 'post.num_comments',
+                            'tags' => ['validators'],
+                            'context' => 'validators',
+                        ],
+                    ]),
+                ]), $options['body']);
+
+                return $successResponse;
+            },
+            'addTranslationsEn' => function (string $method, string $url, array $options = []) use ($successResponse): MockResponse {
+                $this->assertSame('POST', $method);
+                $this->assertSame(http_build_query([
+                    'api_token' => 'API_KEY',
+                    'id' => 'PROJECT_ID',
+                    'language' => 'en',
+                    'data' => json_encode([
+                        [
+                            'term' => 'a',
+                            'context' => 'messages',
+                            'translation' => ['content' => 'trans_en_a'],
+                        ],
+                        [
+                            'term' => 'post.num_comments',
+                            'context' => 'validators',
+                            'translation' => ['content' => '{count, plural, one {# comment} other {# comments}}'],
+                        ],
+                    ]),
+                ]), $options['body']);
+
+                return $successResponse;
+            },
+            'addTranslationsFr' => function (string $method, string $url, array $options = []) use ($successResponse): MockResponse {
+                $this->assertSame('POST', $method);
+                $this->assertSame(http_build_query([
+                    'api_token' => 'API_KEY',
+                    'id' => 'PROJECT_ID',
+                    'language' => 'fr',
+                    'data' => json_encode([
+                        [
+                            'term' => 'a',
+                            'context' => 'messages',
+                            'translation' => ['content' => 'trans_fr_a'],
+                        ],
+                        [
+                            'term' => 'post.num_comments',
+                            'context' => 'validators',
+                            'translation' => ['content' => '{count, plural, one {# commentaire} other {# commentaires}}'],
+                        ],
+                    ]),
+                ]), $options['body']);
+
+                return $successResponse;
+            },
+        ];
+
+        $translatorBag = new TranslatorBag();
+        $translatorBag->addCatalogue(new MessageCatalogue('en', [
+            'messages' => ['a' => 'trans_en_a'],
+            'validators' => ['post.num_comments' => '{count, plural, one {# comment} other {# comments}}'],
+        ]));
+        $translatorBag->addCatalogue(new MessageCatalogue('fr', [
+            'messages' => ['a' => 'trans_fr_a'],
+            'validators' => ['post.num_comments' => '{count, plural, one {# commentaire} other {# commentaires}}'],
+        ]));
+
+        $provider = self::createProvider(
+            new MockHttpClient($responses, 'https://api.poeditor.com/v2/'),
+            $this->getLoader(),
+            $this->getLogger(),
+            $this->getDefaultLocale(),
+            'api.poeditor.com'
+        );
+
+        $provider->write($translatorBag);
+    }
+
+    #[DataProvider('getResponsesForOneLocaleAndOneDomain')]
+    public function testReadForOneLocaleAndOneDomain(string $locale, string $domain, string $responseContent, TranslatorBag $expectedTranslatorBag)
+    {
+        $loader = $this->createMock(LoaderInterface::class);
+        $loader->expects($this->once())
+            ->method('load')
+            ->willReturn((new XliffFileLoader())->load($responseContent, $locale, $domain));
+
+        $responses = [
+            new JsonMockResponse([
+                'response' => [
+                    'status' => 'success',
+                    'code' => '200',
+                    'message' => 'OK',
+                ],
+                'result' => [
+                    'url' => 'https://api.poeditor.com/v2/download/file/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+                ],
+            ]),
+            new MockResponse($responseContent),
+        ];
+
+        $provider = self::createProvider(
+            new MockHttpClient($responses, 'https://api.poeditor.com/v2/'),
+            $loader,
+            $this->getLogger(),
+            $this->getDefaultLocale(),
+            'api.poeditor.com'
+        );
+
+        $translatorBag = $provider->read([$domain], [$locale]);
+        // We don't want to assert equality of metadata here, due to the ArrayLoader usage.
+        foreach ($translatorBag->getCatalogues() as $catalogue) {
+            $catalogue->deleteMetadata('', '');
+        }
+
+        $this->assertEquals($expectedTranslatorBag->getCatalogues(), $translatorBag->getCatalogues());
+    }
+
+    #[DataProvider('getResponsesForManyLocalesAndManyDomains')]
+    public function testReadForManyLocalesAndManyDomains(array $locales, array $domains, array $responseContents, TranslatorBag $expectedTranslatorBag)
+    {
+        $exportResponses = $downloadResponses = [];
+        $consecutiveLoadArguments = [];
+        $consecutiveLoadReturns = [];
+        foreach ($locales as $locale) {
+            foreach ($domains as $domain) {
+                $exportResponses[] = new JsonMockResponse([
+                    'response' => [
+                        'status' => 'success',
+                        'code' => '200',
+                        'message' => 'OK',
+                    ],
+                    'result' => [
+                        'url' => 'https://api.poeditor.com/v2/download/file/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+                    ],
+                ]);
+                $downloadResponses[] = new MockResponse($responseContents[$locale][$domain]);
+                $consecutiveLoadArguments[] = [$responseContents[$locale][$domain], $locale, $domain];
+                $consecutiveLoadReturns[] = (new XliffFileLoader())->load($responseContents[$locale][$domain], $locale, $domain);
+            }
+        }
+
+        $loader = $this->createMock(LoaderInterface::class);
+        $loader->expects($this->exactly(\count($consecutiveLoadArguments)))
+            ->method('load')
+            ->willReturnCallback(function (...$args) use (&$consecutiveLoadArguments, &$consecutiveLoadReturns) {
+                $this->assertSame(array_shift($consecutiveLoadArguments), $args);
+
+                return array_shift($consecutiveLoadReturns);
+            });
+
+        $provider = self::createProvider(
+            new MockHttpClient(array_merge($exportResponses, $downloadResponses), 'https://api.poeditor.com/v2/'),
+            $loader,
+            $this->getLogger(),
+            $this->getDefaultLocale(),
+            'api.poeditor.com'
+        );
+
+        $translatorBag = $provider->read($domains, $locales);
+        // We don't want to assert equality of metadata here, due to the ArrayLoader usage.
+        foreach ($translatorBag->getCatalogues() as $catalogue) {
+            $catalogue->deleteMetadata('', '');
+        }
+
+        $this->assertEquals($expectedTranslatorBag->getCatalogues(), $translatorBag->getCatalogues());
+    }
+
+    public function testDeleteProcess()
+    {
+        $successResponse = new JsonMockResponse([
+            'response' => [
+                'status' => 'success',
+                'code' => '200',
+                'message' => 'OK',
+            ],
+        ]);
+
+        $translatorBag = new TranslatorBag();
+        $translatorBag->addCatalogue(new MessageCatalogue('en', [
+            'messages' => ['a' => 'trans_en_a'],
+            'validators' => ['post.num_comments' => '{count, plural, one {# comment} other {# comments}}'],
+        ]));
+        $translatorBag->addCatalogue(new MessageCatalogue('fr', [
+            'messages' => ['a' => 'trans_fr_a'],
+            'validators' => ['post.num_comments' => '{count, plural, one {# commentaire} other {# commentaires}}'],
+        ]));
+
+        $provider = self::createProvider(
+            new MockHttpClient(function (string $method, string $url, array $options = []) use ($successResponse): MockResponse {
+                $this->assertSame('POST', $method);
+                $this->assertSame(http_build_query([
+                    'api_token' => 'API_KEY',
+                    'id' => 'PROJECT_ID',
+                    'data' => json_encode([
+                        [
+                            'term' => 'a',
+                            'context' => 'messages',
+                        ],
+                        [
+                            'term' => 'post.num_comments',
+                            'context' => 'validators',
+                        ],
+                    ]),
+                ]), $options['body']);
+
+                return $successResponse;
+            }, 'https://api.poeditor.com/v2/'),
+            $this->getLoader(),
+            $this->getLogger(),
+            $this->getDefaultLocale(),
+            'api.poeditor.com'
+        );
+
+        $provider->delete($translatorBag);
+    }
+
+    public static function getResponsesForOneLocaleAndOneDomain(): \Generator
+    {
+        $arrayLoader = new ArrayLoader();
+
+        $expectedTranslatorBagEn = new TranslatorBag();
+        $expectedTranslatorBagEn->addCatalogue($arrayLoader->load([
+            'index.hello' => 'Hello',
+            'index.greetings' => 'Welcome, {firstname}!',
+        ], 'en'));
+
+        yield ['en', 'messages', <<<'XLIFF'
+            <?xml version="1.0" encoding="UTF-8"?>
+            <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+              <file source-language="en" target-language="en" datatype="plaintext" original="ng2.template">
+                <body>
+                  <trans-unit id="hRlpU4" resname="index.hello">
+                    <source>index.hello</source>
+                    <target>Hello</target>
+                  </trans-unit>
+                  <trans-unit id="d3x9Aq" resname="index.greetings">
+                    <source>index.greetings</source>
+                    <target>Welcome, {firstname}!</target>
+                  </trans-unit>
+                </body>
+              </file>
+            </xliff>
+            XLIFF,
+            $expectedTranslatorBagEn,
+        ];
+
+        $expectedTranslatorBagFr = new TranslatorBag();
+        $expectedTranslatorBagFr->addCatalogue($arrayLoader->load([
+            'index.hello' => 'Bonjour',
+            'index.greetings' => 'Bienvenue, {firstname} !',
+        ], 'fr'));
+
+        yield ['fr', 'messages', <<<'XLIFF'
+            <?xml version="1.0" encoding="UTF-8"?>
+            <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+              <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">
+                <body>
+                  <trans-unit id="hRlpU4" resname="index.hello">
+                    <source>index.hello</source>
+                    <target>Bonjour</target>
+                  </trans-unit>
+                  <trans-unit id="d3x9Aq" resname="index.greetings">
+                    <source>index.greetings</source>
+                    <target>Bienvenue, {firstname} !</target>
+                  </trans-unit>
+                </body>
+              </file>
+            </xliff>
+            XLIFF,
+            $expectedTranslatorBagFr,
+        ];
+    }
+
+    public static function getResponsesForManyLocalesAndManyDomains(): \Generator
+    {
+        $arrayLoader = new ArrayLoader();
+
+        $expectedTranslatorBag = new TranslatorBag();
+        $expectedTranslatorBag->addCatalogue($arrayLoader->load([
+            'index.hello' => 'Hello',
+            'index.greetings' => 'Welcome, {firstname}!',
+        ], 'en'));
+        $expectedTranslatorBag->addCatalogue($arrayLoader->load([
+            'index.hello' => 'Bonjour',
+            'index.greetings' => 'Bienvenue, {firstname} !',
+        ], 'fr'));
+        $expectedTranslatorBag->addCatalogue($arrayLoader->load([
+            'firstname.error' => 'Firstname must contains only letters.',
+            'lastname.error' => 'Lastname must contains only letters.',
+        ], 'en', 'validators'));
+        $expectedTranslatorBag->addCatalogue($arrayLoader->load([
+            'firstname.error' => 'Le prénom ne peut contenir que des lettres.',
+            'lastname.error' => 'Le nom de famille ne peut contenir que des lettres.',
+        ], 'fr', 'validators'));
+
+        yield [
+            ['en', 'fr'],
+            ['messages', 'validators'],
+            [
+                'en' => [
+                    'messages' => <<<'XLIFF'
+                        <?xml version="1.0" encoding="UTF-8"?>
+                        <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+                          <file source-language="en" target-language="en" datatype="plaintext" original="ng2.template">
+                            <body>
+                              <trans-unit id="hRlpU4" resname="index.hello">
+                                <source>index.hello</source>
+                                <target>Hello</target>
+                              </trans-unit>
+                              <trans-unit id="d3x9Aq" resname="index.greetings">
+                                <source>index.greetings</source>
+                                <target>Welcome, {firstname}!</target>
+                              </trans-unit>
+                            </body>
+                          </file>
+                        </xliff>
+                        XLIFF,
+                    'validators' => <<<'XLIFF'
+                        <?xml version="1.0" encoding="UTF-8"?>
+                        <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+                          <file source-language="en" target-language="en" datatype="plaintext" original="ng2.template">
+                            <body>
+                              <trans-unit id="fN3s7p" resname="firstname.error">
+                                <source>firstname.error</source>
+                                <target>Firstname must contains only letters.</target>
+                              </trans-unit>
+                              <trans-unit id="lN8x2w" resname="lastname.error">
+                                <source>lastname.error</source>
+                                <target>Lastname must contains only letters.</target>
+                              </trans-unit>
+                            </body>
+                          </file>
+                        </xliff>
+                        XLIFF,
+                ],
+                'fr' => [
+                    'messages' => <<<'XLIFF'
+                        <?xml version="1.0" encoding="UTF-8"?>
+                        <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+                          <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">
+                            <body>
+                              <trans-unit id="hRlpU4" resname="index.hello">
+                                <source>index.hello</source>
+                                <target>Bonjour</target>
+                              </trans-unit>
+                              <trans-unit id="d3x9Aq" resname="index.greetings">
+                                <source>index.greetings</source>
+                                <target>Bienvenue, {firstname} !</target>
+                              </trans-unit>
+                            </body>
+                          </file>
+                        </xliff>
+                        XLIFF,
+                    'validators' => <<<'XLIFF'
+                        <?xml version="1.0" encoding="UTF-8"?>
+                        <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+                          <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">
+                            <body>
+                              <trans-unit id="fN3s7p" resname="firstname.error">
+                                <source>firstname.error</source>
+                                <target>Le prénom ne peut contenir que des lettres.</target>
+                              </trans-unit>
+                              <trans-unit id="lN8x2w" resname="lastname.error">
+                                <source>lastname.error</source>
+                                <target>Le nom de famille ne peut contenir que des lettres.</target>
+                              </trans-unit>
+                            </body>
+                          </file>
+                        </xliff>
+                        XLIFF,
+                ],
+            ],
+            $expectedTranslatorBag,
+        ];
+    }
+}

--- a/src/Symfony/Component/Translation/Bridge/PoEditor/composer.json
+++ b/src/Symfony/Component/Translation/Bridge/PoEditor/composer.json
@@ -1,0 +1,31 @@
+{
+    "name": "symfony/po-editor-translation-provider",
+    "type": "symfony-translation-bridge",
+    "description": "Symfony POEditor Translation Provider Bridge",
+    "keywords": ["poeditor", "translation", "provider"],
+    "homepage": "https://symfony.com",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Mathieu Santostefano",
+            "homepage": "https://github.com/welcomattic"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "https://symfony.com/contributors"
+        }
+    ],
+    "require": {
+        "php": ">=8.4.1",
+        "symfony/config": "^7.4|^8.0",
+        "symfony/http-client": "^7.4|^8.0",
+        "symfony/translation": "^7.4|^8.0"
+    },
+    "autoload": {
+        "psr-4": { "Symfony\\Component\\Translation\\Bridge\\PoEditor\\": "" },
+        "exclude-from-classmap": [
+            "/Tests/"
+        ]
+    },
+    "minimum-stability": "dev"
+}

--- a/src/Symfony/Component/Translation/Bridge/PoEditor/phpunit.xml.dist
+++ b/src/Symfony/Component/Translation/Bridge/PoEditor/phpunit.xml.dist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/13.1/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+         failOnDeprecation="true"
+         failOnRisky="true"
+         failOnWarning="true"
+>
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Symfony PoEditor Translation Provider Bridge Test Suite">
+            <directory>./Tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <source ignoreSuppressionOfDeprecations="true">
+        <include>
+            <directory>./</directory>
+        </include>
+        <exclude>
+            <directory>./Resources</directory>
+            <directory>./Tests</directory>
+            <directory>./vendor</directory>
+        </exclude>
+    </source>
+
+    <extensions>
+        <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension" />
+    </extensions>
+</phpunit>

--- a/src/Symfony/Component/Translation/CHANGELOG.md
+++ b/src/Symfony/Component/Translation/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Preserve the XLIFF `<source>` element when loading and dumping a file, instead of overwriting it with the message key
  * Add a locale-aware `Plural-Forms` header to the output of `PoFileDumper`
+ * Re-add `PoEditorProvider`
 
 8.1
 ---

--- a/src/Symfony/Component/Translation/Exception/UnsupportedSchemeException.php
+++ b/src/Symfony/Component/Translation/Exception/UnsupportedSchemeException.php
@@ -33,6 +33,10 @@ class UnsupportedSchemeException extends LogicException
             'class' => Bridge\Phrase\PhraseProviderFactory::class,
             'package' => 'symfony/phrase-translation-provider',
         ],
+        'poeditor' => [
+            'class' => Bridge\PoEditor\PoEditorProviderFactory::class,
+            'package' => 'symfony/po-editor-translation-provider',
+        ],
     ];
 
     public function __construct(Dsn $dsn, ?string $name = null, array $supported = [])

--- a/src/Symfony/Component/Translation/Tests/Exception/UnsupportedSchemeExceptionTest.php
+++ b/src/Symfony/Component/Translation/Tests/Exception/UnsupportedSchemeExceptionTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\Translation\Bridge\Crowdin\CrowdinProviderFactory;
 use Symfony\Component\Translation\Bridge\Loco\LocoProviderFactory;
 use Symfony\Component\Translation\Bridge\Lokalise\LokaliseProviderFactory;
 use Symfony\Component\Translation\Bridge\Phrase\PhraseProviderFactory;
+use Symfony\Component\Translation\Bridge\PoEditor\PoEditorProviderFactory;
 use Symfony\Component\Translation\Exception\UnsupportedSchemeException;
 use Symfony\Component\Translation\Provider\Dsn;
 
@@ -33,6 +34,7 @@ final class UnsupportedSchemeExceptionTest extends TestCase
             LocoProviderFactory::class => false,
             LokaliseProviderFactory::class => false,
             PhraseProviderFactory::class => false,
+            PoEditorProviderFactory::class => false,
         ]);
     }
 
@@ -53,6 +55,7 @@ final class UnsupportedSchemeExceptionTest extends TestCase
         yield ['loco', 'symfony/loco-translation-provider'];
         yield ['lokalise', 'symfony/lokalise-translation-provider'];
         yield ['phrase', 'symfony/phrase-translation-provider'];
+        yield ['poeditor', 'symfony/po-editor-translation-provider'];
     }
 
     #[DataProvider('messageWhereSchemeIsNotPartOfSchemeToPackageMapProvider')]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #63269
| License       | MIT

This re-adds the POEditor translation provider bridge, removed in #41451 because POEditor's XLIFF export was missing the `resname` attribute, which made the translation keys unusable. POEditor has implemented it since, as verified in https://github.com/symfony/symfony/issues/41374#issuecomment-2585290248, and stof confirmed in #63269 that re-adding the bridge is acceptable now that it works. @Huluti originally planned to work on this and kindly handed it over.

The bridge is the #41451 code brought up to current standards:

- constructor promotion, readonly properties, native types, no more `@experimental` tag;
- the `getCatalogue()` null fallback is gone (the method is not nullable anymore, same as the other bridges);
- fixed a bug in the original `addTranslations()`: responses were assigned with `$responses =` instead of `$responses[] =`, so failures were never collected nor logged;
- tests ported to the current `ProviderTestCase` / `AbstractProviderFactoryTestCase` APIs, with XLIFF fixtures matching what POEditor actually exports today (opaque `id`, key in `resname`), which documents exactly what the original removal was about;
- wiring restored following the checklist of the most recently added bridge (splitsh.json, FrameworkExtension, translation_providers.php, UnsupportedSchemeException and its test).

Test results: bridge 13/13, UnsupportedSchemeException 16/16, FrameworkBundle Translation tests 64/64.

A symfony-docs PR will follow once this is merged.
