### PR TITLE
[DoctrineBridge][FrameworkBundle] Add `doctrine.orm.entity` tag and `AttributeClassesDriver` to auto-discover entities

### DIFF
--- a/src/Symfony/Bridge/Doctrine/CHANGELOG.md
+++ b/src/Symfony/Bridge/Doctrine/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.2
 ---
 
+ * Add `AttributeClassesDriver` to read attribute mapping from an explicit list of classes instead of scanning directories
  * Add IterableToArrayCollectionTransformer for ObjectMapper
  * Throw a `ConstraintDefinitionException` from `UniqueEntity` when a checked field holds an array or is a to-many association, instead of building a query that cannot match
  * Allow using closures with the `#[MapEntity]` attribute

--- a/src/Symfony/Bridge/Doctrine/Mapping/Driver/AttributeClassesDriver.php
+++ b/src/Symfony/Bridge/Doctrine/Mapping/Driver/AttributeClassesDriver.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Mapping\Driver;
+
+use Doctrine\ORM\Mapping\Driver\AttributeDriver;
+
+/**
+ * Reads attribute mapping from an explicit list of classes instead of scanning directories.
+ *
+ * @author Nayte91 <nayte91@gmail.com>
+ */
+final class AttributeClassesDriver extends AttributeDriver
+{
+    /**
+     * @param class-string[] $classes
+     */
+    public function __construct(
+        private readonly array $classes = [],
+    ) {
+        parent::__construct([]);
+    }
+
+    public function getAllClassNames(): array
+    {
+        return $this->classes;
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Mapping/Driver/AttributeClassesDriverTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Mapping/Driver/AttributeClassesDriverTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Mapping\Driver;
+
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\Persistence\Mapping\RuntimeReflectionService;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\Doctrine\Mapping\Driver\AttributeClassesDriver;
+use Symfony\Bridge\Doctrine\Tests\Fixtures\AssociationEntity;
+use Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdEntity;
+
+class AttributeClassesDriverTest extends TestCase
+{
+    public function testGetAllClassNames()
+    {
+        $driver = new AttributeClassesDriver([SingleIntIdEntity::class, AssociationEntity::class]);
+
+        $this->assertSame([SingleIntIdEntity::class, AssociationEntity::class], $driver->getAllClassNames());
+    }
+
+    public function testGetAllClassNamesDefaultsToAnEmptyList()
+    {
+        $this->assertSame([], (new AttributeClassesDriver())->getAllClassNames());
+    }
+
+    public function testLoadMetadataForClass()
+    {
+        $metadata = new ClassMetadata(SingleIntIdEntity::class);
+        $metadata->initializeReflection(new RuntimeReflectionService());
+
+        (new AttributeClassesDriver([SingleIntIdEntity::class]))->loadMetadataForClass(SingleIntIdEntity::class, $metadata);
+
+        $this->assertSame(['id'], $metadata->getIdentifier());
+        $this->assertArrayHasKey('name', $metadata->fieldMappings);
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.2
 ---
 
+ * Add the `doctrine.orm.entity` tag to auto-excluded `#[Entity]` and `#[MappedSuperclass]` classes to allow discovering them
  * Add the `cache.adapter.pdo_tag_aware` cache pool adapter
  * Register the `web_link.json_linkset_serializer`, `web_link.json_linkset_parser`, `web_link.link_template_header_serializer` and `web_link.link_template_header_parser` services
  * Add `framework.asset_mapper.importmap_integrity_algorithms` option to add integrity metadata to importmaps

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
@@ -49,6 +49,7 @@ class UnusedTagsPass implements CompilerPassInterface
         'controller.service_arguments',
         'controller.targeted_value_resolver',
         'data_collector',
+        'doctrine.orm.entity',
         'event_dispatcher.dispatcher',
         'form.type',
         'form.type_extension',

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -812,13 +812,13 @@ class FrameworkExtension extends Extension
             ]);
         });
         $container->registerAttributeForAutoconfiguration(Entity::class, static function (ChildDefinition $definition) {
-            $definition->addTag('container.excluded', ['source' => 'because it\'s a Doctrine entity']);
+            $definition->addTag('container.excluded', ['source' => 'because it\'s a Doctrine entity'])->addTag('doctrine.orm.entity');
         });
         $container->registerAttributeForAutoconfiguration(Embeddable::class, static function (ChildDefinition $definition) {
             $definition->addTag('container.excluded', ['source' => 'because it\'s a Doctrine embeddable']);
         });
         $container->registerAttributeForAutoconfiguration(MappedSuperclass::class, static function (ChildDefinition $definition) {
-            $definition->addTag('container.excluded', ['source' => 'because it\'s a Doctrine mapped superclass']);
+            $definition->addTag('container.excluded', ['source' => 'because it\'s a Doctrine mapped superclass'])->addTag('doctrine.orm.entity');
         });
 
         $container->registerAttributeForAutoconfiguration(JsonStreamable::class, static function (ChildDefinition $definition, JsonStreamable $attribute) {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/UnusedTagsPassUtils.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/UnusedTagsPassUtils.php
@@ -19,6 +19,7 @@ class UnusedTagsPassUtils
     {
         $tags = [
             'container.tracked_for_reset' => true,
+            'doctrine.orm.entity' => true,
             'proxy' => true,
             'routing.controller' => true,
         ];

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection;
 
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\MappedSuperclass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
@@ -1161,6 +1163,23 @@ abstract class FrameworkExtensionTestCase extends TestCase
             [['serializedTypeName' => 'my.type', 'serializedTypeNameAliases' => ['my.legacy.type']]],
             $definition->getTag('messenger.message')
         );
+    }
+
+    public function testDoctrineMappedClassAttributesAreForwardedToTheTag()
+    {
+        $container = $this->createContainerFromFile('default_config', [], true, false);
+        $container->compile();
+
+        foreach ([Entity::class, MappedSuperclass::class] as $attribute) {
+            $configurators = $container->getAttributeAutoconfigurators()[$attribute] ?? [];
+            $this->assertCount(1, $configurators);
+
+            $definition = new ChildDefinition('');
+            $configurators[0]($definition);
+
+            $this->assertCount(1, $definition->getTag('container.excluded'));
+            $this->assertSame([[]], $definition->getTag('doctrine.orm.entity'));
+        }
     }
 
     public function testMessengerRejectRedeliveredMessagesEnabledByDefault()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Contributes to doctrine/DoctrineBundle#2124
| License       | MIT

Since #59987 the container scan already reads `#[Entity]` on every class of `src/`, to auto-exclude it from container. So every entity FQCN is known at compile time, with attribute already read.

This PR exposes that knowledge so entity mappings can be auto-discovered, following the exact pattern of #61492 (`routing.controller` + tagged services):
- `#[Entity]` and `#[MappedSuperclass]` classes now also get a `doctrine.orm.entity` tag (the two attributes `AttributeDriver::isTransient()` treats as mapped);
- DoctrineBridge gains an `AttributeClassesDriver` that reads attribute mapping from an explicit list of classes instead of scanning directories.

With these two halves in place, DoctrineBundle only needs a small compiler pass collecting the tagged FQCNs into this driver to make the `doctrine.orm.mappings` configuration optional — that follow-up is proposed in doctrine/DoctrineBundle#2124.