### PR TITLE
[Mailer] Document the X-MC-ReturnPathDomain header in Mailchimp bridge

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/README.md
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/README.md
@@ -19,6 +19,20 @@ MAILER_DSN=mandrill+api://KEY@default
 where:
  - `KEY` is your Mailchimp API key
 
+Custom Return Path Domains
+--------------------------
+
+When using the `mandrill+api` transport, you can set a custom domain for the
+return path of the message (which Mandrill uses to handle bounces) by adding
+the `X-MC-ReturnPathDomain` header to the email:
+
+```php
+$email->getHeaders()->addTextHeader('X-MC-ReturnPathDomain', 'example.com');
+```
+
+> [!NOTE]
+> Support for the `X-MC-ReturnPathDomain` header was introduced in Symfony 8.2.
+
 Sponsor
 -------
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

This moves the docs added in https://github.com/symfony/symfony-docs/pull/22752