### PR TITLE
[Process] Remove outdated LogicException PHPDoc

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -237,7 +237,6 @@ class Process implements \IteratorAggregate
      * @throws RuntimeException         When process is already running
      * @throws ProcessTimedOutException When process timed out
      * @throws ProcessSignaledException When process stopped after receiving signal
-     * @throws LogicException           In case a callback is provided and output has been disabled
      *
      * @final
      */
@@ -261,7 +260,6 @@ class Process implements \IteratorAggregate
      * @throws RuntimeException         When process is already running
      * @throws ProcessTimedOutException When process timed out
      * @throws ProcessSignaledException When process stopped after receiving signal
-     * @throws LogicException           In case a callback is provided and output has been disabled
      *
      * @final
      */
@@ -293,7 +291,6 @@ class Process implements \IteratorAggregate
      *
      * @throws RuntimeException When process can't be launched
      * @throws RuntimeException When process is already running
-     * @throws LogicException   In case a callback is provided and output has been disabled
      */
     public function start(?callable $callback = null, array $env = [])
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT


### What
The `@throws LogicException In case a callback is provided and output has been disabled` entries on `start()` and `run()` have been stale since #17427 removed the corresponding guard and allowed callbacks while output storage is disabled.

The same stale entry was later copied to `mustRun()` in #63096.

This PR removes the three inaccurate PHPDoc entries. 

### Why
These PHPDoc entries describe an exception that does not reflect the actual behavior of the methods mentioned above.