### PR TITLE
[DependencyInjection] Skip abstract classes and interfaces in findTaggedResourceIds()

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -1408,6 +1408,11 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
                 throw new InvalidArgumentException(\sprintf('The resource "%s" tagged "%s" is missing the "container.excluded" tag.', $id, $tagName));
             }
             $class = $this->parameterBag->resolveValue($definition->getClass());
+            if ($class && $throwOnAbstract && $definition->isAbstract() && ($r = $this->getReflectionClass($class, false)) && ($r->isAbstract() || $r->isInterface())) {
+                // an abstract class or interface matches autoconfiguration rules on behalf
+                // of its subtypes but is not a resource itself: skip it, don't throw
+                continue;
+            }
             if (!$class || $throwOnAbstract && $definition->isAbstract()) {
                 throw new InvalidArgumentException(\sprintf('The resource "%s" tagged "%s" must have a class and not be abstract.', $id, $tagName));
             }

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -61,6 +61,8 @@ use Symfony\Component\DependencyInjection\Tests\Compiler\Wither;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\CaseSensitiveClass;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\CustomDefinition;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\FooWithAbstractArgument;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\AbstractClass;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\FooInterface;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\ProxyAndInheritance;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\ScalarFactory;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\SimilarArgumentsDummy;
@@ -1329,6 +1331,40 @@ class ContainerBuilderTest extends TestCase
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The resource "myservice" tagged "foo" is missing the "container.excluded" tag.');
+        $builder->findTaggedResourceIds('foo');
+    }
+
+    public function testFindTaggedResourceIdsSkipsBaseTypes()
+    {
+        $builder = new ContainerBuilder();
+        $builder->register('concrete', 'Bar\FooClass')
+            ->addResourceTag('foo', ['foo' => 'concrete']);
+        $builder->register('.abstract.'.FooInterface::class, FooInterface::class)
+            ->setAbstract(true)
+            ->addResourceTag('foo', ['foo' => 'interface']);
+        $builder->register('.abstract.'.AbstractClass::class, AbstractClass::class)
+            ->setAbstract(true)
+            ->addResourceTag('foo', ['foo' => 'abstract']);
+
+        $this->assertSame(['concrete' => [['foo' => 'concrete']]], $builder->findTaggedResourceIds('foo'));
+
+        $expected = [
+            'concrete' => [['foo' => 'concrete']],
+            '.abstract.'.FooInterface::class => [['foo' => 'interface']],
+            '.abstract.'.AbstractClass::class => [['foo' => 'abstract']],
+        ];
+        $this->assertSame($expected, $builder->findTaggedResourceIds('foo', false));
+    }
+
+    public function testFindTaggedResourceIdsThrowsOnAbstractDefinitionWithConcreteClass()
+    {
+        $builder = new ContainerBuilder();
+        $builder->register('myservice', 'Bar\FooClass')
+            ->setAbstract(true)
+            ->addResourceTag('foo', ['foo' => 'foo']);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The resource "myservice" tagged "foo" must have a class and not be abstract.');
         $builder->findTaggedResourceIds('foo');
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Since #61578, attributes on discovered abstract classes and interfaces are parsed, and those classes get an `.abstract.<FQCN>` definition. As a side effect, a `#[AutoconfigureResourceTag]` placed on an interface tags these definitions too: the rule matches the interface itself and any abstract class implementing it.

`findTaggedResourceIds()` then throws with the default `$throwOnAbstract = true`:

```php
#[AutoconfigureResourceTag('twig.safe_class')]
interface SafeInterface
{
}
```

With this interface anywhere in the discovery paths, compilation fails with `The resource ".abstract.App\SafeInterface" tagged "twig.safe_class" must have a class and not be abstract.` The same happens for any abstract class implementing the interface. This makes the attribute unusable on base types for consumers that use the default flag, while tagging base types is its documented purpose.

This PR makes `findTaggedResourceIds()` skip definitions whose class is an abstract class or an interface when `$throwOnAbstract` is true: base types match autoconfiguration rules on behalf of their subtypes, they are not resources themselves. Consumers passing `false` (Messenger, ObjectMapper on newer branches) keep seeing these definitions, since routing on a base type is meaningful there. The exception is kept for abstract definitions with a concrete class, which discovery never produces for tagged resources; it keeps guarding manual misregistrations.

Note that `ReflectionClass::isAbstract()` returns false for interfaces that declare no methods, so the check is `isAbstract() || isInterface()`.
