### PR TITLE
[DependencyInjection] Skip interfaces when computing lazy tag attributes

### DIFF
--- a/.github/patch-types.php
+++ b/.github/patch-types.php
@@ -43,9 +43,11 @@ foreach ($loader->getClassMap() as $class => $file) {
         case false !== strpos($file, '/src/Symfony/Component/DependencyInjection/Tests/Fixtures/BarResourceTaggedWithClosure.php'):
         case false !== strpos($file, '/src/Symfony/Component/DependencyInjection/Tests/Fixtures/BarTaggedWithClosure.php'):
         case false !== strpos($file, '/src/Symfony/Component/DependencyInjection/Tests/Fixtures/FooResourceTaggedWithClosure.php'):
+        case false !== strpos($file, '/src/Symfony/Component/DependencyInjection/Tests/Fixtures/FooResourceTaggedWithClosureMarker.php'):
         case false !== strpos($file, '/src/Symfony/Component/DependencyInjection/Tests/Fixtures/FooTaggedWithClosure.php'):
         case false !== strpos($file, '/src/Symfony/Component/DependencyInjection/Tests/Fixtures/PrivateConstructorResourceTaggedWithClosure.php'):
         case false !== strpos($file, '/src/Symfony/Component/DependencyInjection/Tests/Fixtures/ResourceTaggedWithClosureInterface.php'):
+        case false !== strpos($file, '/src/Symfony/Component/DependencyInjection/Tests/Fixtures/ResourceTaggedWithClosureMarkerInterface.php'):
         case false !== strpos($file, '/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TaggedWithClosureInterface.php'):
         case false !== strpos($file, '/src/Symfony/Component/DependencyInjection/Tests/Fixtures/ParentNotExists.php'):
         case false !== strpos($file, '/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Preload/'):

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveInstanceofConditionalsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveInstanceofConditionalsPass.php
@@ -304,9 +304,14 @@ class ResolveInstanceofConditionalsPass implements CompilerPassInterface
      * (private constructors and enums are fine), but a closure cannot run on an abstract class or an
      * interface, and a [class-string, method] callable cannot when the method resolves to an abstract
      * declaration there. Skipping beats throwing because base types legitimately match the instanceof rules.
+     * Interfaces need their own check: ReflectionClass::isAbstract() misses those declaring no methods.
      */
     private static function canComputeTagAttributes(\ReflectionClass $r, array $attributes): bool
     {
+        if ($r->isInterface()) {
+            return false;
+        }
+
         if ($attributes[0] instanceof \Closure) {
             return !$r->isAbstract();
         }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/IntegrationTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/IntegrationTest.php
@@ -52,6 +52,7 @@ use Symfony\Component\DependencyInjection\Tests\Fixtures\FooBarTaggedClass;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\FooBarTaggedForDefaultPriorityClass;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\FooResourceTaggedWithCallable;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\FooResourceTaggedWithClosure;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\FooResourceTaggedWithClosureMarker;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\FooTagClass;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\FooTaggedWithCallable;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\FooTaggedWithClosure;
@@ -60,6 +61,7 @@ use Symfony\Component\DependencyInjection\Tests\Fixtures\PrivateConstructorResou
 use Symfony\Component\DependencyInjection\Tests\Fixtures\PrivateConstructorTaggedWithCallable;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\ResourceTaggedWithCallableInterface;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\ResourceTaggedWithClosureInterface;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\ResourceTaggedWithClosureMarkerInterface;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\StaticMethodTag;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\TaggedConsumerWithExclude;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\TaggedIteratorConsumer;
@@ -468,6 +470,26 @@ class IntegrationTest extends TestCase
         // closures cannot be introspected: abstract classes are skipped, only the marker tag is added
         $this->assertFalse($container->getDefinition('abstract')->hasTag('foo_bar'));
         $this->assertTrue($container->getDefinition('abstract')->hasTag('container.excluded'));
+    }
+
+    public function testAutoconfiguredResourceTagWithClosureAttributesOnMarkerInterface()
+    {
+        if (\PHP_VERSION_ID < 80500) {
+            $this->markTestSkipped('Closures in constant expressions require PHP 8.5.');
+        }
+
+        $container = new ContainerBuilder();
+        $container->register('foo', FooResourceTaggedWithClosureMarker::class)->setAutoconfigured(true);
+        $container->register('interface', ResourceTaggedWithClosureMarkerInterface::class)->setAutoconfigured(true);
+
+        (new RegisterAutoconfigureAttributesPass())->processClass($container, new \ReflectionClass(ResourceTaggedWithClosureMarkerInterface::class));
+        (new ResolveInstanceofConditionalsPass())->process($container);
+
+        $this->assertSame([['class' => FooResourceTaggedWithClosureMarker::class]], $container->getDefinition('foo')->getTag('foo_bar'));
+
+        // an interface without methods is not reported abstract by reflection, closures must not run on it either
+        $this->assertFalse($container->getDefinition('interface')->hasTag('foo_bar'));
+        $this->assertTrue($container->getDefinition('interface')->hasTag('container.excluded'));
     }
 
     public function testAutoconfiguredResourceTagWithCallableArrayAttributes()

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/FooResourceTaggedWithClosureMarker.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/FooResourceTaggedWithClosureMarker.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+class FooResourceTaggedWithClosureMarker implements ResourceTaggedWithClosureMarkerInterface
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/ResourceTaggedWithClosureMarkerInterface.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/ResourceTaggedWithClosureMarkerInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureResourceTag;
+
+#[AutoconfigureResourceTag('foo_bar', attributes: static function (string $class): array {
+    return ['class' => $class];
+})]
+interface ResourceTaggedWithClosureMarkerInterface
+{
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Follow-up to #65434.

`ReflectionClass::isAbstract()` returns true for an interface only when it declares at least one method. The `canComputeTagAttributes()` check added in #65434 relies on `isAbstract()` to keep closures away from types they cannot run on, so a closure attached through a marker interface is invoked with the interface's own class-string when the interface sits in the discovery paths:

```php
#[AutoconfigureResourceTag('app.message', attributes: static function (string $class): array {
    return ['format' => $class::getFormat()];
})]
interface MessageMarkerInterface
{
}
```

Interfaces can never implement a method, so any method call in the closure fatals during compilation as soon as the `.abstract.` definition of the interface is processed.

This PR short-circuits interfaces in `canComputeTagAttributes()`, for the closure and the `[class-string, method]` forms alike.
