### PR TITLE
[Config] Fix dumping keyless prototyped arrays of arrays in XmlReferenceDumper

### DIFF
--- a/src/Symfony/Component/Config/Definition/Dumper/XmlReferenceDumper.php
+++ b/src/Symfony/Component/Config/Definition/Dumper/XmlReferenceDumper.php
@@ -101,7 +101,7 @@ class XmlReferenceDumper
 
                 if ($prototype instanceof PrototypedArrayNode) {
                     $prototype->setName($key ?? '');
-                    $children = [$key => $prototype];
+                    $children = [$key ?? '' => $prototype];
                 } elseif ($prototype instanceof ArrayNode) {
                     $children = $prototype->getChildren();
                 } else {

--- a/src/Symfony/Component/Config/Tests/Definition/Dumper/XmlReferenceDumperTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Dumper/XmlReferenceDumperTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Config\Tests\Definition\Dumper;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\Dumper\XmlReferenceDumper;
 use Symfony\Component\Config\Tests\Fixtures\Configuration\ExampleConfiguration;
 
@@ -31,6 +32,36 @@ class XmlReferenceDumperTest extends TestCase
 
         $dumper = new XmlReferenceDumper();
         $this->assertEquals(str_replace('http://example.org/schema/dic/acme_root', 'http://symfony.com/schema/dic/symfony', $this->getConfigurationAsString()), $dumper->dump($configuration, 'http://symfony.com/schema/dic/symfony'));
+    }
+
+    public function testDumpPrototypedArrayOfArraysWithoutKeyAttribute()
+    {
+        $treeBuilder = new TreeBuilder('acme_root');
+        $treeBuilder->getRootNode()
+            ->children()
+                ->arrayNode('codes')
+                    ->arrayPrototype()
+                        ->scalarPrototype()->end()
+                    ->end()
+                ->end()
+            ->end();
+
+        $dumper = new XmlReferenceDumper();
+        $this->assertEquals(str_replace("\n", \PHP_EOL, <<<'EOL'
+            <!-- Namespace: http://example.org/schema/dic/acme_root -->
+            <config>
+
+                <!-- prototype -->
+                <codes>
+
+                    <!-- prototype -->
+                    <>scalar value</>
+
+                </codes>
+
+            </config>
+
+            EOL), $dumper->dumpNode($treeBuilder->buildTree()));
     }
 
     private function getConfigurationAsString()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

On PHP 8.5, dumping the XML reference of a config tree that contains a keyless prototyped array of arrays triggers `Using null as an array offset is deprecated, use an empty string instead`:

```php
$treeBuilder->getRootNode()
    ->children()
        ->arrayNode('codes')
            ->arrayPrototype()
                ->scalarPrototype()->end()
            ->end()
        ->end()
    ->end();
```

When the outer node has no `useAttributeAsKey()`, `$node->getKeyAttribute()` returns null and `XmlReferenceDumper` uses it as an array key. The line above it already handles the null case for `setName()`, so this applies the same fallback to the array key. The dumped output is unchanged on every PHP version: a null key already rendered as an empty element name.

Any bundle with such a node hits this through `config:dump-reference --format=xml`. Found while preparing #65427, where a new `framework.profiler` option is the first config shape in symfony/symfony to reach this code path; that PR carries this same change for 8.2 as a separate first commit, so once this one is merged up the two sides are identical and either can be kept.
