### PR TITLE
[HttpKernel] Fix concurrent cache warmups corrupting the deprecations log

### DIFF
--- a/src/Symfony/Component/HttpKernel/CacheWarmer/CacheWarmerAggregate.php
+++ b/src/Symfony/Component/HttpKernel/CacheWarmer/CacheWarmerAggregate.php
@@ -120,14 +120,27 @@ class CacheWarmerAggregate implements CacheWarmerInterface
             if ($collectDeprecations) {
                 restore_error_handler();
 
-                if (is_file($this->deprecationLogsFilepath)) {
-                    $previousLogs = unserialize(file_get_contents($this->deprecationLogsFilepath), ['allowed_classes' => false]);
+                if ($h = fopen($this->deprecationLogsFilepath, 'c+')) {
+                    flock($h, \LOCK_EX);
+
+                    set_error_handler(static fn () => true);
+                    try {
+                        $previousLogs = unserialize(stream_get_contents($h), ['allowed_classes' => false]);
+                    } finally {
+                        restore_error_handler();
+                    }
                     if (\is_array($previousLogs)) {
                         $collectedLogs = array_merge($previousLogs, $collectedLogs);
                     }
-                }
 
-                file_put_contents($this->deprecationLogsFilepath, serialize(array_values($collectedLogs)));
+                    $serializedLogs = serialize(array_values($collectedLogs));
+
+                    ftruncate($h, 0);
+                    rewind($h);
+                    fwrite($h, $serializedLogs);
+                    flock($h, \LOCK_UN);
+                    fclose($h);
+                }
             }
         }
 

--- a/src/Symfony/Component/HttpKernel/Tests/CacheWarmer/CacheWarmerAggregateTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/CacheWarmer/CacheWarmerAggregateTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerAggregate;
 use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
+use Symfony\Component\Process\Process;
 
 class CacheWarmerAggregateTest extends TestCase
 {
@@ -171,5 +172,41 @@ class CacheWarmerAggregateTest extends TestCase
 
         $aggregate = new CacheWarmerAggregate([$warmer]);
         $aggregate->warmUp(__DIR__, null, $io);
+    }
+
+    public function testWarmupRecoversFromCorruptedDeprecationLog()
+    {
+        $logFile = tempnam(sys_get_temp_dir(), 'sf_deprecations_');
+        file_put_contents($logFile, 'a:0:{}stale-bytes-from-a-torn-write');
+
+        // collecting deprecations is disabled when PHPUNIT_COMPOSER_INSTALL is defined, hence the child process
+        $srcDir = \dirname((new \ReflectionClass(CacheWarmerAggregate::class))->getFileName());
+        $bootCode = <<<'EOPHP'
+            <?php
+            [, $srcDir, $logFile] = $argv;
+            require $srcDir.'/WarmableInterface.php';
+            require $srcDir.'/CacheWarmerInterface.php';
+            require $srcDir.'/CacheWarmerAggregate.php';
+
+            set_error_handler(static function ($type, $message, $file, $line) {
+                throw new \ErrorException($message, 0, $type, $file, $line);
+            });
+
+            (new \Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerAggregate([], true, $logFile))->warmUp(sys_get_temp_dir());
+
+            echo 'OK';
+            EOPHP;
+
+        $process = new Process([\PHP_BINARY, '--', $srcDir, $logFile]);
+        $process->setInput($bootCode);
+        $process->run();
+
+        try {
+            $this->assertSame('OK', $process->getOutput(), $process->getErrorOutput());
+            $this->assertSame(0, $process->getExitCode());
+            $this->assertSame([], unserialize(file_get_contents($logFile), ['allowed_classes' => false]));
+        } finally {
+            @unlink($logFile);
+        }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65447
| License       | MIT

When several kernels boot at once against a cold cache, they all run `CacheWarmerAggregate::warmUp()`, and the read-modify-write of the deprecations log at the end of it is unguarded. A short write landing inside a longer one leaves a truncated payload followed by stale bytes, so the next `unserialize()` emits `unserialize(): Extra data starting at offset N` and the error handler turns that warning into an exception that aborts the boot. Container dumping is already serialised with `flock` in `Kernel::initializeContainer()`; warmup was not.

This holds an exclusive lock over the whole read/merge/write instead of reading and writing the file in two unrelated calls, so the last writer still wins but nobody observes a half-written file. Merge semantics are unchanged, and concurrent warmups no longer lose each other's collected deprecations.

The read is also made tolerant to invalid content: a log corrupted before this fix, or by a process killed mid-write, is discarded and rewritten instead of aborting every subsequent boot with the `unserialize()` warning.

`$collectDeprecations` is false whenever `PHPUNIT_COMPOSER_INSTALL` is defined, so the corrupted-log test boots `warmUp()` in a child PHP process.
