### PR TITLE
[Routing] Reject "_firewall" as a host parameter

### DIFF
--- a/src/Symfony/Component/Routing/RouteCompiler.php
+++ b/src/Symfony/Component/Routing/RouteCompiler.php
@@ -35,7 +35,7 @@ class RouteCompiler implements RouteCompilerInterface
     public const VARIABLE_MAXIMUM_LENGTH = 32;
 
     /**
-     * @throws \InvalidArgumentException if a path variable is named _fragment or _firewall
+     * @throws \InvalidArgumentException if a path variable is named _fragment or _firewall, or a host variable is named _firewall
      * @throws \LogicException           if a variable is referenced more than once
      * @throws \DomainException          if a variable name starts with a digit or if it is too long to be successfully used as
      *                                   a PCRE subpattern
@@ -52,6 +52,13 @@ class RouteCompiler implements RouteCompilerInterface
 
             $hostVariables = $result['variables'];
             $variables = $hostVariables;
+
+            foreach ($hostVariables as $hostParam) {
+                // "_firewall" selects the firewall handling the route; as a host parameter it would let the Host header choose it
+                if ('_firewall' === $hostParam) {
+                    throw new \InvalidArgumentException(\sprintf('Route host "%s" cannot contain "%s" as a host parameter.', $host, $hostParam));
+                }
+            }
 
             $hostTokens = $result['tokens'];
             $hostRegex = $result['regex'];

--- a/src/Symfony/Component/Routing/Tests/RouteCompilerTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteCompilerTest.php
@@ -292,6 +292,16 @@ class RouteCompilerTest extends TestCase
         $route->compile();
     }
 
+    public function testRouteWithFirewallAsHostParameter()
+    {
+        $route = new Route('/admin', [], [], [], '{_firewall}.example.com');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('cannot contain "_firewall" as a host parameter');
+
+        $route->compile();
+    }
+
     #[DataProvider('getVariableNamesStartingWithADigit')]
     public function testRouteWithVariableNameStartingWithADigit(string $name)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Follow-up to #63112, which added the `firewall` route option.

`RouteCompiler` rejects `_firewall` as a path parameter, with the reason spelled out in the comment: as a path parameter it would let the URL choose the firewall. The check runs over `$pathVariables` only, so the host half of the URL is not covered and this compiles:

```yaml
admin_host:
    path: /admin/host
    host: '{_firewall}.example.com'
```

`FirewallMap::getFirewallContext()` reads `_firewall` from the request attributes, so the Host header then selects the firewall: `open.example.com/admin/host` is served anonymously where `main.example.com/admin/host` returns 401.

This rejects `_firewall` in the host pattern too, with a message naming the host. `_fragment` is left alone: it is only meaningful in the path and has been accepted in host patterns for as long as the option has existed.
