### PR TITLE
[Validator] Add the `EntityExists` and `Ulid` message translation units

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.af.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.af.xlf
@@ -574,6 +574,10 @@
                 <source>The referenced entity does not exist.</source>
                 <target state="needs-review-translation">Die entiteit waarna verwys word, bestaan nie.</target>
             </trans-unit>
+            <trans-unit id="148" resname="This is not a valid ULID.">
+                <source>This value is not a valid ULID.</source>
+                <target state="needs-review-translation">Hierdie waarde is nie 'n geldige ULID nie.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.af.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.af.xlf
@@ -570,6 +570,10 @@
                 <source>This value is not a valid cron expression.</source>
                 <target state="needs-review-translation">Hierdie waarde is nie 'n geldige cron-uitdrukking nie.</target>
             </trans-unit>
+            <trans-unit id="147">
+                <source>The referenced entity does not exist.</source>
+                <target state="needs-review-translation">Die entiteit waarna verwys word, bestaan nie.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.ar.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.ar.xlf
@@ -570,6 +570,10 @@
                 <source>This value is not a valid cron expression.</source>
                 <target>هذه القيمة ليست تعبير cron صالحًا.</target>
             </trans-unit>
+            <trans-unit id="147">
+                <source>The referenced entity does not exist.</source>
+                <target state="needs-review-translation">الكيان المشار إليه غير موجود.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.ar.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.ar.xlf
@@ -574,6 +574,10 @@
                 <source>The referenced entity does not exist.</source>
                 <target state="needs-review-translation">الكيان المشار إليه غير موجود.</target>
             </trans-unit>
+            <trans-unit id="148" resname="This is not a valid ULID.">
+                <source>This value is not a valid ULID.</source>
+                <target state="needs-review-translation">هذه القيمة ليست ULID صالحًا.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.az.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.az.xlf
@@ -570,6 +570,10 @@
                 <source>This value is not a valid cron expression.</source>
                 <target state="needs-review-translation">Bu dəyər etibarlı cron ifadəsi deyil.</target>
             </trans-unit>
+            <trans-unit id="147">
+                <source>The referenced entity does not exist.</source>
+                <target state="needs-review-translation">İstinad edilən varlıq mövcud deyil.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.az.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.az.xlf
@@ -574,6 +574,10 @@
                 <source>The referenced entity does not exist.</source>
                 <target state="needs-review-translation">İstinad edilən varlıq mövcud deyil.</target>
             </trans-unit>
+            <trans-unit id="148" resname="This is not a valid ULID.">
+                <source>This value is not a valid ULID.</source>
+                <target state="needs-review-translation">Bu dəyər etibarlı bir ULID deyil.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.be.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.be.xlf
@@ -574,6 +574,10 @@
                 <source>The referenced entity does not exist.</source>
                 <target state="needs-review-translation">Сутнасць, на якую спасылаюцца, не існуе.</target>
             </trans-unit>
+            <trans-unit id="148" resname="This is not a valid ULID.">
+                <source>This value is not a valid ULID.</source>
+                <target state="needs-review-translation">Гэта значэнне не з'яўляецца сапраўдным ULID.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.be.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.be.xlf
@@ -570,6 +570,10 @@
                 <source>This value is not a valid cron expression.</source>
                 <target state="needs-review-translation">Гэта значэнне не з'яўляецца сапраўдным выразам cron.</target>
             </trans-unit>
+            <trans-unit id="147">
+                <source>The referenced entity does not exist.</source>
+                <target state="needs-review-translation">Сутнасць, на якую спасылаюцца, не існуе.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.bg.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.bg.xlf
@@ -574,6 +574,10 @@
                 <source>The referenced entity does not exist.</source>
                 <target state="needs-review-translation">Обектът, към който се препраща, не съществува.</target>
             </trans-unit>
+            <trans-unit id="148" resname="This is not a valid ULID.">
+                <source>This value is not a valid ULID.</source>
+                <target state="needs-review-translation">Стойността не е валиден ULID.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.bg.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.bg.xlf
@@ -570,6 +570,10 @@
                 <source>This value is not a valid cron expression.</source>
                 <target state="needs-review-translation">Тази стойност не е валиден cron израз.</target>
             </trans-unit>
+            <trans-unit id="147">
+                <source>The referenced entity does not exist.</source>
+                <target state="needs-review-translation">Обектът, към който се препраща, не съществува.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.bs.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.bs.xlf
@@ -570,6 +570,10 @@
                 <source>This value is not a valid cron expression.</source>
                 <target>Ova vrijednost nije važeći cron izraz.</target>
             </trans-unit>
+            <trans-unit id="147">
+                <source>The referenced entity does not exist.</source>
+                <target state="needs-review-translation">Referencirani entitet ne postoji.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.bs.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.bs.xlf
@@ -574,6 +574,10 @@
                 <source>The referenced entity does not exist.</source>
                 <target state="needs-review-translation">Referencirani entitet ne postoji.</target>
             </trans-unit>
+            <trans-unit id="148" resname="This is not a valid ULID.">
+                <source>This value is not a valid ULID.</source>
+                <target state="needs-review-translation">Ova vrijednost nije ispravan ULID.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.ca.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.ca.xlf
@@ -574,6 +574,10 @@
                 <source>The referenced entity does not exist.</source>
                 <target state="needs-review-translation">L'entitat referenciada no existeix.</target>
             </trans-unit>
+            <trans-unit id="148" resname="This is not a valid ULID.">
+                <source>This value is not a valid ULID.</source>
+                <target state="needs-review-translation">Aquest valor no és un ULID vàlid.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.ca.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.ca.xlf
@@ -570,6 +570,10 @@
                 <source>This value is not a valid cron expression.</source>
                 <target state="needs-review-translation">Aquest valor no és una expressió cron vàlida.</target>
             </trans-unit>
+            <trans-unit id="147">
+                <source>The referenced entity does not exist.</source>
+                <target state="needs-review-translation">L'entitat referenciada no existeix.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.cs.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.cs.xlf
@@ -574,6 +574,10 @@
                 <source>The referenced entity does not exist.</source>
                 <target state="needs-review-translation">Odkazovaná entita neexistuje.</target>
             </trans-unit>
+            <trans-unit id="148" resname="This is not a valid ULID.">
+                <source>This value is not a valid ULID.</source>
+                <target state="needs-review-translation">Tato hodnota není platným ULID.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.cs.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.cs.xlf
@@ -570,6 +570,10 @@
                 <source>This value is not a valid cron expression.</source>
                 <target state="needs-review-translation">Tato hodnota není platný výraz cron.</target>
             </trans-unit>
+            <trans-unit id="147">
+                <source>The referenced entity does not exist.</source>
+                <target state="needs-review-translation">Odkazovaná entita neexistuje.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.cy.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.cy.xlf
@@ -570,6 +570,10 @@
                 <source>This value is not a valid cron expression.</source>
                 <target state="needs-review-translation">Nid yw'r gwerth hwn yn fynegiad cron dilys.</target>
             </trans-unit>
+            <trans-unit id="147">
+                <source>The referenced entity does not exist.</source>
+                <target state="needs-review-translation">Nid yw'r endid y cyfeirir ato yn bodoli.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.cy.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.cy.xlf
@@ -574,6 +574,10 @@
                 <source>The referenced entity does not exist.</source>
                 <target state="needs-review-translation">Nid yw'r endid y cyfeirir ato yn bodoli.</target>
             </trans-unit>
+            <trans-unit id="148" resname="This is not a valid ULID.">
+                <source>This value is not a valid ULID.</source>
+                <target state="needs-review-translation">Nid yw'r gwerth hwn yn ULID dilys.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.da.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.da.xlf
@@ -574,6 +574,10 @@
                 <source>The referenced entity does not exist.</source>
                 <target state="needs-review-translation">Den refererede entitet findes ikke.</target>
             </trans-unit>
+            <trans-unit id="148" resname="This is not a valid ULID.">
+                <source>This value is not a valid ULID.</source>
+                <target state="needs-review-translation">Denne værdi er ikke et gyldigt ULID.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.da.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.da.xlf
@@ -570,6 +570,10 @@
                 <source>This value is not a valid cron expression.</source>
                 <target>Denne værdi er ikke et gyldigt cron-udtryk.</target>
             </trans-unit>
+            <trans-unit id="147">
+                <source>The referenced entity does not exist.</source>
+                <target state="needs-review-translation">Den refererede entitet findes ikke.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.de.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.de.xlf
@@ -570,6 +570,10 @@
                 <source>This value is not a valid cron expression.</source>
                 <target>Dieser Wert ist kein gültiger Cron-Ausdruck.</target>
             </trans-unit>
+            <trans-unit id="147">
+                <source>The referenced entity does not exist.</source>
+                <target state="needs-review-translation">Die referenzierte Entität existiert nicht.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.de.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.de.xlf
@@ -574,6 +574,10 @@
                 <source>The referenced entity does not exist.</source>
                 <target state="needs-review-translation">Die referenzierte Entität existiert nicht.</target>
             </trans-unit>
+            <trans-unit id="148" resname="This is not a valid ULID.">
+                <source>This value is not a valid ULID.</source>
+                <target state="needs-review-translation">Dieser Wert ist keine gültige ULID.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.el.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.el.xlf
@@ -574,6 +574,10 @@
                 <source>The referenced entity does not exist.</source>
                 <target state="needs-review-translation">Η αναφερόμενη οντότητα δεν υπάρχει.</target>
             </trans-unit>
+            <trans-unit id="148" resname="This is not a valid ULID.">
+                <source>This value is not a valid ULID.</source>
+                <target state="needs-review-translation">Αυτός ο αριθμός δεν είναι έγκυρη ULID.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.el.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.el.xlf
@@ -570,6 +570,10 @@
                 <source>This value is not a valid cron expression.</source>
                 <target state="needs-review-translation">Αυτή η τιμή δεν είναι έγκυρη έκφραση cron.</target>
             </trans-unit>
+            <trans-unit id="147">
+                <source>The referenced entity does not exist.</source>
+                <target state="needs-review-translation">Η αναφερόμενη οντότητα δεν υπάρχει.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.en.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.en.xlf
@@ -570,6 +570,10 @@
                 <source>This value is not a valid cron expression.</source>
                 <target>This value is not a valid cron expression.</target>
             </trans-unit>
+            <trans-unit id="147">
+                <source>The referenced entity does not exist.</source>
+                <target>The referenced entity does not exist.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.en.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.en.xlf
@@ -574,6 +574,10 @@
                 <source>The referenced entity does not exist.</source>
                 <target>The referenced entity does not exist.</target>
             </trans-unit>
+            <trans-unit id="148" resname="This is not a valid ULID.">
+                <source>This value is not a valid ULID.</source>
+                <target>This value is not a valid ULID.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.es.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.es.xlf
@@ -574,6 +574,10 @@
                 <source>The referenced entity does not exist.</source>
                 <target state="needs-review-translation">La entidad referenciada no existe.</target>
             </trans-unit>
+            <trans-unit id="148" resname="This is not a valid ULID.">
+                <source>This value is not a valid ULID.</source>
+                <target state="needs-review-translation">Este valor no es un ULID válido.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.es.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.es.xlf
@@ -570,6 +570,10 @@
                 <source>This value is not a valid cron expression.</source>
                 <target>Este valor no es una expresión cron válida.</target>
             </trans-unit>
+            <trans-unit id="147">
+                <source>The referenced entity does not exist.</source>
+                <target state="needs-review-translation">La entidad referenciada no existe.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.et.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.et.xlf
@@ -570,6 +570,10 @@
                 <source>This value is not a valid cron expression.</source>
                 <target state="needs-review-translation">See väärtus ei ole kehtiv cron-avaldis.</target>
             </trans-unit>
+            <trans-unit id="147">
+                <source>The referenced entity does not exist.</source>
+                <target state="needs-review-translation">Viidatud olem ei eksisteeri.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.et.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.et.xlf
@@ -574,6 +574,10 @@
                 <source>The referenced entity does not exist.</source>
                 <target state="needs-review-translation">Viidatud olem ei eksisteeri.</target>
             </trans-unit>
+            <trans-unit id="148" resname="This is not a valid ULID.">
+                <source>This value is not a valid ULID.</source>
+                <target state="needs-review-translation">See väärtus ei ole kehtiv ULID.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.eu.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.eu.xlf
@@ -570,6 +570,10 @@
                 <source>This value is not a valid cron expression.</source>
                 <target state="needs-review-translation">Balio hau ez da baliozko cron adierazpena.</target>
             </trans-unit>
+            <trans-unit id="147">
+                <source>The referenced entity does not exist.</source>
+                <target state="needs-review-translation">Erreferentziatutako entitatea ez da existitzen.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.eu.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.eu.xlf
@@ -574,6 +574,10 @@
                 <source>The referenced entity does not exist.</source>
                 <target state="needs-review-translation">Erreferentziatutako entitatea ez da existitzen.</target>
             </trans-unit>
+            <trans-unit id="148" resname="This is not a valid ULID.">
+                <source>This value is not a valid ULID.</source>
+                <target state="needs-review-translation">Balio hau ez da ULID baliozko bat.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.fa.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.fa.xlf
@@ -574,6 +574,10 @@
                 <source>The referenced entity does not exist.</source>
                 <target state="needs-review-translation">موجودیت ارجاع‌شده وجود ندارد.</target>
             </trans-unit>
+            <trans-unit id="148" resname="This is not a valid ULID.">
+                <source>This value is not a valid ULID.</source>
+                <target state="needs-review-translation">این مقدار یک ULID معتبر نیست.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.fa.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.fa.xlf
@@ -570,6 +570,10 @@
                 <source>This value is not a valid cron expression.</source>
                 <target state="needs-review-translation">این مقدار یک عبارت cron معتبر نیست.</target>
             </trans-unit>
+            <trans-unit id="147">
+                <source>The referenced entity does not exist.</source>
+                <target state="needs-review-translation">موجودیت ارجاع‌شده وجود ندارد.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.fi.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.fi.xlf
@@ -570,6 +570,10 @@
                 <source>This value is not a valid cron expression.</source>
                 <target state="needs-review-translation">Tämä arvo ei ole kelvollinen cron-lauseke.</target>
             </trans-unit>
+            <trans-unit id="147">
+                <source>The referenced entity does not exist.</source>
+                <target state="needs-review-translation">Viitattua entiteettiä ei ole olemassa.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.fi.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.fi.xlf
@@ -574,6 +574,10 @@
                 <source>The referenced entity does not exist.</source>
                 <target state="needs-review-translation">Viitattua entiteettiä ei ole olemassa.</target>
             </trans-unit>
+            <trans-unit id="148" resname="This is not a valid ULID.">
+                <source>This value is not a valid ULID.</source>
+                <target state="needs-review-translation">Tämä arvo ei ole kelvollinen ULID.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.fr.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.fr.xlf
@@ -574,6 +574,10 @@
                 <source>The referenced entity does not exist.</source>
                 <target state="needs-review-translation">L'entité référencée n'existe pas.</target>
             </trans-unit>
+            <trans-unit id="148" resname="This is not a valid ULID.">
+                <source>This value is not a valid ULID.</source>
+                <target state="needs-review-translation">Cette valeur n'est pas un ULID valide.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.fr.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.fr.xlf
@@ -570,6 +570,10 @@
                 <source>This value is not a valid cron expression.</source>
                 <target>Cette valeur n'est pas une expression cron valide.</target>
             </trans-unit>
+            <trans-unit id="147">
+                <source>The referenced entity does not exist.</source>
+                <target state="needs-review-translation">L'entité référencée n'existe pas.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.gl.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.gl.xlf
@@ -574,6 +574,10 @@
                 <source>The referenced entity does not exist.</source>
                 <target state="needs-review-translation">A entidade referenciada non existe.</target>
             </trans-unit>
+            <trans-unit id="148" resname="This is not a valid ULID.">
+                <source>This value is not a valid ULID.</source>
+                <target state="needs-review-translation">Este valor non é un ULID válido.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.gl.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.gl.xlf
@@ -570,6 +570,10 @@
                 <source>This value is not a valid cron expression.</source>
                 <target state="needs-review-translation">Este valor non é unha expresión cron válida.</target>
             </trans-unit>
+            <trans-unit id="147">
+                <source>The referenced entity does not exist.</source>
+                <target state="needs-review-translation">A entidade referenciada non existe.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.he.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.he.xlf
@@ -570,6 +570,10 @@
                 <source>This value is not a valid cron expression.</source>
                 <target state="needs-review-translation">ערך זה אינו ביטוי cron תקין.</target>
             </trans-unit>
+            <trans-unit id="147">
+                <source>The referenced entity does not exist.</source>
+                <target state="needs-review-translation">הישות שאליה מפנים אינה קיימת.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.he.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.he.xlf
@@ -574,6 +574,10 @@
                 <source>The referenced entity does not exist.</source>
                 <target state="needs-review-translation">הישות שאליה מפנים אינה קיימת.</target>
             </trans-unit>
+            <trans-unit id="148" resname="This is not a valid ULID.">
+                <source>This value is not a valid ULID.</source>
+                <target state="needs-review-translation">ערך זה אינו ULID תקף.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.hr.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.hr.xlf
@@ -574,6 +574,10 @@
                 <source>The referenced entity does not exist.</source>
                 <target state="needs-review-translation">Referencirani entitet ne postoji.</target>
             </trans-unit>
+            <trans-unit id="148" resname="This is not a valid ULID.">
+                <source>This value is not a valid ULID.</source>
+                <target state="needs-review-translation">Ova vrijednost nije valjani ULID.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.hr.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.hr.xlf
@@ -570,6 +570,10 @@
                 <source>This value is not a valid cron expression.</source>
                 <target>Ova vrijednost nije valjani cron izraz.</target>
             </trans-unit>
+            <trans-unit id="147">
+                <source>The referenced entity does not exist.</source>
+                <target state="needs-review-translation">Referencirani entitet ne postoji.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.hu.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.hu.xlf
@@ -570,6 +570,10 @@
                 <source>This value is not a valid cron expression.</source>
                 <target state="needs-review-translation">Ez az érték nem érvényes cron kifejezés.</target>
             </trans-unit>
+            <trans-unit id="147">
+                <source>The referenced entity does not exist.</source>
+                <target state="needs-review-translation">A hivatkozott entitás nem létezik.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.hu.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.hu.xlf
@@ -574,6 +574,10 @@
                 <source>The referenced entity does not exist.</source>
                 <target state="needs-review-translation">A hivatkozott entitás nem létezik.</target>
             </trans-unit>
+            <trans-unit id="148" resname="This is not a valid ULID.">
+                <source>This value is not a valid ULID.</source>
+                <target state="needs-review-translation">Ez az érték nem érvényes ULID.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.hy.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.hy.xlf
@@ -574,6 +574,10 @@
                 <source>The referenced entity does not exist.</source>
                 <target state="needs-review-translation">Հղված էությունը գոյություն չունի։</target>
             </trans-unit>
+            <trans-unit id="148" resname="This is not a valid ULID.">
+                <source>This value is not a valid ULID.</source>
+                <target state="needs-review-translation">Այս արժեքը վավեր ULID չէ։</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.hy.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.hy.xlf
@@ -570,6 +570,10 @@
                 <source>This value is not a valid cron expression.</source>
                 <target state="needs-review-translation">Այս արժեքը վավեր cron արտահայտություն չէ։</target>
             </trans-unit>
+            <trans-unit id="147">
+                <source>The referenced entity does not exist.</source>
+                <target state="needs-review-translation">Հղված էությունը գոյություն չունի։</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.id.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.id.xlf
@@ -574,6 +574,10 @@
                 <source>The referenced entity does not exist.</source>
                 <target state="needs-review-translation">Entitas yang direferensikan tidak ada.</target>
             </trans-unit>
+            <trans-unit id="148" resname="This is not a valid ULID.">
+                <source>This value is not a valid ULID.</source>
+                <target state="needs-review-translation">Nilai ini bukan ULID yang valid.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.id.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.id.xlf
@@ -570,6 +570,10 @@
                 <source>This value is not a valid cron expression.</source>
                 <target state="needs-review-translation">Nilai ini bukan ekspresi cron yang valid.</target>
             </trans-unit>
+            <trans-unit id="147">
+                <source>The referenced entity does not exist.</source>
+                <target state="needs-review-translation">Entitas yang direferensikan tidak ada.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.it.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.it.xlf
@@ -574,6 +574,10 @@
                 <source>The referenced entity does not exist.</source>
                 <target state="needs-review-translation">L'entità referenziata non esiste.</target>
             </trans-unit>
+            <trans-unit id="148" resname="This is not a valid ULID.">
+                <source>This value is not a valid ULID.</source>
+                <target state="needs-review-translation">Questo valore non è un ULID valido.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.it.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.it.xlf
@@ -570,6 +570,10 @@
                 <source>This value is not a valid cron expression.</source>
                 <target>Questo valore non è un'espressione cron valida.</target>
             </trans-unit>
+            <trans-unit id="147">
+                <source>The referenced entity does not exist.</source>
+                <target state="needs-review-translation">L'entità referenziata non esiste.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.ja.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.ja.xlf
@@ -574,6 +574,10 @@
                 <source>The referenced entity does not exist.</source>
                 <target state="needs-review-translation">参照されたエンティティは存在しません。</target>
             </trans-unit>
+            <trans-unit id="148" resname="This is not a valid ULID.">
+                <source>This value is not a valid ULID.</source>
+                <target state="needs-review-translation">有効なULIDではありません。</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.ja.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.ja.xlf
@@ -570,6 +570,10 @@
                 <source>This value is not a valid cron expression.</source>
                 <target state="needs-review-translation">この値は有効なcron式ではありません。</target>
             </trans-unit>
+            <trans-unit id="147">
+                <source>The referenced entity does not exist.</source>
+                <target state="needs-review-translation">参照されたエンティティは存在しません。</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.lb.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.lb.xlf
@@ -574,6 +574,10 @@
                 <source>The referenced entity does not exist.</source>
                 <target state="needs-review-translation">Déi referenzéiert Entitéit existéiert net.</target>
             </trans-unit>
+            <trans-unit id="148" resname="This is not a valid ULID.">
+                <source>This value is not a valid ULID.</source>
+                <target state="needs-review-translation">Dëse Wäert ass keng gülteg ULID.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.lb.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.lb.xlf
@@ -570,6 +570,10 @@
                 <source>This value is not a valid cron expression.</source>
                 <target state="needs-review-translation">Dëse Wäert ass keen gültegen Cron-Ausdrock.</target>
             </trans-unit>
+            <trans-unit id="147">
+                <source>The referenced entity does not exist.</source>
+                <target state="needs-review-translation">Déi referenzéiert Entitéit existéiert net.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.lt.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.lt.xlf
@@ -570,6 +570,10 @@
                 <source>This value is not a valid cron expression.</source>
                 <target>Ši reikšmė nėra tinkama cron išraiška.</target>
             </trans-unit>
+            <trans-unit id="147">
+                <source>The referenced entity does not exist.</source>
+                <target state="needs-review-translation">Nurodyta esybė neegzistuoja.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.lt.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.lt.xlf
@@ -574,6 +574,10 @@
                 <source>The referenced entity does not exist.</source>
                 <target state="needs-review-translation">Nurodyta esybė neegzistuoja.</target>
             </trans-unit>
+            <trans-unit id="148" resname="This is not a valid ULID.">
+                <source>This value is not a valid ULID.</source>
+                <target state="needs-review-translation">Ši reikšmė nėra tinkamas ULID.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.lv.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.lv.xlf
@@ -570,6 +570,10 @@
                 <source>This value is not a valid cron expression.</source>
                 <target state="needs-review-translation">Šī vērtība nav derīga cron izteiksme.</target>
             </trans-unit>
+            <trans-unit id="147">
+                <source>The referenced entity does not exist.</source>
+                <target state="needs-review-translation">Norādītā entītija neeksistē.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.lv.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.lv.xlf
@@ -574,6 +574,10 @@
                 <source>The referenced entity does not exist.</source>
                 <target state="needs-review-translation">Norādītā entītija neeksistē.</target>
             </trans-unit>
+            <trans-unit id="148" resname="This is not a valid ULID.">
+                <source>This value is not a valid ULID.</source>
+                <target state="needs-review-translation">Šī vērtība nav derīgs ULID.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.mk.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.mk.xlf
@@ -570,6 +570,10 @@
                 <source>This value is not a valid cron expression.</source>
                 <target state="needs-review-translation">Оваа вредност не е валиден cron израз.</target>
             </trans-unit>
+            <trans-unit id="147">
+                <source>The referenced entity does not exist.</source>
+                <target state="needs-review-translation">Референцираниот ентитет не постои.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.mk.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.mk.xlf
@@ -574,6 +574,10 @@
                 <source>The referenced entity does not exist.</source>
                 <target state="needs-review-translation">Референцираниот ентитет не постои.</target>
             </trans-unit>
+            <trans-unit id="148" resname="This is not a valid ULID.">
+                <source>This value is not a valid ULID.</source>
+                <target state="needs-review-translation">Оваа вредност не е валиден ULID.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.mn.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.mn.xlf
@@ -570,6 +570,10 @@
                 <source>This value is not a valid cron expression.</source>
                 <target state="needs-review-translation">Энэ утга нь хүчинтэй cron илэрхийлэл биш байна.</target>
             </trans-unit>
+            <trans-unit id="147">
+                <source>The referenced entity does not exist.</source>
+                <target state="needs-review-translation">Иш татсан объект байхгүй байна.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.mn.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.mn.xlf
@@ -574,6 +574,10 @@
                 <source>The referenced entity does not exist.</source>
                 <target state="needs-review-translation">Иш татсан объект байхгүй байна.</target>
             </trans-unit>
+            <trans-unit id="148" resname="This is not a valid ULID.">
+                <source>This value is not a valid ULID.</source>
+                <target state="needs-review-translation">Энэ утга хүчинтэй ULID биш юм.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.my.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.my.xlf
@@ -570,6 +570,10 @@
                 <source>This value is not a valid cron expression.</source>
                 <target state="needs-review-translation">ဤတန်ဖိုးသည် မှန်ကန်သော cron ဖော်ပြချက် မဟုတ်ပါ။</target>
             </trans-unit>
+            <trans-unit id="147">
+                <source>The referenced entity does not exist.</source>
+                <target state="needs-review-translation">ရည်ညွှန်းထားသော အရာဝတ္ထု မတည်ရှိပါ။</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.my.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.my.xlf
@@ -574,6 +574,10 @@
                 <source>The referenced entity does not exist.</source>
                 <target state="needs-review-translation">ရည်ညွှန်းထားသော အရာဝတ္ထု မတည်ရှိပါ။</target>
             </trans-unit>
+            <trans-unit id="148" resname="This is not a valid ULID.">
+                <source>This value is not a valid ULID.</source>
+                <target state="needs-review-translation">ဤတန်ဖိုးသည် မှန်ကန်သော ULID မဟုတ်ပါ။</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.nb.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.nb.xlf
@@ -574,6 +574,10 @@
                 <source>The referenced entity does not exist.</source>
                 <target state="needs-review-translation">Den refererte entiteten finnes ikke.</target>
             </trans-unit>
+            <trans-unit id="148" resname="This is not a valid ULID.">
+                <source>This value is not a valid ULID.</source>
+                <target state="needs-review-translation">Denne verdien er ikke en gyldig ULID.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.nb.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.nb.xlf
@@ -570,6 +570,10 @@
                 <source>This value is not a valid cron expression.</source>
                 <target state="needs-review-translation">Denne verdien er ikke et gyldig cron-uttrykk.</target>
             </trans-unit>
+            <trans-unit id="147">
+                <source>The referenced entity does not exist.</source>
+                <target state="needs-review-translation">Den refererte entiteten finnes ikke.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.nl.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.nl.xlf
@@ -570,6 +570,10 @@
                 <source>This value is not a valid cron expression.</source>
                 <target state="needs-review-translation">Deze waarde is geen geldige cron-expressie.</target>
             </trans-unit>
+            <trans-unit id="147">
+                <source>The referenced entity does not exist.</source>
+                <target state="needs-review-translation">De gerefereerde entiteit bestaat niet.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.nl.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.nl.xlf
@@ -574,6 +574,10 @@
                 <source>The referenced entity does not exist.</source>
                 <target state="needs-review-translation">De gerefereerde entiteit bestaat niet.</target>
             </trans-unit>
+            <trans-unit id="148" resname="This is not a valid ULID.">
+                <source>This value is not a valid ULID.</source>
+                <target state="needs-review-translation">Deze waarde is geen geldige ULID.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.nn.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.nn.xlf
@@ -570,6 +570,10 @@
                 <source>This value is not a valid cron expression.</source>
                 <target state="needs-review-translation">Denne verdien er ikkje eit gyldig cron-uttrykk.</target>
             </trans-unit>
+            <trans-unit id="147">
+                <source>The referenced entity does not exist.</source>
+                <target state="needs-review-translation">Den refererte entiteten finst ikkje.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.nn.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.nn.xlf
@@ -574,6 +574,10 @@
                 <source>The referenced entity does not exist.</source>
                 <target state="needs-review-translation">Den refererte entiteten finst ikkje.</target>
             </trans-unit>
+            <trans-unit id="148" resname="This is not a valid ULID.">
+                <source>This value is not a valid ULID.</source>
+                <target state="needs-review-translation">Denne verdien er ikkje ein gyldig ULID.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.no.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.no.xlf
@@ -574,6 +574,10 @@
                 <source>The referenced entity does not exist.</source>
                 <target state="needs-review-translation">Den refererte entiteten finnes ikke.</target>
             </trans-unit>
+            <trans-unit id="148" resname="This is not a valid ULID.">
+                <source>This value is not a valid ULID.</source>
+                <target state="needs-review-translation">Denne verdien er ikke en gyldig ULID.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.no.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.no.xlf
@@ -570,6 +570,10 @@
                 <source>This value is not a valid cron expression.</source>
                 <target state="needs-review-translation">Denne verdien er ikke et gyldig cron-uttrykk.</target>
             </trans-unit>
+            <trans-unit id="147">
+                <source>The referenced entity does not exist.</source>
+                <target state="needs-review-translation">Den refererte entiteten finnes ikke.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.pl.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.pl.xlf
@@ -574,6 +574,10 @@
                 <source>The referenced entity does not exist.</source>
                 <target state="needs-review-translation">Wskazana encja nie istnieje.</target>
             </trans-unit>
+            <trans-unit id="148" resname="This is not a valid ULID.">
+                <source>This value is not a valid ULID.</source>
+                <target state="needs-review-translation">Ta wartość nie jest prawidłowym ULID.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.pl.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.pl.xlf
@@ -570,6 +570,10 @@
                 <source>This value is not a valid cron expression.</source>
                 <target>Ta wartość nie jest prawidłowym wyrażeniem cron.</target>
             </trans-unit>
+            <trans-unit id="147">
+                <source>The referenced entity does not exist.</source>
+                <target state="needs-review-translation">Wskazana encja nie istnieje.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.pt.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.pt.xlf
@@ -574,6 +574,10 @@
                 <source>The referenced entity does not exist.</source>
                 <target state="needs-review-translation">A entidade referenciada não existe.</target>
             </trans-unit>
+            <trans-unit id="148" resname="This is not a valid ULID.">
+                <source>This value is not a valid ULID.</source>
+                <target state="needs-review-translation">Este valor não é um ULID válido.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.pt.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.pt.xlf
@@ -570,6 +570,10 @@
                 <source>This value is not a valid cron expression.</source>
                 <target state="needs-review-translation">Este valor não é uma expressão cron válida.</target>
             </trans-unit>
+            <trans-unit id="147">
+                <source>The referenced entity does not exist.</source>
+                <target state="needs-review-translation">A entidade referenciada não existe.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.pt_BR.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.pt_BR.xlf
@@ -570,6 +570,10 @@
                 <source>This value is not a valid cron expression.</source>
                 <target>Este valor não é uma expressão cron válida.</target>
             </trans-unit>
+            <trans-unit id="147">
+                <source>The referenced entity does not exist.</source>
+                <target state="needs-review-translation">A entidade referenciada não existe.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.pt_BR.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.pt_BR.xlf
@@ -574,6 +574,10 @@
                 <source>The referenced entity does not exist.</source>
                 <target state="needs-review-translation">A entidade referenciada não existe.</target>
             </trans-unit>
+            <trans-unit id="148" resname="This is not a valid ULID.">
+                <source>This value is not a valid ULID.</source>
+                <target state="needs-review-translation">Este valor não é um ULID válido.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.ro.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.ro.xlf
@@ -570,6 +570,10 @@
                 <source>This value is not a valid cron expression.</source>
                 <target state="needs-review-translation">Această valoare nu este o expresie cron validă.</target>
             </trans-unit>
+            <trans-unit id="147">
+                <source>The referenced entity does not exist.</source>
+                <target state="needs-review-translation">Entitatea referențiată nu există.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.ro.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.ro.xlf
@@ -574,6 +574,10 @@
                 <source>The referenced entity does not exist.</source>
                 <target state="needs-review-translation">Entitatea referențiată nu există.</target>
             </trans-unit>
+            <trans-unit id="148" resname="This is not a valid ULID.">
+                <source>This value is not a valid ULID.</source>
+                <target state="needs-review-translation">Această valoare nu este un ULID valid.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.ru.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.ru.xlf
@@ -570,6 +570,10 @@
                 <source>This value is not a valid cron expression.</source>
                 <target>Это значение не является корректным выражением cron.</target>
             </trans-unit>
+            <trans-unit id="147">
+                <source>The referenced entity does not exist.</source>
+                <target state="needs-review-translation">Сущность, на которую ссылаются, не существует.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.ru.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.ru.xlf
@@ -574,6 +574,10 @@
                 <source>The referenced entity does not exist.</source>
                 <target state="needs-review-translation">Сущность, на которую ссылаются, не существует.</target>
             </trans-unit>
+            <trans-unit id="148" resname="This is not a valid ULID.">
+                <source>This value is not a valid ULID.</source>
+                <target state="needs-review-translation">Это значение не является действительным ULID.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.sk.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.sk.xlf
@@ -570,6 +570,10 @@
                 <source>This value is not a valid cron expression.</source>
                 <target>Táto hodnota nie je platný cron výraz.</target>
             </trans-unit>
+            <trans-unit id="147">
+                <source>The referenced entity does not exist.</source>
+                <target state="needs-review-translation">Odkazovaná entita neexistuje.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.sk.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.sk.xlf
@@ -574,6 +574,10 @@
                 <source>The referenced entity does not exist.</source>
                 <target state="needs-review-translation">Odkazovaná entita neexistuje.</target>
             </trans-unit>
+            <trans-unit id="148" resname="This is not a valid ULID.">
+                <source>This value is not a valid ULID.</source>
+                <target state="needs-review-translation">Táto hodnota nie je platné ULID.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.sl.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.sl.xlf
@@ -574,6 +574,10 @@
                 <source>The referenced entity does not exist.</source>
                 <target state="needs-review-translation">Referencirana entiteta ne obstaja.</target>
             </trans-unit>
+            <trans-unit id="148" resname="This is not a valid ULID.">
+                <source>This value is not a valid ULID.</source>
+                <target state="needs-review-translation">Ta vrednost ni veljaven ULID.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.sl.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.sl.xlf
@@ -570,6 +570,10 @@
                 <source>This value is not a valid cron expression.</source>
                 <target state="needs-review-translation">Ta vrednost ni veljaven izraz cron.</target>
             </trans-unit>
+            <trans-unit id="147">
+                <source>The referenced entity does not exist.</source>
+                <target state="needs-review-translation">Referencirana entiteta ne obstaja.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.sq.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.sq.xlf
@@ -583,6 +583,10 @@
                 <source>The referenced entity does not exist.</source>
                 <target state="needs-review-translation">Entiteti i referuar nuk ekziston.</target>
             </trans-unit>
+            <trans-unit id="148" resname="This is not a valid ULID.">
+                <source>This value is not a valid ULID.</source>
+                <target state="needs-review-translation">Kjo vlerë nuk është një ULID e vlefshme.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.sq.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.sq.xlf
@@ -579,6 +579,10 @@
                 <source>This value is not a valid cron expression.</source>
                 <target>Kjo vlerë nuk është një shprehje e vlefshme cron.</target>
             </trans-unit>
+            <trans-unit id="147">
+                <source>The referenced entity does not exist.</source>
+                <target state="needs-review-translation">Entiteti i referuar nuk ekziston.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.sr_Cyrl.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.sr_Cyrl.xlf
@@ -574,6 +574,10 @@
                 <source>The referenced entity does not exist.</source>
                 <target state="needs-review-translation">Референцирани ентитет не постоји.</target>
             </trans-unit>
+            <trans-unit id="148" resname="This is not a valid ULID.">
+                <source>This value is not a valid ULID.</source>
+                <target state="needs-review-translation">Ова вредност није валидан ULID.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.sr_Cyrl.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.sr_Cyrl.xlf
@@ -570,6 +570,10 @@
                 <source>This value is not a valid cron expression.</source>
                 <target>Ова вредност није важећи cron израз.</target>
             </trans-unit>
+            <trans-unit id="147">
+                <source>The referenced entity does not exist.</source>
+                <target state="needs-review-translation">Референцирани ентитет не постоји.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.sr_Latn.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.sr_Latn.xlf
@@ -570,6 +570,10 @@
                 <source>This value is not a valid cron expression.</source>
                 <target>Ova vrednost nije važeći cron izraz.</target>
             </trans-unit>
+            <trans-unit id="147">
+                <source>The referenced entity does not exist.</source>
+                <target state="needs-review-translation">Referencirani entitet ne postoji.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.sr_Latn.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.sr_Latn.xlf
@@ -574,6 +574,10 @@
                 <source>The referenced entity does not exist.</source>
                 <target state="needs-review-translation">Referencirani entitet ne postoji.</target>
             </trans-unit>
+            <trans-unit id="148" resname="This is not a valid ULID.">
+                <source>This value is not a valid ULID.</source>
+                <target state="needs-review-translation">Ova vrednost nije validan ULID.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.sv.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.sv.xlf
@@ -570,6 +570,10 @@
                 <source>This value is not a valid cron expression.</source>
                 <target state="needs-review-translation">Detta värde är inte ett giltigt cron-uttryck.</target>
             </trans-unit>
+            <trans-unit id="147">
+                <source>The referenced entity does not exist.</source>
+                <target state="needs-review-translation">Den refererade entiteten finns inte.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.sv.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.sv.xlf
@@ -574,6 +574,10 @@
                 <source>The referenced entity does not exist.</source>
                 <target state="needs-review-translation">Den refererade entiteten finns inte.</target>
             </trans-unit>
+            <trans-unit id="148" resname="This is not a valid ULID.">
+                <source>This value is not a valid ULID.</source>
+                <target state="needs-review-translation">Värdet är inte en giltig ULID.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.th.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.th.xlf
@@ -574,6 +574,10 @@
                 <source>The referenced entity does not exist.</source>
                 <target state="needs-review-translation">เอนทิตีที่อ้างอิงไม่มีอยู่</target>
             </trans-unit>
+            <trans-unit id="148" resname="This is not a valid ULID.">
+                <source>This value is not a valid ULID.</source>
+                <target state="needs-review-translation">ค่านี้ไม่ใช่ ULID ที่ถูกต้อง</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.th.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.th.xlf
@@ -570,6 +570,10 @@
                 <source>This value is not a valid cron expression.</source>
                 <target state="needs-review-translation">ค่านี้ไม่ใช่นิพจน์ cron ที่ถูกต้อง</target>
             </trans-unit>
+            <trans-unit id="147">
+                <source>The referenced entity does not exist.</source>
+                <target state="needs-review-translation">เอนทิตีที่อ้างอิงไม่มีอยู่</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.tl.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.tl.xlf
@@ -570,6 +570,10 @@
                 <source>This value is not a valid cron expression.</source>
                 <target>Ang halagang ito ay hindi wastong cron expression.</target>
             </trans-unit>
+            <trans-unit id="147">
+                <source>The referenced entity does not exist.</source>
+                <target state="needs-review-translation">Ang tinutukoy na entidad ay hindi umiiral.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.tl.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.tl.xlf
@@ -574,6 +574,10 @@
                 <source>The referenced entity does not exist.</source>
                 <target state="needs-review-translation">Ang tinutukoy na entidad ay hindi umiiral.</target>
             </trans-unit>
+            <trans-unit id="148" resname="This is not a valid ULID.">
+                <source>This value is not a valid ULID.</source>
+                <target state="needs-review-translation">Ang halagang ito ay hindi isang wastong ULID.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.tr.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.tr.xlf
@@ -574,6 +574,10 @@
                 <source>The referenced entity does not exist.</source>
                 <target state="needs-review-translation">Başvurulan varlık mevcut değil.</target>
             </trans-unit>
+            <trans-unit id="148" resname="This is not a valid ULID.">
+                <source>This value is not a valid ULID.</source>
+                <target state="needs-review-translation">Bu değer geçerli bir ULID değildir.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.tr.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.tr.xlf
@@ -570,6 +570,10 @@
                 <source>This value is not a valid cron expression.</source>
                 <target>Bu değer geçerli bir cron ifadesi değildir.</target>
             </trans-unit>
+            <trans-unit id="147">
+                <source>The referenced entity does not exist.</source>
+                <target state="needs-review-translation">Başvurulan varlık mevcut değil.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.uk.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.uk.xlf
@@ -574,6 +574,10 @@
                 <source>The referenced entity does not exist.</source>
                 <target state="needs-review-translation">Сутність, на яку посилаються, не існує.</target>
             </trans-unit>
+            <trans-unit id="148" resname="This is not a valid ULID.">
+                <source>This value is not a valid ULID.</source>
+                <target state="needs-review-translation">Це значення не є дійсним ULID.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.uk.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.uk.xlf
@@ -570,6 +570,10 @@
                 <source>This value is not a valid cron expression.</source>
                 <target>Це значення не є дійсним cron-виразом.</target>
             </trans-unit>
+            <trans-unit id="147">
+                <source>The referenced entity does not exist.</source>
+                <target state="needs-review-translation">Сутність, на яку посилаються, не існує.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.ur.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.ur.xlf
@@ -570,6 +570,10 @@
                 <source>This value is not a valid cron expression.</source>
                 <target>یہ ویلیو درست cron ایکسپریشن نہیں ہے</target>
             </trans-unit>
+            <trans-unit id="147">
+                <source>The referenced entity does not exist.</source>
+                <target state="needs-review-translation">حوالہ کردہ وجود موجود نہیں ہے</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.ur.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.ur.xlf
@@ -574,6 +574,10 @@
                 <source>The referenced entity does not exist.</source>
                 <target state="needs-review-translation">حوالہ کردہ وجود موجود نہیں ہے</target>
             </trans-unit>
+            <trans-unit id="148" resname="This is not a valid ULID.">
+                <source>This value is not a valid ULID.</source>
+                <target state="needs-review-translation">یہ ویلیو درست ULID نہیں ہے</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.uz.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.uz.xlf
@@ -570,6 +570,10 @@
                 <source>This value is not a valid cron expression.</source>
                 <target>Ushbu qiymat to'g'ri cron ifodasi emas.</target>
             </trans-unit>
+            <trans-unit id="147">
+                <source>The referenced entity does not exist.</source>
+                <target state="needs-review-translation">Havola qilingan obyekt mavjud emas.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.uz.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.uz.xlf
@@ -574,6 +574,10 @@
                 <source>The referenced entity does not exist.</source>
                 <target state="needs-review-translation">Havola qilingan obyekt mavjud emas.</target>
             </trans-unit>
+            <trans-unit id="148" resname="This is not a valid ULID.">
+                <source>This value is not a valid ULID.</source>
+                <target state="needs-review-translation">Bu qiymat haqiqiy ULID emas.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.vi.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.vi.xlf
@@ -574,6 +574,10 @@
                 <source>The referenced entity does not exist.</source>
                 <target state="needs-review-translation">Thực thể được tham chiếu không tồn tại.</target>
             </trans-unit>
+            <trans-unit id="148" resname="This is not a valid ULID.">
+                <source>This value is not a valid ULID.</source>
+                <target state="needs-review-translation">Giá trị này không phải là ULID hợp lệ.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.vi.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.vi.xlf
@@ -570,6 +570,10 @@
                 <source>This value is not a valid cron expression.</source>
                 <target state="needs-review-translation">Giá trị này không phải là một biểu thức cron hợp lệ.</target>
             </trans-unit>
+            <trans-unit id="147">
+                <source>The referenced entity does not exist.</source>
+                <target state="needs-review-translation">Thực thể được tham chiếu không tồn tại.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.zh_CN.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.zh_CN.xlf
@@ -574,6 +574,10 @@
                 <source>The referenced entity does not exist.</source>
                 <target state="needs-review-translation">引用的实体不存在。</target>
             </trans-unit>
+            <trans-unit id="148" resname="This is not a valid ULID.">
+                <source>This value is not a valid ULID.</source>
+                <target state="needs-review-translation">该值不是有效的 ULID 。</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.zh_CN.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.zh_CN.xlf
@@ -570,6 +570,10 @@
                 <source>This value is not a valid cron expression.</source>
                 <target state="needs-review-translation">该值不是有效的 cron 表达式。</target>
             </trans-unit>
+            <trans-unit id="147">
+                <source>The referenced entity does not exist.</source>
+                <target state="needs-review-translation">引用的实体不存在。</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.zh_TW.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.zh_TW.xlf
@@ -570,6 +570,10 @@
                 <source>This value is not a valid cron expression.</source>
                 <target>這個值不是有效的 cron 表達式。</target>
             </trans-unit>
+            <trans-unit id="147">
+                <source>The referenced entity does not exist.</source>
+                <target state="needs-review-translation">引用的實體不存在。</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.zh_TW.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.zh_TW.xlf
@@ -574,6 +574,10 @@
                 <source>The referenced entity does not exist.</source>
                 <target state="needs-review-translation">引用的實體不存在。</target>
             </trans-unit>
+            <trans-unit id="148" resname="This is not a valid ULID.">
+                <source>This value is not a valid ULID.</source>
+                <target state="needs-review-translation">這個值不是有效的 ULID。</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Translation units are added on the lowest maintained branch so the ids stay aligned across branches. This adds two, to all 57 languages:

- **147**: `The referenced entity does not exist.`, the message of the `EntityExists` constraint being added on 8.2 in #63483.
- **148**: the message of the `Ulid` constraint. An audit of every constraint message default against `validators.en.xlf` (161 messages across the Validator component and the Doctrine, Twig, Form and Security integrations) found exactly one with no unit at all: `Ulid::$message`, while its `Uuid` sibling has unit 83. The unit follows 83's shape, `resname="This is not a valid ULID."` with the corrected `This value is not a valid ULID.` wording as the source, and each language's target is derived from its reviewed UUID translation with the acronym swapped.

Every non-English target is flagged `state="needs-review-translation"` for native speakers to confirm. Note for the merge-up: 8.2 already carries the English unit 147 (it came with #63483, merged today), so the `validators.en.xlf` hunk resolves to the identical block. All 57 files validate against the XLIFF 1.2 schema, and units 147 and 148 are present with unique ids in each.
