### PR TITLE
[Console] Do not resolve core utility parameters as command input

### DIFF
--- a/src/Symfony/Component/Console/ArgumentResolver/ArgumentResolver.php
+++ b/src/Symfony/Component/Console/ArgumentResolver/ArgumentResolver.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Console\ArgumentResolver;
 
 use Psr\Container\ContainerInterface;
+use Symfony\Component\Console\Application;
 use Symfony\Component\Console\ArgumentResolver\Exception\NearMissValueResolverException;
 use Symfony\Component\Console\ArgumentResolver\Exception\ResolverNotFoundException;
 use Symfony\Component\Console\ArgumentResolver\ValueResolver as Resolver;
@@ -35,6 +36,16 @@ use Symfony\Contracts\Service\ServiceProviderInterface;
  */
 final class ArgumentResolver implements ArgumentResolverInterface
 {
+    private const CORE_UTILITY_TYPES = [
+        InputInterface::class,
+        RawInputInterface::class,
+        OutputInterface::class,
+        SymfonyStyle::class,
+        Cursor::class,
+        Application::class,
+        Command::class,
+    ];
+
     /**
      * @param iterable<mixed, ValueResolverInterface> $argumentValueResolvers
      */
@@ -56,6 +67,14 @@ final class ArgumentResolver implements ArgumentResolverInterface
         $arguments = [];
 
         foreach ($argumentReflectors as $argumentName => $member) {
+            $type = $member->getType();
+            $typeName = $type instanceof \ReflectionNamedType ? $type->getName() : null;
+
+            // core utilities are injected by InvokableCommand, so they must not yield an argument here
+            if ($typeName && \in_array($typeName, self::CORE_UTILITY_TYPES, true)) {
+                continue;
+            }
+
             $argumentValueResolvers = $this->argumentValueResolvers;
             $disabledResolvers = [];
 
@@ -109,21 +128,6 @@ final class ArgumentResolver implements ArgumentResolverInterface
 
             // For variadic parameters with explicit input mapping, 0 values is valid
             if ($member->isVariadic() && (Argument::tryFrom($member->getMember()) || Option::tryFrom($member->getMember()))) {
-                continue;
-            }
-
-            $type = $member->getType();
-            $typeName = $type instanceof \ReflectionNamedType ? $type->getName() : null;
-
-            if ($typeName && \in_array($typeName, [
-                InputInterface::class,
-                RawInputInterface::class,
-                OutputInterface::class,
-                SymfonyStyle::class,
-                Cursor::class,
-                \Symfony\Component\Console\Application::class,
-                Command::class,
-            ], true)) {
                 continue;
             }
 

--- a/src/Symfony/Component/Console/Command/InvokableCommand.php
+++ b/src/Symfony/Component/Console/Command/InvokableCommand.php
@@ -148,10 +148,10 @@ class InvokableCommand implements SignalableCommandInterface
                     Cursor::class => new Cursor($output),
                     Application::class => $this->command->getApplication(),
                     Command::class, self::class => $this->command,
-                    default => null,
+                    default => false,
                 };
 
-                if (null !== $argument) {
+                if (false !== $argument) {
                     $coreUtilities[$index] = $argument;
                     continue;
                 }
@@ -177,7 +177,7 @@ class InvokableCommand implements SignalableCommandInterface
         $resolvedIndex = 0;
 
         foreach ($function->getParameters() as $index => $param) {
-            if (isset($coreUtilities[$index])) {
+            if (\array_key_exists($index, $coreUtilities)) {
                 $parameters[] = $coreUtilities[$index];
             } elseif ($param->isVariadic()) {
                 // Variadic parameters consume all remaining resolved arguments

--- a/src/Symfony/Component/Console/Tests/Command/InvokableCommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/InvokableCommandTest.php
@@ -493,6 +493,62 @@ class InvokableCommandTest extends TestCase
         $command->run(new ArrayInput([]), new NullOutput());
     }
 
+    public function testNullableHelpersInjection()
+    {
+        $application = new Application();
+
+        $command = new Command('foo');
+        $command->setCode(static function (
+            ?InputInterface $input,
+            ?OutputInterface $output,
+            ?Cursor $cursor,
+            ?SymfonyStyle $io,
+            ?Application $app,
+            ?Command $cmd,
+            #[Argument] ?string $name = null,
+            #[Option] ?string $format = null,
+        ) use ($command, $application): int {
+            Assert::assertInstanceOf(InputInterface::class, $input);
+            Assert::assertInstanceOf(OutputInterface::class, $output);
+            Assert::assertInstanceOf(Cursor::class, $cursor);
+            Assert::assertInstanceOf(SymfonyStyle::class, $io);
+            Assert::assertSame($application, $app);
+            Assert::assertSame($command, $cmd);
+            Assert::assertSame('test', $name);
+            Assert::assertSame('json', $format);
+
+            return 0;
+        });
+
+        $application->addCommand($command);
+
+        $tester = new CommandTester($command);
+        $tester->execute(['name' => 'test', '--format' => 'json']);
+
+        $tester->assertCommandIsSuccessful();
+    }
+
+    public function testNullableApplicationInjectionWithoutApplication()
+    {
+        $command = new Command('foo');
+        $command->setCode(static function (
+            ?Application $app,
+            #[Argument] ?string $name = null,
+            #[Option] ?string $format = null,
+        ): int {
+            Assert::assertNull($app);
+            Assert::assertSame('test', $name);
+            Assert::assertSame('json', $format);
+
+            return 0;
+        });
+
+        $tester = new CommandTester($command);
+        $tester->execute(['name' => 'test', '--format' => 'json']);
+
+        $tester->assertCommandIsSuccessful();
+    }
+
     public function testDefaultArgumentResolversWithoutApplication()
     {
         $command = new Command('foo');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65454
| License       | MIT

A command that declares a nullable core utility, such as `?SymfonyStyle $io`, received its arguments and options in the wrong parameters:

```php
#[AsCommand(name: 'probe')]
final class Probe
{
    public function __invoke(
        ?SymfonyStyle $io,
        #[Argument] ?string $email = null,
        #[Option] ?string $csv = null,
    ): int {
        // $email was null and $csv held the value meant for $email
    }
}
```

`InvokableCommand::getParameters()` injects the core utilities (`InputInterface`, `RawInputInterface`, `OutputInterface`, `SymfonyStyle`, `Cursor`, `Application`, `Command`) itself and asks the argument resolver only for the remaining parameters, then matches the two lists up by position. `ArgumentResolver` skipped those types too, but only after running the value resolvers, so a nullable one was picked up by `DefaultValueResolver` first and yielded an extra `null`. That extra entry shifted every following value by one.

The check now runs at the top of the loop, so those parameters are left alone whether they are nullable or not.

`InvokableCommand` also treated a `null` from the core utility `match` as "not a core utility", so `?Application $app` on a command with no application went to the resolver as well. It now uses `false` as the sentinel and keeps the slot, which passes `null` through instead of shifting.
