### PR TITLE
[Translation] Fix extracting TranslatableMessage with nikic/php-parser 4

### DIFF
--- a/src/Symfony/Component/Translation/Extractor/Visitor/TranslatableMessageVisitor.php
+++ b/src/Symfony/Component/Translation/Extractor/Visitor/TranslatableMessageVisitor.php
@@ -42,7 +42,7 @@ final class TranslatableMessageVisitor extends AbstractVisitor implements NodeVi
 
         // the name resolver gives a fully qualified name; templates without a "use"
         // statement resolve to the global namespace, which is accepted as well
-        if (!\in_array($className->name, [TranslatableMessage::class, 'TranslatableMessage'], true)) {
+        if (!\in_array($className->toString(), [TranslatableMessage::class, 'TranslatableMessage'], true)) {
             return null;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`Node\Name::$name` was added in nikic/php-parser 5.0, while the component allows `^4.18|^5.0`. On php-parser 4 the check reads an undefined property, so no `new TranslatableMessage()` call is ever matched and every case of `PhpAstExtractorTest` errors with `Undefined property: PhpParser\Node\Name\FullyQualified::$name`. `Name::toString()` exists in both major versions and returns the same fully qualified name.

This is what makes the `low-deps` job red on 6.4 (7 errors in `Translation\Tests\Extractor\PhpAstExtractorTest`).

Checked against php-parser 4.19.5 that `toString()` returns the fully qualified name while `$name` is undefined there. The Translation suite passes with php-parser 5 (714 tests).
