### PR TITLE
[FrameworkBundle] Make the Uid resolver test tolerant of newer argument resolution errors

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/UidTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/UidTest.php
@@ -28,8 +28,8 @@ class UidTest extends AbstractWebTestCase
         $client = $this->createClient(['test_case' => 'Uid', 'root_config' => 'config_disabled.yml']);
         $client->catchExceptions(false);
 
-        $this->expectException(\TypeError::class);
-        $this->expectExceptionMessage('Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Controller\UidController::anyFormat(): Argument #1 ($userId) must be of type Symfony\Component\Uid\UuidV1, string given');
+        $this->expectException(\Throwable::class);
+        $this->expectExceptionMessageMatches('/UidController::anyFormat.+\$userId/');
 
         $client->request('GET', '/1/uuid-v1/'.new UuidV1());
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Since #65386, HttpKernel reports an unresolvable controller argument as a `RuntimeException` naming the argument and the request attribute, instead of letting the call fail with a `TypeError`. This test pins the `TypeError` message, so it fails as soon as HttpKernel 8.2 is installed:

```
Failed asserting that exception of type "RuntimeException" matches expected exception "TypeError".
```

That is what the `high-deps` jobs report on 7.4 and 8.1, and what the `high-deps` job of 8.2 reports when it runs the 8.1 branch against the patched components.

The test is about the resolver being disabled, not about which layer reports the failure, so it now asserts what both messages share: the controller and the argument name. Checked that the pattern matches both messages, and that the case passes on 7.4 with its own HttpKernel.

Merge-up note: 8.2 asserts the new message precisely and should keep its own version of this test.
