### PR TITLE
[DoctrineBridge] Fix the EntityExists validator tests on low-deps and without pdo_sqlite

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/EntityExistsValidatorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/EntityExistsValidatorTest.php
@@ -33,7 +33,7 @@ use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
 
 class EntityExistsValidatorTest extends ConstraintValidatorTestCase
 {
-    protected ?ObjectManager $em;
+    protected ?ObjectManager $em = null;
     protected ManagerRegistry $registry;
 
     protected function setUp(): void
@@ -263,7 +263,7 @@ class EntityExistsValidatorTest extends ConstraintValidatorTestCase
         $this->expectException(ConstraintDefinitionException::class);
         $this->expectExceptionMessage('Object manager "missing" does not exist.');
 
-        $this->validate(1, new EntityExists(entityClass: SingleIntIdEntity::class, em: 'missing'));
+        $this->validator->validate(1, new EntityExists(entityClass: SingleIntIdEntity::class, em: 'missing'));
     }
 
     public function testThrowsWhenManagerForClassCannotBeResolved()
@@ -274,7 +274,7 @@ class EntityExistsValidatorTest extends ConstraintValidatorTestCase
         $this->expectException(ConstraintDefinitionException::class);
         $this->expectExceptionMessage('Unable to find the object manager associated with an entity of class "Symfony\\Bridge\\Doctrine\\Tests\\Fixtures\\SingleIntIdEntity".');
 
-        $this->validate(1, new EntityExists(entityClass: SingleIntIdEntity::class));
+        $this->validator->validate(1, new EntityExists(entityClass: SingleIntIdEntity::class));
     }
 
     private function createRegistryMock(?ObjectManager $em, bool $managerForClassExists = true, bool $throwOnGetManager = false): ManagerRegistry


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Two failures of the new `EntityExists` tests on CI:

- `low-deps`: two cases call `ConstraintValidatorTestCase::validate()`, which only exists since Validator 8.1, while the bridge requires `symfony/validator: ^7.4|^8.0`. They now call the validator the same way the other 17 cases in the class do.
- Windows, `minimal-exts`: `DoctrineTestHelper::createTestEntityManager()` skips the test when `pdo_sqlite` is missing, so `setUp()` stops before assigning `$em`, and `tearDown()` errors with `Typed property ...::$em must not be accessed before initialization` for all 23 cases. The property now defaults to null.

Reproduced the second one locally by making `setUp()` skip: 23 errors before, 23 clean skips after. The DoctrineBridge suite passes (517 tests).
