### PR TITLE
[RateLimiter] Fix a timezone-dependent test

### DIFF
--- a/src/Symfony/Component/RateLimiter/Tests/RateLimiterBuilderTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/RateLimiterBuilderTest.php
@@ -73,7 +73,7 @@ class RateLimiterBuilderTest extends TestCase
     public static function anchorProvider()
     {
         yield 'string' => ['2024-01-01 00:00:00'];
-        yield 'DateTimeImmutable' => [new \DateTimeImmutable('2024-01-01 00:00:00')];
+        yield 'DateTimeImmutable' => [new \DateTimeImmutable('2024-01-01 00:00:00', new \DateTimeZone('UTC'))];
     }
 
     public function testLockIsCreatedPerKey()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`RateLimiterFactory` parses a string anchor as UTC, but keeps the timezone of a `DateTimeInterface` anchor. The data provider builds one with the default timezone, while the assertion formats a retry-after built from a Unix timestamp, so the test only passes when the default timezone is UTC. It fails on the Windows job:

```
-'01 00:00:00'
+'01 07:00:00'
```

Reproduced locally with `-d date.timezone=America/Los_Angeles`. The anchor is now built as UTC, which makes both data sets equivalent. The RateLimiter suite passes in both timezones (111 tests).
