### PR TITLE
[FrameworkBundle] Fix the rate limiter builder when the Lock component is not installed

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -3739,7 +3739,7 @@ class FrameworkExtension extends Extension
             $builderConfig = $config['builder'];
 
             if ('auto' === $builderConfig['lock_factory']) {
-                $builderConfig['lock_factory'] = $this->isInitializedConfigEnabled('lock') ? 'lock.factory' : null;
+                $builderConfig['lock_factory'] = interface_exists(LockInterface::class) && $this->isInitializedConfigEnabled('lock') ? 'lock.factory' : null;
             }
 
             $builder = $container->getDefinition('limiter_builder');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Since #60084, the rate limiter builder is configured for every application that has the RateLimiter component, and its `lock_factory` defaults to `auto`. In `auto` mode the extension takes `lock.factory` as soon as `framework.lock` is enabled, then throws when the Lock component is not installed:

```
Rate Limiter Builder requires the Lock component to be installed. Try running "composer require symfony/lock".
```

An application that enables `framework.lock` without having the component used to build fine, and this is what the `high-deps` job of the 8.2 branch reports on `SecurityBundle\Tests\Functional\FormLoginTest::testLoginThrottling`. `auto` now means "use the lock factory when there is one". An explicitly configured `lock_factory` still throws.

Three states checked with a container built from `framework: {lock: ~, rate_limiter: ~}`:

- before, Lock missing: `LogicException`
- after, Lock missing: no lock wired on `limiter_builder`
- after, Lock installed: `Reference('lock.factory')`, as before

The condition depends on the Lock component being absent, which the monorepo cannot reproduce in a test, so this comes without one. FrameworkBundle's DependencyInjection tests pass (646 tests).
