### PR TITLE
[FrameworkBundle][Security] Require the sibling versions the code actually uses

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -21,7 +21,7 @@
         "ext-xml": "*",
         "symfony/cache": "^8.2",
         "symfony/config": "^8.2",
-        "symfony/dependency-injection": "^8.1.2",
+        "symfony/dependency-injection": "^8.2",
         "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/error-handler": "^7.4|^8.0",
         "symfony/event-dispatcher": "^8.1",

--- a/src/Symfony/Component/Security/Http/composer.json
+++ b/src/Symfony/Component/Security/Http/composer.json
@@ -22,7 +22,7 @@
         "symfony/http-kernel": "^8.1",
         "symfony/polyfill-mbstring": "^1.0",
         "symfony/property-access": "^7.4|^8.0",
-        "symfony/security-core": "^7.4|^8.0",
+        "symfony/security-core": "^8.2",
         "symfony/service-contracts": "^2.5|^3"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Two packages use APIs that their requirements do not cover, which the `low-deps` job reports:

- FrameworkBundle describes `LazyProxyArgument`, added in DependencyInjection 8.2, while requiring `^8.1.2`. The descriptor tests error with `Class "Symfony\Component\DependencyInjection\Argument\LazyProxyArgument" not found`.
- Security\Http signs the extra login link parameters through `SignatureHasher`, which takes them since Security\Core 8.2, while requiring `^7.4|^8.0`. With an older Security\Core the extra argument is ignored, the parameters are left out of the signature, and a tampered one is accepted. Two cases of `LoginLinkHandlerTest` fail there.

The second one is not only a test failure: the same code silently degrades the signature at runtime for anyone resolving that older version.
