### PR TITLE
[Validator] Fix the source of the Ulid message translation unit

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.en.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.en.xlf
@@ -574,8 +574,8 @@
                 <source>The referenced entity does not exist.</source>
                 <target>The referenced entity does not exist.</target>
             </trans-unit>
-            <trans-unit id="148" resname="This is not a valid ULID.">
-                <source>This value is not a valid ULID.</source>
+            <trans-unit id="148">
+                <source>This is not a valid ULID.</source>
                 <target>This value is not a valid ULID.</target>
             </trans-unit>
         </body>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

In `validators.en.xlf` the source of a unit is the constraint message and the target is the English text, while the other locales carry the message in `resname`. The `Ulid` unit added in #65453 was filed the other way around, which makes the XLIFF check of the Integration workflow fail on every branch:

```
Run "php .github/sync-translations.php" to fix XLIFF files.
```

This is the output of that script, and it is the only file it rewrites.
