### PR TITLE
[FrameworkBundle] Skip the PGP mailer tests when the Mime component has no PGP support

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -95,6 +95,8 @@ use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Messenger\Middleware\DecodeFailedMessageMiddleware;
 use Symfony\Component\Messenger\Middleware\DeduplicateMiddleware;
 use Symfony\Component\Messenger\Transport\TransportFactory;
+use Symfony\Component\Mime\Crypto\PgpEncrypter;
+use Symfony\Component\Mime\Crypto\PgpSigner;
 use Symfony\Component\Notifier\ChatterInterface;
 use Symfony\Component\Notifier\TexterInterface;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
@@ -2866,6 +2868,10 @@ abstract class FrameworkExtensionTestCase extends TestCase
 
     public function testMailerPgp()
     {
+        if (!class_exists(PgpSigner::class)) {
+            $this->markTestSkipped('This test requires symfony/mime 8.2 or higher.');
+        }
+
         $container = $this->createContainerFromFile('mailer_with_pgp');
 
         $signer = $container->getDefinition('mailer.pgp_signer');
@@ -2895,6 +2901,10 @@ abstract class FrameworkExtensionTestCase extends TestCase
 
     public function testMailerPgpEncrypterFailsAndDoesNotEncryptForTheSenderByDefault()
     {
+        if (!class_exists(PgpEncrypter::class)) {
+            $this->markTestSkipped('This test requires symfony/mime 8.2 or higher.');
+        }
+
         $container = $this->createContainerFromFile('mailer_with_pgp_repository');
 
         $this->assertSame('my_pgp_repository', (string) $container->getAlias('mailer.pgp_encrypter.repository'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

FrameworkBundle allows a Mime version without PGP/MIME support and reports it with a clear exception, but the two tests that configure it do not account for that, so they fail on the `low-deps` job:

```
PGP/MIME signed messages support cannot be enabled as this version of the Mime component does not support it. Try upgrading "symfony/mime".
```

They now skip when the classes are missing, the way the other version-dependent cases of this class do. The requirement stays as it is, since the support is optional.
