### PR TITLE
[TwigBridge] Pass a valid XML version to DOMDocument in the form layout test case

### DIFF
--- a/src/Symfony/Bridge/Twig/Test/FormLayoutTestCase.php
+++ b/src/Symfony/Bridge/Twig/Test/FormLayoutTestCase.php
@@ -50,18 +50,22 @@ abstract class FormLayoutTestCase extends FormIntegrationTestCase
 
     protected function assertMatchesXpath($html, $expression, $count = 1): void
     {
-        $dom = new \DOMDocument('UTF-8');
+        $dom = new \DOMDocument('1.0', 'UTF-8');
 
         try {
             // Wrap in <root> node so we can load HTML with multiple tags at
             // the top level
-            $dom->loadXML('<root>'.$html.'</root>');
+            $loaded = $dom->loadXML('<root>'.$html.'</root>');
         } catch (\Exception $e) {
             $this->fail(\sprintf(
                 "Failed loading HTML:\n\n%s\n\nError: %s",
                 $html,
                 $e->getMessage()
             ));
+        }
+
+        if (!$loaded) {
+            $this->fail(\sprintf("Failed loading HTML:\n\n%s", $html));
         }
         $xpath = new \DOMXPath($dom);
         $nodeList = $xpath->evaluate('/root'.$expression);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`DOMDocument::__construct()` takes the XML version first and the encoding second, so `new \DOMDocument('UTF-8')` builds a document whose version is `UTF-8`:

```php
$d = new \DOMDocument('UTF-8');
var_dump($d->xmlVersion, $d->saveXML());
// string(5) "UTF-8"
// string(24) "<?xml version="UTF-8"?>"
```

Up to PHP 8.5 `loadXML()` replaces the document and the bogus version goes unnoticed. On PHP 8.6 the layout tests report `DOMDocument::loadXML(): attributes construct error in Entity, line: 1`, `loadXML()` returns false, and 1042 assertions then run against an empty document.

`loadXML()` returns false rather than throwing, so the existing `catch` never fires and the failure surfaced as "matches 0 times" against an empty document instead of as a load error. The return value is now checked.

The Twig bridge suite passes (1755 cases, plus one unrelated local vendor error). The PHP 8.6 job is red for another reason as well, the `{##}` lexer regression of twig 4.x-dev, so the check to make on this pull request is whether the 1042 layout failures disappear.
