### PR TITLE
[FrameworkBundle] Make the Uid resolver test tolerant of the HttpKernel version

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/UidTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/UidTest.php
@@ -28,8 +28,8 @@ class UidTest extends AbstractWebTestCase
         $client = $this->createClient(['test_case' => 'Uid', 'root_config' => 'config_disabled.yml']);
         $client->catchExceptions(false);
 
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Controller "Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Controller\UidController::anyFormat" requires the "$userId" argument that could not be resolved. The "userId" request attribute holds a "string", which cannot be passed to a parameter typed "Symfony\Component\Uid\UuidV1".');
+        $this->expectException(\Throwable::class);
+        $this->expectExceptionMessageMatches('/UidController::anyFormat.+\$userId/');
 
         $client->request('GET', '/1/uuid-v1/'.new UuidV1());
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/config/schema.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/config/schema.json
@@ -3532,6 +3532,47 @@
                                             ]
                                         }
                                     },
+                                    "tracking": {
+                                        "$ref": "#/$defs/types/object_null",
+                                        "properties": {
+                                            "opens": {
+                                                "anyOf": [
+                                                    {
+                                                        "enum": [
+                                                            true,
+                                                            false,
+                                                            null
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$ref": "#/$defs/types/param"
+                                                    }
+                                                ],
+                                                "default": null
+                                            },
+                                            "clicks": {
+                                                "anyOf": [
+                                                    {
+                                                        "enum": [
+                                                            true,
+                                                            false,
+                                                            null
+                                                        ]
+                                                    },
+                                                    {
+                                                        "$ref": "#/$defs/types/param"
+                                                    }
+                                                ],
+                                                "default": null
+                                            }
+                                        },
+                                        "additionalProperties": false,
+                                        "default": {
+                                            "opens": null,
+                                            "clicks": null
+                                        },
+                                        "description": "Default open/click tracking for every message that does not carry an explicit \"X-Track\" header; null keeps each provider's default. An \"X-Track\" entry in the \"headers\" option wins over this one."
+                                    },
                                     "dkim_signer": {
                                         "anyOf": [
                                             {
@@ -3881,6 +3922,10 @@
                             "dsn": null,
                             "transports": [],
                             "headers": [],
+                            "tracking": {
+                                "opens": null,
+                                "clicks": null
+                            },
                             "dkim_signer": {
                                 "enabled": false,
                                 "key": "",
@@ -4057,6 +4102,33 @@
                                         "$ref": "#/$defs/types/boolean",
                                         "default": false
                                     },
+                                    "builder": {
+                                        "$ref": "#/$defs/types/object_null",
+                                        "properties": {
+                                            "lock_factory": {
+                                                "$ref": "#/$defs/types/scalar",
+                                                "default": "auto",
+                                                "description": "The service ID of the lock factory to use with the RateLimiterBuilder."
+                                            },
+                                            "cache_pool": {
+                                                "$ref": "#/$defs/types/scalar",
+                                                "default": "cache.rate_limiter",
+                                                "description": "The cache pool to use with RateLimiterBuilder."
+                                            },
+                                            "storage_service": {
+                                                "$ref": "#/$defs/types/scalar",
+                                                "default": null,
+                                                "description": "The service ID of a custom storage implementation, this precedes any configured \"cache_pool\"."
+                                            }
+                                        },
+                                        "additionalProperties": false,
+                                        "default": {
+                                            "lock_factory": "auto",
+                                            "cache_pool": "cache.rate_limiter",
+                                            "storage_service": null
+                                        },
+                                        "description": "Configuration for the RateLimiterBuilder service."
+                                    },
                                     "limiters": {
                                         "$ref": "#/$defs/types/object_null",
                                         "additionalProperties": {
@@ -4157,6 +4229,11 @@
                         ],
                         "default": {
                             "enabled": false,
+                            "builder": {
+                                "lock_factory": "auto",
+                                "cache_pool": "cache.rate_limiter",
+                                "storage_service": null
+                            },
                             "limiters": []
                         },
                         "description": "Rate limiter configuration"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Same fix as #65457, in the other direction. This test pins the `RuntimeException` message that HttpKernel produces since #65386, while FrameworkBundle requires `symfony/http-kernel: ^8.1`, where the call still fails with a `TypeError`. That is the last failure of the `low-deps` job on 8.2:

```
Failed asserting that exception of type "TypeError" matches expected exception "RuntimeException".
```

The message itself is covered by `HttpKernel\Tests\Controller\ArgumentResolverTest`, which is where it belongs. Here the point is that the argument is not resolved once the value resolver is disabled, so the assertion keeps the controller and the argument name and lets the rest vary.

This also ends the merge conflict on this file between 8.1 and 8.2. The FrameworkBundle suite passes (1578 cases).
