### PR TITLE
[Scheduler] Fix infinite loop in PeriodicalTrigger when the interval cannot move the run date forward

### DIFF
--- a/src/Symfony/Component/Scheduler/Tests/Trigger/PeriodicalTriggerTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/Trigger/PeriodicalTriggerTest.php
@@ -76,6 +76,10 @@ class PeriodicalTriggerTest extends TestCase
         yield [-3600, 'The "$interval" argument must be greater than zero.'];
         yield ['0', 'The "$interval" argument must be greater than zero.'];
         yield [0, 'The "$interval" argument must be greater than zero.'];
+        yield ['PT0S', 'The "$interval" argument must be greater than zero.'];
+        yield ['P0D', 'The "$interval" argument must be greater than zero.'];
+        yield ['0 seconds', 'The "$interval" argument must be greater than zero.'];
+        yield [new \DateInterval('PT0S'), 'The "$interval" argument must be greater than zero.'];
     }
 
     /**
@@ -156,6 +160,27 @@ class PeriodicalTriggerTest extends TestCase
             ],
             20,
         ];
+    }
+
+    /**
+     * @dataProvider provideNonMovingIntervals
+     */
+    public function testThrowsWhenIntervalDoesNotMoveTheRunDateForward(string $interval, string $from, string $run)
+    {
+        $trigger = new PeriodicalTrigger($interval, new \DateTimeImmutable($from));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(\sprintf('The interval of the "every %s" trigger does not move the run date forward. Consider using a cron expression instead.', $interval));
+
+        $trigger->getNextRunDate(new \DateTimeImmutable($run));
+    }
+
+    public static function provideNonMovingIntervals(): iterable
+    {
+        yield 'weekday name matching the current day' => ['Monday', '2024-11-25 15:53:20', '2024-11-25 15:53:20'];
+        yield 'weekday name stalling after one advance' => ['Monday', '2024-11-26 15:53:20', '2024-12-31 00:00:00'];
+        yield 'backward-moving interval' => ['1 day ago', '2024-11-25 15:53:20', '2024-11-25 15:53:20'];
+        yield 'comma-separated weekdays' => ['Monday, Thursday, Saturday', '2024-11-25 15:53:20', '2024-12-31 00:00:00'];
     }
 
     /**

--- a/src/Symfony/Component/Scheduler/Trigger/PeriodicalTrigger.php
+++ b/src/Symfony/Component/Scheduler/Trigger/PeriodicalTrigger.php
@@ -70,6 +70,8 @@ class PeriodicalTrigger implements StatefulTriggerInterface
             } else {
                 $this->interval = $i;
             }
+        } catch (InvalidArgumentException $e) {
+            throw $e;
         } catch (\Exception $e) {
             throw new InvalidArgumentException(\sprintf('Invalid interval "%s": ', $interval instanceof \DateInterval ? 'instance of \DateInterval' : $interval).$e->getMessage(), 0, $e);
         }
@@ -110,7 +112,13 @@ class PeriodicalTrigger implements StatefulTriggerInterface
 
         $this->period ??= new \DatePeriod($this->from, $this->interval, $this->until);
         $iterator = $this->period->getIterator();
+        $previous = null;
         while ($run >= $next = $iterator->current()) {
+            if (null !== $previous && $next <= $previous) {
+                throw new InvalidArgumentException(\sprintf('The interval of the "%s" trigger does not move the run date forward. Consider using a cron expression instead.', $this->description));
+            }
+
+            $previous = $next;
             $iterator->next();
             if (!$iterator->valid()) {
                 return null;
@@ -136,6 +144,12 @@ class PeriodicalTrigger implements StatefulTriggerInterface
 
     private function calcInterval(\DateInterval $interval): float
     {
-        return (float) (new \DateTimeImmutable('@0'))->add($interval)->format('U.u');
+        $seconds = (float) (new \DateTimeImmutable('@0'))->add($interval)->format('U.u');
+
+        if (0.0 >= $seconds) {
+            throw new InvalidArgumentException('The "$interval" argument must be greater than zero.');
+        }
+
+        return $seconds;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #58981, Fix #60745
| License       | MIT

`PeriodicalTrigger` accepts any relative date string as its interval. Some of those strings are points in time rather than distances, so applying one to a date can leave the date unchanged or move it backwards. `DatePeriod` then yields the same date forever and `getNextRunDate()` never returns.

`Monday` applied to a Monday gives back that same Monday. `1 day ago` and `last monday` run backwards. `Monday, Thursday, Saturday` keeps only the last weekday and stalls on it:

```
Mon 2024-11-25 15:53:20
Sat 2024-11-30 15:53:20
Sat 2024-11-30 15:53:20
Sat 2024-11-30 15:53:20
```

Checking the string in the constructor cannot work (that was #61143): `Monday` from a Tuesday moves forward once and stalls only on the next step, while `next tuesday` and `second Saturday` are valid. The check has to look at the step itself, inside the loop. Every date depends only on the one before it, so a step that does not move forward repeats forever, and `<=` catches the backwards case too. Such a trigger now throws:

> The interval of the "every Monday" trigger does not move the run date forward. Consider using a cron expression instead.

Intervals that resolve to zero seconds belong to the same family: `PT0S`, `P0D`, `0 seconds` and `new \DateInterval('PT0S')` slipped past the existing `must be greater than zero` check and failed later with `Typed property Symfony\Component\Scheduler\Trigger\PeriodicalTrigger::$interval must not be accessed before initialization`. They are now rejected in the constructor with the same message as `0` and `-3600`.

Valid intervals are unaffected: `next tuesday`, `second Saturday`, `first monday of next month`, `first day of next month`, `last day of next month`, `1 day`, `1 week`, `1 month`, `tomorrow`.

`getNextRunDate()` is identical in 7.x, so this merges up cleanly.
