### PR TITLE
[Yaml] Fix parsing tagged block scalars inside sequences

### DIFF
--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -200,6 +200,8 @@ class Parser
                         $subTag,
                         $this->parseBlock($this->getRealCurrentLineNb() + 1, $this->getNextEmbedBlock(null, true), $flags)
                     );
+                } elseif (self::preg_match('/^'.self::TAG_PATTERN.' +'.self::BLOCK_SCALAR_HEADER_PATTERN.'$/', $values['value'])) {
+                    $data[] = $this->parseValue($values['value'], $flags, $context);
                 } else {
                     if (
                         isset($values['leadspaces'])

--- a/src/Symfony/Component/Yaml/Tests/DumperTest.php
+++ b/src/Symfony/Component/Yaml/Tests/DumperTest.php
@@ -14,7 +14,6 @@ namespace Symfony\Component\Yaml\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Yaml\Dumper;
 use Symfony\Component\Yaml\Exception\DumpException;
-use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Parser;
 use Symfony\Component\Yaml\Tag\TaggedValue;
 use Symfony\Component\Yaml\Yaml;
@@ -604,12 +603,7 @@ class DumperTest extends TestCase
         ];
         $expected = "- !bar |\n    a\n    b";
         $this->assertSame($expected, $this->dumper->dump($data, 2, 0, Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK));
-
-        // @todo Fix the parser, eliminate these exceptions.
-        $this->expectException(ParseException::class);
-        $this->expectExceptionMessage('Unable to parse at line 3 (near "!bar |").');
-
-        $this->parser->parse($expected, Yaml::PARSE_CUSTOM_TAGS);
+        $this->assertSameData($data, $this->parser->parse($expected, Yaml::PARSE_CUSTOM_TAGS));
     }
 
     public function testDumpingTaggedMultiLineTrailingNewlinesInMap()
@@ -621,11 +615,7 @@ class DumperTest extends TestCase
         $this->assertSame($expected, $this->dumper->dump($data, 2, 0, Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK));
 
         // @todo Fix the parser, the result should be identical to $data.
-        $this->assertSameData(
-            [
-                'foo' => new TaggedValue('bar', "a\nb\n"),
-            ],
-            $this->parser->parse($expected, Yaml::PARSE_CUSTOM_TAGS));
+        $this->assertSameData(['foo' => new TaggedValue('bar', "a\nb\n")], $this->parser->parse($expected, Yaml::PARSE_CUSTOM_TAGS));
     }
 
     public function testDumpingTaggedMultiLineTrailingNewlinesInList()
@@ -636,11 +626,8 @@ class DumperTest extends TestCase
         $expected = "- !bar |\n    a\n    b\n    \n    \n    ";
         $this->assertSame($expected, $this->dumper->dump($data, 2, 0, Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK));
 
-        // @todo Fix the parser, eliminate these exceptions.
-        $this->expectException(ParseException::class);
-        $this->expectExceptionMessage('Unable to parse at line 6 (near "!bar |").');
-
-        $this->parser->parse($expected, Yaml::PARSE_CUSTOM_TAGS);
+        // @todo Fix the parser, the result should be identical to $data.
+        $this->assertSameData([new TaggedValue('bar', "a\nb\n")], $this->parser->parse($expected, Yaml::PARSE_CUSTOM_TAGS));
     }
 
     public function testDumpingInlinedMultiLineIfRnBreakLineInTaggedValue()

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -112,10 +112,36 @@ class ParserTest extends TestCase
             - !text |
               first line
             YAML;
-        // @todo Fix the parser, eliminate this exception.
-        $this->expectException(ParseException::class);
-        $this->expectExceptionMessage('Unable to parse at line 2 (near "!text |").');
-        $this->parser->parse($yml, Yaml::PARSE_CUSTOM_TAGS);
+        $data = $this->parser->parse($yml, Yaml::PARSE_CUSTOM_TAGS);
+        $this->assertSameData([new TaggedValue('text', 'first line')], $data);
+    }
+
+    public function testTaggedBlockScalarsAsListItems()
+    {
+        $yml = <<<'YAML'
+            - !text |
+              first line
+              second line
+            - !text >-
+              folded
+              text
+            - !!binary |
+              SGVsbG8=
+            - plain
+            YAML;
+        $expected = [new TaggedValue('text', "first line\nsecond line\n"), new TaggedValue('text', 'folded text'), 'Hello', 'plain'];
+        $this->assertSameData($expected, $this->parser->parse($yml, Yaml::PARSE_CUSTOM_TAGS));
+    }
+
+    public function testTaggedBlockScalarInNestedList()
+    {
+        $yml = <<<'YAML'
+            foo:
+              - !text |
+                a
+                b
+            YAML;
+        $this->assertSameData(['foo' => [new TaggedValue('text', "a\nb")]], $this->parser->parse($yml, Yaml::PARSE_CUSTOM_TAGS));
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #46728
| License       | MIT

A tagged block scalar used as a sequence item failed to parse:

```yaml
- !text |
  first line
  second line
```

`Yaml::parse($yaml, Yaml::PARSE_CUSTOM_TAGS)` threw `ParseException: Unable to parse at line 3 (near "!text |")`, while the equivalent mapping form (`key: !text |`) and the untagged sequence form (`- |`) both parse fine. The YAML spec allows the construct (spec example 2.23, `application specific tag: !something |`).

This is a regression from the fix for #36624 (shipped in 3.4.44 / 4.4.12 / 5.1.4). Since that change, every `- !tag <value>` sequence item takes the compact notation path, which re-parses the item as an embedded document, and a tag followed by a block scalar header cannot be parsed that way. Before the change, `- !text |` produced a TaggedValue (verified by running the reproducer against the v4.4.11 sources).

The fix routes sequence items that match a tag followed by a block scalar header (`|` or `>`, with optional modifiers and trailing comment) to `parseValue()`, which already handles tagged block scalars and is the code path the mapping form uses. All variants now behave exactly like their mapping twins: `|`, `>`, `|-`, `|+`, `|<n>`, trailing comments, `!!binary` decoding, anchors on the item, and parsing without the `PARSE_CUSTOM_TAGS` flag. Inputs that parsed before (compact notation items, tagged inline collections, `!php/const` first keys) are unaffected, because the new branch only matches inputs that previously threw. Top level block scalars (tagged or not) still do not parse; that is a separate, older limitation not touched here.

This also repairs the Dumper round trip: with `Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK`, dumping `[new TaggedValue('text', "a\nb")]` produces `- !text |` output that the parser refused to read back. Two DumperTest cases and one ParserTest case that pinned the exception with a `@todo Fix the parser` note now assert the parsed result instead.

Checks run: `php ./phpunit src/Symfony/Component/Yaml` passes (848 tests, 1336 assertions, 1 skipped: `InlineTest::testDumpNumericValueWithLocale`, missing fr_FR locale locally, unrelated). Revert check: with the Parser change reverted and the tests kept, the five updated or new tests fail with the pinned `Unable to parse` exceptions; with the change applied they pass.
