### PR TITLE
[Console] Fix clearing more lines than a section holds

### DIFF
--- a/src/Symfony/Component/Console/Output/ConsoleSectionOutput.php
+++ b/src/Symfony/Component/Console/Output/ConsoleSectionOutput.php
@@ -76,7 +76,10 @@ class ConsoleSectionOutput extends StreamOutput
             $this->content = [];
         }
 
-        $this->lines -= $lines;
+        // callers may ask to clear more lines than this section tracks (e.g. ProgressBar
+        // counts "\n"-separated lines while addContent() splits on PHP_EOL), so keep the
+        // counter from going negative, which would break the max-height bookkeeping
+        $this->lines = max(0, $this->lines - $lines);
 
         parent::doWrite($this->popStreamContentUntilCurrentSection($this->maxHeight ? min($this->maxHeight, $lines) : $lines), false);
     }

--- a/src/Symfony/Component/Console/Tests/Output/ConsoleSectionOutputTest.php
+++ b/src/Symfony/Component/Console/Tests/Output/ConsoleSectionOutputTest.php
@@ -59,6 +59,24 @@ class ConsoleSectionOutputTest extends TestCase
         $this->assertEquals("Foo\nBar\nBaz\nFooBar".\PHP_EOL.\sprintf("\x1b[%dA", 2)."\x1b[0J", stream_get_contents($output->getStream()));
     }
 
+    public function testMaxHeightAfterClearingMoreLinesThanTheSectionContains()
+    {
+        $sections = [];
+        $output = new ConsoleSectionOutput($this->stream, $sections, OutputInterface::VERBOSITY_NORMAL, true, new OutputFormatter());
+
+        $output->writeln('Hello');
+        $output->clear(2);
+        $output->setMaxHeight(2);
+        $output->writeln('Line1');
+        $output->writeln('Line2');
+        $output->writeln('Line3');
+
+        $expected = 'Hello'.\PHP_EOL."\x1b[2A\x1b[0J".'Line1'.\PHP_EOL.'Line2'.\PHP_EOL."\x1b[2A\x1b[0J".'Line2'.\PHP_EOL.'Line3'.\PHP_EOL;
+
+        rewind($output->getStream());
+        $this->assertSame($expected, stream_get_contents($output->getStream()));
+    }
+
     public function testClearNumberOfLinesWithMultipleSections()
     {
         $output = new StreamOutput($this->stream);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #54875
| License       | MIT

`ConsoleSectionOutput::clear($lines)` removes at most the lines the section holds, but it subtracts the requested `$lines` from its internal line counter unconditionally. When a caller asks for more lines than the section contains, two things go wrong: the cursor is moved above the section and erases lines that belong to whatever was printed before it, and the counter goes negative.

A negative counter then disables the scrolling done by `setMaxHeight()`, because `doWrite()` only scrolls when `$this->lines > $this->maxHeight`. That is what the example in the documentation shows:

```php
$section = $output->section();
$section->writeln('Hello');
$section->clear(2);
$section->setMaxHeight(2);
$section->writeln('Line1');
$section->writeln('Line2');
$section->writeln('Line3');
```

The section is one line tall when `clear(2)` runs, so its counter drops to -1 and the three following lines only bring it back to 2. Expected output is `Line2` and `Line3`; before this change all three lines stay on screen.

This clamps the number of lines to clear to the height of the section, so the counter never goes below zero and the cursor never moves above the section.

Checks run:

 * `./phpunit src/Symfony/Component/Console/Tests`: 1344 tests, 2343 assertions, 22 skipped, OK. The same suite on the base commit reports 1342 tests, 2341 assertions, 22 skipped, so the two added tests are the only difference. Both runs report the same 2 legacy deprecation notices.
 * Revert check: with the one line of `clear()` put back to its previous state and the tests kept, `testClearMoreLinesThanTheSectionContains` fails with `\x1b[3A` where `\x1b[1A` is expected, and `testMaxHeightAfterClearingMoreLinesThanTheSectionContains` fails because the section never emits the `\x1b[2A\x1b[0J` scroll and keeps `Line1` on screen.
 * Output of `Table::appendRow()` and of a `ProgressBar` rendered inside a section, captured before and after the change at 20, 40 and 80 columns: identical byte for byte. Callers that pass a correct number of lines are not affected.
 * 3000 randomized sequences of `write()`, `writeln()`, `clear()`, `overwrite()` and `setMaxHeight()` calls at 10, 20 and 80 columns: the line counter goes negative on the base commit at every width (for instance `writeln('')` followed by `clear(6)` leaves it at -5), and never with this change. The same runs confirm that the number of content entries stays at or below the line counter, so the clamp can never splice with an offset of zero.
