### PR TITLE
[HttpKernel] Write pending dumps to the output before dd() exits

### DIFF
--- a/src/Symfony/Component/HttpKernel/DataCollector/DumpDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/DumpDataCollector.php
@@ -97,6 +97,12 @@ class DumpDataCollector extends DataCollector implements DataDumperInterface
 
         $this->stopwatch?->stop('dump');
 
+        // dd() exits right after this call, and worker runtimes close the response
+        // before destructors run, so pending dumps are written to the output now.
+        if (!$this->isCollected && $this->isDumpAndDie()) {
+            $this->flush();
+        }
+
         return null;
     }
 
@@ -217,31 +223,39 @@ class DumpDataCollector extends DataCollector implements DataDumperInterface
     {
         if (0 === $this->clonesCount-- && !$this->isCollected && $this->dataCount) {
             $this->clonesCount = 0;
-            $this->isCollected = true;
-
-            $h = headers_list();
-            $i = \count($h);
-            array_unshift($h, 'Content-Type: '.\ini_get('default_mimetype'));
-            while (0 !== stripos($h[$i], 'Content-Type:')) {
-                --$i;
-            }
-
-            if ($this->webMode) {
-                $dumper = new HtmlDumper('php://output', $this->charset);
-                $dumper->setDisplayOptions(['fileLinkFormat' => $this->fileLinkFormat]);
-            } else {
-                $dumper = new CliDumper('php://output', $this->charset);
-                $dumper->setDisplayOptions(['fileLinkFormat' => $this->fileLinkFormat]);
-            }
-
-            foreach ($this->data as $i => $dump) {
-                $this->data[$i] = null;
-                $this->doDump($dumper, $dump['data'], $dump['name'], $dump['file'], $dump['line'], $dump['label'] ?? '');
-            }
-
-            $this->data = [];
-            $this->dataCount = 0;
+            $this->flush();
         }
+    }
+
+    private function flush(): void
+    {
+        $this->isCollected = true;
+
+        if ($this->webMode) {
+            $dumper = new HtmlDumper('php://output', $this->charset);
+        } else {
+            $dumper = new CliDumper('php://output', $this->charset);
+        }
+        $dumper->setDisplayOptions(['fileLinkFormat' => $this->fileLinkFormat]);
+
+        foreach ($this->data as $i => $dump) {
+            $this->data[$i] = null;
+            $this->doDump($dumper, $dump['data'], $dump['name'], $dump['file'], $dump['line'], $dump['label'] ?? '');
+        }
+
+        $this->data = [];
+        $this->dataCount = 0;
+    }
+
+    private function isDumpAndDie(): bool
+    {
+        foreach (debug_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS, 8) as $frame) {
+            if ('dd' === $frame['function'] && !isset($frame['class'])) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function doDump(DataDumperInterface $dumper, Data $data, string $name, string $file, int $line, string $label): void

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/DumpDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/DumpDataCollectorTest.php
@@ -17,6 +17,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\DataCollector\DumpDataCollector;
+use Symfony\Component\Process\Process;
 use Symfony\Component\VarDumper\Cloner\Data;
 use Symfony\Component\VarDumper\Dumper\CliDumper;
 use Symfony\Component\VarDumper\Server\Connection;
@@ -176,5 +177,41 @@ class DumpDataCollectorTest extends TestCase
         ob_start();
         $collector->__destruct();
         $this->assertEmpty(ob_get_clean());
+    }
+
+    public function testDumpAndDieWritesDumpsBeforeTheScriptShutsDown()
+    {
+        $autoload = file_exists(__DIR__.'/../../vendor/autoload.php')
+            ? __DIR__.'/../../vendor/autoload.php'
+            : __DIR__.'/../../../../../../vendor/autoload.php'
+        ;
+
+        $bootCode = <<<'EOPHP'
+            <?php
+            use Symfony\Component\HttpKernel\DataCollector\DumpDataCollector;
+            use Symfony\Component\VarDumper\Cloner\VarCloner;
+            use Symfony\Component\VarDumper\VarDumper;
+
+            require $argv[1];
+
+            $collector = new DumpDataCollector();
+            $cloner = new VarCloner();
+
+            VarDumper::setHandler(static function ($var) use ($collector, $cloner) {
+                $collector->dump($cloner->cloneVar($var));
+            });
+
+            register_shutdown_function(static function () { echo "shutting down\n"; });
+
+            dd('dumped value');
+            EOPHP;
+
+        $process = new Process([\PHP_BINARY, '--', $autoload]);
+        $process->setInput($bootCode);
+        $process->run();
+
+        $output = preg_replace("/\033\[[^m]*m/", '', $process->getOutput());
+
+        $this->assertStringContainsString("\"dumped value\"\nshutting down\n", $output, $process->getErrorOutput());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #61340
| License       | MIT

When DebugBundle is enabled, it installs a VarDumper handler that sends every dump to `DumpDataCollector`, so that dumps show up in the web debug toolbar. The collector keeps them in memory and writes them to the output only from its destructor, and only when nothing else collected them. `dd()` exits the script right after dumping, so today the dump reaches the browser as a side effect of that destructor running during the shutdown sequence that `exit()` starts.

That works when a PHP process handles a single request. It does not work in a worker runtime such as FrankenPHP worker mode, where the collector belongs to a container that outlives the request: the destructor then runs when the worker script terminates, which happens after the runtime has closed the client connection. The result is a blank page, with the dump written to the worker log instead. Users hit this with the default `dunglas/symfony-docker` setup as soon as the debug pack is installed.

This patch writes the pending dumps as soon as a dump comes from `dd()`, so they are written while the request is still open. This is the same moment at which VarDumper's default handler writes them, which is the handler in use when DebugBundle is not installed, and the reporter of the issue confirmed that this case already works in worker mode. Nothing else changes: a plain `dump()` is still buffered for the toolbar, dumps still go to `debug.dump_destination` when one is configured, and the destructor still writes whatever was left uncollected.

Registering a shutdown function instead would not help: shutdown functions and destructors both run in the shutdown sequence that `exit()` starts, so both are too late once the worker runtime has closed the response.

The rest of the diff moves the body of `__destruct()` into a private `flush()` method that both call sites share. The `headers_list()` scan that body contained became unused code when the `webMode` flag was wired into the constructor, and it is dropped here rather than carried into the new method.

Checks run, on PHP 8.5:

* `./phpunit src/Symfony/Component/HttpKernel/Tests`: OK, 1218 tests, 2959 assertions. The base commit gives OK, 1217 tests, 2958 assertions, so the only delta is the added test. Both runs report the same 24 legacy deprecation notices.
* `./phpunit src/Symfony/Bundle/DebugBundle/Tests`: OK, 13 tests. `./phpunit src/Symfony/Bundle/WebProfilerBundle/Tests`: OK, 137 tests. `./phpunit src/Symfony/Component/VarDumper/Tests`: OK, 415 tests, 14 skipped.
* Revert verified: with the source change removed and the test kept, the new test fails with `Failed asserting that 'shutting down\nStandard input code on line 17:\n"dumped value"\n' contains '"dumped value"\nshutting down\n'`, which is the reversed order the bug produces.

The added test runs a child process, because `dd()` exits: it dumps through a collector, then asserts that the dump was written before the output of a registered shutdown function. That ordering is the property this patch is about. FrankenPHP itself is not part of the test environment, so the worker runtime behavior is not covered by an automated test.
