### PR TITLE
[DependencyInjection] Fix sorting tagged services when autoconfiguration duplicates a tag

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/PriorityTaggedServiceTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PriorityTaggedServiceTrait.php
@@ -60,6 +60,7 @@ trait PriorityTaggedServiceTrait
 
             $defaultPriority = null;
             $defaultIndex = null;
+            $indexes = [];
             $definition = $container->getDefinition($serviceId);
             $class = $definition->getClass();
             $class = $container->getParameterBag()->resolveValue($class) ?: null;
@@ -104,6 +105,11 @@ trait PriorityTaggedServiceTrait
                 }
                 $decorated = $definition->getTag('container.decorator')[0]['id'] ?? null;
                 $index ??= $defaultIndex ?? $defaultIndex = $decorated ?? $serviceId;
+
+                if (isset($indexes[$index])) {
+                    continue;
+                }
+                $indexes[$index] = true;
 
                 $services[] = [$priority, ++$i, $index, $serviceId, $class];
             }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/PriorityTaggedServiceTraitTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/PriorityTaggedServiceTraitTest.php
@@ -114,6 +114,32 @@ class PriorityTaggedServiceTraitTest extends TestCase
         $this->assertEquals($expected, $priorityTaggedServiceTraitImplementation->test('my_custom_tag', $container));
     }
 
+    public function testTagAddedByAutoconfigurationDoesNotOverrideThePriority()
+    {
+        $container = new ContainerBuilder();
+        $container->registerForAutoconfiguration(\stdClass::class)->addTag('my_custom_tag');
+        $container->register('service1', \stdClass::class)->setAutoconfigured(true)->addTag('my_custom_tag', ['priority' => -70]);
+        $container->register('service2', \stdClass::class)->setAutoconfigured(true);
+
+        (new ResolveInstanceofConditionalsPass())->process($container);
+
+        $priorityTaggedServiceTraitImplementation = new PriorityTaggedServiceTraitImplementation();
+
+        $expected = [
+            new Reference('service2'),
+            new Reference('service1'),
+        ];
+        $this->assertEquals($expected, $priorityTaggedServiceTraitImplementation->test('my_custom_tag', $container));
+
+        $expected = [
+            'service2' => new TypedReference('service2', \stdClass::class),
+            'service1' => new TypedReference('service1', \stdClass::class),
+        ];
+        $services = $priorityTaggedServiceTraitImplementation->test(new TaggedIteratorArgument('my_custom_tag', needsIndexes: true), $container);
+        $this->assertSame(array_keys($expected), array_keys($services));
+        $this->assertEquals($expected, $services);
+    }
+
     public function testOnlyTheIndexedTagsAreListed()
     {
         $container = new ContainerBuilder();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #50900
| License       | MIT

When a service carries an explicit tag and autoconfiguration adds the same tag, `ResolveInstanceofConditionalsPass` keeps both attribute sets on the definition, for example `[['priority' => -70], []]`.

`PriorityTaggedServiceTrait::findAndSortTaggedServices()` deals with that duplicate only when the caller does not need indexes: it registers the first attribute set and jumps to the next service. When the caller needs indexes, that shortcut is skipped, so both entries are collected. Both resolve to the same index, and `$refs[$index]` keeps the slot of the first entry in the sorted list, which is the entry with the highest priority. That entry is the one autoconfiguration added, with priority 0, so the explicit priority is dropped.

`ControllerArgumentValueResolverPass` asks for indexes, so a value resolver tagged with a negative priority ends up running before the resolvers of priority 0 instead of after them:

```php
$services->set(MyResolver::class)->tag('controller.argument_value_resolver', ['priority' => -70]);
```

With a second resolver of priority 0 registered after it, the compiled `argument_resolver` gets `[my_resolver, other_resolver]` before this change and `[other_resolver, my_resolver]` after it. The second order is the one the tag asks for, and the one the very same container already produces when the tag is consumed without indexes.

The fix keeps, for each service, only the first tag that resolves to a given index. Tags that resolve to different indexes are all kept, so a service registered under several keys is unaffected. This is the same rule the non indexed path has followed since the fix for duplicate autoconfigured tags in 4.4.

Checks run locally on PHP 8.5:

* new test on the unpatched trait: fails with `Failed asserting that two arrays are identical`, keys come out as `service1, service2` instead of `service2, service1`.
* `./phpunit src/Symfony/Component/DependencyInjection/Tests`: 1588 tests, 3384 assertions, 16 skipped, no failure.
* the other users of the trait, all green: HttpKernel (1217 tests), Form (4748), PropertyInfo (554), Routing (1190), Serializer (1151), FrameworkBundle (1373), SecurityBundle (360), TwigBundle (40).
* `php-cs-fixer` on the two touched files: no change.
