### PR TITLE
[DependencyInjection] Fix compiling nested service locators

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ServiceLocatorTagPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ServiceLocatorTagPass.php
@@ -43,7 +43,7 @@ final class ServiceLocatorTagPass extends AbstractRecursivePass
                 $value->setValues($this->findAndSortTaggedServices($taggedIterator, $this->container, $exclude));
             }
 
-            return self::register($this->container, $value->getValues());
+            return self::register($this->container, $this->processValue($value->getValues()));
         }
 
         if ($value instanceof Definition) {
@@ -72,6 +72,7 @@ final class ServiceLocatorTagPass extends AbstractRecursivePass
 
         foreach ($services as $k => $v) {
             if ($v instanceof ServiceClosureArgument) {
+                $services[$k] = $this->processValue($v);
                 continue;
             }
 
@@ -85,7 +86,7 @@ final class ServiceLocatorTagPass extends AbstractRecursivePass
                 $i = null;
             }
 
-            $services[$k] = new ServiceClosureArgument($v);
+            $services[$k] = new ServiceClosureArgument($this->processValue($v));
         }
         ksort($services);
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/IntegrationTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/IntegrationTest.php
@@ -38,6 +38,8 @@ use Symfony\Component\DependencyInjection\Tests\Fixtures\BarTagClass;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\FooBarTaggedClass;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\FooBarTaggedForDefaultPriorityClass;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\FooTagClass;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\NestedAutowireLocatorConsumer;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\ServiceSubscriberWithAutowireLocator;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\StaticMethodTag;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\TaggedConsumerWithExclude;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\TaggedIteratorConsumer;
@@ -421,6 +423,71 @@ class IntegrationTest extends TestCase
         self::assertFalse($s->locator->has('nullable'));
         self::assertSame('foo', $s->locator->get('subscribed'));
         self::assertSame('foo', $s->locator->get('subscribed1'));
+    }
+
+    public function testNestedLocatorConfiguredViaAttribute()
+    {
+        if (!property_exists(SubscribedService::class, 'attributes')) {
+            $this->markTestSkipped('Requires symfony/service-contracts >= 3.2');
+        }
+
+        $container = new ContainerBuilder();
+        $container->register(BarTagClass::class)
+            ->setPublic(true)
+            ->addTag('foo_bar', ['key' => 'bar'])
+        ;
+        $container->register(FooTagClass::class)
+            ->setPublic(true)
+            ->addTag('foo_bar', ['key' => 'foo'])
+        ;
+        $container->register(NestedAutowireLocatorConsumer::class)
+            ->setAutowired(true)
+            ->setPublic(true)
+        ;
+
+        $container->compile();
+
+        /** @var NestedAutowireLocatorConsumer $s */
+        $s = $container->get(NestedAutowireLocatorConsumer::class);
+
+        $nestedLocator = $s->locator->get('nested_locator');
+        self::assertSame(['bar', 'foo'], array_keys($nestedLocator->getProvidedServices()));
+        self::assertSame($container->get(BarTagClass::class), $nestedLocator->get('bar'));
+        self::assertSame($container->get(FooTagClass::class), $nestedLocator->get('foo'));
+
+        self::assertSame([$container->get(BarTagClass::class), $container->get(FooTagClass::class)], iterator_to_array($s->locator->get('nested_iterator')));
+    }
+
+    public function testSubscribedServiceWithAutowireLocatorAttribute()
+    {
+        if (!property_exists(SubscribedService::class, 'attributes')) {
+            $this->markTestSkipped('Requires symfony/service-contracts >= 3.2');
+        }
+
+        $container = new ContainerBuilder();
+        $container->register(BarTagClass::class)
+            ->setPublic(true)
+            ->addTag('foo_bar', ['key' => 'bar'])
+        ;
+        $container->register(FooTagClass::class)
+            ->setPublic(true)
+            ->addTag('foo_bar', ['key' => 'foo'])
+        ;
+        $container->register(ServiceSubscriberWithAutowireLocator::class)
+            ->setAutowired(true)
+            ->setPublic(true)
+            ->addTag('container.service_subscriber')
+        ;
+
+        $container->compile();
+
+        /** @var ServiceSubscriberWithAutowireLocator $s */
+        $s = $container->get(ServiceSubscriberWithAutowireLocator::class);
+
+        $nestedLocator = $s->container->get('nested_locator');
+        self::assertSame(['bar', 'foo'], array_keys($nestedLocator->getProvidedServices()));
+        self::assertSame($container->get(BarTagClass::class), $nestedLocator->get('bar'));
+        self::assertSame($container->get(FooTagClass::class), $nestedLocator->get('foo'));
     }
 
     public function testTaggedServiceWithIndexAttributeAndDefaultMethodConfiguredViaAttribute()

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ServiceLocatorTagPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ServiceLocatorTagPassTest.php
@@ -171,6 +171,25 @@ class ServiceLocatorTagPassTest extends TestCase
         $this->assertSame(TestDefinition2::class, $locator('baz')::class);
     }
 
+    public function testNestedServiceLocatorArgument()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('bar', TestDefinition1::class)->addTag('test_tag');
+
+        $container->register('foo', ServiceLocator::class)
+            ->setArguments([['nested' => new ServiceLocatorArgument(new TaggedIteratorArgument('test_tag', null, null, true))]])
+            ->addTag('container.service_locator')
+        ;
+
+        (new ServiceLocatorTagPass())->process($container);
+
+        $nested = $container->get('foo')->get('nested');
+
+        $this->assertInstanceOf(ServiceLocator::class, $nested);
+        $this->assertSame(TestDefinition1::class, $nested->get('bar')::class);
+    }
+
     public function testIndexedByServiceIdWithDecoration()
     {
         $container = new ContainerBuilder();

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/NestedAutowireLocatorConsumer.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/NestedAutowireLocatorConsumer.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+use Psr\Container\ContainerInterface;
+use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
+use Symfony\Component\DependencyInjection\Attribute\AutowireLocator;
+use Symfony\Contracts\Service\Attribute\SubscribedService;
+
+final class NestedAutowireLocatorConsumer
+{
+    public function __construct(
+        #[AutowireLocator([
+            'nested_locator' => new SubscribedService(type: ContainerInterface::class, attributes: new AutowireLocator('foo_bar', indexAttribute: 'key')),
+            'nested_iterator' => new SubscribedService(type: 'iterable', attributes: new AutowireIterator('foo_bar')),
+        ])]
+        public readonly ContainerInterface $locator,
+    ) {
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/ServiceSubscriberWithAutowireLocator.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/ServiceSubscriberWithAutowireLocator.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+use Psr\Container\ContainerInterface;
+use Symfony\Component\DependencyInjection\Attribute\AutowireLocator;
+use Symfony\Contracts\Service\Attribute\SubscribedService;
+use Symfony\Contracts\Service\ServiceSubscriberInterface;
+
+final class ServiceSubscriberWithAutowireLocator implements ServiceSubscriberInterface
+{
+    public function __construct(
+        public readonly ContainerInterface $container,
+    ) {
+    }
+
+    public static function getSubscribedServices(): array
+    {
+        return [
+            new SubscribedService('nested_locator', ContainerInterface::class, attributes: new AutowireLocator('foo_bar', indexAttribute: 'key')),
+        ];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #54214, Fix #59758
| License       | MIT

`ServiceLocatorTagPass` never looked inside the values it turns into a service locator. When one of these values is itself a `ServiceLocatorArgument`, it was handed straight to `ServiceLocatorTagPass::register()`, which only wraps values in `ServiceClosureArgument`. The inner argument kept its unresolved `TaggedIteratorArgument` and its empty list of values, so the container compiled an empty `ServiceLocator` for it.

Two reported shapes hit this. A locator nested in another locator:

```php
public function __construct(
    #[AutowireLocator([
        'handlers' => new SubscribedService(type: ContainerInterface::class, attributes: new AutowireLocator('app.handler')),
    ])]
    private ContainerInterface $locator,
) {
}
```

And a locator attribute carried by a `SubscribedService` returned from `getSubscribedServices()`, where `RegisterServiceSubscribersPass` puts the attribute inside the subscriber locator:

```php
public static function getSubscribedServices(): array
{
    return [
        new SubscribedService('handlers', ContainerInterface::class, attributes: new AutowireLocator('app.handler')),
    ];
}
```

In both cases `$locator->get('handlers')` returned a locator with no services. The same nesting with `#[AutowireIterator]` worked, because `ResolveTaggedIteratorArgumentPass` walks the whole definition tree while `ServiceLocatorTagPass` stopped at the outer locator.

The fix processes the values in the two places where the pass stopped recursing: before handing a `ServiceLocatorArgument` to `register()`, and while walking the first argument of a definition tagged `container.service_locator`. A nested `ServiceLocatorArgument` then goes through the pass itself and becomes a reference to its own compiled locator. This works at any depth.

Issue #54214 uses `#[TaggedLocator]`, which extends `AutowireLocator` and is therefore fixed as well. The new tests use `AutowireLocator` because `TaggedLocator` is deprecated since 7.1 and removed in 8.1.

Tests added:

* `IntegrationTest::testNestedLocatorConfiguredViaAttribute`, an `#[AutowireLocator]` and an `#[AutowireIterator]` nested in an `#[AutowireLocator]`.
* `IntegrationTest::testSubscribedServiceWithAutowireLocatorAttribute`, an `#[AutowireLocator]` on a `SubscribedService`.
* `ServiceLocatorTagPassTest::testNestedServiceLocatorArgument`, a `ServiceLocatorArgument` placed by hand in the first argument of a definition tagged `container.service_locator`.

Checks run locally on PHP 8.5 with PHPUnit 9.6:

* `./phpunit src/Symfony/Component/DependencyInjection/Tests`: 1590 tests, 3390 assertions, 16 skipped, no failure.
* `./phpunit src/Symfony/Bundle/FrameworkBundle/Tests`: 1373 tests, 4545 assertions, 5 skipped, no failure.
* `./phpunit src/Symfony/Bundle/SecurityBundle/Tests`: 360 tests, 1104 assertions, 1 skipped, no failure.
* `./phpunit src/Symfony/Component/HttpKernel/Tests`: 1217 tests, 2958 assertions, no failure.
* php-cs-fixer on the five touched files: no change.
* With the three new tests kept and `ServiceLocatorTagPass` restored to its previous state, all three fail: the two integration tests report an empty list of provided services, and the unit test raises `Service "bar" not found: the container inside "Symfony\Component\DependencyInjection\Argument\ServiceLocator" is a smaller service locator that is empty`.
* A script that compiles and dumps a container with both shapes returns the two tagged handlers from the inner locator, before and after `PhpDumper`.

Merge-up note for 7.4 and up: the loop over the locator arguments was restructured there, so the second hunk becomes `$services[$k] = $this->processValue($v);` in the `ServiceClosureArgument` branch and `new ServiceClosureArgument($this->processValue($v))` at the end of the same loop. The `property_exists(SubscribedService::class, 'attributes')` guards in the two new integration tests should be dropped from 8.1 up, where `symfony/service-contracts` is constrained to `^3.6`.
