### PR TITLE
[ErrorHandler] Don't autoload when resolving "@return" class constants

### DIFF
--- a/src/Symfony/Component/ErrorHandler/DebugClassLoader.php
+++ b/src/Symfony/Component/ErrorHandler/DebugClassLoader.php
@@ -897,6 +897,11 @@ class DebugClassLoader
                     default => $definingClass,
                 };
 
+                // don't autoload here: the class that holds the constant might extend a class that is still being loaded
+                if (!class_exists($definingClass, false) && !interface_exists($definingClass, false)) {
+                    return;
+                }
+
                 if (!\defined($definingClass.'::'.$constantName)) {
                     return;
                 }

--- a/src/Symfony/Component/ErrorHandler/Tests/DebugClassLoaderTest.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/DebugClassLoaderTest.php
@@ -475,6 +475,7 @@ class DebugClassLoaderTest extends TestCase
             'Method "Symfony\Component\ErrorHandler\Tests\Fixtures\ReturnTypeParent::never()" might add "never" as a native return type declaration in the future. Do the same in child class "Test\Symfony\Component\ErrorHandler\Tests\ReturnType" now to avoid errors or add an explicit @return annotation to suppress this message.',
             'Method "Symfony\Component\ErrorHandler\Tests\Fixtures\ReturnTypeParent::null()" might add "null" as a native return type declaration in the future. Do the same in child class "Test\Symfony\Component\ErrorHandler\Tests\ReturnType" now to avoid errors or add an explicit @return annotation to suppress this message.',
             'Method "Symfony\Component\ErrorHandler\Tests\Fixtures\ReturnTypeParent::classConstant()" might add "string" as a native return type declaration in the future. Do the same in child class "Test\Symfony\Component\ErrorHandler\Tests\ReturnType" now to avoid errors or add an explicit @return annotation to suppress this message.',
+            'Method "Symfony\Component\ErrorHandler\Tests\Fixtures\ReturnTypeInterface::interfaceClassConstant()" might add "string" as a native return type declaration in the future. Do the same in implementation "Test\Symfony\Component\ErrorHandler\Tests\ReturnType" now to avoid errors or add an explicit @return annotation to suppress this message.',
         ], $deprecations);
     }
 
@@ -493,6 +494,12 @@ class DebugClassLoaderTest extends TestCase
         $this->assertSame([
             'Method "Symfony\Component\ErrorHandler\Tests\Fixtures\ReturnTypeParentPhp83::classConstantWithType()" might add "string" as a native return type declaration in the future. Do the same in child class "Test\Symfony\Component\ErrorHandler\Tests\ReturnTypePhp83" now to avoid errors or add an explicit @return annotation to suppress this message.',
         ], $deprecations);
+    }
+
+    public function testClassConstantReturnTypeDoesNotTriggerAutoloading()
+    {
+        $this->assertTrue(class_exists(Fixtures\ReturnTypeClassConstant::class, true));
+        $this->assertFalse(class_exists(Fixtures\ReturnTypeClassConstantHolder::class, false));
     }
 
     public function testOverrideFinalProperty()

--- a/src/Symfony/Component/ErrorHandler/Tests/Fixtures/ReturnType.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/Fixtures/ReturnType.php
@@ -52,4 +52,5 @@ class ReturnType extends ReturnTypeParent implements ReturnTypeInterface, Fixtur
     public function null() { }
     public function outsideMethod() { }
     public function classConstant() { }
+    public function interfaceClassConstant() { }
 }

--- a/src/Symfony/Component/ErrorHandler/Tests/Fixtures/ReturnTypeClassConstant.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/Fixtures/ReturnTypeClassConstant.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\ErrorHandler\Tests\Fixtures;
+
+class ReturnTypeClassConstant extends ReturnTypeClassConstantParent
+{
+}

--- a/src/Symfony/Component/ErrorHandler/Tests/Fixtures/ReturnTypeClassConstantHolder.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/Fixtures/ReturnTypeClassConstantHolder.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Symfony\Component\ErrorHandler\Tests\Fixtures;
+
+class ReturnTypeClassConstantHolder extends ReturnTypeClassConstant
+{
+    const FOO = 'foo';
+}

--- a/src/Symfony/Component/ErrorHandler/Tests/Fixtures/ReturnTypeClassConstantParent.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/Fixtures/ReturnTypeClassConstantParent.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Symfony\Component\ErrorHandler\Tests\Fixtures;
+
+abstract class ReturnTypeClassConstantParent
+{
+    /**
+     * @return \Symfony\Component\ErrorHandler\Tests\Fixtures\ReturnTypeClassConstantHolder::FOO
+     */
+    public function classConstantOfSubClass()
+    {
+    }
+}

--- a/src/Symfony/Component/ErrorHandler/Tests/Fixtures/ReturnTypeInterface.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/Fixtures/ReturnTypeInterface.php
@@ -4,8 +4,15 @@ namespace Symfony\Component\ErrorHandler\Tests\Fixtures;
 
 interface ReturnTypeInterface
 {
+    const BAR = 'bar';
+
     /**
      * @return string
      */
     public function returnTypeInterface();
+
+    /**
+     * @return self::BAR
+     */
+    public function interfaceClassConstant();
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #59051
| License       | MIT

`DebugClassLoader` reads the docblocks of every class it loads. Since 7.2 it also resolves class constants used in `@return` annotations, and the first step of that resolution is `\defined($definingClass.'::'.$constantName)`, which autoloads `$definingClass`.

That autoload runs from inside the loader, while the class that triggered the check is still being declared. PHP refuses to start a second autoload for a class whose autoload is already in progress, so as soon as the constant's class extends the class currently being loaded, the load fails with `Attempted to load class ...`.

The report comes from an application using `danog/MadelineProto`: loading `AbstractAPI` loads its parent `InternalDoc`, whose `getAuthorization()` is annotated with constants of `API`, and `API` extends `AbstractAPI`, which is still being loaded at that point. The application then dies with a `ClassNotFoundError`.

This patch resolves the constant only when its class or interface is already loaded, so the checker never starts an autoload of its own. When the class is not loaded, the annotation is ignored, which is what already happens for an annotation naming a constant that does not exist. The only consequence is that the "might add ... as a native return type declaration in the future" notice can be missing for such a method. Every `@return` class constant in symfony/symfony uses the `self::` form, whose class is loaded by definition, so nothing changes for the notices the test suite relies on.

`ReturnTypeInterface` gains a constant and an annotated method, and `ReturnType` implements it. That part of the test passes on the base commit too: it pins the behavior that constants declared on an interface keep being resolved, which the new guard must preserve. It fails if the guard checks `class_exists()` only.

Checks run locally on PHP 8.5:

* `./phpunit src/Symfony/Component/ErrorHandler/Tests/DebugClassLoaderTest.php`: 29 tests, 33 assertions, OK, 1 skipped (the case-insensitive filesystem test).
* `./phpunit src/Symfony/Component/ErrorHandler/Tests`: 133 tests, 400 assertions, 3 errors, 3 skipped. The 3 errors are in `ErrorDumpCommandTest`, which cannot mock `Symfony\WebpackEncoreBundle\Asset\EntrypointLookupInterface` because that bundle is not installed in this checkout. The base commit gives the same 3 errors (132 tests, 398 assertions).
* `./phpunit src/Symfony/Bridge/PhpUnit/Tests`: 126 tests, 7 errors, 2 failures, 59 skipped, with and without the patch, so all pre-existing locally.
* The new test on the unpatched loader: `Error: Class "Symfony\Component\ErrorHandler\Tests\Fixtures\ReturnTypeClassConstant" not found`.
