### PR TITLE
[DoctrineBridge][EventDispatcher] Fix losing listeners when a lazy listener adds listeners

### DIFF
--- a/src/Symfony/Bridge/Doctrine/ContainerAwareEventManager.php
+++ b/src/Symfony/Bridge/Doctrine/ContainerAwareEventManager.php
@@ -173,26 +173,36 @@ class ContainerAwareEventManager extends EventManager
 
     private function initializeListeners(string $eventName): void
     {
-        $this->initialized[$eventName] = true;
+        do {
+            $this->initialized[$eventName] = true;
 
-        // We'll refill the whole array in order to keep the same order
-        $listeners = [];
-        foreach ($this->listeners[$eventName] as $hash => $listener) {
-            if (\is_string($listener)) {
-                $listener = $this->container->get($listener);
-                $newHash = $this->getHash($listener);
+            // We'll refill the whole array in order to keep the same order
+            $listeners = [];
+            foreach ($this->listeners[$eventName] as $hash => $listener) {
+                if (!isset($this->listeners[$eventName][$hash])) {
+                    // removed while another listener service was being built
+                    continue;
+                }
+                unset($this->listeners[$eventName][$hash]);
 
-                $this->initializedHashMapping[$eventName][$hash] = $newHash;
+                if (\is_string($listener)) {
+                    $listener = $this->container->get($listener);
+                    $newHash = $this->getHash($listener);
 
-                $listeners[$newHash] = $listener;
+                    $this->initializedHashMapping[$eventName][$hash] = $newHash;
 
-                $this->methods[$eventName][$newHash] = $this->getMethod($listener, $eventName);
-            } else {
-                $listeners[$hash] = $listener;
+                    $listeners[$newHash] = $listener;
+
+                    $this->methods[$eventName][$newHash] = $this->getMethod($listener, $eventName);
+                } else {
+                    $listeners[$hash] = $listener;
+                }
             }
-        }
 
-        $this->listeners[$eventName] = $listeners;
+            // Building a listener service can add listeners for the same event.
+            // What is left in $this->listeners[$eventName] is what it added.
+            $this->listeners[$eventName] = $listeners + $this->listeners[$eventName];
+        } while (!isset($this->initialized[$eventName]));
     }
 
     private function initializeSubscribers(): void

--- a/src/Symfony/Bridge/Doctrine/Tests/ContainerAwareEventManagerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/ContainerAwareEventManagerTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Doctrine\ContainerAwareEventManager;
 use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\ServiceLocator;
 
 class ContainerAwareEventManagerTest extends TestCase
 {
@@ -266,6 +267,28 @@ class ContainerAwareEventManagerTest extends TestCase
         $this->evm->addEventListener('foo', $listener2 = new MyListener());
 
         $this->assertSame([$listener1, $listener2], array_values($this->evm->getAllListeners()['foo']));
+    }
+
+    public function testGetListenersWhenALazyListenerAddsListeners()
+    {
+        $listener1 = new MyListener();
+        $listener2 = new MyListener();
+        $listener3 = new MyListener();
+        $evm = null;
+        $container = new ServiceLocator(['lazy2' => static function () use (&$evm, $listener2, $listener3) {
+            $evm->addEventListener('foo', $listener3);
+
+            return $listener2;
+        }]);
+        $evm = new ContainerAwareEventManager($container);
+
+        $evm->addEventListener('foo', $listener1);
+        $evm->addEventListener('foo', 'lazy2');
+
+        $expected = [$listener1, $listener2, $listener3];
+
+        $this->assertSame($expected, array_values($evm->getListeners('foo')));
+        $this->assertSame($expected, array_values($evm->getListeners('foo')));
     }
 
     public function testRemoveEventListener()

--- a/src/Symfony/Component/EventDispatcher/EventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/EventDispatcher.php
@@ -226,18 +226,26 @@ class EventDispatcher implements EventDispatcherInterface
      */
     private function sortListeners(string $eventName): void
     {
-        krsort($this->listeners[$eventName]);
-        $this->sorted[$eventName] = [];
+        do {
+            krsort($this->listeners[$eventName]);
+            // Initializing a lazy listener can add listeners for the same event.
+            // That unsets $this->sorted[$eventName], which is the signal to sort again.
+            $this->sorted[$eventName] = [];
+            $sorted = [];
 
-        foreach ($this->listeners[$eventName] as &$listeners) {
-            foreach ($listeners as &$listener) {
-                if (\is_array($listener) && isset($listener[0]) && $listener[0] instanceof \Closure && 2 >= \count($listener)) {
-                    $listener[0] = $listener[0]();
-                    $listener[1] ??= '__invoke';
+            foreach ($this->listeners[$eventName] as &$listeners) {
+                foreach ($listeners as &$listener) {
+                    if (\is_array($listener) && isset($listener[0]) && $listener[0] instanceof \Closure && 2 >= \count($listener)) {
+                        $listener[0] = $listener[0]();
+                        $listener[1] ??= '__invoke';
+                    }
+                    $sorted[] = $listener;
                 }
-                $this->sorted[$eventName][] = $listener;
             }
-        }
+            unset($listeners, $listener);
+        } while (!isset($this->sorted[$eventName]));
+
+        $this->sorted[$eventName] = $sorted;
     }
 
     /**

--- a/src/Symfony/Component/EventDispatcher/Tests/EventDispatcherTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/EventDispatcherTest.php
@@ -376,6 +376,38 @@ class EventDispatcherTest extends TestCase
         $this->assertSame(['bar' => [[$test, 'foo']]], $this->dispatcher->getListeners());
     }
 
+    public function testGetListenersWhenLazyListenerAddsListeners()
+    {
+        $test1 = new TestWithDispatcher();
+        $test2 = new TestWithDispatcher();
+        $test3 = new TestWithDispatcher();
+        $test4 = new TestWithDispatcher();
+        $test1->name = '1';
+        $test2->name = '2';
+        $test3->name = '3';
+        $test4->name = '4';
+        $dispatcher = $this->dispatcher;
+        $factory = static function () use ($dispatcher, $test2, $test3, $test4) {
+            $dispatcher->addListener('foo', [$test3, 'foo'], 5);
+            $dispatcher->addListener('foo', [$test4, 'foo']);
+
+            return $test2;
+        };
+
+        $this->dispatcher->addListener('foo', [$test1, 'foo']);
+        $this->dispatcher->addListener('foo', [$factory, 'foo']);
+
+        $expected = [
+            [$test3, 'foo'],
+            [$test1, 'foo'],
+            [$test2, 'foo'],
+            [$test4, 'foo'],
+        ];
+
+        $this->assertSame($expected, $this->dispatcher->getListeners('foo'));
+        $this->assertSame($expected, $this->dispatcher->getListeners('foo'));
+    }
+
     public function testMutatingWhilePropagationIsStopped()
     {
         $testLoaded = false;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #48011
| License       | MIT

Two components drop event listeners when instantiating a lazy listener registers another listener for the same event. The same mistake is behind both: a loop refills the list of listeners for an event and runs user code in the middle of that loop, then overwrites the live list with what it collected.

### EventDispatcher

`EventDispatcher::sortListeners()` builds `$this->sorted[$eventName]` and, in the same loop, initializes lazy listeners: for a listener given as `[$factory, $method]`, it calls `$factory()` to get the service. When that factory registers another listener for the same event, `addListener()` unsets `$this->sorted[$eventName]`, which is the array the loop is filling at that very moment. Everything appended before the factory ran is lost, the appends that follow recreate the array from scratch, and the truncated list is then cached until the next call to `addListener()` or `removeListener()`.

Reproducer, with two plain listeners and a lazy third one that registers a fourth listener when it is instantiated:

```php
$dispatcher = new class() extends EventDispatcher {};
$factory = static function () use ($dispatcher, $listener3, $listener4) {
    $dispatcher->addListener('foo', $listener4);

    return $listener3;
};

$dispatcher->addListener('foo', $listener1);
$dispatcher->addListener('foo', $listener2);
$dispatcher->addListener('foo', [$factory, '__invoke']);

$dispatcher->dispatch(new Event(), 'foo');
```

Before this patch that prints `listener3` and `listener4` only, on this dispatch and on every later one. After it, the four listeners run in registration order.

This is the code path behind `getListeners()`, so it affects every dispatcher, and it affects dispatching itself for any subclass of `EventDispatcher`, since only the class itself uses the optimized dispatch path. On that optimized path the listener list is snapshotted when the dispatch starts, so a listener registered during instantiation runs from the next dispatch on, which is unchanged here.

Sorting now fills a local array and assigns it to `$this->sorted[$eventName]` only once the pass is over. Since `addListener()` unsets that entry, finding it missing at the end of a pass is the signal that the listener list changed while lazy listeners were being initialized, and sorting starts over. The extra pass runs no factory, because each one has already been replaced by the service it returned, so the loop stops there. A listener registered with a higher priority during initialization also ends up in the right position, since that second pass sorts the complete list.

### DoctrineBridge

`ContainerAwareEventManager::initializeListeners()` has the same shape. It refills a local array to keep the registration order while it resolves service ids through the container, then overwrites `$this->listeners[$eventName]` with it. A listener registered for the same event while one of those services is being built lands in the array that is about to be overwritten, so it is dropped.

It loses the mirror half of what the dispatcher loses: the dispatcher drops the listeners collected before the factory ran, the event manager drops the ones added while it ran. Here the loss is also permanent, because `addEventListener()` only unsets `$this->initialized[$event]` when the listener is a service id, so nothing asks for another pass.

```php
$evm->addEventListener('onFoo', $listener1);
// building "lazy2" calls $evm->addEventListener('onFoo', $listener3)
$evm->addEventListener('onFoo', 'lazy2');

$evm->dispatchEvent('onFoo');
```

Before this patch that runs `$listener1` and `lazy2` only, on this dispatch and on every later one. `getListeners()` and `getAllListeners()` report the same truncated list.

Entries are now removed from `$this->listeners[$eventName]` as they are processed, so what is left at the end of the pass is exactly what was registered while the services were being built, and it is appended instead of being discarded. When one of those is itself a service id, `$this->initialized[$eventName]` has been unset and another pass resolves it, so `getListeners()` never hands out an unresolved service id.

### Checks

`./phpunit src/Symfony/Component/EventDispatcher` returns 142 tests, 297 assertions, OK. Without the source change and with the new test, it returns 2 failures, one in `EventDispatcherTest` and one in `ChildEventDispatcherTest`, which runs the same tests against a subclass. `./phpunit src/Symfony/Bridge/Doctrine/Tests/ContainerAwareEventManagerTest.php` returns 17 tests, 86 assertions, OK, and 1 failure without the source change. As a smoke test of the dispatchers wired by the container, `./phpunit src/Symfony/Component/HttpKernel` returns 1217 tests OK.
