### PR TITLE
[Finder] Do not report dangling symlinks as both files and directories

### DIFF
--- a/src/Symfony/Component/Finder/Iterator/FileTypeFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/FileTypeFilterIterator.php
@@ -48,6 +48,6 @@ class FileTypeFilterIterator extends \FilterIterator
             return false;
         }
 
-        return true;
+        return !$fileinfo->isLink() || $fileinfo->isFile() || $fileinfo->isDir();
     }
 }

--- a/src/Symfony/Component/Finder/Tests/Iterator/FileTypeFilterIteratorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/FileTypeFilterIteratorTest.php
@@ -63,6 +63,31 @@ class FileTypeFilterIteratorTest extends RealIteratorTestCase
             [FileTypeFilterIterator::ONLY_DIRECTORIES, self::toAbsolute($onlyDirectories)],
         ];
     }
+
+    public function testDanglingSymlinkIsNeitherAFileNorADirectory()
+    {
+        if ('\\' === \DIRECTORY_SEPARATOR) {
+            $this->markTestSkipped('symlinks are not supported on Windows');
+        }
+
+        $tmpDir = realpath(sys_get_temp_dir()).'/symfony_finder_dangling_symlink';
+        mkdir($tmpDir);
+        touch($tmpDir.'/file.txt');
+        mkdir($tmpDir.'/dir');
+        symlink($tmpDir.'/missing', $tmpDir.'/dangling');
+
+        try {
+            $inner = new InnerTypeIterator([$tmpDir.'/file.txt', $tmpDir.'/dir', $tmpDir.'/dangling']);
+
+            $this->assertIterator([$tmpDir.'/file.txt'], new FileTypeFilterIterator($inner, FileTypeFilterIterator::ONLY_FILES));
+            $this->assertIterator([$tmpDir.'/dir'], new FileTypeFilterIterator($inner, FileTypeFilterIterator::ONLY_DIRECTORIES));
+        } finally {
+            unlink($tmpDir.'/dangling');
+            unlink($tmpDir.'/file.txt');
+            rmdir($tmpDir.'/dir');
+            rmdir($tmpDir);
+        }
+    }
 }
 
 class InnerTypeIterator extends \ArrayIterator


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #38526
| License       | MIT

A symlink whose target does not exist is returned by both `files()` and `directories()`. `FileTypeFilterIterator::accept()` only rejects entries of the opposite type: `files()` rejects directories and `directories()` rejects files. A dangling symlink reports `isFile() === false` and `isDir() === false`, so neither mode rejects it and it shows up in both result sets. Callers then crash with "No such file or directory" when they open a path that `files()` returned.

With this change, `files()` and `directories()` skip symlinks that do not resolve. Symlinks that do resolve are not affected: a link to a file is still returned by `files()` and a link to a directory by `directories()`. Plain iteration without `files()` or `directories()` still lists dangling symlinks, as before.

Checks run: `./phpunit src/Symfony/Component/Finder` on PHP 8.5 returns OK (701 tests, 2 skipped and 1 incomplete, all pre-existing: an FTP test needing network access and a test marked incomplete upstream). The new test was added first and fails on the unpatched code with the dangling symlink listed by the ONLY_FILES mode; reverting the source change reproduces that failure.
