### PR TITLE
[Form] Replace the {{ max }} placeholder in the post_max_size error message

### DIFF
--- a/src/Symfony/Component/Form/Extension/HttpFoundation/HttpFoundationRequestHandler.php
+++ b/src/Symfony/Component/Form/Extension/HttpFoundation/HttpFoundationRequestHandler.php
@@ -74,11 +74,10 @@ class HttpFoundationRequestHandler implements RequestHandlerInterface
                 // Submit the form, but don't clear the default values
                 $form->submit(null, false);
 
-                $form->addError(new FormError(
-                    $form->getConfig()->getOption('upload_max_size_message')(),
-                    null,
-                    ['{{ max }}' => $this->serverParams->getNormalizedIniPostMaxSize()]
-                ));
+                $messageTemplate = $form->getConfig()->getOption('upload_max_size_message')();
+                $messageParameters = ['{{ max }}' => $this->serverParams->getNormalizedIniPostMaxSize()];
+
+                $form->addError(new FormError(strtr($messageTemplate, $messageParameters), $messageTemplate, $messageParameters));
 
                 return;
             }

--- a/src/Symfony/Component/Form/NativeRequestHandler.php
+++ b/src/Symfony/Component/Form/NativeRequestHandler.php
@@ -80,11 +80,10 @@ class NativeRequestHandler implements RequestHandlerInterface
                 // Submit the form, but don't clear the default values
                 $form->submit(null, false);
 
-                $form->addError(new FormError(
-                    $form->getConfig()->getOption('upload_max_size_message')(),
-                    null,
-                    ['{{ max }}' => $this->serverParams->getNormalizedIniPostMaxSize()]
-                ));
+                $messageTemplate = $form->getConfig()->getOption('upload_max_size_message')();
+                $messageParameters = ['{{ max }}' => $this->serverParams->getNormalizedIniPostMaxSize()];
+
+                $form->addError(new FormError(strtr($messageTemplate, $messageParameters), $messageTemplate, $messageParameters));
 
                 return;
             }

--- a/src/Symfony/Component/Form/Tests/AbstractRequestHandlerTestCase.php
+++ b/src/Symfony/Component/Form/Tests/AbstractRequestHandlerTestCase.php
@@ -476,7 +476,7 @@ abstract class AbstractRequestHandlerTestCase extends TestCase
         $this->requestHandler->handleRequest($form, $this->request);
 
         if ($shouldFail) {
-            $error = new FormError($options['post_max_size_message'], null, $errorParams);
+            $error = new FormError(\sprintf('Max %s!', $iniMax), $options['post_max_size_message'], $errorParams);
             $error->setOrigin($form);
 
             $this->assertEquals([$error], iterator_to_array($form->getErrors()));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #47644
| License       | MIT

When a POST request exceeds `post_max_size`, PHP delivers an empty `$_POST` and the form is never submitted, so the request handlers add the `post_max_size_message` to the form themselves. That message is documented to accept a `{{ max }}` placeholder. The placeholder was passed as an error parameter only, and never substituted into the message, so a template rendering `error.message` printed it as is: "The uploaded file was too large. Max size is {{ max }}".

Both request handlers now build the error the way `FileType` and `TransformationFailureListener` already do: the message carries the substituted value, and the template plus its parameters stay on the `FormError` for code that re-translates it. Before this change `FormError::getMessageTemplate()` returned the message with the placeholder in it, because the template argument was null; it now returns the same string explicitly, so nothing is lost there.

The translation of the message is unchanged. `UploadValidatorExtension` translates it without parameters through the internal `upload_max_size_message` option, and the substitution is applied on the translated result, so translated messages keep their placeholder replaced too.

Checks run:

- `./phpunit src/Symfony/Component/Form`: 4748 tests, 9348 assertions, no failures, 363 skipped, 8 incomplete. The skipped tests are pre-existing on the base commit: they need an ICU version matching the data shipped by the Intl component, and the machine has an older one.
- Revert check: with the two source files put back to their base state and the test kept, `testAddFormErrorIfPostMaxSizeExceeded` fails on its three failing fixtures with `'message' => 'Max {{ max }}!'` where `'Max 1G!'` is expected.
