### PR TITLE
[Form] Fix generating the CSRF token when the form attributes are replaced

### DIFF
--- a/src/Symfony/Component/Form/Extension/Csrf/Type/FormTypeCsrfExtension.php
+++ b/src/Symfony/Component/Form/Extension/Csrf/Type/FormTypeCsrfExtension.php
@@ -16,6 +16,7 @@ use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Csrf\EventListener\CsrfValidationListener;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormConfigInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\Form\Util\ServerParams;
@@ -50,10 +51,7 @@ class FormTypeCsrfExtension extends AbstractTypeExtension
             return;
         }
 
-        $csrfTokenId = $options['csrf_token_id']
-            ?: $this->defaultTokenId[$builder->getType()->getInnerType()::class]
-            ?? $builder->getName()
-            ?: $builder->getType()->getInnerType()::class;
+        $csrfTokenId = $this->getCsrfTokenId($builder, $options);
         $builder->setAttribute('csrf_token_id', $csrfTokenId);
 
         $builder
@@ -75,8 +73,9 @@ class FormTypeCsrfExtension extends AbstractTypeExtension
     public function finishView(FormView $view, FormInterface $form, array $options): void
     {
         if ($options['csrf_protection'] && !$view->parent && $options['compound']) {
-            $factory = $form->getConfig()->getFormFactory();
-            $tokenId = $form->getConfig()->getAttribute('csrf_token_id');
+            $config = $form->getConfig();
+            $factory = $config->getFormFactory();
+            $tokenId = $config->getAttribute('csrf_token_id') ?? $this->getCsrfTokenId($config, $options);
             $data = (string) $options['csrf_token_manager']->getToken($tokenId);
 
             $csrfForm = $factory->createNamed($options['csrf_field_name'], HiddenType::class, $data, [
@@ -116,5 +115,12 @@ class FormTypeCsrfExtension extends AbstractTypeExtension
     public static function getExtendedTypes(): iterable
     {
         return [FormType::class];
+    }
+
+    private function getCsrfTokenId(FormConfigInterface $config, array $options): string
+    {
+        $type = $config->getType()->getInnerType()::class;
+
+        return $options['csrf_token_id'] ?: $this->defaultTokenId[$type] ?? $config->getName() ?: $type;
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Csrf/Type/FormTypeCsrfExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Csrf/Type/FormTypeCsrfExtensionTest.php
@@ -182,6 +182,26 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
         $this->assertEquals('token', $view['csrf']->vars['value']);
     }
 
+    public function testGenerateCsrfTokenWhenAttributesAreReplaced()
+    {
+        $this->tokenManager->expects($this->once())
+            ->method('getToken')
+            ->with('FORM_NAME')
+            ->willReturn(new CsrfToken('TOKEN_ID', 'token'));
+
+        $view = $this->factory
+            ->createNamedBuilder('FORM_NAME', 'Symfony\Component\Form\Extension\Core\Type\FormType', null, [
+                'csrf_field_name' => 'csrf',
+                'csrf_token_manager' => $this->tokenManager,
+                'compound' => true,
+            ])
+            ->setAttributes([])
+            ->getForm()
+            ->createView();
+
+        $this->assertEquals('token', $view['csrf']->vars['value']);
+    }
+
     public static function provideBoolean()
     {
         return [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #59867
| License       | MIT

`FormTypeCsrfExtension::buildForm()` resolves the CSRF token id once and stores it as a form attribute, and `finishView()` reads it back to ask the token manager for a token. `FormConfigBuilder::setAttributes()` replaces the whole attribute array, so calling it on a form builder drops the stored id, and rendering the form then fails:

```
Symfony\Component\Security\Csrf\CsrfTokenManager::getToken(): Argument #1 ($tokenId) must be of type string, null given
```

It is enough to call `setAttributes()` with an array that does not carry a `csrf_token_id` key:

```php
$this->createFormBuilder()->setAttributes(['whatever' => true])->getForm()->createView();
```

The resolution of the id now lives in a private method, used by `buildForm()` as before and by `finishView()` when the attribute is not there any more. The attribute keeps being set, so code reading it is unaffected.

Branch: 6.4 recomputes the id in `finishView()` and is not affected. The attribute was introduced in 7.2, so 7.4 is the oldest maintained branch carrying the flaw. The file is identical on 8.1 and 8.2, so merging up applies unchanged.

Checks run:

- `./phpunit src/Symfony/Component/Form` on 7.4: 4866 tests, 10123 assertions, no failures, 380 skipped, 8 incomplete. The same suite on the base commit reports 4865 tests, 10120 assertions, no failures and the same 380 skipped, so the skips are pre-existing; they need an ICU version matching the data shipped by the Intl component.
- Revert check: with the source file put back to its base state and the test kept, the new test errors with `TypeError: ...::getToken(): Argument #1 ($tokenId) must be of type string, null given, called in .../FormTypeCsrfExtension.php on line 80`, which is the exact error reported in the issue.
