### PR TITLE
[Form] Fix the money pattern for locales that do not use ASCII digits

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/MoneyType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/MoneyType.php
@@ -132,9 +132,13 @@ class MoneyType extends AbstractType
             // a single space leads to better readability in combination with input
             // fields
 
-            // the regex also considers non-break spaces (0xC2 or 0xA0 in UTF-8)
+            // directional marks are not part of the currency symbol
+            $pattern = preg_replace('/[\x{061C}\x{200E}\x{200F}]/u', '', $pattern);
 
-            preg_match('/^([^\s\xc2\xa0]*)[\s\xc2\xa0]*123(?:[,.]0+)?[\s\xc2\xa0]*([^\s\xc2\xa0]*)$/u', $pattern, $matches);
+            // the regex also considers non-break spaces (0xC2 or 0xA0 in UTF-8)
+            // and digits of any script, as used by Persian or Bengali locales
+
+            preg_match('/^([^\s\xc2\xa0\p{Nd}]*)[\s\xc2\xa0]*\p{Nd}(?:[^\s\xc2\xa0]*\p{Nd})?[\s\xc2\xa0]*([^\s\xc2\xa0\p{Nd}]*)$/u', $pattern, $matches);
 
             if (!empty($matches[1])) {
                 self::$patterns[$locale][$currency] = $matches[1].' {{ widget }}';

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/MoneyTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/MoneyTypeTest.php
@@ -69,6 +69,26 @@ class MoneyTypeTest extends BaseTypeTestCase
         $this->assertSame('{{ widget }} €', $view2->vars['money_pattern']);
     }
 
+    public function testMoneyPatternWorksForLocalesWithNonAsciiDigits()
+    {
+        \Locale::setDefault('fa_IR');
+
+        $view = $this->factory->create(static::TESTED_TYPE)
+            ->createView();
+
+        $this->assertSame('€ {{ widget }}', $view->vars['money_pattern']);
+    }
+
+    public function testMoneyPatternIgnoresDirectionalMarks()
+    {
+        \Locale::setDefault('he_IL');
+
+        $view = $this->factory->create(static::TESTED_TYPE)
+            ->createView();
+
+        $this->assertSame('{{ widget }} €', $view->vars['money_pattern']);
+    }
+
     public function testSubmitNull($expected = null, $norm = null, $view = null)
     {
         parent::testSubmitNull($expected, $norm, '');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #44959
| License       | MIT

`MoneyType` builds the `money_pattern` view variable by formatting the amount 123 with the `NumberFormatter` of the current locale, then reading the currency symbol back out of the result. The regular expression that reads it back looks for the literal `123`, so it only matches locales whose numbering system uses ASCII digits. In `fa_IR`, `ar_SA`, `bn_BD`, `ne_NP` and many others, `NumberFormatter` returns the amount in the local digits, the regular expression does not match, and the currency symbol is dropped: the widget renders with no symbol at all.

A second problem hits locales written right to left. ICU wraps the formatted amount in bidirectional marks (U+200E, U+200F). Those marks are neither spaces nor digits, so the regular expression captured a lone invisible mark as the currency symbol. For `he_IL` the resulting pattern was an invisible character followed by the widget, instead of the widget followed by the euro sign.

The regular expression now matches digits of any script through `\p{Nd}`, and the bidirectional marks are removed before matching. Locales that already worked are unaffected. The formatted output of every ICU locale was compared for 20 currencies before and after the change: 11213 of the 12765 combinations are identical, and all 1552 that differ used to produce either no symbol at all or an invisible mark. A pre-existing limitation stays untouched: symbols that contain a space, such as `F CFA`, are still not recognised, on the old code as well as on the new one.

Checks run:

* `./phpunit src/Symfony/Component/Form/Tests/Extension/Core/Type/MoneyTypeTest.php`: the two new tests fail on the current code (`'€ {{ widget }}'` expected, `'{{ widget }}'` returned; `'{{ widget }} €'` expected, an invisible mark followed by the widget returned) and pass with the fix.
* `./phpunit src/Symfony/Component/Form`: 4750 tests, no failure.
* `./phpunit src/Symfony/Bridge/Twig/Tests`: 1756 tests, no failure.

Note for the merger: `MoneyTypeTest` calls `IntlTestHelper::requireFullIntl()`, so the whole class is skipped unless the installed ICU major version is at least the one the Intl component targets. The new tests were validated by lowering that gate locally on ICU 74.2, together with the tests that were already there.
