### PR TITLE
[FrameworkBundle] Fix debug:config and config:dump-reference when a bundle registers services in its build method

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/AbstractConfigCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AbstractConfigCommand.php
@@ -180,6 +180,12 @@ abstract class AbstractConfigCommand extends ContainerDebugCommand
         $kernel = $this->getApplication()->getKernel();
         $container = $this->getContainerBuilder($kernel);
         $bundles = $kernel->getBundles();
+
+        if ($container->isCompiled()) {
+            // the bundles have already been built while compiling the container
+            return $bundles;
+        }
+
         foreach ($bundles as $bundle) {
             if ($extension = $bundle->getContainerExtension()) {
                 $container->registerExtension($extension);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/ServicesInBuildTestBundle/ServicesInBuildTestBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/ServicesInBuildTestBundle/ServicesInBuildTestBundle.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\ServicesInBuildTestBundle;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class ServicesInBuildTestBundle extends Bundle
+{
+    public function build(ContainerBuilder $container): void
+    {
+        parent::build($container);
+
+        $container->register('services_in_build_test.service', \stdClass::class);
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ConfigDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ConfigDebugCommandTest.php
@@ -76,6 +76,19 @@ class ConfigDebugCommandTest extends AbstractWebTestCase
      * @testWith [true]
      *           [false]
      */
+    public function testDumpWithBundleRegisteringServicesInBuild(bool $debug)
+    {
+        $tester = $this->createCommandTester($debug);
+        $ret = $tester->execute(['name' => 'framework']);
+
+        $this->assertSame(0, $ret, 'Returns 0 in case of success');
+        $this->assertStringContainsString('secret: test', $tester->getDisplay());
+    }
+
+    /**
+     * @testWith [true]
+     *           [false]
+     */
     public function testDumpBundleOption(bool $debug)
     {
         $tester = $this->createCommandTester($debug);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ConfigDumpReferenceCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ConfigDumpReferenceCommandTest.php
@@ -141,7 +141,7 @@ class ConfigDumpReferenceCommandTest extends AbstractWebTestCase
 
     public static function provideCompletionSuggestions(): iterable
     {
-        $name = ['foo', 'default_config_test', 'extension_without_config_test', 'framework', 'test', 'test_dump', 'DefaultConfigTestBundle', 'ExtensionWithoutConfigTestBundle', 'FrameworkBundle', 'TestBundle'];
+        $name = ['foo', 'default_config_test', 'extension_without_config_test', 'framework', 'test', 'test_dump', 'DefaultConfigTestBundle', 'ExtensionWithoutConfigTestBundle', 'FrameworkBundle', 'ServicesInBuildTestBundle', 'TestBundle'];
         yield 'name, no debug' => [false, [''], $name];
         yield 'name, debug' => [true, [''], $name];
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ConfigDump/bundles.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ConfigDump/bundles.php
@@ -12,11 +12,13 @@
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\DefaultConfigTestBundle\DefaultConfigTestBundle;
 use Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\ExtensionWithoutConfigTestBundle\ExtensionWithoutConfigTestBundle;
+use Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\ServicesInBuildTestBundle\ServicesInBuildTestBundle;
 use Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\TestBundle;
 
 return [
     new DefaultConfigTestBundle(),
     new ExtensionWithoutConfigTestBundle(),
     new FrameworkBundle(),
+    new ServicesInBuildTestBundle(),
     new TestBundle(),
 ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #47692
| License       | MIT

`debug:config` and `config:dump-reference` die with `Adding definition to a compiled container is not allowed.` when a bundle registers services from its `build()` method and the kernel does not run in debug mode:

```
$ php bin/console debug:config framework --env=prod

In ContainerBuilder.php line 970:
  [Symfony\Component\DependencyInjection\Exception\BadMethodCallException]
  Adding definition to a compiled container is not allowed.
```

Both commands resolve the extension to display through `AbstractConfigCommand::findExtension()`. That method calls `initializeBundles()`, which registers the bundle extensions and calls `Bundle::build()` on the container returned by `BuildDebugContainerTrait::getContainerBuilder()`. When the XML dump of the container cannot be used, which is always the case outside of debug mode, that trait builds the container from the kernel and compiles it. Adding a definition to a compiled container throws, so the command fails before printing anything.

Rebuilding the bundles there is useless anyway: both branches of `getContainerBuilder()` go through `Kernel::prepareContainer()` (the branch that reads the dump does so since 6.3), and that method registers every bundle extension and calls `Bundle::build()` on the container it returns. `initializeBundles()` now returns the bundles as they are when the container is already compiled.

The test app shared by the functional tests of both commands gets a bundle that registers a service from `build()`, which is what reproduces the crash. That bundle also shows up in the bundle names `config:dump-reference` suggests for completion, hence the updated expectation there.

Checks, all run with PHP 8.5 and PHPUnit 9.6 on 6.4:

* without the fix, `ConfigDebugCommandTest` reports 14 errors and 2 failures out of 40 tests and `ConfigDumpReferenceCommandTest` 5 errors out of 16, all of them `Adding definition to a compiled container is not allowed.` in the non debug data sets, the new test included;
* with the fix both files are green: 40 tests and 116 assertions, 16 tests and 46 assertions;
* the whole FrameworkBundle test suite is green: 1375 tests, 4549 assertions, 5 skipped, no failure.
