### PR TITLE
[FrameworkBundle] Fix ignored --raw option of debug:router

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
@@ -48,6 +48,7 @@ class TextDescriptor extends Descriptor
     protected function describeRouteCollection(RouteCollection $routes, array $options = []): void
     {
         $showControllers = isset($options['show_controllers']) && $options['show_controllers'];
+        $rawOutput = isset($options['raw_text']) && $options['raw_text'];
 
         $tableHeaders = ['Name', 'Method', 'Scheme', 'Host', 'Path'];
         if ($showControllers) {
@@ -67,11 +68,12 @@ class TextDescriptor extends Descriptor
                 $route->getMethods() ? implode('|', $route->getMethods()) : 'ANY',
                 $route->getSchemes() ? implode('|', $route->getSchemes()) : 'ANY',
                 '' !== $route->getHost() ? $route->getHost() : 'ANY',
-                $this->formatControllerLink($controller, $route->getPath(), $options['container'] ?? null),
+                $rawOutput ? $route->getPath() : $this->formatControllerLink($controller, $route->getPath(), $options['container'] ?? null),
             ];
 
             if ($showControllers) {
-                $row[] = $controller ? $this->formatControllerLink($controller, $this->formatCallable($controller), $options['container'] ?? null) : '';
+                $controllerText = $controller ? $this->formatCallable($controller) : '';
+                $row[] = $controller && !$rawOutput ? $this->formatControllerLink($controller, $controllerText, $options['container'] ?? null) : $controllerText;
             }
 
             if ($showAliases) {
@@ -92,9 +94,12 @@ class TextDescriptor extends Descriptor
 
     protected function describeRoute(Route $route, array $options = []): void
     {
+        $rawOutput = isset($options['raw_text']) && $options['raw_text'];
+
         $defaults = $route->getDefaults();
         if (isset($defaults['_controller'])) {
-            $defaults['_controller'] = $this->formatControllerLink($defaults['_controller'], $this->formatCallable($defaults['_controller']), $options['container'] ?? null);
+            $controllerText = $this->formatCallable($defaults['_controller']);
+            $defaults['_controller'] = $rawOutput ? $controllerText : $this->formatControllerLink($defaults['_controller'], $controllerText, $options['container'] ?? null);
         }
 
         $tableHeaders = ['Property', 'Value'];

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/AbstractDescriptorTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/AbstractDescriptorTestCase.php
@@ -268,11 +268,11 @@ abstract class AbstractDescriptorTestCase extends TestCase
 
     abstract protected static function getFormat();
 
-    private function assertDescription($expectedDescription, $describedObject, array $options = [])
+    protected function assertDescription($expectedDescription, $describedObject, array $options = [])
     {
         $options['is_debug'] = false;
         $options['raw_output'] = true;
-        $options['raw_text'] = true;
+        $options['raw_text'] ??= true;
         $output = new BufferedOutput(BufferedOutput::VERBOSITY_NORMAL, true);
 
         if ('txt' === $this->getFormat()) {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/TextDescriptorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/TextDescriptorTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\Console\Descriptor;
 use Symfony\Bundle\FrameworkBundle\Console\Descriptor\TextDescriptor;
 use Symfony\Component\ErrorHandler\ErrorRenderer\FileLinkFormatter;
 use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
 
 class TextDescriptorTest extends AbstractDescriptorTestCase
 {
@@ -31,25 +32,70 @@ class TextDescriptorTest extends AbstractDescriptorTestCase
 
     public static function getDescribeRouteWithControllerLinkTestData()
     {
-        $getDescribeData = static::getDescribeRouteTestData();
-
-        foreach ($getDescribeData as $key => &$data) {
-            $routeStub = $data[0];
-            $routeStub->setDefault('_controller', \sprintf('%s::%s', MyController::class, '__invoke'));
-            $file = $data[2];
-            $file = preg_replace('#(\..*?)$#', '_link$1', $file);
-            $data = file_get_contents(__DIR__.'/../../Fixtures/Descriptor/'.$file);
-            $data = [$routeStub, $data, $file];
-        }
-
-        return $getDescribeData;
+        return static::getDescribeRouteWithControllerTestData('_link');
     }
 
     /** @dataProvider getDescribeRouteWithControllerLinkTestData */
     public function testDescribeRouteWithControllerLink(Route $route, $expectedDescription)
     {
         static::$fileLinkFormatter = new FileLinkFormatter('myeditor://open?file=%f&line=%l');
-        parent::testDescribeRoute($route, str_replace('[:file:]', __FILE__, $expectedDescription));
+        $this->assertDescription(static::expandFixturePlaceholders($expectedDescription), $route, ['raw_text' => false]);
+    }
+
+    public static function getDescribeRouteWithControllerLinkInRawModeTestData()
+    {
+        return static::getDescribeRouteWithControllerTestData('_link_raw');
+    }
+
+    /** @dataProvider getDescribeRouteWithControllerLinkInRawModeTestData */
+    public function testDescribeRouteWithControllerLinkInRawMode(Route $route, $expectedDescription)
+    {
+        static::$fileLinkFormatter = new FileLinkFormatter('myeditor://open?file=%f&line=%l');
+        $this->assertDescription($expectedDescription, $route);
+    }
+
+    public function testDescribeRouteCollectionWithControllerLink()
+    {
+        static::$fileLinkFormatter = new FileLinkFormatter('myeditor://open?file=%f&line=%l');
+        $expectedDescription = file_get_contents(__DIR__.'/../../Fixtures/Descriptor/route_collection_1_link.txt');
+        $this->assertDescription(static::expandFixturePlaceholders($expectedDescription), static::getRouteCollectionWithControllers(), ['show_controllers' => true, 'raw_text' => false]);
+    }
+
+    public function testDescribeRouteCollectionWithControllerLinkInRawMode()
+    {
+        static::$fileLinkFormatter = new FileLinkFormatter('myeditor://open?file=%f&line=%l');
+        $expectedDescription = file_get_contents(__DIR__.'/../../Fixtures/Descriptor/route_collection_1_link_raw.txt');
+        $this->assertDescription($expectedDescription, static::getRouteCollectionWithControllers(), ['show_controllers' => true]);
+    }
+
+    private static function getDescribeRouteWithControllerTestData(string $suffix): array
+    {
+        $getDescribeData = static::getDescribeRouteTestData();
+
+        foreach ($getDescribeData as &$data) {
+            $routeStub = $data[0];
+            $routeStub->setDefault('_controller', \sprintf('%s::%s', MyController::class, '__invoke'));
+            $file = preg_replace('#(\..*?)$#', $suffix.'$1', $data[2]);
+            $data = [$routeStub, file_get_contents(__DIR__.'/../../Fixtures/Descriptor/'.$file), $file];
+        }
+
+        return $getDescribeData;
+    }
+
+    private static function getRouteCollectionWithControllers(): RouteCollection
+    {
+        $collection = new RouteCollection();
+        foreach (ObjectsProvider::getRoutes() as $name => $route) {
+            $route->setDefault('_controller', \sprintf('%s::%s', MyController::class, '__invoke'));
+            $collection->add($name, $route);
+        }
+
+        return $collection;
+    }
+
+    private static function expandFixturePlaceholders(string $expectedDescription): string
+    {
+        return str_replace(['[:file:]', '[:line:]'], [__FILE__, (new \ReflectionMethod(MyController::class, '__invoke'))->getStartLine()], $expectedDescription);
     }
 }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/route_1_link.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/route_1_link.txt
@@ -10,7 +10,7 @@
 | Method       | GET|HEAD                                                                                      |
 | Requirements | name: [a-z]+                                                                                  |
 | Class        | Symfony\Bundle\FrameworkBundle\Tests\Console\Descriptor\RouteStub                             |
-| Defaults     | _controller: ]8;;myeditor://open?file=[:file:]&line=58\Symfony\Bundle\FrameworkBundle\Tests\Console\Descriptor\MyController::__invoke()]8;;\ |
+| Defaults     | _controller: ]8;;myeditor://open?file=[:file:]&line=[:line:]\Symfony\Bundle\FrameworkBundle\Tests\Console\Descriptor\MyController::__invoke()]8;;\ |
 |              | name: Joseph                                                                                  |
 | Options      | compiler_class: Symfony\Component\Routing\RouteCompiler                                       |
 |              | opt1: val1                                                                                    |

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/route_1_link_raw.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/route_1_link_raw.txt
@@ -2,17 +2,17 @@
 |[32m Property     [39m|[32m Value                                                                                         [39m|
 +--------------+-----------------------------------------------------------------------------------------------+
 | Route Name   |                                                                                               |
-| Path         | /name/add                                                                                     |
+| Path         | /hello/{name}                                                                                 |
 | Path Regex   | #PATH_REGEX#                                                                                  |
 | Host         | localhost                                                                                     |
 | Host Regex   | #HOST_REGEX#                                                                                  |
 | Scheme       | http|https                                                                                    |
-| Method       | PUT|POST                                                                                      |
-| Requirements | NO CUSTOM                                                                                     |
+| Method       | GET|HEAD                                                                                      |
+| Requirements | name: [a-z]+                                                                                  |
 | Class        | Symfony\Bundle\FrameworkBundle\Tests\Console\Descriptor\RouteStub                             |
-| Defaults     | _controller: ]8;;myeditor://open?file=[:file:]&line=[:line:]\Symfony\Bundle\FrameworkBundle\Tests\Console\Descriptor\MyController::__invoke()]8;;\ |
+| Defaults     | _controller: Symfony\Bundle\FrameworkBundle\Tests\Console\Descriptor\MyController::__invoke() |
+|              | name: Joseph                                                                                  |
 | Options      | compiler_class: Symfony\Component\Routing\RouteCompiler                                       |
 |              | opt1: val1                                                                                    |
 |              | opt2: val2                                                                                    |
-| Condition    | context.getMethod() in ['GET', 'HEAD', 'POST']                                                |
 +--------------+-----------------------------------------------------------------------------------------------+

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/route_2_link_raw.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/route_2_link_raw.txt
@@ -10,7 +10,7 @@
 | Method       | PUT|POST                                                                                      |
 | Requirements | NO CUSTOM                                                                                     |
 | Class        | Symfony\Bundle\FrameworkBundle\Tests\Console\Descriptor\RouteStub                             |
-| Defaults     | _controller: ]8;;myeditor://open?file=[:file:]&line=[:line:]\Symfony\Bundle\FrameworkBundle\Tests\Console\Descriptor\MyController::__invoke()]8;;\ |
+| Defaults     | _controller: Symfony\Bundle\FrameworkBundle\Tests\Console\Descriptor\MyController::__invoke() |
 | Options      | compiler_class: Symfony\Component\Routing\RouteCompiler                                       |
 |              | opt1: val1                                                                                    |
 |              | opt2: val2                                                                                    |

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/route_collection_1_link.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/route_collection_1_link.txt
@@ -1,0 +1,6 @@
+--------- ---------- ------------ ----------- --------------- ---------------------------------------------------------------------------------- 
+ [32m Name    [39m [32m Method   [39m [32m Scheme     [39m [32m Host      [39m [32m Path          [39m [32m Controller                                                                       [39m 
+ --------- ---------- ------------ ----------- --------------- ---------------------------------------------------------------------------------- 
+  route_1   GET|HEAD   http|https   localhost   ]8;;myeditor://open?file=[:file:]&line=[:line:]\/hello/{name}]8;;\   ]8;;myeditor://open?file=[:file:]&line=[:line:]\Symfony\Bundle\FrameworkBundle\Tests\Console\Descriptor\MyController::__invoke()]8;;\  
+  route_2   PUT|POST   http|https   localhost   ]8;;myeditor://open?file=[:file:]&line=[:line:]\/name/add]8;;\       ]8;;myeditor://open?file=[:file:]&line=[:line:]\Symfony\Bundle\FrameworkBundle\Tests\Console\Descriptor\MyController::__invoke()]8;;\  
+ --------- ---------- ------------ ----------- --------------- ----------------------------------------------------------------------------------

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/route_collection_1_link_raw.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/route_collection_1_link_raw.txt
@@ -1,0 +1,6 @@
+--------- ---------- ------------ ----------- --------------- ---------------------------------------------------------------------------------- 
+ [32m Name    [39m [32m Method   [39m [32m Scheme     [39m [32m Host      [39m [32m Path          [39m [32m Controller                                                                       [39m 
+ --------- ---------- ------------ ----------- --------------- ---------------------------------------------------------------------------------- 
+  route_1   GET|HEAD   http|https   localhost   /hello/{name}   Symfony\Bundle\FrameworkBundle\Tests\Console\Descriptor\MyController::__invoke()  
+  route_2   PUT|POST   http|https   localhost   /name/add       Symfony\Bundle\FrameworkBundle\Tests\Console\Descriptor\MyController::__invoke()  
+ --------- ---------- ------------ ----------- --------------- ----------------------------------------------------------------------------------


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #59743
| License       | MIT

`debug:router` accepts a `--raw` option and forwards it to the descriptors as the `raw_text` option, but the text descriptor never reads that option for routes: neither `describeRouteCollection()` nor `describeRoute()` honors it. As a result, `bin/console debug:router --raw` and `bin/console debug:router` produce exactly the same output.

The only console markup the routes output can contain is the file link wrapped around the path, the controller column and the `_controller` default when a file link formatter is configured (`framework.ide` or the `SYMFONY_IDE` env var). On a decorated terminal those links are emitted as OSC 8 escape sequences. With this change, `--raw` skips the link markup and prints plain text, consistent with what `--raw` already does for `debug:container`, where it drops the color markup around service ids.

On the test side, the controller link test now runs with `raw_text` off: the descriptor test harness always describes objects in raw mode, so that test only passed because the option was ignored for routes. The fixture file and line are now placeholders resolved at runtime, so editing the test file no longer invalidates the link fixtures. New tests cover the raw mode for a single route and for a collection, plus the linked collection output.

Checks run:
- `./phpunit src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor`: OK (190 tests).
- `./phpunit src/Symfony/Bundle/FrameworkBundle/Tests/Functional/RouterDebugCommandTest.php`: OK (11 tests).
- `./phpunit src/Symfony/Bundle/FrameworkBundle/Tests`: OK (1377 tests, 5 pre-existing skips).
- Revert check: with the `TextDescriptor` change stashed, the three new raw-mode tests fail with the hyperlink escapes present in the output; everything else passes.

Merge-up note for 7.4 and above: `describeRouteCollection()` was reworked there (the path cell is no longer linked, the methods column is colorized by `formatMethods()`). Re-apply the `raw_text` guard to the controller link and to the method colors in both `describeRouteCollection()` and `describeRoute()`.
