### PR TITLE
[FrameworkBundle] Show the effective priority of tagged services in debug:container

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
@@ -15,6 +15,7 @@ use Symfony\Component\Config\Resource\ClassExistenceResource;
 use Symfony\Component\Console\Descriptor\DescriptorInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\Alias;
+use Symfony\Component\DependencyInjection\Attribute\AsTaggedItem;
 use Symfony\Component\DependencyInjection\Compiler\AnalyzeServiceReferencesPass;
 use Symfony\Component\DependencyInjection\Compiler\ServiceReferenceGraphEdge;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -256,6 +257,43 @@ abstract class Descriptor implements DescriptorInterface
         }
 
         return $sortedTags;
+    }
+
+    protected function resolvePriorityServiceTags(ContainerBuilder $container, Definition $definition, ?string $tagName = null): array
+    {
+        $tags = null !== $tagName ? $definition->getTag($tagName) : $definition->getTags();
+
+        if (!$r = $container->getReflectionClass($definition->getClass(), false)) {
+            return $tags;
+        }
+
+        $priority = null;
+        if ($r->hasMethod('getDefaultPriority')) {
+            $rm = $r->getMethod('getDefaultPriority');
+            if ($rm->isPublic() && $rm->isStatic() && !$rm->isAbstract() && \is_int($defaultPriority = $rm->invoke(null))) {
+                $priority = $defaultPriority;
+            }
+        } elseif ($definition->isAutoconfigured() && !$definition->hasTag('container.ignore_attributes')) {
+            $priority = ($r->getAttributes(AsTaggedItem::class)[0] ?? null)?->newInstance()->priority;
+        }
+
+        if (!$priority) {
+            return $tags;
+        }
+
+        if (null !== $tagName) {
+            foreach ($tags as &$tag) {
+                $tag['priority'] ??= $priority;
+            }
+        } else {
+            foreach ($tags as &$tagConfigs) {
+                foreach ($tagConfigs as &$tag) {
+                    $tag['priority'] ??= $priority;
+                }
+            }
+        }
+
+        return $tags;
     }
 
     protected function sortByPriority(array $tag): array

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
@@ -300,7 +300,7 @@ class JsonDescriptor extends Descriptor
 
         if (!$omitTags) {
             $data['tags'] = [];
-            foreach ($this->sortTagsByPriority($definition->getTags()) as $tagName => $tagData) {
+            foreach ($this->sortTagsByPriority($container ? $this->resolvePriorityServiceTags($container, $definition) : $definition->getTags()) as $tagName => $tagData) {
                 foreach ($tagData as $parameters) {
                     $data['tags'][] = ['name' => $tagName, 'parameters' => $parameters];
                 }

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/MarkdownDescriptor.php
@@ -260,7 +260,7 @@ class MarkdownDescriptor extends Descriptor
         }
 
         if (!(isset($options['omit_tags']) && $options['omit_tags'])) {
-            foreach ($this->sortTagsByPriority($definition->getTags()) as $tagName => $tagData) {
+            foreach ($this->sortTagsByPriority($container ? $this->resolvePriorityServiceTags($container, $definition) : $definition->getTags()) as $tagName => $tagData) {
                 foreach ($tagData as $parameters) {
                     $output .= "\n".'- Tag: `'.$tagName.'`';
                     foreach ($parameters as $name => $value) {

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
@@ -197,9 +197,15 @@ class TextDescriptor extends Descriptor
 
         $options['output']->title($title);
 
-        $serviceIds = isset($options['tag']) && $options['tag']
-            ? $this->sortTaggedServicesByPriority($container->findTaggedServiceIds($options['tag']))
-            : $this->sortServiceIds($container->getServiceIds());
+        $services = [];
+        if (isset($options['tag']) && $options['tag']) {
+            foreach (array_keys($container->findTaggedServiceIds($options['tag'])) as $serviceId) {
+                $services[$serviceId] = $this->resolvePriorityServiceTags($container, $container->getDefinition($serviceId), $options['tag']);
+            }
+            $serviceIds = $this->sortTaggedServicesByPriority($services);
+        } else {
+            $serviceIds = $this->sortServiceIds($container->getServiceIds());
+        }
         $maxTags = [];
 
         if (isset($options['filter'])) {
@@ -221,7 +227,7 @@ class TextDescriptor extends Descriptor
                     continue;
                 }
                 if ($showTag) {
-                    $tags = $definition->getTag($showTag);
+                    $tags = $services[$serviceId];
                     foreach ($tags as $tag) {
                         foreach ($tag as $key => $value) {
                             if (!isset($maxTags[$key])) {
@@ -252,7 +258,7 @@ class TextDescriptor extends Descriptor
             $styledServiceId = $rawOutput ? $serviceId : \sprintf('<fg=cyan>%s</fg=cyan>', OutputFormatter::escape($serviceId));
             if ($definition instanceof Definition) {
                 if ($showTag) {
-                    foreach ($this->sortByPriority($definition->getTag($showTag)) as $key => $tag) {
+                    foreach ($this->sortByPriority($services[$serviceId]) as $key => $tag) {
                         $tagValues = [];
                         foreach ($tagsNames as $tagName) {
                             if (\is_array($tagValue = $tag[$tagName] ?? '')) {
@@ -297,7 +303,7 @@ class TextDescriptor extends Descriptor
         $tableRows[] = ['Class', $definition->getClass() ?: '-'];
 
         $omitTags = isset($options['omit_tags']) && $options['omit_tags'];
-        if (!$omitTags && ($tags = $definition->getTags())) {
+        if (!$omitTags && ($tags = $container ? $this->resolvePriorityServiceTags($container, $definition) : $definition->getTags())) {
             $tagInformation = [];
             foreach ($tags as $tagName => $tagData) {
                 foreach ($tagData as $tagParameters) {

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
@@ -311,7 +311,7 @@ class XmlDescriptor extends Descriptor
                 continue;
             }
 
-            $serviceXML = $this->getContainerServiceDocument($service, $serviceId, null, $showArguments);
+            $serviceXML = $this->getContainerServiceDocument($service, $serviceId, $service instanceof Definition ? $container : null, $showArguments);
             $containerXML->appendChild($containerXML->ownerDocument->importNode($serviceXML->childNodes->item(0), true));
         }
 
@@ -385,7 +385,7 @@ class XmlDescriptor extends Descriptor
         }
 
         if (!$omitTags) {
-            if ($tags = $this->sortTagsByPriority($definition->getTags())) {
+            if ($tags = $this->sortTagsByPriority($container ? $this->resolvePriorityServiceTags($container, $definition) : $definition->getTags())) {
                 $serviceXML->appendChild($tagsXML = $dom->createElement('tags'));
                 foreach ($tags as $tagName => $tagData) {
                     foreach ($tagData as $parameters) {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/AbstractDescriptorTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/AbstractDescriptorTestCase.php
@@ -361,4 +361,25 @@ abstract class AbstractDescriptorTestCase extends TestCase
 
         return $data;
     }
+
+    /** @dataProvider getDescribeContainerBuilderWithTaggedItemPriorityTagsTestData */
+    public function testDescribeContainerBuilderWithTaggedItemPriorityTags(ContainerBuilder $builder, $expectedDescription, array $options)
+    {
+        $this->assertDescription($expectedDescription, $builder, $options);
+    }
+
+    public static function getDescribeContainerBuilderWithTaggedItemPriorityTagsTestData(): array
+    {
+        $variations = ['priority_tag' => ['tag' => 'tag1']];
+        $data = [];
+        foreach (ObjectsProvider::getContainerBuildersWithTaggedItemPriorityTags() as $name => $object) {
+            foreach ($variations as $suffix => $options) {
+                $file = \sprintf('%s_%s.%s', trim($name, '.'), $suffix, static::getFormat());
+                $description = file_get_contents(__DIR__.'/../../Fixtures/Descriptor/'.$file);
+                $data[] = [$object, $description, $options];
+            }
+        }
+
+        return $data;
+    }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/ObjectsProvider.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/ObjectsProvider.php
@@ -16,6 +16,7 @@ use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Suit;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\Argument\AbstractArgument;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
+use Symfony\Component\DependencyInjection\Attribute\AsTaggedItem;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
@@ -242,6 +243,24 @@ class ObjectsProvider
         ];
     }
 
+    public static function getContainerBuildersWithTaggedItemPriorityTags()
+    {
+        $builder = new ContainerBuilder();
+        $builder->setDefinitions(self::getContainerDefinitionsWithTaggedItemPriorityTags());
+
+        return ['builder_tagged_item' => $builder];
+    }
+
+    public static function getContainerDefinitionsWithTaggedItemPriorityTags()
+    {
+        return [
+            'definition_no_priority' => (new Definition(TaggedItemWithPriorityClass::class))->setPublic(true)->addTag('tag1', ['attr1' => 'val1']),
+            'definition_attribute_priority' => (new Definition(TaggedItemWithPriorityClass::class))->setPublic(true)->setAutoconfigured(true)->addTag('tag1', ['attr1' => 'val1']),
+            'definition_tag_priority' => (new Definition('Full\\Qualified\\Class1'))->setPublic(true)->addTag('tag1', ['priority' => 20]),
+            'definition_method_priority' => (new Definition(TaggedItemWithPriorityMethodClass::class))->setPublic(true)->setAutoconfigured(true)->addTag('tag1')->addTag('tag1', ['priority' => 5]),
+        ];
+    }
+
     public static function getContainerAliases()
     {
         return [
@@ -342,4 +361,18 @@ class ClassWithDocCommentOnMultipleLines
  */
 class ClassWithDocCommentWithoutInitialSpace
 {
+}
+
+#[AsTaggedItem(priority: 30)]
+class TaggedItemWithPriorityClass
+{
+}
+
+#[AsTaggedItem(priority: 99)]
+class TaggedItemWithPriorityMethodClass
+{
+    public static function getDefaultPriority(): int
+    {
+        return 10;
+    }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_tagged_item_priority_tag.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_tagged_item_priority_tag.json
@@ -1,0 +1,97 @@
+{
+    "definitions": {
+        "definition_tag_priority": {
+            "class": "Full\\Qualified\\Class1",
+            "public": true,
+            "synthetic": false,
+            "lazy": false,
+            "shared": true,
+            "abstract": false,
+            "autowire": false,
+            "autoconfigure": false,
+            "deprecated": false,
+            "file": null,
+            "tags": [
+                {
+                    "name": "tag1",
+                    "parameters": {
+                        "priority": 20
+                    }
+                }
+            ],
+            "usages": []
+        },
+        "definition_method_priority": {
+            "class": "Symfony\\Bundle\\FrameworkBundle\\Tests\\Console\\Descriptor\\TaggedItemWithPriorityMethodClass",
+            "public": true,
+            "synthetic": false,
+            "lazy": false,
+            "shared": true,
+            "abstract": false,
+            "autowire": false,
+            "autoconfigure": true,
+            "deprecated": false,
+            "file": null,
+            "tags": [
+                {
+                    "name": "tag1",
+                    "parameters": {
+                        "priority": 10
+                    }
+                },
+                {
+                    "name": "tag1",
+                    "parameters": {
+                        "priority": 5
+                    }
+                }
+            ],
+            "usages": []
+        },
+        "definition_no_priority": {
+            "class": "Symfony\\Bundle\\FrameworkBundle\\Tests\\Console\\Descriptor\\TaggedItemWithPriorityClass",
+            "public": true,
+            "synthetic": false,
+            "lazy": false,
+            "shared": true,
+            "abstract": false,
+            "autowire": false,
+            "autoconfigure": false,
+            "deprecated": false,
+            "file": null,
+            "tags": [
+                {
+                    "name": "tag1",
+                    "parameters": {
+                        "attr1": "val1"
+                    }
+                }
+            ],
+            "usages": []
+        },
+        "definition_attribute_priority": {
+            "class": "Symfony\\Bundle\\FrameworkBundle\\Tests\\Console\\Descriptor\\TaggedItemWithPriorityClass",
+            "public": true,
+            "synthetic": false,
+            "lazy": false,
+            "shared": true,
+            "abstract": false,
+            "autowire": false,
+            "autoconfigure": true,
+            "deprecated": false,
+            "file": null,
+            "tags": [
+                {
+                    "name": "tag1",
+                    "parameters": {
+                        "attr1": "val1",
+                        "priority": 30
+                    }
+                }
+            ],
+            "usages": []
+        }
+    },
+    "aliases": [],
+    "services": []
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_tagged_item_priority_tag.md
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_tagged_item_priority_tag.md
@@ -1,0 +1,68 @@
+Services with tag `tag1`
+========================
+
+Definitions
+-----------
+
+### definition_tag_priority
+
+- Class: `Full\Qualified\Class1`
+- Public: yes
+- Synthetic: no
+- Lazy: no
+- Shared: yes
+- Abstract: no
+- Autowired: no
+- Autoconfigured: no
+- Deprecated: no
+- Tag: `tag1`
+    - Priority: 20
+- Usages: none
+
+### definition_method_priority
+
+- Class: `Symfony\Bundle\FrameworkBundle\Tests\Console\Descriptor\TaggedItemWithPriorityMethodClass`
+- Public: yes
+- Synthetic: no
+- Lazy: no
+- Shared: yes
+- Abstract: no
+- Autowired: no
+- Autoconfigured: yes
+- Deprecated: no
+- Tag: `tag1`
+    - Priority: 10
+- Tag: `tag1`
+    - Priority: 5
+- Usages: none
+
+### definition_no_priority
+
+- Class: `Symfony\Bundle\FrameworkBundle\Tests\Console\Descriptor\TaggedItemWithPriorityClass`
+- Public: yes
+- Synthetic: no
+- Lazy: no
+- Shared: yes
+- Abstract: no
+- Autowired: no
+- Autoconfigured: no
+- Deprecated: no
+- Tag: `tag1`
+    - Attr1: val1
+- Usages: none
+
+### definition_attribute_priority
+
+- Class: `Symfony\Bundle\FrameworkBundle\Tests\Console\Descriptor\TaggedItemWithPriorityClass`
+- Public: yes
+- Synthetic: no
+- Lazy: no
+- Shared: yes
+- Abstract: no
+- Autowired: no
+- Autoconfigured: yes
+- Deprecated: no
+- Tag: `tag1`
+    - Attr1: val1
+    - Priority: 30
+- Usages: none

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_tagged_item_priority_tag.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_tagged_item_priority_tag.txt
@@ -1,0 +1,12 @@
+[33mSymfony Container Services Tagged with "tag1" Tag[39m
+[33m=================================================[39m
+
+ ------------------------------------------ ------- ---------- ------------------------------------------------------------------------------------------- 
+ [32m Service ID                               [39m [32m attr1 [39m [32m priority [39m [32m Class name                                                                                [39m 
+ ------------------------------------------ ------- ---------- ------------------------------------------------------------------------------------------- 
+  definition_attribute_priority              val1    30         Symfony\Bundle\FrameworkBundle\Tests\Console\Descriptor\TaggedItemWithPriorityClass        
+  definition_tag_priority                            20         Full\Qualified\Class1                                                                      
+  definition_method_priority                         10         Symfony\Bundle\FrameworkBundle\Tests\Console\Descriptor\TaggedItemWithPriorityMethodClass  
+   (same service as previous, another tag)           5                                                                                                     
+  definition_no_priority                     val1               Symfony\Bundle\FrameworkBundle\Tests\Console\Descriptor\TaggedItemWithPriorityClass        
+ ------------------------------------------ ------- ---------- -------------------------------------------------------------------------------------------

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_tagged_item_priority_tag.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_tagged_item_priority_tag.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container>
+  <definition id="definition_tag_priority" class="Full\Qualified\Class1" public="true" synthetic="false" lazy="false" shared="true" abstract="false" autowired="false" autoconfigured="false" deprecated="false" file="">
+    <tags>
+      <tag name="tag1">
+        <parameter name="priority">20</parameter>
+      </tag>
+    </tags>
+  </definition>
+  <definition id="definition_method_priority" class="Symfony\Bundle\FrameworkBundle\Tests\Console\Descriptor\TaggedItemWithPriorityMethodClass" public="true" synthetic="false" lazy="false" shared="true" abstract="false" autowired="false" autoconfigured="true" deprecated="false" file="">
+    <tags>
+      <tag name="tag1">
+        <parameter name="priority">10</parameter>
+      </tag>
+      <tag name="tag1">
+        <parameter name="priority">5</parameter>
+      </tag>
+    </tags>
+  </definition>
+  <definition id="definition_no_priority" class="Symfony\Bundle\FrameworkBundle\Tests\Console\Descriptor\TaggedItemWithPriorityClass" public="true" synthetic="false" lazy="false" shared="true" abstract="false" autowired="false" autoconfigured="false" deprecated="false" file="">
+    <tags>
+      <tag name="tag1">
+        <parameter name="attr1">val1</parameter>
+      </tag>
+    </tags>
+  </definition>
+  <definition id="definition_attribute_priority" class="Symfony\Bundle\FrameworkBundle\Tests\Console\Descriptor\TaggedItemWithPriorityClass" public="true" synthetic="false" lazy="false" shared="true" abstract="false" autowired="false" autoconfigured="true" deprecated="false" file="">
+    <tags>
+      <tag name="tag1">
+        <parameter name="attr1">val1</parameter>
+        <parameter name="priority">30</parameter>
+      </tag>
+    </tags>
+  </definition>
+</container>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64593
| License       | MIT

`debug:container --tag=app.handler` sorts the services and fills the `priority` column from the raw tag metadata only. The priorities that `PriorityTaggedServiceTrait` resolves at runtime from `#[AsTaggedItem]` or from a static `getDefaultPriority()` method are ignored, so both the listed order and the displayed values can differ from the actual injection order of a tagged iterator.

This ports #63028, merged on 8.1, to the branches where the bug remains, and completes it for them: the 8.1 version only reads `#[AsTaggedItem]` because the default index and priority methods are deprecated there, which is why the plain backport #64746 was withdrawn. On 6.4 and 7.4 those methods are fully supported, so the new `Descriptor::resolvePriorityServiceTags()` resolves the default priority the way the runtime does: an explicit `priority` tag attribute wins; otherwise a public static `getDefaultPriority()` returning an int; otherwise `#[AsTaggedItem(priority: ...)]`, read only when the definition is autoconfigured and not tagged `container.ignore_attributes`; otherwise nothing.

The txt format now sorts the `--tag` listing by the resolved priorities and shows them in the table. The json, md and xml formats show the resolved priorities on each described definition; their listing order is unchanged, matching the scope of the 8.1 fix.

Checks run:
- New descriptor test across the four formats with four tagged services (attribute priority, explicit tag priority, method priority next to an explicit entry on the same service, and a non autoconfigured service whose attribute must stay ignored). Before the fix, all four format tests fail: the services are ordered by explicit tag priority only and the resolved priorities are missing. After the fix, all pass.
- A probe compared the fixed txt order with `PriorityTaggedServiceTrait::findAndSortTaggedServices()` on the same container: identical, including the method beating the attribute and the attribute being ignored on the non autoconfigured service.
- `./phpunit src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor`: OK (190 tests).
- `./phpunit src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ContainerDebugCommandTest.php`: OK (22 tests).
- `./phpunit src/Symfony/Bundle/FrameworkBundle/Tests`: OK (1377 tests, 5 pre-existing skips).
- Revert check: with the five descriptor src files stashed, the four new tests fail as described; everything else passes.

Merge-up note: applies to 7.4 as is. On 8.1 and above, `Descriptor::resolvePriorityServiceTags()` conflicts with the simpler helper merged there. Prefer this version in the resolution: it also matches the 8.x runtime, which still lets the deprecated static methods win over the attribute and reads the attribute only on autoconfigured definitions, and the new tests then pass unchanged. If the 8.1 helper is kept instead, the new `builder_tagged_item_priority_tag.*` fixtures must be regenerated against it.
