### PR TITLE
[HttpClient] Fix CachingHttpClient when trusted hosts are configured

### DIFF
--- a/src/Symfony/Component/HttpClient/CachingHttpClient.php
+++ b/src/Symfony/Component/HttpClient/CachingHttpClient.php
@@ -11,9 +11,9 @@
 
 namespace Symfony\Component\HttpClient;
 
+use Symfony\Component\HttpClient\Internal\OutgoingRequest;
 use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\HttpClient\Response\ResponseStream;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\HttpCache\HttpCache;
 use Symfony\Component\HttpKernel\HttpCache\StoreInterface;
 use Symfony\Component\HttpKernel\HttpClientKernel;
@@ -74,7 +74,7 @@ class CachingHttpClient implements HttpClientInterface, ResetInterface
             return $this->client->request($method, $url, $options);
         }
 
-        $request = Request::create($url, $method);
+        $request = OutgoingRequest::create($url, $method);
         $request->attributes->set('http_client_options', $options);
 
         foreach ($options['normalized_headers'] as $name => $values) {

--- a/src/Symfony/Component/HttpClient/Internal/OutgoingRequest.php
+++ b/src/Symfony/Component/HttpClient/Internal/OutgoingRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\Internal;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * A request that describes a URL the application asked the client to fetch.
+ *
+ * The list of trusted hosts protects against host injection by remote clients.
+ * It does not apply here: the host comes from the application itself.
+ *
+ * @internal
+ */
+final class OutgoingRequest extends Request
+{
+    public function getHost(): string
+    {
+        return strtolower(preg_replace('/:\d+$/', '', trim($this->headers->get('HOST', ''))));
+    }
+}

--- a/src/Symfony/Component/HttpClient/Tests/CachingHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/CachingHttpClientTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpClient\CachingHttpClient;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\HttpCache\Store;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
@@ -70,6 +71,34 @@ class CachingHttpClientTest extends TestCase
             'accept-language: de',
             'accept-language: fr',
         ], $capturedHeaders['accept-language']);
+    }
+
+    public function testTrustedHostsDoNotAlterRequestedUrls()
+    {
+        $requestedUrls = [];
+
+        $mockClient = new MockHttpClient(static function (string $method, string $url) use (&$requestedUrls) {
+            $requestedUrls[] = $url;
+
+            return new MockResponse('hello', ['response_headers' => ['Cache-Control' => 'public, max-age=60']]);
+        });
+
+        $cacheDir = sys_get_temp_dir().'/sf_http_cache_'.uniqid('', true);
+        $client = new CachingHttpClient($mockClient, new Store($cacheDir));
+
+        Request::setTrustedHosts(['^example\.org$']);
+
+        try {
+            $first = $client->request('GET', 'https://example.com/foo')->getContent();
+            $second = $client->request('GET', 'https://example.com/foo')->getContent();
+        } finally {
+            Request::setTrustedHosts([]);
+            $this->removeDir($cacheDir);
+        }
+
+        self::assertSame(['https://example.com/foo'], $requestedUrls);
+        self::assertSame('hello', $first);
+        self::assertSame('hello', $second);
     }
 
     public function testDoesNotEvaluateResponseBody()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #50276
| License       | MIT

`CachingHttpClient` describes the URL to fetch as a `Symfony\Component\HttpFoundation\Request` and hands it to `HttpCache`. The cache store and `HttpClientKernel` then read that URL back with `Request::getUri()`, which calls `Request::getHost()`.

`Request::getHost()` matches the host against the list of trusted hosts. That list protects against host injection by remote clients, so it has no business validating a URL the application itself asked the client to fetch. When an application sets `framework.trusted_hosts` (or calls `Request::setTrustedHosts()` in its front controller), fetching any URL outside that list breaks: the first `getHost()` call throws a `SuspiciousOperationException`, `HttpCache::lookup()` catches it and falls back to passing the request through, and every later `getHost()` call on the same object returns an empty host. The client ends up being asked for `https:///foo` and fails with `Malformed URL`.

This fixes it by building the request as an internal `Request` subclass that reads the host from the `Host` header without consulting the trusted hosts. Nothing else changes: with no trusted hosts configured, the requested URL, the query string normalization and the cache key are byte for byte what they were before.

Checks run:

* `./phpunit src/Symfony/Component/HttpClient/Tests/CachingHttpClientTest.php` fails on the base commit with `InvalidArgumentException: Malformed URL "https:///foo".`, the exact error of the issue report, and passes with the fix.
* `./phpunit src/Symfony/Component/HttpClient/Tests`: 984 tests, 2230 assertions, 38 skipped, no failure.
* A script comparing several URLs (plain host, host with port, IPv6 host with port, uppercase host, query string) with and without trusted hosts configured now sends the same URL in both cases.
