### PR TITLE
[Mailer] Remove metadata headers from the emails sent by the SES HTTP transports

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesApiAsyncAwsTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesApiAsyncAwsTransportTest.php
@@ -123,6 +123,37 @@ class SesApiAsyncAwsTransportTest extends TestCase
         $this->assertSame('foobar', $message->getMessageId());
     }
 
+    public function testSendWithAttachment()
+    {
+        $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
+            $content = json_decode($options['body'], true);
+            $raw = base64_decode($content['Content']['Raw']['Data']);
+
+            $this->assertStringContainsString('Content-Disposition: attachment; name=foo.txt', $raw);
+            $this->assertStringNotContainsString('X-Metadata-tagName1', $raw);
+            $this->assertStringNotContainsString('X-Metadata-tagName2', $raw);
+            $this->assertSame([['Name' => 'tagName1', 'Value' => 'tag Value1'], ['Name' => 'tagName2', 'Value' => 'tag Value2']], $content['EmailTags']);
+
+            return new MockResponse('{"MessageId": "foobar"}', ['http_code' => 200]);
+        });
+
+        $transport = new SesApiAsyncAwsTransport(new SesClient(Configuration::create(['sharedConfigFile' => false]), new NullProvider(), $client));
+
+        $mail = new Email();
+        $mail->subject('Hello!')
+            ->to(new Address('saif.gmati@symfony.com', 'Saif Eddin'))
+            ->from(new Address('fabpot@symfony.com', 'Fabien'))
+            ->text('Hello There!')
+            ->attach('some attachment', 'foo.txt');
+
+        $mail->getHeaders()->add(new MetadataHeader('tagName1', 'tag Value1'));
+        $mail->getHeaders()->add(new MetadataHeader('tagName2', 'tag Value2'));
+
+        $message = $transport->send($mail);
+
+        $this->assertSame('foobar', $message->getMessageId());
+    }
+
     public function testSendThrowsForErrorResponse()
     {
         $client = new MockHttpClient(static function (string $method, string $url, array $options): ResponseInterface {

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesHttpAsyncAwsTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesHttpAsyncAwsTransportTest.php
@@ -85,6 +85,8 @@ class SesHttpAsyncAwsTransportTest extends TestCase
             $this->assertStringContainsString('Saif Eddin <saif.gmati@symfony.com>', $content);
             $this->assertStringContainsString('Fabien <fabpot@symfony.com>', $content);
             $this->assertStringContainsString('Hello There!', $content);
+            $this->assertStringNotContainsString('X-Metadata-tagName1', $content);
+            $this->assertStringNotContainsString('X-Metadata-tagName2', $content);
             $this->assertSame('aws-configuration-set-name', $body['ConfigurationSetName']);
             $this->assertSame('aws-source-arn', $body['FromEmailAddressIdentityArn']);
             $this->assertSame([['Name' => 'tagName1', 'Value' => 'tag Value1'], ['Name' => 'tagName2', 'Value' => 'tag Value2']], $body['EmailTags']);

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesHttpAsyncAwsTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesHttpAsyncAwsTransport.php
@@ -78,7 +78,7 @@ class SesHttpAsyncAwsTransport extends AbstractTransport
             ]),
             'Content' => [
                 'Raw' => [
-                    'Data' => $message->toString(),
+                    'Data' => $this->getRawData($message),
                 ],
             ],
         ];
@@ -100,5 +100,37 @@ class SesHttpAsyncAwsTransport extends AbstractTransport
         }
 
         return new SendEmailRequest($request);
+    }
+
+    private function getRawData(SentMessage $message): string
+    {
+        $originalMessage = $message->getOriginalMessage();
+
+        if (!$originalMessage instanceof Message) {
+            return $message->toString();
+        }
+
+        $metadataNames = [];
+        foreach ($originalMessage->getHeaders()->all() as $name => $header) {
+            if ($header instanceof MetadataHeader) {
+                $metadataNames[] = $name;
+            }
+        }
+
+        if (!$metadataNames) {
+            return $message->toString();
+        }
+
+        // the metadata is sent as email tags, it must not leak into the delivered email
+        $originalMessage = clone $originalMessage;
+        $headers = $originalMessage->getHeaders();
+        foreach ($metadataNames as $name) {
+            $headers->remove($name);
+        }
+        if (!$headers->has('Message-ID')) {
+            $headers->addIdHeader('Message-ID', $message->getMessageId());
+        }
+
+        return $originalMessage->toString();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #58120
| License       | MIT

Emails carry SES message tags as `MetadataHeader` instances, which render as `X-Metadata-<name>` MIME headers. `SesSmtpTransport` removes them from the message and rewrites them into the `X-SES-MESSAGE-TAGS` header that SES consumes, so the delivered email does not carry them.

`SesHttpAsyncAwsTransport` sends the message as raw MIME and passes the same metadata a second time in the `EmailTags` field of the SES request, but it left the headers in the raw MIME, so recipients received them. `SesApiAsyncAwsTransport` inherits that request builder every time it falls back to raw MIME, which it does for every email that has an attachment.

The raw MIME is now built from a copy of the message without the metadata headers, so the tags travel only through `EmailTags`. The `Message-ID` picked for the message is carried over to that copy, so the header a recipient sees does not change. Messages that are not `Message` instances, and messages without metadata headers, keep using the already prepared `SentMessage`, so nothing is serialized twice.

`SentMessage::toString()` keeps exposing the metadata headers, because they belong to the message the application built. Removing them earlier is not possible: the request builder reads them to fill `EmailTags`, and `SentMessage` serializes its own copy of the message. This also matches the other API transports, which all send a payload that differs from the raw message.

Checks run on PHP 8.5 with PHPUnit 9.6:

* `SesHttpAsyncAwsTransportTest::testSend` now asserts that the raw MIME no longer contains the `X-Metadata-*` headers while `EmailTags` is still filled, and a new `SesApiAsyncAwsTransportTest::testSendWithAttachment` covers the raw fallback of the API transport. Both fail on the base commit with `does not contain "X-Metadata-tagName1"`.
* `./phpunit src/Symfony/Component/Mailer/Bridge/Amazon/Tests`: 52 tests, no failure.
* `./phpunit src/Symfony/Component/Mailer/Tests`: 166 tests, 8 skipped, no failure.
