### PR TITLE
[Messenger] Remove the worker listeners when messenger:consume ends

### DIFF
--- a/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
+++ b/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
@@ -179,8 +179,9 @@ class ConsumeMessagesCommand extends Command implements SignalableCommandInterfa
             }
         }
 
+        $subscribers = [];
         if (null !== $this->resetServicesListener && !$input->getOption('no-reset')) {
-            $this->eventDispatcher->addSubscriber($this->resetServicesListener);
+            $subscribers[] = $this->resetServicesListener;
         }
 
         $stopsWhen = [];
@@ -190,17 +191,17 @@ class ConsumeMessagesCommand extends Command implements SignalableCommandInterfa
             }
 
             $stopsWhen[] = "processed {$limit} messages";
-            $this->eventDispatcher->addSubscriber(new StopWorkerOnMessageLimitListener($limit, $this->logger));
+            $subscribers[] = new StopWorkerOnMessageLimitListener($limit, $this->logger);
         }
 
         if ($failureLimit = $input->getOption('failure-limit')) {
             $stopsWhen[] = "reached {$failureLimit} failed messages";
-            $this->eventDispatcher->addSubscriber(new StopWorkerOnFailureLimitListener($failureLimit, $this->logger));
+            $subscribers[] = new StopWorkerOnFailureLimitListener($failureLimit, $this->logger);
         }
 
         if ($memoryLimit = $input->getOption('memory-limit')) {
             $stopsWhen[] = "exceeded {$memoryLimit} of memory";
-            $this->eventDispatcher->addSubscriber(new StopWorkerOnMemoryLimitListener($this->convertToBytes($memoryLimit), $this->logger));
+            $subscribers[] = new StopWorkerOnMemoryLimitListener($this->convertToBytes($memoryLimit), $this->logger);
         }
 
         if (null !== $timeLimit = $input->getOption('time-limit')) {
@@ -240,10 +241,18 @@ class ConsumeMessagesCommand extends Command implements SignalableCommandInterfa
             $options['queues'] = $queues;
         }
 
+        foreach ($subscribers as $subscriber) {
+            $this->eventDispatcher->addSubscriber($subscriber);
+        }
+
         try {
             $this->worker->run($options);
         } finally {
             $this->worker = null;
+
+            foreach ($subscribers as $subscriber) {
+                $this->eventDispatcher->removeSubscriber($subscriber);
+            }
         }
 
         return 0;

--- a/src/Symfony/Component/Messenger/Tests/Command/ConsumeMessagesCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/ConsumeMessagesCommandTest.php
@@ -153,6 +153,43 @@ class ConsumeMessagesCommandTest extends TestCase
         $this->assertStringContainsString('[OK] Consuming messages from transport "dummy-receiver"', $tester->getDisplay());
     }
 
+    public function testRunTwiceInTheSameProcess()
+    {
+        $envelope = new Envelope(new \stdClass());
+
+        $receiver = $this->createStub(ReceiverInterface::class);
+        $receiver->method('get')->willReturn([$envelope]);
+
+        $receiverLocator = $this->createMock(ContainerInterface::class);
+        $receiverLocator->method('has')->with('dummy-receiver')->willReturn(true);
+        $receiverLocator->method('get')->with('dummy-receiver')->willReturn($receiver);
+
+        $handledMessages = 0;
+        $bus = $this->createMock(RoutableMessageBus::class);
+        $bus->method('dispatch')->willReturnCallback(static function (Envelope $envelope) use (&$handledMessages) {
+            ++$handledMessages;
+
+            return $envelope;
+        });
+
+        $eventDispatcher = new EventDispatcher();
+        $resetServicesListener = new ResetServicesListener(new ServicesResetter(new \ArrayIterator([]), []));
+        $command = new ConsumeMessagesCommand($bus, $receiverLocator, $eventDispatcher, null, [], $resetServicesListener);
+
+        $application = new Application();
+        $application->add($command);
+        $tester = new CommandTester($application->get('messenger:consume'));
+
+        $tester->execute(['receivers' => ['dummy-receiver'], '--limit' => 1]);
+
+        $this->assertSame(1, $handledMessages);
+        $this->assertSame([], $eventDispatcher->getListeners());
+
+        $tester->execute(['receivers' => ['dummy-receiver'], '--limit' => 2]);
+
+        $this->assertSame(3, $handledMessages);
+    }
+
     /**
      * @dataProvider getInvalidOptions
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #35038
| License       | MIT

`messenger:consume` turns its `--limit`, `--failure-limit` and `--memory-limit` options into event subscribers and registers them on the event dispatcher it was given, together with the reset services listener. None of them is removed when the command returns, and that dispatcher is the shared application one.

This stays invisible for a worker started from the command line, because the process ends with the command. It does not stay invisible when several runs share one process, which is what functional tests do. The second run still carries the listeners of the first one: a run with `--limit=3` that follows a run with `--limit=1` stops after a single message, because the leftover listener of the first run stops the worker. The reset services listener is added again on every run, so services also get reset once more per run.

The listeners are now collected while the options are read, registered right before the worker runs, and removed in the `finally` block that already clears the command's worker reference. Registering them just before the run also means that an invalid `--time-limit`, which is validated after the other options, no longer leaves listeners behind.

The new test runs the command twice on one dispatcher, with `--limit=1` then `--limit=2`, and checks that the second run handles two messages and that the dispatcher holds no listener once a run is over.

Checks run:
- `./phpunit src/Symfony/Component/Messenger/Tests/Command/ConsumeMessagesCommandTest.php`: 18 tests, 61 assertions, green.
- `./phpunit src/Symfony/Component/Messenger/Tests`: 411 tests, 1142 assertions, green, with the same 9 legacy deprecation notices the base commit reports (410 tests, 1139 assertions there).
- Revert check: source change removed, test kept, the test fails on the dispatcher assertion, which prints the leftover `StopWorkerOnMessageLimitListener` with `maximumNumberOfMessages => 1` plus the `ResetServicesListener` still subscribed to `WorkerRunningEvent` and `WorkerStoppedEvent`.
- A script running the command twice on one dispatcher, `--limit=1` then `--limit=3`: 1 message then 1 message before the change, 1 message then 3 messages after it.
- Both branches of this sweep touch `ConsumeMessagesCommand::execute()`. Cherry-picking them on top of each other merges without conflict and the Messenger suite stays green (412 tests, 1144 assertions).
