### PR TITLE
[Messenger] Fail when messenger:consume is given no receiver

### DIFF
--- a/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
+++ b/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
@@ -153,17 +153,17 @@ class ConsumeMessagesCommand extends Command implements SignalableCommandInterfa
 
             $input->setArgument('receivers', $io->askQuestion($question));
         }
-
-        if (!$input->getArgument('receivers')) {
-            throw new RuntimeException('Please pass at least one receiver.');
-        }
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        if (!$receiverNames = $input->getArgument('receivers')) {
+            throw new RuntimeException('Please pass at least one receiver.');
+        }
+
         $receivers = [];
         $rateLimiters = [];
-        foreach ($receiverNames = $input->getArgument('receivers') as $receiverName) {
+        foreach ($receiverNames as $receiverName) {
             if (!$this->receiverLocator->has($receiverName)) {
                 $message = \sprintf('The receiver "%s" does not exist.', $receiverName);
                 if ($this->receiverNames) {

--- a/src/Symfony/Component/Messenger/Tests/Command/ConsumeMessagesCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/ConsumeMessagesCommandTest.php
@@ -16,6 +16,7 @@ use Psr\Log\LoggerInterface;
 use Psr\Log\LoggerTrait;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Exception\InvalidOptionException;
+use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Tester\CommandCompletionTester;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\DependencyInjection\Container;
@@ -25,6 +26,7 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpKernel\DependencyInjection\ServicesResetter;
 use Symfony\Component\Messenger\Command\ConsumeMessagesCommand;
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Event\WorkerRunningEvent;
 use Symfony\Component\Messenger\EventListener\ResetServicesListener;
 use Symfony\Component\Messenger\MessageBus;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -184,6 +186,25 @@ class ConsumeMessagesCommandTest extends TestCase
 
         yield 'Zero second time limit' => ['--time-limit', '0', 'Option "time-limit" must be a positive integer, "0" passed.'];
         yield 'Non-numeric time limit' => ['--time-limit', 'whatever', 'Option "time-limit" must be a positive integer, "whatever" passed.'];
+    }
+
+    public function testRunWithoutReceiverInNonInteractiveMode()
+    {
+        $eventDispatcher = new EventDispatcher();
+        $eventDispatcher->addListener(WorkerRunningEvent::class, static function (WorkerRunningEvent $event) {
+            $event->getWorker()->stop();
+        });
+
+        $command = new ConsumeMessagesCommand(new RoutableMessageBus(new Container()), new ServiceLocator([]), $eventDispatcher, null, ['dummy-receiver', 'another-receiver']);
+
+        $application = new Application();
+        $application->add($command);
+        $tester = new CommandTester($application->get('messenger:consume'));
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Please pass at least one receiver.');
+
+        $tester->execute([], ['interactive' => false]);
     }
 
     public function testRunWithTimeLimit()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #48528
| License       | MIT

`messenger:consume` takes the transports to consume as an argument. When several transports are configured and none is given, the command asks which ones to use, and it throws "Please pass at least one receiver." when the answer is empty.

That check lives in `interact()`, which the console only calls when the input is interactive. `--quiet`, `--no-interaction` and a stdin that is not a TTY (cron, CI, a process supervisor) all turn interaction off, so the check is skipped. `execute()` then builds an empty list of receivers and `Worker::run()` loops on it forever: nothing is ever received, nothing ever stops the worker, and with `--quiet` nothing is printed either. The command hangs until it is killed.

The check now runs at the start of `execute()`, so it applies whatever the interactivity is. The interactive flow does not change: the question is still asked, and an empty answer still ends with the same exception. Non-interactive runs now exit with code 1, and the message is still shown under `--quiet` because the console renders exceptions at quiet verbosity.

The new test runs the command with interaction turned off and no receiver, and expects the exception. It also registers a listener that stops the worker as soon as it starts, so that a missing guard makes the test fail with a plain assertion failure instead of hanging.

Checks run:
- `./phpunit src/Symfony/Component/Messenger/Tests/Command/ConsumeMessagesCommandTest.php`: 18 tests, 60 assertions, green.
- `./phpunit src/Symfony/Component/Messenger/Tests`: 411 tests, 1141 assertions, green, with the same 9 legacy deprecation notices the base commit reports (410 tests, 1139 assertions there).
- Revert check: source change removed, test kept, the test fails with `Failed asserting that exception of type "Symfony\Component\Console\Exception\RuntimeException" is thrown.`
- A script driving a real `Application` with `--quiet` and no receiver: before the change the worker starts with an empty receiver list and only returns because the script stops it, with exit code 0 and no output at all; after the change it returns exit code 1 with "Please pass at least one receiver." on stderr.
