### PR TITLE
[MonologBridge] Fix NotifierHandler calling a method that NotifierInterface does not declare

### DIFF
--- a/src/Symfony/Bridge/Monolog/Handler/NotifierHandler.php
+++ b/src/Symfony/Bridge/Monolog/Handler/NotifierHandler.php
@@ -68,7 +68,9 @@ class NotifierHandler extends AbstractHandler
 
         $notification->importanceFromLogLevelName(Logger::getLevelName($record['level']));
 
-        $this->notifier->send($notification, ...$this->notifier->getAdminRecipients());
+        $recipients = method_exists($this->notifier, 'getAdminRecipients') ? $this->notifier->getAdminRecipients() : [];
+
+        $this->notifier->send($notification, ...$recipients);
     }
 
     private function getHighestRecord(array $records): array|LogRecord

--- a/src/Symfony/Bridge/Monolog/Tests/Handler/NotifierHandlerTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Handler/NotifierHandlerTest.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Monolog\Tests\Handler;
+
+use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\Monolog\Handler\NotifierHandler;
+use Symfony\Bridge\Monolog\Tests\RecordFactory;
+use Symfony\Component\Notifier\Notification\Notification;
+use Symfony\Component\Notifier\NotifierInterface;
+use Symfony\Component\Notifier\Recipient\Recipient;
+use Symfony\Component\Notifier\Recipient\RecipientInterface;
+
+class NotifierHandlerTest extends TestCase
+{
+    public function testHandleWithoutAdminRecipients()
+    {
+        $notifier = new class implements NotifierInterface {
+            public ?Notification $notification = null;
+            public array $recipients = [];
+
+            public function send(Notification $notification, RecipientInterface ...$recipients): void
+            {
+                $this->notification = $notification;
+                $this->recipients = $recipients;
+            }
+        };
+
+        (new NotifierHandler($notifier))->handle(RecordFactory::create(Logger::ERROR, 'Something went wrong'));
+
+        $this->assertSame('Something went wrong', $notifier->notification->getSubject());
+        $this->assertSame(Notification::IMPORTANCE_HIGH, $notifier->notification->getImportance());
+        $this->assertSame([], $notifier->recipients);
+    }
+
+    public function testHandleBatchWithoutAdminRecipients()
+    {
+        $notifier = new class implements NotifierInterface {
+            public ?Notification $notification = null;
+            public array $recipients = [];
+
+            public function send(Notification $notification, RecipientInterface ...$recipients): void
+            {
+                $this->notification = $notification;
+                $this->recipients = $recipients;
+            }
+        };
+
+        (new NotifierHandler($notifier))->handleBatch([
+            RecordFactory::create(Logger::WARNING, 'Not handled'),
+            RecordFactory::create(Logger::ERROR, 'Something went wrong'),
+            RecordFactory::create(Logger::CRITICAL, 'Something went very wrong'),
+        ]);
+
+        $this->assertSame('Something went very wrong', $notifier->notification->getSubject());
+        $this->assertSame(Notification::IMPORTANCE_URGENT, $notifier->notification->getImportance());
+        $this->assertSame([], $notifier->recipients);
+    }
+
+    public function testHandleSendsToAdminRecipients()
+    {
+        $notifier = new class implements NotifierInterface {
+            public array $adminRecipients = [];
+            public array $recipients = [];
+
+            public function send(Notification $notification, RecipientInterface ...$recipients): void
+            {
+                $this->recipients = $recipients;
+            }
+
+            public function getAdminRecipients(): array
+            {
+                return $this->adminRecipients;
+            }
+        };
+        $recipient = new Recipient('admin@example.com');
+        $notifier->adminRecipients = [$recipient];
+
+        (new NotifierHandler($notifier))->handle(RecordFactory::create(Logger::ERROR, 'Something went wrong'));
+
+        $this->assertSame([$recipient], $notifier->recipients);
+    }
+}

--- a/src/Symfony/Bridge/Monolog/composer.json
+++ b/src/Symfony/Bridge/Monolog/composer.json
@@ -29,7 +29,8 @@
         "symfony/var-dumper": "^5.4|^6.0|^7.0",
         "symfony/mailer": "^5.4|^6.0|^7.0",
         "symfony/mime": "^5.4|^6.0|^7.0",
-        "symfony/messenger": "^5.4|^6.0|^7.0"
+        "symfony/messenger": "^5.4|^6.0|^7.0",
+        "symfony/notifier": "^5.4|^6.0|^7.0"
     },
     "conflict": {
         "symfony/console": "<5.4",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #42809
| License       | MIT

`NotifierHandler` accepts a `NotifierInterface` and sends its notification with
`...$this->notifier->getAdminRecipients()`. That method is declared on the concrete
`Symfony\Component\Notifier\Notifier` class only. `NotifierInterface` declares `send()` and
nothing else, so any other implementation makes the handler fatal as soon as it handles a record:

```
Error: Call to undefined method App\Notifier\MyNotifier::getAdminRecipients()
```

FrameworkBundle wires `notifier.monolog_handler` with the `notifier` service, so a default setup
never sees this. It breaks when that service is decorated by a class that implements the interface,
or when the handler is built by hand with another implementation.

The handler now reads the admin recipients only from a notifier that provides them, and sends the
notification without recipients otherwise. A notifier that does expose `getAdminRecipients()` still
gets its recipients, whether or not it is the concrete `Notifier` class, so setups that work today
keep behaving the same.

`symfony/notifier` is added to the require-dev of the bridge. The handler has always used the
component while nothing declared it, and the new test needs it to run in the per-package jobs.

Checks that were run:

* `./phpunit src/Symfony/Bridge/Monolog`: OK, 98 tests, 223 assertions. The same command on the base
  commit gives OK, 95 tests, 216 assertions.
* The new tests against the unpatched handler: `testHandleWithoutAdminRecipients` and
  `testHandleBatchWithoutAdminRecipients` fail with
  `Error: Call to undefined method Symfony\Component\Notifier\NotifierInterface@anonymous::getAdminRecipients()`
  raised at `NotifierHandler.php:71`. `testHandleSendsToAdminRecipients` passes on the unpatched
  handler on purpose: it pins the behavior for a notifier that exposes the method without being the
  concrete `Notifier` class.
* `./phpunit src/Symfony/Component/Notifier`: OK, 2027 tests, 2958 assertions, 67 skipped,
  1 incomplete. Identical to the base commit, and no source of that component is touched.
* PHPStan at the level configured in `phpstan.dist.neon` on the handler: the base file reports
  `Call to an undefined method Symfony\Component\Notifier\NotifierInterface::getAdminRecipients()`,
  the patched file reports it no more and reports nothing new.
* php-cs-fixer with the repository config on the three files: no change to make.
