### PR TITLE
[Scheduler] Fix refreshing the checkpoint lock with a negative TTL

### DIFF
--- a/src/Symfony/Component/Scheduler/Generator/Checkpoint.php
+++ b/src/Symfony/Component/Scheduler/Generator/Checkpoint.php
@@ -100,7 +100,10 @@ final class Checkpoint implements CheckpointInterface
         if (!$nextTime) {
             $this->lock->release();
         } elseif ($remaining = $this->lock->getRemainingLifetime()) {
-            $this->lock->refresh((float) $nextTime->format('U.u') - (float) $now->format('U.u') + $remaining);
+            // the lock might have expired during a long run; stores reject negative TTLs and some reject TTLs below one second
+            if (1 <= $ttl = (float) $nextTime->format('U.u') - (float) $now->format('U.u') + $remaining) {
+                $this->lock->refresh($ttl);
+            }
         }
     }
 }

--- a/src/Symfony/Component/Scheduler/Tests/Generator/CheckpointTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/Generator/CheckpointTest.php
@@ -251,6 +251,36 @@ class CheckpointTest extends TestCase
         $checkpoint->release($now, $now->modify('60 sec'));
     }
 
+    public function testWithLockNoRefreshWhenLockExpired()
+    {
+        $lock = $this->createMock(LockInterface::class);
+        $lock->method('acquire')->willReturn(true);
+        $lock->method('getRemainingLifetime')->willReturn(-190.0);
+        $lock->expects($this->never())->method('refresh');
+        $lock->expects($this->never())->method('release');
+
+        $checkpoint = new Checkpoint('dummy', $lock);
+        $now = new \DateTimeImmutable('2020-02-20 20:20:20Z');
+
+        $checkpoint->acquire($now->modify('-10 min'));
+        $checkpoint->release($now, $now->modify('60 sec'));
+    }
+
+    public function testWithLockNoRefreshWhenComputedTtlIsBelowOneSecond()
+    {
+        $lock = $this->createMock(LockInterface::class);
+        $lock->method('acquire')->willReturn(true);
+        $lock->method('getRemainingLifetime')->willReturn(0.4);
+        $lock->expects($this->never())->method('refresh');
+        $lock->expects($this->never())->method('release');
+
+        $checkpoint = new Checkpoint('dummy', $lock);
+        $now = new \DateTimeImmutable('2020-02-20 20:20:20Z');
+
+        $checkpoint->acquire($now->modify('-10 sec'));
+        $checkpoint->release($now, $now->modify('500 ms'));
+    }
+
     public function testWithLockFullCycle()
     {
         $lock = new Lock(new Key('lock'), new InMemoryStore());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #58881
| License       | MIT

When a scheduled task runs longer than the checkpoint lock's lifetime, `Lock::getRemainingLifetime()` turns negative. `Checkpoint::release()` only checked that value for truthiness, so it called `Lock::refresh()` with a negative TTL. Stores that validate the TTL (Doctrine DBAL, PDO, Memcached) throw `InvalidTtlException`, which `Lock::refresh()` wraps into `LockAcquiringException` ("Failed to define an expiration for the ... lock"), and the worker consuming the schedule crashes. The same stores also reject any TTL below one second, which the unguarded computation could produce when the lock was about to expire.

`release()` now computes the TTL first and only refreshes when at least one second remains. Skipping the refresh is safe: it never shortens the current lease, and the next `Checkpoint::acquire()` either re-extends the lock with its initial TTL (`Lock::acquire()` refreshes on success) or detects that another worker took the lock over, which is the designed contention path.

Checks run: the two new tests fail without the fix with `LockInterface::refresh(-130.0) was not expected to be called` and `LockInterface::refresh(0.9) was not expected to be called`, and pass with it. `./phpunit src/Symfony/Component/Scheduler` returns OK (147 tests, 780 assertions). The changed file lints clean on PHP 8.1.
