### PR TITLE
[Scheduler] Fix infinite loop in PeriodicalTrigger for intervals that cannot move forward

### DIFF
--- a/src/Symfony/Component/Scheduler/Tests/Trigger/PeriodicalTriggerTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/Trigger/PeriodicalTriggerTest.php
@@ -158,6 +158,26 @@ class PeriodicalTriggerTest extends TestCase
         ];
     }
 
+    public function testFrozenIntervalThrows()
+    {
+        $trigger = new PeriodicalTrigger('Monday', '2023-03-20 13:45', '2023-06-19');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The interval of the "every Monday" trigger does not move the run date forward.');
+
+        $trigger->getNextRunDate(new \DateTimeImmutable('2023-03-20 13:45'));
+    }
+
+    public function testBackwardsIntervalThrows()
+    {
+        $trigger = new PeriodicalTrigger('last sunday', '2023-03-20 13:45', '2023-06-19');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The interval of the "every last sunday" trigger does not move the run date forward.');
+
+        $trigger->getNextRunDate(new \DateTimeImmutable('2023-03-20 13:45'));
+    }
+
     /**
      * @dataProvider providerGetNextRunDateAgain
      */

--- a/src/Symfony/Component/Scheduler/Trigger/PeriodicalTrigger.php
+++ b/src/Symfony/Component/Scheduler/Trigger/PeriodicalTrigger.php
@@ -110,7 +110,12 @@ class PeriodicalTrigger implements StatefulTriggerInterface
 
         $this->period ??= new \DatePeriod($this->from, $this->interval, $this->until);
         $iterator = $this->period->getIterator();
+        $previous = null;
         while ($run >= $next = $iterator->current()) {
+            if (null !== $previous && $next <= $previous) {
+                throw new InvalidArgumentException(\sprintf('The interval of the "%s" trigger does not move the run date forward.', $this->description));
+            }
+            $previous = $next;
             $iterator->next();
             if (!$iterator->valid()) {
                 return null;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #58981
| License       | MIT

`PeriodicalTrigger` accepts any string understood by `DateInterval::createFromDateString()`. Some of these strings describe a point in time rather than a duration: a bare weekday name like `"Monday"` resolves to a fixed date, so iterating the underlying `DatePeriod` stops moving forward once that date is reached, and `"last sunday"` even moves backwards. In both cases the `while ($run >= $next = $iterator->current())` loop in `getNextRunDate()` never terminates: the first evaluation of such a trigger hangs the worker consuming the schedule.

`getNextRunDate()` now detects that advancing the period iterator did not move the date forward and throws an `InvalidArgumentException` naming the trigger, so the broken schedule definition surfaces as an error instead of a hang. Valid relative intervals such as `"next tuesday"` or `"first monday of next month"` advance strictly and are not affected; they are covered by existing tests.

The check runs during iteration rather than in the constructor because whether an interval gets stuck depends on the date it is applied to; a constructor heuristic would either miss cases or reject valid intervals.

Checks run: the two new tests hang without the fix (killed by a 30 second timeout) and pass with it. `./phpunit src/Symfony/Component/Scheduler` returns OK (147 tests, 782 assertions). The changed file lints clean on PHP 8.1.
