### PR TITLE
[Serializer] Allow the attributes of nested discriminator maps when denormalizing

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -815,13 +815,16 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                 $mappedClasses = array_values($discriminatorMapping->getTypesMapping());
                 $visited = [$classOrObject => true];
 
+                // Forcing extra attributes off makes the mapped classes return their attributes instead of false
+                $mappedContext = [self::ALLOW_EXTRA_ATTRIBUTES => false] + $context;
+
                 while (null !== $mappedClass = array_shift($mappedClasses)) {
                     if (isset($visited[$mappedClass])) {
                         continue;
                     }
                     $visited[$mappedClass] = true;
 
-                    $attributes[] = parent::getAllowedAttributes($mappedClass, $context, $attributesAsString);
+                    $attributes[] = parent::getAllowedAttributes($mappedClass, $mappedContext, $attributesAsString);
 
                     // Mapped classes can declare a discriminator map of their own
                     if (null !== $nestedMapping = $this->classDiscriminatorResolver->getMappingForClass($mappedClass)) {

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -109,6 +109,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
 
     private array $typesCache = [];
     private array $attributesCache = [];
+    private array $typePropertiesCache = [];
     private readonly \Closure $objectClassResolver;
 
     /**
@@ -811,14 +812,63 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
             // are all allowed. The class of an object is known and the others cannot be read from it.
             if (!\is_object($classOrObject) && null !== $discriminatorMapping = $this->classDiscriminatorResolver->getMappingForClass($classOrObject)) {
                 $attributes = [];
-                foreach ($discriminatorMapping->getTypesMapping() as $mappedClass) {
+                $mappedClasses = array_values($discriminatorMapping->getTypesMapping());
+                $visited = [$classOrObject => true];
+
+                while (null !== $mappedClass = array_shift($mappedClasses)) {
+                    if (isset($visited[$mappedClass])) {
+                        continue;
+                    }
+                    $visited[$mappedClass] = true;
+
                     $attributes[] = parent::getAllowedAttributes($mappedClass, $context, $attributesAsString);
+
+                    // Mapped classes can declare a discriminator map of their own
+                    if (null !== $nestedMapping = $this->classDiscriminatorResolver->getMappingForClass($mappedClass)) {
+                        $typeProperty = $nestedMapping->getTypeProperty();
+                        $attributes[] = [$attributesAsString ? $typeProperty : new AttributeMetadata($typeProperty)];
+                        $mappedClasses = array_merge($mappedClasses, array_values($nestedMapping->getTypesMapping()));
+                    }
                 }
+
                 $allowedAttributes = array_merge($allowedAttributes, ...$attributes);
             }
         }
 
         return $allowedAttributes;
+    }
+
+    /**
+     * Tells whether the attribute holds the type of a discriminator map the class takes part in.
+     *
+     * @internal
+     */
+    protected function isDiscriminatorTypeProperty(object|string $classOrObject, string $attribute): bool
+    {
+        if (null === $this->classDiscriminatorResolver) {
+            return false;
+        }
+
+        $class = \is_object($classOrObject) ? $classOrObject::class : $classOrObject;
+
+        if (!isset($this->typePropertiesCache[$class])) {
+            $typeProperties = [];
+
+            if (null !== $mapping = $this->classDiscriminatorResolver->getMappingForMappedObject($classOrObject)) {
+                $typeProperties[$mapping->getTypeProperty()] = true;
+            }
+
+            // getMappingForMappedObject() returns the innermost map only, while nested maps read one type property per level
+            foreach ([$class => $class] + class_parents($class) + class_implements($class) as $mappedClass) {
+                if (null !== $mapping = $this->classDiscriminatorResolver->getMappingForClass($mappedClass)) {
+                    $typeProperties[$mapping->getTypeProperty()] = true;
+                }
+            }
+
+            $this->typePropertiesCache[$class] = $typeProperties;
+        }
+
+        return isset($this->typePropertiesCache[$class][$attribute]);
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
@@ -209,7 +209,7 @@ class GetSetMethodNormalizer extends AbstractObjectNormalizer
 
         $class = \is_object($classOrObject) ? $classOrObject::class : $classOrObject;
 
-        if ($this->classDiscriminatorResolver?->getMappingForMappedObject($classOrObject)?->getTypeProperty() === $attribute) {
+        if ($this->isDiscriminatorTypeProperty($classOrObject, $attribute)) {
             return true;
         }
 

--- a/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
@@ -151,7 +151,7 @@ class ObjectNormalizer extends AbstractObjectNormalizer
 
         $class = \is_object($classOrObject) ? $classOrObject::class : $classOrObject;
 
-        if ($this->classDiscriminatorResolver?->getMappingForMappedObject($classOrObject)?->getTypeProperty() === $attribute) {
+        if ($this->isDiscriminatorTypeProperty($classOrObject, $attribute)) {
             return true;
         }
 

--- a/src/Symfony/Component/Serializer/Normalizer/PropertyNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/PropertyNormalizer.php
@@ -118,7 +118,7 @@ class PropertyNormalizer extends AbstractObjectNormalizer
             return false;
         }
 
-        if ($this->classDiscriminatorResolver?->getMappingForMappedObject($classOrObject)?->getTypeProperty() === $attribute) {
+        if ($this->isDiscriminatorTypeProperty($classOrObject, $attribute)) {
             return true;
         }
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
@@ -648,6 +648,25 @@ class GetSetMethodNormalizerTest extends TestCase
         $this->assertInstanceOf(GetSetMethodDiscriminatedDummyOne::class, $obj);
     }
 
+    public function testDenormalizeNestedDiscriminatorMapWithAllowExtraAttributesFalse()
+    {
+        $classMetadataFactory = new ClassMetadataFactory(new AttributeLoader());
+        $discriminator = new ClassDiscriminatorFromClassMetadata($classMetadataFactory);
+        $normalizer = new GetSetMethodNormalizer($classMetadataFactory, null, null, $discriminator);
+
+        $obj = $normalizer->denormalize(
+            ['type' => 'sub', 'nested_type' => 'sub_sub', 'foo' => 'FOO', 'bar' => 'BAR', 'baz' => 'BAZ'],
+            GetSetMethodNestedDiscriminatorBase::class,
+            null,
+            [AbstractNormalizer::ALLOW_EXTRA_ATTRIBUTES => false]
+        );
+
+        $this->assertInstanceOf(GetSetMethodNestedDiscriminatorSubSub::class, $obj);
+        $this->assertSame('FOO', $obj->getFoo());
+        $this->assertSame('BAR', $obj->getBar());
+        $this->assertSame('BAZ', $obj->getBaz());
+    }
+
     public function testSkipVoidNeverReturnTypeAccessors()
     {
         $obj = new VoidNeverReturnTypeDummy();
@@ -1146,5 +1165,58 @@ class GetSetDummyWithCanOnly
     public function canWrite(): bool
     {
         return false;
+    }
+}
+
+#[DiscriminatorMap(typeProperty: 'type', mapping: [
+    'base' => GetSetMethodNestedDiscriminatorBase::class,
+    'sub' => GetSetMethodNestedDiscriminatorSub::class,
+])]
+class GetSetMethodNestedDiscriminatorBase
+{
+    private string $foo = 'foo';
+
+    public function getFoo(): string
+    {
+        return $this->foo;
+    }
+
+    public function setFoo(string $foo): void
+    {
+        $this->foo = $foo;
+    }
+}
+
+#[DiscriminatorMap(typeProperty: 'nested_type', mapping: [
+    'sub' => GetSetMethodNestedDiscriminatorSub::class,
+    'sub_sub' => GetSetMethodNestedDiscriminatorSubSub::class,
+])]
+class GetSetMethodNestedDiscriminatorSub extends GetSetMethodNestedDiscriminatorBase
+{
+    private string $bar = 'bar';
+
+    public function getBar(): string
+    {
+        return $this->bar;
+    }
+
+    public function setBar(string $bar): void
+    {
+        $this->bar = $bar;
+    }
+}
+
+class GetSetMethodNestedDiscriminatorSubSub extends GetSetMethodNestedDiscriminatorSub
+{
+    private string $baz = 'baz';
+
+    public function getBaz(): string
+    {
+        return $this->baz;
+    }
+
+    public function setBaz(string $baz): void
+    {
+        $this->baz = $baz;
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -1519,6 +1519,27 @@ class ObjectNormalizerTest extends TestCase
         $this->assertSame('BAR', $denormalized->bar);
         $this->assertSame('BAZ', $denormalized->baz);
     }
+
+    public function testDenormalizeDiscriminatorMapWithUnrestrictedMappedClass()
+    {
+        $normalizer = new ObjectNormalizer(new ClassMetadataFactory(new AttributeLoader()));
+
+        $denormalized = $normalizer->denormalize(['type' => 'plain', 'bar' => 'BAR'], DiscriminatorWithIgnoredAttribute::class);
+
+        $this->assertInstanceOf(DiscriminatorWithoutIgnoredAttribute::class, $denormalized);
+        $this->assertSame('BAR', $denormalized->bar);
+    }
+
+    public function testDenormalizeDiscriminatorMapKeepsIgnoredAttributes()
+    {
+        $normalizer = new ObjectNormalizer(new ClassMetadataFactory(new AttributeLoader()));
+
+        $denormalized = $normalizer->denormalize(['type' => 'ignoring', 'foo' => 'FOO', 'hidden' => 'HIDDEN'], DiscriminatorWithIgnoredAttribute::class);
+
+        $this->assertInstanceOf(DiscriminatorWithIgnoredAttribute::class, $denormalized);
+        $this->assertSame('FOO', $denormalized->foo);
+        $this->assertSame('hidden', $denormalized->hidden);
+    }
 }
 
 class ProxyObjectDummy extends ObjectDummy
@@ -2282,4 +2303,21 @@ class NestedDiscriminatorSub extends NestedDiscriminatorBase
 class NestedDiscriminatorSubSub extends NestedDiscriminatorSub
 {
     public string $baz = 'baz';
+}
+
+#[DiscriminatorMap(typeProperty: 'type', mapping: [
+    'ignoring' => DiscriminatorWithIgnoredAttribute::class,
+    'plain' => DiscriminatorWithoutIgnoredAttribute::class,
+])]
+class DiscriminatorWithIgnoredAttribute
+{
+    public string $foo = 'foo';
+
+    #[Ignore]
+    public string $hidden = 'hidden';
+}
+
+class DiscriminatorWithoutIgnoredAttribute
+{
+    public string $bar = 'bar';
 }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -1507,6 +1507,18 @@ class ObjectNormalizerTest extends TestCase
         $this->assertSame('FOO', $denormalized->foo);
         $this->assertSame('BAR', $denormalized->bar);
     }
+
+    public function testDenormalizeNestedDiscriminatorMapWithoutExtraAttributes()
+    {
+        $normalizer = new ObjectNormalizer(new ClassMetadataFactory(new AttributeLoader()));
+
+        $denormalized = $normalizer->denormalize(['type' => 'sub', 'nested_type' => 'sub_sub', 'foo' => 'FOO', 'bar' => 'BAR', 'baz' => 'BAZ'], NestedDiscriminatorBase::class, null, [AbstractNormalizer::ALLOW_EXTRA_ATTRIBUTES => false]);
+
+        $this->assertInstanceOf(NestedDiscriminatorSubSub::class, $denormalized);
+        $this->assertSame('FOO', $denormalized->foo);
+        $this->assertSame('BAR', $denormalized->bar);
+        $this->assertSame('BAZ', $denormalized->baz);
+    }
 }
 
 class ProxyObjectDummy extends ObjectDummy
@@ -2247,4 +2259,27 @@ class ObjectNormalizerDiscriminatorSub extends ObjectNormalizerDiscriminatorBase
     public const BAR = 'bar';
 
     public string $bar = self::BAR;
+}
+
+#[DiscriminatorMap(typeProperty: 'type', mapping: [
+    'base' => NestedDiscriminatorBase::class,
+    'sub' => NestedDiscriminatorSub::class,
+])]
+class NestedDiscriminatorBase
+{
+    public string $foo = 'foo';
+}
+
+#[DiscriminatorMap(typeProperty: 'nested_type', mapping: [
+    'sub' => NestedDiscriminatorSub::class,
+    'sub_sub' => NestedDiscriminatorSubSub::class,
+])]
+class NestedDiscriminatorSub extends NestedDiscriminatorBase
+{
+    public string $bar = 'bar';
+}
+
+class NestedDiscriminatorSubSub extends NestedDiscriminatorSub
+{
+    public string $baz = 'baz';
 }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
@@ -572,6 +572,25 @@ class PropertyNormalizerTest extends TestCase
         $this->assertInstanceOf(PropertyDiscriminatedDummyOne::class, $obj);
     }
 
+    public function testDenormalizeNestedDiscriminatorMapWithAllowExtraAttributesFalse()
+    {
+        $classMetadataFactory = new ClassMetadataFactory(new AttributeLoader());
+        $discriminator = new ClassDiscriminatorFromClassMetadata($classMetadataFactory);
+        $normalizer = new PropertyNormalizer($classMetadataFactory, null, null, $discriminator);
+
+        $obj = $normalizer->denormalize(
+            ['type' => 'sub', 'nested_type' => 'sub_sub', 'foo' => 'FOO', 'bar' => 'BAR', 'baz' => 'BAZ'],
+            PropertyNestedDiscriminatorBase::class,
+            null,
+            [AbstractNormalizer::ALLOW_EXTRA_ATTRIBUTES => false]
+        );
+
+        $this->assertInstanceOf(PropertyNestedDiscriminatorSubSub::class, $obj);
+        $this->assertSame('FOO', $obj->foo);
+        $this->assertSame('BAR', $obj->bar);
+        $this->assertSame('BAZ', $obj->baz);
+    }
+
     /**
      * @dataProvider provideTypedPropertyDummies
      */
@@ -758,4 +777,27 @@ class PropertyDiscriminatedDummyOne implements PropertyDummyInterface
 class PropertyDiscriminatedDummyTwo implements PropertyDummyInterface
 {
     public $url = 'URL_TWO';
+}
+
+#[DiscriminatorMap(typeProperty: 'type', mapping: [
+    'base' => PropertyNestedDiscriminatorBase::class,
+    'sub' => PropertyNestedDiscriminatorSub::class,
+])]
+class PropertyNestedDiscriminatorBase
+{
+    public string $foo = 'foo';
+}
+
+#[DiscriminatorMap(typeProperty: 'nested_type', mapping: [
+    'sub' => PropertyNestedDiscriminatorSub::class,
+    'sub_sub' => PropertyNestedDiscriminatorSubSub::class,
+])]
+class PropertyNestedDiscriminatorSub extends PropertyNestedDiscriminatorBase
+{
+    public string $bar = 'bar';
+}
+
+class PropertyNestedDiscriminatorSubSub extends PropertyNestedDiscriminatorSub
+{
+    public string $baz = 'baz';
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #43085
| License       | MIT

A class listed in a discriminator map can declare a discriminator map of its own. Denormalizing such a payload works while extra attributes are allowed, and throws `ExtraAttributesException` as soon as `allow_extra_attributes` is `false`:

```php
#[DiscriminatorMap(typeProperty: 'type', mapping: ['base' => Base::class, 'sub' => Sub::class])]
class Base { public string $foo = 'foo'; }

#[DiscriminatorMap(typeProperty: 'nested_type', mapping: ['sub' => Sub::class, 'sub_sub' => SubSub::class])]
class Sub extends Base { public string $bar = 'bar'; }

class SubSub extends Sub { public string $baz = 'baz'; }

$normalizer->denormalize(
    ['type' => 'sub', 'nested_type' => 'sub_sub', 'foo' => 'FOO', 'bar' => 'BAR', 'baz' => 'BAZ'],
    Base::class,
    null,
    [AbstractNormalizer::ALLOW_EXTRA_ATTRIBUTES => false]
);
// Extra attributes are not allowed ("type", "nested_type", "baz" are unknown).
```

Two things go wrong.

`AbstractObjectNormalizer::getAllowedAttributes()` reads the discriminator map of the denormalized class one level deep. The attributes of a class reached through a nested map (`baz`), and the type property that nested map reads (`nested_type`), never enter the allowed list. It now walks the whole tree of maps. A map that maps a type to the class declaring it is a cycle, so visited classes are tracked.

`ObjectNormalizer::isAllowedAttribute()`, and the same two lines in `PropertyNormalizer` and `GetSetMethodNormalizer`, accept the type property returned by `ClassDiscriminatorResolverInterface::getMappingForMappedObject()`. That call reports the innermost map only, so the type property of the outer map (`type`) is refused on an object resolved through a nested map. The check moved to `AbstractObjectNormalizer::isDiscriminatorTypeProperty()`, which also reads the maps declared by the parent classes and the interfaces, and keeps one list of type properties per class. The method is `@internal`.

Normalizing an object that a nested map resolves still writes the innermost type property only, so feeding the result back to `Base::class` cannot work. That is a separate defect and is left alone here.

The second commit fixes a crash in the same loop. A discriminator map does not have to point at subclasses of the class declaring it, and `getMappedClass()` never asks for that. When a mapped class puts no restriction on its attributes, `AbstractNormalizer::getAllowedAttributes()` answers `false` instead of a list, and merging that into the union raised `TypeError: array_merge(): Argument #2 must be of type array, false given`:

```php
#[DiscriminatorMap(typeProperty: 'type', mapping: ['ignoring' => Holder::class, 'plain' => Payload::class])]
class Holder { public string $foo = 'foo'; #[Ignore] public string $hidden = 'hidden'; }

class Payload { public string $bar = 'bar'; }

$normalizer->denormalize(['type' => 'plain', 'bar' => 'BAR'], Holder::class);
```

The mapped classes are now asked for their list with extra attributes turned off, which is what returns the attributes rather than `false`. Answering `false` for the whole call would have been shorter, but it drops the restriction the declaring class asks for, and `#[Ignore]` is only ever enforced through that list.

Fabbot asks to drop the two `@return mixed` tags of `AbstractObjectNormalizer`, which it lints because this pull request touches the file. Both methods declare no return type, so the tags are not superfluous and are kept.

Checks: `./phpunit src/Symfony/Component/Serializer` returns 1158 tests, 2335 assertions, 11 skipped and one legacy deprecation notice. The same command on the base commit returns 1153 tests, 2318 assertions, and the same skips and notice. php-cs-fixer with the repository configuration reports nothing on the touched files.

The three normalizers have one test each for the nested maps, and each one fails without the fix. With both source changes reverted they fail with `Extra attributes are not allowed ("type", "nested_type", "baz" are unknown)`. With only the `getAllowedAttributes()` walk reverted they fail with `("nested_type", "baz" are unknown)`. With only the three `isAllowedAttribute()` call sites reverted they fail with `("type" is unknown)`. That is what makes each of the two changes load bearing. The two tests of the second commit both fail with the `TypeError` without it, and `testDenormalizeDiscriminatorMapKeepsIgnoredAttributes` also fails when the loop answers `false` for the whole call.
