### PR TITLE
[Serializer] Allow array indexes in the property paths of attributes when denormalizing

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
@@ -169,7 +169,7 @@ class ObjectNormalizer extends AbstractObjectNormalizer
             return self::$isWritableCache[$cacheKey];
         }
 
-        if (str_contains($attribute, '.') || $this->propertyInfoExtractor->isWritable($class, $attribute, $context)) {
+        if (str_contains($attribute, '.') || str_contains($attribute, '[') || $this->propertyInfoExtractor->isWritable($class, $attribute, $context)) {
             return self::$isWritableCache[$cacheKey] = true;
         }
 

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/property-path-mapping.yaml
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/property-path-mapping.yaml
@@ -3,3 +3,8 @@ Symfony\Component\Serializer\Tests\Normalizer\ObjectOuter:
         inner.foo:
             serialized_name: inner_foo
             groups: [ 'read' ]
+Symfony\Component\Serializer\Tests\Normalizer\ObjectWithArrayProperty:
+    attributes:
+        values[first]:
+            serialized_name: first_value
+            groups: [ 'read' ]

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -1050,6 +1050,16 @@ class ObjectNormalizerTest extends TestCase
         $this->assertEquals($expected, $obj);
     }
 
+    public function testDenormalizeWithPropertyPathIndex()
+    {
+        $classMetadataFactory = new ClassMetadataFactory(new YamlFileLoader(__DIR__.'/../Fixtures/property-path-mapping.yaml'));
+        $normalizer = new ObjectNormalizer($classMetadataFactory, new MetadataAwareNameConverter($classMetadataFactory));
+
+        $obj = $normalizer->denormalize(['first_value' => 'foo'], ObjectWithArrayProperty::class, 'json', ['groups' => 'read']);
+
+        $this->assertSame(['first' => 'foo'], $obj->values);
+    }
+
     public function testObjectNormalizerWithAttributeLoaderAndObjectHasStaticProperty()
     {
         $class = new class {
@@ -1670,6 +1680,11 @@ class ObjectInner
 {
     public $foo;
     public $bar;
+}
+
+class ObjectWithArrayProperty
+{
+    public array $values = [];
 }
 
 class LazyObjectInner extends ObjectInner


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #58689
| License       | MIT

`ObjectNormalizer` writes attributes through the PropertyAccess component, so the name of an attribute can be a property path. The writability check added in 6.4.7 does not understand property paths, and #57187 restored the ones made of dots. A path that addresses an array index is still refused, so its value is dropped without any error:

```yaml
App\Entity\Foo:
    attributes:
        segments[Default]:
            serialized_name: default_segment
```

The same happens for a plain payload key such as `segments[Default]`. Both were written until 6.4.6, when `AbstractNormalizer::isAllowedAttribute()` answered without looking at writability.

The exception made for dots now covers array indexes. What surrounds it is unchanged: a path whose first element names no property is still ignored, because PropertyAccess raises `NoSuchPropertyException` and `ObjectNormalizer::setAttributeValue()` catches it. Normalization already worked, since the read side asks PropertyAccess directly when the object is at hand, and it is untouched.

One trait of property paths is worth knowing, and it is not introduced here: when the property named by the path exists and holds `null`, PropertyAccess throws `UnexpectedTypeException` out of the denormalizer. Dot paths behave that way on 6.4 already, and array indexes now join them.

Checks: `./phpunit src/Symfony/Component/Serializer/Tests` returns 1152 tests, 2317 assertions, 11 skipped and one legacy deprecation notice. The same command on the base commit returns 1151 tests, 2316 assertions, and the same skips and notice. With the source change reverted and the test kept, the test fails with `Failed asserting that two arrays are identical`, the written array being empty.
