### PR TITLE
[Serializer] Fix XmlEncoder skipping normalizers for nested Traversable values

### DIFF
--- a/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Serializer\Encoder;
 
 use Symfony\Component\Serializer\Exception\BadMethodCallException;
 use Symfony\Component\Serializer\Exception\NotEncodableValueException;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\SerializerAwareInterface;
 use Symfony\Component\Serializer\SerializerAwareTrait;
 
@@ -454,7 +455,7 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
         } elseif ($val instanceof \SimpleXMLElement) {
             $child = $node->ownerDocument->importNode(dom_import_simplexml($val), true);
             $node->appendChild($child);
-        } elseif ($val instanceof \Traversable) {
+        } elseif ($val instanceof \Traversable && (!$this->serializer instanceof NormalizerInterface || !$this->serializer->supportsNormalization($val, $format))) {
             $this->buildXml($node, $val, $format, $context);
         } elseif ($val instanceof \DOMNode) {
             $child = $node->ownerDocument->importNode($val, true);

--- a/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
@@ -26,6 +26,7 @@ use Symfony\Component\Serializer\Tests\Fixtures\EnvelopeNormalizer;
 use Symfony\Component\Serializer\Tests\Fixtures\EnvelopeObject;
 use Symfony\Component\Serializer\Tests\Fixtures\NormalizableTraversableDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\ScalarDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\ScalarTraversableDummy;
 
 class XmlEncoderTest extends TestCase
 {
@@ -438,6 +439,21 @@ class XmlEncoderTest extends TestCase
             XML;
 
         $this->assertEquals($expected, $serializer->serialize(new NormalizableTraversableDummy(), 'xml'));
+    }
+
+    public function testEncodeNestedTraversableWhenNormalizable()
+    {
+        $serializer = new Serializer([new CustomNormalizer()], ['xml' => new XmlEncoder()]);
+
+        $expected = <<<'XML'
+            <?xml version="1.0"?>
+            <response><scalar>normalized</scalar><nested><foo>normalizedFoo</foo><bar>normalizedBar</bar></nested></response>
+
+            XML;
+
+        $data = ['scalar' => new ScalarTraversableDummy(), 'nested' => new NormalizableTraversableDummy()];
+
+        $this->assertSame($expected, $serializer->serialize($data, 'xml'));
     }
 
     public function testDecode()

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/ScalarTraversableDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/ScalarTraversableDummy.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+use Symfony\Component\Serializer\Normalizer\NormalizableInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+class ScalarTraversableDummy extends TraversableDummy implements NormalizableInterface
+{
+    public function normalize(NormalizerInterface $normalizer, ?string $format = null, array $context = []): array|string|int|float|bool
+    {
+        return 'normalized';
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #39255
| License       | MIT

`XmlEncoder::buildXml()` checks whether a normalizer claims the value before it iterates a `Traversable`:

```php
if (\is_array($data) || ($data instanceof \Traversable && (null === $this->serializer || !$this->serializer->supportsNormalization($data, $format)))) {
```

`selectNodeType()`, which handles every value nested inside a document, had no such check and always fell into `buildXml()` for a `Traversable`. `buildXml()` then re-applied its own check, normalized the object, and reached the branch that handles a top level object normalized into a scalar:

```php
// top level data object was normalized into a scalar
if (!$parentNode->parentNode->parentNode) {
    $root = $parentNode->parentNode;
    $root->removeChild($parentNode);
```

That branch assumes the node is already attached to the document. Nested nodes are built detached and attached afterwards by `appendNode()`, so `$parentNode->parentNode` is `null` there. Encoding any `Traversable` whose normalizer returns a scalar therefore ended in a warning followed by `Error: Call to a member function removeChild() on null`.

This patch gives `selectNodeType()` the same guard as `buildXml()`. A `Traversable` a normalizer claims now goes to the `is_object()` branch, which normalizes it and appends the result, exactly like a non `Traversable` object. The reproducer from the issue now returns `<response><id>fixed_id</id></response>`.

Nothing else changes. A `Traversable` without a serializer, or one no normalizer claims, still gets iterated as before. A `Traversable` whose normalizer returns an array already went through the normalizer, because `buildXml()` applied the guard one level down, and it produces the same document as before. `SimpleXMLElement` is matched by an earlier branch and is untouched. The two guards are now written identically, so no path can reach the top level branch of `buildXml()` with a detached node again.

The new test uses a new fixture, `ScalarTraversableDummy`, a `Traversable` that normalizes to a string. It sits next to `NormalizableTraversableDummy`, which normalizes to an array and is used by the existing `testEncodeTraversableWhenNormalizable`.

Checks run on 6.4:

- `./phpunit src/Symfony/Component/Serializer/Tests`: 1152 tests, 2317 assertions, 11 skipped, no failure. The same suite on the base commit reports 1151 tests, 2317 assertions, 11 skipped.
- `./phpunit src/Symfony/Component/Messenger/Tests`: 410 tests, 1139 assertions, no failure. Messenger builds an `XmlEncoder` in its serializer transport.
- `./phpunit src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/RequestPayloadValueResolverTest.php`: 49 tests, 101 assertions, no failure.
- Revert check: with `XmlEncoder.php` restored to its base state and the new test kept, `testEncodeNestedTraversableWhenNormalizable` errors with `Attempt to read property "parentNode" on null` at `XmlEncoder.php:405`, which is the reported failure.
- Output comparison on base and on the branch for a nested `Traversable` normalized to an array and for a generator under a string key: byte identical documents in both states.
- `php-cs-fixer fix --dry-run` on the touched files exits 0.

PHPStan was not run because the tool is not installed in this checkout. The added call, `$this->serializer->supportsNormalization($val, $format)`, is the same call `buildXml()` already makes on the same property.
