### PR TITLE
[Translation] Stop leaking a temporary schema copy per validated XLIFF file inside a phar

### DIFF
--- a/src/Symfony/Component/Translation/Tests/Util/XliffUtilsTest.php
+++ b/src/Symfony/Component/Translation/Tests/Util/XliffUtilsTest.php
@@ -81,6 +81,95 @@ class XliffUtilsTest extends TestCase
         }
     }
 
+    public function testSchemaValidationInsideAPharDoesNotLeakTemporaryFiles()
+    {
+        if (!\extension_loaded('phar')) {
+            $this->markTestSkipped('The "phar" extension is not loaded.');
+        }
+
+        $workspace = sys_get_temp_dir().\DIRECTORY_SEPARATOR.uniqid('symfony_xliff_phar_', false);
+        $tmpDir = $workspace.\DIRECTORY_SEPARATOR.'tmp';
+
+        if (!@mkdir($tmpDir, 0o777, true) && !is_dir($tmpDir)) {
+            $this->markTestSkipped(\sprintf('Could not create tmp dir "%s".', $tmpDir));
+        }
+
+        $code = <<<'EOPHP'
+            <?php
+
+            [, $componentDir, $workspace] = $argv;
+
+            if (!Phar::canWrite()) {
+                echo 'SKIP';
+                exit(0);
+            }
+
+            $phar = new Phar($workspace.'/translation.phar');
+            $phar->addFile($componentDir.'/Util/XliffUtils.php', 'Util/XliffUtils.php');
+            $phar->addFile($componentDir.'/Resources/schemas/xliff-core-1.2-transitional.xsd', 'Resources/schemas/xliff-core-1.2-transitional.xsd');
+            $phar->addFile($componentDir.'/Resources/schemas/xml.xsd', 'Resources/schemas/xml.xsd');
+            $phar->setStub('<?php __HALT_COMPILER();');
+            unset($phar);
+
+            require 'phar://'.$workspace.'/translation.phar/Util/XliffUtils.php';
+
+            $xliff = '<?xml version="1.0"?><xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2"><file source-language="en" datatype="plaintext" original="file.ext"><body><trans-unit id="1"><source>foo</source><target>bar</target></trans-unit></body></file></xliff>';
+
+            $validateAndCountTempFiles = function () use ($xliff) {
+                $dom = new DOMDocument();
+                $dom->loadXML($xliff);
+
+                if ([] !== $errors = Symfony\Component\Translation\Util\XliffUtils::validateSchema($dom)) {
+                    echo 'KO ', json_encode($errors);
+                    exit(1);
+                }
+
+                return count(glob(sys_get_temp_dir().'/symfony*'));
+            };
+
+            $afterOne = $validateAndCountTempFiles();
+
+            for ($i = 0; $i < 4; ++$i) {
+                $afterFive = $validateAndCountTempFiles();
+            }
+
+            echo 'OK ', $afterOne, ' ', $afterFive;
+            EOPHP;
+
+        $command = [\PHP_BINARY, '-d', 'phar.readonly=0', '-d', 'sys_temp_dir="'.$tmpDir.'"', '--', \dirname(__DIR__, 2), $workspace];
+
+        if (!\is_resource($process = @proc_open($command, [['pipe', 'r'], ['pipe', 'w'], ['pipe', 'w']], $pipes))) {
+            $this->markTestSkipped('Could not start a PHP subprocess.');
+        }
+
+        try {
+            fwrite($pipes[0], $code);
+            fclose($pipes[0]);
+            $output = stream_get_contents($pipes[1]);
+            $error = stream_get_contents($pipes[2]);
+            fclose($pipes[1]);
+            fclose($pipes[2]);
+
+            $this->assertSame(0, proc_close($process), $output.$error);
+
+            if ('SKIP' === $output) {
+                $this->markTestSkipped('Phar archives cannot be created.');
+            }
+
+            [$status, $afterOne, $afterFive] = explode(' ', $output) + [null, null, null];
+            $this->assertSame('OK', $status, $output.$error);
+            $this->assertSame($afterOne, $afterFive, 'Validating more files must not copy the schema again.');
+            $this->assertSame([], glob($tmpDir.'/symfony*'), 'Temporary files must be removed when the process ends.');
+        } finally {
+            foreach (glob($tmpDir.'/*') as $file) {
+                @unlink($file);
+            }
+            @unlink($workspace.'/translation.phar');
+            @rmdir($tmpDir);
+            @rmdir($workspace);
+        }
+    }
+
     /**
      * @return array{php_warnings: list<string>, libxml_errors: list<string>}
      */

--- a/src/Symfony/Component/Translation/Util/XliffUtils.php
+++ b/src/Symfony/Component/Translation/Util/XliffUtils.php
@@ -159,11 +159,18 @@ class XliffUtils
      */
     private static function fixXmlLocation(string $schemaSource, string $xmlUri): string
     {
-        $path = __DIR__.'/../Resources/schemas/xml.xsd';
+        static $newPath;
 
-        if (0 === stripos($path, 'phar://')) {
-            if ($tmpfile = tempnam(sys_get_temp_dir(), 'symfony')) {
+        if (null === $newPath) {
+            $path = __DIR__.'/../Resources/schemas/xml.xsd';
+
+            if (0 !== stripos($path, 'phar://')) {
+                $newPath = self::getFileUrl($path);
+            } elseif ($tmpfile = tempnam(sys_get_temp_dir(), 'symfony')) {
                 copy($path, $tmpfile);
+                register_shutdown_function(static function () use ($tmpfile) {
+                    @unlink($tmpfile);
+                });
                 $newPath = self::getFileUrl($tmpfile);
             } else {
                 $parts = explode('/', '\\' === \DIRECTORY_SEPARATOR ? str_replace('\\', '/', $path) : $path);
@@ -171,8 +178,6 @@ class XliffUtils
                 $drive = '\\' === \DIRECTORY_SEPARATOR ? array_shift($parts).'/' : '';
                 $newPath = 'phar:///'.$drive.implode('/', array_map('rawurlencode', $parts));
             }
-        } else {
-            $newPath = self::getFileUrl($path);
         }
 
         return str_replace($xmlUri, $newPath, $schemaSource);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #49499
| License       | MIT

`XliffUtils::validateSchema()` validates an XLIFF file against an XSD that pulls in `xml.xsd`. When the component runs from a phar archive, the path of that shipped `xml.xsd` starts with `phar://`, so `XliffUtils` copies it to a temporary file and points the schema at that copy through a plain `file:///` URL.

The copy was made again for every validated file, and it was never removed. An application packaged as a phar left one 9 KB file behind in the system temporary directory per XLIFF file it read. The report counted about 166 leftovers for a single `cache:clear`.

The location of that schema does not depend on the file being validated, so it is now resolved once per process, and the temporary copy is unlinked on shutdown, the way `shouldEnableEntityLoader()` already does for the file it creates.

Nothing changes outside a phar. The schema location is still the `file:///` URL of the shipped `xml.xsd`, only computed once instead of once per validated file.

Checks run:

* New test `XliffUtilsTest::testSchemaValidationInsideAPharDoesNotLeakTemporaryFiles`. It builds a phar holding `XliffUtils` and the schemas, validates five XLIFF documents in a subprocess that has its own temporary directory, then asserts that the number of temporary files does not grow with the number of validated documents and that none of them survives the process. On the base commit it reports 2 files after one validation and 6 after five. With only the caching half of the fix applied, it still finds one file left after the process ends, so both halves are covered.
* `./phpunit src/Symfony/Component/Translation/Tests`: 577 tests, 1110 assertions, green. The same run on the base commit gives 576 tests, 1106 assertions, and the same 2 legacy deprecation notices.
* The three `TranslationFilesTest` suites that call `XliffUtils` (Validator, Security/Core, Form): 115 tests and 117 assertions each, green.
