### PR TITLE
[TwigBridge] Fix the broken error box around Bootstrap 4 date and time widgets

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
@@ -26,7 +26,7 @@
 
 {% block datetime_widget -%}
     {%- if widget != 'single_text' and not valid -%}
-        {% set attr = attr|merge({class: (attr.class|default('') ~ ' form-control is-invalid')|trim}) -%}
+        {% set attr = attr|merge({class: (attr.class|default('') ~ ' is-invalid')|trim}) -%}
         {% set valid = true %}
     {%- endif -%}
     {{- parent() -}}
@@ -34,7 +34,7 @@
 
 {% block date_widget -%}
     {%- if widget != 'single_text' and not valid -%}
-        {% set attr = attr|merge({class: (attr.class|default('') ~ ' form-control is-invalid')|trim}) -%}
+        {% set attr = attr|merge({class: (attr.class|default('') ~ ' is-invalid')|trim}) -%}
         {% set valid = true %}
     {%- endif -%}
     {{- parent() -}}
@@ -42,7 +42,7 @@
 
 {% block time_widget -%}
     {%- if widget != 'single_text' and not valid -%}
-        {% set attr = attr|merge({class: (attr.class|default('') ~ ' form-control is-invalid')|trim}) -%}
+        {% set attr = attr|merge({class: (attr.class|default('') ~ ' is-invalid')|trim}) -%}
         {% set valid = true %}
     {%- endif -%}
     {{- parent() -}}
@@ -50,7 +50,7 @@
 
 {% block dateinterval_widget -%}
     {%- if widget != 'single_text' and not valid -%}
-        {% set attr = attr|merge({class: (attr.class|default('') ~ ' form-control is-invalid')|trim}) -%}
+        {% set attr = attr|merge({class: (attr.class|default('') ~ ' is-invalid')|trim}) -%}
         {% set valid = true %}
     {%- endif -%}
     {%- if widget == 'single_text' -%}

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap4LayoutTestCase.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap4LayoutTestCase.php
@@ -14,6 +14,8 @@ namespace Symfony\Bridge\Twig\Tests\Extension;
 use Symfony\Component\Form\Extension\Core\Type\ButtonType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\DateIntervalType;
+use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Form\Extension\Core\Type\DateType;
 use Symfony\Component\Form\Extension\Core\Type\FileType;
 use Symfony\Component\Form\Extension\Core\Type\MoneyType;
@@ -21,6 +23,7 @@ use Symfony\Component\Form\Extension\Core\Type\PercentType;
 use Symfony\Component\Form\Extension\Core\Type\RadioType;
 use Symfony\Component\Form\Extension\Core\Type\RangeType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\TimeType;
 use Symfony\Component\Form\FormError;
 
 /**
@@ -1275,6 +1278,66 @@ abstract class AbstractBootstrap4LayoutTestCase extends AbstractBootstrap3Layout
     [@min="5"]
     [@max="57"]
     [@class="my&class form-control-range"]
+'
+        );
+    }
+
+    public function testDateTimeWithError()
+    {
+        $form = $this->factory->createNamed('name', DateTimeType::class, null, [
+            'input' => 'string',
+            'with_seconds' => false,
+            'widget' => 'choice',
+        ]);
+        $form->submit(['date' => ['year' => '2018', 'month' => '2', 'day' => '3'], 'time' => ['hour' => '4', 'minute' => '5']]);
+        $form->addError(new FormError('[trans]Error![/trans]'));
+
+        $this->assertWidgetMatchesXpath($form->createView(), ['attr' => ['class' => 'my&class']],
+            '/div
+    [@class="my&class is-invalid form-inline"]
+    [count(.//select)=5]
+'
+        );
+    }
+
+    public function testDateWithError()
+    {
+        $form = $this->factory->createNamed('name', DateType::class, null, ['widget' => 'choice']);
+        $form->submit(['year' => '2018', 'month' => '2', 'day' => '3']);
+        $form->addError(new FormError('[trans]Error![/trans]'));
+
+        $this->assertWidgetMatchesXpath($form->createView(), ['attr' => ['class' => 'my&class']],
+            '/div
+    [@class="my&class is-invalid form-inline"]
+    [count(.//select)=3]
+'
+        );
+    }
+
+    public function testTimeWithError()
+    {
+        $form = $this->factory->createNamed('name', TimeType::class, null, ['widget' => 'choice']);
+        $form->submit(['hour' => '4', 'minute' => '5']);
+        $form->addError(new FormError('[trans]Error![/trans]'));
+
+        $this->assertWidgetMatchesXpath($form->createView(), ['attr' => ['class' => 'my&class']],
+            '/div
+    [@class="my&class is-invalid form-inline"]
+    [count(.//select)=2]
+'
+        );
+    }
+
+    public function testDateIntervalWithError()
+    {
+        $form = $this->factory->createNamed('name', DateIntervalType::class);
+        $form->submit(['years' => '1', 'months' => '2', 'days' => '3']);
+        $form->addError(new FormError('[trans]Error![/trans]'));
+
+        $this->assertWidgetMatchesXpath($form->createView(), ['attr' => ['class' => 'my&class']],
+            '/div
+    [@class="my&class is-invalid form-inline"]
+    [count(.//select)=3]
 '
         );
     }

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap5LayoutTestCase.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap5LayoutTestCase.php
@@ -16,6 +16,7 @@ use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\ColorType;
 use Symfony\Component\Form\Extension\Core\Type\CountryType;
+use Symfony\Component\Form\Extension\Core\Type\DateIntervalType;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Form\Extension\Core\Type\DateType;
 use Symfony\Component\Form\Extension\Core\Type\FileType;
@@ -1889,6 +1890,66 @@ abstract class AbstractBootstrap5LayoutTestCase extends AbstractBootstrap4Layout
         /following-sibling::label
             [@for="name"]
     ]
+'
+        );
+    }
+
+    public function testDateTimeWithError()
+    {
+        $form = $this->factory->createNamed('name', DateTimeType::class, null, [
+            'input' => 'string',
+            'with_seconds' => false,
+            'widget' => 'choice',
+        ]);
+        $form->submit(['date' => ['year' => '2018', 'month' => '2', 'day' => '3'], 'time' => ['hour' => '4', 'minute' => '5']]);
+        $form->addError(new FormError('[trans]Error![/trans]'));
+
+        $this->assertWidgetMatchesXpath($form->createView(), ['attr' => ['class' => 'my&class']],
+            '/div
+    [@class="my&class is-invalid"]
+    [count(.//select)=5]
+'
+        );
+    }
+
+    public function testDateWithError()
+    {
+        $form = $this->factory->createNamed('name', DateType::class, null, ['widget' => 'choice']);
+        $form->submit(['year' => '2018', 'month' => '2', 'day' => '3']);
+        $form->addError(new FormError('[trans]Error![/trans]'));
+
+        $this->assertWidgetMatchesXpath($form->createView(), ['attr' => ['class' => 'my&class']],
+            '/div
+    [@class="my&class is-invalid"]
+    [count(.//select)=3]
+'
+        );
+    }
+
+    public function testTimeWithError()
+    {
+        $form = $this->factory->createNamed('name', TimeType::class, null, ['widget' => 'choice']);
+        $form->submit(['hour' => '4', 'minute' => '5']);
+        $form->addError(new FormError('[trans]Error![/trans]'));
+
+        $this->assertWidgetMatchesXpath($form->createView(), ['attr' => ['class' => 'my&class']],
+            '/div
+    [@class="my&class is-invalid"]
+    [count(.//select)=2]
+'
+        );
+    }
+
+    public function testDateIntervalWithError()
+    {
+        $form = $this->factory->createNamed('name', DateIntervalType::class);
+        $form->submit(['years' => '1', 'months' => '2', 'days' => '3']);
+        $form->addError(new FormError('[trans]Error![/trans]'));
+
+        $this->assertWidgetMatchesXpath($form->createView(), ['attr' => ['class' => 'my&class']],
+            '/div
+    [@class="my&class is-invalid"]
+    [count(.//select)=3]
 '
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #29147
| License       | MIT

When a `DateType`, `TimeType`, `DateTimeType` or `DateIntervalType` field is rendered with any widget other than `single_text` and the field is invalid, the Bootstrap 4 theme merges `form-control is-invalid` into the attributes of the `<div>` that wraps the sub widgets:

```twig
{% block datetime_widget -%}
    {%- if widget != 'single_text' and not valid -%}
        {% set attr = attr|merge({class: (attr.class|default('') ~ ' form-control is-invalid')|trim}) -%}
```

That container is not a form control. Bootstrap renders `.form-control` as a single line input with its own height, border and padding, and since Bootstrap 4.2 it also paints an error icon inside `.form-control.is-invalid`. Applied to a container that holds several `<select>` elements, this draws a second box around the whole group with the error cross floating in it, which is the broken rendering reported in the issue.

The Bootstrap 5 theme already merges `is-invalid` alone in the same four blocks. This change does the same in the Bootstrap 4 theme, for the `datetime`, `date`, `time` and `dateinterval` widgets.

Two points worth knowing:

* The error messages stay visible. The theme prints them in a `<span class="invalid-feedback d-block ...">`, and the `d-block` utility forces the display, so it does not depend on a preceding `.form-control.is-invalid` sibling the way plain Bootstrap markup does. I checked the rendered row of an invalid compound `DateTimeType` with a probe script: the feedback span and both messages are still there after the change.
* The container keeps `is-invalid`, so a project that styles the compound widget itself keeps its hook. An earlier attempt (#29158) deleted the whole `datetime_widget` override instead, which dropped that hook and only covered one of the four widgets. It was refused for that reason.

Checks run, all from the branch root with PHP 8.5 and PHPUnit 9.6:

* `./phpunit src/Symfony/Bridge/Twig/Tests` after the change: 1772 tests, 2058 assertions, 14 skipped, 1 legacy deprecation notice, no failure. The same suite on the base commit: 1756 tests, 2042 assertions, 14 skipped, 1 legacy deprecation notice, no failure. The skips and the deprecation notice are pre-existing and unrelated.
* Revert check: with the template put back to its base state and the new tests kept, the 4 new Bootstrap 4 tests and their 4 horizontal counterparts fail with `matches exactly once. Matches 0 times in <div id="my&id" class="my&class form-control is-invalid form-inline">`. The 8 Bootstrap 5 counterparts pass in that state, as expected, since they guard behavior the Bootstrap 5 theme already had.
* PHP CS Fixer on the two touched test files: nothing to fix.

The tests are `testDateTimeWithError`, `testDateWithError`, `testTimeWithError` and `testDateIntervalWithError`, added to `AbstractBootstrap4LayoutTestCase` and overridden in `AbstractBootstrap5LayoutTestCase` with the class the Bootstrap 5 theme produces. Through the layout test hierarchy they run against the four themes: Bootstrap 4, Bootstrap 4 horizontal, Bootstrap 5 and Bootstrap 5 horizontal.
