### PR TITLE
[HttpKernel] Send the response content before terminating the kernel in the test client

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpKernelBrowser.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernelBrowser.php
@@ -32,6 +32,8 @@ class HttpKernelBrowser extends AbstractBrowser
 {
     protected $kernel;
     private bool $catchExceptions = true;
+    private ?object $sentResponse = null;
+    private string $sentContent = '';
 
     /**
      * @param array $server The server parameters (equivalent of $_SERVER)
@@ -63,6 +65,15 @@ class HttpKernelBrowser extends AbstractBrowser
     protected function doRequest(object $request)
     {
         $response = $this->kernel->handle($request, HttpKernelInterface::MAIN_REQUEST, $this->catchExceptions);
+
+        // the content must be sent before the kernel is terminated, as when serving a real request
+        ob_start();
+        try {
+            $response->sendContent();
+        } finally {
+            $this->sentResponse = $response;
+            $this->sentContent = ob_get_clean();
+        }
 
         if ($this->kernel instanceof TerminableInterface) {
             $this->kernel->terminate($request, $response);
@@ -188,10 +199,16 @@ class HttpKernelBrowser extends AbstractBrowser
      */
     protected function filterResponse(object $response): DomResponse
     {
-        // this is needed to support StreamedResponse
-        ob_start();
-        $response->sendContent();
-        $content = ob_get_clean();
+        if ($response === $this->sentResponse) {
+            $content = $this->sentContent;
+            $this->sentResponse = null;
+            $this->sentContent = '';
+        } else {
+            // this is needed to support StreamedResponse
+            ob_start();
+            $response->sendContent();
+            $content = ob_get_clean();
+        }
 
         return new DomResponse($content, $response->getStatusCode(), $response->headers->all());
     }

--- a/src/Symfony/Component/HttpKernel/Tests/HttpKernelBrowserTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpKernelBrowserTest.php
@@ -18,6 +18,8 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpKernel\HttpKernelBrowser;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\TerminableInterface;
 use Symfony\Component\HttpKernel\Tests\Fixtures\MockableUploadFileWithClientSize;
 use Symfony\Component\HttpKernel\Tests\Fixtures\TestClient;
 
@@ -43,6 +45,33 @@ class HttpKernelBrowserTest extends TestCase
 
         $client->request('GET', 'http://www.example.com/?parameter=http://example.com');
         $this->assertEquals('http://www.example.com/?parameter='.urlencode('http://example.com'), $client->getRequest()->getUri(), '->doRequest() uses the request handler to make the request');
+    }
+
+    public function testKernelIsTerminatedAfterTheResponseContentIsSent()
+    {
+        $kernel = new class implements HttpKernelInterface, TerminableInterface {
+            public array $calls = [];
+
+            public function handle(Request $request, int $type = self::MAIN_REQUEST, bool $catch = true): Response
+            {
+                return new StreamedResponse(function () {
+                    $this->calls[] = 'sendContent';
+
+                    echo 'streamed content';
+                });
+            }
+
+            public function terminate(Request $request, Response $response): void
+            {
+                $this->calls[] = 'terminate';
+            }
+        };
+
+        $client = new HttpKernelBrowser($kernel);
+        $client->request('GET', '/');
+
+        $this->assertSame(['sendContent', 'terminate'], $kernel->calls);
+        $this->assertSame('streamed content', $client->getInternalResponse()->getContent());
     }
 
     public function testGetScript()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #16293
| License       | MIT

When a request is served for real, the front controller calls `$response->send()` first and `$kernel->terminate()` after. `TerminableInterface` documents that order: terminate "should be called after sending the response and before shutting down the kernel".

The test client does the opposite. `HttpKernelBrowser::doRequest()` terminates the kernel as soon as the kernel returned the response, and the content is sent later, in `filterResponse()`, when the browser converts the framework response into a BrowserKit one. Every listener on `kernel.terminate` therefore runs before the content is produced.

The visible symptom is a `kernel.terminate` listener that cleans up something the response still needs. A controller that returns a `BinaryFileResponse` for a temporary file and deletes that file on `kernel.terminate` works in a browser and fails under the test client:

```
Warning: fopen(/tmp/....pdf): Failed to open stream: No such file or directory
TypeError: feof(): Argument #1 ($stream) must be of type resource, false given
```

A `StreamedResponse` whose callback reads state that terminate listeners tear down fails the same way.

This patch sends the content in `doRequest()`, right before the kernel is terminated, and lets `filterResponse()` reuse the content captured for that response. `filterResponse()` still sends the content itself when it gets a response that did not come from `doRequest()`, which keeps insulated requests and direct calls working. The content is still captured with an output buffer, so nothing is printed; the buffer is now closed in a `finally` block, so a response that throws while sending no longer leaves an open buffer that hides the rest of the test output.

Two known limits. Insulated requests (`$client->insulate()`) keep sending the content in the parent process, after the child process terminated the kernel, because the response crosses a process boundary and the content cannot travel with it without changing the protocol between the two processes. And a custom browser that overrides `filterResponse()` without calling the parent implementation now gets a response whose content has already been sent.

Checks run on PHP 8.5, on the 6.4 branch:

* the new test `HttpKernelBrowserTest::testKernelIsTerminatedAfterTheResponseContentIsSent` fails on the unpatched source with `['terminate', 'sendContent']` where `['sendContent', 'terminate']` is expected, and passes with the patch;
* `./phpunit src/Symfony/Component/HttpKernel/Tests`: OK, 1218 tests, 2960 assertions;
* `./phpunit src/Symfony/Component/BrowserKit/Tests`: OK, 242 tests, 587 assertions;
* `./phpunit src/Symfony/Bundle/SecurityBundle/Tests/Functional`: OK, 115 tests, 372 assertions;
* `./phpunit src/Symfony/Bundle/WebProfilerBundle/Tests`: OK, 137 tests, 392 assertions;
* `./phpunit src/Symfony/Bundle/FrameworkBundle/Tests/Functional`: 208 tests, 620 assertions, one error in `ConfigDebugCommandTest` caused by a cache directory shared between parallel local runs; that file passes on its own (38 tests, 112 assertions);
* php-cs-fixer on both touched files: no change.

Merge-up note: on 7.4 and up, `filterResponse()` captures the content with an `ob_start()` callback inside a `try`/`finally`. The resolution is the same as here: move that capture block into `doRequest()` before the `terminate()` call, keep the captured response and content in the two new properties, and keep the sending branch in `filterResponse()` for responses that did not come from `doRequest()`.
