### PR TITLE
[DoctrineBridge] Filter out invalid GUID values in the entity loader

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/ChoiceList/ORMQueryBuilderLoader.php
+++ b/src/Symfony/Bridge/Doctrine/Form/ChoiceList/ORMQueryBuilderLoader.php
@@ -14,6 +14,7 @@ namespace Symfony\Bridge\Doctrine\Form\ChoiceList;
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\GuidType;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\QueryBuilder;
 use Symfony\Bridge\Doctrine\Types\AbstractUidType;
@@ -78,6 +79,12 @@ class ORMQueryBuilderLoader implements EntityLoaderInterface
             // Convert values into right type
             if (Type::hasType($type)) {
                 $doctrineType = Type::getType($type);
+
+                if ($doctrineType instanceof GuidType) {
+                    // This type doesn't check its values, so filter out the ones that databases such as PostgreSQL reject
+                    $values = array_values(array_filter($values, static fn ($v) => preg_match('/^\{[0-9a-f]{4}(?:-?[0-9a-f]{4}){7}\}$|^[0-9a-f]{4}(?:-?[0-9a-f]{4}){7}$/i', (string) $v)));
+                }
+
                 $platform = $qb->getEntityManager()->getConnection()->getDatabasePlatform();
                 foreach ($values as &$value) {
                     try {

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/ChoiceList/ORMQueryBuilderLoaderTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/ChoiceList/ORMQueryBuilderLoaderTest.php
@@ -24,6 +24,7 @@ use Symfony\Bridge\Doctrine\Form\ChoiceList\ORMQueryBuilderLoader;
 use Symfony\Bridge\Doctrine\Tests\DoctrineTestHelper;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\CustomUuidIdType;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\EmbeddedIdentifierEntity;
+use Symfony\Bridge\Doctrine\Tests\Fixtures\GuidIdEntity;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\LegacyQueryMock;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdEntity;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\SingleStringIdEntity;
@@ -145,6 +146,37 @@ class ORMQueryBuilderLoaderTest extends TestCase
 
         $loader = new ORMQueryBuilderLoader($qb);
         $loader->getEntitiesByIds('id', ['71c5fd46-3f16-4abb-bad7-90ac1e654a2d', '', 'b98e8e11-2897-44df-ad24-d2627eb7f499']);
+    }
+
+    public function testFilterInvalidGuids()
+    {
+        $em = DoctrineTestHelper::createTestEntityManager();
+
+        $query = $this->getQueryMock();
+
+        $query
+            ->method('getResult')
+            ->willReturn([]);
+
+        $query->expects($this->once())
+            ->method('setParameter')
+            ->with('ORMQueryBuilderLoader_getEntitiesByIds_id', ['71c5fd46-3f16-4abb-bad7-90ac1e654a2d', 'B98E8E11289744DFAD24D2627EB7F499', '{4d0a0dcb-2ba2-4b30-b4b5-2b3e26b45ae7}'], class_exists(ArrayParameterType::class) ? ArrayParameterType::STRING : Connection::PARAM_STR_ARRAY)
+            ->willReturn($query);
+
+        $qb = $this->getMockBuilder(QueryBuilder::class)
+            ->setConstructorArgs([$em])
+            ->onlyMethods(['getQuery'])
+            ->getMock();
+
+        $qb->expects($this->once())
+            ->method('getQuery')
+            ->willReturn($query);
+
+        $qb->select('e')
+            ->from(GuidIdEntity::class, 'e');
+
+        $loader = new ORMQueryBuilderLoader($qb);
+        $loader->getEntitiesByIds('id', ['71c5fd46-3f16-4abb-bad7-90ac1e654a2d', 'foo', 1, 'B98E8E11289744DFAD24D2627EB7F499', '{4d0a0dcb-2ba2-4b30-b4b5-2b3e26b45ae7}', '{4d0a0dcb-2ba2-4b30-b4b5-2b3e26b45ae7']);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #17488
| License       | MIT

`ORMQueryBuilderLoader::getEntitiesByIds()` passes the submitted identifiers to the database as they are. For integer identifiers it already drops the values the column cannot hold, because PostgreSQL raises an error on them. Identifiers mapped to the `guid` type had no such filter: Doctrine's `GuidType` extends `StringType` and converts nothing, so a value like `asdf` reached the query and PostgreSQL answered `SQLSTATE[22P02]: Invalid text representation: 7 ERROR: invalid input syntax for uuid: "asdf"`. Any form with an `EntityType` field pointing at an entity with a `guid` identifier therefore turned an invalid submission into a 500 response.

Identifiers mapped to the `uuid` and `ulid` types are already covered: those types refuse what they cannot convert, and the loader turns that refusal into a `TransformationFailedException`.

This patch drops the values a `guid` column cannot hold, the way the integer branch above it does. The check accepts everything PostgreSQL accepts for its `uuid` type, that is 32 hexadecimal digits, with optional surrounding braces and an optional hyphen after any group of four digits. Being that permissive means no value the database could have matched is dropped. What is dropped is now reported by the form as an invalid choice, which is what MySQL and SQLite users already got for the same input.

Behavior change to be aware of: on a platform without a native GUID type, a `guid` column is a plain `CHAR(36)` and can hold anything. An entity whose identifier is not shaped like a UUID is no longer looked up and its choice is reported as invalid.

Checks run:
- `./phpunit src/Symfony/Bridge/Doctrine/Tests/Form/ChoiceList/ORMQueryBuilderLoaderTest.php` with the source change stashed: the new test fails with `Failed asserting that two arrays are equal`, the actual array still holding `foo`, `1` and the value with an unbalanced brace. The 12 other tests of the file pass, so the test proves the fix and does not just pin existing behavior.
- `./phpunit src/Symfony/Bridge/Doctrine/Tests`: 454 tests, 1052 assertions, 22 skipped, green. Same result on the base commit apart from the new test.
- php-cs-fixer on the two touched directories: no change reported.
