### PR TITLE
[Process] Do not wait for output when the input iterator has more data

### DIFF
--- a/src/Symfony/Component/Process/Pipes/AbstractPipes.php
+++ b/src/Symfony/Component/Process/Pipes/AbstractPipes.php
@@ -175,11 +175,25 @@ abstract class AbstractPipes implements PipesInterface
             $this->input = null;
             fclose($this->pipes[0]);
             unset($this->pipes[0]);
-        } elseif (!$w) {
+        } elseif (!$w || $this->hasReadyInput()) {
             return [$this->pipes[0]];
         }
 
         return null;
+    }
+
+    /**
+     * Tells whether the next chunk of input can be written without waiting.
+     */
+    private function hasReadyInput(): bool
+    {
+        if (!$this->input instanceof \Iterator || !$this->input->valid()) {
+            return false;
+        }
+
+        $input = $this->input->current();
+
+        return \is_scalar($input) && '' !== (string) $input;
     }
 
     private function closeBrokenInputPipe(): void

--- a/src/Symfony/Component/Process/Tests/ProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessTest.php
@@ -1249,6 +1249,23 @@ class ProcessTest extends TestCase
         $this->assertSame('pingpong', $process->getOutput());
     }
 
+    public function testIteratorInputDoesNotWaitForOutput()
+    {
+        $writes = [];
+        $input = static function () use (&$writes) {
+            for ($i = 0; $i < 20; ++$i) {
+                $writes[] = microtime(true);
+                yield 'x';
+            }
+        };
+
+        $process = $this->getProcessForCode('while (!feof(STDIN)) { fread(STDIN, 1024); }', null, null, $input());
+        $process->run();
+
+        $this->assertCount(20, $writes);
+        $this->assertLessThan(Process::TIMEOUT_PRECISION, end($writes) - $writes[0]);
+    }
+
     public function testSimpleInputStream()
     {
         $input = new InputStream();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #20114
| License       | MIT

Feeding a process with an iterator (a generator, an `InputStream`, another `Process`) transfers one item every 200ms when the child writes nothing on stdout and stderr. On a 4 bytes per item generator this is 20 bytes per second.

`AbstractPipes::write()` moves one item of the iterator into the write buffer, writes that buffer to stdin, and returns `null` once everything went through. `null` means "no pipe is waiting for a write", so `UnixPipes::readAndWrite()` polls stdout and stderr alone and waits there for `Process::TIMEOUT_PRECISION`, which is 0.2 seconds. A silent child never interrupts that wait, so the next item is sent only when the poll expires. `WindowsPipes::readAndWrite()` has the same shape and calls `usleep()` for the same duration.

The patch reports stdin as pending when the input iterator holds another chunk that is ready to be written. The poll then keeps stdin in its write set and returns as soon as the pipe accepts more data. Two cases are left untouched on purpose:

* when the stdin pipe is full, the poll still blocks until the child drains it, so a child that ignores its input does not spin;
* when the iterator has nothing ready, which is what `InputStream` signals by yielding an empty string, the poll still blocks on the read side, so an idle input keeps costing no CPU.

Measurements on Linux with php 8.5, a generator feeding `php -r 'while (!feof(STDIN)) { fread(STDIN, 1024); }'`:

| items | before | after |
| ----- | ------ | ----- |
| 50 | 4.62s | 0.06s |
| 20000 | timed out after 60s | 0.33s |

Parent CPU while an `InputStream` stays idle for one second: 0.071s before, 0.073s after. Parent CPU for the 20000 items run: 0.32s.

Checks that were run:

* new test `ProcessTest::testIteratorInputDoesNotWaitForOutput`, which sends 20 items to a silent child and asserts the whole transfer takes less than one poll window. On the unpatched source it fails with `Failed asserting that 1.6050550937652588 is less than 0.2`; with the patch the same run measures 0.003s.
* full `src/Symfony/Component/Process` suite with the patch: 185 tests, 309 assertions, 6 skipped, no failure. The same suite with the source file reverted and the test kept: the new test is the only failure.
* php-cs-fixer on both changed files: no change reported.
* manual probes on iterator items that are stream resources, empty items mixed with data, items larger than the pipe buffer, a child that never reads stdin under a 1 second timeout, a process piped into another process, and an `InputStream` written from the output callback. All behave as before, and the child that ignores stdin still times out after 1.008s using 0.002s of CPU.

The issue is labeled Enhancement and Performance. It reads as a bug in the polling loop to me: `write()` does not report a pipe it has data for, so the loop sleeps although work is pending. The code is identical on 6.4, 7.4, 8.1 and 8.2, so the patch applies unchanged if it should target the development branch instead. Windows was not tested locally; the change reaches `WindowsPipes` through the same return value and removes the `usleep()` there as well.
