### PR TITLE
[Serializer] Fix XmlEncoder dropping the extra attributes of item elements on decode

### DIFF
--- a/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
@@ -310,7 +310,7 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
             $val = $this->parseXml($subnode, $context);
 
             if ('item' === $subnode->nodeName && isset($val['@key'])) {
-                $value[$val['@key']] = $val['#'] ?? $val;
+                $value[$val['@key']] = 2 === \count($val) && isset($val['#']) ? $val['#'] : $val;
             } else {
                 $value[$subnode->nodeName][] = $val;
             }

--- a/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
@@ -758,6 +758,20 @@ class XmlEncoderTest extends TestCase
         $this->assertEquals($expected, $this->encoder->decode($xml, 'xml'));
     }
 
+    public function testDecodeItemWithAdditionalAttributes()
+    {
+        $source = '<?xml version="1.0"?>'."\n".
+            '<response><item key="0" foo="bar"/><item key="1" foo="baz">qux</item><item key="2">quux</item></response>'."\n";
+
+        $expected = [
+            0 => ['@key' => 0, '@foo' => 'bar', '#' => ''],
+            1 => ['@key' => 1, '@foo' => 'baz', '#' => 'qux'],
+            2 => 'quux',
+        ];
+
+        $this->assertSame($expected, $this->encoder->decode($source, 'xml'));
+    }
+
     public function testDecodeInvalidXml()
     {
         $this->expectException(UnexpectedValueException::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #23302
| License       | MIT

When `XmlEncoder` decodes a document, an element named `item` that carries a `key` attribute is treated as one entry of a PHP array: the `key` attribute becomes the array key and the element becomes the value. The code that did this read only the text content of the element and threw away everything else:

```php
$value[$val['@key']] = $val['#'] ?? $val;
```

Every other attribute of the element was lost. Encoding `[['@foo' => 'bar']]` gives `<response><item key="0" foo="bar"/></response>`, and decoding that back gave `[0 => '']` instead of the data that went in.

An element with any other name does not lose anything: `<foo bar="baz">qux</foo>` decodes to `['@bar' => 'baz', '#' => 'qux']`. This patch gives `item` elements the same treatment. The text content is still returned on its own when `key` is the only attribute, which is the common case produced by the encoder, so `<item key="0">baz</item>` still decodes to `[0 => 'baz']`. When the element carries more attributes, the full array is returned instead:

```xml
<response><item key="0" foo="bar"/><item key="1" foo="baz">qux</item><item key="2">quux</item></response>
```

now decodes to:

```php
[
    0 => ['@key' => 0, '@foo' => 'bar', '#' => ''],
    1 => ['@key' => 1, '@foo' => 'baz', '#' => 'qux'],
    2 => 'quux',
]
```

`@key` stays inside the returned array. That is what the decoder already does for an `item` element holding child elements, and `XmlEncoderTest::testDecodeWithoutItemHash` asserts it, so the patch does not change it. Removing it everywhere would be a separate behavior change.

The only inputs whose decoded value changes are `item` elements that carry attributes besides `key`. Those are exactly the inputs that silently lost data before.

Checks run on 6.4:

- `./phpunit src/Symfony/Component/Serializer/Tests`: 1152 tests, 2317 assertions, 11 skipped, no failure. The same suite on the base commit reports 1151 tests, 2317 assertions, 11 skipped.
- `./phpunit src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/RequestPayloadValueResolverTest.php` (the other place in the tree that decodes XML through this encoder): 49 tests, 101 assertions, no failure.
- Revert check: with `XmlEncoder.php` restored to its base state and the new test kept, `testDecodeItemWithAdditionalAttributes` fails with `Failed asserting that two arrays are identical`, reporting `0 => ''` and `1 => 'qux'` where the arrays are expected.
- `php-cs-fixer fix --dry-run` on the touched files exits 0.

PHPStan was not run because the tool is not installed in this checkout. The patch adds no new call, only a condition on existing local values.
