### PR TITLE
[Console] Keep backslashes preceding < and > when escaping text

### DIFF
--- a/src/Symfony/Component/Console/Formatter/OutputFormatter.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatter.php
@@ -41,7 +41,7 @@ class OutputFormatter implements WrappableOutputFormatterInterface
      */
     public static function escape(string $text): string
     {
-        $text = preg_replace('/([^\\\\]|^)([<>])/', '$1\\\\$2', $text);
+        $text = str_replace(['<', '>'], ['\\<', '\\>'], $text);
 
         return self::escapeTrailingBackslash($text);
     }

--- a/src/Symfony/Component/Console/Tests/Formatter/OutputFormatterTest.php
+++ b/src/Symfony/Component/Console/Tests/Formatter/OutputFormatterTest.php
@@ -33,14 +33,24 @@ class OutputFormatterTest extends TestCase
         $this->assertEquals("foo << \033[32mbar \\ baz\033[39m \\", $formatter->format('foo << <info>bar \\ baz</info> \\'));
         $this->assertEquals('<info>some info</info>', $formatter->format('\\<info>some info\\</info>'));
         $this->assertEquals('\\<info\\>some info\\</info\\>', OutputFormatter::escape('<info>some info</info>'));
-        // every < and > gets escaped if not already escaped, but already escaped ones do not get escaped again
-        // and escaped backslashes remain as such, same with backslashes escaping non-special characters
-        $this->assertEquals('foo \\< bar \\< baz \\\\< foo \\> bar \\> baz \\\\> \\x', OutputFormatter::escape('foo < bar \\< baz \\\\< foo > bar \\> baz \\\\> \\x'));
+        // every < and > gets escaped, backslashes are left as they are
+        $this->assertEquals('foo \\< bar \\\\< baz \\\\\\< foo \\> bar \\\\> baz \\\\\\> \\x', OutputFormatter::escape('foo < bar \\< baz \\\\< foo > bar \\> baz \\\\> \\x'));
 
         $this->assertEquals(
             "\033[33mSymfony\\Component\\Console does work very well!\033[39m",
             $formatter->format('<comment>Symfony\Component\Console does work very well!</comment>')
         );
+    }
+
+    public function testFormatRestoresEscapedText()
+    {
+        $formatter = new OutputFormatter(true);
+
+        $this->assertEquals('foo \\<bar', $formatter->format(OutputFormatter::escape('foo \\<bar')));
+        $this->assertEquals('foo \\>bar', $formatter->format(OutputFormatter::escape('foo \\>bar')));
+        $this->assertEquals('foo \\\\<bar>', $formatter->format(OutputFormatter::escape('foo \\\\<bar>')));
+        $this->assertEquals('foo \\<info>bar\\</info>', $formatter->format(OutputFormatter::escape('foo \\<info>bar\\</info>')));
+        $this->assertEquals('foo \\', $formatter->format(OutputFormatter::escape('foo \\')));
     }
 
     public function testBundledStyles()
@@ -105,7 +115,7 @@ class OutputFormatterTest extends TestCase
         $formatter = new OutputFormatter(true);
 
         $this->assertEquals(
-            "(\033[32mz>=2.0,<<<a2.3\\\033[39m)",
+            "(\033[32mz>=2.0,<\\<<a2.3\\\033[39m)",
             $formatter->format('(<info>'.$formatter->escape('z>=2.0,<\\<<a2.3\\').'</info>)')
         );
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #34065
| License       | MIT

`OutputFormatter::escape()` turns text into markup that `format()` renders back as the original text. That does not hold when the text has a backslash right before a `<` or a `>`: the backslash is silently dropped.

```php
OutputFormatter::escape('A\<B>'); // 'A\<B\>'
OutputFormatter::escape('A<B>');  // 'A\<B\>', the very same string

(new OutputFormatter())->format('A\<B\>'); // 'A<B>', so the first text cannot come back
```

`escape()` skips a `<` or a `>` that already follows a backslash. In the escaped form `\<` stands for a literal `<`, and a backslash on its own stands for a literal backslash, so both texts above end up with the same representation and one of them is lost. What the user sees is a missing character: `C:\dir\<file>` prints as `C:\dir<file>`, and a block built with `SymfonyStyle::warning()` or `FormatterHelper::formatBlock()` loses it the same way.

The fix escapes every `<` and every `>`, whether or not a backslash comes first. The decoding side already reads `\\<` as a literal backslash followed by a literal `<`, so `format()` needs no change: only the encoder was wrong.

### Behavior change to weigh

**`escape()` is no longer idempotent. `escape(escape($text))` used to return `escape($text)`, and now returns markup that renders the escape sequences literally.** The two properties cannot both hold, because `\<` in the input has to mean either "a backslash, then a tag opening" or "an already escaped tag opening", and only the first reading keeps the text recoverable. Code that escapes twice, or that hand escapes a `<` before passing the string to an API that escapes as well, now shows the backslash instead of hiding it.

Checks run:

- The new test `OutputFormatterTest::testFormatRestoresEscapedText` fails on the current code, with `'foo \<bar'` rendered as `'foo <bar'`, and passes with the patch.
- Two existing assertions recorded the loss and are updated: the `escape()` output in `testLGCharEscaping`, and the round trip through a style in `testStyleEscaping`.
- Full Console suite: 1343 tests, 2346 assertions, 22 skipped, no failure. Also green for the components that call `escape()`: FrameworkBundle console tests (199), Dotenv (194), Monolog bridge (95), Twig bridge commands (26).
- A fuzz run over 200000 random strings built from `a i n f o < > \ / space = e-acute` compares `format(escape($s))` with `$s`: 10875 mismatches before the patch, 0 after, and 0 as well when the escaped text sits inside `<info>...</info>`, which also shows the escaped text never opens or closes a tag.
- The block width computed by `FormatterHelper::formatBlock()` does not move, because `format()` consumes exactly one backslash per `<` or `>` in both states.

Two points this does not cover. A text holding a NUL byte still comes back wrong, since `format()` maps NUL to a backslash; that is a separate defect of the same encoding and it is left alone. And the performance part of the issue does not reproduce: `formatAndWrap(str_repeat('A<B>C</>', $n))` takes 0.028s, 0.060s, 0.151s and 0.410s for n of 12500, 25000, 50000 and 100000, which is not quadratic.
