### PR TITLE
[PropertyInfo] Fix the priority of the accessor named after the property

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -264,16 +264,17 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
         $camelProp = $this->camelize($property);
         $getsetter = lcfirst($camelProp); // jQuery style, e.g. read: last(), write: last($item)
 
-        foreach ($this->accessorPrefixes as $prefix) {
-            $methodName = $prefix.$camelProp;
+        $accessorMethods = array_map(static fn ($prefix) => $prefix.$camelProp, $this->accessorPrefixes);
 
+        if ($allowGetterSetter) {
+            $getterPosition = array_search('get'.$camelProp, $accessorMethods, true);
+            array_splice($accessorMethods, false === $getterPosition ? \count($accessorMethods) : $getterPosition + 1, 0, [$getsetter]);
+        }
+
+        foreach ($accessorMethods as $methodName) {
             if ($reflClass->hasMethod($methodName) && ($m = $reflClass->getMethod($methodName))->getModifiers() & $this->methodReflectionFlags && !$m->getNumberOfRequiredParameters() && !\in_array((string) $m->getReturnType(), ['void', 'never'], true)) {
                 return new PropertyReadInfo(PropertyReadInfo::TYPE_METHOD, $methodName, $this->getReadVisibilityForMethod($m), $m->isStatic(), false);
             }
-        }
-
-        if ($allowGetterSetter && $reflClass->hasMethod($getsetter) && ($m = $reflClass->getMethod($getsetter))->getModifiers() & $this->methodReflectionFlags && !$m->getNumberOfRequiredParameters() && !\in_array((string) $m->getReturnType(), ['void', 'never'], true)) {
-            return new PropertyReadInfo(PropertyReadInfo::TYPE_METHOD, $getsetter, $this->getReadVisibilityForMethod($m), $m->isStatic(), false);
         }
 
         if ($allowMagicGet && $reflClass->hasMethod('__get') && (($r = $reflClass->getMethod('__get'))->getModifiers() & $this->methodReflectionFlags)) {

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\PropertyInfo\Tests\Fixtures\AdderRemoverDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\AsymmetricVisibility;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\DefaultValue;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\DummyWithGetterSetter;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\DummyWithHasser;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\MultiParameterAdderDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\MultiParameterAdderParentDummy;
@@ -592,6 +593,19 @@ class ReflectionExtractorTest extends TestCase
             [UnderscoreDummy::class, 'foo_bar', false, null, null, null, null],
             [UnderscoreDummy::class, '_foo_', false, null, null, null, null],
         ];
+    }
+
+    public function testGetReadAccessorPrefersTheGetterSetterOverIsHasCanAccessors()
+    {
+        $readAccessor = $this->extractor->getReadInfo(DummyWithGetterSetter::class, 'payments', ['enable_getter_setter_extraction' => true]);
+
+        $this->assertSame(PropertyReadInfo::TYPE_METHOD, $readAccessor->getType());
+        $this->assertSame('payments', $readAccessor->getName());
+
+        $readAccessor = $this->extractor->getReadInfo(DummyWithGetterSetter::class, 'payments');
+
+        $this->assertSame(PropertyReadInfo::TYPE_METHOD, $readAccessor->getType());
+        $this->assertSame('hasPayments', $readAccessor->getName());
     }
 
     /**

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/DummyWithGetterSetter.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/DummyWithGetterSetter.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
+
+class DummyWithGetterSetter
+{
+    private array $payments = [];
+
+    public function payments(): array
+    {
+        return $this->payments;
+    }
+
+    public function hasPayments(): bool
+    {
+        return (bool) $this->payments;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #37260
| License       | MIT

`ReflectionExtractor::getReadInfo()` decides which method PropertyAccess calls to read a property. Up to 5.0 the order was `getFoo()`, then `foo()` (the jQuery style accessor, only considered when the `enable_getter_setter_extraction` context option is on), then `isFoo()`, `hasFoo()` and `canFoo()`. When that logic moved from PropertyAccess to PropertyInfo in 5.1, the loop over the accessor prefixes ended up running before the `foo()` check, so every prefixed accessor now wins over `foo()`.

With this class:

```php
class Order
{
    private array $payments = [];

    public function payments(): array
    {
        return $this->payments;
    }

    public function hasPayments(): bool
    {
        return [] !== $this->payments;
    }
}
```

reading `payments` returns `true` since 5.1, because `hasPayments()` is picked, instead of the array returned by `payments()`.

This patch restores the previous order: the getter first, then the method named after the property, then the is/has/can accessors. `getTypes()` already tries `is`, `has` and `can` last, so read info and type info agree again for such classes.

Points worth knowing:

* The method named after the property is only a candidate when `enable_getter_setter_extraction` is on. PropertyAccess always sets it and ObjectNormalizer forwards it when the serialization context carries it. Callers that leave it off see no change at all.
* When a custom accessor prefix list without `get` is passed to the constructor, the method named after the property is still tried last, exactly as before.
* Classes concerned are those exposing both `foo()` and one of `isFoo()`, `hasFoo()` or `canFoo()`, without a `getFoo()`. Reading such a property through PropertyAccess, directly or through Form or Serializer, now returns what `foo()` returns.
* PropertyAccessor caches the resolved accessor, so a warm `cache.property_access` pool keeps returning the previous one until it is cleared.
* A method named after the property that takes a required argument, returns `void` or `never`, or is not visible enough is still skipped, and the is/has/can accessors are used then.

Checks run on this branch with PHP 8.5 and PHPUnit 9.6:

* `./phpunit src/Symfony/Component/PropertyInfo/Tests`: OK, 555 tests, 890 assertions.
* `./phpunit src/Symfony/Component/PropertyAccess/Tests`: OK, 482 tests, 557 assertions.
* `./phpunit src/Symfony/Component/Serializer/Tests`: OK, 1151 tests, 2316 assertions, 11 skipped.
* `./phpunit src/Symfony/Component/Form/Tests`: OK, 4748 tests, 9348 assertions, 363 skipped, 8 incomplete.
* `./phpunit src/Symfony/Component/Validator/Tests`: OK, 4803 tests, 8493 assertions, 68 skipped.
* Source change reverted, new test kept: only `ReflectionExtractorTest::testGetReadAccessorPrefersTheGetterSetterOverIsHasCanAccessors` fails, on `'payments'` vs `'hasPayments'`, and the 164 other tests of that file still pass.
