### PR TITLE
[Security] Refresh the impersonator while impersonating

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -210,6 +210,10 @@ class ContextListener extends AbstractListener
      */
     protected function refreshUser(TokenInterface $token): ?TokenInterface
     {
+        if ($token instanceof SwitchUserToken && $token->getOriginalToken()->getUser() && !$this->refreshUser($token->getOriginalToken())) {
+            return null;
+        }
+
         $user = $token->getUser();
 
         $userNotFoundByProvider = false;

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
@@ -29,11 +29,13 @@ use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\UsageTrackingTokenStorage;
+use Symfony\Component\Security\Core\Authentication\Token\SwitchUserToken;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 use Symfony\Component\Security\Core\User\InMemoryUser;
+use Symfony\Component\Security\Core\User\InMemoryUserProvider;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Symfony\Component\Security\Http\Firewall\ContextListener;
@@ -337,6 +339,57 @@ class ContextListenerTest extends TestCase
         $this->assertSame($goodRefreshedUser, $tokenStorage->getToken()->getUser());
     }
 
+    public function testImpersonatorIsRefreshed()
+    {
+        $tokenStorage = new TokenStorage();
+        $userProvider = new RefreshTrackingUserProvider([
+            'admin' => ['password' => 'admin-pass', 'roles' => ['ROLE_ADMIN']],
+            'user' => ['password' => 'user-pass', 'roles' => ['ROLE_USER']],
+        ]);
+
+        $originalToken = new UsernamePasswordToken(new InMemoryUser('admin', 'admin-pass', ['ROLE_ADMIN']), 'context_key', ['ROLE_ADMIN']);
+        $token = new SwitchUserToken(new InMemoryUser('user', 'user-pass', ['ROLE_USER']), 'context_key', ['ROLE_USER', 'ROLE_PREVIOUS_ADMIN'], $originalToken);
+
+        $session = new Session(new MockArraySessionStorage());
+        $session->set('_security_context_key', serialize($token));
+
+        $request = new Request();
+        $request->setSession($session);
+        $request->cookies->set('MOCKSESSID', true);
+
+        $listener = new ContextListener($tokenStorage, [$userProvider], 'context_key');
+        $listener(new RequestEvent($this->createStub(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST));
+
+        $this->assertSame(['admin', 'user'], $userProvider->refreshedIdentifiers);
+        $this->assertInstanceOf(SwitchUserToken::class, $tokenStorage->getToken());
+        $this->assertSame('user', $tokenStorage->getToken()->getUserIdentifier());
+        $this->assertSame('admin', $tokenStorage->getToken()->getOriginalToken()->getUserIdentifier());
+    }
+
+    public function testTokenIsDeauthenticatedWhenImpersonatorHasChanged()
+    {
+        $tokenStorage = new TokenStorage();
+        $userProvider = new InMemoryUserProvider([
+            'admin' => ['password' => 'admin-pass', 'roles' => ['ROLE_ADMIN'], 'enabled' => false],
+            'user' => ['password' => 'user-pass', 'roles' => ['ROLE_USER']],
+        ]);
+
+        $originalToken = new UsernamePasswordToken(new InMemoryUser('admin', 'admin-pass', ['ROLE_ADMIN']), 'context_key', ['ROLE_ADMIN']);
+        $token = new SwitchUserToken(new InMemoryUser('user', 'user-pass', ['ROLE_USER']), 'context_key', ['ROLE_USER', 'ROLE_PREVIOUS_ADMIN'], $originalToken);
+
+        $session = new Session(new MockArraySessionStorage());
+        $session->set('_security_context_key', serialize($token));
+
+        $request = new Request();
+        $request->setSession($session);
+        $request->cookies->set('MOCKSESSID', true);
+
+        $listener = new ContextListener($tokenStorage, [$userProvider], 'context_key');
+        $listener(new RequestEvent($this->createStub(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST));
+
+        $this->assertNull($tokenStorage->getToken());
+    }
+
     public function testTryAllUserProvidersUntilASupportingUserProviderIsFound()
     {
         $refreshedUser = new InMemoryUser('foobar', 'baz');
@@ -585,6 +638,18 @@ class SupportingUserProvider implements UserProviderInterface
     public function supportsClass($class): bool
     {
         return InMemoryUser::class === $class;
+    }
+}
+
+class RefreshTrackingUserProvider extends InMemoryUserProvider
+{
+    public array $refreshedIdentifiers = [];
+
+    public function refreshUser(UserInterface $user): UserInterface
+    {
+        $this->refreshedIdentifiers[] = $user->getUserIdentifier();
+
+        return parent::refreshUser($user);
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #37307
| License       | MIT

On every request, `ContextListener` reloads the token's user from the user providers and drops the token when the stored user no longer matches the fresh one. The comparison is `ContextListener::hasUserChanged()`: `EquatableInterface::isEqualTo()` when the user implements it, otherwise password, salt, roles and identifier.

While someone impersonates another user, the token is a `SwitchUserToken` and `$token->getUser()` returns the impersonated user. Only that user was reloaded and compared. The impersonator lives in `SwitchUserToken::getOriginalToken()` and was read only to build a log line, so it was never reloaded and never compared.

The consequence is that impersonation outlives the impersonator's account. Once the switch has happened, locking that account, changing its password or taking its roles away has no effect: the session keeps working, and exiting the impersonation hands back the stale account object.

This patch reloads the original token first, through the same `refreshUser()` code path, so the impersonator goes through the providers and through `hasUserChanged()` like any other user. When the impersonator has changed, the whole token is dropped and the session is deauthenticated, which is what already happens to a user who is not impersonating. The original token's user object is also replaced by the fresh one, so the account is up to date when the impersonation ends.

Two notes on the scope:

* the extra user provider call happens only while impersonating;
* a `SwitchUserToken` whose original token carries no user is left alone, so no new failure mode appears for hand built tokens.

Checks run on the branch with PHP 8.5 and PHPUnit 9.6:

* `src/Symfony/Component/Security/Http/Tests`: OK (530 tests, 996 assertions)
* `src/Symfony/Component/Security/Core/Tests`: OK (349 tests, 537 assertions)
* `src/Symfony/Component/Security/Csrf/Tests`: OK (86 tests, 212 assertions)
* `src/Symfony/Bundle/SecurityBundle/Tests`: OK (360 tests, 1104 assertions, 1 skip in `XmlCompleteConfigurationTest::testFirewallPatterns` that also skips on the base commit)
* PHP CS Fixer on both touched files: no change reported

`SwitchUserTest` is the end to end proof that the new call runs against the real container wiring: instrumenting the new branch shows it hit seven times during that test class, with the `RewindableGenerator` the bundle injects as user providers, and the seven tests still pass.

Putting `ContextListener` back to its base state while keeping the two new tests makes both fail:

* `testImpersonatorIsRefreshed`: the provider records `['user']` instead of `['admin', 'user']`
* `testTokenIsDeauthenticatedWhenImpersonatorHasChanged`: the `SwitchUserToken` is still in the token storage instead of being dropped
