### PR TITLE
[VarDumper] Fix losing colors when dumping to php://output on the CLI

### DIFF
--- a/src/Symfony/Component/VarDumper/Dumper/CliDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/CliDumper.php
@@ -537,7 +537,7 @@ class CliDumper extends AbstractDumper
     protected function supportsColors(): bool
     {
         if ($this->outputStream !== static::$defaultOutput) {
-            return $this->hasColorSupport($this->outputStream);
+            return $this->hasColorSupport($this->getColorSupportStream());
         }
         if (isset(static::$defaultColors)) {
             return static::$defaultColors;
@@ -567,10 +567,7 @@ class CliDumper extends AbstractDumper
             }
         }
 
-        $h = stream_get_meta_data($this->outputStream) + ['wrapper_type' => null];
-        $h = 'Output' === $h['stream_type'] && 'PHP' === $h['wrapper_type'] ? fopen('php://stdout', 'w') : $this->outputStream;
-
-        return static::$defaultColors = $this->hasColorSupport($h);
+        return static::$defaultColors = $this->hasColorSupport($this->getColorSupportStream());
     }
 
     /**
@@ -606,6 +603,20 @@ class CliDumper extends AbstractDumper
         }
 
         $this->dumpLine($cursor->depth, true);
+    }
+
+    /**
+     * Returns the stream to probe for color support: on the CLI, php://output is backed by STDOUT.
+     */
+    private function getColorSupportStream(): mixed
+    {
+        if (!\defined('STDOUT') || !\is_resource($this->outputStream) || 'stream' !== get_resource_type($this->outputStream)) {
+            return $this->outputStream;
+        }
+
+        $h = stream_get_meta_data($this->outputStream) + ['wrapper_type' => null];
+
+        return 'Output' === $h['stream_type'] && 'PHP' === $h['wrapper_type'] ? \STDOUT : $this->outputStream;
     }
 
     /**

--- a/src/Symfony/Component/VarDumper/Tests/Dumper/CliDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/CliDumperTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\VarDumper\Tests\Dumper;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\ErrorHandler\ErrorRenderer\FileLinkFormatter;
+use Symfony\Component\Process\Process;
 use Symfony\Component\VarDumper\Caster\ClassStub;
 use Symfony\Component\VarDumper\Caster\CutStub;
 use Symfony\Component\VarDumper\Cloner\Data;
@@ -520,5 +521,22 @@ class CliDumperTest extends TestCase
                 $_ENV['SYMFONY_IDE'] = $ide;
             }
         }
+    }
+
+    public function testColorsOnTerminalWhenDumpingToPhpOutput()
+    {
+        if (!Process::isPtySupported()) {
+            $this->markTestSkipped('PTY is not supported.');
+        }
+
+        $process = new Process([\PHP_BINARY, __DIR__.'/../Fixtures/dump_colors.php'], null, [
+            'COMPONENT_ROOT' => __DIR__.'/../../',
+            'TERM' => 'xterm-256color',
+            'NO_COLOR' => false,
+        ]);
+        $process->setPty(true);
+        $process->mustRun();
+
+        $this->assertSame('tty=true colors=true', trim($process->getOutput()));
     }
 }

--- a/src/Symfony/Component/VarDumper/Tests/Fixtures/dump_colors.php
+++ b/src/Symfony/Component/VarDumper/Tests/Fixtures/dump_colors.php
@@ -1,0 +1,18 @@
+<?php
+
+use Symfony\Component\VarDumper\Cloner\VarCloner;
+use Symfony\Component\VarDumper\Dumper\CliDumper;
+
+$componentRoot = $_SERVER['COMPONENT_ROOT'];
+
+if (!is_file($file = $componentRoot.'/vendor/autoload.php')) {
+    $file = $componentRoot.'/../../../../vendor/autoload.php';
+}
+
+require $file;
+
+ob_start();
+(new CliDumper('php://output'))->dump((new VarCloner())->cloneVar(123));
+$dump = ob_get_clean();
+
+fwrite(\STDOUT, \sprintf('tty=%s colors=%s', var_export(stream_isatty(\STDOUT), true), var_export(str_contains($dump, "\033["), true)));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #37768
| License       | MIT

`CliDumper::supportsColors()` decides whether to emit ANSI sequences. When the dumper writes to its default output, it resolves `php://output` to the `php://stdout` stream that backs it before probing for a terminal. When the dumper writes to any other stream, that step was skipped and the stream itself was probed. `php://output` is never a terminal: `stream_isatty()` returns false on it even when the process runs in one. Every dumper built with `new CliDumper('php://output')` therefore printed plain text.

This is what users see when DebugBundle is enabled on the CLI. `DumpDataCollector` sends the collected dumps to `new CliDumper('php://output', ...)` when the profiler cannot show them, so `dump()` in a console script or in a plain PHP script loses its colors as soon as the bundle is registered, while the same call is colored without it.

The fix moves the `php://output` to `php://stdout` resolution into a helper used by both branches of `supportsColors()`. The resolution is limited to the `cli` and `phpdbg` SAPIs: under the built-in web server (`php -S`) the process stdout is the developer's terminal while `php://output` is the HTTP response body, so escape sequences must not leak into it.

Nothing else changes. Dumps sent to a file, to a memory stream or to a callable are unaffected, output still goes to `php://output` so `ob_*` capture and output ordering are preserved, and a dumper whose colors were set with `setColors()` keeps that value.

The new test starts a PHP subprocess on a pseudo terminal, because color detection depends on a real terminal being attached. It is skipped where `proc_open()` has no pty support, and it reports whether the pty was obtained, so that an environment problem cannot be mistaken for the defect. On the unfixed code it reports `tty=true colors=false` instead of `tty=true colors=true`.

Checks run locally on PHP 8.5 with PHPUnit 9.6, each of them twice, once from a plain pipe and once from a terminal:

- `./phpunit src/Symfony/Component/VarDumper`: OK, 416 tests, 536 assertions, 14 skipped
- `./phpunit src/Symfony/Component/HttpKernel`: OK, 1217 tests, 2958 assertions
- `./phpunit src/Symfony/Component/ErrorHandler`: OK, 128 tests, 391 assertions, 3 skipped
- `./phpunit src/Symfony/Bridge/Monolog`: OK, 95 tests, 216 assertions
- `./phpunit src/Symfony/Bundle/DebugBundle`: OK, 13 tests, 30 assertions
- `./phpunit src/Symfony/Bridge/Doctrine/Tests/DataCollector`: OK, 45 tests, 44 assertions, 9 skipped

I also checked the built-in web server by hand: `php -S` serving a script that dumps to `php://output` returns a body free of escape sequences, and returns one full of them when the SAPI guard is removed.
