### PR TITLE
[Messenger] Stop applying serialization groups and attribute filters to stamps

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/Transport/Serialization/SerializerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Serialization/SerializerTest.php
@@ -15,13 +15,21 @@ use PHPUnit\Framework\Constraint\Constraint;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
+use Symfony\Component\Messenger\Stamp\BusNameStamp;
 use Symfony\Component\Messenger\Stamp\NonSendableStampInterface;
 use Symfony\Component\Messenger\Stamp\SerializedMessageStamp;
 use Symfony\Component\Messenger\Stamp\SerializerStamp;
 use Symfony\Component\Messenger\Stamp\ValidationStamp;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Messenger\Transport\Serialization\Serializer;
+use Symfony\Component\Serializer\Attribute\Groups;
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
+use Symfony\Component\Serializer\Mapping\Loader\AttributeLoader;
+use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
+use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
+use Symfony\Component\Serializer\Serializer as SymfonySerializer;
 use Symfony\Component\Serializer\SerializerInterface as SerializerComponentInterface;
 
 class SerializerTest extends TestCase
@@ -171,6 +179,26 @@ class SerializerTest extends TestCase
         ]);
     }
 
+    public function testStampsIgnoreTheAttributeSelectionOfTheContext()
+    {
+        if (!class_exists(AttributeLoader::class)) {
+            $this->markTestSkipped('The "AttributeLoader" class from symfony/serializer 6.4 is required.');
+        }
+
+        $symfonySerializer = new SymfonySerializer([new ArrayDenormalizer(), new ObjectNormalizer(new ClassMetadataFactory(new AttributeLoader()))], [new JsonEncoder()]);
+        $serializer = new Serializer($symfonySerializer, 'json', [
+            AbstractNormalizer::GROUPS => ['dummy'],
+            AbstractNormalizer::ATTRIBUTES => ['message'],
+            AbstractNormalizer::IGNORED_ATTRIBUTES => ['busName'],
+        ]);
+
+        $encoded = $serializer->encode(new Envelope(new DummySymfonySerializerGroupedMessage('Hello'), [new BusNameStamp('the_bus')]));
+
+        $this->assertSame('{"message":"Hello"}', $encoded['body']);
+        $this->assertSame('[{"busName":"the_bus"}]', $encoded['headers']['X-Message-Stamp-'.BusNameStamp::class]);
+        $this->assertEquals([new BusNameStamp('the_bus')], $serializer->decode($encoded)->all(BusNameStamp::class));
+    }
+
     public function testDecodingFailsWithBadFormat()
     {
         $this->expectException(MessageDecodingFailedException::class);
@@ -272,5 +300,15 @@ class DummySymfonySerializerInvalidConstructor
 {
     public function __construct(string $missingArgument)
     {
+    }
+}
+class DummySymfonySerializerGroupedMessage
+{
+    #[Groups(['dummy'])]
+    public string $message;
+
+    public function __construct(string $message)
+    {
+        $this->message = $message;
     }
 }

--- a/src/Symfony/Component/Messenger/Transport/Serialization/Serializer.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/Serializer.php
@@ -21,6 +21,7 @@ use Symfony\Component\Messenger\Stamp\StampInterface;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Encoder\XmlEncoder;
 use Symfony\Component\Serializer\Exception\ExceptionInterface;
+use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
@@ -38,12 +39,15 @@ class Serializer implements SerializerInterface
     private SymfonySerializerInterface $serializer;
     private string $format;
     private array $context;
+    private array $stampContext;
 
     public function __construct(?SymfonySerializerInterface $serializer = null, string $format = 'json', array $context = [])
     {
         $this->serializer = $serializer ?? self::create()->serializer;
         $this->format = $format;
         $this->context = $context + [self::MESSENGER_SERIALIZATION_CONTEXT => true];
+        // stamps have no serialization metadata, so selecting the attributes of the message would encode them empty
+        $this->stampContext = array_diff_key($this->context, array_flip([AbstractNormalizer::ATTRIBUTES, AbstractNormalizer::GROUPS, AbstractNormalizer::IGNORED_ATTRIBUTES]));
     }
 
     public static function create(): self
@@ -120,7 +124,7 @@ class Serializer implements SerializerInterface
             }
 
             try {
-                $stamps[] = $this->serializer->deserialize($value, substr($name, \strlen(self::STAMP_HEADER_PREFIX)).'[]', $this->format, $this->context);
+                $stamps[] = $this->serializer->deserialize($value, substr($name, \strlen(self::STAMP_HEADER_PREFIX)).'[]', $this->format, $this->stampContext);
             } catch (ExceptionInterface $e) {
                 throw new MessageDecodingFailedException('Could not decode stamp: '.$e->getMessage(), $e->getCode(), $e);
             }
@@ -140,7 +144,7 @@ class Serializer implements SerializerInterface
 
         $headers = [];
         foreach ($allStamps as $class => $stamps) {
-            $headers[self::STAMP_HEADER_PREFIX.$class] = $this->serializer->serialize($stamps, $this->format, $this->context);
+            $headers[self::STAMP_HEADER_PREFIX.$class] = $this->serializer->serialize($stamps, $this->format, $this->stampContext);
         }
 
         return $headers;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #37991
| License       | MIT

The context configured on the Messenger transport serializer is also passed when stamps are written to headers and read back. Three of its keys select which attributes get serialized: `groups`, `attributes` and `ignored_attributes`. They describe the message class, and stamps have no matching serialization metadata, so every stamp is encoded as an empty object:

```
X-Message-Stamp-Symfony\Component\Messenger\Stamp\BusNameStamp: [[]]
```

Consuming such a message then fails:

> Could not decode stamp: Cannot create an instance of "Symfony\Component\Messenger\Stamp\BusNameStamp" from serialized data because its constructor requires the following parameters to be present : "$busName".

That is what `framework.messenger.serializer.symfony_serializer.context: { groups: [...] }` produces, because the framework serializer has a class metadata factory. `attributes` and `ignored_attributes` break stamps even without one.

This patch keeps those three keys out of the context used for stamps. The rest of the context still applies to them, including `messenger_serialization`, which `FlattenExceptionNormalizer` needs for the exception held by `ErrorDetailsStamp`, and `datetime_format`, used by `RedeliveryStamp`.

One behavior note: an application that worked around the bug by giving its custom stamps the same serialization groups as its messages will now serialize all attributes of those stamps, since the groups no longer apply there.

Checks run:

- `./phpunit src/Symfony/Component/Messenger/Tests` on this branch: OK, 411 tests, 1142 assertions, 9 legacy deprecation notices. The same suite on the base commit: OK, 410 tests, 1139 assertions, same 9 notices.
- Revert verify: with the change to `Serializer.php` reverted and the new test kept, `SerializerTest` reports 16 tests, 1 failure, the new test getting `[[]]` for the `BusNameStamp` header.
- A standalone script using `ObjectNormalizer` with a `ClassMetadataFactory` reproduces the reported error before the change, for each of the three context keys, and round trips `BusNameStamp`, `ErrorDetailsStamp` and `RedeliveryStamp` after it.
