### PR TITLE
[Form] Apply the guessed "pattern" and "maxlength" attributes to text inputs only

### DIFF
--- a/src/Symfony/Component/Form/FormFactory.php
+++ b/src/Symfony/Component/Form/FormFactory.php
@@ -73,15 +73,15 @@ class FormFactory implements FormFactoryInterface
 
         $type = $typeGuess ? $typeGuess->getType() : TextType::class;
 
-        $maxLength = $maxLengthGuess?->getValue();
-        $pattern = $patternGuess?->getValue();
+        // the "pattern" and "maxlength" attributes are valid on text inputs only
+        if ($this->isTextInput($type)) {
+            if (null !== $pattern = $patternGuess?->getValue()) {
+                $options = array_replace_recursive(['attr' => ['pattern' => $pattern]], $options);
+            }
 
-        if (null !== $pattern) {
-            $options = array_replace_recursive(['attr' => ['pattern' => $pattern]], $options);
-        }
-
-        if (null !== $maxLength) {
-            $options = array_replace_recursive(['attr' => ['maxlength' => $maxLength]], $options);
+            if (null !== $maxLength = $maxLengthGuess?->getValue()) {
+                $options = array_replace_recursive(['attr' => ['maxlength' => $maxLength]], $options);
+            }
         }
 
         if ($requiredGuess) {
@@ -100,5 +100,18 @@ class FormFactory implements FormFactoryInterface
         }
 
         return $this->createNamedBuilder($property, $type, $data, $options);
+    }
+
+    private function isTextInput(string $type): bool
+    {
+        $resolvedType = $this->registry->getType($type);
+
+        do {
+            if ($resolvedType->getInnerType() instanceof TextType) {
+                return true;
+            }
+        } while ($resolvedType = $resolvedType->getParent());
+
+        return false;
     }
 }

--- a/src/Symfony/Component/Form/Tests/FormFactoryTest.php
+++ b/src/Symfony/Component/Form/Tests/FormFactoryTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Form\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormFactory;
@@ -144,6 +145,40 @@ class FormFactoryTest extends TestCase
         $this->assertSame('firstName', $builder->getName());
         $this->assertSame(['maxlength' => 20, 'pattern' => '.{5,}', 'class' => 'tinymce'], $builder->getOption('attr'));
         $this->assertInstanceOf(TextType::class, $builder->getType()->getInnerType());
+    }
+
+    public function testCreateBuilderUsesMaxLengthAndPatternForChildrenOfTextType()
+    {
+        $this->guesser1->configureTypeGuess(PasswordType::class, [], Guess::HIGH_CONFIDENCE);
+        $this->guesser1->configureMaxLengthGuess(20, Guess::HIGH_CONFIDENCE);
+        $this->guesser2->configurePatternGuess('.{5,}', Guess::HIGH_CONFIDENCE);
+
+        $builder = $this->factory->createBuilderForProperty('Application\Author', 'firstName');
+
+        $this->assertSame(['maxlength' => 20, 'pattern' => '.{5,}'], $builder->getOption('attr'));
+        $this->assertInstanceOf(PasswordType::class, $builder->getType()->getInnerType());
+    }
+
+    public function testCreateBuilderIgnoresMaxLengthAndPatternForTypesOtherThanTextInputs()
+    {
+        $this->guesser1->configureTypeGuess(ChoiceType::class, [], Guess::HIGH_CONFIDENCE);
+        $this->guesser1->configureMaxLengthGuess(20, Guess::HIGH_CONFIDENCE);
+        $this->guesser2->configurePatternGuess('.{5,}', Guess::HIGH_CONFIDENCE);
+
+        $builder = $this->factory->createBuilderForProperty('Application\Author', 'firstName');
+
+        $this->assertSame([], $builder->getOption('attr'));
+        $this->assertInstanceOf(ChoiceType::class, $builder->getType()->getInnerType());
+    }
+
+    public function testCreateBuilderKeepsExplicitAttributesForTypesOtherThanTextInputs()
+    {
+        $this->guesser1->configureTypeGuess(ChoiceType::class, [], Guess::HIGH_CONFIDENCE);
+        $this->guesser1->configureMaxLengthGuess(20, Guess::HIGH_CONFIDENCE);
+
+        $builder = $this->factory->createBuilderForProperty('Application\Author', 'firstName', null, ['attr' => ['maxlength' => 11]]);
+
+        $this->assertSame(['maxlength' => 11], $builder->getOption('attr'));
     }
 
     public function testCreateBuilderUsesRequiredSettingWithHighestConfidence()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #39066
| License       | MIT

When a field is built from a property instead of an explicit type, `FormFactory::createBuilderForProperty()` asks the type guessers for a type, a maximum length and a pattern, then merges the last two into the `attr` option. That merge happens whatever type was guessed. `pattern` and `maxlength` are attributes of text inputs, so the result is invalid HTML as soon as the guessed type renders something else.

A property carrying `#[Assert\Country]` and `#[Assert\Length(min: 2, max: 2)]` produced a `<select>` with `maxlength="2" pattern=".{2,}"`. A boolean property with a `Length` constraint produced a checkbox with `maxlength`. A date property produced date widgets with `maxlength`. The same happened through the Doctrine guesser, where the length of a mapped column ended up on the `<select>` of an `EntityType`.

`TextareaType` already worked around one case of this by dropping `pattern` from the view. This patch fixes the general case at the source: the guessed `pattern` and `maxlength` are applied only when the guessed type is `TextType` or descends from it. Attributes set explicitly by the user are left alone, whatever the type.

One behavior change to be aware of: a type that renders a single text input without descending from `TextType` no longer receives the guessed attributes either. In practice that means `NumberType` combined with an explicit `Length` constraint, and `IntegerType` with `grouping: true`. Both guessers already return an empty guess for float and decimal fields, so the common numeric mappings were not producing the attributes anyway. In its default configuration `IntegerType` renders `<input type="number">`, where `maxlength` was invalid too.

Checks run:

* `./phpunit src/Symfony/Component/Form/Tests/FormFactoryTest.php`: the new test for non text types fails on the current code (`['maxlength' => 20, 'pattern' => '.{5,}']` returned where `[]` is expected) and passes with the fix. The two other new tests pass on both states; they pin behavior that must not change, namely that children of `TextType` still get the guessed attributes and that explicit attributes survive on other types.
* `./phpunit src/Symfony/Component/Form`: 4751 tests, no failure.
* `./phpunit src/Symfony/Bridge/Doctrine/Tests/Form`: 131 tests, no failure.
* `./phpunit src/Symfony/Bridge/Twig/Tests`: 1756 tests, no failure.
