### PR TITLE
[Validator] Fix auto-mapping strategies being ignored on inherited properties

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/DoctrineLoaderParentEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/DoctrineLoaderParentEntity.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bridge\Doctrine\Tests\Fixtures;
 
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[ORM\MappedSuperclass]
 class DoctrineLoaderParentEntity
@@ -21,6 +22,9 @@ class DoctrineLoaderParentEntity
 
     #[ORM\Column(length: 30)]
     private $privateParentMaxLength;
+
+    #[ORM\Column(length: 25), Assert\DisableAutoMapping]
+    protected $parentNoAutoMapping;
 
     public function getPrivateParentMaxLength()
     {

--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/DoctrineLoaderTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/DoctrineLoaderTest.php
@@ -83,6 +83,12 @@ class DoctrineLoaderTest extends TestCase
         $this->assertInstanceOf(Length::class, $publicParentMaxLengthConstraints[0]);
         $this->assertSame(35, $publicParentMaxLengthConstraints[0]->max);
 
+        /** @var PropertyMetadata[] $parentNoAutoMappingMetadata */
+        $parentNoAutoMappingMetadata = $classMetadata->getPropertyMetadata('parentNoAutoMapping');
+        $this->assertCount(1, $parentNoAutoMappingMetadata);
+        $this->assertCount(0, $parentNoAutoMappingMetadata[0]->getConstraints());
+        $this->assertSame(AutoMappingStrategy::DISABLED, $parentNoAutoMappingMetadata[0]->getAutoMappingStrategy());
+
         $embeddedMetadata = $classMetadata->getPropertyMetadata('embedded');
         $this->assertCount(1, $embeddedMetadata);
         $this->assertSame(CascadingStrategy::CASCADE, $embeddedMetadata[0]->getCascadingStrategy());

--- a/src/Symfony/Component/Validator/Mapping/Factory/LazyLoadingMetadataFactory.php
+++ b/src/Symfony/Component/Validator/Mapping/Factory/LazyLoadingMetadataFactory.php
@@ -12,10 +12,16 @@
 namespace Symfony\Component\Validator\Mapping\Factory;
 
 use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Validator\Constraints\DisableAutoMapping;
+use Symfony\Component\Validator\Constraints\EnableAutoMapping;
 use Symfony\Component\Validator\Exception\NoSuchMetadataException;
+use Symfony\Component\Validator\Mapping\AutoMappingStrategy;
+use Symfony\Component\Validator\Mapping\CascadingStrategy;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 use Symfony\Component\Validator\Mapping\Loader\LoaderInterface;
+use Symfony\Component\Validator\Mapping\MemberMetadata;
 use Symfony\Component\Validator\Mapping\MetadataInterface;
+use Symfony\Component\Validator\Mapping\PropertyMetadata;
 
 /**
  * Creates new {@link ClassMetadataInterface} instances.
@@ -96,7 +102,14 @@ class LazyLoadingMetadataFactory implements MetadataFactoryInterface
 
         $metadata = new ClassMetadata($class);
 
-        $this->loader?->loadClassMetadata($metadata);
+        if (null !== $this->loader) {
+            // Loaders that map constraints automatically need to know about the strategies declared in parent classes
+            $placeholders = $this->inheritAutoMappingStrategies($metadata);
+
+            $this->loader->loadClassMetadata($metadata);
+
+            $this->removeUnusedPlaceholders($metadata, $placeholders);
+        }
 
         if (null !== $cacheItem) {
             $this->cache->save($cacheItem->set($metadata));
@@ -142,6 +155,71 @@ class LazyLoadingMetadataFactory implements MetadataFactoryInterface
         $class = ltrim(\is_object($value) ? $value::class : $value, '\\');
 
         return class_exists($class) || interface_exists($class, false);
+    }
+
+    /**
+     * Copies the auto-mapping strategies declared on the parent's properties.
+     *
+     * @return array<string, array{PropertyMetadata, int}> the property metadata created to carry them
+     */
+    private function inheritAutoMappingStrategies(ClassMetadata $metadata): array
+    {
+        if (!$parent = $metadata->getReflectionClass()->getParentClass()) {
+            return [];
+        }
+
+        $parentMetadata = $this->getMetadataFor($parent->name);
+
+        if (!$parentMetadata instanceof ClassMetadata) {
+            return [];
+        }
+
+        $class = $metadata->getClassName();
+        $placeholders = [];
+
+        foreach ($parentMetadata->getConstrainedProperties() as $property) {
+            foreach ($parentMetadata->getPropertyMetadata($property) as $member) {
+                if (!$member instanceof PropertyMetadata || $member->isPrivate($class)) {
+                    continue;
+                }
+
+                if (AutoMappingStrategy::NONE !== $strategy = $member->getAutoMappingStrategy()) {
+                    $metadata->addPropertyConstraint($property, AutoMappingStrategy::DISABLED === $strategy ? new DisableAutoMapping() : new EnableAutoMapping());
+                    $placeholders[$property] = [$metadata->properties[$property], $strategy];
+                }
+
+                // The first property metadata is the one declared closest to the class, so it wins
+                break;
+            }
+        }
+
+        return $placeholders;
+    }
+
+    /**
+     * Drops the placeholders the loaders left untouched, and moves the remaining
+     * ones last, where merging the parent's metadata would have put them.
+     *
+     * @param array<string, array{PropertyMetadata, int}> $placeholders
+     */
+    private function removeUnusedPlaceholders(ClassMetadata $metadata, array $placeholders): void
+    {
+        foreach ($placeholders as $property => [$placeholder, $strategy]) {
+            if (!$placeholder->getConstraints() && $strategy === $placeholder->getAutoMappingStrategy() && CascadingStrategy::NONE === $placeholder->getCascadingStrategy()) {
+                $metadata->members[$property] = array_values(array_filter($metadata->members[$property], static fn (MemberMetadata $member) => $member !== $placeholder));
+
+                if ($placeholder === ($metadata->properties[$property] ?? null)) {
+                    unset($metadata->properties[$property]);
+                }
+            }
+
+            $members = $metadata->members[$property];
+            unset($metadata->members[$property]);
+
+            if ($members) {
+                $metadata->members[$property] = $members;
+            }
+        }
     }
 
     /**

--- a/src/Symfony/Component/Validator/Tests/Fixtures/PropertyInfoLoaderChildEntity.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/PropertyInfoLoaderChildEntity.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Fixtures;
+
+class PropertyInfoLoaderChildEntity extends PropertyInfoLoaderParentEntity
+{
+    public $string;
+}

--- a/src/Symfony/Component/Validator/Tests/Fixtures/PropertyInfoLoaderParentEntity.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/PropertyInfoLoaderParentEntity.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Fixtures;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+class PropertyInfoLoaderParentEntity
+{
+    #[Assert\DisableAutoMapping]
+    protected $parentNoAutoMapping;
+}

--- a/src/Symfony/Component/Validator/Tests/Mapping/Factory/LazyLoadingMetadataFactoryTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Factory/LazyLoadingMetadataFactoryTest.php
@@ -15,9 +15,12 @@ use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Validator\Constraints\Callback;
+use Symfony\Component\Validator\Constraints\DisableAutoMapping;
+use Symfony\Component\Validator\Constraints\EnableAutoMapping;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Traverse;
 use Symfony\Component\Validator\Exception\NoSuchMetadataException;
+use Symfony\Component\Validator\Mapping\AutoMappingStrategy;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 use Symfony\Component\Validator\Mapping\Factory\LazyLoadingMetadataFactory;
 use Symfony\Component\Validator\Mapping\Loader\LoaderInterface;
@@ -101,6 +104,92 @@ class LazyLoadingMetadataFactoryTest extends TestCase
         $metadata = $factory->getMetadataFor(self::CLASS_NAME);
 
         $this->assertSame(TraversalStrategy::NONE, $metadata->getTraversalStrategy());
+    }
+
+    public function testLoadersSeeAutoMappingStrategyOfParentProperties()
+    {
+        $loader = new class implements LoaderInterface {
+            public int $strategy = AutoMappingStrategy::NONE;
+
+            public function loadClassMetadata(ClassMetadata $metadata): bool
+            {
+                if (EntityParent::class === $metadata->getClassName()) {
+                    $metadata->addPropertyConstraint('firstName', new DisableAutoMapping());
+
+                    return true;
+                }
+
+                foreach ($metadata->getPropertyMetadata('firstName') as $propertyMetadata) {
+                    $this->strategy = $propertyMetadata->getAutoMappingStrategy();
+                }
+
+                return true;
+            }
+        };
+
+        $factory = new LazyLoadingMetadataFactory($loader);
+        $factory->getMetadataFor(self::CLASS_NAME);
+
+        $this->assertSame(AutoMappingStrategy::DISABLED, $loader->strategy);
+    }
+
+    public function testInheritedAutoMappingStrategiesKeepTheOrderOfProperties()
+    {
+        $loader = new class implements LoaderInterface {
+            public function loadClassMetadata(ClassMetadata $metadata): bool
+            {
+                if (EntityParent::class === $metadata->getClassName()) {
+                    $metadata->addPropertyConstraint('firstName', new DisableAutoMapping());
+                    $metadata->addPropertyConstraint('firstName', new NotBlank());
+                } elseif (Entity::class === $metadata->getClassName()) {
+                    $metadata->addPropertyConstraint('lastName', new NotBlank());
+                    $metadata->addPropertyConstraint('reference', new NotBlank());
+                }
+
+                return true;
+            }
+        };
+
+        $factory = new LazyLoadingMetadataFactory($loader);
+        $metadata = $factory->getMetadataFor(self::CLASS_NAME);
+
+        $this->assertSame(['lastName', 'reference', 'firstName'], $metadata->getConstrainedProperties());
+
+        $firstNameMetadata = $metadata->getPropertyMetadata('firstName');
+        $this->assertCount(1, $firstNameMetadata);
+        $this->assertSame(self::PARENT_CLASS, $firstNameMetadata[0]->getClassName());
+        $this->assertSame(AutoMappingStrategy::DISABLED, $firstNameMetadata[0]->getAutoMappingStrategy());
+    }
+
+    public function testInheritedAutoMappingStrategiesAreKeptWhenLoadersMapTheProperty()
+    {
+        $loader = new class implements LoaderInterface {
+            public function loadClassMetadata(ClassMetadata $metadata): bool
+            {
+                if (EntityParent::class === $metadata->getClassName()) {
+                    $metadata->addPropertyConstraint('firstName', new EnableAutoMapping());
+
+                    return true;
+                }
+
+                foreach ($metadata->getPropertyMetadata('firstName') as $propertyMetadata) {
+                    if (AutoMappingStrategy::ENABLED === $propertyMetadata->getAutoMappingStrategy()) {
+                        $metadata->addPropertyConstraint('firstName', new NotBlank());
+                    }
+                }
+
+                return true;
+            }
+        };
+
+        $factory = new LazyLoadingMetadataFactory($loader);
+        $metadata = $factory->getMetadataFor(self::CLASS_NAME);
+
+        $firstNameMetadata = $metadata->getPropertyMetadata('firstName');
+        $this->assertCount(2, $firstNameMetadata);
+        $this->assertSame(self::CLASS_NAME, $firstNameMetadata[0]->getClassName());
+        $this->assertCount(1, $firstNameMetadata[0]->getConstraints());
+        $this->assertSame(AutoMappingStrategy::ENABLED, $firstNameMetadata[0]->getAutoMappingStrategy());
     }
 
     public function testCachedMetadata()

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/PropertyInfoLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/PropertyInfoLoaderTest.php
@@ -24,6 +24,7 @@ use Symfony\Component\Validator\Mapping\ClassMetadata;
 use Symfony\Component\Validator\Mapping\Loader\PropertyInfoLoader;
 use Symfony\Component\Validator\Mapping\PropertyMetadata;
 use Symfony\Component\Validator\Tests\Fixtures\NestedAttribute\Entity;
+use Symfony\Component\Validator\Tests\Fixtures\PropertyInfoLoaderChildEntity;
 use Symfony\Component\Validator\Tests\Fixtures\PropertyInfoLoaderEntity;
 use Symfony\Component\Validator\Tests\Fixtures\PropertyInfoLoaderNoAutoMappingEntity;
 use Symfony\Component\Validator\Validation;
@@ -183,6 +184,41 @@ class PropertyInfoLoaderTest extends TestCase
         $this->assertSame(AutoMappingStrategy::DISABLED, $noAutoMappingMetadata[0]->getAutoMappingStrategy());
         $noAutoMappingConstraints = $noAutoMappingMetadata[0]->getConstraints();
         $this->assertCount(0, $noAutoMappingConstraints, 'DisableAutoMapping constraint is not added in the list');
+    }
+
+    public function testInheritedAutoMappingStrategy()
+    {
+        $propertyInfoStub = $this->createStub(PropertyInfoExtractorInterface::class);
+        $propertyInfoStub
+            ->method('getProperties')
+            ->willReturn(['string', 'parentNoAutoMapping'])
+        ;
+        $propertyInfoStub
+            ->method('getTypes')
+            ->willReturn([new Type(Type::BUILTIN_TYPE_STRING)])
+        ;
+        $propertyInfoStub
+            ->method('isWritable')
+            ->willReturn(true)
+        ;
+
+        $propertyInfoLoader = new PropertyInfoLoader($propertyInfoStub, $propertyInfoStub, $propertyInfoStub, '{.*}');
+        $validator = Validation::createValidatorBuilder()
+            ->enableAttributeMapping()
+            ->addLoader($propertyInfoLoader)
+            ->getValidator()
+        ;
+
+        /** @var ClassMetadata $classMetadata */
+        $classMetadata = $validator->getMetadataFor(new PropertyInfoLoaderChildEntity());
+
+        $this->assertCount(2, $classMetadata->getPropertyMetadata('string')[0]->getConstraints());
+
+        /** @var PropertyMetadata[] $parentNoAutoMappingMetadata */
+        $parentNoAutoMappingMetadata = $classMetadata->getPropertyMetadata('parentNoAutoMapping');
+        $this->assertCount(1, $parentNoAutoMappingMetadata);
+        $this->assertCount(0, $parentNoAutoMappingMetadata[0]->getConstraints());
+        $this->assertSame(AutoMappingStrategy::DISABLED, $parentNoAutoMappingMetadata[0]->getAutoMappingStrategy());
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #40293, Fix #35399
| License       | MIT

`Assert\DisableAutoMapping` declared on a property of a mapped superclass, or of any parent class, was ignored: the child class still got the constraints that auto-mapping guesses, here a `Length` built from the column definition.

`LazyLoadingMetadataFactory::getMetadataFor()` builds a fresh `ClassMetadata`, hands it to the loaders, and only then merges the constraints of the parent classes into it. The attribute, XML and YAML loaders only map the properties a class declares itself, since inheritance is what that merge is for. So when `DoctrineLoader` and `PropertyInfoLoader` ask `getPropertyMetadata()` for the auto-mapping strategy of an inherited property, they read an empty list and map the property as if nothing had been declared. The strategy does land in the metadata, but one step too late to be of any use.

The fix copies the auto-mapping strategies declared on the parent's properties into the new metadata before the loaders run. Only the strategy is copied, not the constraints, so the merge keeps doing its job. Adding a `DisableAutoMapping` or `EnableAutoMapping` constraint to a property does not store a constraint, it only sets the strategy, so the metadata gains nothing else. A property redeclared with its own strategy still wins, since the loaders run afterwards and write to the same property metadata.

Copying a strategy creates an empty property metadata that the loaders may or may not fill. The ones they leave untouched are removed once loading is done, so that the merge adds the parent's one back at its usual place. This keeps `getConstrainedProperties()`, and therefore the order of the violations, as it is today, and keeps `getPropertyMetadata()` returning the same entries as before.

What to watch when upgrading:
- `DisableAutoMapping` on an inherited property now removes the guessed constraints from the child classes, so values that used to be rejected are accepted;
- `EnableAutoMapping` works in the other direction: it now adds the guessed constraints to the child classes, so values that used to be accepted can start being rejected;
- an inherited property that declares `EnableAutoMapping` while auto-mapping is enabled for the class anyway is now listed after the other inherited properties instead of before them.

What this does not change:
- private properties of a parent class: they are not part of the child class, and the loaders map them on the class that declares them, where the strategy is already visible;
- a strategy declared on a getter, which the auto-mapping loaders match by field name only;
- `DisableAutoMapping` declared on a parent class rather than on a property. That one is not inherited at all today, since the constraint is never stored and therefore never merged. Changing it would silently drop the auto-mapped constraints of every child class, which is a decision of its own.

The regression is guarded at the layer it was reported on, with a mapped superclass fixture for `DoctrineLoader` and a parent class fixture for `PropertyInfoLoader`. With the source change reverted and the tests kept:
- `DoctrineLoaderTest::testLoadClassMetadata` fails with `Failed asserting that actual size 2 matches expected size 1`, the guessed `Length` sitting on the child class next to the parent's strategy;
- `PropertyInfoLoaderTest::testInheritedAutoMappingStrategy` fails the same way;
- `LazyLoadingMetadataFactoryTest::testLoadersSeeAutoMappingStrategyOfParentProperties` fails with `Failed asserting that 0 is identical to 2`, that is the loader reads `AutoMappingStrategy::NONE` for the inherited property.

Full suites: `./phpunit src/Symfony/Component/Validator/Tests` 4807 tests green, `./phpunit src/Symfony/Bridge/Doctrine/Tests` 453 tests green, `./phpunit src/Symfony/Component/Form/Tests` 4748 tests green.
