### PR TITLE
[BrowserKit] Fix decoding raw cookie values that contain a plus sign

### DIFF
--- a/src/Symfony/Component/BrowserKit/Cookie.php
+++ b/src/Symfony/Component/BrowserKit/Cookie.php
@@ -62,7 +62,7 @@ class Cookie
     {
         if ($encodedValue) {
             $this->rawValue = $value ?? '';
-            $this->value = urldecode($this->rawValue);
+            $this->value = rawurldecode($this->rawValue);
         } else {
             $this->value = $value ?? '';
             $this->rawValue = rawurlencode($this->value);

--- a/src/Symfony/Component/BrowserKit/Tests/CookieTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/CookieTest.php
@@ -136,6 +136,14 @@ class CookieTest extends TestCase
 
         $cookie = new Cookie('foo', 'bar%3Dbaz', null, '/', '', false, true, true); // raw value
         $this->assertEquals('bar=baz', $cookie->getValue(), '->getValue() returns the urldecoded cookie value');
+
+        $cookie = new Cookie('foo', 'bar+baz', null, '/', '', false, true, true); // raw value
+        $this->assertEquals('bar+baz', $cookie->getValue(), '->getValue() keeps plus signs of the raw cookie value');
+
+        $cookie = new Cookie('foo', 'bar%2Bbaz', null, '/', '', false, true, true); // raw value
+        $this->assertEquals('bar+baz', $cookie->getValue(), '->getValue() decodes percent-encoded plus signs');
+
+        $this->assertEquals('bar+baz', Cookie::fromString('foo=bar+baz')->getValue());
     }
 
     public function testGetRawValue()
@@ -144,6 +152,9 @@ class CookieTest extends TestCase
         $this->assertEquals('bar%3Dbaz', $cookie->getRawValue(), '->getRawValue() returns the urlencoded cookie value');
         $cookie = new Cookie('foo', 'bar%3Dbaz', null, '/', '', false, true, true); // raw value
         $this->assertEquals('bar%3Dbaz', $cookie->getRawValue(), '->getRawValue() returns the non-urldecoded cookie value');
+
+        $cookie = new Cookie('foo', 'bar+baz'); // decoded value
+        $this->assertEquals('bar%2Bbaz', $cookie->getRawValue(), '->getRawValue() encodes plus signs of the cookie value');
     }
 
     public function testGetPath()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #42538
| License       | MIT

`BrowserKit\Cookie` encodes values with `rawurlencode()` but decodes them with `urldecode()`. The two functions disagree on the plus sign: `rawurlencode()` turns a plus sign into `%2B`, while `urldecode()` turns a plus sign into a space. A response carrying `Set-Cookie: foo=bar+baz` therefore lands in the jar with the value `bar baz`.

That is what makes a forwarded cookie change on the way. `AbstractBrowser` builds the next request from `CookieJar::allValues()`, which returns decoded values, so a raw cookie value of `bar+baz` reaches the next controller as `bar baz`.

PHP itself does not behave that way. Checked on PHP 8.5 with the built-in server:

```
$ curl -H 'Cookie: plus=foo+bar; pct=foo%2Bbar; sp=foo%20bar' http://127.0.0.1:8799/
array (
  'plus' => 'foo+bar',
  'pct' => 'foo+bar',
  'sp' => 'foo bar',
)
```

and on the sending side, `setcookie('space', 'a b')` emits `Set-Cookie: space=a%20b` while `setcookie('plus', 'a+b')` emits `plus=a%2Bb`. PHP uses the raw variants on both sides, so a plus sign in a cookie value survives a round trip.

This patch decodes with `rawurldecode()`. The two sides of `Cookie` become symmetric and `CookieJar::allValues()` now returns what `$_COOKIE` would hold for the same header.

The `urldecode()` call in `HttpFoundation\Cookie::fromString()` mentioned in the report is a different code path and is left alone: its `$decode` argument defaults to `false` and the only caller in the framework, `ResponseHeaderBag::__construct()`, does not ask for decoding.

Checks run:

- `./phpunit src/Symfony/Component/BrowserKit`: 242 tests, 591 assertions, green. Same command on the branch point: 242 tests, 587 assertions, green.
- `./phpunit src/Symfony/Component/HttpKernel/Tests` (owner of `HttpKernelBrowser`, the consumer of `allValues()`): 1217 tests, 2958 assertions, green.
- PHP CS Fixer dry run on both touched files: clean.
- Revert check: with `Cookie.php` back at its base state the new assertion fails with `->getValue() keeps plus signs of the raw cookie value / Failed asserting that two strings are equal. -'bar+baz' +'bar baz'`.

One assertion in `testGetRawValue()` passes on the base state as well. It is there to pin the encoding side, which the patch must not change.
