### PR TITLE
[Mime] Reject an unquoted "@" in the local part of an email address

### DIFF
--- a/src/Symfony/Component/Mime/Address.php
+++ b/src/Symfony/Component/Mime/Address.php
@@ -54,7 +54,7 @@ final class Address
             throw new InvalidArgumentException('Email address contains control characters.');
         }
 
-        if (!self::$validator->isValid($this->address, class_exists(MessageIDValidation::class) ? new MessageIDValidation() : new RFCValidation())) {
+        if (!self::isValidAddrSpec($this->address)) {
             throw new RfcComplianceException(\sprintf('Email "%s" does not comply with addr-spec of RFC 2822.', $address));
         }
     }
@@ -120,5 +120,20 @@ final class Address
         }
 
         return $addrs;
+    }
+
+    private static function isValidAddrSpec(string $address): bool
+    {
+        // the message id validation is needed as this class also holds the ids of the Message-ID,
+        // In-Reply-To and References headers, but it accepts an unquoted "@" in the local part
+        if (!self::$validator->isValid($address, class_exists(MessageIDValidation::class) ? new MessageIDValidation() : new RFCValidation())) {
+            return false;
+        }
+
+        if (substr_count($address, '@') < 2) {
+            return true;
+        }
+
+        return self::$validator->isValid(substr($address, 0, strrpos($address, '@')).'@example.com', new RFCValidation());
     }
 }

--- a/src/Symfony/Component/Mime/Tests/AddressTest.php
+++ b/src/Symfony/Component/Mime/Tests/AddressTest.php
@@ -38,6 +38,19 @@ class AddressTest extends TestCase
         new Address('fab   pot@symfony.com');
     }
 
+    public function testConstructorWithUnquotedAtSignInLocalPart()
+    {
+        $this->expectException(RfcComplianceException::class);
+        $this->expectExceptionMessage('Email "em@il@example.test" does not comply with addr-spec of RFC 2822.');
+        new Address('em@il@example.test');
+    }
+
+    public function testConstructorWithQuotedAtSignInLocalPart()
+    {
+        $a = new Address('"em@il"@example.test');
+        $this->assertSame('"em@il"@example.test', $a->getAddress());
+    }
+
     /**
      * @dataProvider provideAddressesWithControlCharacters
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #44094
| License       | MIT

`new Address('em@il@example.test')` is accepted today, although the exception `Address` throws for a rejected value promises compliance with the addr-spec of RFC 2822, where the local part can only hold an `@` when it is quoted.

`Address` validates with `MessageIDValidation` because the class also holds the ids of the `Message-ID`, `In-Reply-To` and `References` headers, which follow the msg-id syntax of RFC 2822 (3.6.4). That syntax is more permissive on the right hand side of the `@`, and the implementation also lets a second unquoted `@` through: `foo@bar@example.com`, `"quoted"@a@example.com` and `foo@example@` are all reported as valid.

Validating with `RFCValidation` instead, as the report suggests, changes more than the reported defect. `RFCValidation` also enforces RFC 1035 on the domain, so ids such as `a@b.c+&%$.d`, which the `IdentificationHeader` tests cover, and addresses such as `foo@bar_baz.com` would start throwing. It would also mean validating the header ids elsewhere and duplicating there the control character check that `Address` runs against header injection.

So the message id validation stays, and the local part is checked on its own: when the address holds more than one `@`, the part before the last one is paired with a domain known to be valid and validated with `RFCValidation`. The last `@` is already where `IdnAddressEncoder` splits the local part from the domain, so this matches how the component reads an address elsewhere. Addresses with a single `@` skip the extra check and keep their exact current behavior.

What changes for users: `new Address()`, and everything built on it such as `Email::from()` and `Email::to()`, now throws `RfcComplianceException` for an address whose local part holds an unquoted `@`. The quoted form `"em@il"@example.test` keeps working.

Checks that were run:

- `./phpunit src/Symfony/Component/Mime`: 403 tests, 1620 assertions, 1 skipped, green. The suite had 401 tests before the two new ones.
- `./phpunit src/Symfony/Component/Mailer/Tests`: 166 tests, green. `./phpunit src/Symfony/Bridge/Twig/Tests/Mime`: 24 tests, green. `./phpunit src/Symfony/Component/Notifier/Tests`: 162 tests, green.
- With `Address.php` put back to its base state and the tests kept, `testConstructorWithUnquotedAtSignInLocalPart` fails with `Failed asserting that exception of type "Symfony\Component\Mime\Exception\RfcComplianceException" is thrown`. `testConstructorWithQuotedAtSignInLocalPart` passes on the base state as well: it guards existing behavior, it does not prove the fix.
- A search over `src/Symfony` found no test fixture using an address with two `@`, so nothing else in the repository relies on the old behavior.
