### PR TITLE
[PhpUnitBridge] Fix finding the project root when vendor/ is a symlink

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/Tests/SimplePhpunitTest.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/SimplePhpunitTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\PhpUnit\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+class SimplePhpunitTest extends TestCase
+{
+    private $tmpDir;
+
+    protected function tearDown(): void
+    {
+        if ($this->tmpDir) {
+            exec('rm -rf '.escapeshellarg($this->tmpDir));
+        }
+    }
+
+    public function testInstallsInTheProjectVendorWhenVendorIsASymlink()
+    {
+        if ('\\' === \DIRECTORY_SEPARATOR) {
+            $this->markTestSkipped('This test cannot be run on Windows.');
+        }
+
+        $this->tmpDir = realpath(sys_get_temp_dir()).'/sf_simple_phpunit_'.bin2hex(random_bytes(6));
+        $project = $this->tmpDir.'/project';
+        $vendor = $this->tmpDir.'/vendor';
+
+        mkdir($project, 0777, true);
+        mkdir($vendor.'/bin', 0777, true);
+        mkdir($vendor.'/symfony/phpunit-bridge/bin', 0777, true);
+        file_put_contents($project.'/composer.json', '{}');
+
+        foreach (['composer.json', 'DeprecationErrorHandler.php', 'bin/simple-phpunit', 'bin/simple-phpunit.php'] as $file) {
+            copy(\dirname(__DIR__).'/'.$file, $vendor.'/symfony/phpunit-bridge/'.$file);
+        }
+
+        symlink('../symfony/phpunit-bridge/bin/simple-phpunit', $vendor.'/bin/simple-phpunit');
+        symlink($vendor, $project.'/vendor');
+
+        // stops the run at the first composer call and reports where PHPUnit would be installed
+        $composer = $this->tmpDir.'/composer';
+        file_put_contents($composer, "#!/usr/bin/env php\n<?php\necho 'INSTALLING IN ', getcwd(), \"\\n\";\nexit(1);\n");
+
+        $php = escapeshellarg(\PHP_BINARY).('phpdbg' === \PHP_SAPI ? ' -qrr' : '');
+        $cmd = $php.' vendor/bin/simple-phpunit 2>&1';
+        $env = ['PATH' => getenv('PATH'), 'COMPOSER_BINARY' => $composer];
+        $process = proc_open($cmd, [1 => ['pipe', 'w']], $pipes, $project, $env);
+        $output = stream_get_contents($pipes[1]);
+        fclose($pipes[1]);
+        proc_close($process);
+
+        $this->assertStringContainsString('INSTALLING IN '.$vendor.'/bin/.phpunit', $output);
+    }
+}

--- a/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit.php
+++ b/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit.php
@@ -115,13 +115,19 @@ $PHPUNIT_REMOVE_RETURN_TYPEHINT = filter_var($getEnvVar('SYMFONY_PHPUNIT_REMOVE_
 
 $COMPOSER_JSON = getenv('COMPOSER') ?: 'composer.json';
 
-$root = __DIR__;
-while (!file_exists($root.'/'.$COMPOSER_JSON) || file_exists($root.'/DeprecationErrorHandler.php')) {
-    if ($root === dirname($root)) {
-        break;
+$findRoot = static function ($dir) use ($COMPOSER_JSON) {
+    while (!file_exists($dir.'/'.$COMPOSER_JSON) || file_exists($dir.'/DeprecationErrorHandler.php')) {
+        if ($dir === dirname($dir)) {
+            return null;
+        }
+        $dir = dirname($dir);
     }
-    $root = dirname($root);
-}
+
+    return $dir;
+};
+
+// __DIR__ has symlinks resolved, so the walk up leaves the project when vendor/ points outside of it
+$root = $findRoot(__DIR__) ?? $findRoot(getcwd()) ?? getcwd();
 
 $oldPwd = getcwd();
 $PHPUNIT_DIR = rtrim($getEnvVar('SYMFONY_PHPUNIT_DIR', $root.'/vendor/bin/.phpunit'), '/'.\DIRECTORY_SEPARATOR);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #44863
| License       | MIT

`simple-phpunit` looks for the project root by walking up from `__DIR__` until it finds a directory that has a `composer.json` and is not the bridge itself. That directory decides where PHPUnit is installed, in `vendor/bin/.phpunit`.

`__DIR__` has symlinks resolved. When `vendor/` is a symlink to a directory outside the project, the walk starts outside the project and never reaches the project's `composer.json`, so it stops at the filesystem root. `$PHPUNIT_DIR` becomes `/vendor/bin/.phpunit`, which cannot be created:

```
$ ./vendor/bin/simple-phpunit
PHP Warning:  chdir(): No such file or directory (errno 2) in .../symfony/phpunit-bridge/bin/simple-phpunit.php
Creating a "phpunit/phpunit" project at "./phpunit-9.6-0"
```

PHPUnit is then installed into the current directory, and because the cache marker cannot be written either, it is reinstalled on every single run.

The fix keeps the existing walk and adds a second one from the working directory when the first finds nothing. The working directory is not resolved through the symlink, so it stays inside the project. When the first walk succeeds nothing changes, which covers every layout that works today, including the one symfony/symfony itself uses, where `vendor/symfony/phpunit-bridge` is a symlink into `src/`.

Checks that were run:

* New test `SimplePhpunitTest::testInstallsInTheProjectVendorWhenVendorIsASymlink`. It builds a project in a temporary directory with a symlinked `vendor/`, points `COMPOSER_BINARY` at a stub that prints the working directory and exits, and asserts where the install would happen. Without the fix it reports `INSTALLING IN <tmp>/project` together with the `chdir()` warning quoted above; with the fix it reports `INSTALLING IN <tmp>/vendor/bin/.phpunit`. The test is skipped on Windows.
* Full bridge suite, PHP 8.5 with PHPUnit 9.6: 131 tests, 349 assertions, 1 error, 3 failures. The same error and the same 3 failures happen on the base commit (130 tests, 348 assertions). They are local environment noise: three `.phpt` tests run a PHPUnit install that requires PHP >= 8.4 under an older binary, and `DeprecationTest::testMethodInheritedFromAnInternalClassIsNotLegacy` hits a PHPUnit 9.6 `DocBlock` incompatibility on PHP 8.5.
* Manual runs of `vendor/bin/simple-phpunit` in four fixture layouts: a plain `vendor/`, a `vendor/` symlinked outside the project, the symfony/symfony layout with the bridge symlinked into `src/`, and a project without any `composer.json`. The middle two were also run from a subdirectory of the project. All of them install into `<project>/vendor/bin/.phpunit`.

The detection code is byte for byte identical on 6.4, 7.4, 8.1 and 8.2, so the patch merges up unchanged.
