### PR TITLE
[Serializer] Fix SerializedName being ignored on denormalization when the attribute has groups

### DIFF
--- a/src/Symfony/Component/Serializer/NameConverter/MetadataAwareNameConverter.php
+++ b/src/Symfony/Component/Serializer/NameConverter/MetadataAwareNameConverter.php
@@ -115,30 +115,35 @@ final class MetadataAwareNameConverter implements AdvancedNameConverterInterface
             return [];
         }
 
-        $classMetadata = $this->metadataFactory->getMetadataFor($class);
+        $attributesMetadata = $this->metadataFactory->getMetadataFor($class)->getAttributesMetadata();
+        $contextGroups = (array) ($context[AbstractNormalizer::GROUPS] ?? []);
 
         $cache = [];
-        foreach ($classMetadata->getAttributesMetadata() as $name => $metadata) {
-            if (null === $metadata->getSerializedName()) {
+        foreach ($attributesMetadata as $name => $metadata) {
+            if (null === $serializedName = $metadata->getSerializedName()) {
                 continue;
             }
 
-            if (null !== $metadata->getSerializedName() && null !== $metadata->getSerializedPath()) {
+            if (null !== $metadata->getSerializedPath()) {
                 throw new LogicException(\sprintf('Found SerializedName and SerializedPath attributes on property "%s" of class "%s".', $name, $class));
             }
 
             $metadataGroups = $metadata->getGroups();
-            $contextGroups = (array) ($context[AbstractNormalizer::GROUPS] ?? []);
 
-            if ($contextGroups && !$metadataGroups) {
+            if (!$contextGroups) {
+                $sameNameMetadata = $attributesMetadata[$serializedName] ?? null;
+
+                // without groups to tell them apart, the attribute using that name for itself wins
+                if ($metadataGroups && $sameNameMetadata && null === $sameNameMetadata->getSerializedName()) {
+                    continue;
+                }
+            } elseif (!$metadataGroups) {
+                continue;
+            } elseif (!array_intersect($metadataGroups, $contextGroups) && !\in_array('*', $contextGroups, true)) {
                 continue;
             }
 
-            if ($metadataGroups && !array_intersect($metadataGroups, $contextGroups) && !\in_array('*', $contextGroups, true)) {
-                continue;
-            }
-
-            $cache[$metadata->getSerializedName()] = $name;
+            $cache[$serializedName] = $name;
         }
 
         return $cache;

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/OtherSerializedNameDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/OtherSerializedNameDummy.php
@@ -22,6 +22,9 @@ class OtherSerializedNameDummy
     #[Groups(['a'])]
     private $buz;
 
+    #[Groups(['a']), SerializedName('quux')]
+    public $qux;
+
     public function setBuz($buz)
     {
         $this->buz = $buz;

--- a/src/Symfony/Component/Serializer/Tests/NameConverter/MetadataAwareNameConverterTest.php
+++ b/src/Symfony/Component/Serializer/Tests/NameConverter/MetadataAwareNameConverterTest.php
@@ -150,6 +150,16 @@ final class MetadataAwareNameConverterTest extends TestCase
         ];
     }
 
+    public function testDenormalizeSerializedNameOfGroupedAttributeWithoutContextGroups()
+    {
+        $classMetadataFactory = new ClassMetadataFactory(new AttributeLoader());
+
+        $nameConverter = new MetadataAwareNameConverter($classMetadataFactory);
+
+        $this->assertSame('quux', $nameConverter->normalize('qux', OtherSerializedNameDummy::class));
+        $this->assertSame('qux', $nameConverter->denormalize('quux', OtherSerializedNameDummy::class));
+    }
+
     public function testDenormalizeWithCacheContext()
     {
         $classMetadataFactory = new ClassMetadataFactory(new AttributeLoader());

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -643,6 +643,18 @@ class ObjectNormalizerTest extends TestCase
         );
     }
 
+    public function testDenormalizeSerializedNameOfGroupedAttributeWithoutContextGroups()
+    {
+        $classMetadataFactory = new ClassMetadataFactory(new AttributeLoader());
+        $this->normalizer = new ObjectNormalizer($classMetadataFactory, new MetadataAwareNameConverter($classMetadataFactory));
+        $this->normalizer->setSerializer($this->serializer);
+
+        $obj = new OtherSerializedNameDummy();
+        $obj->qux = 'Aldrin';
+
+        $this->assertEquals($obj, $this->normalizer->denormalize(['quux' => 'Aldrin'], OtherSerializedNameDummy::class));
+    }
+
     // ignored attributes
 
     protected function getNormalizerForIgnoredAttributes(): ObjectNormalizer


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #45379
| License       | MIT

`MetadataAwareNameConverter` applies `#[SerializedName]` in one direction only when the attribute also carries `#[Groups]` and the denormalization context has no groups.

```php
class Dummy
{
    #[Groups(['a']), SerializedName('renamed')]
    public $property;
}

$converter->normalize('property', Dummy::class);   // "renamed"
$converter->denormalize('renamed', Dummy::class);  // "renamed", the property is never found
```

The round trip loses the value: denormalizing what the serializer just produced returns an object whose `$property` is null. With `allow_extra_attributes` set to `false`, the same payload throws `ExtraAttributesException: Extra attributes are not allowed ("renamed" is unknown).`

`getCacheValueForAttributesMetadata()` builds the map from serialized names to attribute names and skips every attribute whose groups do not intersect the groups of the context. When the context carries no groups that intersection is empty for every grouped attribute, so all of their serialized names are dropped. Filtering by group is pointless there: with no groups in the context the normalizer does not filter attributes by group either, so all of them are in play.

The patch stops filtering by group when the context has no groups. It keeps the one rule that decides a name clash today: when the serialized name is also the name of another attribute that has no serialized name of its own, that attribute keeps the name for itself. Nothing tells the two apart in that case. The `OtherSerializedNameDummy` fixture is exactly that shape, with a writable `buz` property and a read-only `getBuzForExport()` exported as `buz`, and its existing expectations pin the rule: removing the rule makes `MetadataAwareNameConverterTest::testDenormalizeWithGroups` data set #5 and `testDenormalizeWithCacheContext` fail.

Behavior therefore changes only for serialized names that the converter used to drop, which today fall through to the raw attribute name. Two attributes that swap their serialized names, for instance, now denormalize into the right properties instead of into each other.

Checks run, on PHP 8.5 with PHPUnit 9.6:

- `./phpunit src/Symfony/Component/Serializer`: 1153 tests, 2319 assertions, 11 skipped, no failure. The 11 skips and the single legacy deprecation notice are also there with the patch reverted.
- The two new tests were written before the fix and fail without it: `MetadataAwareNameConverterTest::testDenormalizeSerializedNameOfGroupedAttributeWithoutContextGroups` fails with `-'qux' +'quux'`, and `ObjectNormalizerTest::testDenormalizeSerializedNameOfGroupedAttributeWithoutContextGroups` fails with `'qux' => null` where `'qux' => 'Aldrin'` is expected.
- Reverting only `MetadataAwareNameConverter.php` and running the whole component again gives 1153 tests with exactly those 2 failures, so nothing else in the component depends on the dropped names.

Merging up: 7.4 and 8.2 carry the same defect in a different shape of the method, which supports per-group serialized names and the default groups flag. There, "no groups in the context" is `!$groupsHasBeenDefined`, computed before the default groups are merged into `$groups`, and the clash check has to read `getSerializedName($groups)`.
