### PR TITLE
[HttpKernel] Ignore the session id that PHP kept from a previous request

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/AbstractSessionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/AbstractSessionListener.php
@@ -78,6 +78,8 @@ abstract class AbstractSessionListener implements EventSubscriberInterface, Rese
                 static $sess;
 
                 if (!$sess) {
+                    // PHP keeps the id of the previous request when it cannot be reset, e.g. once some output has been sent
+                    $previousSessionId = session_id();
                     $sess = $this->getSession();
                     $request->setSession($sess);
 
@@ -88,7 +90,12 @@ abstract class AbstractSessionListener implements EventSubscriberInterface, Rese
                      * Do not set it when a native php session is active.
                      */
                     if ($sess && !$sess->isStarted() && \PHP_SESSION_ACTIVE !== session_status()) {
-                        $sessionId = $sess->getId() ?: $request->cookies->get($sess->getName(), '');
+                        $sessionId = $sess->getId();
+
+                        if ('' === $sessionId || $previousSessionId === $sessionId) {
+                            $sessionId = $request->cookies->get($sess->getName(), '');
+                        }
+
                         $sess->setId($sessionId);
                     }
                 }

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/SessionListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/SessionListenerTest.php
@@ -26,6 +26,7 @@ use Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage;
 use Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorageFactory;
 use Symfony\Component\HttpFoundation\Session\Storage\PhpBridgeSessionStorageFactory;
 use Symfony\Component\HttpFoundation\Session\Storage\SessionStorageFactoryInterface;
+use Symfony\Component\HttpFoundation\Session\Storage\SessionStorageInterface;
 use Symfony\Component\HttpKernel\DataCollector\RequestDataCollector;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
@@ -216,16 +217,51 @@ class SessionListenerTest extends TestCase
     /**
      * @runInSeparateProcess
      */
+    public function testSessionIdKeptByPhpFromAPreviousRequestIsIgnored()
+    {
+        $previousSessionId = $this->createValidSessionId();
+
+        $this->assertSame($previousSessionId, session_id());
+
+        $request = new Request();
+        $request->cookies->set('PHPSESSID', 'REQUEST-SESSION-ID');
+
+        $listener = $this->createListener($request, new NativeSessionStorageFactory());
+
+        $kernel = $this->createStub(HttpKernelInterface::class);
+        $listener->onKernelRequest(new RequestEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST));
+
+        $this->assertSame('REQUEST-SESSION-ID', $request->getSession()->getId());
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
     public function testNewSessionIdIsNotOverwritten()
     {
         $newSessionId = $this->createValidSessionId();
 
         $this->assertNotEmpty($newSessionId);
 
+        // the id comes from the storage factory below, not from the state PHP kept from a previous request
+        session_id('');
+
         $request = new Request();
         $request->cookies->set('PHPSESSID', 'OLD-SESSION-ID');
 
-        $listener = $this->createListener($request, new NativeSessionStorageFactory());
+        $listener = $this->createListener($request, new class($newSessionId) implements SessionStorageFactoryInterface {
+            public function __construct(private string $sessionId)
+            {
+            }
+
+            public function createStorage(?Request $request): SessionStorageInterface
+            {
+                $storage = new NativeSessionStorage();
+                $storage->setId($this->sessionId);
+
+                return $storage;
+            }
+        });
 
         $kernel = $this->createStub(HttpKernelInterface::class);
         $listener->onKernelRequest(new RequestEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #46206
| License       | MIT

`AbstractSessionListener` binds the incoming request to a session id with this line:

```php
$sessionId = $sess->getId() ?: $request->cookies->get($sess->getName(), '');
$sess->setId($sessionId);
```

A session object is built for every request, so `getId()` is empty unless the application deliberately set an id while the session was being created. That does not hold for the native storage: `NativeSessionStorage::getId()` returns `session_id()`, which is process global state. The listener clears it in `reset()`, but only when no headers were sent:

```php
if (!headers_sent()) { // session id can only be reset when no headers were so we check for headers_sent first
    session_id('');
}
```

On the CLI, `headers_sent()` returns true as soon as anything has been written to the output, and `session_id('')` is refused once that happened. The reset is therefore a no-op during a PHPUnit run, and in a worker runtime that writes anything to stdout. PHP keeps the id of the previous request, and the listener prefers it over the cookie the client sent.

In a test suite this shows up as a request being served with the session of the previous request: after `loginUser()` writes a new session id into the cookie jar, the next request still runs on the previous session and the user looks logged out. In a worker runtime the same code binds one visitor to the session of the visitor before them.

The fix reads `session_id()` before the session is created and treats an id equal to that leftover value like an empty one, so the cookie wins. An id set by the application while the session was being created still wins over the cookie, which is the behavior added in #45394.

`testNewSessionIdIsNotOverwritten` used to cover that behavior by leaving an id in PHP global state before the request, which is exactly the leftover case this fix rules out. It now sets the id from the session storage factory, which is how the use case behind #45394 actually works, and it passes both with and without the fix.

Not every report in the issue thread has this cause. The comments about `stateless: true` firewalls describe a different problem, which the reporter of those comments already said is unrelated. Applications whose test configuration uses `session.storage.factory.mock_file` never hit this line either, because a mock storage keeps no state between requests.

Checks run:

- `php ./phpunit src/Symfony/Component/HttpKernel/Tests`: OK, 1218 tests, 2960 assertions.
- The new test on the unpatched source: `Failed asserting that two strings are identical. -'REQUEST-SESSION-ID' +'f9cec36dc56133a1684fcad25e264af1'`.
- No style tool available locally, so the hosted style check has not been reproduced.
