### PR TITLE
[Messenger] Ignore the option-less handler tag added by autoconfiguration

### DIFF
--- a/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
+++ b/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
@@ -65,6 +65,11 @@ class MessengerPass implements CompilerPassInterface
         $handlerToOriginalServiceIdMapping = [];
 
         foreach ($container->findTaggedServiceIds('messenger.message_handler', true) as $serviceId => $tags) {
+            // an option-less tag comes from autoconfiguration; it would defeat the configured ones
+            if ($configuredTags = array_filter($tags)) {
+                $tags = $configuredTags;
+            }
+
             foreach ($tags as $tag) {
                 if (isset($tag['bus']) && !\in_array($tag['bus'], $busIds, true)) {
                     throw new RuntimeException(\sprintf('Invalid handler service "%s": bus "%s" specified on the tag "messenger.message_handler" does not exist (known ones are: "%s").', $serviceId, $tag['bus'], implode('", "', $busIds)));

--- a/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerPassTest.php
+++ b/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerPassTest.php
@@ -34,6 +34,9 @@ use Symfony\Component\Messenger\Command\SetupTransportsCommand;
 use Symfony\Component\Messenger\DataCollector\MessengerDataCollector;
 use Symfony\Component\Messenger\DependencyInjection\MessengerPass;
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Handler\Acknowledger;
+use Symfony\Component\Messenger\Handler\BatchHandlerInterface;
+use Symfony\Component\Messenger\Handler\BatchHandlerTrait;
 use Symfony\Component\Messenger\Handler\HandlersLocator;
 use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
 use Symfony\Component\Messenger\Handler\MessageSubscriberInterface;
@@ -250,6 +253,41 @@ class MessengerPassTest extends TestCase
             UnionTypeTwoMessage::class,
             [[TaggedDummyHandlerWithUnionTypes::class, 'handleUnionTypeMessage']]
         );
+    }
+
+    public function testTaggedBatchMessageHandlerIsRegisteredOnce()
+    {
+        $container = $this->getContainerBuilder($busId = 'message_bus');
+        $container->registerForAutoconfiguration(BatchHandlerInterface::class)->addTag('messenger.message_handler');
+        $container->registerAttributeForAutoconfiguration(AsMessageHandler::class, static function (ChildDefinition $definition, AsMessageHandler $attribute, \ReflectionClass|\ReflectionMethod $reflector): void {
+            $tagAttributes = get_object_vars($attribute);
+            $tagAttributes['from_transport'] = $tagAttributes['fromTransport'];
+            unset($tagAttributes['fromTransport']);
+            if ($reflector instanceof \ReflectionMethod) {
+                $tagAttributes['method'] = $reflector->getName();
+            }
+
+            $definition->addTag('messenger.message_handler', $tagAttributes);
+        });
+        $container
+            ->register(TaggedDummyBatchHandler::class, TaggedDummyBatchHandler::class)
+            ->setAutoconfigured(true)
+        ;
+
+        (new AttributeAutoconfigurationPass())->process($container);
+        (new ResolveInstanceofConditionalsPass())->process($container);
+        (new MessengerPass())->process($container);
+
+        $handlerDescriptionMapping = $container->getDefinition($busId.'.messenger.handlers_locator')->getArgument(0);
+
+        $this->assertCount(1, $handlerDescriptionMapping);
+
+        $handlerDescriptors = $handlerDescriptionMapping[DummyMessage::class]->getValues();
+        $this->assertCount(1, $handlerDescriptors);
+
+        $handlerDescriptorDefinition = $container->getDefinition((string) $handlerDescriptors[0]);
+        $this->assertSame(['from_transport' => 'async'], $handlerDescriptorDefinition->getArgument(1));
+        $this->assertEquals([new Reference(TaggedDummyBatchHandler::class), '__invoke'], $container->getDefinition((string) $handlerDescriptorDefinition->getArgument(0))->getArgument(0));
     }
 
     public function testProcessHandlersByBus()
@@ -970,6 +1008,21 @@ class MessengerPassTest extends TestCase
 class DummyHandler
 {
     public function __invoke(DummyMessage $message): void
+    {
+    }
+}
+
+#[AsMessageHandler(fromTransport: 'async')]
+class TaggedDummyBatchHandler implements BatchHandlerInterface
+{
+    use BatchHandlerTrait;
+
+    public function __invoke(DummyMessage $message, ?Acknowledger $ack = null): mixed
+    {
+        return $this->handle($message, $ack);
+    }
+
+    private function process(array $jobs): void
     {
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #46784
| License       | MIT

FrameworkBundle autoconfigures `BatchHandlerInterface` (and `MessageHandlerInterface` on 6.4) by adding a `messenger.message_handler` tag with no attributes. When such a class also carries `#[AsMessageHandler(...)]`, or is tagged in the service configuration, the service ends up with two tags: the configured one and the option-less one. `ResolveInstanceofConditionalsPass` drops a tag only when it is strictly identical to one the definition already has, so both survive and `MessengerPass` registers the handler twice.

The extra registration has no options, so it ignores `from_transport`, `bus`, `handles`, `method` and `priority`. A batch handler declared with `#[AsMessageHandler(fromTransport: 'async')]` is registered for every transport and every bus on top of the configured one, and the tag cannot be overridden from the service configuration either.

The pass now keeps only the configured tags of a service when it has any. A service that carries option-less tags only is registered as before.

Checks run on 6.4: `./phpunit src/Symfony/Component/Messenger/Tests` (OK, 411 tests, 1143 assertions), `./phpunit src/Symfony/Bundle/FrameworkBundle/Tests` (OK, 1373 tests, 4545 assertions, 5 skipped) and `./phpunit src/Symfony/Component/Scheduler/Tests` (OK, 145 tests, 778 assertions). The new test fails without the patch with "Failed asserting that actual size 2 matches expected size 1".
