### PR TITLE
[Messenger] Tell apart handler services that share the same class

### DIFF
--- a/src/Symfony/Component/Messenger/Command/DebugCommand.php
+++ b/src/Symfony/Component/Messenger/Command/DebugCommand.php
@@ -85,7 +85,7 @@ class DebugCommand extends Command
                 $tableRows[] = [\sprintf('<fg=cyan>%s</fg=cyan>', $message)];
                 foreach ($handlers as $handler) {
                     $tableRows[] = [
-                        \sprintf('    handled by <info>%s</>', $handler[0]).$this->formatConditions($handler[1]),
+                        \sprintf('    handled by <info>%s</>', $handler[0]).$this->formatConditions($handler[1], $handler[0]),
                     ];
                     if ($handlerDescription = self::getClassDescription($handler[0])) {
                         $tableRows[] = [\sprintf('               <comment>%s</>', $handlerDescription)];
@@ -106,8 +106,13 @@ class DebugCommand extends Command
         return 0;
     }
 
-    private function formatConditions(array $options): string
+    private function formatConditions(array $options, string $serviceId): string
     {
+        // the alias MessengerPass generates is the service id, which is already displayed as the handler
+        if ($serviceId === ($options['alias'] ?? null)) {
+            unset($options['alias']);
+        }
+
         if (!$options) {
             return '';
         }

--- a/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
+++ b/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
@@ -161,7 +161,27 @@ class MessengerPass implements CompilerPassInterface
         foreach ($handlersByBusAndMessage as $bus => $handlersByMessage) {
             foreach ($handlersByMessage as $message => $handlersByPriority) {
                 krsort($handlersByPriority);
-                $handlersByBusAndMessage[$bus][$message] = array_merge(...$handlersByPriority);
+                $handlers = array_merge(...$handlersByPriority);
+                $serviceIdsByName = [];
+
+                foreach ($handlers as $key => [$definitionId, $options]) {
+                    $serviceId = $handlerToOriginalServiceIdMapping[$definitionId];
+                    $name = $this->getServiceClass($container, $serviceId).'::'.($options['method'] ?? '__invoke');
+                    $serviceIdsByName[$name][$key] = $serviceId;
+                }
+
+                // several services sharing a name cannot be told apart at runtime, name them after their service id
+                foreach ($serviceIdsByName as $serviceIds) {
+                    if (1 === \count(array_unique($serviceIds))) {
+                        continue;
+                    }
+
+                    foreach ($serviceIds as $key => $serviceId) {
+                        $handlers[$key][1]['alias'] ??= $serviceId;
+                    }
+                }
+
+                $handlersByBusAndMessage[$bus][$message] = $handlers;
             }
         }
 

--- a/src/Symfony/Component/Messenger/Tests/Command/DebugCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/DebugCommandTest.php
@@ -50,11 +50,11 @@ class DebugCommandTest extends TestCase
             'command_bus' => [
                 DummyCommand::class => [[DummyCommandHandler::class, ['option1' => '1', 'option2' => '2']]],
                 DummyCommandWithDescription::class => [[DummyCommandWithDescriptionHandler::class, []]],
-                MultipleBusesMessage::class => [[MultipleBusesMessageHandler::class, []]],
+                MultipleBusesMessage::class => [[MultipleBusesMessageHandler::class, ['alias' => MultipleBusesMessageHandler::class]]],
             ],
             'query_bus' => [
                 DummyQuery::class => [[DummyQueryHandler::class, []]],
-                MultipleBusesMessage::class => [[MultipleBusesMessageHandler::class, []]],
+                MultipleBusesMessage::class => [[MultipleBusesMessageHandler::class, ['alias' => 'legacy']]],
             ],
         ]);
 
@@ -90,14 +90,14 @@ class DebugCommandTest extends TestCase
 
              The following messages can be dispatched:
 
-             --------------------------------------------------------------------------------------- 
-              Symfony\Component\Messenger\Tests\Fixtures\DummyQuery                                  
-                  handled by Symfony\Component\Messenger\Tests\Fixtures\DummyQueryHandler            
-                                                                                                     
-              Symfony\Component\Messenger\Tests\Fixtures\MultipleBusesMessage                        
-                  handled by Symfony\Component\Messenger\Tests\Fixtures\MultipleBusesMessageHandler  
-                                                                                                     
-             --------------------------------------------------------------------------------------- 
+             ----------------------------------------------------------------------------------------------------------- 
+              Symfony\Component\Messenger\Tests\Fixtures\DummyQuery                                                      
+                  handled by Symfony\Component\Messenger\Tests\Fixtures\DummyQueryHandler                                
+                                                                                                                         
+              Symfony\Component\Messenger\Tests\Fixtures\MultipleBusesMessage                                            
+                  handled by Symfony\Component\Messenger\Tests\Fixtures\MultipleBusesMessageHandler (when alias=legacy)  
+                                                                                                                         
+             ----------------------------------------------------------------------------------------------------------- 
 
 
             TXT,
@@ -116,14 +116,14 @@ class DebugCommandTest extends TestCase
 
              The following messages can be dispatched:
 
-             --------------------------------------------------------------------------------------- 
-              Symfony\Component\Messenger\Tests\Fixtures\DummyQuery                                  
-                  handled by Symfony\Component\Messenger\Tests\Fixtures\DummyQueryHandler            
-                                                                                                     
-              Symfony\Component\Messenger\Tests\Fixtures\MultipleBusesMessage                        
-                  handled by Symfony\Component\Messenger\Tests\Fixtures\MultipleBusesMessageHandler  
-                                                                                                     
-             --------------------------------------------------------------------------------------- 
+             ----------------------------------------------------------------------------------------------------------- 
+              Symfony\Component\Messenger\Tests\Fixtures\DummyQuery                                                      
+                  handled by Symfony\Component\Messenger\Tests\Fixtures\DummyQueryHandler                                
+                                                                                                                         
+              Symfony\Component\Messenger\Tests\Fixtures\MultipleBusesMessage                                            
+                  handled by Symfony\Component\Messenger\Tests\Fixtures\MultipleBusesMessageHandler (when alias=legacy)  
+                                                                                                                         
+             ----------------------------------------------------------------------------------------------------------- 
 
 
             TXT,

--- a/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerPassTest.php
+++ b/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerPassTest.php
@@ -290,6 +290,59 @@ class MessengerPassTest extends TestCase
         $this->assertEquals([new Reference(TaggedDummyBatchHandler::class), '__invoke'], $container->getDefinition((string) $handlerDescriptorDefinition->getArgument(0))->getArgument(0));
     }
 
+    public function testHandlersOfTheSameClassAreAliasedByServiceId()
+    {
+        $container = $this->getContainerBuilder($busId = 'message_bus');
+        $container->register('handler_a', DummyHandler::class)->addTag('messenger.message_handler');
+        $container->register('handler_b', DummyHandler::class)->addTag('messenger.message_handler');
+
+        (new MessengerPass())->process($container);
+
+        $handlerDescriptionMapping = $container->getDefinition($busId.'.messenger.handlers_locator')->getArgument(0);
+
+        $this->assertHandlerDescriptor($container, $handlerDescriptionMapping, DummyMessage::class, ['handler_a', 'handler_b'], [['alias' => 'handler_a'], ['alias' => 'handler_b']]);
+    }
+
+    public function testHandlersOfTheSameClassHandlingDifferentMessagesAreNotAliased()
+    {
+        $container = $this->getContainerBuilder($busId = 'message_bus');
+        $container->register('handler_a', DummyHandler::class)->addTag('messenger.message_handler', ['handles' => DummyMessage::class]);
+        $container->register('handler_b', DummyHandler::class)->addTag('messenger.message_handler', ['handles' => SecondMessage::class]);
+
+        (new MessengerPass())->process($container);
+
+        $handlerDescriptionMapping = $container->getDefinition($busId.'.messenger.handlers_locator')->getArgument(0);
+
+        $this->assertHandlerDescriptor($container, $handlerDescriptionMapping, DummyMessage::class, ['handler_a']);
+        $this->assertHandlerDescriptor($container, $handlerDescriptionMapping, SecondMessage::class, ['handler_b']);
+    }
+
+    public function testHandlersOfTheSameClassOnDifferentBusesAreNotAliased()
+    {
+        $container = $this->getContainerBuilder($commandBusId = 'command_bus');
+        $container->register($queryBusId = 'query_bus', MessageBusInterface::class)->setArgument(0, [])->addTag('messenger.bus');
+        $container->register('handler_a', DummyHandler::class)->addTag('messenger.message_handler', ['bus' => $commandBusId]);
+        $container->register('handler_b', DummyHandler::class)->addTag('messenger.message_handler', ['bus' => $queryBusId]);
+
+        (new MessengerPass())->process($container);
+
+        $this->assertHandlerDescriptor($container, $container->getDefinition($commandBusId.'.messenger.handlers_locator')->getArgument(0), DummyMessage::class, ['handler_a'], [['bus' => $commandBusId]]);
+        $this->assertHandlerDescriptor($container, $container->getDefinition($queryBusId.'.messenger.handlers_locator')->getArgument(0), DummyMessage::class, ['handler_b'], [['bus' => $queryBusId]]);
+    }
+
+    public function testUserDefinedHandlerAliasIsKept()
+    {
+        $container = $this->getContainerBuilder($busId = 'message_bus');
+        $container->register('handler_a', DummyHandler::class)->addTag('messenger.message_handler', ['alias' => 'first']);
+        $container->register('handler_b', DummyHandler::class)->addTag('messenger.message_handler');
+
+        (new MessengerPass())->process($container);
+
+        $handlerDescriptionMapping = $container->getDefinition($busId.'.messenger.handlers_locator')->getArgument(0);
+
+        $this->assertHandlerDescriptor($container, $handlerDescriptionMapping, DummyMessage::class, ['handler_a', 'handler_b'], [['alias' => 'first'], ['alias' => 'handler_b']]);
+    }
+
     public function testProcessHandlersByBus()
     {
         $container = $this->getContainerBuilder($commandBusId = 'command_bus');

--- a/src/Symfony/Component/Messenger/Tests/Handler/HandlerDescriptorTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Handler/HandlerDescriptorTest.php
@@ -46,6 +46,13 @@ class HandlerDescriptorTest extends TestCase
         }, 'class@anonymous%sHandlerDescriptorTest.php%s::__invoke'];
     }
 
+    public function testTheAliasIsPartOfTheName()
+    {
+        $descriptor = new HandlerDescriptor(new DummyCommandHandler(), ['alias' => 'handler_a']);
+
+        $this->assertSame(DummyCommandHandler::class.'::__invoke@handler_a', $descriptor->getName());
+    }
+
     public function testGetOptions()
     {
         $options = ['option1' => 'value1', 'option2' => 'value2'];

--- a/src/Symfony/Component/Messenger/Tests/Handler/HandlersLocatorTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Handler/HandlersLocatorTest.php
@@ -33,6 +33,18 @@ class HandlersLocatorTest extends TestCase
         $this->assertEquals([$descriptor], iterator_to_array($locator->getHandlers(new Envelope(new DummyMessage('a')))));
     }
 
+    public function testItYieldsHandlersHavingTheSameNameOnlyOnce()
+    {
+        $locator = new HandlersLocator([
+            DummyMessage::class => [
+                $first = new HandlerDescriptor(new HandlersLocatorTestCallable()),
+                new HandlerDescriptor(new HandlersLocatorTestCallable()),
+            ],
+        ]);
+
+        $this->assertSame([$first], iterator_to_array($locator->getHandlers(new Envelope(new DummyMessage('Body')))));
+    }
+
     public function testItReturnsOnlyHandlersMatchingTransport()
     {
         $firstHandler = new HandlersLocatorTestCallable();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #46791
| License       | MIT

A handler is identified by the name of its descriptor, which is `Class::method` taken from the handler instance. `HandlersLocator` uses that name to skip a handler it already yielded, and `HandleMessageMiddleware` uses it to skip the handlers that already ran when a message comes back after a failure. Two handler services of the same class therefore collapse into one: `debug:messenger` lists both, but only the first one is ever called.

The name is a display name, so this patch stops relying on it alone. `MessengerPass` sets the `alias` option on the descriptors that would otherwise share a name, so their names become `Class::method@service_id`. That name is unique and stable across processes, so a redelivered message skips only the handlers that already ran, and `HandlerFailedException` reports one entry per failed handler.

The alias is added only where the name is really ambiguous, which is when several services of the same class are registered for the same message on the same bus. A class registered as several services that handle different messages keeps its plain name. `Symfony\Component\Notifier\Messenger\MessageHandler` is one of those, registered three times by FrameworkBundle. This matters because the name is stored in `HandledStamp` inside serialized envelopes: renaming a handler would make an in-flight envelope stop matching its descriptor after the upgrade, and a handler that already succeeded would run a second time.

`debug:messenger` does not print that alias as a dispatch condition, since it repeats the service id already shown as the handler. An alias set by hand on the tag is still printed.

What changes for applications:

 * An application that registers the same handler class as two services for the same message now calls both handlers, which is what `debug:messenger` already reported.
 * If such a message is dispatched through `HandleTrait`, the trait now throws a `LogicException` saying the message was handled multiple times, where it used to return the result of the first handler. Two handlers now return a result where the trait expects one. This surfaces a misconfiguration that the collapsing was hiding.

Handlers whose class the container cannot predict are out of reach of this patch. A handler that a decorator replaces at runtime is named after the decorator, which is only known once the container is built, so two handlers sharing a decorator class still collapse into one, as before.

Checks run on 6.4: `./phpunit src/Symfony/Component/Messenger/Tests` (OK, 416 tests, 1169 assertions), `./phpunit src/Symfony/Bundle/FrameworkBundle/Tests` (OK, 1373 tests, 4545 assertions, 5 skipped), `./phpunit src/Symfony/Component/Scheduler/Tests` (OK, 145 tests, 778 assertions) and `./phpunit src/Symfony/Component/Notifier/Tests` (OK, 162 tests, 300 assertions). Dispatching through a compiled container with two services of the same handler class, one of them failing, ran only the first handler before the patch and none of them once the envelope came back with that handler's stamp; with the patch both run, and the redelivered envelope runs the failing one again and raises `HandlerFailedException`.
