### PR TITLE
[Form] Add an allow_array_submission option to let PRE_SUBMIT listeners transform submitted arrays

### DIFF
--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add `#[AsFormType]` and `#[FormField]` attributes to derive a form type from the properties of a data class
+ * Add the `allow_array_submission` option to let `PRE_SUBMIT` listeners turn a submitted array into data the form accepts
  * Add support for grouping and nested steps in `FormFlowType`
  * Deprecate the `regions` option of `TimezoneType`, it has had no effect since 5.0
  * Add `PolymorphicCollectionType` for collections whose entries do not all share the same type

--- a/src/Symfony/Component/Form/Extension/Core/Type/ColorType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ColorType.php
@@ -38,9 +38,10 @@ class ColorType extends AbstractType
         }
 
         $translator = $this->translator;
-        $builder->addEventListener(FormEvents::PRE_SUBMIT, static function (FormEvent $event) use ($translator): void {
+        $allowArraySubmission = $options['allow_array_submission'];
+        $builder->addEventListener(FormEvents::PRE_SUBMIT, static function (FormEvent $event) use ($translator, $allowArraySubmission): void {
             $value = $event->getData();
-            if (null === $value || '' === $value) {
+            if (null === $value || '' === $value || ($allowArraySubmission && \is_array($value))) {
                 return;
             }
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/FileType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FileType.php
@@ -76,7 +76,7 @@ class FileType extends AbstractType
                 $event->setData($data);
             } elseif ($requestHandler->isFileUpload($event->getData()) && method_exists($requestHandler, 'getUploadFileError') && null !== $errorCode = $requestHandler->getUploadFileError($event->getData())) {
                 $form->addError($this->getFileUploadError($errorCode));
-            } elseif (!$requestHandler->isFileUpload($event->getData())) {
+            } elseif (!($options['allow_array_submission'] && \is_array($event->getData())) && !$requestHandler->isFileUpload($event->getData())) {
                 $event->setData(null);
             }
         });

--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -182,6 +182,7 @@ class FormType extends BaseType
             'post_max_size_message' => 'The uploaded file was too large. Please try to upload a smaller file.',
             'upload_max_size_message' => $uploadMaxSizeMessage, // internal
             'allow_file_upload' => false,
+            'allow_array_submission' => false,
             'help' => null,
             'help_attr' => [],
             'help_html' => false,

--- a/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
@@ -83,7 +83,7 @@ class TimeType extends AbstractType
         if ('single_text' === $options['widget']) {
             $builder->addEventListener(FormEvents::PRE_SUBMIT, static function (FormEvent $e) use ($options) {
                 $data = $e->getData();
-                if ($data && preg_match('/^(?P<hours>\d{2}):(?P<minutes>\d{2})(?::(?P<seconds>\d{2})(?:\.\d+)?)?$/', $data, $matches)) {
+                if (\is_string($data) && preg_match('/^(?P<hours>\d{2}):(?P<minutes>\d{2})(?::(?P<seconds>\d{2})(?:\.\d+)?)?$/', $data, $matches)) {
                     if ($options['with_seconds']) {
                         // handle seconds ignored by user's browser when with_seconds enabled
                         // https://codereview.chromium.org/450533009/
@@ -102,7 +102,7 @@ class TimeType extends AbstractType
                 $builder->addEventListener(FormEvents::PRE_SUBMIT, static function (FormEvent $event) use ($options) {
                     $data = $event->getData();
 
-                    if (preg_match('/^\d{2}:\d{2}(:\d{2})?$/', $data)) {
+                    if (\is_string($data) && preg_match('/^\d{2}:\d{2}(:\d{2})?$/', $data)) {
                         $event->setData($options['reference_date']->format('Y-m-d ').$data);
                     }
                 });

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -444,6 +444,8 @@ class Form implements \IteratorAggregate, FormInterface, ClearableErrorsInterfac
             $this->setData($this->config->getData());
         }
 
+        $arrayNotAllowed = false;
+
         // Treat false as NULL to support binding false to checkboxes.
         // Don't convert NULL to a string here in order to determine later
         // whether an empty value has been submitted or whether no value has
@@ -459,8 +461,14 @@ class Form implements \IteratorAggregate, FormInterface, ClearableErrorsInterfac
                 $this->transformationFailure = new TransformationFailedException('Submitted data was expected to be text or number, file upload given.');
             }
         } elseif (\is_array($submittedData) && !$this->config->getCompound() && !$this->config->getOption('multiple', false)) {
-            $submittedData = null;
-            $this->transformationFailure = new TransformationFailedException('Submitted data was expected to be text or number, array given.');
+            if ($this->config->getOption('allow_array_submission', false)) {
+                // The failure is reported after PRE_SUBMIT so that listeners
+                // get a chance to turn the array into data the form accepts.
+                $arrayNotAllowed = true;
+            } else {
+                $submittedData = null;
+                $this->transformationFailure = new TransformationFailedException('Submitted data was expected to be text or number, array given.');
+            }
         }
 
         $dispatcher = $this->config->getEventDispatcher();
@@ -479,6 +487,20 @@ class Form implements \IteratorAggregate, FormInterface, ClearableErrorsInterfac
                 $event = new PreSubmitEvent($this, $submittedData);
                 $dispatcher->dispatch($event, FormEvents::PRE_SUBMIT);
                 $submittedData = $event->getData();
+            }
+
+            if ($arrayNotAllowed && \is_array($submittedData)) {
+                if (!$this->config->getRequestHandler()->isFileUpload($submittedData)) {
+                    $submittedData = null;
+
+                    throw new TransformationFailedException('Submitted data was expected to be text or number, array given.');
+                }
+
+                if (!$this->config->getOption('allow_file_upload')) {
+                    $submittedData = null;
+
+                    throw new TransformationFailedException('Submitted data was expected to be text or number, file upload given.');
+                }
             }
 
             // Check whether the form is compound.

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ColorTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ColorTypeTest.php
@@ -15,6 +15,8 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Component\Form\Extension\Core\Type\ColorType;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormErrorIterator;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
 
 final class ColorTypeTest extends BaseTypeTestCase
 {
@@ -79,6 +81,57 @@ final class ColorTypeTest extends BaseTypeTestCase
             ['#12345', '#12345'],
             [' #ffffff ', ' #ffffff ', false],
         ];
+    }
+
+    public function testSubmitArrayWhenAllowed()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'html5' => true,
+            'allow_array_submission' => true,
+        ]);
+
+        $form->submit(['#000000']);
+
+        $this->assertFalse($form->isSynchronized());
+        $this->assertSame('Submitted data was expected to be text or number, array given.', $form->getTransformationFailure()->getMessage());
+        $errors = iterator_to_array($form->getErrors());
+        $this->assertCount(1, $errors);
+        $this->assertSame('Please select a valid color.', $errors[0]->getMessage());
+    }
+
+    public function testPreSubmitListenersCanTurnArraysIntoColors()
+    {
+        $form = $this->factory
+            ->createBuilder(static::TESTED_TYPE, null, ['html5' => true, 'allow_array_submission' => true])
+            ->addEventListener(FormEvents::PRE_SUBMIT, static function (FormEvent $event) {
+                $event->setData($event->getData()['hex']);
+            })
+            ->getForm();
+
+        $form->submit(['hex' => '#ff0000']);
+
+        $this->assertTrue($form->isSynchronized());
+        $this->assertSame('#ff0000', $form->getData());
+        $this->assertCount(0, $form->getErrors());
+    }
+
+    public function testArraySetByPreSubmitListenersIsReportedWhenNotAllowed()
+    {
+        $form = $this->factory
+            ->createBuilder(static::TESTED_TYPE, null, ['html5' => true])
+            ->addEventListener(FormEvents::PRE_SUBMIT, static function (FormEvent $event) {
+                $event->setData(['#000000']);
+            }, 1)
+            ->getForm();
+
+        $form->submit('#000000');
+
+        $expectedFormError = new FormError('This value is not a valid HTML5 color.', 'This value is not a valid HTML5 color.', [
+            '{{ value }}' => 'array',
+        ]);
+        $expectedFormError->setOrigin($form);
+
+        $this->assertEquals([$expectedFormError], iterator_to_array($form->getErrors()));
     }
 
     public function testSubmitNull($expected = null, $norm = null, $view = null)

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/FileTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/FileTypeTest.php
@@ -16,6 +16,8 @@ use Symfony\Component\Form\Extension\Core\CoreExtension;
 use Symfony\Component\Form\Extension\Core\Type\FileType;
 use Symfony\Component\Form\Extension\HttpFoundation\HttpFoundationRequestHandler;
 use Symfony\Component\Form\Extension\Validator\ViolationMapper\ViolationMapperInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\NativeRequestHandler;
 use Symfony\Component\Form\RequestHandlerInterface;
 use Symfony\Component\HttpFoundation\File\File;
@@ -170,6 +172,53 @@ class FileTypeTest extends BaseTypeTestCase
         $this->assertSame([], $form->getData());
         $this->assertSame([], $form->getNormData());
         $this->assertSame([], $form->getViewData());
+    }
+
+    #[DataProvider('requestHandlerProvider')]
+    public function testSubmitArrayValueWhenNotMultipleButAllowed(RequestHandlerInterface $requestHandler)
+    {
+        $form = $this->factory
+            ->createBuilder(static::TESTED_TYPE, null, ['allow_array_submission' => true])
+            ->setRequestHandler($requestHandler)
+            ->getForm();
+        $form->submit(['file.txt']);
+
+        $this->assertFalse($form->isSynchronized());
+        $this->assertSame('Submitted data was expected to be text or number, array given.', $form->getTransformationFailure()->getMessage());
+    }
+
+    #[DataProvider('requestHandlerProvider')]
+    public function testArraySetByPreSubmitListenersIsDiscardedWhenNotAllowed(RequestHandlerInterface $requestHandler)
+    {
+        $form = $this->factory
+            ->createBuilder(static::TESTED_TYPE)
+            ->setRequestHandler($requestHandler)
+            ->addEventListener(FormEvents::PRE_SUBMIT, static function (FormEvent $event) {
+                $event->setData(['file.txt']);
+            }, 1)
+            ->getForm();
+        $form->submit('file.txt');
+
+        $this->assertNull($form->getData());
+    }
+
+    public function testPreSubmitListenersCanTurnArraysIntoFileUploads()
+    {
+        $requestHandler = new NativeRequestHandler();
+        $file = $this->createUploadedFile($requestHandler, __DIR__.'/../../../Fixtures/foo', 'foo.jpg');
+
+        $form = $this->factory
+            ->createBuilder(static::TESTED_TYPE, null, ['allow_array_submission' => true])
+            ->setRequestHandler($requestHandler)
+            ->addEventListener(FormEvents::PRE_SUBMIT, static function (FormEvent $event) {
+                $event->setData($event->getData()['upload']);
+            })
+            ->getForm();
+
+        $form->submit(['upload' => $file]);
+
+        $this->assertTrue($form->isSynchronized());
+        $this->assertSame($file, $form->getData());
     }
 
     public static function requestHandlerProvider(): array

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
@@ -278,6 +278,37 @@ class TimeTypeTest extends BaseTypeTestCase
         $this->assertEquals('03:04', $form->getViewData());
     }
 
+    public function testSubmitArrayToSingleTextWidgetWhenAllowed()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
+            'widget' => 'single_text',
+            'allow_array_submission' => true,
+        ]);
+
+        $form->submit(['03:04']);
+
+        $this->assertFalse($form->isSynchronized());
+        $this->assertSame('Submitted data was expected to be text or number, array given.', $form->getTransformationFailure()->getMessage());
+    }
+
+    public function testSubmitArrayToSingleTextWidgetWithReferenceDateWhenAllowed()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
+            'widget' => 'single_text',
+            'reference_date' => new \DateTimeImmutable('2023-06-15', new \DateTimeZone('UTC')),
+            'allow_array_submission' => true,
+        ]);
+
+        $form->submit(['03:04']);
+
+        $this->assertFalse($form->isSynchronized());
+        $this->assertSame('Submitted data was expected to be text or number, array given.', $form->getTransformationFailure()->getMessage());
+    }
+
     public function testSubmitStringSingleTextWithoutMinutes()
     {
         $form = $this->factory->create(static::TESTED_TYPE, null, [

--- a/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_1.json
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_1.json
@@ -37,6 +37,7 @@
         "parent": {
             "Symfony\\Component\\Form\\Extension\\Core\\Type\\FormType": [
                 "action",
+                "allow_array_submission",
                 "allow_file_upload",
                 "attr",
                 "attr_translation_parameters",

--- a/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_1.txt
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_1.txt
@@ -8,23 +8,24 @@ Symfony\Component\Form\Extension\Core\Type\ChoiceType (Block prefix: "choice")
   choice_attr                     FormType             FormType                       FormTypeCsrfExtension  
   choice_filter                  -------------------- ------------------------------ ----------------------- 
   choice_help                     compound             action                         csrf_field_name        
-  choice_label                    data_class           allow_file_upload              csrf_message           
-  choice_lazy                     empty_data           attr                           csrf_protection        
-  choice_loader                   error_bubbling       attr_translation_parameters    csrf_token_id          
-  choice_name                     invalid_message      auto_initialize                csrf_token_manager     
-  choice_translation_domain       trim                 block_name                                            
-  choice_translation_parameters                        block_prefix                                          
-  choice_value                                         by_reference                                          
-  choices                                              data                                                  
-  duplicate_preferred_choices                          disabled                                              
-  expanded                                             form_attr                                             
-  group_by                                             getter                                                
-  multiple                                             help                                                  
-  placeholder                                          help_attr                                             
-  placeholder_attr                                     help_html                                             
-  preferred_choices                                    help_translation_parameters                           
-  separator                                            inherit_data                                          
-  separator_html                                       invalid_message_parameters                            
+  choice_label                    data_class           allow_array_submission         csrf_message           
+  choice_lazy                     empty_data           allow_file_upload              csrf_protection        
+  choice_loader                   error_bubbling       attr                           csrf_token_id          
+  choice_name                     invalid_message      attr_translation_parameters    csrf_token_manager     
+  choice_translation_domain       trim                 auto_initialize                                       
+  choice_translation_parameters                        block_name                                            
+  choice_value                                         block_prefix                                          
+  choices                                              by_reference                                          
+  duplicate_preferred_choices                          data                                                  
+  expanded                                             disabled                                              
+  group_by                                             form_attr                                             
+  multiple                                             getter                                                
+  placeholder                                          help                                                  
+  placeholder_attr                                     help_attr                                             
+  preferred_choices                                    help_html                                             
+  separator                                            help_translation_parameters                           
+  separator_html                                       inherit_data                                          
+                                                       invalid_message_parameters                            
                                                        is_empty_callback                                     
                                                        label                                                 
                                                        label_attr                                            

--- a/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_2.json
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_2.json
@@ -4,6 +4,7 @@
     "options": {
         "own": [
             "action",
+            "allow_array_submission",
             "allow_file_upload",
             "attr",
             "attr_translation_parameters",

--- a/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_2.txt
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Descriptor/resolved_form_type_2.txt
@@ -6,6 +6,7 @@ Symfony\Component\Form\Extension\Core\Type\FormType (Block prefix: "form")
   Options                       
  ------------------------------ 
   action                        
+  allow_array_submission        
   allow_file_upload             
   attr                          
   attr_translation_parameters   

--- a/src/Symfony/Component/Form/Tests/SimpleFormTest.php
+++ b/src/Symfony/Component/Form/Tests/SimpleFormTest.php
@@ -937,6 +937,87 @@ class SimpleFormTest extends TestCase
         $this->assertSame(0, $called, 'PRE_SUBMIT event listeners are not called for wrong data');
     }
 
+    public function testArrayDataIsRejectedBeforeListenersByDefault()
+    {
+        $called = 0;
+
+        $form = $this->getBuilder()
+            ->addEventListener(FormEvents::PRE_SUBMIT, static function () use (&$called) {
+                ++$called;
+            })
+            ->getForm();
+
+        $form->submit(['bar' => 'baz']);
+
+        $this->assertSame(0, $called);
+        $this->assertFalse($form->isSynchronized());
+        $this->assertSame('Submitted data was expected to be text or number, array given.', $form->getTransformationFailure()->getMessage());
+    }
+
+    public function testPreSubmitListenersCanTurnArrayDataIntoScalarData()
+    {
+        $form = $this->getBuilder('name', null, ['allow_array_submission' => true])
+            ->addEventListener(FormEvents::PRE_SUBMIT, static function (FormEvent $event) {
+                $event->setData($event->getData()['bar']);
+            })
+            ->getForm();
+
+        $form->submit(['bar' => 'baz']);
+
+        $this->assertTrue($form->isSynchronized());
+        $this->assertSame('baz', $form->getData());
+    }
+
+    public function testArrayDataKeptByPreSubmitListenersIsRejected()
+    {
+        $called = 0;
+
+        $form = $this->getBuilder('name', null, ['allow_array_submission' => true])
+            ->addEventListener(FormEvents::PRE_SUBMIT, static function () use (&$called) {
+                ++$called;
+            })
+            ->getForm();
+
+        $form->submit(['bar' => 'baz']);
+
+        $this->assertSame(1, $called);
+        $this->assertFalse($form->isSynchronized());
+        $this->assertSame('Submitted data was expected to be text or number, array given.', $form->getTransformationFailure()->getMessage());
+        $this->assertNull($form->getData());
+        $this->assertNull($form->getViewData());
+    }
+
+    public function testPreSubmitListenersCanTurnArrayDataIntoFileUploads()
+    {
+        $file = ['name' => 'foo.jpg', 'type' => 'image/jpeg', 'tmp_name' => '/tmp/foo', 'error' => \UPLOAD_ERR_OK, 'size' => 3];
+
+        $form = $this->getBuilder('name', null, ['allow_array_submission' => true, 'allow_file_upload' => true])
+            ->addEventListener(FormEvents::PRE_SUBMIT, static function (FormEvent $event) {
+                $event->setData($event->getData()['upload']);
+            })
+            ->getForm();
+
+        $form->submit(['upload' => $file]);
+
+        $this->assertTrue($form->isSynchronized());
+        $this->assertSame($file, $form->getData());
+    }
+
+    public function testFileUploadSetByPreSubmitListenersIsRejectedWhenNotAllowed()
+    {
+        $form = $this->getBuilder('name', null, ['allow_array_submission' => true, 'allow_file_upload' => false])
+            ->addEventListener(FormEvents::PRE_SUBMIT, static function (FormEvent $event) {
+                $event->setData(['name' => 'foo.jpg', 'type' => 'image/jpeg', 'tmp_name' => '/tmp/foo', 'error' => \UPLOAD_ERR_OK, 'size' => 3]);
+            })
+            ->getForm();
+
+        $form->submit(['bar' => 'baz']);
+
+        $this->assertFalse($form->isSynchronized());
+        $this->assertSame('Submitted data was expected to be text or number, file upload given.', $form->getTransformationFailure()->getMessage());
+        $this->assertNull($form->getData());
+    }
+
     public function testHandleRequestForwardsToRequestHandler()
     {
         $handler = $this->createMock(RequestHandlerInterface::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #47093
| License       | MIT

`Form::submit()` rejects array data submitted to a form that is neither compound nor `multiple`. It does so before `PRE_SUBMIT` is dispatched: the data is replaced by `null`, a `TransformationFailedException` is recorded, and listeners are never called. Applications that submit JSON payloads cannot map such a payload to a scalar field, because no listener ever sees the value.

This PR adds an `allow_array_submission` option to `FormType`, defaulting to `false`.

When the option is enabled, the check moves after `PRE_SUBMIT`: listeners receive the submitted array and can replace it with data the form accepts. The deferred check then applies the same rules as the eager one. Data that is still an array fails with the same exception message as today, unless a listener turned it into a file upload: such data is accepted when `allow_file_upload` is true, and reported as "file upload given" otherwise, which is what the same value gets when it is submitted directly. The option mirrors `allow_file_upload`, which gates the sibling branch of the same check.

When the option is left to `false`, nothing changes: listeners are not called for array data, and the form fails exactly as before, with the same message and the same `null` view data.

## Why opt-in

An earlier revision of this PR moved the check unconditionally and targeted 6.4 as a bugfix. That changes the input domain of every deployed `PRE_SUBMIT` listener on a scalar field: any client can post `field[]=x`, so listeners written against the "never an array" guarantee become reachable with client-controlled arrays. Three core types needed guards for exactly that reason, and third-party listeners would have been exposed the same way with no guard at all. The option keeps the old guarantee unless a form opts in, and scopes the new listener contract to that form.

## Core listeners

With the option enabled, the listeners registered by core types can receive arrays too, so the three affected ones now handle them:

 * `FileType` with `multiple: false` replaces anything that is not a file upload by `null`, so an array would validate as "no file uploaded" with no error at all. It now leaves arrays alone, so the form reports them.
 * `ColorType` with `html5: true` added its own "This value is not a valid HTML5 color." error for arrays, even when a later listener turned the value into a valid color. It now skips arrays, so the html5 check applies to values a listener has normalized.
 * `TimeType` with `widget: single_text` passed the submitted value straight to `preg_match()`, which raises a `TypeError` on arrays. Both of its listeners now check for a string first, and the form reports "Please enter a valid time." instead.

The `FileType` and `ColorType` guards are gated on the option, so a form that does not opt in keeps the behavior it has today, including for an array set by a `PRE_SUBMIT` listener registered at a priority above `0`. The `TimeType` guard is not gated: an array can reach those listeners today through such a priority, and a `TypeError` is never the right report.

On a `ChoiceType` field that is neither `multiple` nor `expanded` and that enables the option, the type's own `PRE_SUBMIT` listener runs first: a nested invalid array is reported as "All choices submitted must be NULL, strings or ints.", and an array that survives the listener is rejected by the deferred check. Nothing changes for choice fields that do not enable the option.

## Checks

Run on this branch with PHP 8.5 and PHPUnit 13.3:

 * `./phpunit src/Symfony/Component/Form`: 5100 tests, 10773 assertions, 384 skipped, 8 incomplete, no failure. The base commit runs 5085 tests with the same skipped and incomplete counts.
 * php-cs-fixer on the files this PR touches: clean.
 * The console descriptor fixtures were regenerated, since they list the options of `FormType`.

Revert verified, running the same suite in three states:

 * All source files restored to their 8.2 state, tests kept: 7 errors and 8 failures. The tests that pass the new option error with `The option "allow_array_submission" does not exist`, the four descriptor fixtures no longer match, and the `SimpleFormTest` cases built on a raw `FormBuilder` fail on their behavior assertions. `testArrayDataIsRejectedBeforeListenersByDefault`, `ColorTypeTest::testArraySetByPreSubmitListenersIsReportedWhenNotAllowed` and `FileTypeTest::testArraySetByPreSubmitListenersIsDiscardedWhenNotAllowed` still pass, since they protect existing behavior.
 * Only the three type files restored: 2 errors and 5 failures. `TimeTypeTest` raises `TypeError: preg_match(): Argument #2 ($subject) must be of type string, array given`, `ColorTypeTest::testSubmitArrayWhenAllowed` gets "This value is not a valid HTML5 color." instead of "Please select a valid color.", and the `FileTypeTest` cases report the form as synchronized or lose the resolved upload.
 * This branch: no failure.

## For the documentation

 * Document `allow_array_submission` in the form options reference: what it enables, default `false`.
 * Show the JSON payload use case: a `PRE_SUBMIT` listener that maps the submitted array to the field's scalar value.
 * Note that enabling the option means every `PRE_SUBMIT` listener on that form must be ready to receive an array; core type listeners already are.
 * Note that a listener may also resolve an array to a file upload, which the form accepts when `allow_file_upload` is true.
