### PR TITLE
[HttpKernel] Forward the request headers to inline rendered fragments

### DIFF
--- a/src/Symfony/Component/HttpKernel/Fragment/InlineFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/InlineFragmentRenderer.php
@@ -111,13 +111,21 @@ class InlineFragmentRenderer extends RoutableFragmentRenderer
         $cookies = $request->cookies->all();
         $server = $request->server->all();
 
+        // Request::create() derives headers from $server, so headers set on the request must be copied there
+        foreach ($request->headers->all() as $key => $value) {
+            $key = strtoupper(str_replace('-', '_', $key));
+
+            if (\in_array($key, ['CONTENT_TYPE', 'CONTENT_LENGTH', 'CONTENT_MD5'], true)) {
+                $server[$key] = implode(', ', $value);
+            } else {
+                $server['HTTP_'.$key] = implode(', ', $value);
+            }
+        }
+
         unset($server['HTTP_IF_MODIFIED_SINCE']);
         unset($server['HTTP_IF_NONE_MATCH']);
 
         $subRequest = Request::create($uri, 'get', [], $cookies, [], $server);
-        if ($request->headers->has('Surrogate-Capability')) {
-            $subRequest->headers->set('Surrogate-Capability', $request->headers->get('Surrogate-Capability'));
-        }
 
         static $setSession;
 

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/InlineFragmentRendererTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/InlineFragmentRendererTest.php
@@ -192,6 +192,7 @@ class InlineFragmentRendererTest extends TestCase
     {
         $expectedSubRequest = Request::create('/');
         $expectedSubRequest->headers->set('Surrogate-Capability', 'abc="ESI/1.0"');
+        $expectedSubRequest->server->set('HTTP_SURROGATE_CAPABILITY', 'abc="ESI/1.0"');
 
         if (Request::HEADER_X_FORWARDED_FOR & Request::getTrustedHeaderSet()) {
             $expectedSubRequest->headers->set('x-forwarded-for', ['127.0.0.1']);
@@ -216,6 +217,48 @@ class InlineFragmentRendererTest extends TestCase
         Request::setTrustedProxies([], -1);
     }
 
+    public function testHeadersSetOnTheRequestAreKeptInSubrequest()
+    {
+        $expectedSubRequest = Request::create('/');
+        $expectedSubRequest->headers->set('X-Custom', 'foo');
+        $expectedSubRequest->server->set('HTTP_X_CUSTOM', 'foo');
+
+        if (Request::HEADER_X_FORWARDED_FOR & Request::getTrustedHeaderSet()) {
+            $expectedSubRequest->headers->set('x-forwarded-for', ['127.0.0.1']);
+            $expectedSubRequest->server->set('HTTP_X_FORWARDED_FOR', '127.0.0.1');
+        }
+        $expectedSubRequest->headers->set('forwarded', ['for="127.0.0.1";host="localhost";proto=http']);
+        $expectedSubRequest->server->set('HTTP_FORWARDED', 'for="127.0.0.1";host="localhost";proto=http');
+
+        $strategy = new InlineFragmentRenderer($this->getKernelExpectingRequest($expectedSubRequest));
+
+        $request = Request::create('/');
+        $request->headers->set('X-Custom', 'foo');
+        $strategy->render('/', $request);
+    }
+
+    public function testForwardedProtoSetOnTheRequestIsSeenBySubrequest()
+    {
+        Request::setTrustedProxies(['127.0.0.1'], Request::HEADER_X_FORWARDED_FOR | Request::HEADER_X_FORWARDED_PROTO);
+
+        try {
+            $kernel = $this->createMock(HttpKernelInterface::class);
+            $kernel
+                ->expects($this->once())
+                ->method('handle')
+                ->with($this->callback(static fn (Request $subRequest) => 'https' === $subRequest->getScheme()))
+                ->willReturn(new Response('foo'))
+            ;
+
+            $request = Request::create('/');
+            $request->headers->set('X-Forwarded-Proto', 'https');
+
+            (new InlineFragmentRenderer($kernel))->render('/', $request);
+        } finally {
+            Request::setTrustedProxies([], -1);
+        }
+    }
+
     public function testHeadersPossiblyResultingIn304AreNotAssignedToSubrequest()
     {
         $expectedSubRequest = Request::create('/');
@@ -235,6 +278,7 @@ class InlineFragmentRendererTest extends TestCase
 
         $expectedSubRequest = Request::create('/');
         $expectedSubRequest->headers->set('Surrogate-Capability', 'abc="ESI/1.0"');
+        $expectedSubRequest->server->set('HTTP_SURROGATE_CAPABILITY', 'abc="ESI/1.0"');
         $expectedSubRequest->server->set('REMOTE_ADDR', '127.0.0.1');
         $expectedSubRequest->headers->set('x-forwarded-for', ['127.0.0.1']);
         $expectedSubRequest->headers->set('forwarded', ['for="127.0.0.1";host="localhost";proto=http']);
@@ -254,6 +298,7 @@ class InlineFragmentRendererTest extends TestCase
     {
         $expectedSubRequest = Request::create('/');
         $expectedSubRequest->headers->set('Surrogate-Capability', 'abc="ESI/1.0"');
+        $expectedSubRequest->server->set('HTTP_SURROGATE_CAPABILITY', 'abc="ESI/1.0"');
         $expectedSubRequest->server->set('REMOTE_ADDR', '127.0.0.1');
         $expectedSubRequest->headers->set('x-forwarded-for', ['127.0.0.1']);
         $expectedSubRequest->headers->set('forwarded', ['for="127.0.0.1";host="localhost";proto=http']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #47163
| License       | MIT

`InlineFragmentRenderer::createSubRequest()` builds the sub-request with `Request::create()` and gives it the parent server parameters only. `Request::create()` rebuilds the header bag from those server parameters, so a header that lives on the parent header bag without a matching `HTTP_*` server entry never reaches the sub-request.

This happens whenever a header is set after the request object was built:

* a listener calling `$request->headers->set(...)`;
* a request created by `HttpFoundationFactory` out of a PSR-7 request. The bridge copies the PSR-7 headers into the header bag, while the server parameters keep whatever the PSR-7 server params carried. A middleware running `$request = $request->withHeader('X-Forwarded-Proto', ...)` before the bridge is the case reported in the issue.

The consequence is silent. With trusted proxies configured, a fragment rendered from such a request sees `http` instead of `https`, so links and absolute URLs built inside the fragment use the wrong scheme.

The renderer already worked around one instance of this: it copied `Surrogate-Capability` by hand after creating the sub-request, because `AbstractSurrogate` sets that header on the header bag only. This patch removes the special case and instead projects the whole header bag into the server parameters before `Request::create()` is called, with the same mapping `Request::overrideGlobals()` uses. Doing it before the call matters: `Request::create()` still derives `HTTP_HOST`, `HTTPS`, `SERVER_PORT` and the auth parameters from the fragment URI afterwards, so an absolute fragment URI keeps winning over the parent `Host` header. `If-Modified-Since` and `If-None-Match` are still dropped, and they are now dropped even when they exist on the header bag only.

Two consequences worth naming:

* the sub-request server bag now carries an `HTTP_*` entry for every header, `Surrogate-Capability` included. Four existing expectations in `InlineFragmentRendererTest` were updated for that.
* a fragment that renders another fragment now keeps the headers at every level, which was not the case before.

Untrusted forwarded headers are still removed by `SubRequestHandler`, before and after this patch. A reproduction that sets `X-Forwarded-Proto` without configuring trusted proxies therefore still shows no header in the sub-request, which is the expected behavior.

Checks run on PHP 8.5 with PHPUnit 9.6:

* `./phpunit src/Symfony/Component/HttpKernel/Tests` on the base commit: OK (1217 tests, 2958 assertions), 24 legacy deprecation notices.
* the same command with this patch: OK (1219 tests, 2960 assertions), the same 24 legacy deprecation notices.
* the two new tests with `InlineFragmentRenderer.php` restored to its base state: both fail with `Expectation failed for method name is "handle" when invoked 1 time(s) [...] does not match expected value.`
* `./phpunit src/Symfony/Bridge/PsrHttpMessage/Tests`: OK (38 tests, 257 assertions).
* `php-cs-fixer fix --dry-run --diff` on both touched files: no change, exit code 0.
