### PR TITLE
[FrameworkBundle] Fix dispatching console events after cache:clear

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
@@ -13,13 +13,16 @@ namespace Symfony\Bundle\FrameworkBundle\Command;
 
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Dumper\Preloader;
 use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
@@ -72,6 +75,8 @@ class CacheClearCommand extends Command
         $io = new SymfonyStyle($input, $output);
 
         $kernel = $this->getApplication()->getKernel();
+        // resolve the console listeners now, the container they are loaded from is about to be cleared
+        $dispatcher = $this->createConsoleDispatcher($kernel->getContainer());
         $realCacheDir = $kernel->getContainer()->getParameter('kernel.cache_dir');
         $realBuildDir = $kernel->getContainer()->hasParameter('kernel.build_dir') ? $kernel->getContainer()->getParameter('kernel.build_dir') : $realCacheDir;
         // the old cache dir name must not be longer than the real one to avoid exceeding
@@ -107,7 +112,7 @@ class CacheClearCommand extends Command
         $this->cacheClearer->clear($realCacheDir);
 
         // The current event dispatcher is stale, let's not use it anymore
-        $this->getApplication()->setDispatcher(new EventDispatcher());
+        $this->getApplication()->setDispatcher($dispatcher);
 
         $containerFile = (new \ReflectionObject($kernel->getContainer()))->getFileName();
         $containerDir = basename(\dirname($containerFile));
@@ -255,5 +260,23 @@ class CacheClearCommand extends Command
         if ($preload && file_exists($preloadFile = $warmupDir.'/'.$kernel->getContainer()->getParameter('kernel.container_class').'.preload.php')) {
             Preloader::append($preloadFile, $preload);
         }
+    }
+
+    private function createConsoleDispatcher(ContainerInterface $container): EventDispatcher
+    {
+        $dispatcher = new EventDispatcher();
+        $currentDispatcher = $container->has('event_dispatcher') ? $container->get('event_dispatcher') : null;
+
+        if (!$currentDispatcher instanceof EventDispatcherInterface) {
+            return $dispatcher;
+        }
+
+        foreach ([ConsoleEvents::ERROR, ConsoleEvents::SIGNAL, ConsoleEvents::TERMINATE] as $eventName) {
+            foreach ($currentDispatcher->getListeners($eventName) as $listener) {
+                $dispatcher->addListener($eventName, $listener, $currentDispatcher->getListenerPriority($eventName, $listener) ?? 0);
+            }
+        }
+
+        return $dispatcher;
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CacheClearCommand/CacheClearCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CacheClearCommand/CacheClearCommandTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\Command\CacheClearCommand;
 
 use Symfony\Bundle\FrameworkBundle\Command\CacheClearCommand;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Tests\Command\CacheClearCommand\Fixture\TerminateListener;
 use Symfony\Bundle\FrameworkBundle\Tests\Command\CacheClearCommand\Fixture\TestAppKernel;
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
 use Symfony\Component\Config\ConfigCacheFactory;
@@ -98,6 +99,19 @@ class CacheClearCommandTest extends TestCase
             file_get_contents($containerFile),
             'kernel.container_class is properly set on the dumped container'
         );
+    }
+
+    public function testConsoleTerminateListenersAreCalled()
+    {
+        TerminateListener::$calls = 0;
+
+        $input = new ArrayInput(['cache:clear']);
+        $application = new Application($this->kernel);
+        $application->setCatchExceptions(false);
+
+        $application->doRun($input, new NullOutput());
+
+        $this->assertSame(1, TerminateListener::$calls);
     }
 
     public function testCacheIsWarmedWhenCalledTwice()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CacheClearCommand/Fixture/TestAppKernel.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CacheClearCommand/Fixture/TestAppKernel.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\Command\CacheClearCommand\Fixture
 use Psr\Log\NullLogger;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
 use Symfony\Component\HttpKernel\Kernel;
@@ -42,6 +43,8 @@ class TestAppKernel extends Kernel
         $container->register('logger', NullLogger::class);
         $container->register(DummyFileCacheWarmer::class)
             ->addTag('kernel.cache_warmer');
+        $container->register(TerminateListener::class)
+            ->addTag('kernel.event_listener', ['event' => ConsoleEvents::TERMINATE, 'method' => 'onConsoleTerminate']);
     }
 }
 
@@ -57,5 +60,15 @@ class DummyFileCacheWarmer implements CacheWarmerInterface
         file_put_contents($cacheDir.'/dummy.txt', 'Hello');
 
         return [];
+    }
+}
+
+class TerminateListener
+{
+    public static int $calls = 0;
+
+    public function onConsoleTerminate(): void
+    {
+        ++self::$calls;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #47669
| License       | MIT

Listeners of `ConsoleEvents::TERMINATE` are called for every command except `cache:clear`. Listeners of `ConsoleEvents::ERROR` and `ConsoleEvents::SIGNAL` are lost the same way when the event happens in the second half of that command.

The reason is this line, halfway through `CacheClearCommand::execute()`:

```php
// The current event dispatcher is stale, let's not use it anymore
$this->getApplication()->setDispatcher(new EventDispatcher());
```

The intent is sound. The listeners of the current dispatcher are lazy: each of them is a closure that loads a service from the container the command is about to replace, and whose cache directory is being emptied. Dispatching on that dispatcher after the swap can therefore load files that are gone. What it costs is every console listener of the application, Symfony's own `ErrorListener`, which logs a failing command, included.

The console listeners are now resolved at the very start of the command, while the container is still untouched, and the listeners obtained that way are moved to the dispatcher that replaces the current one. `EventDispatcher::getListeners()` replaces the closure of a lazy listener with the service it loads, so the new dispatcher holds plain instances and never touches the old container. Only the three events that can still be dispatched after the swap are carried over.

What changes for applications: a listener of `console.terminate`, `console.error` or `console.signal` is instantiated when `cache:clear` starts, and called as it is for any other command.

Checks, all run with PHP 8.5 and PHPUnit 9.6 on 6.4:

* the new test `CacheClearCommandTest::testConsoleTerminateListenersAreCalled` fails without the fix with `Failed asserting that 0 is identical to 1.` and passes with it;
* `Tests/Command/CacheClearCommand` is green: 5 tests, 7 assertions;
* the whole FrameworkBundle test suite is green: 1374 tests, 4546 assertions, 5 skipped, no failure;
* an instrumented run printed what the new dispatcher receives during that test: `SuggestMissingPackageSubscriber::onConsoleError`, `ErrorListener::onConsoleError`, `ErrorListener::onConsoleTerminate` and the listener of the test, all of them plain instances, which confirms that nothing is left to load from the old container.
