### PR TITLE
[Translation] Fix pushing numeric translation keys to Lokalise

### DIFF
--- a/src/Symfony/Component/Translation/Bridge/Lokalise/LokaliseProvider.php
+++ b/src/Symfony/Component/Translation/Bridge/Lokalise/LokaliseProvider.php
@@ -70,31 +70,27 @@ final class LokaliseProvider implements ProviderInterface
         }
 
         $this->ensureAllLocalesAreCreated($translatorBag);
-        $existingKeysByDomain = [];
+        $keysByDomain = [];
 
         foreach ($defaultCatalogue->getDomains() as $domain) {
-            if (!\array_key_exists($domain, $existingKeysByDomain)) {
-                $existingKeysByDomain[$domain] = [];
+            if (!\array_key_exists($domain, $keysByDomain)) {
+                $keysByDomain[$domain] = [];
             }
 
-            $existingKeysByDomain[$domain] += $this->getKeysIds([], $domain);
+            $keysByDomain[$domain] += $this->getKeysIds([], $domain);
         }
 
-        $keysToCreate = $createdKeysByDomain = [];
+        $keysToCreate = [];
 
-        foreach ($existingKeysByDomain as $domain => $existingKeys) {
-            $allKeysForDomain = array_keys($defaultCatalogue->all($domain));
-            foreach (array_keys($existingKeys) as $keyName) {
-                unset($allKeysForDomain[$keyName]);
-            }
-            $keysToCreate[$domain] = $allKeysForDomain;
+        foreach ($keysByDomain as $domain => $existingKeys) {
+            $keysToCreate[$domain] = array_diff(array_keys($defaultCatalogue->all($domain)), array_keys($existingKeys));
         }
 
         foreach ($keysToCreate as $domain => $keys) {
-            $createdKeysByDomain[$domain] = $this->createKeys($keys, $domain);
+            $keysByDomain[$domain] = $this->createKeys($keys, $domain) + $keysByDomain[$domain];
         }
 
-        $this->updateTranslations(array_merge_recursive($createdKeysByDomain, $existingKeysByDomain), $translatorBag);
+        $this->updateTranslations($keysByDomain, $translatorBag);
     }
 
     public function read(array $domains, array $locales): TranslatorBag
@@ -296,7 +292,7 @@ final class LokaliseProvider implements ProviderInterface
 
         foreach ($keys as $key) {
             $keysToCreate[] = [
-                'key_name' => $key,
+                'key_name' => (string) $key,
                 'platforms' => ['web'],
                 'filenames' => [
                     'web' => $this->getLokaliseFilenameFromDomain($domain),
@@ -352,6 +348,7 @@ final class LokaliseProvider implements ProviderInterface
 
         foreach ($keysByDomain as $domain => $keys) {
             foreach ($keys as $keyName => $keyId) {
+                $keyName = (string) $keyName;
                 $keysToUpdate[] = [
                     'key_id' => $keyId,
                     'platforms' => ['web'],

--- a/src/Symfony/Component/Translation/Bridge/Lokalise/Tests/LokaliseProviderTest.php
+++ b/src/Symfony/Component/Translation/Bridge/Lokalise/Tests/LokaliseProviderTest.php
@@ -251,6 +251,155 @@ class LokaliseProviderTest extends ProviderTestCase
         $this->assertTrue($updateProcessed, 'Translations update was not called.');
     }
 
+    public function testWriteSendsNumericKeysAsStrings()
+    {
+        $getLanguagesResponse = function (string $method, string $url): ResponseInterface {
+            $this->assertSame('GET', $method);
+            $this->assertSame('https://api.lokalise.com/api2/projects/PROJECT_ID/languages', $url);
+
+            return new JsonMockResponse(['languages' => [
+                ['lang_iso' => 'en'],
+                ['lang_iso' => 'fr'],
+            ]]);
+        };
+
+        $getKeysIdsResponse = function (string $method, string $url, array $options = []): ResponseInterface {
+            $this->assertSame('GET', $method);
+            $this->assertSame(['filter_keys' => '', 'filter_filenames' => 'messages.xliff', 'limit' => 5000, 'page' => 1], $options['query']);
+
+            return new JsonMockResponse(['keys' => []]);
+        };
+
+        $createKeysResponse = function (string $method, string $url, array $options = []): ResponseInterface {
+            $this->assertSame('POST', $method);
+            $this->assertSame(['0', 'young_dog'], array_column(json_decode($options['body'], true)['keys'], 'key_name'));
+
+            return new JsonMockResponse(['keys' => [
+                ['key_name' => ['web' => '0'], 'key_id' => 7],
+                ['key_name' => ['web' => 'young_dog'], 'key_id' => 29],
+            ]]);
+        };
+
+        $updateProcessed = false;
+        $updateTranslationsResponse = function (string $method, string $url, array $options = []) use (&$updateProcessed): ResponseInterface {
+            $updateProcessed = true;
+            $keys = json_decode($options['body'], true)['keys'];
+
+            $this->assertSame('PUT', $method);
+            $this->assertSame([7, 29], array_column($keys, 'key_id'));
+            $this->assertSame([
+                [
+                    ['language_iso' => 'en', 'translation' => 'zero'],
+                    ['language_iso' => 'fr', 'translation' => 'zéro'],
+                ],
+                [
+                    ['language_iso' => 'en', 'translation' => 'puppy'],
+                    ['language_iso' => 'fr', 'translation' => 'chiot'],
+                ],
+            ], array_column($keys, 'translations'));
+
+            return new MockResponse();
+        };
+
+        $provider = self::createProvider((new MockHttpClient([
+            $getLanguagesResponse,
+            $getKeysIdsResponse,
+            $createKeysResponse,
+            $updateTranslationsResponse,
+        ]))->withOptions([
+            'base_uri' => 'https://api.lokalise.com/api2/projects/PROJECT_ID/',
+            'headers' => ['X-Api-Token' => 'API_KEY'],
+        ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'api.lokalise.com');
+
+        $translatorBag = new TranslatorBag();
+        $translatorBag->addCatalogue(new MessageCatalogue('en', [
+            'messages' => ['0' => 'zero', 'young_dog' => 'puppy'],
+        ]));
+        $translatorBag->addCatalogue(new MessageCatalogue('fr', [
+            'messages' => ['0' => 'zéro', 'young_dog' => 'chiot'],
+        ]));
+
+        $provider->write($translatorBag);
+        $this->assertTrue($updateProcessed, 'Translations update was not called.');
+    }
+
+    public function testWriteDoesNotCreateKeysAlreadyExistingOnLokalise()
+    {
+        $getLanguagesResponse = function (string $method, string $url): ResponseInterface {
+            $this->assertSame('GET', $method);
+            $this->assertSame('https://api.lokalise.com/api2/projects/PROJECT_ID/languages', $url);
+
+            return new JsonMockResponse(['languages' => [
+                ['lang_iso' => 'en'],
+                ['lang_iso' => 'fr'],
+            ]]);
+        };
+
+        $getKeysIdsResponse = function (string $method, string $url, array $options = []): ResponseInterface {
+            $this->assertSame('GET', $method);
+            $this->assertSame(['filter_keys' => '', 'filter_filenames' => 'messages.xliff', 'limit' => 5000, 'page' => 1], $options['query']);
+
+            return new JsonMockResponse(['keys' => [
+                ['key_name' => ['web' => '11'], 'key_id' => 42],
+            ]]);
+        };
+
+        $createKeysResponse = function (string $method, string $url, array $options = []): ResponseInterface {
+            $this->assertSame('POST', $method);
+            $this->assertSame(['10', '12'], array_column(json_decode($options['body'], true)['keys'], 'key_name'));
+
+            return new JsonMockResponse(['keys' => [
+                ['key_name' => ['web' => '10'], 'key_id' => 7],
+                ['key_name' => ['web' => '12'], 'key_id' => 8],
+            ]]);
+        };
+
+        $updateProcessed = false;
+        $updateTranslationsResponse = function (string $method, string $url, array $options = []) use (&$updateProcessed): ResponseInterface {
+            $updateProcessed = true;
+            $keys = json_decode($options['body'], true)['keys'];
+
+            $this->assertSame('PUT', $method);
+            $this->assertSame([7, 8, 42], array_column($keys, 'key_id'));
+            $this->assertSame([
+                [
+                    ['language_iso' => 'en', 'translation' => 'ten'],
+                    ['language_iso' => 'fr', 'translation' => 'dix'],
+                ],
+                [
+                    ['language_iso' => 'en', 'translation' => 'twelve'],
+                ],
+                [
+                    ['language_iso' => 'en', 'translation' => 'eleven'],
+                    ['language_iso' => 'fr', 'translation' => 'onze'],
+                ],
+            ], array_column($keys, 'translations'));
+
+            return new MockResponse();
+        };
+
+        $provider = self::createProvider((new MockHttpClient([
+            $getLanguagesResponse,
+            $getKeysIdsResponse,
+            $createKeysResponse,
+            $updateTranslationsResponse,
+        ]))->withOptions([
+            'base_uri' => 'https://api.lokalise.com/api2/projects/PROJECT_ID/',
+            'headers' => ['X-Api-Token' => 'API_KEY'],
+        ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'api.lokalise.com');
+
+        $translatorBag = new TranslatorBag();
+        $translatorBag->addCatalogue(new MessageCatalogue('en', [
+            'messages' => ['10' => 'ten', '11' => 'eleven', '12' => 'twelve'],
+        ]));
+        $translatorBag->addCatalogue(new MessageCatalogue('fr', [
+            'messages' => ['10' => 'dix', '11' => 'onze'],
+        ]));
+
+        $provider->write($translatorBag);
+        $this->assertTrue($updateProcessed, 'Translations update was not called.');
+    }
+
     public function testUpdateProcessWhenLocalTranslationsMatchLokaliseTranslations()
     {
         $getLanguagesResponse = function (string $method, string $url): ResponseInterface {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #48225
| License       | MIT

PHP stores an array key that looks like an integer as an integer. A translation file with keys such as `0` or `10` therefore ends up with integer keys in the message catalogue, and `LokaliseProvider` put those keys straight into the JSON body of the create-keys request:

```json
{"keys":[{"key_name":10,"platforms":["web"],"filenames":{"web":"messages.xliff"}}]}
```

Lokalise answers `{"error":{"message":"key_name parameter should be a string","code":400}}` and rejects the request as a whole, so none of the up to 500 keys of that batch is created. The provider only logs the error and continues, which is how a push ends with keys missing on Lokalise and no failure reported to the user.

Two more defects on the same code path show up with such keys.

The keys Lokalise already knows were removed from the batch by list position instead of by name: `unset($allKeysForDomain[$keyName])` was applied to the list returned by `array_keys()`, so an existing key named `11` removed the twelfth entry of the batch instead of itself. With regular keys the filter never matched anything at all, so every key was sent for creation again on every push.

The created keys and the existing ones were then merged with `array_merge_recursive()`, which renumbers integer keys: an existing key named `11` came back as `13`. Its translations were looked up under a name the catalogue does not contain, and since `MessageCatalogue::get()` returns the key itself when there is no message, the key name was pushed as the translation of that key for every locale.

The fix casts key names to strings when the request body is built, filters the batch by name with `array_diff()`, and merges the created and existing keys with the union operator, which keeps key names intact. The `key_id` to key name mapping is now also used as a string when the translations are collected, so a locale that has no message for a key no longer receives the key name as its translation.

Checks run:

* `./phpunit src/Symfony/Component/Translation/Bridge/Lokalise`: 28 tests, 164 assertions, green. The suite had 26 tests before the two added here.
* `./phpunit src/Symfony/Component/Translation`: 716 tests, 2352 assertions, green. It reports 2 legacy deprecation notices, which the base commit reports as well (714 tests, 2332 assertions).
* Revert check with `LokaliseProvider.php` back to its base state and the tests kept: `testWriteSendsNumericKeysAsStrings` fails with `0 => '0'` expected against `0 => 0` actual, and `testWriteDoesNotCreateKeysAlreadyExistingOnLokalise` fails with `['10', '12']` expected against `[10, 11, 12]` actual.
* `php-cs-fixer fix --dry-run --diff --path-mode=intersection src/Symfony/Component/Translation/Bridge/Lokalise`: no file to fix.

The report also describes keys going missing when the 500-key batches are created concurrently, which nobody could reproduce. That half is not addressed here. It was asked in the discussion to re-test it once batches stop failing, so the issue may be worth keeping open until the reporter can confirm.
