### PR TITLE
[DomCrawler] Detect the charset from meta tags only

### DIFF
--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -152,7 +152,7 @@ class Crawler implements \Countable, \IteratorAggregate
 
         // http://www.w3.org/TR/encoding/#encodings
         // http://www.w3.org/TR/REC-xml/#NT-EncName
-        $content = preg_replace_callback('/(charset *= *["\']?)([a-zA-Z\-0-9_:.]+)/i', function ($m) use (&$charset) {
+        $content = preg_replace_callback('/(<meta[^>]+charset *= *["\']?)([a-zA-Z\-0-9_:.]+)/i', function ($m) use (&$charset) {
             if ('charset=' === $this->convertToHtmlEntities('charset=', $m[2])) {
                 $charset = $m[2];
             }

--- a/src/Symfony/Component/DomCrawler/Tests/AbstractCrawlerTestCase.php
+++ b/src/Symfony/Component/DomCrawler/Tests/AbstractCrawlerTestCase.php
@@ -200,6 +200,10 @@ abstract class AbstractCrawlerTestCase extends TestCase
         $crawler = $this->createCrawler();
         $crawler->addContent($this->getDoctype().'<html><script>var foo = "bär";</script></html>', 'text/html; charset=UTF-8');
         $this->assertEquals('var foo = "bär";', $crawler->filterXPath('//script')->text(), '->addContent() does not interfere with script content');
+
+        $crawler = $this->createCrawler();
+        $crawler->addContent($this->getDoctype().'<html><script>var foo = "charset=utf-16";</script></html>', 'text/html; charset=UTF-8');
+        $this->assertEquals('var foo = "charset=utf-16";', $crawler->filterXPath('//script')->text(), '->addContent() does not rewrite charsets found outside meta tags');
     }
 
     /**
@@ -210,6 +214,16 @@ abstract class AbstractCrawlerTestCase extends TestCase
         $crawler = $this->createCrawler();
         $crawler->addContent(iconv('UTF-8', 'SJIS', $this->getDoctype().'<html><head><meta charset="Shift_JIS"></head><body>日本語</body></html>'));
         $this->assertEquals('日本語', $crawler->filterXPath('//body')->text(), '->addContent() can recognize "Shift_JIS" in html5 meta charset tag');
+    }
+
+    /**
+     * @requires extension mbstring
+     */
+    public function testAddContentIgnoresCharsetOutsideMetaTags()
+    {
+        $crawler = $this->createCrawler();
+        $crawler->addContent($this->getDoctype().'<html><head><script charset="utf-8" src="foo.js"></script><meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-15"></head><body><p>10'."\xA4".'</p></body></html>');
+        $this->assertSame('10€', $crawler->filterXPath('//p')->text(), '->addContent() reads the charset from the meta tag, not from a preceding script tag');
     }
 
     public function testAddDocument()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #49738
| License       | MIT

`Crawler::addContent()` has to know the encoding of the content before it can parse it. It scans the content for a `charset=` declaration, and passes what it finds to the parser.

The pattern it uses matches the first `charset=` found anywhere in the string, so any occurrence placed before the `<meta>` tag wins. The common case is a `<script charset="utf-8" src="...">` element: on `script`, `link` and `a`, the `charset` attribute describes the linked resource, not the document. With this markup:

```html
<script charset="utf-8" src="tracker.js"></script>
<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-15">
```

the page is parsed as UTF-8 although it is encoded in ISO-8859-15, and every non-ASCII character is lost.

The same pattern also rewrites what it matched, because an encoding name the parser does not support must be replaced before parsing. When the match is not a meta tag, that rewrite corrupts the page. `<script>var foo = "charset=utf-16";</script>` is turned into `<script>var foo = "charset=UTF-8";</script>` before parsing.

This restores the `<meta[^>]+` prefix the pattern had before #45256. Both forms of the declaration are still matched: `<meta charset="...">` and `<meta http-equiv="Content-Type" content="...; charset=...">`. When no meta tag declares an encoding, the fallback is unchanged: UTF-8 when the content is valid UTF-8, ISO-8859-1 otherwise. Content that declares an encoding only outside a meta tag now uses that fallback instead of the value it found there, which is the point of the fix.

Checks run:

* `php phpunit src/Symfony/Component/DomCrawler/Tests`: 589 tests, 1154 assertions, OK.
* `php phpunit src/Symfony/Component/BrowserKit/Tests`: 242 tests, 587 assertions, OK. BrowserKit is the only caller of `addContent()` in the monorepo.
* Revert check with the tests kept and `Crawler.php` put back in its base state: 4 failures, `'10€'` expected against `'10'` with the HTML5 parser and against `'10?'` with the native parser, plus `'var foo = "charset=utf-16";'` expected against `'var foo = "charset=UTF-8";'` on both.
* php-cs-fixer on both touched files: no change reported.
* Edge cases run by hand against the patched code: uppercase tag and attribute names, an attribute list split over several lines, `<meta charset=ISO-8859-15>` without quotes, a self-closing meta tag, a `<link charset>` before the meta tag, a meta tag holding an unsupported encoding name, and XML content with and without an encoding declaration. XML results are identical before and after the change.
