### PR TITLE
[BrowserKit] Return the most specific cookie when several ones match

### DIFF
--- a/src/Symfony/Component/BrowserKit/CookieJar.php
+++ b/src/Symfony/Component/BrowserKit/CookieJar.php
@@ -33,14 +33,18 @@ class CookieJar
     /**
      * Gets a cookie by name.
      *
+     * When several cookies match, the one with the longest path is returned,
+     * then the one with the most specific domain.
+     *
      * You should never use an empty domain, but if you do so,
-     * this method returns the first cookie for the given name/path
-     * (this behavior ensures a BC behavior with previous versions of
-     * Symfony).
+     * this method matches cookies of any domain (this behavior ensures
+     * a BC behavior with previous versions of Symfony).
      */
     public function get(string $name, string $path = '/', ?string $domain = null): ?Cookie
     {
         $this->flushExpiredCookies();
+
+        $match = null;
 
         foreach ($this->cookieJar as $cookieDomain => $pathCookies) {
             if ($cookieDomain && $domain) {
@@ -51,16 +55,16 @@ class CookieJar
             }
 
             foreach ($pathCookies as $cookiePath => $namedCookies) {
-                if (!str_starts_with($path, $cookiePath)) {
+                if (!str_starts_with($path, $cookiePath) || !isset($namedCookies[$name])) {
                     continue;
                 }
-                if (isset($namedCookies[$name])) {
-                    return $namedCookies[$name];
+                if (null === $match || self::isMoreSpecific($namedCookies[$name], $match)) {
+                    $match = $namedCookies[$name];
                 }
             }
         }
 
-        return null;
+        return $match;
     }
 
     /**
@@ -195,12 +199,16 @@ class CookieJar
                         continue;
                     }
 
-                    $cookies[$cookie->getName()] = $returnsRawValue ? $cookie->getRawValue() : $cookie->getValue();
+                    $name = $cookie->getName();
+
+                    if (!isset($cookies[$name]) || self::isMoreSpecific($cookie, $cookies[$name])) {
+                        $cookies[$name] = $cookie;
+                    }
                 }
             }
         }
 
-        return $cookies;
+        return array_map(static fn (Cookie $cookie) => $returnsRawValue ? $cookie->getRawValue() : $cookie->getValue(), $cookies);
     }
 
     /**
@@ -227,5 +235,17 @@ class CookieJar
                 }
             }
         }
+    }
+
+    private static function isMoreSpecific(Cookie $cookie, Cookie $other): bool
+    {
+        $pathLength = \strlen($cookie->getPath());
+        $otherPathLength = \strlen($other->getPath());
+
+        if ($pathLength !== $otherPathLength) {
+            return $pathLength > $otherPathLength;
+        }
+
+        return \strlen(ltrim($cookie->getDomain(), '.')) > \strlen(ltrim($other->getDomain(), '.'));
     }
 }

--- a/src/Symfony/Component/BrowserKit/Tests/CookieJarTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/CookieJarTest.php
@@ -207,6 +207,50 @@ class CookieJarTest extends TestCase
         $this->assertEquals(['foo' => 'bar2'], $cookieJar->allValues('http://bar.example.com/'));
     }
 
+    public function testCookieGetPrefersTheMostSpecificDomain()
+    {
+        $cookieJar = new CookieJar();
+        $cookieJar->set($parent = new Cookie('foo', 'bar1', null, '/', 'example.com'));
+        $cookieJar->set($child = new Cookie('foo', 'bar2', null, '/', 'admin.example.com'));
+
+        $this->assertEquals($child, $cookieJar->get('foo', '/', 'admin.example.com'));
+        $this->assertEquals($parent, $cookieJar->get('foo', '/', 'www.example.com'));
+
+        $cookieJar = new CookieJar();
+        $cookieJar->set($child = new Cookie('foo', 'bar2', null, '/', 'admin.example.com'));
+        $cookieJar->set($parent = new Cookie('foo', 'bar1', null, '/', 'example.com'));
+
+        $this->assertEquals($child, $cookieJar->get('foo', '/', 'admin.example.com'));
+        $this->assertEquals($parent, $cookieJar->get('foo', '/', 'www.example.com'));
+    }
+
+    public function testCookieGetPrefersTheLongestPath()
+    {
+        $cookieJar = new CookieJar();
+        $cookieJar->set($root = new Cookie('foo', 'bar1', null, '/'));
+        $cookieJar->set($admin = new Cookie('foo', 'bar2', null, '/admin'));
+
+        $this->assertEquals($admin, $cookieJar->get('foo', '/admin'));
+        $this->assertEquals($root, $cookieJar->get('foo', '/'));
+    }
+
+    public function testAllValuesPrefersTheMostSpecificCookie()
+    {
+        $cookieJar = new CookieJar();
+        $cookieJar->set(new Cookie('foo', 'bar2', null, '/', 'admin.example.com'));
+        $cookieJar->set(new Cookie('foo', 'bar1', null, '/', 'example.com'));
+
+        $this->assertEquals(['foo' => 'bar2'], $cookieJar->allValues('http://admin.example.com/'));
+        $this->assertEquals(['foo' => 'bar1'], $cookieJar->allValues('http://www.example.com/'));
+
+        $cookieJar = new CookieJar();
+        $cookieJar->set(new Cookie('foo', 'bar2', null, '/admin'));
+        $cookieJar->set(new Cookie('foo', 'bar1', null, '/'));
+
+        $this->assertEquals(['foo' => 'bar2'], $cookieJar->allValues('http://example.com/admin'));
+        $this->assertEquals(['foo' => 'bar1'], $cookieJar->allValues('http://example.com/'));
+    }
+
     public function testCookieGetWithSubdomain()
     {
         $cookieJar = new CookieJar();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #50237
| License       | MIT

`CookieJar` stores cookies as `[domain][path][name]`. `get()` walked that structure and returned the first entry it found; `allValues()` let the last entry it found overwrite the previous one. Both walks follow insertion order, so which cookie answers a lookup depended on the order the cookies had been set in, not on the request being matched.

With two cookies named `test`, one on `localhost` and one on `admin.localhost`:

- set `localhost` first, and `get('test', '/', 'admin.localhost')` returns the `localhost` cookie
- set `admin.localhost` first, and the same call returns the `admin.localhost` cookie

Paths have the same problem. With a cookie on `/` and a cookie on `/admin`, `get('test', '/admin')` returns whichever was set first. RFC 6265 section 5.4 is explicit for paths: a user agent lists cookies with longer paths before cookies with shorter paths. PHP keeps the first value when a name appears twice in a `Cookie` header, so the longest path is what an application actually reads. Returning the shorter one is a plain violation.

`get()` and `allValues()` now select the most specific match instead of an arbitrary one: longest path first, then most specific domain. RFC 6265 does not rank domains against each other, but a parent domain cookie shadowing an exact match is the reported symptom, and specificity is the only rule that gives the same answer whatever the insertion order.

The array `allValues()` returns keeps its key order: a name stays at the position of its first match, only the value it carries can now differ. No existing test expectation had to be adjusted.

Checks run:

- `./phpunit src/Symfony/Component/BrowserKit`: 245 tests, 597 assertions, green. Same command on the branch point: 242 tests, 587 assertions, green.
- `./phpunit src/Symfony/Component/HttpKernel/Tests`: 1217 tests, 2958 assertions, green.
- `./phpunit src/Symfony/Bundle/FrameworkBundle/Tests`: 1373 tests, 4545 assertions, 5 skipped, no failures.
- `./phpunit src/Symfony/Bundle/SecurityBundle/Tests`: 360 tests, 1104 assertions, 1 skipped, no failures.
- `./phpunit src/Symfony/Bundle/WebProfilerBundle/Tests`: 137 tests, 392 assertions, green.
- `./phpunit src/Symfony/Component/AssetMapper/Tests`: 352 tests, 953 assertions, 1 skipped, no failures.
- `./phpunit src/Symfony/Bridge/PsrHttpMessage/Tests`: 38 tests, 257 assertions, green.
- PHP CS Fixer dry run on both touched files: clean.
- Revert check: with `CookieJar.php` back at its base state the three new tests fail, each on the value of the cookie that was set first.
