### PR TITLE
[WebProfilerBundle] Fix the mailer panel crashing when an attached file was deleted

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/mailer.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/mailer.html.twig
@@ -336,8 +336,10 @@
                                 <strong>To:</strong>
                                 {{ message.headers.get('to').bodyAsString()|default('(empty)') }}
                             </p>
-                            {% for header in message.headers.all|filter(header => (header.name ?? '')|lower not in ['subject', 'from', 'to']) %}
-                                <p class="mailer-message-header-secondary">{{ header.toString }}</p>
+                            {% for header in message.headers.all %}
+                                {% if (header.name ?? '')|lower not in ['subject', 'from', 'to'] %}
+                                    <p class="mailer-message-header-secondary">{{ header.toString }}</p>
+                                {% endif %}
                             {% endfor %}
                         </div>
                     </div>
@@ -345,7 +347,7 @@
                     {% if message.attachments is defined and message.attachments %}
                         <div class="card-block">
                             {% set num_of_attachments = message.attachments|length %}
-                            {% set total_attachments_size_in_bytes = message.attachments|reduce((total_size, attachment) => total_size + attachment.body|length, 0) %}
+                            {% set total_attachments_size_in_bytes = message.attachments|reduce((total_size, attachment) => total_size + profiler_mailer_body(attachment)|length, 0) %}
                             <p class="mailer-message-attachments-title">
                                 {{ source('@WebProfiler/Icon/attachment.svg') }}
                                 Attachments <span>({{ num_of_attachments }} file{{ num_of_attachments > 1 ? 's' }} / {{ _self.render_file_size_humanized(total_attachments_size_in_bytes) }})</span>
@@ -353,6 +355,7 @@
 
                             <ul class="mailer-message-attachments-list">
                                 {% for attachment in message.attachments %}
+                                    {% set attachment_body = profiler_mailer_body(attachment) %}
                                     <li>
                                         {{ source('@WebProfiler/Icon/file.svg') }}
 
@@ -362,9 +365,13 @@
                                             <em>(no filename)</em>
                                         {% endif %}
 
-                                        ({{ _self.render_file_size_humanized(attachment.body|length) }})
+                                        {% if attachment_body is null %}
+                                            <em>(the file is not readable anymore)</em>
+                                        {% else %}
+                                            ({{ _self.render_file_size_humanized(attachment_body|length) }})
 
-                                        <a href="data:{{ attachment.contentType|default('application/octet-stream') }};base64,{{ collector.base64Encode(attachment.body) }}" download="{{ attachment.filename|default('attachment') }}">Download</a>
+                                            <a href="data:{{ attachment.contentType|default('application/octet-stream') }};base64,{{ collector.base64Encode(attachment_body) }}" download="{{ attachment.filename|default('attachment') }}">Download</a>
+                                        {% endif %}
                                     </li>
                                 {% endfor %}
                             </ul>
@@ -424,7 +431,7 @@
                                 </div>
                             </div>
                         {% else %}
-                            {% set body = message.body ? message.body.toString() : null %}
+                            {% set body = message.body ? profiler_mailer_as_string(message.body) : null %}
                             <div class="tab {{ not body ? 'disabled' }} {{ body ? 'active' }}">
                                 <h3 class="tab-title">Content</h3>
                                 <div class="tab-content">
@@ -432,6 +439,10 @@
                                         <pre class="mailer-email-body prewrap" style="max-height: 600px">
                                             {{- body }}
                                         </pre>
+                                    {% elseif message.body %}
+                                        <div class="mailer-empty-email-body">
+                                            <p>The body is not readable anymore.</p>
+                                        </div>
                                     {% else %}
                                         <div class="mailer-empty-email-body">
                                             <p>The body is empty.</p>
@@ -455,12 +466,19 @@
             <div class="tab">
                 <h3 class="tab-title">Raw Message</h3>
                 <div class="tab-content">
-                    <a class="mailer-message-download-raw" href="data:application/octet-stream;base64,{{ collector.base64Encode(message.toString()) }}" download="email.eml">
-                        {{ source('@WebProfiler/Icon/download.svg') }}
-                        Download as EML file
-                    </a>
+                    {% set raw_message = profiler_mailer_as_string(message) %}
+                    {% if raw_message is null %}
+                        <div class="mailer-empty-email-body">
+                            <p>The raw message is not readable anymore.</p>
+                        </div>
+                    {% else %}
+                        <a class="mailer-message-download-raw" href="data:application/octet-stream;base64,{{ collector.base64Encode(raw_message) }}" download="email.eml">
+                            {{ source('@WebProfiler/Icon/download.svg') }}
+                            Download as EML file
+                        </a>
 
-                    <pre class="prewrap" style="max-height: 600px; margin-left: 5px">{{ message.toString() }}</pre>
+                        <pre class="prewrap" style="max-height: 600px; margin-left: 5px">{{ raw_message }}</pre>
+                    {% endif %}
                 </div>
             </div>
         </div>

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/Resources/MailerPanelTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/Resources/MailerPanelTest.php
@@ -1,0 +1,124 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\WebProfilerBundle\Tests\Resources;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\WebProfilerBundle\Twig\WebProfilerExtension;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Mailer\DataCollector\MessageDataCollector;
+use Symfony\Component\Mailer\Envelope;
+use Symfony\Component\Mailer\Event\MessageEvent;
+use Symfony\Component\Mailer\EventListener\MessageLoggerListener;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\Email;
+use Symfony\Component\Mime\Header\Headers;
+use Symfony\Component\Mime\Message;
+use Symfony\Component\Mime\Part\DataPart;
+use Symfony\Component\Mime\Part\File;
+use Symfony\Component\Mime\RawMessage;
+use Twig\Environment;
+use Twig\Loader\FilesystemLoader;
+
+class MailerPanelTest extends TestCase
+{
+    private string $attachmentPath;
+
+    protected function setUp(): void
+    {
+        if (!class_exists(MessageDataCollector::class)) {
+            $this->markTestSkipped('The Mailer component is not installed.');
+        }
+
+        $this->attachmentPath = tempnam(sys_get_temp_dir(), 'sf_mailer_panel_');
+        file_put_contents($this->attachmentPath, 'attachment content');
+    }
+
+    protected function tearDown(): void
+    {
+        if (isset($this->attachmentPath)) {
+            @unlink($this->attachmentPath);
+        }
+    }
+
+    public function testPanelRendersTheAttachmentAndTheRawMessage()
+    {
+        $panel = $this->renderPanel($this->createEmail(), false);
+
+        $this->assertStringContainsString('Attachments <span>(1 file / 18 bytes)</span>', $panel);
+        $this->assertStringContainsString('file.txt', $panel);
+        $this->assertStringContainsString('Download as EML file', $panel);
+        $this->assertStringNotContainsString('not readable anymore', $panel);
+    }
+
+    public function testPanelRendersWhenTheAttachedFileIsDeleted()
+    {
+        $panel = $this->renderPanel($this->createEmail(), true);
+
+        $this->assertStringContainsString('Attachments <span>(1 file / 0 bytes)</span>', $panel);
+        $this->assertStringContainsString('(the file is not readable anymore)', $panel);
+        $this->assertStringContainsString('The raw message is not readable anymore.', $panel);
+        $this->assertStringNotContainsString('Download as EML file', $panel);
+    }
+
+    public function testPanelRendersWhenTheFileOfANonEmailMessageIsDeleted()
+    {
+        $headers = (new Headers())->addMailboxListHeader('From', ['fabien@example.com']);
+        $message = new Message($headers, new DataPart(new File($this->attachmentPath), 'file.txt', 'text/plain'));
+
+        $panel = $this->renderPanel($message, true);
+
+        $this->assertStringContainsString('The body is not readable anymore.', $panel);
+        $this->assertStringContainsString('The raw message is not readable anymore.', $panel);
+    }
+
+    private function createEmail(): Email
+    {
+        $email = (new Email())
+            ->from('fabien@example.com')
+            ->to('helene@example.com')
+            ->subject('Hello')
+            ->text('Hello!')
+            ->html('<p>Hello!</p>')
+        ;
+        $email->attachFromPath($this->attachmentPath, 'file.txt', 'text/plain');
+
+        return $email;
+    }
+
+    private function renderPanel(RawMessage $message, bool $deleteFile): string
+    {
+        $listener = new MessageLoggerListener();
+        $listener->onMessage(new MessageEvent($message, new Envelope(new Address('fabien@example.com'), [new Address('helene@example.com')]), 'null://'));
+
+        $collector = new MessageDataCollector($listener);
+        $collector->collect(new Request(), new Response());
+
+        // the profiler renders the panel from the stored profile, long after the request
+        $collector = unserialize(serialize($collector));
+
+        if ($deleteFile) {
+            unlink($this->attachmentPath);
+        }
+
+        $loader = new FilesystemLoader();
+        $loader->addPath(\dirname(__DIR__, 2).'/Resources/views', 'WebProfiler');
+
+        $twig = new Environment($loader, ['strict_variables' => true]);
+        $twig->addExtension(new WebProfilerExtension());
+
+        return $twig
+            ->load('@WebProfiler/Collector/mailer.html.twig')
+            ->renderBlock('panel', ['collector' => $collector])
+        ;
+    }
+}

--- a/src/Symfony/Bundle/WebProfilerBundle/Twig/WebProfilerExtension.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Twig/WebProfilerExtension.php
@@ -11,6 +11,10 @@
 
 namespace Symfony\Bundle\WebProfilerBundle\Twig;
 
+use Symfony\Component\Mime\Exception\InvalidArgumentException;
+use Symfony\Component\Mime\Part\AbstractPart;
+use Symfony\Component\Mime\Part\DataPart;
+use Symfony\Component\Mime\RawMessage;
 use Symfony\Component\VarDumper\Cloner\Data;
 use Symfony\Component\VarDumper\Dumper\HtmlDumper;
 use Twig\Environment;
@@ -61,7 +65,33 @@ class WebProfilerExtension extends ProfilerExtension
         return [
             new TwigFunction('profiler_dump', $this->dumpData(...), ['is_safe' => ['html'], 'needs_environment' => true]),
             new TwigFunction('profiler_dump_log', $this->dumpLog(...), ['is_safe' => ['html'], 'needs_environment' => true]),
+            new TwigFunction('profiler_mailer_body', $this->mailerBody(...)),
+            new TwigFunction('profiler_mailer_as_string', $this->mailerAsString(...)),
         ];
+    }
+
+    /**
+     * Returns null when the part refers to a file that cannot be read anymore.
+     */
+    public function mailerBody(DataPart $part): ?string
+    {
+        try {
+            return $part->getBody();
+        } catch (InvalidArgumentException) {
+            return null;
+        }
+    }
+
+    /**
+     * Returns null when the message or the part refers to a file that cannot be read anymore.
+     */
+    public function mailerAsString(RawMessage|AbstractPart $message): ?string
+    {
+        try {
+            return $message->toString();
+        } catch (InvalidArgumentException) {
+            return null;
+        }
     }
 
     public function dumpData(Environment $env, Data $data, int $maxDepth = 0): string


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #50527
| License       | MIT

Attaching a file with `new DataPart(new File($path))` and deleting that file once the mail is sent makes the mailer panel of the profiler answer 500:

```
An exception has been thrown during the rendering of a template
("file_get_contents(/tmp/...): Failed to open stream: No such file or directory")
```

A part built from a `File` reads the file lazily, and it stays lazy across serialization on purpose, so that a stored profile does not carry a copy of every attachment. The panel renders all its tabs in one pass, long after the request, and it reads the file in three places: the attachment list, the Raw Message tab through `message.toString()`, and the Content tab of a message that is not an `Email` through `message.body.toString()`. `TextPart::getBody()` throws when the file is gone, so any of these reads takes the whole page down.

The template now goes through two Twig functions of `WebProfilerExtension`, `profiler_mailer_body()` and `profiler_mailer_as_string()`, which return null instead of throwing when the file cannot be read anymore. Nothing changes outside of the bundle. When the file is gone:

- the attachment prints "(the file is not readable anymore)" in place of its size and its download link, and counts as 0 bytes in the `Attachments (n files / X)` header;
- the Raw Message tab prints "The raw message is not readable anymore." in place of the EML download link and the raw dump;
- the Content tab of a message that is not an `Email` prints "The body is not readable anymore." instead of claiming that the body is empty.

Nothing changes when the files are readable.

The panel also crashed with Twig 4 for every email, before reaching any of the above. `{% for header in message.headers.all|filter(...) %}` filters a generator, Twig's `LoopIterator` rewinds it twice, and PHP refuses the second rewind as soon as the filter dropped the first item. The loop always drops `From`, so the panel was dead. Moving the filter inside the loop avoids it. This is the only place in the profiler templates where `|filter` is applied to a generator, and Twig should probably be fixed too.

How this was checked:

- `./phpunit src/Symfony/Bundle/WebProfilerBundle`: 140 tests, 402 assertions, green. 137 before.
- The new `MailerPanelTest` renders the `panel` block of `mailer.html.twig` against a collector that went through `serialize()` and `unserialize()`, the way the profiler storage does. It is the first rendering test of that panel. Putting back any of the template hunks makes it fail on the file that is gone, and putting back the whole template makes it fail on the Twig 4 rewind. It skips when the Mailer component is not installed, so the bundle gains no dev dependency on it.
