### PR TITLE
[Form] Do not inherit translation parameters for translatable labels and help messages

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/BaseType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/BaseType.php
@@ -18,6 +18,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * Encapsulates common logic of {@link FormType} and {@link ButtonType}.
@@ -63,7 +64,10 @@ abstract class BaseType extends AbstractType
 
             $translationDomain ??= $view->parent->vars['translation_domain'];
 
-            $labelTranslationParameters = array_merge($view->parent->vars['label_translation_parameters'], $labelTranslationParameters);
+            if (!$options['label'] instanceof TranslatableInterface) {
+                $labelTranslationParameters = array_merge($view->parent->vars['label_translation_parameters'], $labelTranslationParameters);
+            }
+
             $attrTranslationParameters = array_merge($view->parent->vars['attr_translation_parameters'], $attrTranslationParameters);
 
             if (!$labelFormat) {

--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -89,7 +89,9 @@ class FormType extends BaseType
                 $view->vars['attr']['readonly'] = true;
             }
 
-            $helpTranslationParameters = array_merge($view->parent->vars['help_translation_parameters'], $helpTranslationParameters);
+            if (!$options['help'] instanceof TranslatableInterface) {
+                $helpTranslationParameters = array_merge($view->parent->vars['help_translation_parameters'], $helpTranslationParameters);
+            }
         }
 
         $formConfig = $form->getConfig();

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/EnumTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/EnumTypeTest.php
@@ -276,6 +276,21 @@ class EnumTypeTest extends BaseTypeTestCase
         $this->assertEquals('Left', $view->children[0]->vars['label']->trans(new IdentityTranslator()));
     }
 
+    public function testTranslatableChoiceLabelDoesNotInheritLabelTranslationParameters()
+    {
+        $form = $this->factory->create($this->getTestedType(), null, [
+            'multiple' => false,
+            'expanded' => true,
+            'class' => TranslatableTextAlign::class,
+            'label_translation_parameters' => ['%count%' => 12],
+        ]);
+
+        $view = $form->createView();
+
+        $this->assertSame(['%count%' => 12], $view->vars['label_translation_parameters']);
+        $this->assertSame([], $view->children[0]->vars['label_translation_parameters']);
+    }
+
     public function testChoices()
     {
         $form = $this->factory->create($this->getTestedType(), null, [

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
@@ -28,6 +28,7 @@ use Symfony\Component\Form\Tests\Fixtures\Author;
 use Symfony\Component\Form\Tests\Fixtures\FixedDataTransformer;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 use Symfony\Component\PropertyAccess\PropertyPath;
+use Symfony\Component\Translation\TranslatableMessage;
 use Symfony\Component\Validator\Validation;
 
 class FormTest_AuthorWithoutRefSetter
@@ -750,6 +751,36 @@ $ref2
             ->createView();
 
         $this->assertEquals(['%parent_param%' => 'parent_value', '%override_param%' => 'child_value'], $view['child']->vars['help_translation_parameters']);
+    }
+
+    public function testTranslatableLabelDoesNotInheritLabelTranslationParameters()
+    {
+        $view = $this->factory
+            ->createNamedBuilder('parent', self::TESTED_TYPE, null, [
+                'label_translation_parameters' => ['%param%' => 'value'],
+            ])
+            ->add('child', $this->getTestedType(), [
+                'label' => new TranslatableMessage('child.label'),
+            ])
+            ->getForm()
+            ->createView();
+
+        $this->assertSame([], $view['child']->vars['label_translation_parameters']);
+    }
+
+    public function testTranslatableHelpDoesNotInheritHelpTranslationParameters()
+    {
+        $view = $this->factory
+            ->createNamedBuilder('parent', self::TESTED_TYPE, null, [
+                'help_translation_parameters' => ['%param%' => 'value'],
+            ])
+            ->add('child', $this->getTestedType(), [
+                'help' => new TranslatableMessage('child.help'),
+            ])
+            ->getForm()
+            ->createView();
+
+        $this->assertSame([], $view['child']->vars['help_translation_parameters']);
     }
 
     public function testErrorBubblingDoesNotSkipCompoundFieldsWithInheritDataConfigured()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #51520
| License       | MIT

`BaseType::buildView()` merges the parent's `label_translation_parameters` into the ones of every child, and `FormType::buildView()` does the same with `help_translation_parameters`. When the label or the help of the child is a `TranslatableInterface`, these parameters have no meaning, because the object carries its own. The Twig `trans` filter refuses that combination:

```
TypeError: Argument 2 passed to "Symfony\Bridge\Twig\Extension\TranslationExtension::trans()" must be a locale passed as a string when the message is a "Symfony\Contracts\Translation\TranslatableInterface", "array" given.
```

The user cannot work around it. Setting the option on the child does not clear what the parent contributes, since the two are merged, and the children of an expanded `ChoiceType` are built by the type itself with no way to configure them. So rendering an expanded choice field whose choice labels are `TranslatableMessage` objects or a translatable enum always fails as soon as the field itself has `label_translation_parameters`.

This patch skips the inherited parameters when the label, or the help, is a `TranslatableInterface`. Parameters set on the field itself are kept, so an explicit combination of a translatable message and parameters still reports the error. `ViolationMapper` already ignores label parameters for a translatable label, so the component was inconsistent with itself here.

`attr_translation_parameters` is left as it is. Those parameters apply to every attribute of the field, so they cannot be dropped for one translatable attribute value without changing what the other attributes render.

Checks that were run on this branch, with PHP 8.5 and PHPUnit 9.6:

 * `./phpunit src/Symfony/Component/Form/Tests`: 4751 tests, 9352 assertions, 363 skipped, 8 incomplete, no failure. The base commit reports 4748 tests with the same skipped and incomplete counts.
 * `./phpunit src/Symfony/Bridge/Twig/Tests`: 1756 tests, no failure, same as the base commit.
 * `./phpunit src/Symfony/Bridge/Doctrine/Tests`: 453 tests, no failure, same as the base commit.
 * php-cs-fixer on the four touched files: clean.
 * A script that builds the expanded translatable enum of the report and calls `TranslationExtension::trans()` with the vars of the first child, as `form_div_layout.html.twig` does: it throws the `TypeError` above on the base commit and renders the label on this branch.

Revert verified. With `BaseType.php` and `FormType.php` restored to their current state and the tests kept, the three new tests fail because the parent parameters are still present in the child view.
