### PR TITLE
[PropertyInfo] Use the same mutator method for types and write info

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -93,8 +93,9 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
         $this->magicMethodsFlags = $magicMethodsFlags;
         $this->inflector = $inflector ?? new EnglishInflector();
 
-        $this->arrayMutatorPrefixesFirst = array_merge($this->arrayMutatorPrefixes, array_diff($this->mutatorPrefixes, $this->arrayMutatorPrefixes));
-        $this->arrayMutatorPrefixesLast = array_reverse($this->arrayMutatorPrefixesFirst);
+        $nonArrayMutatorPrefixes = array_diff($this->mutatorPrefixes, $this->arrayMutatorPrefixes);
+        $this->arrayMutatorPrefixesFirst = array_merge($this->arrayMutatorPrefixes, $nonArrayMutatorPrefixes);
+        $this->arrayMutatorPrefixesLast = array_merge($nonArrayMutatorPrefixes, $this->arrayMutatorPrefixes);
     }
 
     public function getProperties(string $class, array $context = []): ?array

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
@@ -23,6 +23,7 @@ use Symfony\Component\PropertyInfo\Tests\Fixtures\DummyWithHasser;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\MultiParameterAdderDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\MultiParameterAdderParentDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\MultiParameterAdderValue;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\MutatorPrefixesDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\NotAnAccessorDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\NotInstantiable;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Php71Dummy;
@@ -871,5 +872,26 @@ class ReflectionExtractorTest extends TestCase
     public function testIsserUsedForBoolPropertyWithoutOtherTypeSource()
     {
         $this->assertEquals([new Type(Type::BUILTIN_TYPE_BOOL)], $this->extractor->getTypes(DummyWithHasser::class, 'enabled'));
+    }
+
+    public function testTypeAndWriteInfoUseTheSameMutator()
+    {
+        $setFirstExtractor = new ReflectionExtractor(['set', 'with']);
+
+        $this->assertEquals([new Type(Type::BUILTIN_TYPE_OBJECT, false, \stdClass::class)], $setFirstExtractor->getTypes(MutatorPrefixesDummy::class, 'prop'));
+        $this->assertSame('setProp', $setFirstExtractor->getWriteInfo(MutatorPrefixesDummy::class, 'prop')->getName());
+
+        $withFirstExtractor = new ReflectionExtractor(['with', 'set']);
+
+        $this->assertEquals([new Type(Type::BUILTIN_TYPE_STRING)], $withFirstExtractor->getTypes(MutatorPrefixesDummy::class, 'prop'));
+        $this->assertSame('withProp', $withFirstExtractor->getWriteInfo(MutatorPrefixesDummy::class, 'prop')->getName());
+    }
+
+    public function testSingularPropertyTypeComesFromTheAdder()
+    {
+        $expected = [new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_OBJECT, false, \DateTime::class))];
+
+        $this->assertEquals($expected, $this->extractor->getTypes(MutatorPrefixesDummy::class, 'item'));
+        $this->assertSame('addItem', $this->extractor->getWriteInfo(MutatorPrefixesDummy::class, 'item')->getAdderInfo()->getName());
     }
 }

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/MutatorPrefixesDummy.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/MutatorPrefixesDummy.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
+
+class MutatorPrefixesDummy
+{
+    public function setProp(\stdClass $prop): void
+    {
+    }
+
+    public function withProp(string $prop): static
+    {
+        return $this;
+    }
+
+    public function addItem(\DateTime $item): void
+    {
+    }
+
+    public function removeItem(\DateTimeImmutable $item): void
+    {
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #51785
| License       | MIT

`ReflectionExtractor` looks up the mutator method twice, and the two lookups did not agree on which prefix wins.

`getWriteInfo()` walks the configured `$mutatorPrefixes` in order. The type side (`getTypes()`, through `getMutatorMethod()`) walks a derived list instead: `arrayMutatorPrefixesFirst` when the property name has a distinct singular, `arrayMutatorPrefixesLast` otherwise. That second list was built with `array_reverse()`, so it did not only push the array mutator prefixes to the end, it also reversed the other ones.

With the default prefixes there is only one non-array prefix (`set`), so the reversal is invisible. It becomes visible as soon as a second one is configured. For `new ReflectionExtractor(['set', 'with'])` and a class declaring both `withProp(string $prop)` and `setProp(\stdClass $prop)`, `getTypes()` reports `string`, read from `withProp()`, while `getWriteInfo()` returns `setProp()`. A denormalizer then casts the incoming value to a string and calls a method that requires an object.

The fix builds `arrayMutatorPrefixesLast` by appending the array mutator prefixes to the configured ones, instead of reversing the whole list. That is what the property name says and what the change that introduced it set out to do: check the array mutator prefixes last when the property is singular. The non-array prefixes now keep their configured order on both sides.

Dropping `array_reverse()` has one visible side effect with the default prefixes. For a singular property backed by an adder and a remover but no setter, the collection value type now comes from the adder instead of the remover. The adder is the method the write side reports and the one PropertyAccess calls to write, so the two sides agree here as well. In any class where the adder and the remover accept the same element type, nothing changes. The second added test covers this case.

Checks run:

* `./phpunit src/Symfony/Component/PropertyInfo`: OK, 556 tests, 892 assertions (554 before the two new tests). One legacy deprecation notice, also reported on the base commit.
* `./phpunit src/Symfony/Component/PropertyAccess`: OK, 482 tests, 557 assertions.
* `./phpunit src/Symfony/Component/Serializer`: OK, 1151 tests, 2316 assertions, 11 skipped.
* Revert check: source change reverted, tests kept. `testTypeAndWriteInfoUseTheSameMutator` fails with `'builtinType' => 'string'` / `'class' => null` where `object` / `stdClass` is expected, and `testSingularPropertyTypeComesFromTheAdder` fails with `'class' => 'DateTimeImmutable'` where `DateTime` is expected. The rest of the component stays green.

Merge up: the two changed lines of `ReflectionExtractor::__construct()` are identical on 7.4, 8.1 and 8.2, so the source part merges as is. The new tests call `getTypes()`, which is deprecated on 7.4 and removed on 8.2, so they have to be rewritten against `getType()` when the merge reaches those branches: `Type::object(\stdClass::class)`, `Type::string()` and `Type::list(Type::object(\DateTime::class))`.
