### PR TITLE
[Security] Match check paths given as a route alias

### DIFF
--- a/src/Symfony/Component/Security/Http/HttpUtils.php
+++ b/src/Symfony/Component/Security/Http/HttpUtils.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Security\Http;
 
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Exception\ExceptionInterface;
 use Symfony\Component\Routing\Exception\MethodNotAllowedException;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -135,7 +136,7 @@ class HttpUtils
         if ('/' !== $path[0]) {
             // Shortcut if request has already been matched before
             if ($request->attributes->has('_route')) {
-                return $path === $request->attributes->get('_route');
+                return $path === $request->attributes->get('_route') || $this->generatesRequestPath($request, $path, $request->attributes->get('_route_params', []));
             }
 
             try {
@@ -146,7 +147,7 @@ class HttpUtils
                     $parameters = $this->urlMatcher->match($request->getPathInfo());
                 }
 
-                return isset($parameters['_route']) && $path === $parameters['_route'];
+                return isset($parameters['_route']) && ($path === $parameters['_route'] || $this->generatesRequestPath($request, $path, $parameters));
             } catch (MethodNotAllowedException) {
                 return false;
             } catch (ResourceNotFoundException) {
@@ -196,5 +197,27 @@ class HttpUtils
         }
 
         return $url;
+    }
+
+    /**
+     * Tells whether generating the given route leads to the path of the current request.
+     *
+     * This makes route aliases work, since matching a request always yields the canonical route name.
+     */
+    private function generatesRequestPath(Request $request, string $route, array $parameters): bool
+    {
+        if (null === $this->urlGenerator) {
+            return false;
+        }
+
+        unset($parameters['_route'], $parameters['_controller']);
+
+        try {
+            $url = $this->urlGenerator->generate($route, $parameters);
+        } catch (ExceptionInterface) {
+            return false;
+        }
+
+        return $url === $request->getBaseUrl().$request->getPathInfo();
     }
 }

--- a/src/Symfony/Component/Security/Http/Tests/HttpUtilsTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/HttpUtilsTest.php
@@ -418,6 +418,78 @@ class HttpUtilsTest extends TestCase
         $this->assertFalse($utils->checkRequestPath($request, 'foobar'));
     }
 
+    public function testCheckRequestPathWithRouteAlias()
+    {
+        $request = $this->getRequest('/foo/bar');
+        $request->attributes->set('_route', 'foobar');
+
+        $routes = new RouteCollection();
+        $routes->add('foobar', new Route('/foo/bar'));
+        $routes->add('other', new Route('/other'));
+        $routes->addAlias('App\Controller\FooBarController', 'foobar');
+
+        $utils = new HttpUtils(new UrlGenerator($routes, (new RequestContext())->fromRequest($request)));
+
+        $this->assertTrue($utils->checkRequestPath($request, 'App\Controller\FooBarController'));
+        $this->assertFalse($utils->checkRequestPath($request, 'other'));
+        $this->assertFalse($utils->checkRequestPath($request, 'undefined'));
+    }
+
+    public function testCheckRequestPathWithRouteAliasAndUrlMatcher()
+    {
+        $request = $this->getRequest('/foo/bar');
+
+        $routes = new RouteCollection();
+        $routes->add('foobar', new Route('/foo/bar'));
+        $routes->addAlias('App\Controller\FooBarController', 'foobar');
+
+        $urlMatcher = $this->createStub(RequestMatcherInterface::class);
+        $urlMatcher
+            ->method('matchRequest')
+            ->with($request)
+            ->willReturn(['_route' => 'foobar'])
+        ;
+
+        $utils = new HttpUtils(new UrlGenerator($routes, (new RequestContext())->fromRequest($request)), $urlMatcher);
+
+        $this->assertTrue($utils->checkRequestPath($request, 'App\Controller\FooBarController'));
+    }
+
+    public function testCheckRequestPathWithRouteAliasAndParameters()
+    {
+        $request = $this->getRequest('/foo/bar');
+        $request->attributes->set('_route', 'foobar');
+        $request->attributes->set('_route_params', ['name' => 'bar']);
+
+        $routes = new RouteCollection();
+        $routes->add('foobar', new Route('/foo/{name}'));
+        $routes->addAlias('App\Controller\FooBarController', 'foobar');
+
+        $utils = new HttpUtils(new UrlGenerator($routes, (new RequestContext())->fromRequest($request)));
+
+        $this->assertTrue($utils->checkRequestPath($request, 'App\Controller\FooBarController'));
+    }
+
+    public function testCheckRequestPathWithRouteAliasAndParametersAndUrlMatcher()
+    {
+        $request = $this->getRequest('/foo/bar');
+
+        $routes = new RouteCollection();
+        $routes->add('foobar', new Route('/foo/{name}'));
+        $routes->addAlias('App\Controller\FooBarController', 'foobar');
+
+        $urlMatcher = $this->createStub(RequestMatcherInterface::class);
+        $urlMatcher
+            ->method('matchRequest')
+            ->with($request)
+            ->willReturn(['_route' => 'foobar', '_controller' => 'App\Controller\FooBarController::index', 'name' => 'bar'])
+        ;
+
+        $utils = new HttpUtils(new UrlGenerator($routes, (new RequestContext())->fromRequest($request)), $urlMatcher);
+
+        $this->assertTrue($utils->checkRequestPath($request, 'App\Controller\FooBarController'));
+    }
+
     public function testCheckPathWithoutRouteParam()
     {
         $urlMatcher = $this->createStub(UrlMatcherInterface::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #53736
| License       | MIT

`HttpUtils::checkRequestPath()` tells the firewall whether the current request targets a configured path: the `check_path` of `form_login` and `json_login`, the `logout_path` of `logout`, the `check_route` of `login_link`. When the configured value is a route name rather than a URL path, the check compares that name with the name of the route the router matched.

Matching a request always reports the canonical name of the matched route, so a route alias never compares equal. Since 6.4 every route created from a controller also gets an alias named after the controller class, so `check_path: App\Controller\LoginController` matched nothing: the login form was submitted, the authenticator ignored the request, and the user landed back on the login page without any error. Aliases declared by hand in YAML, XML or PHP behave the same way.

The name comparison stays first, and nothing changes when it succeeds. When it fails, the configured route is generated using the route parameters of the current request, and the resulting path is compared with the path of the current request. That is what makes an alias and its target match, including for a route that takes parameters. Without a URL generator there is no fallback, and a route that cannot be generated, because the name is unknown or a parameter is missing, does not match, as before.

The fallback is wider than aliases: any route name that generates the path of the current request now matches, not only an alias of the matched route. This is what the method documents, since the question it answers is whether the request targets the configured URL, and it stays bounded. A route must have matched first, so a 404 or a 405 returns false before the generator is consulted, and a host or scheme requirement produces a URL that cannot equal the current path. One consequence is worth knowing: `LogoutListener::requiresLogout()` has no HTTP method guard of its own, so with a routing table where two routes share the logout path, a request routed to the other one now triggers logout. Its CSRF check still applies.

The coverage stays in the component that owns `HttpUtils`. An earlier version of this PR also added a `FormLoginTest` data set in SecurityBundle, with a firewall configured through route aliases. It is dropped: the isolated low-deps and high-deps jobs resolve `symfony/security-http` from packagist, 6.3.x-dev and 7.4.x-dev respectively, so a SecurityBundle test can only assert behavior that has already been released there. That end-to-end data set can be added on the dev branch, where SecurityBundle requires the sibling branch and the local package wins in both jobs.

Checks run:
- `./phpunit src/Symfony/Component/Security/Http/Tests/HttpUtilsTest.php`: 44 tests, 69 assertions, OK.
- Reverting `HttpUtils.php` while keeping the tests: the four new tests fail with "Failed asserting that false is true.", the other 40 stay green.
- `./phpunit src/Symfony/Bundle/SecurityBundle/Tests/Functional/FormLoginTest.php`: 9 tests, 56 assertions, OK.
- PHP CS Fixer on the touched files reports nothing to fix.
