### PR TITLE
[FrameworkBundle] Fix lint:container skipping services matched by tagged iterators

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerLintCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerLintCommand.php
@@ -22,6 +22,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\DependencyInjection\Compiler\CheckTypeDeclarationsPass;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\Compiler\ResolveFactoryClassPass;
+use Symfony\Component\DependencyInjection\Compiler\ResolveTaggedIteratorArgumentPass;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
@@ -100,7 +101,9 @@ final class ContainerLintCommand extends Command
             $refl->setValue($parameterBag, true);
 
             $container->getCompilerPassConfig()->setBeforeOptimizationPasses([]);
-            $container->getCompilerPassConfig()->setOptimizationPasses([new ResolveFactoryClassPass()]);
+            // the XML dump doesn't keep the services matched by tagged iterators,
+            // resolving them again keeps the removing passes from dropping them
+            $container->getCompilerPassConfig()->setOptimizationPasses([new ResolveFactoryClassPass(), new ResolveTaggedIteratorArgumentPass()]);
             $container->getCompilerPassConfig()->setBeforeRemovingPasses([]);
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/TaggedConsumer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/TaggedConsumer.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Fixtures;
+
+class TaggedConsumer
+{
+    public function __construct(iterable $items)
+    {
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/TaggedItem.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/TaggedItem.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Fixtures;
+
+class TaggedItem
+{
+    public function __construct(array $options)
+    {
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ContainerLintCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ContainerLintCommandTest.php
@@ -40,6 +40,21 @@ class ContainerLintCommandTest extends AbstractWebTestCase
         $this->assertStringContainsString($expectedOutput, $tester->getDisplay());
     }
 
+    public function testLintContainerChecksServicesOnlyReferencedByTaggedIterators()
+    {
+        $kernel = static::createKernel([
+            'test_case' => 'ContainerLint',
+            'debug' => true,
+        ]);
+        $this->application = new Application($kernel);
+
+        $tester = $this->createCommandTester();
+        $exitCode = $tester->execute([]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('Invalid definition for service "tagged_item"', $tester->getDisplay());
+    }
+
     public static function containerLintProvider(): array
     {
         return [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ContainerLint/bundles.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ContainerLint/bundles.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+
+return [
+    new FrameworkBundle(),
+];

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ContainerLint/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ContainerLint/config.yml
@@ -1,0 +1,13 @@
+imports:
+    - { resource: ../config/default.yml }
+
+services:
+    tagged_consumer:
+        public: true
+        class: Symfony\Bundle\FrameworkBundle\Tests\Fixtures\TaggedConsumer
+        arguments: [!tagged_iterator app.tagged]
+
+    tagged_item:
+        class: Symfony\Bundle\FrameworkBundle\Tests\Fixtures\TaggedItem
+        arguments: ['not an array']
+        tags: ['app.tagged']


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #53839
| License       | MIT

In debug mode `lint:container` does not rebuild the container. It reloads the XML dump written by `ContainerBuilderDebugDumpPass`, replaces the optimization passes with `ResolveFactoryClassPass` alone, and then runs the removing passes plus `CheckTypeDeclarationsPass`.

The XML dump writes a tagged iterator as its metadata only, for example `<argument type="tagged_iterator" tag="app.tagged"/>`. The list of services that `ResolveTaggedIteratorArgumentPass` resolved during the real build is not part of it. After the reload that argument holds no reference, so `RemoveUnusedDefinitionsPass` treats every service reachable only through the iterator as unused and removes it. `CheckTypeDeclarationsPass` never looks at those services and the command reports success while they are misconfigured. Running the same command with `APP_DEBUG=0` rebuilds the container from scratch and does report the error, which is what makes the debug behaviour surprising.

The fix resolves the tagged iterators again on the reloaded container, by adding `ResolveTaggedIteratorArgumentPass` next to `ResolveFactoryClassPass`. The references are back before the removing passes run, so the tagged services stay in the container and get checked.

An earlier attempt, #63694, removed `RemoveUnusedDefinitionsPass` instead. That does not work. The dump is taken before the removing passes, so it still holds the definitions the real build discards, including broken ones, and the command would then report errors on services the application never instantiates.

Effect measured on the functional test applications of this bundle: between 5 and 11 services per application were silently skipped by the linter, among them `router.cache_warmer`, `validator.mapping.cache_warmer`, `config_builder.warmer`, `config.resource.self_checking_resource_checker`, `messenger.transport.sync.factory`, `twig.template_iterator` and the `translation.extractor.visitor.*` services. All of them are services the real container keeps: none of the newly checked ids appears in the compiler log with `reason: unused`. No service that was checked before is dropped.

Checks run: `./phpunit src/Symfony/Bundle/FrameworkBundle` on PHP 8.5, 1374 tests, 4547 assertions, 5 skipped, no failures, 31 legacy deprecation notices that all come from `@group legacy` tests. The new test fails on the unpatched command with `Failed asserting that 0 is identical to 1`, because the command exits 0 instead of reporting the type error. `lint:container` was also run against nine functional test applications with and without the change and stays green in both states.

For the merge up: 7.4 and later read a serialized `ContainerBuilder` (the `.ser` file) instead of the XML dump, and that keeps the resolved values, so the defect is not reachable there on the normal path. The XML branch survives as a fallback for when the serialization fails, so the added pass belongs in that branch only rather than in the shared pass setup. The `ContainerLint` test application already exists on 7.4 and its `bundles.php` registers `TestBundle`, whose `build()` adds `CheckTypeDeclarationsPass`; the fixture used here fails at kernel boot with that bundle, so on merge the test needs an application without it, or can be dropped since the path it covers is the fallback.
