### PR TITLE
[HttpKernel] Restore the locale that was in use before a sub-request

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/LocaleAwareListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/LocaleAwareListener.php
@@ -27,6 +27,7 @@ class LocaleAwareListener implements EventSubscriberInterface
 {
     private iterable $localeAwareServices;
     private RequestStack $requestStack;
+    private array $storedLocales = [];
 
     /**
      * @param iterable<mixed, LocaleAwareInterface> $localeAwareServices
@@ -39,11 +40,24 @@ class LocaleAwareListener implements EventSubscriberInterface
 
     public function onKernelRequest(RequestEvent $event): void
     {
+        if (!$event->isMainRequest()) {
+            $locales = [];
+
+            foreach ($this->localeAwareServices as $key => $service) {
+                $locales[$key] = $service->getLocale();
+            }
+
+            $this->storedLocales[spl_object_id($event->getRequest())] = $locales;
+        }
+
         $this->setLocale($event->getRequest()->getLocale(), $event->getRequest()->getDefaultLocale());
     }
 
     public function onKernelFinishRequest(FinishRequestEvent $event): void
     {
+        $storedLocales = $this->storedLocales[$id = spl_object_id($event->getRequest())] ?? [];
+        unset($this->storedLocales[$id]);
+
         if (null === $parentRequest = $this->requestStack->getParentRequest()) {
             foreach ($this->localeAwareServices as $service) {
                 $service->setLocale($event->getRequest()->getDefaultLocale());
@@ -52,7 +66,7 @@ class LocaleAwareListener implements EventSubscriberInterface
             return;
         }
 
-        $this->setLocale($parentRequest->getLocale(), $parentRequest->getDefaultLocale());
+        $this->setLocale($parentRequest->getLocale(), $parentRequest->getDefaultLocale(), $storedLocales);
     }
 
     public static function getSubscribedEvents(): array
@@ -64,11 +78,11 @@ class LocaleAwareListener implements EventSubscriberInterface
         ];
     }
 
-    private function setLocale(string $locale, string $defaultLocale): void
+    private function setLocale(string $locale, string $defaultLocale, array $storedLocales = []): void
     {
-        foreach ($this->localeAwareServices as $service) {
+        foreach ($this->localeAwareServices as $key => $service) {
             try {
-                $service->setLocale($locale);
+                $service->setLocale($storedLocales[$key] ?? $locale);
             } catch (\InvalidArgumentException) {
                 $service->setLocale($defaultLocale);
             }

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/LocaleAwareListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/LocaleAwareListenerTest.php
@@ -115,6 +115,39 @@ class LocaleAwareListenerTest extends TestCase
         $this->listener->onKernelFinishRequest($event);
     }
 
+    public function testLocaleSetOutsideOfTheListenerIsRestoredAfterASubRequest()
+    {
+        $service = new class implements LocaleAwareInterface {
+            private string $locale = 'en';
+
+            public function setLocale(string $locale): void
+            {
+                $this->locale = $locale;
+            }
+
+            public function getLocale(): string
+            {
+                return $this->locale;
+            }
+        };
+        $listener = new LocaleAwareListener(new \ArrayIterator([$service]), $this->requestStack);
+        $kernel = $this->createStub(HttpKernelInterface::class);
+
+        $this->requestStack->push($mainRequest = $this->createRequest('en'));
+        $listener->onKernelRequest(new RequestEvent($kernel, $mainRequest, HttpKernelInterface::MAIN_REQUEST));
+
+        $service->setLocale('fr');
+
+        $this->requestStack->push($subRequest = $this->createRequest('de'));
+        $listener->onKernelRequest(new RequestEvent($kernel, $subRequest, HttpKernelInterface::SUB_REQUEST));
+        $this->assertSame('de', $service->getLocale());
+
+        $listener->onKernelFinishRequest(new FinishRequestEvent($kernel, $subRequest, HttpKernelInterface::SUB_REQUEST));
+        $this->requestStack->pop();
+
+        $this->assertSame('fr', $service->getLocale());
+    }
+
     private function createRequest(string $locale): Request
     {
         $request = new Request();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #53904
| License       | MIT

`LocaleAwareListener` gives every `kernel.locale_aware` service the locale of the request being handled, and puts the locale back when a sub-request ends. To put it back it read the locale of the parent request, which is not the same as the locale that was in use when the sub-request started.

`LocaleSwitcher` is one of those services, and it is the documented way to change the locale programmatically. That combination produced the reported bug:

1. a controller calls `$localeSwitcher->setLocale('fr')`, which sets `fr` on the translator and on every other locale aware service;
2. the template renders a fragment with `{{ render(controller(...)) }}`;
3. the sub-request runs with its own locale, as it should;
4. when it ends, every locale aware service is set to the locale of the parent request, `en`;
5. the rest of the parent template renders in `en`.

The reporter saw form labels fall back to the request locale while validation messages, translated before the fragment, still used `fr`. Moving the fragment below the form worked around it.

The listener now records the locale of each service when a sub-request starts, and restores those values when it ends. When a sub-request never reached the listener on `kernel.request`, there is nothing recorded and the listener falls back to the parent request locale, as before. The end of the main request is untouched: services are still reset to the default locale.

One case behaves differently now. When the locale of the parent request was changed after `kernel.request`, without telling the locale aware services, finishing a sub-request used to push that new locale into them as a side effect. It no longer does. Setting the locale on the request alone never updated the services on its own, so this only removes an effect that depended on rendering a fragment.

Checks run:

* New test `LocaleAwareListenerTest::testLocaleSetOutsideOfTheListenerIsRestoredAfterASubRequest`. On the base commit it ends with `en` instead of `fr`.
* A script wiring a real `HttpKernel`, `LocaleListener`, `LocaleAwareListener`, `Translator` and `LocaleSwitcher`, with the controller rendering a sub-request: `fr` before the sub-request and `en` after it on the base commit, `fr` in both places with the fix. Same result whether the services are passed as an `ArrayIterator` or as the `RewindableGenerator` the container builds for a tagged iterator.
* `./phpunit src/Symfony/Component/HttpKernel/Tests`: 1218 tests, 2960 assertions, green. The same run on the base commit gives 1217 tests, 2958 assertions, and the same 24 legacy deprecation notices.
