### PR TITLE
[Mailer] Fix emails reported twice when they are queued and sent in the same process

### DIFF
--- a/src/Symfony/Component/Mailer/Event/MessageEvents.php
+++ b/src/Symfony/Component/Mailer/Event/MessageEvents.php
@@ -63,12 +63,22 @@ class MessageEvents
      */
     public function getMessages(?string $name = null): array
     {
-        $events = $this->getEvents($name);
         $messages = [];
-        foreach ($events as $event) {
+        $sent = 0;
+
+        // an email that is queued and then sent in the same process is reported by two events; keep only the sent one
+        foreach (array_reverse($this->getEvents($name)) as $event) {
+            if (!$event->isQueued()) {
+                ++$sent;
+            } elseif ($sent > 0) {
+                --$sent;
+
+                continue;
+            }
+
             $messages[] = $event->getMessage();
         }
 
-        return $messages;
+        return array_reverse($messages);
     }
 }

--- a/src/Symfony/Component/Mailer/Tests/Event/MessageEventsTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Event/MessageEventsTest.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Tests\Event;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Mailer\Event\MessageEvent;
+use Symfony\Component\Mailer\Event\MessageEvents;
+use Symfony\Component\Mailer\EventListener\MessageLoggerListener;
+use Symfony\Component\Mailer\Mailer;
+use Symfony\Component\Mailer\Messenger\MessageHandler;
+use Symfony\Component\Mailer\Messenger\SendEmailMessage;
+use Symfony\Component\Mailer\Transport\NullTransport;
+use Symfony\Component\Mailer\Transport\Transports;
+use Symfony\Component\Messenger\Handler\HandlersLocator;
+use Symfony\Component\Messenger\MessageBus;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Middleware\HandleMessageMiddleware;
+use Symfony\Component\Mime\Email;
+
+class MessageEventsTest extends TestCase
+{
+    public function testMessageSentThroughASynchronousBusIsReportedOnce()
+    {
+        $dispatcher = new EventDispatcher();
+        $logger = new MessageLoggerListener();
+        $transports = new Transports(['main' => new NullTransport($dispatcher)]);
+        $bus = new MessageBus([new HandleMessageMiddleware(new HandlersLocator([SendEmailMessage::class => [new MessageHandler($transports)]]))]);
+
+        $events = $this->sendTwoEmails($dispatcher, $logger, $transports, $bus);
+
+        $this->assertCount(4, $events->getEvents());
+
+        $messages = $events->getMessages();
+        $this->assertCount(2, $messages);
+        $this->assertSame('First', $messages[0]->getSubject());
+        $this->assertSame('Second', $messages[1]->getSubject());
+        $this->assertSame('sent', $messages[0]->getHeaders()->get('X-Status')->getBody());
+        $this->assertSame('sent', $messages[1]->getHeaders()->get('X-Status')->getBody());
+    }
+
+    public function testMessageLeftInTheQueueIsStillReported()
+    {
+        $dispatcher = new EventDispatcher();
+        $logger = new MessageLoggerListener();
+        $transports = new Transports(['main' => new NullTransport($dispatcher)]);
+
+        $events = $this->sendTwoEmails($dispatcher, $logger, $transports, new MessageBus());
+
+        $this->assertCount(2, $events->getEvents());
+
+        $messages = $events->getMessages();
+        $this->assertCount(2, $messages);
+        $this->assertSame('First', $messages[0]->getSubject());
+        $this->assertSame('Second', $messages[1]->getSubject());
+        $this->assertSame('queued', $messages[0]->getHeaders()->get('X-Status')->getBody());
+        $this->assertSame('queued', $messages[1]->getHeaders()->get('X-Status')->getBody());
+    }
+
+    public function testQueuedMessageIsKeptWhenAnEmailWasSentBefore()
+    {
+        $dispatcher = new EventDispatcher();
+        $logger = new MessageLoggerListener();
+        $dispatcher->addSubscriber($logger);
+        $transports = new Transports(['main' => new NullTransport($dispatcher)]);
+
+        $mailer = new Mailer($transports, null, $dispatcher);
+        $mailer->send((new Email())->from('sender@example.com')->to('recipient@example.com')->subject('Sent')->text('Hello'));
+
+        $mailer = new Mailer($transports, new MessageBus(), $dispatcher);
+        $mailer->send((new Email())->from('sender@example.com')->to('recipient@example.com')->subject('Queued')->text('Hello'));
+
+        $messages = $logger->getEvents()->getMessages();
+        $this->assertCount(2, $messages);
+        $this->assertSame('Sent', $messages[0]->getSubject());
+        $this->assertSame('Queued', $messages[1]->getSubject());
+    }
+
+    private function sendTwoEmails(EventDispatcher $dispatcher, MessageLoggerListener $logger, Transports $transports, MessageBusInterface $bus): MessageEvents
+    {
+        $dispatcher->addSubscriber($logger);
+        $dispatcher->addListener(MessageEvent::class, static function (MessageEvent $event) {
+            $event->getMessage()->getHeaders()->addTextHeader('X-Status', $event->isQueued() ? 'queued' : 'sent');
+        });
+
+        $mailer = new Mailer($transports, $bus, $dispatcher);
+        $mailer->send((new Email())->from('sender@example.com')->to('recipient@example.com')->subject('First')->text('Hello'));
+        $mailer->send((new Email())->from('sender@example.com')->to('recipient@example.com')->subject('Second')->text('Hello'));
+
+        return $logger->getEvents();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #54161
| License       | MIT

When the mailer is wired to a message bus, every email produces two `MessageEvent` instances: one dispatched by `Mailer::send()` before the email goes to the bus, with `queued` set to true, and one dispatched by the transport when the email is really sent. As soon as the bus handles `SendEmailMessage` synchronously, which is what happens by default once `symfony/messenger` is installed and no routing is configured, both events happen in the same process.

`MessageEvents::getMessages()`, which backs `getMailerMessages()` and `getMailerMessage()` in `MailerAssertionsTrait`, returned one message per event. Tests therefore saw every email twice, and `getMailerMessage(1)` returned the queued copy of the first email instead of the second one. `assertEmailCount()` did not have the problem because the `EmailCount` constraint already ignores queued events, which is why the two disagreed.

`getMessages()` now reports each email once. An email that was queued and then sent in the same process is reported through its sent message, which is the rendered one the transport received. An email that is still in the queue keeps being reported through its queued message, so tests that route emails to a real asynchronous transport are unaffected. `getMailerEvents()` still exposes both events, so `assertQueuedEmailCount()` and the profiler panel are unchanged.

The pairing is positional: a queued email is folded into the next email sent after it. The queued event and the sent event cannot be correlated by identity, because both carry a different clone of the message. The one case this cannot tell apart is an application that leaves an email in a queue and then sends an unrelated email through the same transport in the same process, which requires two differently wired mailer services.

Checks run on PHP 8.5 with PHPUnit 9.6:

* new `Symfony\Component\Mailer\Tests\Event\MessageEventsTest`, which drives a real `Mailer`, a synchronous `MessageBus` and the `MessageLoggerListener`: fails on the base commit with `Failed asserting that actual size 4 matches expected size 2`, passes with the fix.
* `./phpunit src/Symfony/Component/Mailer/Tests`: 169 tests, 8 skipped, no failure.
* `./phpunit src/Symfony/Bundle/FrameworkBundle/Tests`: 1374 tests, 5 skipped, no failure. The 31 legacy deprecation notices are reported on the base commit as well.

