### PR TITLE
[Security] Track session usage when a lazy firewall reads the token

### DIFF
--- a/src/Symfony/Component/Security/Core/Authentication/Token/Storage/UsageTrackingTokenStorage.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/Storage/UsageTrackingTokenStorage.php
@@ -36,12 +36,15 @@ final class UsageTrackingTokenStorage implements TokenStorageInterface, ServiceS
 
     public function getToken(): ?TokenInterface
     {
+        // reading the token can enable usage tracking, e.g. when a lazy firewall loads it from the session
+        $token = $this->storage->getToken();
+
         if ($this->shouldTrackUsage()) {
             // increments the internal session usage index
             $this->getSession()->getMetadataBag();
         }
 
-        return $this->storage->getToken();
+        return $token;
     }
 
     public function setToken(?TokenInterface $token = null): void

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Token/Storage/UsageTrackingTokenStorageTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Token/Storage/UsageTrackingTokenStorageTest.php
@@ -16,6 +16,7 @@ use Psr\Container\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpFoundation\Session\Storage\MetadataBag;
 use Symfony\Component\Security\Core\Authentication\Token\NullToken;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\UsageTrackingTokenStorage;
@@ -62,6 +63,38 @@ class UsageTrackingTokenStorageTest extends TestCase
         $this->assertSame(1, $sessionAccess);
 
         $trackingStorage->disableUsageTracking();
+        $this->assertSame($token, $trackingStorage->getToken());
+        $this->assertSame(1, $sessionAccess);
+    }
+
+    public function testGetTokenTracksUsageEnabledByTheInitializer()
+    {
+        $sessionAccess = 0;
+        $session = $this->createMock(SessionInterface::class);
+        $session->method('getMetadataBag')->willReturnCallback(static function () use (&$sessionAccess) {
+            ++$sessionAccess;
+
+            return new MetadataBag();
+        });
+
+        $request = new Request();
+        $request->setSession($session);
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        $locator = new class(['request_stack' => static fn () => $requestStack]) implements ContainerInterface {
+            use ServiceLocatorTrait;
+        };
+
+        $tokenStorage = new TokenStorage();
+        $trackingStorage = new UsageTrackingTokenStorage($tokenStorage, $locator);
+        $token = new NullToken();
+
+        $tokenStorage->setInitializer(static function () use ($tokenStorage, $trackingStorage, $token) {
+            $trackingStorage->enableUsageTracking();
+            $tokenStorage->setToken($token);
+        });
+
         $this->assertSame($token, $trackingStorage->getToken());
         $this->assertSame(1, $sessionAccess);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #54475
| License       | MIT

With a lazy firewall the security token is loaded on first read, by an initializer registered on the token storage. `UsageTrackingTokenStorage::getToken()` decided whether to mark the session as used before delegating to that storage:

```php
if ($this->shouldTrackUsage()) {
    // increments the internal session usage index
    $this->getSession()->getMetadataBag();
}

return $this->storage->getToken();
```

Usage tracking is turned on by `ContextListener`, which runs inside that initializer, so it is still off when the check above runs. The first read of the token is never counted. `AbstractSessionListener` then sees a usage index of 0 on the response and leaves the cache headers alone, so a response whose content depends on who is logged in can be stored in a shared cache.

The reproducer of the issue shows the shape of it: an ESI fragment that calls `getUser()` once is cached, a fragment that calls it twice is not, because only the second call is counted.

The fix delegates first and marks the usage afterwards, which is the order `setToken()` already uses. A firewall that is not lazy is unaffected, since `ContextListener` has already enabled tracking before the controller runs.

The issue was reported as specific to the mock session storages. That turns out to be a side effect rather than the cause: `AbstractSessionListener` calls `Session::isEmpty()` on a started session before it looks at the usage index, and `isEmpty()` increments that index. A session that was started is therefore always seen as used, which hides the missing increment. In the reported scenario no session cookie exists, the session is never started, and nothing hides it.

Responses that were cacheable before become private when the application reads the security token, which is the point of the fix and matches what a firewall that is not lazy already does.

Checks run:

- `php ./phpunit src/Symfony/Component/Security/Core/Tests`: OK, 350 tests, 539 assertions.
- `php ./phpunit src/Symfony/Component/Security/Http/Tests`: OK, 528 tests, 991 assertions.
- `php ./phpunit src/Symfony/Bundle/SecurityBundle/Tests`: OK, 360 tests, 1104 assertions, 1 skipped (pre-existing).
- `php ./phpunit src/Symfony/Bundle/FrameworkBundle/Tests`: OK, 1373 tests, 4545 assertions, 5 skipped (pre-existing).
- The new test on the unpatched source: `Failed asserting that 0 is identical to 1`.
- No style tool available locally, so the hosted style check has not been reproduced.
