### PR TITLE
[Finder] Fix gitignore matching of negated patterns and excluded directories

### DIFF
--- a/src/Symfony/Component/Finder/Iterator/VcsIgnoredFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/VcsIgnoredFilterIterator.php
@@ -21,7 +21,7 @@ final class VcsIgnoredFilterIterator extends \FilterIterator
     private string $baseDir;
 
     /**
-     * @var array<string, array{0: string, 1: string}|null>
+     * @var array<string, list<array{0: string, 1: bool, 2: bool}>|null>
      */
     private array $gitignoreFilesCache = [];
 
@@ -58,38 +58,40 @@ final class VcsIgnoredFilterIterator extends \FilterIterator
 
     private function isIgnored(string $fileRealPath): bool
     {
-        if (is_dir($fileRealPath) && !str_ends_with($fileRealPath, '/')) {
-            $fileRealPath .= '/';
-        }
-
         if (isset($this->ignoredPathsCache[$fileRealPath])) {
             return $this->ignoredPathsCache[$fileRealPath];
         }
 
         $ignored = false;
+        $parentDirectories = $this->parentDirectoriesDownwards($fileRealPath);
 
-        foreach ($this->parentDirectoriesDownwards($fileRealPath) as $parentDirectory) {
-            if ($this->isIgnored($parentDirectory)) {
-                // rules in ignored directories are ignored, no need to check further.
-                break;
-            }
+        if ($parentDirectories && $this->baseDir !== $parentDirectory = $parentDirectories[\count($parentDirectories) - 1]) {
+            // paths inside an ignored directory are ignored and cannot be re-included
+            $ignored = $this->isIgnored($parentDirectory);
+        }
 
-            $fileRelativePath = substr($fileRealPath, \strlen($parentDirectory) + 1);
+        if (!$ignored) {
+            $isDir = is_dir($fileRealPath);
 
-            if (null === $regexps = $this->readGitignoreFile("{$parentDirectory}/.gitignore")) {
-                continue;
-            }
+            // the last matching rule of the deepest .gitignore file decides
+            foreach (array_reverse($parentDirectories) as $parentDirectory) {
+                if (null === $rules = $this->readGitignoreFile("{$parentDirectory}/.gitignore")) {
+                    continue;
+                }
 
-            [$exclusionRegex, $inclusionRegex] = $regexps;
+                $fileRelativePath = substr($fileRealPath, \strlen($parentDirectory) + 1);
 
-            if (preg_match($exclusionRegex, $fileRelativePath)) {
-                $ignored = true;
+                foreach ($rules as [$regex, $isNegated, $isDirOnly]) {
+                    if ($isDirOnly && !$isDir) {
+                        continue;
+                    }
 
-                continue;
-            }
+                    if (preg_match($regex, $fileRelativePath, $matches) && $matches[0] === $fileRelativePath) {
+                        $ignored = !$isNegated;
 
-            if (preg_match($inclusionRegex, $fileRelativePath)) {
-                $ignored = false;
+                        break 2;
+                    }
+                }
             }
         }
 
@@ -138,7 +140,9 @@ final class VcsIgnoredFilterIterator extends \FilterIterator
     }
 
     /**
-     * @return array{0: string, 1: string}|null
+     * Returns the rules of a .gitignore file, last one first, as [regex, isNegated, isDirOnly] tuples.
+     *
+     * @return list<array{0: string, 1: bool, 2: bool}>|null
      */
     private function readGitignoreFile(string $path): ?array
     {
@@ -154,12 +158,28 @@ final class VcsIgnoredFilterIterator extends \FilterIterator
             throw new \RuntimeException("The \"ignoreVCSIgnored\" option cannot be used by the Finder as the \"{$path}\" file is not readable.");
         }
 
-        $gitignoreFileContent = file_get_contents($path);
+        $rules = [];
 
-        return $this->gitignoreFilesCache[$path] = [
-            Gitignore::toRegex($gitignoreFileContent),
-            Gitignore::toRegexMatchingNegatedPatterns($gitignoreFileContent),
-        ];
+        foreach (preg_split('~\r\n?|\n~', file_get_contents($path)) as $line) {
+            $line = preg_replace('~(?<!\\\\)#[^\n\r]*~', '', $line);
+            $line = preg_replace('~(?<!\\\\)[ \t]+$~', '', $line);
+
+            if ($isNegated = str_starts_with($line, '!')) {
+                $line = substr($line, 1);
+            }
+
+            if ($isDirOnly = str_ends_with($line, '/')) {
+                $line = substr($line, 0, -1);
+            }
+
+            if ('' === $line) {
+                continue;
+            }
+
+            $rules[] = [Gitignore::toRegex($line), $isNegated, $isDirOnly];
+        }
+
+        return $this->gitignoreFilesCache[$path] = array_reverse($rules);
     }
 
     private function normalizePath(string $path): string

--- a/src/Symfony/Component/Finder/Tests/Iterator/VcsIgnoredFilterIteratorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/VcsIgnoredFilterIteratorTest.php
@@ -358,7 +358,80 @@ class VcsIgnoredFilterIteratorTest extends IteratorTestCase
                 'a/c.txt',
             ],
             [
+                'a',
                 'a/b.txt',
+            ],
+        ];
+
+        yield 'negated pattern re-includes a file excluded by an earlier pattern' => [
+            [
+                '.gitignore' => "*.txt\n!a.txt",
+            ],
+            [
+                'a.txt',
+                'b.txt',
+                'dir/',
+                'dir/a.txt',
+            ],
+            [
+                'a.txt',
+                'dir',
+                'dir/a.txt',
+            ],
+        ];
+
+        yield 'later pattern wins over an earlier negated pattern' => [
+            [
+                '.gitignore' => "!/a.txt\n*.txt",
+            ],
+            [
+                'a.txt',
+                'b.txt',
+            ],
+            [],
+        ];
+
+        yield 'negated directory pattern re-includes the directory content' => [
+            [
+                '.gitignore' => "/b/*\n!/b/foo",
+            ],
+            [
+                'b/',
+                'b/bar/',
+                'b/bar/file.txt',
+                'b/foo/',
+                'b/foo/file.txt',
+            ],
+            [
+                'b',
+                'b/foo',
+                'b/foo/file.txt',
+            ],
+        ];
+
+        yield 'directory content cannot be re-included when the directory is excluded' => [
+            [
+                '.gitignore' => "/a/\n!/a/foo",
+            ],
+            [
+                'a/',
+                'a/foo/',
+                'a/foo/file.txt',
+            ],
+            [],
+        ];
+
+        yield 'file cannot be re-included when its parent directory is excluded' => [
+            [
+                '.gitignore' => "/d/*\n!/d/foo/file.txt",
+            ],
+            [
+                'd/',
+                'd/foo/',
+                'd/foo/file.txt',
+            ],
+            [
+                'd',
             ],
         ];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #58175
| License       | MIT

`ignoreVCSIgnored(true)` diverges from git as soon as a `.gitignore` file combines exclusions and negations across directory levels. For the `.gitignore` from the linked issue, only one of the five files git tracks was reported, next to three files git ignores. The same defect broke PHP-CS-Fixer's file discovery (PHP-CS-Fixer/PHP-CS-Fixer#9285).

Root cause: `VcsIgnoredFilterIterator` matched each path against two flat regexes built from the whole `.gitignore` content, where a negated pattern only protects the exact path it names. Three git rules cannot be expressed that way:
* a negation that re-includes a directory re-includes its content: with `b/*` plus `!b/foo`, the files inside `b/foo` stayed excluded because they match the `b/*` prefix while the negation lookahead only covers `b/foo` itself;
* a path inside an excluded directory cannot be re-included: with `a/` plus `!a/foo`, the Finder yielded the directory `a/foo` (while dropping its content), git ignores everything below `a`;
* `b/*` must not match the directory `b` itself, but the flat regex matched `b/` with an empty `*`, so the whole directory was pruned.

The iterator now follows git's algorithm. Each `.gitignore` file is parsed once into an ordered rule list, each pattern still compiled with the public `Gitignore::toRegex()`. A path inside an ignored directory is ignored and cannot be re-included. Otherwise the last matching rule of the deepest `.gitignore` file decides, where a rule has to match the path itself, not a path below it, and directory-only patterns (trailing slash) apply to directories only. The public API of the `Gitignore` class is unchanged.

One existing test expectation changed: with `/a/**` plus `!/a/b.txt`, the directory `a` is now listed. `a/**` matches what is inside `a`, not `a` itself, and `git check-ignore a` confirms the directory is not ignored. The previous expectation hid the directory while still yielding the re-included file inside it.

Verification:
* the full scenario from the issue now returns exactly the files `git ls-files` reports;
* 800 randomized `.gitignore` trees (wildcards, `**`, character classes, anchored, directory-only and negated patterns, nested `.gitignore` files) were compared path by path against `git check-ignore`, with zero divergence;
* `./phpunit src/Symfony/Component/Finder` on PHP 8.5 returns OK (705 tests, 2 skipped and 1 incomplete, all pre-existing). The five added test cases were written first with expectations produced by real git; four of them fail on the unpatched code, and reverting the source file reproduces those failures.

Out of scope, unchanged: the global `core.excludesFile` and `.git/info/exclude` are still not read, files already tracked by git are listed no matter what the rules say, and `Gitignore::toRegex()` keeps its current handling of escapes and comments.
