### PR TITLE
[Form] Apply the configured rounding mode when no scale is set

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/NumberToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/NumberToLocalizedStringTransformer.php
@@ -164,9 +164,9 @@ class NumberToLocalizedStringTransformer implements DataTransformerInterface
 
         if (null !== $this->scale) {
             $formatter->setAttribute(\NumberFormatter::FRACTION_DIGITS, $this->scale);
-            $formatter->setAttribute(\NumberFormatter::ROUNDING_MODE, $this->roundingMode);
         }
 
+        $formatter->setAttribute(\NumberFormatter::ROUNDING_MODE, $this->roundingMode);
         $formatter->setAttribute(\NumberFormatter::GROUPING_USED, $this->grouping);
 
         return $formatter;

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/NumberToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/NumberToLocalizedStringTransformerTest.php
@@ -226,6 +226,19 @@ class NumberToLocalizedStringTransformerTest extends TestCase
         $this->assertEquals('1234,547', $transformer->transform(1234.547));
     }
 
+    public function testTransformAppliesRoundingModeIfNoScale()
+    {
+        // Since we test against "de_AT", we need the full implementation
+        IntlTestHelper::requireFullIntl($this);
+
+        \Locale::setDefault('de_AT');
+
+        $this->assertSame('1,063', (new NumberToLocalizedStringTransformer())->transform(1.0625));
+        $this->assertSame('1,062', (new NumberToLocalizedStringTransformer(null, null, \NumberFormatter::ROUND_HALFEVEN))->transform(1.0625));
+        $this->assertSame('1,062', (new NumberToLocalizedStringTransformer(null, null, \NumberFormatter::ROUND_DOWN))->transform(1.0625));
+        $this->assertSame('1,063', (new NumberToLocalizedStringTransformer(null, null, \NumberFormatter::ROUND_UP))->transform(1.0625));
+    }
+
     /**
      * @dataProvider provideTransformations
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #58204
| License       | MIT

`NumberType` defaults `rounding_mode` to `\NumberFormatter::ROUND_HALFUP` and passes it to `NumberToLocalizedStringTransformer`, but the transformer set `\NumberFormatter::ROUNDING_MODE` on the formatter only when a `scale` was configured. `scale` defaults to null, and in that case ICU still limits a decimal number to three fraction digits and rounds them with its own default, `ROUND_HALFEVEN`. So 1.0625 was displayed as "1.062", and setting `rounding_mode` had no effect at all: the option was silently ignored.

The rounding mode is now set on the formatter in every case, while the number of fraction digits keeps being set only when a scale is configured. `PercentToLocalizedStringTransformer` already worked like this. With the default options 1.0625 is now displayed as "1.063", and an explicit `rounding_mode` is honored.

What does not change: submitted values. `NumberToLocalizedStringTransformer::round()` still rounds only when a scale is set, because without a scale there is no number of decimals to round to, and `NumberFormatter::parse()` is not affected by the rounding mode. Form types that always set a scale are unaffected as well, which covers `IntegerType` (scale 0), `MoneyType` (scale 2 by default) and `PercentType`.

This is a visible change for a `NumberType` field with no `scale` whose value has more than three decimals: it is now rounded half up instead of half even, and any other mode can be selected.

Checks run:

- `./phpunit src/Symfony/Component/Form`: 4749 tests, 9348 assertions, no failures, 364 skipped, 8 incomplete. The skips are pre-existing: the tests that format numbers in a given locale require an ICU version matching the data shipped by the Intl component, and the machine has ICU 74.2 while the component ships 78.3. The new test is one of them, so it was also run with that guard disabled.
- Same suite with the ICU guard disabled so all the number formatting tests actually run: 4749 tests, 9883 assertions, no failures, 8 skipped, 8 incomplete.
- Same suite with the ICU guard disabled and the source file reverted to its base state: exactly one failure, the new test, `Failed asserting that two strings are identical. -'1,063' +'1,062'`.
