### PR TITLE
[CssSelector] Fix :disabled and :enabled inside nested fieldsets

### DIFF
--- a/src/Symfony/Component/CssSelector/Tests/XPath/TranslatorTest.php
+++ b/src/Symfony/Component/CssSelector/Tests/XPath/TranslatorTest.php
@@ -177,6 +177,42 @@ class TranslatorTest extends TestCase
         $this->assertSame('A', $nodeList->item(0)->textContent);
     }
 
+    public function testDisabledAndEnabledInsideFieldsets()
+    {
+        $translator = new Translator();
+        $translator->registerExtension(new HtmlExtension($translator));
+        $document = new \DOMDocument();
+        $document->loadHTML(<<<'HTML'
+            <html>
+              <body>
+                <fieldset id="outer" disabled="disabled">
+                  <legend><input type="text" id="first-legend-input"></legend>
+                  <legend><input type="text" id="second-legend-input"></legend>
+                  <input type="text" id="direct-input">
+                  <fieldset id="nested"><input type="text" id="nested-input"></fieldset>
+                </fieldset>
+                <fieldset id="standalone"><input type="text" id="standalone-input"></fieldset>
+              </body>
+            </html>
+            HTML
+        );
+
+        $xpath = new \DOMXPath($document);
+
+        $disabled = [];
+        foreach ($xpath->query($translator->cssToXPath(':disabled')) as $node) {
+            $disabled[] = $node->getAttribute('id');
+        }
+
+        $enabled = [];
+        foreach ($xpath->query($translator->cssToXPath(':enabled')) as $node) {
+            $enabled[] = $node->getAttribute('id');
+        }
+
+        $this->assertSame(['outer', 'second-legend-input', 'direct-input', 'nested', 'nested-input'], $disabled);
+        $this->assertSame(['first-legend-input', 'standalone', 'standalone-input'], $enabled);
+    }
+
     public static function getXpathLiteralTestData()
     {
         return [

--- a/src/Symfony/Component/CssSelector/XPath/Extension/HtmlExtension.php
+++ b/src/Symfony/Component/CssSelector/XPath/Extension/HtmlExtension.php
@@ -28,6 +28,8 @@ use Symfony\Component\CssSelector\XPath\XPathExpr;
  */
 class HtmlExtension extends AbstractExtension
 {
+    private const DISABLING_FIELDSET = 'ancestor-or-self::*[parent::fieldset[@disabled]][not(self::legend) or preceding-sibling::legend]';
+
     public function __construct(Translator $translator)
     {
         $translator
@@ -91,10 +93,10 @@ class HtmlExtension extends AbstractExtension
                 ." or name(.) = 'button'"
                 ." or name(.) = 'select'"
                 ." or name(.) = 'textarea'"
+                ." or name(.) = 'fieldset'"
             .')'
-            .' and ancestor::fieldset[@disabled]'
+            .' and '.self::DISABLING_FIELDSET
         );
-        // todo: in the second half, add "and is not a descendant of that fieldset element's first legend element child, if any."
     }
 
     public function translateEnabled(XPathExpr $xpath): XPathExpr
@@ -109,7 +111,6 @@ class HtmlExtension extends AbstractExtension
             .') or ('
                 .'('
                     ."name(.) = 'command'"
-                    ." or name(.) = 'fieldset'"
                     ." or name(.) = 'optgroup'"
                 .')'
                 .' and not(@disabled)'
@@ -120,8 +121,9 @@ class HtmlExtension extends AbstractExtension
                     ." or name(.) = 'select'"
                     ." or name(.) = 'textarea'"
                     ." or name(.) = 'keygen'"
+                    ." or name(.) = 'fieldset'"
                 .')'
-                .' and not (@disabled or ancestor::fieldset[@disabled])'
+                .' and not(@disabled or '.self::DISABLING_FIELDSET.')'
             .') or ('
                 ."name(.) = 'option' and not("
                     .'@disabled or ancestor::optgroup[@disabled]'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #58297
| License       | MIT

The `:disabled` and `:enabled` pseudo-classes did not translate the HTML rules about `fieldset` elements correctly.

HTML says that a form control is disabled when it is a descendant of a `fieldset` element that has a `disabled` attribute, unless it is a descendant of the first `legend` child of that `fieldset`. A `fieldset` element follows the same rule, so a `fieldset` nested inside a disabled one is disabled too.

Two things were missing in `:disabled`:

* the inherited half listed only `input`, `button`, `select` and `textarea`, so a nested `fieldset` was never reported as disabled;
* the first `legend` child was not excluded, so the controls inside it were reported as disabled. The file carried a `todo` comment about that case.

`:enabled` had the mirror defects: it reported a nested `fieldset` as enabled, and it did not report a control placed in the first `legend` as enabled.

Both translations now share this sub-expression:

```
ancestor-or-self::*[parent::fieldset[@disabled]][not(self::legend) or preceding-sibling::legend]
```

It selects the ancestor, or the element itself, that is a child of a disabled `fieldset`, and it drops the case where that child is the first `legend` of the `fieldset`. `optgroup` and `option` keep their own rules, because HTML does not propagate the `fieldset` state to them.

With the document from the issue:

```html
<fieldset id="outer" disabled="disabled">
    <fieldset id="target1"></fieldset>
    <legend>
        <fieldset id="target2"></fieldset>
    </legend>
    <legend>
        <fieldset id="target3"></fieldset>
    </legend>
</fieldset>
```

`:disabled` used to return `outer` alone. It now returns `outer`, `target1` and `target3`, which is what `Dom\HTMLDocument::querySelectorAll(':disabled')` returns on PHP 8.4 and up. Note that `DOMDocument::loadHTML()` uses the HTML 4 parser, which moves a `fieldset` out of the `legend` it is written in, so this snippet has to be loaded with `loadXML()` or with `Dom\HTMLDocument` to keep the tree shown above.

Checks that were run:

* `./phpunit src/Symfony/Component/CssSelector`: OK, 525 tests, 1054 assertions.
* `./phpunit src/Symfony/Component/DomCrawler`, the main consumer of the translator: OK, 587 tests, 1150 assertions.
* revert verification: with the source restored to its previous state and the new test kept, the test fails on the `:disabled` list, which reports `first-legend-input` as disabled and misses the nested `fieldset`.
* `php-cs-fixer` on both touched files: no change.
* the existing `:disabled` and `:enabled` rows of `TranslatorTest` and their `ids.html` fixture are untouched and still pass.
