### PR TITLE
[DependencyInjection] Keep % escaping when resolving values against a resolved parameter bag

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -1098,7 +1098,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
         }
 
         if (null !== $definition->getFile()) {
-            require_once $parameterBag->resolveValue($definition->getFile());
+            require_once $parameterBag->unescapeValue($parameterBag->resolveValue($definition->getFile()));
         }
 
         $arguments = $definition->getArguments();

--- a/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
@@ -230,7 +230,7 @@ class ParameterBag implements ParameterBagInterface
 
             $resolving[$key] = true;
 
-            return $this->resolved ? $this->get($key) : $this->resolveValue($this->get($key), $resolving);
+            return $this->resolved ? $this->escapeValue($this->get($key)) : $this->resolveValue($this->get($key), $resolving);
         }
 
         return preg_replace_callback('/%%|%([^%\s]+)%/', function ($match) use ($resolving, $value) {
@@ -253,7 +253,7 @@ class ParameterBag implements ParameterBagInterface
             $resolved = (string) $resolved;
             $resolving[$key] = true;
 
-            return $this->isResolved() ? $resolved : $this->resolveString($resolved, $resolving);
+            return $this->isResolved() ? $this->escapeValue($resolved) : $this->resolveString($resolved, $resolving);
         }, $value);
     }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
@@ -1427,6 +1427,28 @@ class AutowirePassTest extends TestCase
         $this->assertSame(['foo'], $definition->getArguments());
     }
 
+    public function testAutowireAttributeKeepsPercentEscaping()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('foo', AutowireAttributeNullFallback::class)
+            ->setAutowired(true)
+            ->setPublic(true)
+        ;
+
+        $container->setParameter('required.parameter', 'my friend %%s has %%d dogs');
+        $container->setParameter('optional.parameter', '50%%%% off');
+
+        $container->compile();
+
+        $this->assertSame('my friend %%s has %%d dogs', $container->getDefinition('foo')->getArgument(0));
+
+        $service = $container->get('foo');
+
+        $this->assertSame('my friend %s has %d dogs', $service->required);
+        $this->assertSame('50%% off', $service->optional);
+    }
+
     public function testAsDecoratorAttribute()
     {
         $container = new ContainerBuilder();

--- a/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/ParameterBagTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/ParameterBagTest.php
@@ -332,6 +332,16 @@ class ParameterBagTest extends TestCase
         $this->assertEquals(['bar' => ['ding' => 'I\'m a bar %foo %bar']], $bag->get('foo'), '->resolveValue() supports % escaping by doubling it');
     }
 
+    public function testResolveValueKeepsEscapingOnAResolvedBag()
+    {
+        $bag = new ParameterBag(['foo' => 'I\'m a %%bar%%']);
+        $bag->resolve();
+
+        $this->assertSame('I\'m a %%bar%%', $bag->resolveValue('%foo%'), '->resolveValue() returns escaped values once the bag is resolved');
+        $this->assertSame('ding I\'m a %%bar%% dong', $bag->resolveValue('ding %foo% dong'), '->resolveValue() returns escaped values once the bag is resolved');
+        $this->assertSame('I\'m a %bar%', $bag->unescapeValue($bag->resolveValue('%foo%')));
+    }
+
     public function testEscapeValue()
     {
         $bag = new ParameterBag();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #58970
| License       | MIT

Container parameters are held in an escaped form: a literal percent sign is written `%%`, and `ParameterBag::resolve()` unescapes every value once, at the end of the compilation. Whatever reads a definition argument afterwards expects that same escaped form and unescapes it itself, both `PhpDumper` and `ContainerBuilder::createService()`.

`ParameterBag::resolveValue()` stops honoring that rule once the bag is resolved. From that point the stored values are literal, and the two `isResolved()` branches of `resolveString()` splice them into the result untouched. What comes back mixes the two forms: text written in the source string keeps its `%%`, text coming from a parameter does not.

`AutowirePass` runs after `ResolveParameterPlaceHoldersPass`, so this is exactly what `#[Autowire]` receives. With

```yaml
parameters:
    string_format: 'my friend %%s has %%d dogs'
```

```php
public function __construct(#[Autowire('%string_format%')] private string $format)
{
}
```

the definition argument became `my friend %s has %d dogs`, and the dumped container read `%s has %` back as a parameter reference:

```php
new \App\Twig\AppExtension('my friend '.$container->getParameter('s has ').'d dogs');
```

so the compiled container failed at runtime with `You have requested a non-existent parameter "s has "`. Passing the same parameter as a plain YAML argument works, because that value is resolved before the bag is resolved.

The fix escapes the values that leave a resolved bag, so `resolveValue()` returns the escaped form in both states. `ContainerBuilder::createService()` now unescapes the file it includes, like the three sibling calls next to it already do.

Values without a percent sign are untouched. Two more cases become correct for values that have one: an argument whose literal value contains `%%` no longer loses one of the two signs when the service is built by `ContainerBuilder` itself, and an array parameter holding escaped values is now dumped with its values unescaped instead of being read back from `$container->parameters`.

Checks run on this branch, PHP 8.5, PHPUnit 9.6:

- `./phpunit src/Symfony/Component/DependencyInjection`: 1589 tests, 3387 assertions, 16 skipped, no failure. The base has 1587 tests, the two added tests are the difference.
- `./phpunit src/Symfony/Bundle/FrameworkBundle`: 1373 tests, no failure.
- `./phpunit src/Symfony/Bundle/TwigBundle`: 40 tests, no failure.
- `./phpunit src/Symfony/Bundle/SecurityBundle`: 360 tests, no failure.
- `./phpunit src/Symfony/Component/HttpKernel`: 1217 tests, no failure.
- Revert check: with the two source files put back to their base state and the tests kept, `ParameterBagTest::testResolveValueKeepsEscapingOnAResolvedBag` fails with `-'I'm a %%bar%%'` against `+'I'm a %bar%'`, and `AutowirePassTest::testAutowireAttributeKeepsPercentEscaping` fails with `-'my friend %%s has %%d dogs'` against `+'my friend %s has %d dogs'`.

The three lines are identical on 7.4, 8.1 and 8.2, so the merge up is a straight copy.
