### PR TITLE
[Scheduler] Reject canceled scheduled messages so async transports do not redeliver them

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/scheduler.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/scheduler.php
@@ -32,6 +32,7 @@ return static function (ContainerConfigurator $container) {
             ->args([
                 tagged_locator('scheduler.schedule_provider', 'name'),
                 service('event_dispatcher'),
+                service('messenger.receiver_locator'),
             ])
             ->tag('kernel.event_subscriber')
     ;

--- a/src/Symfony/Component/Scheduler/EventListener/DispatchSchedulerEventListener.php
+++ b/src/Symfony/Component/Scheduler/EventListener/DispatchSchedulerEventListener.php
@@ -29,6 +29,7 @@ class DispatchSchedulerEventListener implements EventSubscriberInterface
     public function __construct(
         private readonly ContainerInterface $scheduleProviderLocator,
         private readonly EventDispatcherInterface $eventDispatcher,
+        private readonly ?ContainerInterface $receiverLocator = null,
     ) {
     }
 
@@ -57,6 +58,12 @@ class DispatchSchedulerEventListener implements EventSubscriberInterface
 
         if ($preRunEvent->shouldCancel()) {
             $event->shouldHandle(false);
+
+            $receiverName = $event->getReceiverName();
+
+            if ($this->receiverLocator?->has($receiverName)) {
+                $this->receiverLocator->get($receiverName)->reject($envelope);
+            }
         }
     }
 

--- a/src/Symfony/Component/Scheduler/Tests/EventListener/DispatchSchedulerEventListenerTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/EventListener/DispatchSchedulerEventListenerTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
 use Symfony\Component\Messenger\Event\WorkerMessageHandledEvent;
 use Symfony\Component\Messenger\Event\WorkerMessageReceivedEvent;
+use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
 use Symfony\Component\Scheduler\Event\FailureEvent;
 use Symfony\Component\Scheduler\Event\PostRunEvent;
 use Symfony\Component\Scheduler\Event\PreRunEvent;
@@ -60,6 +61,59 @@ class DispatchSchedulerEventListenerTest extends TestCase
         $this->assertTrue($secondListener->preInvoked);
         $this->assertTrue($secondListener->postInvoked);
         $this->assertTrue($secondListener->failureInvoked);
+    }
+
+    public function testCanceledMessageIsRejected()
+    {
+        $trigger = $this->createStub(TriggerInterface::class);
+        $defaultRecurringMessage = RecurringMessage::trigger($trigger, (object) ['id' => 'default']);
+
+        $schedulerProvider = new SomeScheduleProvider([$defaultRecurringMessage]);
+        $scheduleProviderLocator = $this->createMock(ContainerInterface::class);
+        $scheduleProviderLocator->expects($this->any())->method('has')->willReturn(true);
+        $scheduleProviderLocator->expects($this->any())->method('get')->willReturn($schedulerProvider);
+
+        $context = new MessageContext('default', 'default', $trigger, new \DateTimeImmutable());
+        $envelope = (new Envelope(new \stdClass()))->with(new ScheduledStamp($context));
+
+        $receiver = $this->createMock(ReceiverInterface::class);
+        $receiver->expects($this->once())->method('reject')->with($envelope);
+        $receiverLocator = $this->createMock(ContainerInterface::class);
+        $receiverLocator->expects($this->any())->method('has')->with('async')->willReturn(true);
+        $receiverLocator->expects($this->any())->method('get')->with('async')->willReturn($receiver);
+
+        $listener = new DispatchSchedulerEventListener($scheduleProviderLocator, $eventDispatcher = new EventDispatcher(), $receiverLocator);
+        $eventDispatcher->addListener(PreRunEvent::class, static function (PreRunEvent $event) { $event->shouldCancel(true); });
+
+        $workerReceivedEvent = new WorkerMessageReceivedEvent($envelope, 'async');
+        $listener->onMessageReceived($workerReceivedEvent);
+
+        $this->assertFalse($workerReceivedEvent->shouldHandle());
+    }
+
+    public function testNotCanceledMessageIsNotRejected()
+    {
+        $trigger = $this->createStub(TriggerInterface::class);
+        $defaultRecurringMessage = RecurringMessage::trigger($trigger, (object) ['id' => 'default']);
+
+        $schedulerProvider = new SomeScheduleProvider([$defaultRecurringMessage]);
+        $scheduleProviderLocator = $this->createMock(ContainerInterface::class);
+        $scheduleProviderLocator->expects($this->any())->method('has')->willReturn(true);
+        $scheduleProviderLocator->expects($this->any())->method('get')->willReturn($schedulerProvider);
+
+        $context = new MessageContext('default', 'default', $trigger, new \DateTimeImmutable());
+        $envelope = (new Envelope(new \stdClass()))->with(new ScheduledStamp($context));
+
+        $receiverLocator = $this->createMock(ContainerInterface::class);
+        $receiverLocator->expects($this->never())->method('has');
+        $receiverLocator->expects($this->never())->method('get');
+
+        $listener = new DispatchSchedulerEventListener($scheduleProviderLocator, new EventDispatcher(), $receiverLocator);
+
+        $workerReceivedEvent = new WorkerMessageReceivedEvent($envelope, 'async');
+        $listener->onMessageReceived($workerReceivedEvent);
+
+        $this->assertTrue($workerReceivedEvent->shouldHandle());
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #61891
| License       | MIT

The scheduler keeps the `ScheduledStamp` on messages redispatched through `RedispatchMessage`, so `PreRunEvent` is also dispatched when the inner message is consumed from a real transport (Redis, AMQP, Doctrine, ...). When a listener cancels the run with `$event->shouldCancel(true)`, `DispatchSchedulerEventListener` sets `shouldHandle(false)` on the `WorkerMessageReceivedEvent` and `Worker::handleMessage()` returns before any ack or reject. On the scheduler transport this is harmless because its `ack()` and `reject()` are no-ops, but on a real transport the envelope is never acknowledged: with Redis it stays in the pending entries list and is redelivered on every claim interval, forever.

The listener now rejects the canceled envelope through the receiver locator, removing that occurrence from the transport. Rejecting rather than acking bypasses the retry and failure-transport pipeline, which matches what canceling means: this run must not happen. On the scheduler transport `reject()` stays a no-op, so in-process schedules behave exactly as before.

The receiver locator is a new optional constructor argument, wired to `messenger.receiver_locator` in FrameworkBundle. That service always exists when the scheduler is enabled since the scheduler configuration requires messenger. Code constructing the listener manually keeps the previous behavior until it passes a locator. Worker semantics for `shouldHandle(false)` are unchanged for every other use case, as listeners outside the scheduler may rely on the message staying in the transport.

Checks run: the new test fails without the fix with `Method was expected to be called 1 times, actually called 0 times` for `ReceiverInterface::reject`, and passes with it. `./phpunit src/Symfony/Component/Scheduler` returns OK (147 tests, 782 assertions), `./phpunit src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection` returns OK (607 tests, 5 pre-existing skips) and the full `./phpunit src/Symfony/Bundle/FrameworkBundle/Tests` suite returns OK (1373 tests, 5 pre-existing skips). The changed files lint clean on PHP 8.1.
