### PR TITLE
[ErrorHandler] Fix leaking an exception handler when not replacing the error handler

### DIFF
--- a/src/Symfony/Component/ErrorHandler/ErrorHandler.php
+++ b/src/Symfony/Component/ErrorHandler/ErrorHandler.php
@@ -145,6 +145,11 @@ class ErrorHandler
                 $prev[0]->setExceptionHandler($p);
             }
         } else {
+            if (!$handlerIsRegistered && null === $prev) {
+                // another error handler is in charge and there is no exception handler to decorate
+                restore_exception_handler();
+            }
+
             $handler->setExceptionHandler($prev ?? [$handler, 'renderException']);
         }
 

--- a/src/Symfony/Component/ErrorHandler/Tests/ErrorHandlerTest.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/ErrorHandlerTest.php
@@ -67,6 +67,49 @@ class ErrorHandlerTest extends TestCase
         }
     }
 
+    public function testRegisterWithoutReplaceLeavesForeignHandlersInPlace()
+    {
+        $foreignHandler = static fn () => false;
+        set_error_handler($foreignHandler);
+
+        try {
+            $handler = ErrorHandler::register(null, false);
+
+            $errorHandler = set_error_handler('var_dump');
+            restore_error_handler();
+            $exceptionHandler = set_exception_handler('var_dump');
+            restore_exception_handler();
+
+            $this->assertInstanceOf(ErrorHandler::class, $handler);
+            $this->assertSame($foreignHandler, $errorHandler);
+            $this->assertNull($exceptionHandler);
+        } finally {
+            restore_exception_handler();
+            restore_error_handler();
+        }
+    }
+
+    public function testRegisterWithoutReplaceStillDecoratesTheExceptionHandler()
+    {
+        $foreignErrorHandler = static fn () => false;
+        $foreignExceptionHandler = static function (\Throwable $e) {};
+        set_error_handler($foreignErrorHandler);
+        set_exception_handler($foreignExceptionHandler);
+
+        try {
+            $handler = ErrorHandler::register(null, false);
+
+            $exceptionHandler = set_exception_handler('var_dump');
+            restore_exception_handler();
+
+            $this->assertSame([$handler, 'handleException'], $exceptionHandler);
+        } finally {
+            restore_exception_handler();
+            restore_exception_handler();
+            restore_error_handler();
+        }
+    }
+
     public function testErrorGetLast()
     {
         $logger = new NullLogger();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #63693
| License       | MIT

`ErrorHandler::register($handler, $replace = false)` means "install this handler unless something else is already in charge". The error handler half of the method honours that: when `set_error_handler()` reports a foreign handler, the call is undone with `restore_error_handler()` and the foreign handler stays in place. The exception handler half did not. It kept our handler on the exception handler stack in every case, including when we had just declined to touch the error handler.

`FrameworkBundle::boot()` calls `ErrorHandler::register(null, false)` when `symfony/runtime` is not installed. PHPUnit installs its own error handler around every test and installs no exception handler of its own. So booting a kernel from a test left a Symfony exception handler behind that nothing ever pops, and PHPUnit 11 and later, which compare the handler stack before and after each test, report:

```
1) Test::test
Test code or tested code did not remove its own exception handlers
```

The fix makes the exception handler follow the same rule as the error handler, with one limit: when another error handler is in charge but there already is an exception handler, our handler still wraps it. That case only adds behaviour to an existing chain and is what makes fatal errors readable in a nested setup, so it is left alone. What changes is that `ErrorHandler` no longer becomes the process' only exception handler while explicitly declining to be its error handler.

Only calls with `$replace = false` are concerned. That argument is used in exactly one place in the monorepo, `FrameworkBundle::boot()`, and the default `$replace = true` path is untouched.

Two tests are added to `ErrorHandlerTest`. `testRegisterWithoutReplaceLeavesForeignHandlersInPlace` covers the fix: with a foreign error handler installed and no exception handler, both stacks are unchanged after the call. `testRegisterWithoutReplaceStillDecoratesTheExceptionHandler` pins the case that is deliberately preserved. The existing `phpt/decorate_exception_handler.phpt`, which nests `register(null, false)` under a foreign error handler and a foreign exception handler, is a second guard for that case and still passes unchanged.

Checks run, all on PHP 8.5:

* `./phpunit src/Symfony/Component/ErrorHandler`: 130 tests, 395 assertions, 3 skipped, no failures. On the base commit the same suite is 128 tests, 391 assertions, 3 skipped.
* `testRegisterWithoutReplaceLeavesForeignHandlersInPlace` with the source reverted to the base commit: fails with `Failed asserting that Array (0 => Symfony\Component\ErrorHandler\ErrorHandler Object (...), 1 => 'handleException') is null.` The second test passes on the base commit, as intended.
* End to end under PHPUnit 11.5, a test that runs the no-runtime branch of `FrameworkBundle::boot()`: on the base commit PHPUnit reports `1 risky test: Test code or tested code did not remove its own exception handlers`, and with the patch it reports `OK (1 test, 1 assertion)`.
* Consumers of the API: `./phpunit src/Symfony/Component/Runtime` 16 tests green, `./phpunit src/Symfony/Component/HttpKernel/Tests` 1217 tests green, `./phpunit src/Symfony/Bundle/FrameworkBundle/Tests` 1373 tests, 5 skipped, no failures.

Not covered: `FrameworkBundle::boot()` itself. Its no-runtime branch is guarded by `class_exists(SymfonyRuntime::class)`, which is always true inside the monorepo, so that branch cannot be reached from a test here. The end to end check above runs the same call the branch makes.
