### PR TITLE
[Tui] Stop delivering the rest of an over-cap paste as key events

### DIFF
--- a/src/Symfony/Component/Tui/Input/StdinBuffer.php
+++ b/src/Symfony/Component/Tui/Input/StdinBuffer.php
@@ -38,6 +38,7 @@ final class StdinBuffer
     private ?\Closure $onPaste = null;
 
     private bool $inPaste = false;
+    private bool $pasteOverflowed = false;
     private string $pasteBuffer = '';
 
     /**
@@ -90,14 +91,21 @@ final class StdinBuffer
             // If in paste mode, accumulate until end marker
             if ($this->inPaste) {
                 if (false !== $endPos = strpos($this->buffer, "\x1b[201~")) {
-                    $this->pasteBuffer .= substr($this->buffer, 0, $endPos);
+                    $content = null;
+
+                    if (!$this->pasteOverflowed) {
+                        $this->pasteBuffer .= substr($this->buffer, 0, $endPos);
+                        $content = $this->pasteBuffer;
+                    }
+
                     $this->buffer = substr($this->buffer, $endPos + 6);
                     $this->inPaste = false;
-
-                    if (null !== $this->onPaste) {
-                        ($this->onPaste)($this->pasteBuffer);
-                    }
+                    $this->pasteOverflowed = false;
                     $this->pasteBuffer = '';
+
+                    if (null !== $content && null !== $this->onPaste) {
+                        ($this->onPaste)($content);
+                    }
                 } else {
                     // Still waiting for the end marker. A read can split it, so
                     // hold back a trailing part of it instead of moving it into
@@ -111,31 +119,35 @@ final class StdinBuffer
                     }
 
                     if (0 < $hold) {
-                        $this->pasteBuffer .= substr($this->buffer, 0, -$hold);
+                        $chunk = substr($this->buffer, 0, -$hold);
                         $this->buffer = substr($this->buffer, -$hold);
                     } else {
-                        $this->pasteBuffer .= $this->buffer;
+                        $chunk = $this->buffer;
                         $this->buffer = '';
                     }
 
-                    // Cap reached without an end marker: discard the partial
-                    // paste and emit a visible overflow notice through the
-                    // paste callback so the user can see why their paste did
-                    // not land. Defense against unbounded buffering from a
-                    // missing/spoofed end marker. This has to run on the held
-                    // path too: a writer that ends every chunk with a byte of
-                    // the end marker would otherwise never reach the check.
-                    if (\strlen($this->pasteBuffer) > self::MAX_PASTE_BYTES) {
-                        $this->pasteBuffer = '';
-                        $this->inPaste = false;
+                    if (!$this->pasteOverflowed) {
+                        $this->pasteBuffer .= $chunk;
 
-                        if (null !== $this->onPaste) {
-                            ($this->onPaste)(self::PASTE_OVERFLOW_MESSAGE);
+                        // Cap reached without an end marker: discard the
+                        // content and stop accumulating, as a defense against
+                        // unbounded buffering from a missing/spoofed end
+                        // marker. The paste stays open, because the terminal
+                        // is still sending it and the rest of it must not be
+                        // delivered as key events. A visible overflow notice
+                        // goes out through the paste callback so the user can
+                        // see why their paste did not land. The check has to
+                        // run on the held path too: a writer that ends every
+                        // chunk with a byte of the end marker would otherwise
+                        // never reach it.
+                        if (\strlen($this->pasteBuffer) > self::MAX_PASTE_BYTES) {
+                            $this->pasteBuffer = '';
+                            $this->pasteOverflowed = true;
+
+                            if (null !== $this->onPaste) {
+                                ($this->onPaste)(self::PASTE_OVERFLOW_MESSAGE);
+                            }
                         }
-
-                        // The paste is over, so the held bytes are no longer a
-                        // partial end marker: parse them as normal input.
-                        continue;
                     }
 
                     if (0 < $hold) {
@@ -181,6 +193,7 @@ final class StdinBuffer
         $this->buffer = '';
         $this->pasteBuffer = '';
         $this->inPaste = false;
+        $this->pasteOverflowed = false;
     }
 
     /**
@@ -191,8 +204,10 @@ final class StdinBuffer
      */
     public function flush(): void
     {
-        // If we have a single ESC waiting, emit it as a standalone Escape key
-        if ("\x1b" === $this->buffer && null !== $this->onData) {
+        // If we have a single ESC waiting, emit it as a standalone Escape key.
+        // While a paste is open that ESC is the start of a held end marker
+        // instead, and emitting it would leave the paste with no way to close.
+        if (!$this->inPaste && "\x1b" === $this->buffer && null !== $this->onData) {
             ($this->onData)("\x1b");
             $this->buffer = '';
         }

--- a/src/Symfony/Component/Tui/Tests/Input/StdinBufferTest.php
+++ b/src/Symfony/Component/Tui/Tests/Input/StdinBufferTest.php
@@ -432,8 +432,56 @@ class StdinBufferTest extends TestCase
         $this->assertSame([], $sequences);
         $this->assertSame(['[paste exceeded 16 MiB limit]'], $pastes);
 
+        // The terminal is still sending the paste, so what follows is pasted
+        // content and not typing.
+        $buffer->process("rm -rf /tmp/x\r");
+
+        $this->assertSame([], $sequences, 'Content sent after the abort is dropped, not delivered as keys');
+        $this->assertSame(['[paste exceeded 16 MiB limit]'], $pastes, 'The overflow notice is sent once');
+    }
+
+    public function testInputResumesOnceAnAbortedPasteEnds()
+    {
+        $buffer = new StdinBuffer();
+        $sequences = [];
+        $pastes = [];
+
+        $buffer->onData(static function (string $data) use (&$sequences) { $sequences[] = $data; });
+        $buffer->onPaste(static function (string $data) use (&$pastes) { $pastes[] = $data; });
+
+        $buffer->process("\x1b[200~");
+        $buffer->process(str_repeat('A', 17 * 1024 * 1024));
+        $buffer->process("tail\x1b");
+        $buffer->process('[201~');
+
+        $this->assertSame([], $sequences, 'The end marker is not delivered as a key');
+        $this->assertSame(['[paste exceeded 16 MiB limit]'], $pastes);
+
         $buffer->process('B');
-        $this->assertSame(['B'], $sequences, 'Buffer should accept new input after abort');
+        $buffer->process("\x1b[200~next\x1b[201~");
+
+        $this->assertSame(['B'], $sequences);
+        $this->assertSame(['[paste exceeded 16 MiB limit]', 'next'], $pastes);
+    }
+
+    public function testFlushKeepsAHeldEndMarkerWhileAPasteIsOpen()
+    {
+        $buffer = new StdinBuffer();
+        $sequences = [];
+        $pastes = [];
+
+        $buffer->onData(static function (string $data) use (&$sequences) { $sequences[] = $data; });
+        $buffer->onPaste(static function (string $data) use (&$pastes) { $pastes[] = $data; });
+
+        // A read can end on the ESC of the end marker. Emitting it as the
+        // Escape key would leave the paste open with no way to close it.
+        $buffer->process("\x1b[200~AA\x1b");
+        $buffer->flush();
+        $buffer->process('[201~x');
+        $buffer->flush();
+
+        $this->assertSame(['AA'], $pastes);
+        $this->assertSame(['x'], $sequences);
     }
 
     public function testUnterminatedPasteAbortsAtCapWhenEveryWriteEndsWithAPartialEndMarker()

--- a/src/Symfony/Component/Tui/Tests/Widget/BracketedPasteTraitTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/BracketedPasteTraitTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Tui\Tests\Widget;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Tui\Widget\BracketedPasteTrait;
 
@@ -205,6 +206,47 @@ class BracketedPasteTraitTest extends TestCase
         $data = "\x1b[200~next\x1b[201~";
         $result = $handler->processBracketedPaste($data);
         $this->assertSame('next', $result, 'The next paste is delivered');
+    }
+
+    public function testPartialPasteEndMarkerIsKeptAsContent()
+    {
+        $handler = $this->createHandler();
+
+        $data = "\x1b[200~AA\x1b[2";
+        $this->assertNull($handler->processBracketedPaste($data));
+
+        $data = "XX\x1b[201~";
+        $this->assertSame("AA\x1b[2XX", $handler->processBracketedPaste($data));
+    }
+
+    #[DataProvider('provideSplitPasteEndMarkers')]
+    public function testOverflowedPasteEndMarkerCanBeSplitAcrossChunks(string $first, string $second)
+    {
+        $handler = $this->createHandler();
+
+        $data = "\x1b[200~";
+        $handler->processBracketedPaste($data);
+
+        $data = str_repeat('A', 17 * 1024 * 1024);
+        $this->assertSame('[paste exceeded 16 MiB limit]', $handler->processBracketedPaste($data));
+
+        $data = 'tail'.$first;
+        $this->assertNull($handler->processBracketedPaste($data));
+        $this->assertSame('', $data);
+
+        $data = $second.'after';
+        $this->assertNull($handler->processBracketedPaste($data));
+        $this->assertSame('after', $data);
+        $this->assertFalse($handler->isBufferingPaste());
+    }
+
+    public static function provideSplitPasteEndMarkers(): iterable
+    {
+        $marker = "\x1b[201~";
+
+        for ($i = 1; $i < \strlen($marker); ++$i) {
+            yield "split after {$i} byte(s)" => [substr($marker, 0, $i), substr($marker, $i)];
+        }
     }
 
     private function createHandler(): BracketedPasteHandler

--- a/src/Symfony/Component/Tui/Tests/Widget/BracketedPasteTraitTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/BracketedPasteTraitTest.php
@@ -186,12 +186,25 @@ class BracketedPasteTraitTest extends TestCase
         $result = $handler->processBracketedPaste($data);
 
         $this->assertSame('[paste exceeded 16 MiB limit]', $result);
-        $this->assertFalse($handler->isBufferingPaste());
+        $this->assertSame('', $data);
+        $this->assertTrue($handler->isBufferingPaste(), 'The paste stays open until the end marker');
 
+        // The terminal is still sending the paste, so what follows is pasted
+        // content and not typing.
         $data = 'plain';
         $result = $handler->processBracketedPaste($data);
         $this->assertNull($result);
-        $this->assertSame('plain', $data);
+        $this->assertSame('', $data);
+
+        $data = "more\x1b[201~after";
+        $result = $handler->processBracketedPaste($data);
+        $this->assertNull($result, 'The dropped content is not returned');
+        $this->assertSame('after', $data);
+        $this->assertFalse($handler->isBufferingPaste());
+
+        $data = "\x1b[200~next\x1b[201~";
+        $result = $handler->processBracketedPaste($data);
+        $this->assertSame('next', $result, 'The next paste is delivered');
     }
 
     private function createHandler(): BracketedPasteHandler

--- a/src/Symfony/Component/Tui/Widget/BracketedPasteTrait.php
+++ b/src/Symfony/Component/Tui/Widget/BracketedPasteTrait.php
@@ -29,6 +29,7 @@ trait BracketedPasteTrait
     private const string PASTE_OVERFLOW_MESSAGE = '[paste exceeded 16 MiB limit]';
 
     private bool $inPaste = false;
+    private bool $pasteOverflowed = false;
     private string $pasteBuffer = '';
 
     private function isBufferingPaste(): bool
@@ -55,7 +56,8 @@ trait BracketedPasteTrait
      *                     paste is in progress. If a paste exceeds the
      *                     internal cap, {@see PASTE_OVERFLOW_MESSAGE} is
      *                     returned in lieu of the partial content so the
-     *                     caller can surface a visible notice.
+     *                     caller can surface a visible notice; the rest of
+     *                     that paste is then dropped up to the end marker.
      */
     private function processBracketedPaste(string &$data): ?string
     {
@@ -73,26 +75,40 @@ trait BracketedPasteTrait
         }
 
         if (false !== $endIndex = strpos($data, "\x1b[201~")) {
-            $this->pasteBuffer .= substr($data, 0, $endIndex);
-            $pastedText = $this->pasteBuffer;
+            $pastedText = null;
+
+            if (!$this->pasteOverflowed) {
+                $this->pasteBuffer .= substr($data, 0, $endIndex);
+                $pastedText = $this->pasteBuffer;
+            }
+
             $this->inPaste = false;
+            $this->pasteOverflowed = false;
             $this->pasteBuffer = '';
             $data = $prefix.substr($data, $endIndex + 6);
 
             return $pastedText;
         }
 
+        if ($this->pasteOverflowed) {
+            $data = $prefix;
+
+            return null;
+        }
+
         $this->pasteBuffer .= $data;
         $data = $prefix;
 
-        // Cap reached without an end marker: discard the partial paste and
-        // exit paste mode. Returns a visible overflow notice in place of
-        // the partial content so the caller can show the user why their
-        // paste did not land. Defense against unbounded buffering from a
-        // missing/spoofed end marker.
+        // Cap reached without an end marker: discard the content and stop
+        // accumulating, as a defense against unbounded buffering from a
+        // missing/spoofed end marker. Returns a visible overflow notice in
+        // place of the partial content so the caller can show the user why
+        // their paste did not land. The paste stays open, because the terminal
+        // is still sending it and the rest of it must not be handled as key
+        // input.
         if (\strlen($this->pasteBuffer) > self::MAX_PASTE_BYTES) {
             $this->pasteBuffer = '';
-            $this->inPaste = false;
+            $this->pasteOverflowed = true;
 
             return self::PASTE_OVERFLOW_MESSAGE;
         }

--- a/src/Symfony/Component/Tui/Widget/BracketedPasteTrait.php
+++ b/src/Symfony/Component/Tui/Widget/BracketedPasteTrait.php
@@ -31,6 +31,7 @@ trait BracketedPasteTrait
     private bool $inPaste = false;
     private bool $pasteOverflowed = false;
     private string $pasteBuffer = '';
+    private string $pasteEndMarkerBuffer = '';
 
     private function isBufferingPaste(): bool
     {
@@ -72,6 +73,12 @@ trait BracketedPasteTrait
             $data = substr($data, $start + 6);
             $this->inPaste = true;
             $this->pasteBuffer = '';
+            $this->pasteEndMarkerBuffer = '';
+        }
+
+        if ('' !== $this->pasteEndMarkerBuffer) {
+            $data = $this->pasteEndMarkerBuffer.$data;
+            $this->pasteEndMarkerBuffer = '';
         }
 
         if (false !== $endIndex = strpos($data, "\x1b[201~")) {
@@ -85,19 +92,34 @@ trait BracketedPasteTrait
             $this->inPaste = false;
             $this->pasteOverflowed = false;
             $this->pasteBuffer = '';
+            $this->pasteEndMarkerBuffer = '';
             $data = $prefix.substr($data, $endIndex + 6);
 
             return $pastedText;
         }
 
-        if ($this->pasteOverflowed) {
-            $data = $prefix;
+        $hold = 0;
+        for ($n = min(5, \strlen($data)); $n > 0; --$n) {
+            if (str_starts_with("\x1b[201~", substr($data, -$n))) {
+                $hold = $n;
+                break;
+            }
+        }
 
+        if (0 < $hold) {
+            $chunk = substr($data, 0, -$hold);
+            $this->pasteEndMarkerBuffer = substr($data, -$hold);
+        } else {
+            $chunk = $data;
+        }
+
+        $data = $prefix;
+
+        if ($this->pasteOverflowed) {
             return null;
         }
 
-        $this->pasteBuffer .= $data;
-        $data = $prefix;
+        $this->pasteBuffer .= $chunk;
 
         // Cap reached without an end marker: discard the content and stop
         // accumulating, as a defense against unbounded buffering from a


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65342
| License       | MIT

`StdinBuffer` caps a bracketed paste at 16 MiB. When the cap fired, it dropped the partial content and left paste mode. The terminal is still sending the paste at that point, so every byte that followed was parsed as a key sequence and handed to the application as typing, newlines included, and the closing `\e[201~` came out as a key as well. Bracketed paste exists so that pasted bytes are never taken as key input, so above 16 MiB that guarantee was inverted.

Wiring a `StdinBuffer` to an `InputWidget` the way `Terminal` does, then pasting 17 MiB of `A` followed by `rm -rf /tmp/x\r`, fed in 4096 byte reads:

| | before | after |
| --- | --- | --- |
| widget value | `[paste exceeded 16 MiB limit]` plus 1044481 typed `A` plus `rm -rf /tmp/x` | `[paste exceeded 16 MiB limit]` |
| `\r` delivered as a key | yes | no |
| `\e[201~` delivered as a key | yes | no |

The paste now stays open when the cap fires: content is dropped as it arrives while the scan for the end marker continues, so memory stays bounded and the rest of the paste stays inert. The overflow notice still goes out once, at the cap. `Widget\BracketedPasteTrait`, the widget side of the same protocol, had the same recovery and gets the same treatment.

`flush()` is part of this fix. `Terminal` calls it after every read, and it emitted a lone pending ESC as the Escape key. While a paste is open that ESC is the first byte of an end marker held back across reads, so flushing it consumed the marker and the paste could never close afterwards. That was already a way to lose input, and with the paste now staying open at the cap it is also what lets the drain end.

Behavior change worth naming: an unterminated paste past the cap no longer resumes key parsing on its own. It stays inert until the end marker arrives or `clear()` is called. `testUnterminatedPasteAbortsAtCap` pinned the old recovery in both `StdinBufferTest` and `BracketedPasteTraitTest` and is updated. The component is `@experimental` and `StdinBuffer` is `@internal`. A writer that never sends the end marker can keep input inert, which is the intended trade: that writer is exactly the one whose bytes must not become keystrokes, and a paste under the cap that never terminates already behaves this way.

Checks run:

- `php8.5 ./phpunit src/Symfony/Component/Tui`: OK, 1775 tests, 4887 assertions. On the base commit the same suite is OK with 1773 tests, 4875 assertions.
- Revert check: with both source files put back to their base state and the tests kept, `StdinBufferTest::testUnterminatedPasteAbortsAtCap` fails on `Content sent after the abort is dropped, not delivered as keys`, `::testInputResumesOnceAnAbortedPasteEnds` fails on `The end marker is not delivered as a key`, `::testFlushKeepsAHeldEndMarkerWhileAPasteIsOpen` fails because no paste is delivered at all, and `BracketedPasteTraitTest::testUnterminatedPasteAbortsAtCap` fails on `The paste stays open until the end marker`.
- Drain bound: feeding 80 MiB inside one paste, 60 MiB in plain 1 MiB writes then 20 MiB in writes that each end with a lone ESC, keeps peak memory at 23 MiB, emits the notice once and no key event, and delivers the bytes after the end marker as keys again.
- One unrelated failure appeared in one local run out of seven, `Loop\TickSchedulerTest::testRunDueDoesNotDriftBehindTheInterval`. That test derives its timestamps from `microtime(true)`, and the float rounding makes it count 59 instead of 60 for about 1.3% of start times, measured over 5000 iterations of its body. The scheduler is untouched here.
