### PR TITLE
[Mailer][Cloudflare] Add an SMTP transport

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Cloudflare/README.md
+++ b/src/Symfony/Component/Mailer/Bridge/Cloudflare/README.md
@@ -8,11 +8,17 @@ Configuration example:
 ```env
 # API
 MAILER_DSN=cloudflare+api://ACCOUNT_ID:API_TOKEN@default
+
+# SMTP
+MAILER_DSN=cloudflare+smtp://api_token:API_TOKEN@default
 ```
 
 where:
  - `ACCOUNT_ID` is your Cloudflare Account ID
  - `API_TOKEN` is your Cloudflare API token (requires write permissions to `Email Sending`)
+
+The SMTP transport does not use the account ID. Cloudflare requires the literal
+`api_token` as the user name.
 
 Resources
 ---------

--- a/src/Symfony/Component/Mailer/Bridge/Cloudflare/Tests/Transport/CloudflareSmtpTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Cloudflare/Tests/Transport/CloudflareSmtpTransportTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\Cloudflare\Tests\Transport;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Mailer\Bridge\Cloudflare\Transport\CloudflareSmtpTransport;
+
+/**
+ * @author vadage
+ */
+final class CloudflareSmtpTransportTest extends TestCase
+{
+    #[DataProvider('getTransportData')]
+    public function testToString(CloudflareSmtpTransport $transport, string $expected)
+    {
+        $this->assertSame($expected, (string) $transport);
+    }
+
+    public static function getTransportData(): array
+    {
+        return [
+            [
+                new CloudflareSmtpTransport('API_TOKEN'),
+                'smtps://smtp.mx.cloudflare.net',
+            ],
+        ];
+    }
+
+    public function testCredentials()
+    {
+        $transport = new CloudflareSmtpTransport('API_TOKEN');
+
+        // Cloudflare requires literal value `api_token` as username.
+        $this->assertSame('api_token', $transport->getUsername());
+        $this->assertSame('API_TOKEN', $transport->getPassword());
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/Cloudflare/Tests/Transport/CloudflareTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Cloudflare/Tests/Transport/CloudflareTransportFactoryTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Mailer\Bridge\Cloudflare\Tests\Transport;
 use Psr\Log\NullLogger;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\Mailer\Bridge\Cloudflare\Transport\CloudflareApiTransport;
+use Symfony\Component\Mailer\Bridge\Cloudflare\Transport\CloudflareSmtpTransport;
 use Symfony\Component\Mailer\Bridge\Cloudflare\Transport\CloudflareTransportFactory;
 use Symfony\Component\Mailer\Test\AbstractTransportFactoryTestCase;
 use Symfony\Component\Mailer\Test\IncompleteDsnTestTrait;
@@ -43,6 +44,11 @@ final class CloudflareTransportFactoryTest extends AbstractTransportFactoryTestC
             new Dsn('cloudflare+api', 'default'),
             true,
         ];
+
+        yield [
+            new Dsn('cloudflare+smtp', 'default'),
+            true,
+        ];
     }
 
     public static function createProvider(): iterable
@@ -63,13 +69,22 @@ final class CloudflareTransportFactoryTest extends AbstractTransportFactoryTestC
             new Dsn('cloudflare+api', 'CLOUDFLARE_HOST', self::USER, self::PASSWORD),
             new CloudflareApiTransport(self::USER, self::PASSWORD, new MockHttpClient(), null, new NullLogger())->setHost('CLOUDFLARE_HOST'),
         ];
+        yield [
+            new Dsn('cloudflare+smtp', 'default', password: self::PASSWORD),
+            new CloudflareSmtpTransport(self::PASSWORD, null, new NullLogger()),
+        ];
     }
 
     public static function unsupportedSchemeProvider(): iterable
     {
         yield [
             new Dsn('cloudflare+foo', 'default', self::USER, self::PASSWORD),
-            'The "cloudflare+foo" scheme is not supported; supported schemes for mailer "cloudflare" are: "cloudflare", "cloudflare+api".',
+            'The "cloudflare+foo" scheme is not supported; supported schemes for mailer "cloudflare" are: "cloudflare", "cloudflare+api", "cloudflare+smtp".',
+        ];
+
+        yield [
+            new Dsn('cloudflare+foo', 'default'),
+            'The "cloudflare+foo" scheme is not supported; supported schemes for mailer "cloudflare" are: "cloudflare", "cloudflare+api", "cloudflare+smtp".',
         ];
     }
 
@@ -81,5 +96,6 @@ final class CloudflareTransportFactoryTest extends AbstractTransportFactoryTestC
         yield [new Dsn('cloudflare+api', 'default')];
         yield [new Dsn('cloudflare+api', 'default', self::USER)];
         yield [new Dsn('cloudflare+api', 'default', null, self::PASSWORD)];
+        yield [new Dsn('cloudflare+smtp', 'default')];
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Cloudflare/Transport/CloudflareSmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Cloudflare/Transport/CloudflareSmtpTransport.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\Cloudflare\Transport;
+
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport;
+
+/**
+ * @author vadage
+ */
+final class CloudflareSmtpTransport extends EsmtpTransport
+{
+    public function __construct(#[\SensitiveParameter] string $apiToken, ?EventDispatcherInterface $dispatcher = null, ?LoggerInterface $logger = null)
+    {
+        parent::__construct('smtp.mx.cloudflare.net', 465, true, $dispatcher, $logger);
+
+        $this->setUsername('api_token');
+        $this->setPassword($apiToken);
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/Cloudflare/Transport/CloudflareTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Bridge/Cloudflare/Transport/CloudflareTransportFactory.php
@@ -24,10 +24,10 @@ final class CloudflareTransportFactory extends AbstractTransportFactory
     public function create(Dsn $dsn): TransportInterface
     {
         $scheme = $dsn->getScheme();
-        $accountId = $this->getUser($dsn);
-        $apiToken = $this->getPassword($dsn);
 
         if ('cloudflare+api' === $scheme || 'cloudflare' === $scheme) {
+            $accountId = $this->getUser($dsn);
+            $apiToken = $this->getPassword($dsn);
             $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
             $port = $dsn->getPort();
 
@@ -36,11 +36,15 @@ final class CloudflareTransportFactory extends AbstractTransportFactory
                 ->setPort($port);
         }
 
+        if ('cloudflare+smtp' === $scheme) {
+            return new CloudflareSmtpTransport($this->getPassword($dsn), $this->dispatcher, $this->logger);
+        }
+
         throw new UnsupportedSchemeException($dsn, 'cloudflare', $this->getSupportedSchemes());
     }
 
     protected function getSupportedSchemes(): array
     {
-        return ['cloudflare', 'cloudflare+api'];
+        return ['cloudflare', 'cloudflare+api', 'cloudflare+smtp'];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

This change adds a transport for [Cloudflare SMTP](https://developers.cloudflare.com/email-service/api/send-emails/smtp/).

https://github.com/symfony/symfony-docs/pull/22717 needs to be updated or followed up on, depending on which PR gets merged first.

---

The pull request template says to update CHANGELOG.md when it's a new feature. Can this be omitted since this bridge was added for Symfony 8.2 anyway?