### PR TITLE
[Filesystem] Fix mirror() deleting files from the origin directory

### DIFF
--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -560,11 +560,7 @@ class Filesystem
 
         // Iterate in destination folder to remove obsolete entries
         if ($this->exists($targetDir) && isset($options['delete']) && $options['delete']) {
-            $deleteIterator = $iterator;
-            if (null === $deleteIterator) {
-                $flags = \FilesystemIterator::SKIP_DOTS;
-                $deleteIterator = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($targetDir, $flags), \RecursiveIteratorIterator::CHILD_FIRST);
-            }
+            $deleteIterator = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($targetDir, \FilesystemIterator::SKIP_DOTS), \RecursiveIteratorIterator::CHILD_FIRST);
             $targetDirLen = \strlen($targetDir);
             foreach ($deleteIterator as $file) {
                 $origin = $originDir.substr($file->getPathname(), $targetDirLen);

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -1271,6 +1271,26 @@ class FilesystemTest extends FilesystemTestCase
         $this->assertFalse($this->filesystem->exists($targetPath.'directory'.\DIRECTORY_SEPARATOR.'file1'));
     }
 
+    public function testMirrorWithCustomIteratorAndDeleteOption()
+    {
+        $sourcePath = $this->workspace.\DIRECTORY_SEPARATOR.'source-with-a-longer-name'.\DIRECTORY_SEPARATOR;
+        $targetPath = $this->workspace.\DIRECTORY_SEPARATOR.'target'.\DIRECTORY_SEPARATOR;
+
+        mkdir($sourcePath);
+        file_put_contents($sourcePath.'file1', 'FILE1');
+
+        mkdir($targetPath);
+        file_put_contents($targetPath.'obsolete', 'OBSOLETE');
+
+        $iterator = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($sourcePath, \FilesystemIterator::SKIP_DOTS), \RecursiveIteratorIterator::SELF_FIRST);
+
+        $this->filesystem->mirror($sourcePath, $targetPath, $iterator, ['delete' => true]);
+
+        $this->assertStringEqualsFile($sourcePath.'file1', 'FILE1');
+        $this->assertStringEqualsFile($targetPath.'file1', 'FILE1');
+        $this->assertFileDoesNotExist($targetPath.'obsolete');
+    }
+
     public function testMirrorCreatesEmptyDirectory()
     {
         $sourcePath = $this->workspace.\DIRECTORY_SEPARATOR.'source'.\DIRECTORY_SEPARATOR;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #14068
| License       | MIT

`Filesystem::mirror()` takes an optional iterator that selects which files and directories to copy out of the origin directory. When the `delete` option is on, `mirror()` also walks the target directory to remove the entries that no longer exist in the origin. That second pass reused the iterator given by the caller, and the caller's iterator walks the origin, not the target.

The delete pass maps each entry back to the origin with `$originDir.substr($file->getPathname(), $targetDirLen)`, which is only meaningful for a path that starts with the target directory. Given an origin path, it builds a path that does not exist, concludes the entry is obsolete, and removes it. The entry it removes sits inside the origin directory.

Here is a run on 6.4 with an iterator that keeps only the `.txt` files of the origin, an origin holding `keep.txt`, `skip.bin` and `sub/deep.txt`, and a target holding `obsolete.txt` and a stale `skip.bin`:

```
THREW: UnexpectedValueException: RecursiveDirectoryIterator::__construct(.../source-directory-long/sub): Failed to open directory: No such file or directory
source: keep.txt, skip.bin
target: obsolete.txt, skip.bin
```

The origin lost `sub/` and `sub/deep.txt`, nothing was copied, and the call ended on an exception because the iterator then tried to descend into the directory it had just deleted. When the origin and the target paths happen to have the same length, the computed path is the entry itself, so nothing is deleted and the `delete` option silently does nothing.

The fix builds the delete iterator from the target directory in all cases, which is what the pass already did when no iterator was passed. The caller's iterator keeps its documented role of selecting what to copy. The same run after the fix:

```
source: keep.txt, skip.bin, sub, sub/deep.txt
target: keep.txt, skip.bin, sub, sub/deep.txt
```

The origin is untouched, the selected files are copied and `obsolete.txt` is gone. `skip.bin` stays in the target because it still exists in the origin: `delete` removes what is missing from the origin directory, not what the iterator filtered out. That is the documented behavior of the option and it is unchanged here.

This does not add a second, caller-supplied iterator for the target side. That was proposed in #40689 and declined there as a feature.

Checks run:

- `./phpunit src/Symfony/Component/Filesystem`: 485 tests, 657 assertions, 3 skipped, no failure. The 3 skips are environment ones already skipped on the base commit (two Windows-only tests and one needing `phar.readonly=0`).
- The new test against the unpatched `Filesystem.php`: fails with `Failed asserting that file ".../source-with-a-longer-name/file1" exists.`, which is the origin file the delete pass removed.
- `./phpunit src/Symfony/Bundle/FrameworkBundle/Tests/Command`: 86 tests, 186 assertions, OK. `AssetsInstallCommand` is the only caller in the tree that passes an iterator, and it does not use `delete`, so no in-tree behavior changes.
- PHP-CS-Fixer on both touched files: clean.
