### PR TITLE
[Form] Fix rendering and parsing dates before the Gregorian cutover

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformer.php
@@ -172,6 +172,12 @@ class DateTimeToLocalizedStringTransformer extends BaseDateTimeTransformer
         $calendar = $this->calendar;
         $pattern = $this->pattern;
 
+        if (\IntlDateFormatter::GREGORIAN === $calendar && class_exists(\IntlGregorianCalendar::class, false)) {
+            // ICU uses the Julian calendar before October 1582, PHP always uses the Gregorian one
+            $calendar = new \IntlGregorianCalendar($timezone, \Locale::getDefault());
+            $calendar->setGregorianChange(-\PHP_FLOAT_MAX);
+        }
+
         $intlDateFormatter = new \IntlDateFormatter(\Locale::getDefault(), $dateFormat, $timeFormat, $timezone, $calendar, $pattern ?? '');
 
         // new \intlDateFormatter may return null instead of false in case of failure, see https://bugs.php.net/66323

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformerTest.php
@@ -167,6 +167,17 @@ class DateTimeToLocalizedStringTransformerTest extends BaseDateTimeTransformerTe
         date_default_timezone_set($tz);
     }
 
+    public function testTransformDateBeforeTheGregorianCutover()
+    {
+        if (4 === \PHP_INT_SIZE) {
+            $this->markTestSkipped('Dates before 1582 do not fit in a 32 bit timestamp.');
+        }
+
+        $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', null, null, \IntlDateFormatter::GREGORIAN, 'yyyy-MM-dd');
+
+        $this->assertSame('1582-01-01', $transformer->transform(new \DateTime('1582-01-01 UTC')));
+    }
+
     public function testTransformWithDifferentPatterns()
     {
         $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', \IntlDateFormatter::FULL, \IntlDateFormatter::FULL, \IntlDateFormatter::GREGORIAN, 'MM*yyyy*dd HH|mm|ss');
@@ -258,6 +269,17 @@ class DateTimeToLocalizedStringTransformerTest extends BaseDateTimeTransformerTe
         $dateTime = new \DateTime('2017-01-10 11:00', new \DateTimeZone('Europe/Berlin'));
 
         $this->assertDateTimeEquals($dateTime, $transformer->reverseTransform('2017-01-10'));
+    }
+
+    public function testReverseTransformDateBeforeTheGregorianCutover()
+    {
+        if (4 === \PHP_INT_SIZE) {
+            $this->markTestSkipped('Dates before 1582 do not fit in a 32 bit timestamp.');
+        }
+
+        $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', null, null, \IntlDateFormatter::GREGORIAN, 'yyyy-MM-dd');
+
+        $this->assertDateTimeEquals(new \DateTime('1582-01-01 UTC'), $transformer->reverseTransform('1582-01-01'));
     }
 
     public function testReverseTransformWithDifferentPatterns()

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
@@ -73,6 +73,25 @@ class DateTypeTest extends BaseTypeTestCase
         $this->assertEquals('2010-06-02', $form->getViewData());
     }
 
+    public function testSubmitFromSingleTextDateTimeBeforeTheGregorianCutover()
+    {
+        if (4 === \PHP_INT_SIZE) {
+            $this->markTestSkipped('Dates before 1582 do not fit in a 32 bit timestamp.');
+        }
+
+        $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
+            'widget' => 'single_text',
+            'input' => 'datetime',
+        ]);
+
+        $form->submit('1582-01-01');
+
+        $this->assertEquals(new \DateTime('1582-01-01 UTC'), $form->getData());
+        $this->assertSame('1582-01-01', $form->getViewData());
+    }
+
     public function testSubmitFromSingleTextDateTimeWithCustomFormat()
     {
         $form = $this->factory->create(static::TESTED_TYPE, null, [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #29610, Fix #31057
| License       | MIT

`DateType`, `BirthdayType` and `DateTimeType` render and read their value through `IntlDateFormatter` when the `single_text` widget is used. That formatter is built with the `GREGORIAN` calendar, and ICU reads that as the historical calendar: Julian before 15 October 1582, Gregorian from that day on. PHP dates never switch, they apply Gregorian rules to every year.

The two calendars disagree by ten days or more before the cutover, so the form shows a date the model does not hold, and it stores a date the user did not type:

```php
$form = $factory->create(DateType::class, null, ['widget' => 'single_text']);

$form->setData(new \DateTime('1582-01-01'));
$form->getViewData(); // '1581-12-22'

$form->submit('1582-01-01');
$form->getData(); // \DateTime('1582-01-11')
```

The shift is silent: rendering the stored date again gives back the string the user typed, so nothing on screen tells them that ten days were added. In the ten days that the reform skipped, 5 to 14 October 1582, even that is lost: submitting `1582-10-10` stores `1582-10-20` and the widget then shows `1582-10-20`.

This affects one path only. Every other date path in the component already uses the calendar PHP uses:

* `widget: choice` and `widget: text` go through `DateTimeToArrayTransformer` and show year 1582, month 1, day 1;
* `DateTimeType` with the HTML5 format goes through `DateTimeToHtml5LocalDateTimeTransformer` and shows `1582-01-01T00:00`;
* `input: string` round trips `1582-01-01` unchanged;
* when ext-intl is missing, `symfony/polyfill-intl-icu` also returns `1582-01-01`, so the same application answers differently depending on whether the extension is installed.

The fix asks ICU for the calendar PHP uses, by moving the Julian to Gregorian switch out of the representable range:

```php
$calendar = new \IntlGregorianCalendar($timezone, \Locale::getDefault());
$calendar->setGregorianChange(-\PHP_FLOAT_MAX);
```

`IntlGregorianCalendar` comes from ext-intl and `symfony/polyfill-intl-icu` does not provide it, so the calendar object is only built when the class exists. Without the extension the polyfill keeps its current behavior, which is already the corrected one. The substitution also only happens when the configured calendar is `IntlDateFormatter::GREGORIAN`, so `IntlDateFormatter::TRADITIONAL` and the `calendar` option added in 7.2 keep full control. The calendar carries the same timezone and locale as the formatter, so nothing else about the formatter changes.

Scope of the behavior change: dates from 15 October 1582 on are untouched. I compared the old and the new formatter over 8 locales, 6 patterns, 4 timezones and 9 dates between 1583 and 9999. All 1728 formatted strings are identical. Parsing differs in 8 of those cases, all of them with the `YYYY-ww-EEEE` week of week year pattern on a date in 1583, where week numbering has to look back into the cutover year. `DateType` rejects such a pattern anyway, since `format` must contain `y`, `M` or `d`.

Checks run:

* `./phpunit src/Symfony/Component/Form/Tests` on PHP 8.5 with ICU 74.2: 4754 tests, 9354 assertions, green, 365 skipped and 8 incomplete, the same counts as the base commit which has 4750 tests.
* the same suite with ext-intl disabled so that `symfony/polyfill-intl-icu` is used: 4754 tests, green, and the new `DateType` test runs and passes there too.
* revert check, source reverted and tests kept: `testTransformDateBeforeTheGregorianCutover` fails with `'1582-01-01'` against `'1581-12-22'`, `testReverseTransformDateBeforeTheGregorianCutover` with `1582-01-01T00:00:00+00:00` against `1582-01-11T00:00:00+00:00`, and the `DateType` and `BirthdayType` tests with the same ten day shift.
* PHP 8.1, 8.2, 8.3, 8.4 and 8.5 with ICU 74.2: `new \IntlGregorianCalendar($timezone, $locale)` and `setGregorianChange(-\PHP_FLOAT_MAX)` behave the same on every version, and the transformer round trips `1582-01-01`, `0950-12-19` and `2010-06-02` on all of them.
* model and view timezones UTC, America/Los_Angeles and a mix of both, under three different default timezones: the submitted date and the re-rendered view data match on all twelve combinations.
* `php-cs-fixer` on the three touched files: no change.
