### PR TITLE
[Form] Map violations to child forms named after the snake cased property

### DIFF
--- a/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/ViolationMapper.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/ViolationMapper.php
@@ -17,6 +17,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormRendererInterface;
 use Symfony\Component\Form\Util\InheritDataAwareIterator;
 use Symfony\Component\PropertyAccess\PropertyPathBuilder;
+use Symfony\Component\PropertyAccess\PropertyPathInterface;
 use Symfony\Component\PropertyAccess\PropertyPathIterator;
 use Symfony\Component\PropertyAccess\PropertyPathIteratorInterface;
 use Symfony\Component\Validator\Constraints\File;
@@ -236,6 +237,9 @@ class ViolationMapper implements ViolationMapperInterface
         $target = null;
         $chunk = '';
         $foundAtIndex = null;
+        $camelizedTarget = null;
+        $camelizedChunk = '';
+        $camelizedFoundAtIndex = null;
 
         // Construct mapping rules for the given form
         $rules = [];
@@ -248,12 +252,18 @@ class ViolationMapper implements ViolationMapperInterface
         }
 
         $children = iterator_to_array(new \RecursiveIteratorIterator(new InheritDataAwareIterator($form)), false);
+        $camelizedChildren = $children;
 
         while ($it->valid()) {
+            $index = $it->key();
+            $element = $it->current();
+
             if ($it->isIndex()) {
-                $chunk .= '['.$it->current().']';
+                $chunk .= '['.$element.']';
+                $camelizedChunk .= '['.$element.']';
             } else {
-                $chunk .= ('' === $chunk ? '' : '.').$it->current();
+                $chunk .= ('' === $chunk ? '' : '.').$element;
+                $camelizedChunk .= ('' === $camelizedChunk ? '' : '.').self::camelize($element);
             }
 
             // Test mapping rules as long as we have any
@@ -276,7 +286,7 @@ class ViolationMapper implements ViolationMapperInterface
                 $childPath = (string) $child->getPropertyPath();
                 if ($childPath === $chunk) {
                     $target = $child;
-                    $foundAtIndex = $it->key();
+                    $foundAtIndex = $index;
                 } elseif (str_starts_with($childPath, $chunk)) {
                     continue;
                 }
@@ -284,7 +294,28 @@ class ViolationMapper implements ViolationMapperInterface
                 unset($children[$i]);
             }
 
+            /** @var FormInterface $child */
+            foreach ($camelizedChildren as $i => $child) {
+                $childPath = self::camelizePath($child->getPropertyPath());
+                if ($childPath === $camelizedChunk) {
+                    $camelizedTarget = $child;
+                    $camelizedFoundAtIndex = $index;
+                } elseif (str_starts_with($childPath, $camelizedChunk)) {
+                    continue;
+                }
+
+                unset($camelizedChildren[$i]);
+            }
+
             $it->next();
+        }
+
+        // The property accessor camelizes property paths when it looks for getters and
+        // setters, which makes a child named "discount_price" read and write the
+        // "discountPrice" property the violation points at.
+        if (null === $target) {
+            $target = $camelizedTarget;
+            $foundAtIndex = $camelizedFoundAtIndex;
         }
 
         if (null !== $foundAtIndex) {
@@ -322,7 +353,7 @@ class ViolationMapper implements ViolationMapperInterface
                 // Cut the piece out of the property path and proceed
                 $propertyPathBuilder->remove($i);
             } else {
-                /** @var \Symfony\Component\PropertyAccess\PropertyPathInterface $propertyPath */
+                /** @var PropertyPathInterface $propertyPath */
                 $propertyPath = $scope->getPropertyPath();
 
                 if (null === $propertyPath) {
@@ -344,5 +375,33 @@ class ViolationMapper implements ViolationMapperInterface
     private function acceptsErrors(FormInterface $form): bool
     {
         return $this->allowNonSynchronized || $form->isSynchronized();
+    }
+
+    private static function camelizePath(?PropertyPathInterface $path): string
+    {
+        if (null === $path) {
+            return '';
+        }
+
+        $camelized = '';
+
+        foreach ($path->getElements() as $i => $element) {
+            if ($path->isIndex($i)) {
+                $camelized .= '['.$element.']';
+            } else {
+                $camelized .= ('' === $camelized ? '' : '.').self::camelize($element);
+            }
+        }
+
+        return $camelized;
+    }
+
+    private static function camelize(string $string): string
+    {
+        if ('' === ltrim($string, '_')) {
+            return $string;
+        }
+
+        return str_replace(' ', '', ucwords(str_replace('_', ' ', $string)));
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/ViolationMapper/ViolationMapperTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/ViolationMapper/ViolationMapperTest.php
@@ -1581,6 +1581,72 @@ class ViolationMapperTest extends TestCase
         $this->assertEquals([$this->getFormError($violation3, $grandChild3)], iterator_to_array($grandChild3->getErrors()), $grandChild3->getName().' should have an error, but has none');
     }
 
+    public function testMapErrorToChildWhoseNameIsTheSnakeCasedProperty()
+    {
+        $violation = $this->getConstraintViolation('data.discountPrice');
+        $parent = $this->getForm('parent');
+        $child = $this->getForm('discount_price', 'discount_price');
+
+        $parent->add($child);
+        $parent->submit([]);
+
+        $this->mapper->mapViolation($violation, $parent);
+
+        $this->assertCount(0, $parent->getErrors(), $parent->getName().' should not have an error, but has one');
+        $this->assertEquals([$this->getFormError($violation, $child)], iterator_to_array($child->getErrors()), $child->getName().' should have an error, but has none');
+    }
+
+    public function testMapErrorToNestedChildWhoseNameIsTheSnakeCasedProperty()
+    {
+        $violation = $this->getConstraintViolation('data.billingAddress.zipCode');
+        $parent = $this->getForm('parent');
+        $child = $this->getForm('billing_address', 'billing_address');
+        $grandChild = $this->getForm('zip_code', 'zip_code');
+
+        $parent->add($child);
+        $child->add($grandChild);
+        $parent->submit([]);
+
+        $this->mapper->mapViolation($violation, $parent);
+
+        $this->assertCount(0, $parent->getErrors(), $parent->getName().' should not have an error, but has one');
+        $this->assertCount(0, $child->getErrors(), $child->getName().' should not have an error, but has one');
+        $this->assertEquals([$this->getFormError($violation, $grandChild)], iterator_to_array($grandChild->getErrors()), $grandChild->getName().' should have an error, but has none');
+    }
+
+    public function testPreferTheChildMatchingThePropertyPathExactly()
+    {
+        $violation = $this->getConstraintViolation('data.discountPrice');
+        $parent = $this->getForm('parent');
+        $snakeCased = $this->getForm('discount_price', 'discount_price');
+        $camelCased = $this->getForm('discountPrice', 'discountPrice');
+
+        $parent->add($snakeCased);
+        $parent->add($camelCased);
+        $parent->submit([]);
+
+        $this->mapper->mapViolation($violation, $parent);
+
+        $this->assertCount(0, $parent->getErrors(), $parent->getName().' should not have an error, but has one');
+        $this->assertCount(0, $snakeCased->getErrors(), $snakeCased->getName().' should not have an error, but has one');
+        $this->assertEquals([$this->getFormError($violation, $camelCased)], iterator_to_array($camelCased->getErrors()), $camelCased->getName().' should have an error, but has none');
+    }
+
+    public function testDoNotMapErrorToChildWhoseArrayKeyOnlyDiffersInCase()
+    {
+        $violation = $this->getConstraintViolation('data[discountPrice]');
+        $parent = $this->getForm('parent');
+        $child = $this->getForm('discount_price', '[discount_price]');
+
+        $parent->add($child);
+        $parent->submit([]);
+
+        $this->mapper->mapViolation($violation, $parent);
+
+        $this->assertEquals([$this->getFormError($violation, $parent)], iterator_to_array($parent->getErrors()), $parent->getName().' should have an error, but has none');
+        $this->assertCount(0, $child->getErrors(), $child->getName().' should not have an error, but has one');
+    }
+
     public function testMessageWithLabel1()
     {
         $this->mapper = new ViolationMapper(new FormRenderer(new DummyFormRendererEngine()), new FixedTranslator(['Name' => 'Custom Name']));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #38531
| License       | MIT

A form child may be named after the snake cased version of the property it is bound to. The property accessor accepts that: it camelizes `discount_price` and finds `getDiscountPrice()` and `setDiscountPrice()`, so the value is read and written on the `discountPrice` property.

Validation violations did not follow the same rule. The violation raised on that property has the path `discountPrice`, and `ViolationMapper::matchChild()` compared each child property path with the current path segment byte for byte. `discount_price` never equals `discountPrice`, so no child matched and the error was mapped to the root form instead of the field. Renaming the child to `discountPrice` was the only way to get the error next to the input.

The mapper now walks the violation path twice in the same pass: once with the exact comparison it already did, and once with both sides camelized the way the property accessor camelizes them. Array index segments are left alone, because array keys are matched exactly by the property accessor too, so `[discount_price]` still does not match `[discountPrice]`.

The camelized result is used only when the exact comparison matched nothing at all. That keeps three properties:

* a violation that is mapped today keeps its current target;
* a child whose property path matches exactly wins over a sibling that only matches after camelization;
* an `error_mapping` rule wins over both, because rules are tested first and return immediately, so applications that worked around this with `error_mapping` keep their current behavior.

Applications that hit the bug will see the error move from the root form to the field it belongs to, which is the point of the fix.

Checks run:

* `./phpunit src/Symfony/Component/Form/Tests/Extension/Validator/ViolationMapper/ViolationMapperTest.php`: 1025 tests, 3346 assertions, all green.
* `./phpunit src/Symfony/Component/Form/Tests`: 4754 tests, 9358 assertions, 365 skipped, 8 incomplete, no failure. The same run on the base commit gives 4750 tests with the identical 365 skipped and 8 incomplete, so the four added tests are the only difference.
* Revert check: with the fix reverted and the tests kept, `testMapErrorToChildWhoseNameIsTheSnakeCasedProperty` and `testMapErrorToNestedChildWhoseNameIsTheSnakeCasedProperty` fail with `parent should not have an error, but has one / Failed asserting that actual size 1 matches expected size 0`. The other two added tests pass on the base commit as well, on purpose: they pin the behavior the fix must not change.
* End to end check with a real entity, the validator and the form factory: a form with `data_class` and a `discount_price` child raised the `NotBlank` violation on the root form before the fix and on the `discount_price` child after it, while the `discountPrice` spelling behaves the same in both states.
* Syntax check on PHP 8.1 and 8.2 as well, since 6.4 supports them. No PHP 8.2 only syntax is used.
