### PR TITLE
[HttpKernel] Fix caching responses that cannot provide their content

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpCache/Store.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/Store.php
@@ -197,15 +197,21 @@ class Store implements StoreInterface
             }
         // Everything seems ok, omit writing content to disk
         } else {
+            // Responses that cannot provide their content, like BinaryFileResponse or
+            // StreamedResponse, have no entity to store, so no entry is written
+            if (false === $content = $response->getContent()) {
+                return $key;
+            }
+
             $digest = $this->generateContentDigest($response);
             $response->headers->set('X-Content-Digest', $digest);
 
-            if (!$this->save($digest, $response->getContent(), false)) {
+            if (!$this->save($digest, $content, false)) {
                 throw new \RuntimeException('Unable to store the entity.');
             }
 
             if (!$response->headers->has('Transfer-Encoding')) {
-                $response->headers->set('Content-Length', \strlen($response->getContent()));
+                $response->headers->set('Content-Length', \strlen($content));
             }
         }
 

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\HttpKernel\Tests\HttpCache;
 
 use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\TerminateEvent;
@@ -587,6 +588,41 @@ class HttpCacheTest extends HttpCacheTestCase
         $this->request('GET', '/');
         $this->assertEquals(200, $this->response->getStatusCode());
         $this->assertTraceNotContains('store');
+    }
+
+    public function testDoesNotCacheBinaryFileResponses()
+    {
+        $file = tempnam(sys_get_temp_dir(), 'sf_binary_file_');
+        file_put_contents($file, 'Hello World');
+
+        $this->kernel = new class($file) extends TestHttpKernel {
+            public function __construct(private string $file)
+            {
+                parent::__construct(null, 200, []);
+            }
+
+            public function callController(Request $request): Response
+            {
+                $this->called = true;
+
+                return (new BinaryFileResponse($this->file, 200, ['Content-Type' => 'text/plain']))->setMaxAge(10);
+            }
+        };
+
+        $this->request('GET', '/');
+        $this->assertHttpKernelIsCalled();
+        $this->assertEquals(200, $this->response->getStatusCode());
+
+        $this->request('GET', '/');
+        $this->assertHttpKernelIsCalled();
+        $this->assertTraceNotContains('fresh');
+        $this->assertInstanceOf(BinaryFileResponse::class, $this->response);
+
+        ob_start();
+        $this->response->sendContent();
+        $this->assertSame('Hello World', ob_get_clean());
+
+        unlink($file);
     }
 
     public function testCachesResponsesWithExplicitNoCacheDirective()

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/StoreTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/StoreTest.php
@@ -12,9 +12,11 @@
 namespace Symfony\Component\HttpKernel\Tests\HttpCache;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpKernel\HttpCache\HttpCache;
 use Symfony\Component\HttpKernel\HttpCache\Store;
 
@@ -320,6 +322,21 @@ class StoreTest extends TestCase
         $this->store->write($request, $response);
         $this->assertArrayNotHasKey('set-cookie', $this->getStoreMetadata($request)[0][1]);
         $this->assertNotEmpty($response->headers->getCookies());
+    }
+
+    public function testDoesNotStoreResponsesWithUnreadableContent()
+    {
+        $request = Request::create('https://example.com/file');
+        $this->store->write($request, new BinaryFileResponse(__FILE__, 200, ['Cache-Control' => 'max-age=420']));
+
+        $this->assertEmpty($this->getStoreMetadata($request));
+        $this->assertNull($this->store->lookup($request));
+
+        $request = Request::create('https://example.com/stream');
+        $this->store->write($request, new StreamedResponse(static function () { echo 'foo'; }, 200, ['Cache-Control' => 'max-age=420']));
+
+        $this->assertEmpty($this->getStoreMetadata($request));
+        $this->assertNull($this->store->lookup($request));
     }
 
     public function testDiscardsInvalidBodyEval()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #9128
| License       | MIT

`HttpCache` created a cache entry for responses whose body it cannot read, then served that empty entry.

`Store::write()` passes `Response::getContent()` to the content digest and to the entity store. `BinaryFileResponse` and `StreamedResponse` both return `false` there. The store therefore saved an empty entity, wrote metadata pointing at it and set `Content-Length: 0`. The next request matched that metadata, found the entity file on disk and returned a cache hit with an empty body. So a controller returning a `BinaryFileResponse` sent the file once and then sent nothing until the entry went stale. Serving files through AssetMapper in dev with `framework.http_cache` enabled runs into this.

Behavior before, with a controller returning a `BinaryFileResponse` with `max-age=60`:

```
GET /file  ->  200, body "the file content", X-Symfony-Cache: miss, store
GET /file  ->  200, body "",                 X-Symfony-Cache: fresh
```

Behavior after:

```
GET /file  ->  200, body "the file content", X-Symfony-Cache: miss, store
GET /file  ->  200, body "the file content", X-Symfony-Cache: miss, store
```

The fix makes `Store::write()` return without writing anything when `Response::getContent()` returns `false`. The default store simply does not cache those responses. The response keeps its cache headers, so a reverse proxy, a CDN or the browser in front of the application still caches it, which is what the reporter asked for.

The check sits in `Store` rather than in `HttpCache::store()` on purpose. A custom `StoreInterface` implementation can store a `BinaryFileResponse`, and at least one third party store does, so `HttpCache` has to keep handing those responses to the store it was given.

This does not teach the default store to cache the file itself. That needs decisions a bug fix should not take: copying the file into the cache directory, the memory cost of reading the body back with `file_get_contents()` on every hit, and range requests that are stored under a cache key that does not vary on `Range`. It stays a feature request.

One detail stays visible in the traces: the request is still recorded as `store`, because `HttpCache` records that it asked the store to write. The store writes nothing.

Checks run:

* `./phpunit src/Symfony/Component/HttpKernel/Tests`: 1219 tests, 2968 assertions, OK, with 24 legacy deprecation notices. The same run on the base commit gives 1217 tests, 2958 assertions, OK, with the same 24 notices.
* `./phpunit src/Symfony/Component/HttpClient/Tests/CachingHttpClientTest.php`, the other caller of `HttpCache` and `Store` in the tree: 6 tests, 13 assertions, OK.
* Revert check with the two new tests kept and `Store.php` back in its base state: `StoreTest::testDoesNotStoreResponsesWithUnreadableContent` fails with "Failed asserting that an array is empty" (metadata was written for a `BinaryFileResponse`), and `HttpCacheTest::testDoesNotCacheBinaryFileResponses` fails on the second request with "Failed asserting that false is true", meaning the backend was not called and the empty cache entry was served instead.
* A scenario where a URL first returns a normal cacheable response and later a `BinaryFileResponse`: on the base commit the stale entry is replaced by the empty one and the next request serves an empty body; with the fix the stale entry is left alone, revalidation keeps forwarding to the backend and the file is served every time.
