### PR TITLE
[Serializer] Fix denormalizing mime messages typed as RawMessage

### DIFF
--- a/src/Symfony/Bridge/Twig/Tests/Mime/TemplatedEmailTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Mime/TemplatedEmailTest.php
@@ -111,7 +111,8 @@ class TemplatedEmailTest extends TestCase
                         }
                     ]
                 },
-                "body": null
+                "body": null,
+                "class": "Symfony\\\\Bridge\\\\Twig\\\\Mime\\\\TemplatedEmail"
             }
             EOF;
 

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -44,7 +44,7 @@
         "symfony/security-core": "^5.4|^6.0|^7.0",
         "symfony/security-csrf": "^5.4|^6.0|^7.0",
         "symfony/security-http": "^5.4|^6.0|^7.0",
-        "symfony/serializer": "^6.4.3|^7.0.3",
+        "symfony/serializer": "^6.4.44|^7.4.17",
         "symfony/stopwatch": "^5.4|^6.0|^7.0",
         "symfony/console": "^5.4|^6.0|^7.0",
         "symfony/expression-language": "^5.4|^6.0|^7.0",

--- a/src/Symfony/Component/Mime/Tests/EmailTest.php
+++ b/src/Symfony/Component/Mime/Tests/EmailTest.php
@@ -688,7 +688,8 @@ class EmailTest extends TestCase
                         }
                     ]
                 },
-                "body": null
+                "body": null,
+                "class": "Symfony\\\Component\\\Mime\\\Email"
             }
             EOF;
 

--- a/src/Symfony/Component/Mime/Tests/MessageTest.php
+++ b/src/Symfony/Component/Mime/Tests/MessageTest.php
@@ -264,7 +264,8 @@ class MessageTest extends TestCase
                         ]
                     },
                     "class": "Symfony\\\\Component\\\\Mime\\\\Part\\\\Multipart\\\\MixedPart"
-                }
+                },
+                "class": "Symfony\\\\Component\\\\Mime\\\\Message"
             }
             EOF;
 

--- a/src/Symfony/Component/Mime/composer.json
+++ b/src/Symfony/Component/Mime/composer.json
@@ -29,7 +29,7 @@
         "symfony/process": "^5.4|^6.4|^7.0",
         "symfony/property-access": "^5.4|^6.0|^7.0",
         "symfony/property-info": "^5.4|^6.0|^7.0",
-        "symfony/serializer": "^6.4.3|^7.0.3"
+        "symfony/serializer": "^6.4.44|^7.4.17"
     },
     "conflict": {
         "egulias/email-validator": "~3.0.0",

--- a/src/Symfony/Component/Serializer/Normalizer/MimeMessageNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/MimeMessageNormalizer.php
@@ -15,7 +15,6 @@ use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Header\HeaderInterface;
 use Symfony\Component\Mime\Header\Headers;
 use Symfony\Component\Mime\Header\UnstructuredHeader;
-use Symfony\Component\Mime\Message;
 use Symfony\Component\Mime\Part\AbstractPart;
 use Symfony\Component\Mime\RawMessage;
 use Symfony\Component\Serializer\Exception\LogicException;
@@ -48,7 +47,7 @@ final class MimeMessageNormalizer implements NormalizerInterface, DenormalizerIn
         $isCacheable = __CLASS__ === static::class || $this->hasCacheableSupportsMethod();
 
         return [
-            Message::class => $isCacheable,
+            RawMessage::class => $isCacheable,
             Headers::class => $isCacheable,
             HeaderInterface::class => $isCacheable,
             Address::class => $isCacheable,
@@ -83,8 +82,12 @@ final class MimeMessageNormalizer implements NormalizerInterface, DenormalizerIn
             unset($ret['seekable'], $ret['cid'], $ret['handle']);
         }
 
-        if ($object instanceof RawMessage && \array_key_exists('message', $ret) && null === $ret['message']) {
-            unset($ret['message']);
+        if ($object instanceof RawMessage) {
+            $ret['class'] = $object::class;
+
+            if (\array_key_exists('message', $ret) && null === $ret['message']) {
+                unset($ret['message']);
+            }
         }
 
         return $ret;
@@ -104,15 +107,15 @@ final class MimeMessageNormalizer implements NormalizerInterface, DenormalizerIn
         }
 
         if (AbstractPart::class === $type) {
-            $class = $data['class'] ?? null;
-
-            if (!\is_string($class) || !is_a($class, AbstractPart::class, true)) {
-                throw NotNormalizableValueException::createForUnexpectedDataType(\sprintf('Expected a subclass of "%s", got "%s".', AbstractPart::class, \is_string($class) ? $class : get_debug_type($class)), $data, [AbstractPart::class], $context['deserialization_path'] ?? null);
-            }
-
-            $type = $class;
+            $type = $this->resolveClass($data, AbstractPart::class, $context);
             unset($data['class']);
             $data['headers'] = $this->serializer->denormalize($data['headers'], Headers::class, $format, $context);
+        } elseif (\is_array($data) && is_a($type, RawMessage::class, true)) {
+            if (RawMessage::class === $type && \array_key_exists('class', $data)) {
+                $type = $this->resolveClass($data, RawMessage::class, $context);
+            }
+
+            unset($data['class']);
         }
 
         return $this->normalizer->denormalize($data, $type, $format, $context);
@@ -120,12 +123,12 @@ final class MimeMessageNormalizer implements NormalizerInterface, DenormalizerIn
 
     public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
-        return $data instanceof Message || $data instanceof Headers || $data instanceof HeaderInterface || $data instanceof Address || $data instanceof AbstractPart;
+        return $data instanceof RawMessage || $data instanceof Headers || $data instanceof HeaderInterface || $data instanceof Address || $data instanceof AbstractPart;
     }
 
     public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
-        return is_a($type, Message::class, true) || Headers::class === $type || AbstractPart::class === $type;
+        return is_a($type, RawMessage::class, true) || Headers::class === $type || AbstractPart::class === $type;
     }
 
     /**
@@ -136,5 +139,16 @@ final class MimeMessageNormalizer implements NormalizerInterface, DenormalizerIn
         trigger_deprecation('symfony/serializer', '6.3', 'The "%s()" method is deprecated, implement "%s::getSupportedTypes()" instead.', __METHOD__, get_debug_type($this));
 
         return true;
+    }
+
+    private function resolveClass(mixed $data, string $baseClass, array $context): string
+    {
+        $class = $data['class'] ?? null;
+
+        if (!\is_string($class) || !is_a($class, $baseClass, true)) {
+            throw NotNormalizableValueException::createForUnexpectedDataType(\sprintf('Expected a subclass of "%s", got "%s".', $baseClass, \is_string($class) ? $class : get_debug_type($class)), $data, [$baseClass], $context['deserialization_path'] ?? null);
+        }
+
+        return $class;
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/MimeMessageNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/MimeMessageNormalizerTest.php
@@ -12,8 +12,10 @@
 namespace Symfony\Component\Serializer\Tests\Normalizer;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Mime\Email;
 use Symfony\Component\Mime\Part\AbstractPart;
 use Symfony\Component\Mime\Part\TextPart;
+use Symfony\Component\Mime\RawMessage;
 use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
@@ -61,6 +63,66 @@ class MimeMessageNormalizerTest extends TestCase
         $this->expectExceptionMessage('Expected a subclass of "Symfony\Component\Mime\Part\AbstractPart", got "array".');
 
         $serializer->denormalize(['class' => [], 'headers' => []], AbstractPart::class);
+    }
+
+    public function testNormalizeAddsTheMessageClass()
+    {
+        $serializer = $this->createMimeSerializer();
+
+        $this->assertSame(Email::class, $serializer->normalize(new Email())['class']);
+        $this->assertSame(RawMessage::class, $serializer->normalize(new RawMessage('Raw content'))['class']);
+    }
+
+    public function testDenormalizeMessageFromRawMessageType()
+    {
+        $serializer = $this->createMimeSerializer();
+
+        // no addresses: egulias/email-validator is not installed on low-deps
+        $email = (new Email())->subject('Text subject')->text('Text content');
+
+        $denormalized = $serializer->denormalize($serializer->normalize($email), RawMessage::class);
+
+        $this->assertInstanceOf(Email::class, $denormalized);
+        $this->assertSame('Text content', $denormalized->getTextBody());
+        $this->assertEquals($email->getHeaders(), $denormalized->getHeaders());
+    }
+
+    public function testDenormalizeRawMessageFromRawMessageType()
+    {
+        $serializer = $this->createMimeSerializer();
+
+        $denormalized = $serializer->denormalize($serializer->normalize(new RawMessage('Raw content')), RawMessage::class);
+
+        $this->assertSame(RawMessage::class, $denormalized::class);
+        $this->assertSame('Raw content', $denormalized->toString());
+    }
+
+    public function testDenormalizeRejectsForeignClassInMessage()
+    {
+        $serializer = $this->createMimeSerializer();
+
+        $this->expectException(NotNormalizableValueException::class);
+        $this->expectExceptionMessage('Expected a subclass of "Symfony\Component\Mime\RawMessage", got "Symfony\Component\Serializer\Tests\Normalizer\MimeMessageNormalizerTestForeignClass".');
+
+        $serializer->denormalize(['class' => MimeMessageNormalizerTestForeignClass::class, 'marker' => 'foo'], RawMessage::class);
+    }
+
+    public function testDenormalizeRejectsNonArrayDataInPart()
+    {
+        $serializer = $this->createMimeSerializer();
+
+        $this->expectException(NotNormalizableValueException::class);
+        $this->expectExceptionMessage('Expected a subclass of "Symfony\Component\Mime\Part\AbstractPart", got "null".');
+
+        $serializer->denormalize('a string', AbstractPart::class);
+    }
+
+    public function testDenormalizeNonArrayDataAsMessage()
+    {
+        $serializer = $this->createMimeSerializer();
+
+        $this->assertSame(RawMessage::class, $serializer->denormalize('a string', RawMessage::class)::class);
+        $this->assertInstanceOf(Email::class, $serializer->denormalize('a string', Email::class));
     }
 
     private function createMimeSerializer(): Serializer


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #33394
| License       | MIT

Sending emails asynchronously does not work when the messenger transport uses the Symfony serializer instead of the PHP one.

`SendEmailMessage` declares its message as `Symfony\Component\Mime\RawMessage`, so the serializer is asked to denormalize the payload into that base class. `MimeMessageNormalizer` did not support it: `supportsDenormalization()` only accepted `Message` and its subclasses, so the generic object normalizer took over. It built a `RawMessage` with a `null` body, because `RawMessage::__construct()` accepts `mixed`. The email was therefore silently replaced by an empty raw message, and the worker later failed with `foreach() argument must be of type array|object, null given` when the transport tried to read it. On older versions, where that constructor had no type declaration, the same payload produced the `MissingConstructorArgumentsException` reported in the issue.

The normalizer already records the concrete class of mime parts under a `class` key, so that they can be restored from the abstract `AbstractPart` type. This applies the same treatment to messages: `normalize()` now adds the message class, and `denormalize()` uses it when the requested type is `RawMessage` itself. As for parts, the value is rejected when it does not name a subclass of `RawMessage`.

Backward compatibility:

* payloads written before this change carry no `class` key, and denormalizing them into a concrete type such as `Email` behaves exactly as before;
* payloads written after this change carry one extra key, which older consumers ignore as an unknown attribute;
* when a concrete type is requested, that type still wins, so `denormalize($data, Email::class)` keeps returning an `Email`;
* `denormalize(['message' => 'raw'], RawMessage::class)` keeps returning a plain `RawMessage`;
* malformed payloads keep reporting serializer exceptions rather than PHP errors, so `COLLECT_DENORMALIZATION_ERRORS` still works on them.

`supportsNormalization()` widens to `RawMessage` as well, so a plain raw message now goes through this normalizer instead of the generic object normalizer. Its content used to be dropped: `normalize(new RawMessage('raw body'))` returned an empty array. It now returns the body and the class. Two edge cases come with that change. A raw message built on a resource now throws a `NotNormalizableValueException`, which matches the docblock of the class saying that such messages are not serializable. A raw message built on a generator now has that generator consumed by `normalize()`, so the object itself cannot be sent afterwards. Both used to normalize to an empty array, which lost the message anyway.

What to watch on CI, none of which is expected to be fixed here:

* the two `^` groups of the high-deps job are red and stay red. That job runs the 5.4 tests of the patched components against this branch, and the 5.4 serialization fixtures of Mime and of the Twig bridge do not expect the new `class` key. Those fixtures sit on a frozen branch, so merging this up does not clear them. There is no runtime incompatibility behind it: a 5.4 shaped consumer denormalizing a new payload into `Email` still gets a correct `Email`. Whether that is acceptable is the one call to make before merging, since the leg would then be red for any later 6.4 pull request touching Mime, the Twig bridge or the Serializer.
* the plain `Mime` and `Twig` groups of the same job are red for a different and temporary reason. The dev requirement is raised to `^6.4.44|^7.4.17` and nothing released matches yet. Low deps then falls back to the local package and is green, while high deps picks the upstream `7.4.x-dev`, which satisfies `^7.4.17` but does not carry the fix. This clears once the change is merged up into 7.4.
* the four failures of the `Serializer^` group are pre-existing on any 6.4 serializer patch and are unrelated to mime.

The `conflict` entry of Mime still reads `symfony/serializer: <6.4.3|>7.0,<7.0.3`. It is left alone on purpose. Mime itself is not modified here, and old and new payloads are read correctly by both the old and the new serializer, so there is no version pair to forbid.

Checks that were run:

* `MimeMessageNormalizerTest` against the unpatched normalizer: 2 errors and 2 failures, the central one being `Failed asserting that Symfony\Component\Mime\RawMessage Object (...) is an instance of class "Symfony\Component\Mime\Email"`;
* `src/Symfony/Component/Serializer/Tests`: 1157 tests, 2329 assertions, 11 skipped, no failure;
* `src/Symfony/Component/Mime/Tests`: 401 tests, 1617 assertions, 1 skipped, no failure;
* `src/Symfony/Bridge/Twig/Tests`: 1756 tests, 2042 assertions, 14 skipped, no failure;
* `src/Symfony/Component/Mailer/Tests` and `src/Symfony/Component/Messenger/Tests`: 166 and 410 tests, no failure;
* a script that encodes a `SendEmailMessage` with `Symfony\Component\Messenger\Transport\Serialization\Serializer` and decodes it back: it returned a `RawMessage` with a null body before the change, and returns the original `Email` with its headers and text body after it;
* the same script fed with a malformed body such as `{"message":"raw text","envelope":null}`: it returns a `RawMessage` both before and after the change.
