### PR TITLE
[DependencyInjection] Detect circular references through a shared factory builder

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckFactoryBuilderCircularReferencePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckFactoryBuilderCircularReferencePass.php
@@ -17,8 +17,9 @@ use Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceExce
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
- * Detects cycles where a service's factory is `[Definition $b, $method]` and $b's
- * own properties/method calls/configurator transitively require that same service
+ * Detects cycles where a service's factory is `[$b, $method]`, with $b either an
+ * inlined definition or a reference to another service, and $b's own
+ * properties/method calls/configurator transitively require that same service
  * through constructor references.
  *
  * The soft-circular instantiation pattern relies on storing the service's instance
@@ -42,18 +43,36 @@ class CheckFactoryBuilderCircularReferencePass implements CompilerPassInterface
         try {
             foreach ($container->getDefinitions() as $id => $definition) {
                 $factory = $definition->getFactory();
-                if (!\is_array($factory) || !$factory[0] instanceof Definition) {
+                if (!\is_array($factory)) {
                     continue;
                 }
 
-                $builder = $factory[0];
+                $builderId = null;
+
+                if ($factory[0] instanceof Reference) {
+                    $builderId = (string) $factory[0];
+                    while ($container->hasAlias($builderId)) {
+                        $builderId = (string) $container->getAlias($builderId);
+                    }
+
+                    if (!$container->hasDefinition($builderId)) {
+                        continue;
+                    }
+
+                    $builder = $container->getDefinition($builderId);
+                } elseif ($factory[0] instanceof Definition) {
+                    $builder = $factory[0];
+                } else {
+                    continue;
+                }
+
                 if (!$builder->getMethodCalls() && !$builder->getProperties() && null === $builder->getConfigurator()) {
                     continue;
                 }
 
                 $this->currentId = $id;
                 $this->visited = [$id => true];
-                $this->path = [$id];
+                $this->path = null === $builderId ? [$id] : [$id, $builderId];
 
                 $setup = [$builder->getProperties(), $builder->getMethodCalls(), $builder->getConfigurator()];
                 if ($this->setupReferencesCurrent($setup)) {

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckFactoryBuilderCircularReferencePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckFactoryBuilderCircularReferencePassTest.php
@@ -61,6 +61,31 @@ class CheckFactoryBuilderCircularReferencePassTest extends TestCase
         $container->compile();
     }
 
+    public function testThrowsWhenBuilderIsSharedWithAnotherConsumer()
+    {
+        // A second consumer keeps the builder out of the produced service: the
+        // factory stays a Reference and the builder is a shared service of its
+        // own. The dumper then shares the builder before running its setters, so
+        // the re-entrant call builds the product from an unconfigured builder.
+        $container = new ContainerBuilder();
+        $container->register('builder', 'stdClass')
+            ->addMethodCall('useExtension', [new Reference('extension')]);
+        $container->register('product', 'stdClass')
+            ->setFactory([new Reference('builder'), 'build'])
+            ->setPublic(true);
+        $container->register('builder_consumer', 'stdClass')
+            ->setPublic(true)
+            ->addArgument(new Reference('builder'));
+        $container->register('extension', 'stdClass')
+            ->setPublic(true)
+            ->addArgument(new Reference('product'));
+
+        $this->expectException(ServiceCircularReferenceException::class);
+        $this->expectExceptionMessage('Circular reference detected for service "product", path: "product -> builder -> extension -> product"');
+
+        $container->compile();
+    }
+
     public function testAllowsBuilderWithoutSetup()
     {
         // The factory builder has no method calls/properties/configurator, so the


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #36361
| License       | MIT

`CheckFactoryBuilderCircularReferencePass` rejects containers where a service is built by `[$builder, $method]` and the builder's own setters need that same service back. The dumper cannot serve such a cycle: it shares the builder before running its setters, so the re-entrant call reads an unconfigured builder and the factory returns a service that is missing everything the setters were meant to install.

The pass only looked at builders that had been inlined into the produced service (`$factory[0] instanceof Definition`). A builder that stays a service of its own, because a second service also uses it, keeps a `Reference` in the factory and was skipped, even though the dumped code has exactly the same defect.

That is the shape of the framework's own validator. `validator` is built from `validator.builder`, and `validator.builder` is also injected into `validator.mapping.cache_warmer`, so it is never inlined. Every piece of the validator configuration is a setter on that builder: the constraint validator factory, the translator, the mapping loaders and the object initializers. When any service reached by those setters needs `ValidatorInterface` through its constructor, the container returns a validator with no mapping loaders, no constraint validator factory and no translator. Nothing fails; validation just accepts every value.

Reproduced on the compiled container before the fix, with the framework's wiring (`validator` built from a shared `validator.builder`, a second consumer of the builder, and a service in the builder setters that takes the validator in its constructor): the dumped `getValidatorService()` returns the instance stored by the re-entrant call, and reflection on it shows a null mapping loader and zero object initializers.

The fix resolves the referenced builder to its definition and runs the same walk on it, so the cycle is reported at compile time:

    Circular reference detected for service "validator", path: "validator -> validator.builder -> app.subscriber -> validator".

The path now names the builder, which is where the offending setter lives.

Note for people upgrading: an application that has such a cycle compiles today and runs with validation silently disabled. It will now fail to compile until the cycle is broken, for example by making the service that needs the validator lazy, or by injecting a service locator instead of `ValidatorInterface`.

Checks run:

* `./phpunit src/Symfony/Component/DependencyInjection/Tests`: 1588 tests, 3383 assertions, 16 skipped, no failures.
* `./phpunit src/Symfony/Bundle/FrameworkBundle/Tests`: 1373 tests, 4545 assertions, 5 skipped, no failures. This is the suite that compiles full framework containers, so it covers the risk of the new check firing on a stock application.
* `./phpunit` on SecurityBundle (360), TwigBundle (40), WebProfilerBundle (137), DebugBundle (13), HttpKernel (1217), Messenger (410), Doctrine bridge (453) and Validator (4803): all green.
* php-cs-fixer on both touched files: clean.
* Revert check: with the source file back to its previous state and the new test kept, the test fails with `Failed asserting that exception of type "Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException" is thrown.` and the nine existing tests still pass.
