### PR TITLE
[Mailer] Fix the SMTP scheme check in the transport factory test case

### DIFF
--- a/src/Symfony/Component/Mailer/Test/TransportFactoryTestCase.php
+++ b/src/Symfony/Component/Mailer/Test/TransportFactoryTestCase.php
@@ -72,7 +72,7 @@ abstract class TransportFactoryTestCase extends TestCase
         $factory = $this->getFactory();
 
         $this->assertEquals($transport, $factory->create($dsn));
-        if (str_contains('smtp', $dsn->getScheme())) {
+        if (\in_array($dsn->getScheme(), ['smtp', 'smtps'], true)) {
             $this->assertStringMatchesFormat($dsn->getScheme().'://%S'.$dsn->getHost().'%S', (string) $transport);
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`TransportFactoryTestCase::testCreate()` checks that an SMTP DSN keeps its scheme and its host in the transport it creates. The condition has its arguments the wrong way round:

```php
if (str_contains('smtp', $dsn->getScheme())) {
```

This asks whether the scheme is a substring of `smtp`, so it is true only for the `smtp` scheme and false for `smtps`. Every `smtps` data set skipped the assertion. `EsmtpTransportFactoryTest` ran 18 assertions; it runs 31 now.

Swapping the two arguments is not the fix. `mailgun+smtp` and every other bridge scheme would then be checked too, and none of them can pass: a bridge DSN reads `mailgun+smtp://KEY@default` while the transport it builds renders as `smtp://smtp.mailgun.org:587`. The assertion only holds for the schemes the native SMTP factory handles, so the condition now names them.

The assertion is load-bearing again: with `SmtpTransport::__toString()` mutated to drop the `s` of `smtps`, the test case stays green on 6.4 and reports 13 failures with this patch.

Ran `Mailer` (166 tests) and every mailer bridge on 6.4, all green.

Merge-up note: on 7.4 and above `testCreate()` sits in `AbstractTransportFactoryTestCase`, so the same one-line change goes there and the 6.4 shim keeps nothing.
