### PR TITLE
[Scheduler] Fix infinite loop in MessageGenerator when a trigger does not move the run date forward

### DIFF
--- a/src/Symfony/Component/Scheduler/Generator/MessageGenerator.php
+++ b/src/Symfony/Component/Scheduler/Generator/MessageGenerator.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Scheduler\Generator;
 
 use Psr\Clock\ClockInterface;
 use Symfony\Component\Clock\Clock;
+use Symfony\Component\Scheduler\Exception\LogicException;
 use Symfony\Component\Scheduler\RecurringMessage;
 use Symfony\Component\Scheduler\Schedule;
 use Symfony\Component\Scheduler\ScheduleProviderInterface;
@@ -76,6 +77,10 @@ final class MessageGenerator implements MessageGeneratorInterface
             }
 
             if ($nextTime = $trigger->getNextRunDate($time)) {
+                if ($nextTime <= $time) {
+                    throw new LogicException(\sprintf('The "%s" trigger does not move the run date forward. Its "getNextRunDate()" method must return a date strictly after the given one.', $trigger));
+                }
+
                 $heap->insert([$nextTime, $index, $recurringMessage]);
             }
 

--- a/src/Symfony/Component/Scheduler/Tests/Generator/MessageGeneratorTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/Generator/MessageGeneratorTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Scheduler\Tests\Generator;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Clock\MockClock;
+use Symfony\Component\Scheduler\Exception\LogicException;
 use Symfony\Component\Scheduler\Generator\Checkpoint;
 use Symfony\Component\Scheduler\Generator\MessageContext;
 use Symfony\Component\Scheduler\Generator\MessageGenerator;
@@ -244,6 +245,30 @@ class MessageGeneratorTest extends TestCase
         // The "second" message at 22:12:30 was never yielded. It must be picked up now
         // instead of being silently dropped to the next interval at 22:13:00.
         $this->assertSame([$second], iterator_to_array($scheduler2->getMessages(), false));
+    }
+
+    public function testThrowsWhenTriggerDoesNotMoveTheRunDateForward()
+    {
+        $clock = new MockClock(self::makeDateTime('22:12:00'));
+
+        $trigger = $this->createStub(TriggerInterface::class);
+        $trigger->method('__toString')->willReturn('frozen');
+        $trigger->method('getNextRunDate')->willReturn(self::makeDateTime('22:13:00'));
+
+        $schedule = (new Schedule())->add(RecurringMessage::trigger($trigger, (object) []));
+        $schedule->stateful(new ArrayAdapter());
+
+        $scheduler = new MessageGenerator($schedule, 'dummy', $clock);
+
+        // Warmup. The first run always returns nothing.
+        $this->assertSame([], iterator_to_array($scheduler->getMessages(), false));
+
+        $clock->sleep(2 * 60);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('The "frozen" trigger does not move the run date forward.');
+
+        iterator_to_array($scheduler->getMessages(), false);
     }
 
     public static function messagesProvider(): \Generator


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65543
| License       | MIT

`MessageGenerator::getMessages()` puts whatever date a trigger returns straight back into its heap. When that date is not later than the one just used, the entry stays due and the `while` loop keeps extracting it. The worker then spins with no message and no error.

#65469 fixed this for `PeriodicalTrigger`, but every trigger reaches the generator, so `CallbackTrigger` or any other `TriggerInterface` implementation can still hang it. `JitterTrigger` breaks out of its own loop and then returns a date that is not later than `$run`, which hands the same problem over.

`getNextRunDate()` is documented to return a date strictly after `$run`, so the generator now checks that before the insert and throws, naming the trigger:

> The "every Monday" trigger does not move the run date forward. Its "getNextRunDate()" method must return a date strictly after the given one.

`LogicException` rather than the `InvalidArgumentException` of #65469, because nothing was passed in wrong here: the trigger implementation breaks its own interface contract, like the other `LogicException`s in this component.

Skipping the insert instead would end the loop, but the task would then disappear from the schedule with no message and no error, which is the silent failure again.

The second insert, in `heap()`, needs no check. It runs once per recurring message inside a `foreach`, so it cannot spin on its own, and a stale date it inserts is caught on the first extraction in `getMessages()`.

On 7.4 and up the check belongs right after `$nextTime = $trigger->getNextRunDate($time);`, not next to the `if ($nextTime)` insert, because the `shouldProcessOnlyLastMissedRun()` loop sits in between and would hang before the check is reached. That loop calls `getNextRunDate()` itself and needs the same guard; I'll send it as a follow-up against 7.4 once this lands.
