### PR TITLE
[VarDumper] Fix division by zero when dumping a DatePeriod whose interval does not move forward

### DIFF
--- a/src/Symfony/Component/VarDumper/Caster/DateCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/DateCaster.php
@@ -104,11 +104,18 @@ class DateCaster
         $dates = [];
         foreach (clone $p as $i => $d) {
             if (self::PERIOD_LIMIT === $i) {
+                if (!$end = $p->getEndDate()) {
+                    $dates[] = \sprintf('%s more', $p->recurrences - $i);
+                    break;
+                }
+
                 $now = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
-                $dates[] = \sprintf('%s more', ($end = $p->getEndDate())
-                    ? ceil(($end->format('U.u') - $d->format('U.u')) / ((int) $now->add($p->getDateInterval())->format('U.u') - (int) $now->format('U.u')))
-                    : $p->recurrences - $i
-                );
+                $numberOfSeconds = (float) $now->add($p->getDateInterval())->format('U.u') - (float) $now->format('U.u');
+
+                if (0 < $numberOfSeconds) {
+                    $dates[] = \sprintf('%s more', ceil(($end->format('U.u') - $d->format('U.u')) / $numberOfSeconds));
+                }
+
                 break;
             }
             $dates[] = \sprintf('%s) %s', $i + 1, self::formatDateTime($d));

--- a/src/Symfony/Component/VarDumper/Tests/Caster/DateCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/DateCasterTest.php
@@ -450,6 +450,40 @@ class DateCasterTest extends TestCase
         $this->assertDumpMatchesFormat($xDump, $cast["\0~\0period"]);
     }
 
+    /**
+     * @dataProvider provideNonForwardIntervals
+     */
+    public function testCastPeriodWithNonForwardInterval($interval, $xDates)
+    {
+        $p = new \DatePeriod(new \DateTimeImmutable('2017-01-01', new \DateTimeZone('UTC')), $interval, new \DateTimeImmutable('2018-01-01', new \DateTimeZone('UTC')));
+        $stub = new Stub();
+
+        $cast = DateCaster::castPeriod($p, [], $stub, false, 0);
+
+        $this->assertSame($xDates, $cast["\0~\0period"]->value);
+    }
+
+    public static function provideNonForwardIntervals()
+    {
+        $sameDate = "1) 2017-01-01 00:00:00.0\n2) 2017-01-01 00:00:00.0\n3) 2017-01-01 00:00:00.0";
+
+        return [
+            [new \DateInterval('PT0S'), $sameDate],
+            [new \DateInterval('P0D'), $sameDate],
+            [\DateInterval::createFromDateString('1 day ago'), "1) 2017-01-01 00:00:00.0\n2) 2016-12-31 00:00:00.0\n3) 2016-12-30 00:00:00.0"],
+        ];
+    }
+
+    public function testCastPeriodWithSubSecondInterval()
+    {
+        $p = new \DatePeriod(new \DateTimeImmutable('2017-01-01', new \DateTimeZone('UTC')), \DateInterval::createFromDateString('500 milliseconds'), new \DateTimeImmutable('2017-01-02', new \DateTimeZone('UTC')));
+        $stub = new Stub();
+
+        $cast = DateCaster::castPeriod($p, [], $stub, false, 0);
+
+        $this->assertSame("1) 2017-01-01 00:00:00.0\n2) 2017-01-01 00:00:00.500\n3) 2017-01-01 00:00:01.0\n172797 more", $cast["\0~\0period"]->value);
+    }
+
     public static function providePeriods()
     {
         $periods = [
@@ -473,6 +507,8 @@ class DateCasterTest extends TestCase
 
             ['2017-01-01', 'P1D', '2017-01-04', \DatePeriod::EXCLUDE_START_DATE, 'every + 1d, from ]2017-01-01 00:00:00.0 to 2017-01-04 00:00:00.0[', '1) 2017-01-02%a2) 2017-01-03'],
             ['2017-01-01', 'P1D', 2, \DatePeriod::EXCLUDE_START_DATE, 'every + 1d, from ]2017-01-01 00:00:00.0 recurring 2 time/s', '1) 2017-01-02%a2) 2017-01-03'],
+
+            ['2017-01-01', 'PT0S', '2017-01-05', 0, 'every 0s, from [2017-01-01 00:00:00.0 to 2017-01-05 00:00:00.0[', '1) 2017-01-01%a2) 2017-01-01%a3) 2017-01-01'],
         ];
 
         return $periods;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65545
| License       | MIT

`DateCaster::castPeriod()` counts the remaining dates of a `DatePeriod` by dividing the distance to the end date by the length of one step, and it measures that step by adding the interval to *now*. An interval that does not move the date forward, such as `PT0S`, gives a step of 0, so dumping the period fails with a `DivisionByZeroError`. A backwards interval gives a negative step and a meaningless count like `-367 more`.

The division now only happens when the step is positive. Otherwise the count is left out and the first three dates are still shown, since there is no finite number of remaining dates to report. The `recurrences` branch is untouched: it never divides, and it is only reached when at least one recurrence is left.

The two casts around the step were also `(int)` while the dividend is a float, which rounded any sub-second interval down to 0 and hit the same crash. They are floats now, so a period built with `DateInterval::createFromDateString('500 milliseconds')` gets a real count instead.

```php
dump(new DatePeriod(
    new DateTimeImmutable('today 10:00'),
    new DateInterval('PT0S'),
    new DateTimeImmutable('+1 year')
));
```

Before: `DivisionByZeroError: Division by zero`. After: the period dumps normally.
