### PR TITLE
[Tui] Share the terminal event dispatcher with Tui

### DIFF
--- a/src/Symfony/Component/Tui/CHANGELOG.md
+++ b/src/Symfony/Component/Tui/CHANGELOG.md
@@ -8,7 +8,7 @@ CHANGELOG
  * Add `AnsiUtils::sliceToWidth()` to extract a fixed-width range of columns from a line
  * Add `AbstractWidget::postRender()` to post-process a widget's finished lines, chrome included
  * Make `LoopClock` part of the public API
- * Dispatch paste lifecycle events through an optional terminal event dispatcher
+ * Dispatch paste lifecycle events through the terminal event dispatcher
  * Reuse unchanged rendered line segments during differential updates
  * Add `AbstractWidget::attachChild()` and `AbstractWidget::detachChild()` to wire child widgets
  * Add multi-select support to `SelectListWidget`

--- a/src/Symfony/Component/Tui/Terminal/TeeTerminal.php
+++ b/src/Symfony/Component/Tui/Terminal/TeeTerminal.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Tui\Terminal;
 
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
 /**
  * Terminal that delegates to multiple terminals simultaneously.
  *
@@ -36,6 +38,11 @@ final class TeeTerminal implements TerminalInterface
         private TerminalInterface $primary,
         private TerminalInterface $secondary,
     ) {
+    }
+
+    public function getEventDispatcher(): EventDispatcherInterface
+    {
+        return $this->primary->getEventDispatcher();
     }
 
     public function start(callable $onInput, callable $onResize, callable $onKittyProtocolActivated): void

--- a/src/Symfony/Component/Tui/Terminal/Terminal.php
+++ b/src/Symfony/Component/Tui/Terminal/Terminal.php
@@ -12,8 +12,9 @@
 namespace Symfony\Component\Tui\Terminal;
 
 use Revolt\EventLoop;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Tui\Input\StdinBuffer;
-use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
  * Real terminal implementation using stdin/stdout.
@@ -48,8 +49,13 @@ final class Terminal implements TerminalInterface
     private ?int $cachedRows = null;
 
     public function __construct(
-        private readonly ?EventDispatcherInterface $eventDispatcher = null,
+        private readonly EventDispatcherInterface $eventDispatcher = new EventDispatcher(),
     ) {
+    }
+
+    public function getEventDispatcher(): EventDispatcherInterface
+    {
+        return $this->eventDispatcher;
     }
 
     public function start(callable $onInput, callable $onResize, callable $onKittyProtocolActivated): void

--- a/src/Symfony/Component/Tui/Terminal/TerminalInterface.php
+++ b/src/Symfony/Component/Tui/Terminal/TerminalInterface.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Tui\Terminal;
 
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
 /**
  * Interface for terminal implementations.
  *
@@ -34,6 +36,11 @@ interface TerminalInterface
      * @param callable(): void       $onKittyProtocolActivated Called when Kitty keyboard protocol is detected
      */
     public function start(callable $onInput, callable $onResize, callable $onKittyProtocolActivated): void;
+
+    /**
+     * Get the event dispatcher used for terminal events.
+     */
+    public function getEventDispatcher(): EventDispatcherInterface;
 
     /**
      * Stop the terminal and restore original state.

--- a/src/Symfony/Component/Tui/Terminal/VirtualTerminal.php
+++ b/src/Symfony/Component/Tui/Terminal/VirtualTerminal.php
@@ -11,8 +11,9 @@
 
 namespace Symfony\Component\Tui\Terminal;
 
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Tui\Input\StdinBuffer;
-use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
  * Virtual terminal for testing.
@@ -41,8 +42,13 @@ final class VirtualTerminal implements TerminalInterface
         private int $columns = 80,
         private int $rows = 24,
         private bool $kittyProtocolActive = false,
-        private readonly ?EventDispatcherInterface $eventDispatcher = null,
+        private readonly EventDispatcherInterface $eventDispatcher = new EventDispatcher(),
     ) {
+    }
+
+    public function getEventDispatcher(): EventDispatcherInterface
+    {
+        return $this->eventDispatcher;
     }
 
     public function start(callable $onInput, callable $onResize, callable $onKittyProtocolActivated): void

--- a/src/Symfony/Component/Tui/Tests/TuiTest.php
+++ b/src/Symfony/Component/Tui/Tests/TuiTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Tui\Tests;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Tui\Ansi\AnsiUtils;
 use Symfony\Component\Tui\Event\InputEvent;
 use Symfony\Component\Tui\Event\TickEvent;
@@ -31,6 +32,17 @@ use Symfony\Component\Tui\Widget\TextWidget;
 
 class TuiTest extends TestCase
 {
+    public function testRejectsTerminalUsingDifferentEventDispatcher()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The terminal must use the TUI event dispatcher.');
+
+        new Tui(
+            terminal: new VirtualTerminal(),
+            eventDispatcher: new EventDispatcher(),
+        );
+    }
+
     public function testBasicRender()
     {
         $terminal = new VirtualTerminal(40, 10);

--- a/src/Symfony/Component/Tui/Tests/Widget/EditorTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/EditorTest.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Tui\Tests\Widget;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Tui\Ansi\AnsiUtils;
 use Symfony\Component\Tui\Event\ChangeEvent;
 use Symfony\Component\Tui\Event\PasteCompletedEvent;
@@ -110,9 +109,8 @@ class EditorTest extends TestCase
 
     public function testPasteLifecycleEventsAreDispatchedWhilePasteIsReceived()
     {
-        $dispatcher = new EventDispatcher();
-        $terminal = new VirtualTerminal(80, 24, eventDispatcher: $dispatcher);
-        $tui = new Tui(terminal: $terminal, eventDispatcher: $dispatcher);
+        $terminal = new VirtualTerminal(80, 24);
+        $tui = new Tui(terminal: $terminal);
         $editor = new EditorWidget();
         $events = [];
 

--- a/src/Symfony/Component/Tui/Tui.php
+++ b/src/Symfony/Component/Tui/Tui.php
@@ -84,7 +84,8 @@ class Tui implements RenderRequestorInterface, TickRuntimeInterface
     private ?Suspension $runSuspension = null;
 
     /**
-     * @param Renderer|null $renderer @internal Override the default renderer; framework-internal use only
+     * @param Renderer|null                 $renderer        @internal Override the default renderer; framework-internal use only
+     * @param EventDispatcherInterface|null $eventDispatcher Reference dispatcher; the terminal must use the same instance
      */
     public function __construct(
         ?StyleSheet $styleSheet = null,
@@ -94,8 +95,12 @@ class Tui implements RenderRequestorInterface, TickRuntimeInterface
         ?Renderer $renderer = null,
         ?EventDispatcherInterface $eventDispatcher = null,
     ) {
-        $this->eventDispatcher = $eventDispatcher ?? new EventDispatcher();
+        $this->eventDispatcher = $eventDispatcher ?? $terminal?->getEventDispatcher() ?? new EventDispatcher();
         $this->terminal = $terminal ?? new Terminal($this->eventDispatcher);
+
+        if ($this->eventDispatcher !== $this->terminal->getEventDispatcher()) {
+            throw new InvalidArgumentException('The terminal must use the TUI event dispatcher.');
+        }
         $this->keybindings = $keybindings ?? new Keybindings();
         $this->root = new ContainerWidget();
         $this->root->expandVertically(true);
@@ -323,15 +328,14 @@ class Tui implements RenderRequestorInterface, TickRuntimeInterface
     }
 
     /**
-     * Register a listener for a widget event.
+     * Register a listener for a TUI event.
      *
      * The event class is inferred from the listener's first parameter type hint:
      *
      *     $tui->addListener(function (InputEvent $event) { ... });
      *
-     * This is the primary way to react to widget events (submit, cancel,
-     * change, select, etc.). All events dispatched by any widget in the
-     * tree are routed through this single dispatcher.
+     * This is the primary way to react to widget and lifecycle events. All
+     * events are routed through a single dispatcher.
      *
      * Use {@see AbstractEvent::getTarget()} to filter by source widget when
      * listening for a shared event type like CancelEvent.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Related to #65384 <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

Make terminals expose their event dispatcher and ensure each TUI and its terminal share the TUI dispatcher so terminal-originated events always reach TUI listeners.
