### PR TITLE
[Validator] Review Brazilian Portuguese translations

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.pt_BR.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.pt_BR.xlf
@@ -572,11 +572,11 @@
             </trans-unit>
             <trans-unit id="147">
                 <source>The referenced entity does not exist.</source>
-                <target state="needs-review-translation">A entidade referenciada não existe.</target>
+                <target>A entidade referenciada não existe.</target>
             </trans-unit>
             <trans-unit id="148" resname="This is not a valid ULID.">
                 <source>This value is not a valid ULID.</source>
-                <target state="needs-review-translation">Este valor não é um ULID válido.</target>
+                <target>Este valor não é um ULID válido.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65551
| License       | MIT

As a native Brazilian Portuguese speaker, I reviewed the translations for the referenced entity and ULID validation messages. Both match the terminology and tone of the existing catalog, so this removes their `state="needs-review-translation"` markers.

The updated file and all 57 Validator XLIFF catalogs pass XML and XLIFF 1.2 schema validation.
