### PR TITLE
[Validator] Review French translations

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.fr.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.fr.xlf
@@ -572,11 +572,11 @@
             </trans-unit>
             <trans-unit id="147">
                 <source>The referenced entity does not exist.</source>
-                <target state="needs-review-translation">L'entité référencée n'existe pas.</target>
+                <target>L'entité référencée n'existe pas.</target>
             </trans-unit>
             <trans-unit id="148" resname="This is not a valid ULID.">
                 <source>This value is not a valid ULID.</source>
-                <target state="needs-review-translation">Cette valeur n'est pas un ULID valide.</target>
+                <target>Cette valeur n'est pas un ULID valide.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65555
| License       | MIT

Reviews the two French translations flagged as `needs-review-translation` in `validators.fr.xlf`, as a native speaker:

- `The referenced entity does not exist.` -> `L'entité référencée n'existe pas.`
- `This is not a valid ULID.` -> `Cette valeur n'est pas un ULID valide.` (same wording as the existing UUID entry)

Both translations were already correct, so this only removes the `state` attributes.
