### PR TITLE
[Form] Apply the guessed "pattern" and "maxlength" attributes to the types rendered as text inputs

### DIFF
--- a/src/Symfony/Component/Form/FormFactory.php
+++ b/src/Symfony/Component/Form/FormFactory.php
@@ -11,7 +11,12 @@
 
 namespace Symfony\Component\Form;
 
+use Symfony\Component\Form\Extension\Core\Type\ColorType;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\Form\Extension\Core\Type\MoneyType;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
+use Symfony\Component\Form\Extension\Core\Type\PercentType;
+use Symfony\Component\Form\Extension\Core\Type\RangeType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 
 class FormFactory implements FormFactoryInterface
@@ -107,7 +112,14 @@ class FormFactory implements FormFactoryInterface
         $resolvedType = $this->registry->getType($type);
 
         do {
-            if ($resolvedType->getInnerType() instanceof TextType) {
+            $innerType = $resolvedType->getInnerType();
+
+            // both descend from TextType but render their own input types
+            if ($innerType instanceof RangeType || $innerType instanceof ColorType) {
+                return false;
+            }
+
+            if ($innerType instanceof TextType || $innerType instanceof NumberType || $innerType instanceof MoneyType || $innerType instanceof PercentType) {
                 return true;
             }
         } while ($resolvedType = $resolvedType->getParent());

--- a/src/Symfony/Component/Form/Tests/FormFactoryTest.php
+++ b/src/Symfony/Component/Form/Tests/FormFactoryTest.php
@@ -13,7 +13,9 @@ namespace Symfony\Component\Form\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
+use Symfony\Component\Form\Extension\Core\Type\RangeType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormFactory;
 use Symfony\Component\Form\FormRegistry;
@@ -179,6 +181,30 @@ class FormFactoryTest extends TestCase
         $builder = $this->factory->createBuilderForProperty('Application\Author', 'firstName', null, ['attr' => ['maxlength' => 11]]);
 
         $this->assertSame(['maxlength' => 11], $builder->getOption('attr'));
+    }
+
+    public function testCreateBuilderUsesMaxLengthAndPatternForTypesRenderedAsTextInputs()
+    {
+        $this->guesser1->configureTypeGuess(NumberType::class, [], Guess::HIGH_CONFIDENCE);
+        $this->guesser1->configureMaxLengthGuess(4, Guess::HIGH_CONFIDENCE);
+        $this->guesser2->configurePatternGuess('.{1,}', Guess::HIGH_CONFIDENCE);
+
+        $builder = $this->factory->createBuilderForProperty('Application\Author', 'firstName');
+
+        $this->assertSame(['maxlength' => 4, 'pattern' => '.{1,}'], $builder->getOption('attr'));
+        $this->assertInstanceOf(NumberType::class, $builder->getType()->getInnerType());
+    }
+
+    public function testCreateBuilderIgnoresMaxLengthAndPatternForChildrenOfTextTypeRenderedAsOtherInputs()
+    {
+        $this->guesser1->configureTypeGuess(RangeType::class, [], Guess::HIGH_CONFIDENCE);
+        $this->guesser1->configureMaxLengthGuess(20, Guess::HIGH_CONFIDENCE);
+        $this->guesser2->configurePatternGuess('.{5,}', Guess::HIGH_CONFIDENCE);
+
+        $builder = $this->factory->createBuilderForProperty('Application\Author', 'firstName');
+
+        $this->assertSame([], $builder->getOption('attr'));
+        $this->assertInstanceOf(RangeType::class, $builder->getType()->getInnerType());
     }
 
     public function testCreateBuilderUsesRequiredSettingWithHighestConfidence()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Follow-up on #65505, which stopped applying the guessed `pattern` and `maxlength` attributes to types other than text inputs. It decides that with `isTextInput()`, which walks the parent chain looking for `TextType`. Descending from `TextType` and rendering a text input are not the same thing, and the two sets differ in both directions.

`NumberType` renders `type="text"` on purpose, because `type="number"` does not accept localized floats, but it extends `AbstractType`, so it stopped receiving both attributes. This path is reachable with the default guessers: a single `#[Assert\Range(min: 1, max: 1000)]` guesses `NumberType`, a `maxlength` of `strlen((string) $max)` and a `pattern` of `.{1,}`, all three from that one constraint. So a number field that carried a working `maxlength` until 6.4.x now renders without one. `MoneyType` and `PercentType` render text inputs too and are in the same position, reachable through a custom guesser.

`RangeType` and `ColorType` are the mirror case: both return `TextType::class` from `getParent()` while rendering `type="range"` and `type="color"`, where neither attribute applies. They kept receiving attributes that #65505 set out to remove. No built-in guesser returns them, so this half is only reachable through a custom guesser or a type that extends them.

`isTextInput()` now tests what the widget renders instead of what the type extends: `RangeType` and `ColorType` are excluded before the parent walk reaches `TextType`, and `NumberType`, `MoneyType` and `PercentType` join `TextType` as text inputs. Types extending any of them inherit the right answer, which the tests cover through the parent chain.

`TextareaType` is unchanged. It still descends from `TextType` and still relies on its own `pattern` stripping in `buildView()`.

Checks run on PHP 8.4 with PHPUnit 9.6:

* the two new tests in `FormFactoryTest` fail on the parent commit with the expected errors and pass with the fix: `NumberType` gets `[]` instead of `['maxlength' => 4, 'pattern' => '.{1,}']`, and `RangeType` gets `['maxlength' => 20, 'pattern' => '.{5,}']` instead of `[]`.
* `./phpunit src/Symfony/Component/Form`: 4755 tests, 359 skipped, 8 incomplete, no failure.
* `./phpunit src/Symfony/Bridge/Twig`: 1756 tests, 14 skipped, 1 error. The error is `TemplatedEmailTest::testSymfonySerialize` failing on a local `phpdocumentor/reflection-docblock` v6 install, present on the parent commit as well and unrelated to forms.
* probed the resolved answer for every core type: `TextType`, `PasswordType`, `SearchType`, `EmailType`, `UrlType`, `TelType`, `TextareaType`, `NumberType`, `MoneyType` and `PercentType` are text inputs; `IntegerType` (renders `type="number"`), `RangeType`, `ColorType`, `ChoiceType`, `DateType` and `CheckboxType` are not. A custom type extending `RangeType` is excluded and one extending `NumberType` is included.
