### PR TITLE
[TypeInfo] Fix resolving constants defined on interfaces

### DIFF
--- a/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyWithConstantsInterface.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyWithConstantsInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\TypeInfo\Tests\Fixtures;
+
+interface DummyWithConstantsInterface
+{
+    public const DUMMY_STRING_A = 'a';
+    public const DUMMY_INT_A = 1;
+}

--- a/src/Symfony/Component/TypeInfo/Tests/TypeResolver/StringTypeResolverTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/TypeResolver/StringTypeResolverTest.php
@@ -22,6 +22,7 @@ use Symfony\Component\TypeInfo\Tests\Fixtures\DummyBackedEnumInterface;
 use Symfony\Component\TypeInfo\Tests\Fixtures\DummyCollection;
 use Symfony\Component\TypeInfo\Tests\Fixtures\DummyEnum;
 use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithConstants;
+use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithConstantsInterface;
 use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithTemplates;
 use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithTemplateTypeAlias;
 use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithTypeAliases;
@@ -131,6 +132,11 @@ class StringTypeResolverTest extends TestCase
         yield [Type::array(null, Type::union(Type::int(), Type::string())), DummyWithConstants::class.'::DUMMY_ARRAY_*'];
         yield [Type::enum(DummyEnum::class, Type::string()), DummyWithConstants::class.'::DUMMY_ENUM_*'];
         yield [Type::union(Type::enum(DummyEnum::class, Type::string()), Type::array(Type::mixed(), Type::union(Type::int(), Type::string())), Type::string(), Type::int(), Type::float(), Type::bool(), Type::null()), DummyWithConstants::class.'::DUMMY_MIX_*'];
+
+        // const fetch on interface
+        yield [Type::string(), DummyWithConstantsInterface::class.'::DUMMY_STRING_*'];
+        yield [Type::int(), DummyWithConstantsInterface::class.'::DUMMY_INT_*'];
+        yield [Type::array(Type::string(), Type::string()), 'array<'.DummyWithConstantsInterface::class.'::DUMMY_STRING_*, '.DummyWithConstantsInterface::class.'::DUMMY_STRING_*>'];
 
         // identifiers
         yield [Type::bool(), 'bool'];

--- a/src/Symfony/Component/TypeInfo/TypeResolver/StringTypeResolver.php
+++ b/src/Symfony/Component/TypeInfo/TypeResolver/StringTypeResolver.php
@@ -157,7 +157,7 @@ final class StringTypeResolver implements TypeResolverInterface
                     $className = $classType->getClassName();
                 }
 
-                if (!class_exists($className)) {
+                if (!class_exists($className) && !interface_exists($className)) {
                     return Type::mixed();
                 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

When a PHPDoc references a class constant that is declared on an interface, `StringTypeResolver` resolves it to `Type::mixed()` instead of the type of the constant value.

```php
interface Foo
{
    public const BAR_A = 'a';
}

// resolves to "mixed" instead of "string"
(new StringTypeResolver())->resolve(Foo::class.'::BAR_*');
```

Since the key type resolves to `mixed`, a collection keyed by such a constant fails:

```
Symfony\Component\TypeInfo\Exception\InvalidArgumentException: "mixed" is not a valid array key type.
```

The constant name is resolved to a class name, then guarded by `class_exists()`, which is false for an interface. The guard now accepts interfaces too.
