### PR TITLE
[Notifier] Fix SendFailedMessageToNotifierListener rejecting any notifier but the concrete one

### DIFF
--- a/src/Symfony/Component/Notifier/EventListener/SendFailedMessageToNotifierListener.php
+++ b/src/Symfony/Component/Notifier/EventListener/SendFailedMessageToNotifierListener.php
@@ -15,7 +15,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
 use Symfony\Component\Messenger\Exception\HandlerFailedException;
 use Symfony\Component\Notifier\Notification\Notification;
-use Symfony\Component\Notifier\Notifier;
+use Symfony\Component\Notifier\NotifierInterface;
 
 /**
  * Sends a rejected message to the notifier.
@@ -24,9 +24,9 @@ use Symfony\Component\Notifier\Notifier;
  */
 class SendFailedMessageToNotifierListener implements EventSubscriberInterface
 {
-    private Notifier $notifier;
+    private NotifierInterface $notifier;
 
-    public function __construct(Notifier $notifier)
+    public function __construct(NotifierInterface $notifier)
     {
         $this->notifier = $notifier;
     }
@@ -49,7 +49,9 @@ class SendFailedMessageToNotifierListener implements EventSubscriberInterface
         $notification = Notification::fromThrowable($throwable)->importance(Notification::IMPORTANCE_HIGH);
         $notification->subject(\sprintf('A "%s" message has just failed: %s.', $envelope->getMessage()::class, $notification->getSubject()));
 
-        $this->notifier->send($notification, ...$this->notifier->getAdminRecipients());
+        $recipients = method_exists($this->notifier, 'getAdminRecipients') ? $this->notifier->getAdminRecipients() : [];
+
+        $this->notifier->send($notification, ...$recipients);
     }
 
     public static function getSubscribedEvents(): array

--- a/src/Symfony/Component/Notifier/Tests/EventListener/SendFailedMessageToNotifierListenerTest.php
+++ b/src/Symfony/Component/Notifier/Tests/EventListener/SendFailedMessageToNotifierListenerTest.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Tests\EventListener;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
+use Symfony\Component\Notifier\EventListener\SendFailedMessageToNotifierListener;
+use Symfony\Component\Notifier\Notification\Notification;
+use Symfony\Component\Notifier\NotifierInterface;
+use Symfony\Component\Notifier\Recipient\Recipient;
+use Symfony\Component\Notifier\Recipient\RecipientInterface;
+
+class SendFailedMessageToNotifierListenerTest extends TestCase
+{
+    public function testItSendsWithoutAdminRecipients()
+    {
+        $notifier = new class implements NotifierInterface {
+            public ?Notification $notification = null;
+            public array $recipients = [];
+
+            public function send(Notification $notification, RecipientInterface ...$recipients): void
+            {
+                $this->notification = $notification;
+                $this->recipients = $recipients;
+            }
+        };
+
+        (new SendFailedMessageToNotifierListener($notifier))->onMessageFailed($this->createEvent(new \RuntimeException('Boom')));
+
+        $this->assertSame('A "stdClass" message has just failed: RuntimeException: Boom.', $notifier->notification->getSubject());
+        $this->assertSame(Notification::IMPORTANCE_HIGH, $notifier->notification->getImportance());
+        $this->assertSame([], $notifier->recipients);
+    }
+
+    public function testItSendsToAdminRecipients()
+    {
+        $notifier = new class implements NotifierInterface {
+            public array $adminRecipients = [];
+            public array $recipients = [];
+
+            public function send(Notification $notification, RecipientInterface ...$recipients): void
+            {
+                $this->recipients = $recipients;
+            }
+
+            public function getAdminRecipients(): array
+            {
+                return $this->adminRecipients;
+            }
+        };
+        $recipient = new Recipient('admin@example.com');
+        $notifier->adminRecipients = [$recipient];
+
+        (new SendFailedMessageToNotifierListener($notifier))->onMessageFailed($this->createEvent(new \RuntimeException('Boom')));
+
+        $this->assertSame([$recipient], $notifier->recipients);
+    }
+
+    public function testItSendsNothingWhenTheMessageWillBeRetried()
+    {
+        $notifier = new class implements NotifierInterface {
+            public bool $sent = false;
+
+            public function send(Notification $notification, RecipientInterface ...$recipients): void
+            {
+                $this->sent = true;
+            }
+        };
+
+        $event = $this->createEvent(new \RuntimeException('Boom'));
+        $event->setForRetry();
+
+        (new SendFailedMessageToNotifierListener($notifier))->onMessageFailed($event);
+
+        $this->assertFalse($notifier->sent);
+    }
+
+    private function createEvent(\Throwable $throwable): WorkerMessageFailedEvent
+    {
+        return new WorkerMessageFailedEvent(new Envelope(new \stdClass()), 'receiver', $throwable);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #42809
| License       | MIT

Follow-up to #65488, for the second consumer of `getAdminRecipients()`.

`SendFailedMessageToNotifierListener` type-hints the concrete `Notifier` class, while FrameworkBundle
wires it with the `notifier` service, whose public contract is `NotifierInterface`. Decorating that
service with a class that implements the interface makes the container fail:

```
TypeError: Symfony\Component\Notifier\EventListener\SendFailedMessageToNotifierListener::__construct():
Argument #1 ($notifier) must be of type Symfony\Component\Notifier\Notifier, App\Notifier\MyNotifier given
```

The failure is not the one reported in #42809 (there, the handler calls a method the interface does not
declare), but it has the same cause: `getAdminRecipients()` is declared on the concrete class only, so
this listener pinned itself to that class to be able to call it.

The listener now accepts any `NotifierInterface`, and reads the admin recipients only from a notifier
that provides them. Widening a constructor parameter type is safe for callers, and the concrete
`Notifier` still goes through the same path, so the default setup keeps behaving the same.

Checks that were run:

* `./phpunit src/Symfony/Component/Notifier`: OK, 2030 tests, 2963 assertions, 67 skipped, 1 incomplete.
  The same command on the base commit gives 2027 tests, 2958 assertions.
* The three new tests against the unpatched listener: all fail at construction with the `TypeError`
  above. `testItSendsWithoutAdminRecipients` and `testItSendsToAdminRecipients` cover the change itself;
  `testItSendsNothingWhenTheMessageWillBeRetried` covers existing behavior that had no test, since this
  listener had no test file at all.
* php-cs-fixer with the repository config on the two files: no change to make.
