### PR TITLE
[Notifier] Add AdminRecipientsProviderInterface

### DIFF
--- a/UPGRADE-8.2.md
+++ b/UPGRADE-8.2.md
@@ -133,6 +133,7 @@ Notifier
 --------
 
  * Deprecate `NovuSubscriberRecipient::getOverrides()` and its `$overrides` constructor parameter, pass overrides to `NovuOptions` instead
+ * Deprecate declaring `getAdminRecipients()` on a `NotifierInterface` implementation without implementing `AdminRecipientsProviderInterface`
 
 Scheduler
 ---------

--- a/src/Symfony/Bridge/Monolog/Handler/NotifierHandler.php
+++ b/src/Symfony/Bridge/Monolog/Handler/NotifierHandler.php
@@ -15,6 +15,7 @@ use Monolog\Handler\AbstractHandler;
 use Monolog\Level;
 use Monolog\Logger;
 use Monolog\LogRecord;
+use Symfony\Component\Notifier\AdminRecipientsProviderInterface;
 use Symfony\Component\Notifier\Notification\Notification;
 use Symfony\Component\Notifier\NotifierInterface;
 
@@ -62,7 +63,22 @@ final class NotifierHandler extends AbstractHandler
 
         $notification->importanceFromLogLevelName($record->level->getName());
 
-        $this->notifier->send($notification, ...$this->notifier->getAdminRecipients());
+        $this->notifier->send($notification, ...$this->getAdminRecipients());
+    }
+
+    private function getAdminRecipients(): array
+    {
+        if ($this->notifier instanceof AdminRecipientsProviderInterface) {
+            return $this->notifier->getAdminRecipients();
+        }
+
+        if (!method_exists($this->notifier, 'getAdminRecipients')) {
+            return [];
+        }
+
+        trigger_deprecation('symfony/notifier', '8.2', 'Declaring "getAdminRecipients()" on "%s" without implementing "%s" is deprecated.', get_debug_type($this->notifier), AdminRecipientsProviderInterface::class);
+
+        return $this->notifier->getAdminRecipients();
     }
 
     private function getHighestRecord(array $records): array|LogRecord

--- a/src/Symfony/Bridge/Monolog/Tests/Handler/NotifierHandlerTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Handler/NotifierHandlerTest.php
@@ -1,0 +1,123 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Monolog\Tests\Handler;
+
+use Monolog\Level;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\Monolog\Handler\NotifierHandler;
+use Symfony\Bridge\Monolog\Tests\RecordFactory;
+use Symfony\Component\Notifier\AdminRecipientsProviderInterface;
+use Symfony\Component\Notifier\Notification\Notification;
+use Symfony\Component\Notifier\NotifierInterface;
+use Symfony\Component\Notifier\Recipient\Recipient;
+use Symfony\Component\Notifier\Recipient\RecipientInterface;
+
+class NotifierHandlerTest extends TestCase
+{
+    public function testHandleWithoutAdminRecipients()
+    {
+        $notifier = new class implements NotifierInterface {
+            public ?Notification $notification = null;
+            public array $recipients = [];
+
+            public function send(Notification $notification, RecipientInterface ...$recipients): void
+            {
+                $this->notification = $notification;
+                $this->recipients = $recipients;
+            }
+        };
+
+        (new NotifierHandler($notifier))->handle(RecordFactory::create(Level::Error, 'Something went wrong'));
+
+        $this->assertSame('Something went wrong', $notifier->notification->getSubject());
+        $this->assertSame(Notification::IMPORTANCE_HIGH, $notifier->notification->getImportance());
+        $this->assertSame([], $notifier->recipients);
+    }
+
+    public function testHandleBatchWithoutAdminRecipients()
+    {
+        $notifier = new class implements NotifierInterface {
+            public ?Notification $notification = null;
+            public array $recipients = [];
+
+            public function send(Notification $notification, RecipientInterface ...$recipients): void
+            {
+                $this->notification = $notification;
+                $this->recipients = $recipients;
+            }
+        };
+
+        (new NotifierHandler($notifier))->handleBatch([
+            RecordFactory::create(Level::Warning, 'Not handled'),
+            RecordFactory::create(Level::Error, 'Something went wrong'),
+            RecordFactory::create(Level::Critical, 'Something went very wrong'),
+        ]);
+
+        $this->assertSame('Something went very wrong', $notifier->notification->getSubject());
+        $this->assertSame(Notification::IMPORTANCE_URGENT, $notifier->notification->getImportance());
+        $this->assertSame([], $notifier->recipients);
+    }
+
+    public function testHandleSendsToAdminRecipients()
+    {
+        $notifier = new class implements NotifierInterface, AdminRecipientsProviderInterface {
+            public array $adminRecipients = [];
+            public array $recipients = [];
+
+            public function send(Notification $notification, RecipientInterface ...$recipients): void
+            {
+                $this->recipients = $recipients;
+            }
+
+            public function getAdminRecipients(): array
+            {
+                return $this->adminRecipients;
+            }
+        };
+        $recipient = new Recipient('admin@example.com');
+        $notifier->adminRecipients = [$recipient];
+
+        (new NotifierHandler($notifier))->handle(RecordFactory::create(Level::Error, 'Something went wrong'));
+
+        $this->assertSame([$recipient], $notifier->recipients);
+    }
+
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
+    public function testHandleSendsToAdminRecipientsOfANotifierThatDoesNotImplementTheInterface()
+    {
+        $notifier = new class implements NotifierInterface {
+            public array $adminRecipients = [];
+            public array $recipients = [];
+
+            public function send(Notification $notification, RecipientInterface ...$recipients): void
+            {
+                $this->recipients = $recipients;
+            }
+
+            public function getAdminRecipients(): array
+            {
+                return $this->adminRecipients;
+            }
+        };
+        $recipient = new Recipient('admin@example.com');
+        $notifier->adminRecipients = [$recipient];
+
+        $this->expectUserDeprecationMessage(\sprintf('Since symfony/notifier 8.2: Declaring "getAdminRecipients()" on "%s" without implementing "Symfony\Component\Notifier\AdminRecipientsProviderInterface" is deprecated.', get_debug_type($notifier)));
+
+        (new NotifierHandler($notifier))->handle(RecordFactory::create(Level::Error, 'Something went wrong'));
+
+        $this->assertSame([$recipient], $notifier->recipients);
+    }
+}

--- a/src/Symfony/Bridge/Monolog/composer.json
+++ b/src/Symfony/Bridge/Monolog/composer.json
@@ -18,6 +18,7 @@
     "require": {
         "php": ">=8.4.1",
         "monolog/monolog": "^3",
+        "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/service-contracts": "^2.5|^3",
         "symfony/http-kernel": "^7.4|^8.0"
     },
@@ -28,6 +29,7 @@
         "symfony/mailer": "^7.4|^8.0",
         "symfony/messenger": "^7.4|^8.0",
         "symfony/mime": "^7.4|^8.0",
+        "symfony/notifier": "^7.4|^8.0",
         "symfony/var-dumper": "^7.4|^8.0"
     },
     "autoload": {

--- a/src/Symfony/Component/Notifier/AdminRecipientsProviderInterface.php
+++ b/src/Symfony/Component/Notifier/AdminRecipientsProviderInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier;
+
+use Symfony\Component\Notifier\Recipient\RecipientInterface;
+
+/**
+ * Provides the recipients that administrative notifications are sent to.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+interface AdminRecipientsProviderInterface
+{
+    /**
+     * @return RecipientInterface[]
+     */
+    public function getAdminRecipients(): array;
+}

--- a/src/Symfony/Component/Notifier/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add `AdminRecipientsProviderInterface`
+ * Deprecate declaring `getAdminRecipients()` without implementing `AdminRecipientsProviderInterface`
+
 8.0
 ---
 

--- a/src/Symfony/Component/Notifier/EventListener/SendFailedMessageToNotifierListener.php
+++ b/src/Symfony/Component/Notifier/EventListener/SendFailedMessageToNotifierListener.php
@@ -14,8 +14,9 @@ namespace Symfony\Component\Notifier\EventListener;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
 use Symfony\Component\Messenger\Exception\HandlerFailedException;
+use Symfony\Component\Notifier\AdminRecipientsProviderInterface;
 use Symfony\Component\Notifier\Notification\Notification;
-use Symfony\Component\Notifier\Notifier;
+use Symfony\Component\Notifier\NotifierInterface;
 
 /**
  * Sends a rejected message to the notifier.
@@ -25,7 +26,7 @@ use Symfony\Component\Notifier\Notifier;
 class SendFailedMessageToNotifierListener implements EventSubscriberInterface
 {
     public function __construct(
-        private Notifier $notifier,
+        private NotifierInterface $notifier,
     ) {
     }
 
@@ -44,7 +45,7 @@ class SendFailedMessageToNotifierListener implements EventSubscriberInterface
         $notification = Notification::fromThrowable($throwable)->importance(Notification::IMPORTANCE_HIGH);
         $notification->subject(\sprintf('A "%s" message has just failed: %s.', $envelope->getMessage()::class, $notification->getSubject()));
 
-        $this->notifier->send($notification, ...$this->notifier->getAdminRecipients());
+        $this->notifier->send($notification, ...$this->getAdminRecipients());
     }
 
     public static function getSubscribedEvents(): array
@@ -52,5 +53,20 @@ class SendFailedMessageToNotifierListener implements EventSubscriberInterface
         return [
             WorkerMessageFailedEvent::class => 'onMessageFailed',
         ];
+    }
+
+    private function getAdminRecipients(): array
+    {
+        if ($this->notifier instanceof AdminRecipientsProviderInterface) {
+            return $this->notifier->getAdminRecipients();
+        }
+
+        if (!method_exists($this->notifier, 'getAdminRecipients')) {
+            return [];
+        }
+
+        trigger_deprecation('symfony/notifier', '8.2', 'Declaring "getAdminRecipients()" on "%s" without implementing "%s" is deprecated.', get_debug_type($this->notifier), AdminRecipientsProviderInterface::class);
+
+        return $this->notifier->getAdminRecipients();
     }
 }

--- a/src/Symfony/Component/Notifier/Notifier.php
+++ b/src/Symfony/Component/Notifier/Notifier.php
@@ -24,7 +24,7 @@ use Symfony\Component\Notifier\Recipient\RecipientInterface;
 /**
  * @author Fabien Potencier <fabien@symfony.com>
  */
-final class Notifier implements NotifierInterface
+final class Notifier implements NotifierInterface, AdminRecipientsProviderInterface
 {
     private array $adminRecipients = [];
 
@@ -55,9 +55,6 @@ final class Notifier implements NotifierInterface
         $this->adminRecipients[] = $recipient;
     }
 
-    /**
-     * @return RecipientInterface[]
-     */
     public function getAdminRecipients(): array
     {
         return $this->adminRecipients;

--- a/src/Symfony/Component/Notifier/Tests/EventListener/SendFailedMessageToNotifierListenerTest.php
+++ b/src/Symfony/Component/Notifier/Tests/EventListener/SendFailedMessageToNotifierListenerTest.php
@@ -1,0 +1,123 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Tests\EventListener;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
+use Symfony\Component\Notifier\AdminRecipientsProviderInterface;
+use Symfony\Component\Notifier\EventListener\SendFailedMessageToNotifierListener;
+use Symfony\Component\Notifier\Notification\Notification;
+use Symfony\Component\Notifier\NotifierInterface;
+use Symfony\Component\Notifier\Recipient\Recipient;
+use Symfony\Component\Notifier\Recipient\RecipientInterface;
+
+class SendFailedMessageToNotifierListenerTest extends TestCase
+{
+    public function testItSendsWithoutAdminRecipients()
+    {
+        $notifier = new class implements NotifierInterface {
+            public ?Notification $notification = null;
+            public array $recipients = [];
+
+            public function send(Notification $notification, RecipientInterface ...$recipients): void
+            {
+                $this->notification = $notification;
+                $this->recipients = $recipients;
+            }
+        };
+
+        (new SendFailedMessageToNotifierListener($notifier))->onMessageFailed($this->createEvent(new \RuntimeException('Boom')));
+
+        $this->assertSame('A "stdClass" message has just failed: RuntimeException: Boom.', $notifier->notification->getSubject());
+        $this->assertSame(Notification::IMPORTANCE_HIGH, $notifier->notification->getImportance());
+        $this->assertSame([], $notifier->recipients);
+    }
+
+    public function testItSendsToAdminRecipients()
+    {
+        $notifier = new class implements NotifierInterface, AdminRecipientsProviderInterface {
+            public array $adminRecipients = [];
+            public array $recipients = [];
+
+            public function send(Notification $notification, RecipientInterface ...$recipients): void
+            {
+                $this->recipients = $recipients;
+            }
+
+            public function getAdminRecipients(): array
+            {
+                return $this->adminRecipients;
+            }
+        };
+        $recipient = new Recipient('admin@example.com');
+        $notifier->adminRecipients = [$recipient];
+
+        (new SendFailedMessageToNotifierListener($notifier))->onMessageFailed($this->createEvent(new \RuntimeException('Boom')));
+
+        $this->assertSame([$recipient], $notifier->recipients);
+    }
+
+    public function testItSendsNothingWhenTheMessageWillBeRetried()
+    {
+        $notifier = new class implements NotifierInterface {
+            public bool $sent = false;
+
+            public function send(Notification $notification, RecipientInterface ...$recipients): void
+            {
+                $this->sent = true;
+            }
+        };
+
+        $event = $this->createEvent(new \RuntimeException('Boom'));
+        $event->setForRetry();
+
+        (new SendFailedMessageToNotifierListener($notifier))->onMessageFailed($event);
+
+        $this->assertFalse($notifier->sent);
+    }
+
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
+    public function testItSendsToAdminRecipientsOfANotifierThatDoesNotImplementTheInterface()
+    {
+        $notifier = new class implements NotifierInterface {
+            public array $adminRecipients = [];
+            public array $recipients = [];
+
+            public function send(Notification $notification, RecipientInterface ...$recipients): void
+            {
+                $this->recipients = $recipients;
+            }
+
+            public function getAdminRecipients(): array
+            {
+                return $this->adminRecipients;
+            }
+        };
+        $recipient = new Recipient('admin@example.com');
+        $notifier->adminRecipients = [$recipient];
+
+        $this->expectUserDeprecationMessage(\sprintf('Since symfony/notifier 8.2: Declaring "getAdminRecipients()" on "%s" without implementing "Symfony\Component\Notifier\AdminRecipientsProviderInterface" is deprecated.', get_debug_type($notifier)));
+
+        (new SendFailedMessageToNotifierListener($notifier))->onMessageFailed($this->createEvent(new \RuntimeException('Boom')));
+
+        $this->assertSame([$recipient], $notifier->recipients);
+    }
+
+    private function createEvent(\Throwable $throwable): WorkerMessageFailedEvent
+    {
+        return new WorkerMessageFailedEvent(new Envelope(new \stdClass()), 'receiver', $throwable);
+    }
+}

--- a/src/Symfony/Component/Notifier/composer.json
+++ b/src/Symfony/Component/Notifier/composer.json
@@ -17,7 +17,8 @@
     ],
     "require": {
         "php": ">=8.4.1",
-        "psr/log": "^1|^2|^3"
+        "psr/log": "^1|^2|^3",
+        "symfony/deprecation-contracts": "^2.5|^3"
     },
     "require-dev": {
         "symfony/event-dispatcher-contracts": "^2.5|^3",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Issues        | -
| License       | MIT

Follow-up to #65488 and #65580, which stopped `NotifierHandler` and
`SendFailedMessageToNotifierListener` from breaking on a notifier that is not the concrete `Notifier`
class. Both now reach `getAdminRecipients()` through `method_exists()`, because nothing declares that
method beyond `Notifier` itself.

This adds the missing contract:

```php
namespace Symfony\Component\Notifier;

interface AdminRecipientsProviderInterface
{
    /**
     * @return RecipientInterface[]
     */
    public function getAdminRecipients(): array;
}
```

`Notifier` implements it, and both consumers check for it before falling back to `method_exists()`.
A notifier that declares the method without implementing the interface still gets its recipients, and
triggers a deprecation.

The method is not added to `NotifierInterface` on purpose. Sending a notification and holding the
address book that administrative notifications go to are two different jobs, and `NotifierInterface`
has one method that every implementation must provide. A separate interface also leaves room for a
notifier that has no admin recipients at all.

The duck-typed alternative does work today, so the addition is about when the mistake surfaces. An
implementation that returns the wrong thing is only caught when a record is actually handled:

```
TypeError: ...@anonymous(): Argument #2 must be of type Symfony\Component\Notifier\Recipient\RecipientInterface,
string given, called in .../NotifierHandler.php on line 66
```

which in practice means in production, while an error is being logged. With an interface to implement,
the signature is declared, static analysis checks it, and the requirement is discoverable from the
component instead of from the body of a handler.

`symfony/deprecation-contracts` is added to the requirements of `symfony/notifier` and
`symfony/monolog-bridge`, which both trigger the new deprecation. `symfony/notifier` is added to the
require-dev of the bridge, which has always used the component while nothing declared it.

Checks that were run:

* `./phpunit src/Symfony/Component/Notifier`: OK, 2553 tests, 3967 assertions, 3 skipped. The same
  command on the base commit gives 2549 tests, 3960 assertions.
* `./phpunit src/Symfony/Bridge/Monolog`: OK, 99 tests, 288 assertions. The same command on the base
  commit gives 95 tests, 279 assertions.
* The eight new tests with the three changed source files put back to their base state: seven fail,
  with `Call to undefined method ...::getAdminRecipients()` for the handler, the `TypeError` on the
  concrete `Notifier` type hint for the listener, and a missing deprecation for the two legacy tests.
  `testHandleSendsToAdminRecipients` passes in that state on purpose: it pins the behavior of a
  notifier that does provide admin recipients.
* `./phpunit src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection --filter=Notifier`: OK,
  22 tests, 236 assertions.
* php-cs-fixer with the repository config on the changed files: no change to make.

Documentation should say that a notifier meant to provide admin recipients implements
`AdminRecipientsProviderInterface`, and that decorating the `notifier` service with a class that only
implements `NotifierInterface` means administrative notifications are sent without recipients.
