### PR TITLE
[CssSelector] Fix :disabled and :enabled inside nested fieldsets

### DIFF
--- a/src/Symfony/Component/CssSelector/Tests/XPath/TranslatorTest.php
+++ b/src/Symfony/Component/CssSelector/Tests/XPath/TranslatorTest.php
@@ -177,6 +177,42 @@ class TranslatorTest extends TestCase
         $this->assertSame('A', $nodeList->item(0)->textContent);
     }
 
+    public function testDisabledAndEnabledInsideFieldsets()
+    {
+        $translator = new Translator();
+        $translator->registerExtension(new HtmlExtension($translator));
+        $document = new \DOMDocument();
+        $document->loadHTML(<<<'HTML'
+            <html>
+              <body>
+                <fieldset id="outer" disabled="disabled">
+                  <legend><input type="text" id="first-legend-input"></legend>
+                  <legend><input type="text" id="second-legend-input"></legend>
+                  <input type="text" id="direct-input">
+                  <fieldset id="nested"><input type="text" id="nested-input"></fieldset>
+                </fieldset>
+                <fieldset id="standalone"><input type="text" id="standalone-input"></fieldset>
+              </body>
+            </html>
+            HTML
+        );
+
+        $xpath = new \DOMXPath($document);
+
+        $disabled = [];
+        foreach ($xpath->query($translator->cssToXPath(':disabled')) as $node) {
+            $disabled[] = $node->getAttribute('id');
+        }
+
+        $enabled = [];
+        foreach ($xpath->query($translator->cssToXPath(':enabled')) as $node) {
+            $enabled[] = $node->getAttribute('id');
+        }
+
+        $this->assertSame(['outer', 'second-legend-input', 'direct-input', 'nested', 'nested-input'], $disabled);
+        $this->assertSame(['first-legend-input', 'standalone', 'standalone-input'], $enabled);
+    }
+
     public static function getXpathLiteralTestData()
     {
         return [

--- a/src/Symfony/Component/CssSelector/XPath/Extension/HtmlExtension.php
+++ b/src/Symfony/Component/CssSelector/XPath/Extension/HtmlExtension.php
@@ -28,6 +28,13 @@ use Symfony\Component\CssSelector\XPath\XPathExpr;
  */
 class HtmlExtension extends AbstractExtension
 {
+    // Each disabled fieldset ancestor disables the element, except the one whose first legend
+    // child the element sits in. Those excepted fieldsets are exactly the parents of the
+    // ancestors-or-self that are a first legend child of a disabled fieldset, one for one, so
+    // the element is disabled as soon as the first count exceeds the second one. Counting keeps
+    // this to two cheap ancestor walks instead of a predicate run on every ancestor.
+    private const DISABLING_FIELDSET = 'count(ancestor::fieldset[@disabled]) > count(ancestor-or-self::legend[not(preceding-sibling::legend)][parent::fieldset[@disabled]])';
+
     public function __construct(Translator $translator)
     {
         $translator
@@ -91,10 +98,10 @@ class HtmlExtension extends AbstractExtension
                 ." or name(.) = 'button'"
                 ." or name(.) = 'select'"
                 ." or name(.) = 'textarea'"
+                ." or name(.) = 'fieldset'"
             .')'
-            .' and ancestor::fieldset[@disabled]'
+            .' and '.self::DISABLING_FIELDSET
         );
-        // todo: in the second half, add "and is not a descendant of that fieldset element's first legend element child, if any."
     }
 
     public function translateEnabled(XPathExpr $xpath): XPathExpr
@@ -109,7 +116,6 @@ class HtmlExtension extends AbstractExtension
             .') or ('
                 .'('
                     ."name(.) = 'command'"
-                    ." or name(.) = 'fieldset'"
                     ." or name(.) = 'optgroup'"
                 .')'
                 .' and not(@disabled)'
@@ -120,8 +126,9 @@ class HtmlExtension extends AbstractExtension
                     ." or name(.) = 'select'"
                     ." or name(.) = 'textarea'"
                     ." or name(.) = 'keygen'"
+                    ." or name(.) = 'fieldset'"
                 .')'
-                .' and not (@disabled or ancestor::fieldset[@disabled])'
+                .' and not(@disabled or '.self::DISABLING_FIELDSET.')'
             .') or ('
                 ."name(.) = 'option' and not("
                     .'@disabled or ancestor::optgroup[@disabled]'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #58297
| License       | MIT

Replaces #65531, which fixed the same bug with a more expensive XPath expression.

HTML says an element is disabled when it is a descendant of a fieldset carrying `disabled`,
unless it is a descendant of that fieldset's first `legend` element child, and it says a
fieldset nested in a disabled fieldset is itself disabled. `:disabled` and `:enabled`
implemented neither clause:

```php
$converter = new CssSelectorConverter();
$doc = new \DOMDocument();
$doc->loadXML('<div>
    <fieldset id="outer" disabled>
        <legend><input id="target1" type="text"></legend>
        <legend><input id="target2" type="text"></legend>
        <fieldset id="target3"></fieldset>
    </fieldset>
</div>');
$xpath = new \DOMXPath($doc);

foreach ($xpath->query($converter->toXPath(':disabled')) as $node) {
    echo $node->getAttribute('id'), "\n";
}
// before: outer
// after:  outer, target1, target3
```

`target1` sits in the first legend, so it stays enabled; `target2` sits in a later legend and is
disabled; `target3` is a nested fieldset and is disabled. Both `translateDisabled()` and
`translateEnabled()` are corrected, and `fieldset` moves out of the group that only checks its own
`disabled` attribute into the group that also inherits the state of its ancestors.

The shared sub-expression counts instead of scanning:

```
count(ancestor::fieldset[@disabled]) > count(ancestor-or-self::legend[not(preceding-sibling::legend)][parent::fieldset[@disabled]])
```

Each disabled fieldset ancestor has exactly one child on the path down to the element, and it
fails to disable the element exactly when that child is its first legend child. Those children
correspond one for one with the ancestors-or-self that are a first legend child of a disabled
fieldset, so the element is disabled as soon as the first count exceeds the second. Both operands
are plain name-test walks whose predicates only run on fieldsets and on legends.

The direct transcription of the rule, `ancestor-or-self::*[parent::fieldset[@disabled]][not(self::legend) or preceding-sibling::legend]`,
returns the same answer but costs much more: its `*` node test makes libxml2 evaluate a predicate
on every ancestor, and it cannot stop at the first hit the way a name-test axis does in boolean
context. Measured through `DOMXPath::query`, min of 25 runs, PHP 8.5.8 with libxml 2.9.14:

| document | selector | 6.4 | scanning | counting |
| --- | --- | --- | --- | --- |
| form page, 3214 elements, 200 fieldsets | `:disabled` | 4.64 ms | 7.04 ms | 5.90 ms |
| form page, 3214 elements, 200 fieldsets | `:enabled` | 8.82 ms | 10.38 ms | 9.60 ms |
| 300 nested fieldsets, outermost disabled | `:disabled` | 7.86 ms | 29.44 ms | 15.93 ms |
| one disabled fieldset over 300 nested divs | `:disabled` | 0.85 ms | 4.67 ms | 1.30 ms |

The residual cost over 6.4 is mostly the `name(.) = 'fieldset'` term, which is evaluated for every
element in the document and which the fix requires.

Results change in three ways, all of them cases where the previous answer contradicted the
standard and every browser: a fieldset nested in a disabled fieldset is reported by `:disabled`
instead of `:enabled`; form controls inside the first legend child of a disabled fieldset are
reported by `:enabled` instead of `:disabled`; and `:enabled` mirrors both. A fieldset with its own
`disabled` attribute, a control with its own `disabled` attribute, controls directly under a
disabled fieldset, `optgroup` and `option`, and the `a|link|area[href]` half of `:enabled` are all
unchanged.

Checks: `./phpunit src/Symfony/Component/CssSelector` gives 525 tests and 1054 assertions, and
`./phpunit src/Symfony/Component/DomCrawler` gives 589 tests and 1154 assertions. Reverting the
source and keeping the new test makes it fail on the `:disabled` list, which gains
`first-legend-input` and loses `nested`.

Both expressions were checked against headless Chromium on 60 generated documents covering 18265
elements: they agree with the browser on all 120 queries, where 6.4 disagrees on 74. They return
byte identical result sets over a 400 document fuzz corpus of 97399 elements, and the raw
sub-expression agrees as a boolean on every element of 300 further documents.
