### PR TITLE
[Form] Map violations to child forms named after the snake cased property

### DIFF
--- a/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/ViolationMapper.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/ViolationMapper.php
@@ -17,6 +17,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormRendererInterface;
 use Symfony\Component\Form\Util\InheritDataAwareIterator;
 use Symfony\Component\PropertyAccess\PropertyPathBuilder;
+use Symfony\Component\PropertyAccess\PropertyPathInterface;
 use Symfony\Component\PropertyAccess\PropertyPathIterator;
 use Symfony\Component\PropertyAccess\PropertyPathIteratorInterface;
 use Symfony\Component\Validator\Constraints\File;
@@ -248,6 +249,8 @@ class ViolationMapper implements ViolationMapperInterface
         }
 
         $children = iterator_to_array(new \RecursiveIteratorIterator(new InheritDataAwareIterator($form)), false);
+        $allChildren = $children;
+        $startIndex = $it->valid() ? $it->key() : null;
 
         while ($it->valid()) {
             if ($it->isIndex()) {
@@ -287,6 +290,58 @@ class ViolationMapper implements ViolationMapperInterface
             $it->next();
         }
 
+        // No child matched the violation path verbatim: retry with camelized paths.
+        if (null === $target && null !== $startIndex) {
+            return $this->matchCamelizedChild($allChildren, $it, $startIndex);
+        }
+
+        if (null !== $foundAtIndex) {
+            $it->seek($foundAtIndex);
+        }
+
+        return $target;
+    }
+
+    /**
+     * Tries to match the beginning of the property path at the current position
+     * against the children of the scope, comparing camelized property paths.
+     *
+     * The property accessor camelizes property paths when it looks for getters and
+     * setters, which makes a child named "discount_price" read and write the
+     * "discountPrice" property the violation points at.
+     *
+     * @param list<FormInterface> $children
+     */
+    private function matchCamelizedChild(array $children, PropertyPathIteratorInterface $it, int $startIndex): ?FormInterface
+    {
+        $target = null;
+        $chunk = '';
+        $foundAtIndex = null;
+        $childPaths = [];
+
+        foreach ($children as $i => $child) {
+            $childPaths[$i] = self::camelizePath($child->getPropertyPath());
+        }
+
+        for ($it->seek($startIndex); $it->valid(); $it->next()) {
+            if ($it->isIndex()) {
+                $chunk .= '['.$it->current().']';
+            } else {
+                $chunk .= ('' === $chunk ? '' : '.').self::camelize($it->current());
+            }
+
+            foreach ($childPaths as $i => $childPath) {
+                if ($childPath === $chunk) {
+                    $target = $children[$i];
+                    $foundAtIndex = $it->key();
+                } elseif (str_starts_with($childPath, $chunk)) {
+                    continue;
+                }
+
+                unset($childPaths[$i]);
+            }
+        }
+
         if (null !== $foundAtIndex) {
             $it->seek($foundAtIndex);
         }
@@ -322,7 +377,7 @@ class ViolationMapper implements ViolationMapperInterface
                 // Cut the piece out of the property path and proceed
                 $propertyPathBuilder->remove($i);
             } else {
-                /** @var \Symfony\Component\PropertyAccess\PropertyPathInterface $propertyPath */
+                /** @var PropertyPathInterface $propertyPath */
                 $propertyPath = $scope->getPropertyPath();
 
                 if (null === $propertyPath) {
@@ -344,5 +399,33 @@ class ViolationMapper implements ViolationMapperInterface
     private function acceptsErrors(FormInterface $form): bool
     {
         return $this->allowNonSynchronized || $form->isSynchronized();
+    }
+
+    private static function camelizePath(?PropertyPathInterface $path): string
+    {
+        if (null === $path) {
+            return '';
+        }
+
+        $camelized = '';
+
+        foreach ($path->getElements() as $i => $element) {
+            if ($path->isIndex($i)) {
+                $camelized .= '['.$element.']';
+            } else {
+                $camelized .= ('' === $camelized ? '' : '.').self::camelize($element);
+            }
+        }
+
+        return $camelized;
+    }
+
+    private static function camelize(string $string): string
+    {
+        if ('' === ltrim($string, '_')) {
+            return $string;
+        }
+
+        return str_replace(' ', '', ucwords(str_replace('_', ' ', $string)));
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/ViolationMapper/ViolationMapperTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/ViolationMapper/ViolationMapperTest.php
@@ -1581,6 +1581,72 @@ class ViolationMapperTest extends TestCase
         $this->assertEquals([$this->getFormError($violation3, $grandChild3)], iterator_to_array($grandChild3->getErrors()), $grandChild3->getName().' should have an error, but has none');
     }
 
+    public function testMapErrorToChildWhoseNameIsTheSnakeCasedProperty()
+    {
+        $violation = $this->getConstraintViolation('data.discountPrice');
+        $parent = $this->getForm('parent');
+        $child = $this->getForm('discount_price', 'discount_price');
+
+        $parent->add($child);
+        $parent->submit([]);
+
+        $this->mapper->mapViolation($violation, $parent);
+
+        $this->assertCount(0, $parent->getErrors(), $parent->getName().' should not have an error, but has one');
+        $this->assertEquals([$this->getFormError($violation, $child)], iterator_to_array($child->getErrors()), $child->getName().' should have an error, but has none');
+    }
+
+    public function testMapErrorToNestedChildWhoseNameIsTheSnakeCasedProperty()
+    {
+        $violation = $this->getConstraintViolation('data.billingAddress.zipCode');
+        $parent = $this->getForm('parent');
+        $child = $this->getForm('billing_address', 'billing_address');
+        $grandChild = $this->getForm('zip_code', 'zip_code');
+
+        $parent->add($child);
+        $child->add($grandChild);
+        $parent->submit([]);
+
+        $this->mapper->mapViolation($violation, $parent);
+
+        $this->assertCount(0, $parent->getErrors(), $parent->getName().' should not have an error, but has one');
+        $this->assertCount(0, $child->getErrors(), $child->getName().' should not have an error, but has one');
+        $this->assertEquals([$this->getFormError($violation, $grandChild)], iterator_to_array($grandChild->getErrors()), $grandChild->getName().' should have an error, but has none');
+    }
+
+    public function testPreferTheChildMatchingThePropertyPathExactly()
+    {
+        $violation = $this->getConstraintViolation('data.discountPrice');
+        $parent = $this->getForm('parent');
+        $snakeCased = $this->getForm('discount_price', 'discount_price');
+        $camelCased = $this->getForm('discountPrice', 'discountPrice');
+
+        $parent->add($snakeCased);
+        $parent->add($camelCased);
+        $parent->submit([]);
+
+        $this->mapper->mapViolation($violation, $parent);
+
+        $this->assertCount(0, $parent->getErrors(), $parent->getName().' should not have an error, but has one');
+        $this->assertCount(0, $snakeCased->getErrors(), $snakeCased->getName().' should not have an error, but has one');
+        $this->assertEquals([$this->getFormError($violation, $camelCased)], iterator_to_array($camelCased->getErrors()), $camelCased->getName().' should have an error, but has none');
+    }
+
+    public function testDoNotMapErrorToChildWhoseArrayKeyOnlyDiffersInCase()
+    {
+        $violation = $this->getConstraintViolation('data[discountPrice]');
+        $parent = $this->getForm('parent');
+        $child = $this->getForm('discount_price', '[discount_price]');
+
+        $parent->add($child);
+        $parent->submit([]);
+
+        $this->mapper->mapViolation($violation, $parent);
+
+        $this->assertEquals([$this->getFormError($violation, $parent)], iterator_to_array($parent->getErrors()), $parent->getName().' should have an error, but has none');
+        $this->assertCount(0, $child->getErrors(), $child->getName().' should not have an error, but has one');
+    }
+
     public function testMessageWithLabel1()
     {
         $this->mapper = new ViolationMapper(new FormRenderer(new DummyFormRendererEngine()), new FixedTranslator(['Name' => 'Custom Name']));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #38531
| License       | MIT

Replaces #65539, which fixed the same bug with an eager second pass that cost roughly 50 to 70
percent of the mapping time on forms where the fallback is never needed.

A form child may be named after the snake cased version of the property it is bound to. The
property accessor accepts that: it camelizes `discount_price` and finds `getDiscountPrice()` and
`setDiscountPrice()`, so the value is read and written on the `discountPrice` property.

Violations did not follow the same rule. The violation raised on that property has the path
`discountPrice`, and `ViolationMapper::matchChild()` compared each child property path with the
current path segment byte for byte. `discount_price` never equals `discountPrice`, so no child
matched and the error was mapped to the root form instead of the field. Renaming the child to
`discountPrice` was the only way to get the error next to the input.

`matchChild()` now keeps its verbatim walk unchanged, and when that walk ends without a target it
calls `matchCamelizedChild()`, which seeks the iterator back to where the walk started and repeats
it with both sides camelized the way the property accessor camelizes them. Array index segments
are left alone, because array keys are matched exactly by the property accessor too, so
`[discount_price]` still does not match `[discountPrice]`.

Running the second pass only when the first one found nothing keeps three properties:

* a violation that is mapped today keeps its current target;
* a child whose property path matches exactly wins over a sibling that only matches after
  camelization;
* an `error_mapping` rule wins over both, because rules are tested first and return immediately,
  so applications that worked around this with `error_mapping` keep their current behavior.

Applications that hit the bug will see the error move from the root form to the field it belongs
to, which is the point of the fix.

It also keeps the cost where it belongs. Computing the camelized answer eagerly and discarding it
whenever the verbatim one is set, as #65539 did, is dead work on every violation that maps to a
child, which is the common case: `(string) $child->getPropertyPath()` reads a string the form
already cached, while `camelizePath()` rebuilds one from `getElements()` with an `isIndex()` and a
`camelize()` call per element. Driving `ViolationMapper` directly on PHP 8.5.8, variants
interleaved per measurement and compared as paired ratios:

| form | violations | 6.4 | eager | lazy |
| --- | --- | --- | --- | --- |
| 600 flat fields | 600 | 0.314 s | +69% | +2% |
| 400 row collection | 400 | 0.147 s | +59% | +8% |
| 25 scalars, 3 nested groups, 10x3 collection | 14, x300 | 0.254 s | +52% | +8% |

A tighter run of 15 repetitions per cell puts the last column at +0.1%, -2.2% and +3.8%, so the
three shapes are back at the 6.4 cost within the noise of that machine. A violation that matches
no child verbatim still pays a second walk, which is intrinsic: a snake cased field, a class level
constraint or a property with no form field has to be scanned twice.

Checks run:

* `./phpunit src/Symfony/Component/Form/Tests`: 4767 tests, 9377 assertions, 366 skipped, 8
  incomplete, no failure.
* `./phpunit src/Symfony/Component/Form/Tests/Extension/Validator/ViolationMapper`: 1064 tests,
  3529 assertions, all green.
* Revert check: with the source reverted and the tests kept,
  `testMapErrorToChildWhoseNameIsTheSnakeCasedProperty` and
  `testMapErrorToNestedChildWhoseNameIsTheSnakeCasedProperty` fail with `parent should not have an
  error, but has one / Failed asserting that actual size 1 matches expected size 0`. The other two
  added tests pass on the base commit as well, on purpose: they pin the behavior the fix must not
  change.
* Differential check against the eager version of #65539 over 46000 cases in four runs, covering
  nested subforms, `inherit_data` groups, `error_mapping` prefix and `.` rules, unmapped and
  unsynchronized children, collection rows, array keys differing only in case, and multi-element
  property paths. Both map every violation to the same target, while 6.4 differs on 148 and 371 of
  those cases depending on the run.
* Syntax check on PHP 8.1 to 8.4 as well, since 6.4 supports them.
