### PR TITLE
[Validator] Review the German translations for the EntityExists and Ulid messages

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.de.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.de.xlf
@@ -572,11 +572,11 @@
             </trans-unit>
             <trans-unit id="147">
                 <source>The referenced entity does not exist.</source>
-                <target state="needs-review-translation">Die referenzierte Entität existiert nicht.</target>
+                <target>Die referenzierte Entität existiert nicht.</target>
             </trans-unit>
             <trans-unit id="148" resname="This is not a valid ULID.">
                 <source>This value is not a valid ULID.</source>
-                <target state="needs-review-translation">Dieser Wert ist keine gültige ULID.</target>
+                <target>Dieser Wert ist keine gültige ULID.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65556
| License       | MIT

I am a German native speaker and I checked the two strings from #65556.

Both are correct and they fit the style of the file, so I only removed the `state="needs-review-translation"` markers:

- `The referenced entity does not exist.` -> `Die referenzierte Entität existiert nicht.`
- `This value is not a valid ULID.` -> `Dieser Wert ist keine gültige ULID.`

The ULID one has the same wording as the UUID string in the same file (`Dieser Wert ist keine gültige UUID.`, id 83), and `fr` already did it the same way for id 147.
