### PR TITLE
[CI] Stop pinning ext-mongodb in integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -208,7 +208,7 @@ jobs:
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           coverage: "none"
-          extensions: "json,couchbase-3.2.2,memcached,mongodb-1.12.0,redis,rdkafka,xsl,ldap,relay"
+          extensions: "json,couchbase-3.2.2,memcached,mongodb,redis,rdkafka,xsl,ldap,relay"
           ini-values: date.timezone=UTC,memory_limit=-1,default_socket_timeout=10,session.gc_probability=0,apc.enable_cli=1,zend.assertions=1,intl.default_locale=en,intl.error_level=0
           php-version: "${{ matrix.php }}"
           tools: pecl


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The Integration workflow asks setup-php for `mongodb-1.12.0`. Because that is a pinned version, setup-php cannot use the extension that ships with the runner image and compiles the driver from source on every run. Removing the pin makes it enable the bundled one instead.

### Where the pin comes from

It was added in 2021, when the same workflow ran `composer require --dev --no-update mongodb/mongodb`. The pin only existed to match the `ext-mongodb` constraint of that library.

The library requirement was removed in #52336, which made the Lock and HttpFoundation MongoDB adapters usable with `ext-mongodb` alone. The `composer require` line went away there, the pin stayed. Since then nothing in the tree constrains the driver version: no `composer.json` mentions MongoDB, and the tests use local stubs for the library classes. Compatibility with ext-mongodb v2 was added in #58668 and is present on 6.4.

The 8.2 branch already runs these tests unpinned, on driver 2.3.3, and is green.

### Effect

Time spent setting up the extensions in the Integration job. The 8.2 branch is not listed because it is already unpinned:

| Branch | Before | After |
| ------ | ------ | ----- |
| 6.4    | 115s   | 50s   |
| 7.4    | 89s    | 36s   |
| 8.1    | 59s    | 26s   |

The "after" column is a projection from the per-extension timings. On this pull request's own Integration run the `Setup Extensions` phase took 35s, and mongodb is reported as `Enabled` instead of `Installed and enabled`, on driver 2.3.3. The job is green.

### Merge-ups

After this change the `extensions:` line is identical on 6.4, 7.4, 8.1 and 8.2, so it stops being a conflict site in merge-ups.
