### PR TITLE
[CssSelector] Fix quadratic token probing in Reader::findPattern()

### DIFF
--- a/src/Symfony/Component/CssSelector/Parser/Reader.php
+++ b/src/Symfony/Component/CssSelector/Parser/Reader.php
@@ -61,9 +61,17 @@ class Reader
 
     public function findPattern(string $pattern): array|false
     {
-        $source = substr($this->source, $this->position);
+        // Match against the source in place instead of copying the remaining text for
+        // every probe, which is quadratic on token-dense selectors (O(tokens x length)).
+        // "^" combined with an offset only matches at the true subject start, so a leading
+        // anchor is rewritten to "\\G", which matches exactly at the match-start offset -
+        // the same position "^" anchored to when the remaining text was a fresh substring.
+        $delimiter = $pattern[0];
+        if ('^' === ($pattern[1] ?? '')) {
+            $pattern = $delimiter.'\\G'.substr($pattern, 2);
+        }
 
-        if (preg_match($pattern, $source, $matches)) {
+        if (preg_match($pattern, $this->source, $matches, 0, $this->position)) {
             return $matches;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

`Reader::findPattern()` copies the whole remaining selector via `substr()` before every token-handler regex probe. The number of probes grows with the number of tokens, so total work is O(tokens × length) - quadratic for token-dense selectors:

```php
$selector = str_repeat(':is(', 100000); // 400 KB

// before: ~11.4 s, ~200 GB of intermediate memcpy
// after:  ~1.5 s, in-place matching (measured on PHP 8.4)
```

The fix matches against the source buffer in place using `preg_match()`'s offset argument. Because `^` combined with an offset only matches at the true subject start (unlike `substr()`, where it always anchors at position 0), a leading `^` anchor is rewritten to `\G`, which matches exactly at the match-start offset - preserving the previous semantics. All tokenizer patterns are leading-anchored; `Reader` is `@internal`, so the contract change is contained.

The full component test suite passes (610 tests).
