### PR TITLE
[CssSelector] Cap the nesting depth of :is() and :where()

### DIFF
--- a/src/Symfony/Component/CssSelector/Parser/Parser.php
+++ b/src/Symfony/Component/CssSelector/Parser/Parser.php
@@ -27,7 +27,10 @@ use Symfony\Component\CssSelector\Parser\Tokenizer\Tokenizer;
  */
 class Parser implements ParserInterface
 {
+    private const NESTING_LIMIT = 16;
+
     private Tokenizer $tokenizer;
+    private int $nestingDepth = 0;
 
     public function __construct(?Tokenizer $tokenizer = null)
     {
@@ -236,7 +239,7 @@ class Parser implements ParserInterface
 
                     $result = new Node\NegationNode($result, $argument);
                 } elseif ('is' === strtolower($identifier)) {
-                    $selectors = $this->parseSelectorList($stream, true);
+                    $selectors = $this->parseNestedSelectorList($stream, 'is');
 
                     $next = $stream->getNext();
                     if (!$next->isDelimiter([')'])) {
@@ -245,7 +248,7 @@ class Parser implements ParserInterface
 
                     $result = new Node\MatchingNode($result, $selectors);
                 } elseif ('where' === strtolower($identifier)) {
-                    $selectors = $this->parseSelectorList($stream, true);
+                    $selectors = $this->parseNestedSelectorList($stream, 'where');
 
                     $next = $stream->getNext();
                     if (!$next->isDelimiter([')'])) {
@@ -290,6 +293,26 @@ class Parser implements ParserInterface
         }
 
         return [$result, $pseudoElement];
+    }
+
+    /**
+     * @return Node\SelectorNode[]
+     *
+     * @throws SyntaxErrorException
+     */
+    private function parseNestedSelectorList(TokenStream $stream, string $identifier): array
+    {
+        if ($this->nestingDepth >= self::NESTING_LIMIT) {
+            throw new SyntaxErrorException(\sprintf('Got too deeply nested :%s().', $identifier));
+        }
+
+        ++$this->nestingDepth;
+
+        try {
+            return $this->parseSelectorList($stream, true);
+        } finally {
+            --$this->nestingDepth;
+        }
     }
 
     private function parseElementNode(TokenStream $stream): Node\ElementNode

--- a/src/Symfony/Component/CssSelector/Tests/Parser/ParserTest.php
+++ b/src/Symfony/Component/CssSelector/Tests/Parser/ParserTest.php
@@ -192,6 +192,51 @@ class ParserTest extends TestCase
         ];
     }
 
+    #[DataProvider('getNestedMatchingData')]
+    public function testMatchingNestingDepthLimit(int $depth, string $selector, string $message)
+    {
+        $parser = new Parser();
+        $property = new \ReflectionProperty(Parser::class, 'nestingDepth');
+        $property->setValue($parser, $depth);
+
+        $this->expectException(SyntaxErrorException::class);
+        $this->expectExceptionMessage($message);
+
+        $parser->parse($selector);
+    }
+
+    public static function getNestedMatchingData(): iterable
+    {
+        yield 'is at the limit' => [16, ':is(a)', 'Got too deeply nested :is().'];
+        yield 'where at the limit' => [16, ':where(a)', 'Got too deeply nested :where().'];
+        yield 'where nested in is' => [15, 'div:is(:where(a))', 'Got too deeply nested :where().'];
+    }
+
+    public function testMatchingNestingWithinLimitIsAccepted()
+    {
+        $parser = new Parser();
+        $property = new \ReflectionProperty(Parser::class, 'nestingDepth');
+        $property->setValue($parser, 15);
+
+        $this->assertCount(1, $parser->parse(':is(:where)'));
+        $this->assertSame(15, $property->getValue($parser));
+    }
+
+    #[DataProvider('getDeeplyNestedSelectorData')]
+    public function testDeeplyNestedSelectorsAreRejected(string $selector)
+    {
+        $this->expectException(SyntaxErrorException::class);
+
+        (new Parser())->parse($selector);
+    }
+
+    public static function getDeeplyNestedSelectorData(): iterable
+    {
+        yield 'nested is' => [str_repeat(':is(', 100).'a'.str_repeat(')', 100)];
+        yield 'nested where' => [':where('.str_repeat(':is(', 100).'a'.str_repeat(')', 100).')'];
+        yield 'nested is in not' => [str_repeat(':not(:is(', 100).'a'.str_repeat('))', 100)];
+    }
+
     public static function getPseudoElementsTestData()
     {
         return [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

`:is()` and `:where()` recurse through `parseSelectorList()` and `parseSimpleSelector()` with no depth guard, so a selector such as `str_repeat(':is(', 200000)` builds a node graph as deep as the input allows. The other nesting pseudo-classes are already capped: `:not()` refuses a second level, and on 8.1 `:has()` stops at 16.

This applies the same cap to `:is()` and `:where()`, at a depth of 16. One counter is shared by all of them, so mixed nesting such as `:where(:is(:where(...)))` is counted as a whole. Past the limit the parser throws a `SyntaxErrorException`:

```php
// before: parses, and memory grows with the input
// after:  SyntaxErrorException: Got too deeply nested :is().
(new Parser())->parse(str_repeat(':is(', 100).'a'.str_repeat(')', 100));
```

### What the cap does not fix

Deep nesting is not a stack overflow. PHP keeps its call frames on the heap-allocated VM stack, so nesting grows memory in proportion to the input and not faster. At a fixed input of 400 KB, `:is(` nesting peaked at 348.4 MB, the descendant selector `a a a ...` at 104.9 MB and the attribute chain `a[a=b][a=b]...` at 70.9 MB. Nesting costs about 3 to 5 times more per byte than a flat selector, which is not a different order of magnitude.

There is a hard crash, but it comes from freeing the node graph: the destructor chain recurses on the C stack, and `str_repeat(':is(', 60000)` segfaults PHP (exit 139). This cap does not remove that crash, because `a a a ...` and `a[a=b][a=b]...` repeated 100000 times segfault as well. It closes one route out of three.

Fixing the remaining shapes needs a budget on the total number of nodes or on the input length. That is a separate change, and since it would reject inputs that nothing rejects today, it most likely belongs on 8.2.

### Related

#65599, on 6.4, removes quadratic token probing in the same component. The two are independent and complementary: that one cuts the tokenizer's time cost, this one caps the parser's depth. Measured on 8.1 with `(new Parser())->parse(str_repeat(':is(', 128000))`, the base takes 13889 ms, this pull request alone 11835 ms, and both together 1116 ms.
