### PR TITLE
[Filesystem] Keep tempnam() files private when a suffix is given

### DIFF
--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -650,7 +650,15 @@ class Filesystem
 
             // Use fopen instead of file_exists as some streams do not support stat
             // Use mode 'x+' to atomically check existence and create to avoid a TOCTOU vulnerability
-            if (!$handle = self::box('fopen', $tmpFile, 'x+')) {
+            // Force the umask so that the file is created private, as PHP's tempnam() does
+            $umask = umask(0o077);
+            try {
+                $handle = self::box('fopen', $tmpFile, 'x+');
+            } finally {
+                umask($umask);
+            }
+
+            if (!$handle) {
                 continue;
             }
 

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -1494,6 +1494,24 @@ class FilesystemTest extends FilesystemTestCase
         $this->assertFileExists($filename);
     }
 
+    public function testTempnamWithSuffixIsPrivate()
+    {
+        if ('\\' === \DIRECTORY_SEPARATOR) {
+            $this->markTestSkipped('This test cannot run on Windows.');
+        }
+
+        $oldUmask = umask(0o022);
+        try {
+            $filename = $this->filesystem->tempnam($this->workspace, 'foo', '.txt');
+
+            $this->assertFileExists($filename);
+            $this->assertSame(0o600, fileperms($filename) & 0o777);
+            $this->assertSame(0o022, umask());
+        } finally {
+            umask($oldUmask);
+        }
+    }
+
     public function testTempnamTrimsTrailingWhitespaceFromTruncatedPrefix()
     {
         // PHP's tempnam() truncates the prefix to 63 characters; if that leaves a


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`Filesystem::tempnam()` has two branches. Without a suffix, and when the directory lives on the plain file scheme, it delegates to PHP's `tempnam()`, which always creates the file with mode `0600` whatever the process umask is. With a suffix, or on any other stream, it builds the name itself and creates the file with `fopen($tmpFile, 'x+')`. That call goes through `open(2)` with mode `0666`, so it honours the umask: under the common `0022` umask the file was created `0644`, and under a `0000` umask it was created `0666`.

The two branches of the same method therefore did not offer the same guarantee, and the private one is the one the component relies on: `dumpFile()` writes the payload into the temporary file before relaxing its mode, so the content is exposed to every local user for as long as the file is wider than `0600`.

This forces the umask to `0077` around the `fopen()` call and restores it right after. The file is private from the moment it exists, so there is no window where another process can open it, and no `chmod()` is needed. Custom stream wrappers benefit too: many do not implement `stream_metadata`, so a `chmod()` on them would have done nothing at all.

`umask()` is the same mechanism the component already uses in `copy()` and `dumpFile()`, and the same pattern as `Console\Input\File\InputFile`.

Reproduction under a `0022` umask:

```php
$fs = new Filesystem();

printf("%o\n", fileperms($fs->tempnam(sys_get_temp_dir(), 'a')) & 0777);
// 600, both before and after

printf("%o\n", fileperms($fs->tempnam(sys_get_temp_dir(), 'b', '.txt')) & 0777);
// 644 before, 600 after
```
