### PR TITLE
[Filesystem] Fix makeRelative() stripping leading dots when the base path is a root

### DIFF
--- a/src/Symfony/Component/Filesystem/Path.php
+++ b/src/Symfony/Component/Filesystem/Path.php
@@ -534,7 +534,17 @@ final class Path
         if ('' === $root && '' !== $baseRoot) {
             // If base path is already in its root
             if ('' === $relativeBasePath) {
-                $relativePath = ltrim($relativePath, './'.\DIRECTORY_SEPARATOR);
+                // The base path is the root directory, so any number of leading
+                // "../" segments resolves to the root itself and "./" prefixes
+                // carry no information. Remove them as segments: a leading dot
+                // that is not one (e.g. ".htaccess") must survive.
+                while (str_starts_with($relativePath, './') || str_starts_with($relativePath, '../')) {
+                    $relativePath = substr($relativePath, str_starts_with($relativePath, '../') ? 3 : 2);
+                }
+
+                if ('..' === $relativePath) {
+                    $relativePath = '';
+                }
             }
 
             return $relativePath;

--- a/src/Symfony/Component/Filesystem/Tests/PathTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/PathTest.php
@@ -639,6 +639,19 @@ class PathTest extends TestCase
         // second argument shorter than first
         yield ['/webmozart/symfony', '/css', '../webmozart/symfony'];
 
+        // base path is the root: leading dots of dotfile names must survive
+        yield ['/.htaccess', '/', '.htaccess'];
+        yield ['/./.htaccess', '/', '.htaccess'];
+        yield ['./.env', '/', '.env'];
+        yield ['.env', '/', '.env'];
+        yield ['../.hidden/.file', '/', '.hidden/.file'];
+        yield ['...', '/', '...'];
+        yield ['..foo', '/', '..foo'];
+        yield ['.env', 'phar:///', '.env'];
+        yield ['..', '/', ''];
+        yield ['../..', '/', ''];
+        yield ['..', 'phar:///', ''];
+
         yield ['phar:///webmozart/symfony/css/style.css', 'phar:///webmozart/symfony', 'css/style.css'];
         yield ['phar:///webmozart/css/style.css', 'phar:///webmozart/symfony', '../css/style.css'];
         yield ['phar:///css/style.css', 'phar:///webmozart/symfony', '../../css/style.css'];
@@ -694,6 +707,11 @@ class PathTest extends TestCase
             yield ['..\\style.css', 'phar://C:\\', 'style.css'];
             yield ['.\\style.css', 'phar://C:\\', 'style.css'];
             yield ['..\\..\\style.css', 'phar://C:\\', 'style.css'];
+
+            yield ['.env', 'C:\\', '.env'];
+            yield ['.\\.env', 'C:\\', '.env'];
+            yield ['..\\.env', 'C:/', '.env'];
+            yield ['..', 'C:\\', ''];
 
             yield ['css\\..\\style.css', 'C:\\', 'style.css'];
             yield ['css\\.\\style.css', 'C:\\', 'css/style.css'];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

When the first argument of `Path::makeRelative()` is a relative path and the second one is a bare root (`/`, `C:/`, `phar:///`), the result went through:

```php
$relativePath = ltrim($relativePath, './'.\DIRECTORY_SEPARATOR);
```

`ltrim()` removes a set of *characters*, not a prefix, so every leading `.` and `/` of the canonical path was eaten. A file name that legitimately starts with a dot lost that dot:

```php
Path::makeRelative('.env', '/');          // 'env' before, '.env' after
Path::makeRelative('.hidden/file', '/');  // 'hidden/file' before, '.hidden/file' after
Path::makeRelative('...', '/');           // '' before, '...' after
```

This removes `./` and `../` as segments instead. Above a root, `../` resolves to the root itself, so the existing contract is kept: a path made only of such segments still gives `''`, and `makeRelative('../style.css', '/')` still gives `'style.css'`.

The `\DIRECTORY_SEPARATOR` in the old character list was unused code: `canonicalize()` calls `normalize()`, which has already turned every `\` into `/` by that point, on Windows too.

Only that one branch changes. Over an exhaustive grid of path pairs, the only results that differ are the ones where the first argument is relative and the second is a bare root, and each of them is this bug being undone. Every input that raised an `InvalidArgumentException` still raises the same one.
