### PR TITLE
[CssSelector] Fix quadratic token probing in Reader::findPattern()

### DIFF
--- a/src/Symfony/Component/CssSelector/Parser/Reader.php
+++ b/src/Symfony/Component/CssSelector/Parser/Reader.php
@@ -23,6 +23,8 @@ namespace Symfony\Component\CssSelector\Parser;
  */
 class Reader
 {
+    private static array $anchoredPatterns = [];
+
     private string $source;
     private int $length;
     private int $position = 0;
@@ -65,9 +67,12 @@ class Reader
 
     public function findPattern(string $pattern): array|false
     {
-        $source = substr($this->source, $this->position);
+        // Match in place instead of copying the remaining source before every probe.
+        // Combined with an offset, "^" still anchors at the start of the whole subject,
+        // so a leading anchor is turned into "\\G", which anchors at the offset instead.
+        $pattern = self::$anchoredPatterns[$pattern] ??= '^' === ($pattern[1] ?? '') ? $pattern[0].'\\G'.substr($pattern, 2) : $pattern;
 
-        if (preg_match($pattern, $source, $matches)) {
+        if (preg_match($pattern, $this->source, $matches, 0, $this->position)) {
             return $matches;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

`Reader::findPattern()` copied the whole remaining selector with `substr()` before every regex probe. The tokenizer calls it once per handler per token, so the total work grows as O(tokens x length). That makes tokenizing a token-dense selector quadratic.

Measured on 6.4, tokenizing `str_repeat(':is(', $n)`:

| input size | before | after |
| --- | --- | --- |
| 128 KB | 989.5 ms | 284.7 ms |
| 256 KB | 3231.5 ms | 586.5 ms |
| 512 KB | 11065.6 ms | 1097.5 ms |

Before the change, each doubling of the input multiplies the time by 3.3, then 3.4. After it, the ratio stays near 2.0, which is linear.

The fix matches against the source buffer in place, using the offset argument of `preg_match()`. Combined with an offset, `^` still anchors at the start of the whole subject, so a leading `^` is rewritten to `\G`, which anchors at the offset instead. That rewrite is done once per distinct pattern and cached, because `findPattern()` is on the hot path and rebuilding the pattern string on every call costs more than the `substr()` it replaces.

Behaviour is unchanged. This was checked by running base and patched side by side over 43984 inputs (every string literal in the CssSelector and DomCrawler test suites, combinations and truncations of selector atoms, and every single byte from 0x00 to 0xFF alone and inside a selector) and comparing the full token stream, the `toXPath()` output, and the class and message of any exception: no difference in any case.
