### PR TITLE
[HttpKernel][RateLimiter] Add option to expose `X-RateLimit-*` headers for the `#[RateLimit]` attribute

### DIFF
--- a/src/Symfony/Component/HttpKernel/Attribute/RateLimit.php
+++ b/src/Symfony/Component/HttpKernel/Attribute/RateLimit.php
@@ -16,6 +16,10 @@ use Symfony\Component\ExpressionLanguage\Expression;
 /**
  * Rate limits the controller.
  *
+ * When several attributes apply, the `X-RateLimit-*` headers describe the limiter closest to
+ * rejecting, out of those with $exposeHeaders enabled. A rejecting limiter always wins; when it
+ * does not expose its state, the response carries no `X-RateLimit-*` headers at all.
+ *
  * @see https://symfony.com/doc/current/rate_limiter.html
  *
  * @author Ayyoub AFW-ALLAH <ayyoub.afwallah@gmail.com>
@@ -27,16 +31,18 @@ final class RateLimit
     public readonly array $methods;
 
     /**
-     * @param string                          $limiter The configured limiter name
-     * @param string|Expression|\Closure|null $key     A literal string key, an Expression, or a Closure (defaults to client IP + method + path)
-     * @param int                             $tokens  The number of tokens to consume
-     * @param string[]|string                 $methods HTTP methods to rate limit; empty means all methods
+     * @param string                          $limiter       The configured limiter name
+     * @param string|Expression|\Closure|null $key           A literal string key, an Expression, or a Closure (defaults to client IP + method + path)
+     * @param int                             $tokens        The number of tokens to consume
+     * @param string[]|string                 $methods       HTTP methods to rate limit; empty means all methods
+     * @param bool                            $exposeHeaders Whether this limiter's state may be exposed via the `X-RateLimit-*` response headers, opt-in
      */
     public function __construct(
         public readonly string $limiter,
         public readonly string|Expression|\Closure|null $key = null,
         public readonly int $tokens = 1,
         array|string $methods = [],
+        public readonly bool $exposeHeaders = false,
     ) {
         if ($this->tokens < 1) {
             throw new \InvalidArgumentException(\sprintf('The "$tokens" argument of "%s" must be greater than 0, "%d" given.', self::class, $this->tokens));

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -17,6 +17,7 @@ CHANGELOG
  * Allow union and intersection type-hints when autowiring controller arguments
  * Add the `$excludedPaths` and `$excludedHttpCodes` arguments to `ProfilerListener::__construct()` to skip profiling some requests
  * Make `#[MapRequestPayload]` deserialize any media type carrying a structured syntax suffix with the encoder of the suffix format, e.g. `application/vnd.api+json` with the `json` encoder
+ * Add the `$exposeHeaders` argument to `#[RateLimit]`
 
 8.1
 ---

--- a/src/Symfony/Component/HttpKernel/EventListener/RateLimitAttributeListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/RateLimitAttributeListener.php
@@ -15,8 +15,10 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Attribute\RateLimit;
 use Symfony\Component\HttpKernel\Event\ControllerArgumentsEvent;
 use Symfony\Component\HttpKernel\Event\ControllerAttributeEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
 use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\HttpKernel\RateLimiter\AppliedRateLimit;
 use Symfony\Component\RateLimiter\Event\RateLimitExceededEvent;
 use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
@@ -29,6 +31,8 @@ use Symfony\Contracts\Service\ServiceProviderInterface;
  */
 final class RateLimitAttributeListener implements EventSubscriberInterface
 {
+    private const RATE_LIMIT_ATTRIBUTE = '_rate_limit';
+
     /**
      * @param ServiceProviderInterface<RateLimiterFactoryInterface> $limiters
      */
@@ -61,19 +65,64 @@ final class RateLimitAttributeListener implements EventSubscriberInterface
 
         $rateLimit = $this->limiters->get($attribute->limiter)->create($key)->consume($attribute->tokens);
 
+        $candidate = $attribute->exposeHeaders && null !== $rateLimit->getResetAt()
+            ? new AppliedRateLimit($rateLimit, $attribute->tokens)
+            : null;
+
         if (!$rateLimit->isAccepted()) {
+            $request->attributes->set(self::RATE_LIMIT_ATTRIBUTE, $candidate);
+
             if ($dispatcher && class_exists(RateLimitExceededEvent::class)) {
                 $dispatcher->dispatch(new RateLimitExceededEvent($rateLimit, $attribute->limiter, $key));
             }
 
             throw new TooManyRequestsHttpException(max(0, $rateLimit->getRetryAfter()->getTimestamp() - time()));
         }
+
+        if ($candidate) {
+            /** @var AppliedRateLimit|null $applied */
+            $applied = $request->attributes->get(self::RATE_LIMIT_ATTRIBUTE);
+
+            if (!$applied instanceof AppliedRateLimit || $candidate->getRemainingCalls() < $applied->getRemainingCalls()) {
+                $request->attributes->set(self::RATE_LIMIT_ATTRIBUTE, $candidate);
+            }
+        }
+    }
+
+    /**
+     * Adds the X-RateLimit-* headers to the response.
+     */
+    public function onKernelResponse(ResponseEvent $event): void
+    {
+        $applied = $event->getRequest()->attributes->get(self::RATE_LIMIT_ATTRIBUTE);
+
+        if (!$event->isMainRequest() || !$applied instanceof AppliedRateLimit) {
+            return;
+        }
+
+        $response = $event->getResponse();
+
+        $headers = [
+            'X-RateLimit-Limit' => intdiv($applied->rateLimit->getLimit(), $applied->tokens),
+            'X-RateLimit-Remaining' => max(0, (int) $applied->getRemainingCalls()),
+            'X-RateLimit-Reset' => $applied->rateLimit->getResetAt()->getTimestamp(),
+        ];
+
+        foreach (array_keys($headers) as $name) {
+            if ($response->headers->has($name)) {
+                return;
+            }
+        }
+
+        $response->setPrivate();
+        $response->headers->add($headers);
     }
 
     public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::CONTROLLER_ARGUMENTS.'.'.RateLimit::class => 'onKernelControllerAttribute',
+            KernelEvents::RESPONSE => 'onKernelResponse',
         ];
     }
 }

--- a/src/Symfony/Component/HttpKernel/RateLimiter/AppliedRateLimit.php
+++ b/src/Symfony/Component/HttpKernel/RateLimiter/AppliedRateLimit.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\RateLimiter;
+
+use Symfony\Component\RateLimiter\RateLimit;
+
+/**
+ * The rate limit that governs the response, out of every #[RateLimit] consumed for the request,
+ * along with the number of tokens its matching attribute consumes per call.
+ *
+ * @author Ayyoub AFW-ALLAH <ayyoub.afwallah@gmail.com>
+ *
+ * @internal
+ */
+final class AppliedRateLimit
+{
+    public function __construct(
+        public readonly RateLimit $rateLimit,
+        public readonly int $tokens,
+    ) {
+    }
+
+    /**
+     * The number of calls left, as opposed to the number of tokens remaining.
+     */
+    public function getRemainingCalls(): float
+    {
+        return $this->rateLimit->getRemainingTokens() / $this->tokens;
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Attribute/RateLimitTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Attribute/RateLimitTest.php
@@ -24,6 +24,7 @@ class RateLimitTest extends TestCase
         $this->assertNull($rl->key);
         $this->assertSame(1, $rl->tokens);
         $this->assertSame([], $rl->methods);
+        $this->assertFalse($rl->exposeHeaders);
     }
 
     public function testTokensMustBePositive()

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/RateLimitAttributeListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/RateLimitAttributeListenerTest.php
@@ -11,28 +11,45 @@
 
 namespace Symfony\Component\HttpKernel\Tests\EventListener;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Attribute\Cache;
 use Symfony\Component\HttpKernel\Attribute\RateLimit;
+use Symfony\Component\HttpKernel\Controller\ArgumentResolver;
+use Symfony\Component\HttpKernel\Controller\ControllerResolver;
 use Symfony\Component\HttpKernel\Event\ControllerArgumentsEvent;
 use Symfony\Component\HttpKernel\Event\ControllerAttributeEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\EventListener\CacheAttributeListener;
+use Symfony\Component\HttpKernel\EventListener\ControllerAttributesListener;
+use Symfony\Component\HttpKernel\EventListener\ErrorListener;
 use Symfony\Component\HttpKernel\EventListener\RateLimitAttributeListener;
 use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
+use Symfony\Component\HttpKernel\HttpCache\HttpCache;
+use Symfony\Component\HttpKernel\HttpCache\Store;
+use Symfony\Component\HttpKernel\HttpKernel;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\HttpKernel\Tests\HttpCache\HttpCacheTestCase;
 use Symfony\Component\RateLimiter\Event\RateLimitExceededEvent;
 use Symfony\Component\RateLimiter\LimiterInterface;
+use Symfony\Component\RateLimiter\Policy\NoLimiter;
 use Symfony\Component\RateLimiter\RateLimit as RateLimitResult;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
 use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
+use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
 use Symfony\Contracts\Service\ServiceProviderInterface;
 
 class RateLimitAttributeListenerTest extends TestCase
 {
     private function makeListener(bool $accept = true): RateLimitAttributeListener
     {
-        $result = new RateLimitResult($accept ? 4 : 0, new \DateTimeImmutable('+1 minute'), $accept, 5);
+        $result = new RateLimitResult($accept ? 4 : 0, new \DateTimeImmutable($accept ? 'now' : '+1 minute'), $accept, 5, new \DateTimeImmutable('+1 minute'));
 
         $limiter = $this->createStub(LimiterInterface::class);
         $limiter->method('consume')->willReturn($result);
@@ -50,7 +67,7 @@ class RateLimitAttributeListenerTest extends TestCase
 
     private function makeListenerCapturingKey(?string &$usedKey): RateLimitAttributeListener
     {
-        $result = new RateLimitResult(4, new \DateTimeImmutable('+1 minute'), true, 5);
+        $result = new RateLimitResult(4, new \DateTimeImmutable('now'), true, 5, new \DateTimeImmutable('+1 minute'));
 
         $limiter = $this->createStub(LimiterInterface::class);
         $limiter->method('consume')->willReturn($result);
@@ -81,10 +98,538 @@ class RateLimitAttributeListenerTest extends TestCase
         ), $el);
     }
 
+    private function makeResponseEvent(Request $request, Response $response, int $requestType = HttpKernelInterface::MAIN_REQUEST): ResponseEvent
+    {
+        return new ResponseEvent($this->createStub(HttpKernelInterface::class), $request, $requestType, $response);
+    }
+
     public function testAccepted()
     {
         $this->makeListener()->onKernelControllerAttribute($this->makeEvent(new RateLimit('api'), Request::create('/')));
         $this->addToAssertionCount(1);
+    }
+
+    public function testAcceptedSetsRateLimitHeadersOnResponse()
+    {
+        $listener = $this->makeListener();
+        $request = Request::create('/');
+
+        $listener->onKernelControllerAttribute($this->makeEvent(new RateLimit('api', exposeHeaders: true), $request));
+
+        $response = new Response();
+        $listener->onKernelResponse($this->makeResponseEvent($request, $response));
+
+        $this->assertSame('5', $response->headers->get('X-RateLimit-Limit'));
+        $this->assertSame('4', $response->headers->get('X-RateLimit-Remaining'));
+        $this->assertThat((int) $response->headers->get('X-RateLimit-Reset'), $this->logicalAnd($this->greaterThan(time() + 50), $this->lessThanOrEqual(time() + 60)));
+    }
+
+    public function testAddingHeadersMarksResponsePrivate()
+    {
+        $listener = $this->makeListener();
+        $request = Request::create('/');
+
+        $listener->onKernelControllerAttribute($this->makeEvent(new RateLimit('api', exposeHeaders: true), $request));
+
+        $response = new Response();
+        $response->setPublic();
+        $response->setMaxAge(3600);
+
+        $listener->onKernelResponse($this->makeResponseEvent($request, $response));
+
+        $this->assertTrue($response->headers->hasCacheControlDirective('private'));
+        $this->assertFalse($response->headers->hasCacheControlDirective('public'));
+    }
+
+    public function testResponseWithoutHeadersKeepsItsCacheControl()
+    {
+        $listener = $this->makeListener();
+        $response = new Response();
+        $response->setPublic();
+
+        $listener->onKernelResponse($this->makeResponseEvent(Request::create('/'), $response));
+
+        $this->assertTrue($response->headers->hasCacheControlDirective('public'));
+    }
+
+    public function testRealFixedWindowLimiterHeaderSequenceAcrossCalls()
+    {
+        $factory = new RateLimiterFactory([
+            'id' => 'api',
+            'policy' => 'fixed_window',
+            'limit' => 5,
+            'interval' => '1 minute',
+        ], new InMemoryStorage());
+
+        $locator = $this->createStub(ServiceProviderInterface::class);
+        $locator->method('has')->willReturn(true);
+        $locator->method('get')->willReturn($factory);
+        $locator->method('getProvidedServices')->willReturn(['api' => RateLimiterFactoryInterface::class]);
+
+        $listener = new RateLimitAttributeListener($locator);
+        $resetAt = null;
+
+        foreach ([4, 3, 2, 1, 0] as $remaining) {
+            $request = Request::create('/', server: ['REMOTE_ADDR' => '1.2.3.4']);
+            $listener->onKernelControllerAttribute($this->makeEvent(new RateLimit('api', exposeHeaders: true), $request));
+
+            $response = new Response();
+            $listener->onKernelResponse($this->makeResponseEvent($request, $response));
+
+            // the reset is the window's end, then stays constant for every call within the window
+            $resetAt ??= (int) $response->headers->get('X-RateLimit-Reset');
+            $this->assertEqualsWithDelta(time() + 60, $resetAt, 1);
+
+            $this->assertSame('5', $response->headers->get('X-RateLimit-Limit'));
+            $this->assertSame((string) $remaining, $response->headers->get('X-RateLimit-Remaining'));
+            $this->assertSame($resetAt, (int) $response->headers->get('X-RateLimit-Reset'));
+        }
+
+        $request = Request::create('/', server: ['REMOTE_ADDR' => '1.2.3.4']);
+        try {
+            $listener->onKernelControllerAttribute($this->makeEvent(new RateLimit('api', exposeHeaders: true), $request));
+            $this->fail('Expected TooManyRequestsHttpException');
+        } catch (TooManyRequestsHttpException) {
+        }
+
+        $response = new Response('', 429);
+        $listener->onKernelResponse($this->makeResponseEvent($request, $response));
+
+        $this->assertSame('0', $response->headers->get('X-RateLimit-Remaining'));
+        $this->assertSame($resetAt, (int) $response->headers->get('X-RateLimit-Reset'));
+    }
+
+    public function testNoLimitStackedWithBoundedLimiterOnlyBoundedOneIsReported()
+    {
+        $request = Request::create('/');
+
+        $bounded = $this->makeListenerWithResult('bounded', new RateLimitResult(2, new \DateTimeImmutable('now'), true, 5, new \DateTimeImmutable('+1 minute')));
+        $bounded->onKernelControllerAttribute($this->makeEvent(new RateLimit('bounded', exposeHeaders: true), $request));
+
+        $unboundedFactory = $this->createStub(RateLimiterFactoryInterface::class);
+        $unboundedFactory->method('create')->willReturn(new NoLimiter());
+        $unboundedLocator = $this->createStub(ServiceProviderInterface::class);
+        $unboundedLocator->method('has')->willReturn(true);
+        $unboundedLocator->method('get')->willReturn($unboundedFactory);
+        $unboundedLocator->method('getProvidedServices')->willReturn(['unbounded' => RateLimiterFactoryInterface::class]);
+        (new RateLimitAttributeListener($unboundedLocator))->onKernelControllerAttribute($this->makeEvent(new RateLimit('unbounded', exposeHeaders: true), $request));
+
+        $response = new Response();
+        $bounded->onKernelResponse($this->makeResponseEvent($request, $response));
+
+        $this->assertSame('5', $response->headers->get('X-RateLimit-Limit'));
+        $this->assertSame('2', $response->headers->get('X-RateLimit-Remaining'));
+    }
+
+    private function makeListenerWithResult(string $limiterName, RateLimitResult $result): RateLimitAttributeListener
+    {
+        $limiter = $this->createStub(LimiterInterface::class);
+        $limiter->method('consume')->willReturn($result);
+
+        $factory = $this->createStub(RateLimiterFactoryInterface::class);
+        $factory->method('create')->willReturn($limiter);
+
+        $locator = $this->createStub(ServiceProviderInterface::class);
+        $locator->method('has')->willReturn(true);
+        $locator->method('get')->willReturn($factory);
+        $locator->method('getProvidedServices')->willReturn([$limiterName => RateLimiterFactoryInterface::class]);
+
+        return new RateLimitAttributeListener($locator);
+    }
+
+    public function testRejectedLimiterOverridesAcceptedEvenWithHigherRemainingCalls()
+    {
+        $request = Request::create('/');
+
+        $accepted = $this->makeListenerWithResult('api', new RateLimitResult(1, new \DateTimeImmutable('now'), true, 5, new \DateTimeImmutable('+1 minute')));
+        $accepted->onKernelControllerAttribute($this->makeEvent(new RateLimit('api', exposeHeaders: true), $request));
+
+        // rejected despite a higher remaining count: it didn't have enough tokens for this call
+        $rejected = $this->makeListenerWithResult('other', new RateLimitResult(3, new \DateTimeImmutable('+2 minutes'), false, 5, new \DateTimeImmutable('+2 minutes')));
+
+        try {
+            $rejected->onKernelControllerAttribute($this->makeEvent(new RateLimit('other', exposeHeaders: true), $request));
+            $this->fail('Expected TooManyRequestsHttpException');
+        } catch (TooManyRequestsHttpException) {
+        }
+
+        $response = new Response('', 429);
+        $accepted->onKernelResponse($this->makeResponseEvent($request, $response));
+
+        $this->assertSame('5', $response->headers->get('X-RateLimit-Limit'));
+        $this->assertSame('3', $response->headers->get('X-RateLimit-Remaining'));
+    }
+
+    public function testHeadersFalseSuppressesHeaders()
+    {
+        $listener = $this->makeListener();
+        $request = Request::create('/');
+
+        $listener->onKernelControllerAttribute($this->makeEvent(new RateLimit('api', exposeHeaders: false), $request));
+
+        $response = new Response();
+        $listener->onKernelResponse($this->makeResponseEvent($request, $response));
+
+        $this->assertFalse($response->headers->has('X-RateLimit-Limit'));
+    }
+
+    public function testHeadersFalseExcludesLimiterEvenWhenMoreRestrictive()
+    {
+        $request = Request::create('/');
+
+        // tighter, but opted out of exposing its state
+        $sensitive = $this->makeListenerWithResult('login', new RateLimitResult(1, new \DateTimeImmutable('now'), true, 5, new \DateTimeImmutable('+1 minute')));
+        $sensitive->onKernelControllerAttribute($this->makeEvent(new RateLimit('login', exposeHeaders: false), $request));
+
+        $generic = $this->makeListenerWithResult('api', new RateLimitResult(90, new \DateTimeImmutable('now'), true, 100, new \DateTimeImmutable('+1 minute')));
+        $generic->onKernelControllerAttribute($this->makeEvent(new RateLimit('api', exposeHeaders: true), $request));
+
+        $response = new Response();
+        $generic->onKernelResponse($this->makeResponseEvent($request, $response));
+
+        $this->assertSame('100', $response->headers->get('X-RateLimit-Limit'));
+        $this->assertSame('90', $response->headers->get('X-RateLimit-Remaining'));
+    }
+
+    public function testHeadersFalseOnRejectingLimiterStillThrowsWithRetryAfterButNoRateLimitHeaders()
+    {
+        $request = Request::create('/');
+
+        $sensitive = $this->makeListenerWithResult('login', new RateLimitResult(0, new \DateTimeImmutable('+1 minute'), false, 5));
+
+        try {
+            $sensitive->onKernelControllerAttribute($this->makeEvent(new RateLimit('login', exposeHeaders: false), $request));
+            $this->fail('Expected TooManyRequestsHttpException');
+        } catch (TooManyRequestsHttpException $e) {
+            $this->assertArrayHasKey('Retry-After', $e->getHeaders());
+        }
+
+        $response = new Response('', 429);
+        $sensitive->onKernelResponse($this->makeResponseEvent($request, $response));
+
+        $this->assertFalse($response->headers->has('X-RateLimit-Limit'));
+    }
+
+    public function testAppPresetHeaderKeepsTheWholeTripletUntouched()
+    {
+        $listener = $this->makeListener();
+        $request = Request::create('/');
+
+        $listener->onKernelControllerAttribute($this->makeEvent(new RateLimit('api', exposeHeaders: true), $request));
+
+        $response = new Response();
+        $response->setPublic();
+        $response->headers->set('X-RateLimit-Limit', 'custom');
+        $listener->onKernelResponse($this->makeResponseEvent($request, $response));
+
+        $this->assertSame('custom', $response->headers->get('X-RateLimit-Limit'));
+        $this->assertFalse($response->headers->has('X-RateLimit-Remaining'));
+        $this->assertFalse($response->headers->has('X-RateLimit-Reset'));
+        $this->assertTrue($response->headers->hasCacheControlDirective('public'));
+    }
+
+    public function testUnrelatedRequestAttributeIsIgnored()
+    {
+        $listener = $this->makeListener();
+        $request = Request::create('/');
+        $request->attributes->set('_rate_limit', 'a route default');
+
+        $listener->onKernelControllerAttribute($this->makeEvent(new RateLimit('api', exposeHeaders: true), $request));
+
+        $response = new Response();
+        $listener->onKernelResponse($this->makeResponseEvent($request, $response));
+
+        // the route default is replaced, not dereferenced
+        $this->assertSame('5', $response->headers->get('X-RateLimit-Limit'));
+        $this->assertSame('4', $response->headers->get('X-RateLimit-Remaining'));
+    }
+
+    public function testRejectingLimiterWithoutResetTimeSuppressesAnotherLimitersHeaders()
+    {
+        $request = Request::create('/');
+
+        $accepted = $this->makeListenerWithResult('api', new RateLimitResult(90, new \DateTimeImmutable('now'), true, 100, new \DateTimeImmutable('+1 minute')));
+        $accepted->onKernelControllerAttribute($this->makeEvent(new RateLimit('api', exposeHeaders: true), $request));
+
+        // a limiter with no reset time never becomes the candidate, so it must clear the accepted one
+        $rejected = $this->makeListenerWithResult('other', new RateLimitResult(0, new \DateTimeImmutable('+1 minute'), false, 5));
+
+        try {
+            $rejected->onKernelControllerAttribute($this->makeEvent(new RateLimit('other', exposeHeaders: true), $request));
+            $this->fail('Expected TooManyRequestsHttpException');
+        } catch (TooManyRequestsHttpException) {
+        }
+
+        $response = new Response('', 429);
+        $accepted->onKernelResponse($this->makeResponseEvent($request, $response));
+
+        $this->assertFalse($response->headers->has('X-RateLimit-Limit'));
+    }
+
+    private function makeRealKernel(array $config, bool $withErrorHandling = false): HttpKernel
+    {
+        return $this->makeRealKernelWithLimiters(['api' => $config], $withErrorHandling);
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $configByName
+     */
+    private function makeRealKernelWithLimiters(array $configByName, bool $withErrorHandling = false): HttpKernel
+    {
+        $factories = [];
+        foreach ($configByName as $name => $config) {
+            $factories[$name] = new RateLimiterFactory(array_replace($config, ['id' => $name]), new InMemoryStorage());
+        }
+
+        $locator = $this->createStub(ServiceProviderInterface::class);
+        $locator->method('has')->willReturnCallback(static fn (string $id): bool => isset($factories[$id]));
+        $locator->method('get')->willReturnCallback(static fn (string $id): RateLimiterFactory => $factories[$id]);
+        $locator->method('getProvidedServices')->willReturn(array_map(static fn (): string => RateLimiterFactoryInterface::class, $factories));
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addSubscriber(new ControllerAttributesListener([
+            KernelEvents::CONTROLLER_ARGUMENTS => [RateLimit::class => true],
+        ]));
+        $dispatcher->addSubscriber(new RateLimitAttributeListener($locator));
+
+        if ($withErrorHandling) {
+            // a non-error response makes handleThrowable() stamp the 429 and Retry-After itself
+            $dispatcher->addSubscriber(new ErrorListener(static fn () => new Response('error')));
+        }
+
+        return new HttpKernel($dispatcher, new ControllerResolver(), null, new ArgumentResolver());
+    }
+
+    private function handleThrough(HttpKernel $kernel, object $controller): Response
+    {
+        $request = Request::create('/', server: ['REMOTE_ADDR' => '1.2.3.4']);
+        $request->attributes->set('_controller', $controller);
+
+        return $kernel->handle($request);
+    }
+
+    public static function policyProvider(): iterable
+    {
+        yield 'fixed_window' => [['policy' => 'fixed_window', 'limit' => 5, 'interval' => '1 minute']];
+        yield 'sliding_window' => [['policy' => 'sliding_window', 'limit' => 5, 'interval' => '1 minute']];
+        yield 'token_bucket' => [['policy' => 'token_bucket', 'limit' => 5, 'rate' => ['interval' => '1 minute', 'amount' => 1]]];
+    }
+
+    #[DataProvider('policyProvider')]
+    public function testHeadersReachTheResponseThroughARealKernelDispatch(array $config)
+    {
+        $kernel = $this->makeRealKernel($config);
+
+        foreach ([4, 3] as $remaining) {
+            $response = $this->handleThrough($kernel, new RateLimitedController());
+
+            $this->assertSame(200, $response->getStatusCode());
+            $this->assertSame('5', $response->headers->get('X-RateLimit-Limit'));
+            $this->assertSame((string) $remaining, $response->headers->get('X-RateLimit-Remaining'));
+            $reset = (int) $response->headers->get('X-RateLimit-Reset') - time();
+            $this->assertGreaterThan(0, $reset);
+            $this->assertLessThanOrEqual(120, $reset);
+        }
+    }
+
+    #[DataProvider('policyProvider')]
+    public function testSharedCacheDoesNotServeOneClientsQuotaToAnother(array $config)
+    {
+        $kernel = $this->makeRealKernel(array_replace($config, ['limit' => 100]));
+        $storeDir = sys_get_temp_dir().'/sf_ratelimit_cache_'.bin2hex(random_bytes(6));
+        $cache = new HttpCache($kernel, new Store($storeDir));
+
+        $makeRequest = static function (string $ip) {
+            $r = Request::create('/', server: ['REMOTE_ADDR' => $ip]);
+            $r->attributes->set('_controller', new PubliclyCacheableRateLimitedController());
+
+            return $r;
+        };
+
+        try {
+            // a literal key puts both clients on one counter, so a leak shows as a stale number
+            $a = $cache->handle($makeRequest('1.1.1.1'));
+            $b = $cache->handle($makeRequest('2.2.2.2'));
+        } finally {
+            HttpCacheTestCase::clearDirectory($storeDir);
+            @rmdir($storeDir);
+        }
+
+        $this->assertSame('99', $a->headers->get('X-RateLimit-Remaining'));
+        $this->assertSame('98', $b->headers->get('X-RateLimit-Remaining'), 'client B must consume its own call, not be served A\'s cached counters');
+        $this->assertTrue($a->headers->hasCacheControlDirective('private'));
+        $this->assertFalse($a->headers->hasCacheControlDirective('public'));
+    }
+
+    public function testCacheAttributeCannotReShareThePerClientHeaders()
+    {
+        $factory = new RateLimiterFactory(['id' => 'api', 'policy' => 'fixed_window', 'limit' => 5, 'interval' => '1 minute'], new InMemoryStorage());
+
+        $locator = $this->createStub(ServiceProviderInterface::class);
+        $locator->method('has')->willReturn(true);
+        $locator->method('get')->willReturn($factory);
+        $locator->method('getProvidedServices')->willReturn(['api' => RateLimiterFactoryInterface::class]);
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addSubscriber(new ControllerAttributesListener([
+            KernelEvents::CONTROLLER_ARGUMENTS => [RateLimit::class => true, Cache::class => true],
+            KernelEvents::RESPONSE => [Cache::class => true],
+        ]));
+        $dispatcher->addSubscriber(new CacheAttributeListener());
+        $dispatcher->addSubscriber(new RateLimitAttributeListener($locator));
+
+        $kernel = new HttpKernel($dispatcher, new ControllerResolver(), null, new ArgumentResolver());
+        $response = $this->handleThrough($kernel, new CachedRateLimitedController());
+
+        // #[Cache] processes the response at priority 10000, so the listener runs after it and privacy wins
+        $this->assertSame('4', $response->headers->get('X-RateLimit-Remaining'));
+        $this->assertTrue($response->headers->hasCacheControlDirective('private'));
+        $this->assertFalse($response->headers->hasCacheControlDirective('public'));
+    }
+
+    #[DataProvider('policyProvider')]
+    public function testRejectionThroughARealKernelKeepsTheHeadersOnThe429(array $config)
+    {
+        // limit 1 so the second call is always the rejection, whatever the policy
+        $kernel = $this->makeRealKernel(array_replace($config, ['limit' => 1]), true);
+
+        $accepted = $this->handleThrough($kernel, new RateLimitedController());
+        $rejected = $this->handleThrough($kernel, new RateLimitedController());
+
+        $this->assertSame(200, $accepted->getStatusCode());
+        $this->assertSame(429, $rejected->getStatusCode());
+
+        // Retry-After is a plain delta in seconds, never an epoch
+        $this->assertLessThanOrEqual(3600, (int) $rejected->headers->get('Retry-After'));
+        $this->assertGreaterThan(0, (int) $rejected->headers->get('Retry-After'));
+
+        $this->assertSame('1', $rejected->headers->get('X-RateLimit-Limit'));
+        $this->assertSame('0', $rejected->headers->get('X-RateLimit-Remaining'));
+        $this->assertGreaterThan(time(), (int) $rejected->headers->get('X-RateLimit-Reset'));
+        $this->assertTrue($rejected->headers->hasCacheControlDirective('private'));
+    }
+
+    public function testStackedLimitersThroughARealKernelReportTheTightestOne()
+    {
+        $kernel = $this->makeRealKernelWithLimiters([
+            'generous' => ['policy' => 'fixed_window', 'limit' => 100, 'interval' => '1 minute'],
+            'tight' => ['policy' => 'fixed_window', 'limit' => 5, 'interval' => '1 minute'],
+        ]);
+
+        $first = $this->handleThrough($kernel, new StackedRateLimitController());
+        $this->assertSame('5', $first->headers->get('X-RateLimit-Limit'), 'the tight limiter is reported, not the generous one');
+        $this->assertSame('4', $first->headers->get('X-RateLimit-Remaining'));
+
+        $second = $this->handleThrough($kernel, new StackedRateLimitController());
+        $this->assertSame('3', $second->headers->get('X-RateLimit-Remaining'));
+    }
+
+    public function testStackedLimitersThroughARealKernelNormalizeByTokenCost()
+    {
+        $kernel = $this->makeRealKernelWithLimiters([
+            'cheap' => ['policy' => 'fixed_window', 'limit' => 1000, 'interval' => '1 minute'],
+            // 10 calls left at 10 tokens each, so this is the tighter one despite the bigger limit
+            'pricey' => ['policy' => 'fixed_window', 'limit' => 100, 'interval' => '1 minute'],
+        ]);
+
+        $response = $this->handleThrough($kernel, new StackedTokenCostController());
+
+        $this->assertSame('10', $response->headers->get('X-RateLimit-Limit'));
+        $this->assertSame('9', $response->headers->get('X-RateLimit-Remaining'));
+    }
+
+    public function testStackedRejectingLimiterSpeaksForThe429ThroughARealKernel()
+    {
+        $kernel = $this->makeRealKernelWithLimiters([
+            'generous' => ['policy' => 'fixed_window', 'limit' => 100, 'interval' => '1 minute'],
+            'tight' => ['policy' => 'fixed_window', 'limit' => 1, 'interval' => '1 minute'],
+        ], true);
+
+        $this->handleThrough($kernel, new StackedRateLimitController());
+        $rejected = $this->handleThrough($kernel, new StackedRateLimitController());
+
+        $this->assertSame(429, $rejected->getStatusCode());
+        $this->assertSame('1', $rejected->headers->get('X-RateLimit-Limit'), 'the rejecting limiter, not the generous one');
+        $this->assertSame('0', $rejected->headers->get('X-RateLimit-Remaining'));
+
+        // the reset and Retry-After describe the same limiter, so they must not contradict
+        $resetIn = (int) $rejected->headers->get('X-RateLimit-Reset') - time();
+        $this->assertGreaterThanOrEqual((int) $rejected->headers->get('Retry-After') - 1, $resetIn);
+    }
+
+    public function testStackedRejectingOptedOutLimiterLeaksNothingThroughARealKernel()
+    {
+        $kernel = $this->makeRealKernelWithLimiters([
+            'generous' => ['policy' => 'fixed_window', 'limit' => 100, 'interval' => '1 minute'],
+            'tight' => ['policy' => 'fixed_window', 'limit' => 1, 'interval' => '1 minute'],
+        ], true);
+
+        $this->handleThrough($kernel, new StackedRejectingOptedOutController());
+        $rejected = $this->handleThrough($kernel, new StackedRejectingOptedOutController());
+
+        $this->assertSame(429, $rejected->getStatusCode());
+        $this->assertNotNull($rejected->headers->get('Retry-After'));
+        $this->assertFalse($rejected->headers->has('X-RateLimit-Limit'), 'an opted-out limiter must not leak through its sibling');
+        $this->assertFalse($rejected->headers->has('X-RateLimit-Remaining'));
+        $this->assertFalse($rejected->headers->has('X-RateLimit-Reset'));
+    }
+
+    public function testOptInDefaultHoldsThroughARealKernel()
+    {
+        $kernel = $this->makeRealKernel(['policy' => 'fixed_window', 'limit' => 1, 'interval' => '1 minute'], true);
+
+        $accepted = $this->handleThrough($kernel, new BareRateLimitController());
+
+        $this->assertSame(200, $accepted->getStatusCode());
+        $this->assertFalse($accepted->headers->has('X-RateLimit-Limit'));
+        $this->assertFalse($accepted->headers->has('X-RateLimit-Remaining'));
+        $this->assertFalse($accepted->headers->has('X-RateLimit-Reset'));
+        $this->assertTrue($accepted->headers->hasCacheControlDirective('public'), 'an opted-out limiter must not force the response private');
+
+        $rejected = $this->handleThrough($kernel, new BareRateLimitController());
+        $this->assertSame(429, $rejected->getStatusCode());
+        $this->assertNotNull($rejected->headers->get('Retry-After'));
+    }
+
+    public function testNoLimitPolicyThroughARealKernelEmitsNothingAndNoWarning()
+    {
+        $failOnWarning = static function (int $severity, string $message): bool {
+            throw new \RuntimeException(\sprintf('Unexpected PHP warning: "%s".', $message));
+        };
+
+        foreach ([new RateLimitedController(), new TokenCostRateLimitController()] as $controller) {
+            $kernel = $this->makeRealKernel(['policy' => 'no_limit']);
+
+            set_error_handler($failOnWarning, \E_WARNING | \E_USER_WARNING);
+            try {
+                $response = $this->handleThrough($kernel, $controller);
+            } finally {
+                restore_error_handler();
+            }
+
+            $this->assertSame(200, $response->getStatusCode());
+            $this->assertFalse($response->headers->has('X-RateLimit-Limit'), $controller::class);
+            $this->assertFalse($response->headers->has('X-RateLimit-Remaining'));
+            $this->assertFalse($response->headers->has('X-RateLimit-Reset'));
+        }
+    }
+
+    public function testSubRequestResponseIsLeftAloneThroughARealKernel()
+    {
+        $kernel = $this->makeRealKernel(['policy' => 'fixed_window', 'limit' => 5, 'interval' => '1 minute']);
+
+        // same client as handleThrough(), so both hit the same limiter key
+        $request = Request::create('/', server: ['REMOTE_ADDR' => '1.2.3.4']);
+        $request->attributes->set('_controller', new RateLimitedController());
+        $subResponse = $kernel->handle($request, HttpKernelInterface::SUB_REQUEST);
+
+        $this->assertFalse($subResponse->headers->has('X-RateLimit-Limit'));
+        $this->assertFalse($subResponse->headers->has('X-RateLimit-Remaining'));
+        $this->assertFalse($subResponse->headers->has('X-RateLimit-Reset'));
+
+        // the limiter still ran for the fragment, only the header emission was skipped
+        $mainResponse = $this->handleThrough($kernel, new RateLimitedController());
+        $this->assertSame('3', $mainResponse->headers->get('X-RateLimit-Remaining'), 'the sub-request consumed one, the main request the next');
     }
 
     public function testRejectedThrowsWith429AndRetryAfter()
@@ -182,7 +727,7 @@ class RateLimitAttributeListenerTest extends TestCase
             $dispatched[] = $event;
         });
 
-        $result = new RateLimitResult(4, new \DateTimeImmutable('+1 minute'), true, 5);
+        $result = new RateLimitResult(4, new \DateTimeImmutable('now'), true, 5, new \DateTimeImmutable('+1 minute'));
 
         $limiter = $this->createStub(LimiterInterface::class);
         $limiter->method('consume')->willReturn($result);
@@ -213,5 +758,89 @@ class RateLimitAttributeListenerTest extends TestCase
 
         $listener = new RateLimitAttributeListener($locator);
         $listener->onKernelControllerAttribute($this->makeEvent(new RateLimit('api', methods: ['POST']), Request::create('/', 'GET')));
+    }
+}
+
+class RateLimitedController
+{
+    #[RateLimit('api', exposeHeaders: true)]
+    public function __invoke(): Response
+    {
+        return new Response('ok');
+    }
+}
+
+class CachedRateLimitedController
+{
+    #[Cache(smaxage: 3600)]
+    #[RateLimit('api', exposeHeaders: true)]
+    public function __invoke(): Response
+    {
+        return new Response('ok');
+    }
+}
+
+class PubliclyCacheableRateLimitedController
+{
+    #[RateLimit('api', key: 'shared', exposeHeaders: true)]
+    public function __invoke(): Response
+    {
+        $response = new Response('ok');
+        $response->setPublic();
+        $response->setMaxAge(3600);
+
+        return $response;
+    }
+}
+
+class TokenCostRateLimitController
+{
+    #[RateLimit('api', tokens: 3, exposeHeaders: true)]
+    public function __invoke(): Response
+    {
+        return new Response('ok');
+    }
+}
+
+class BareRateLimitController
+{
+    #[RateLimit('api')]
+    public function __invoke(): Response
+    {
+        $response = new Response('ok');
+        $response->setPublic();
+        $response->setMaxAge(3600);
+
+        return $response;
+    }
+}
+
+class StackedRateLimitController
+{
+    #[RateLimit('generous', key: 'k', exposeHeaders: true)]
+    #[RateLimit('tight', key: 'k', exposeHeaders: true)]
+    public function __invoke(): Response
+    {
+        return new Response('ok');
+    }
+}
+
+class StackedRejectingOptedOutController
+{
+    #[RateLimit('generous', key: 'k', exposeHeaders: true)]
+    #[RateLimit('tight', key: 'k', exposeHeaders: false)]
+    public function __invoke(): Response
+    {
+        return new Response('ok');
+    }
+}
+
+class StackedTokenCostController
+{
+    #[RateLimit('cheap', key: 'k', exposeHeaders: true)]
+    #[RateLimit('pricey', key: 'k', tokens: 10, exposeHeaders: true)]
+    public function __invoke(): Response
+    {
+        return new Response('ok');
     }
 }

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -57,6 +57,7 @@
         "symfony/dependency-injection": "<8.2",
         "symfony/flex": "<2.10",
         "symfony/http-client-contracts": "<2.5",
+        "symfony/rate-limiter": "<8.2",
         "symfony/serializer": "<7.4.15|>=8.0,<8.0.15|>=8.1,<8.1.2",
         "symfony/translation-contracts": "<2.5",
         "symfony/var-dumper": "<8.1",

--- a/src/Symfony/Component/RateLimiter/CHANGELOG.md
+++ b/src/Symfony/Component/RateLimiter/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Add `RateLimitExceededEvent`
  * Add `RateLimiterBuilder`
  * Allow `\DateInterval` for the `interval` and `rate.interval` options of `RateLimiterFactory`
+ * Add `RateLimit::getResetAt()`
 
 8.1
 ---

--- a/src/Symfony/Component/RateLimiter/Policy/FixedWindowLimiter.php
+++ b/src/Symfony/Component/RateLimiter/Policy/FixedWindowLimiter.php
@@ -81,14 +81,14 @@ final class FixedWindowLimiter implements LimiterInterface
                     $window = new CalendarAlignedWindow($this->id, $this->limit, $periodStart, $periodEnd);
                 }
             } elseif (!$window instanceof Window) {
-                $window = new Window($this->id, $this->intervalInSeconds, $this->limit);
+                $window = new Window($this->id, $this->intervalInSeconds, $this->limit, $now);
             }
 
             $availableTokens = $window->getAvailableTokens($now);
 
             if (0 === $tokens) {
                 $waitDuration = $window->calculateTimeForTokens(1, $now);
-                $reservation = new Reservation($now + $waitDuration, new RateLimit($window->getAvailableTokens($now), \DateTimeImmutable::createFromFormat('U', floor($now + $waitDuration)), true, $this->limit));
+                $reservation = new Reservation($now + $waitDuration, new RateLimit($window->getAvailableTokens($now), \DateTimeImmutable::createFromTimestamp((int) ($now + $waitDuration)), true, $this->limit, $this->resetAt($window, $now)));
             } elseif ($availableTokens >= $tokens) {
                 $window->add($tokens, $now);
 
@@ -97,18 +97,18 @@ final class FixedWindowLimiter implements LimiterInterface
                     $retryAfter += $window->calculateTimeForTokens(1, $now);
                 }
 
-                $reservation = new Reservation($now, new RateLimit($window->getAvailableTokens($now), \DateTimeImmutable::createFromFormat('U', floor($retryAfter)), true, $this->limit));
+                $reservation = new Reservation($now, new RateLimit($window->getAvailableTokens($now), \DateTimeImmutable::createFromTimestamp((int) $retryAfter), true, $this->limit, $this->resetAt($window, $now)));
             } else {
                 $waitDuration = $window->calculateTimeForTokens($tokens, $now);
 
                 if (null !== $maxTime && $waitDuration > $maxTime) {
                     // process needs to wait longer than set interval
-                    throw new MaxWaitDurationExceededException(\sprintf('The rate limiter wait time ("%d" seconds) is longer than the provided maximum time ("%d" seconds).', $waitDuration, $maxTime), new RateLimit($window->getAvailableTokens($now), \DateTimeImmutable::createFromFormat('U', floor($now + $waitDuration)), false, $this->limit));
+                    throw new MaxWaitDurationExceededException(\sprintf('The rate limiter wait time ("%d" seconds) is longer than the provided maximum time ("%d" seconds).', $waitDuration, $maxTime), new RateLimit($window->getAvailableTokens($now), \DateTimeImmutable::createFromTimestamp((int) ($now + $waitDuration)), false, $this->limit, $this->resetAt($window, $now)));
                 }
 
                 $window->add($tokens, $now);
 
-                $reservation = new Reservation($now + $waitDuration, new RateLimit($window->getAvailableTokens($now), \DateTimeImmutable::createFromFormat('U', floor($now + $waitDuration)), false, $this->limit));
+                $reservation = new Reservation($now + $waitDuration, new RateLimit($window->getAvailableTokens($now), \DateTimeImmutable::createFromTimestamp((int) ($now + $waitDuration)), false, $this->limit, $this->resetAt($window, $now)));
             }
 
             if (0 !== $tokens) {
@@ -133,6 +133,11 @@ final class FixedWindowLimiter implements LimiterInterface
     public function getAvailableTokens(int $hitCount): int
     {
         return $this->limit - $hitCount;
+    }
+
+    private function resetAt(Window|CalendarAlignedWindow $window, float $now): \DateTimeImmutable
+    {
+        return \DateTimeImmutable::createFromTimestamp((int) ($now + $window->calculateTimeForTokens($this->limit, $now)));
     }
 
     /**

--- a/src/Symfony/Component/RateLimiter/Policy/SlidingWindow.php
+++ b/src/Symfony/Component/RateLimiter/Policy/SlidingWindow.php
@@ -82,6 +82,23 @@ final class SlidingWindow implements LimiterStateInterface
         return (int) floor($this->hitCountForLastWindow * (1 - $percentOfCurrentTimeFrame) + $this->hitCount);
     }
 
+    /**
+     * Returns when the window holds no hits at all.
+     */
+    public function getFullCapacityTime(): float
+    {
+        // hits only start decaying once carried into the next window
+        if ($this->hitCount) {
+            return $this->windowEndAt + $this->intervalInSeconds * (1 - 1 / $this->hitCount);
+        }
+
+        if ($this->hitCountForLastWindow) {
+            return $this->windowEndAt - $this->intervalInSeconds / $this->hitCountForLastWindow;
+        }
+
+        return microtime(true);
+    }
+
     public function calculateTimeForTokens(int $maxSize, int $tokens): float
     {
         $remaining = $maxSize - $this->getHitCount();

--- a/src/Symfony/Component/RateLimiter/Policy/SlidingWindowLimiter.php
+++ b/src/Symfony/Component/RateLimiter/Policy/SlidingWindowLimiter.php
@@ -72,7 +72,7 @@ final class SlidingWindowLimiter implements LimiterInterface
                 $resetDuration = $window->calculateTimeForTokens($this->limit, $window->getHitCount());
                 $resetTime = \DateTimeImmutable::createFromFormat('U', $availableTokens ? floor($now) : floor($now + $resetDuration));
 
-                return new Reservation($now, new RateLimit($availableTokens, $resetTime, true, $this->limit));
+                return new Reservation($now, new RateLimit($availableTokens, $resetTime, true, $this->limit, $this->resetAt($window, $now)));
             }
             if ($availableTokens >= $tokens) {
                 $window->add($tokens);
@@ -82,18 +82,18 @@ final class SlidingWindowLimiter implements LimiterInterface
                     $retryAfter += $window->calculateTimeForTokens($this->limit, $window->getHitCount());
                 }
 
-                $reservation = new Reservation($now, new RateLimit($this->getAvailableTokens($window->getHitCount()), \DateTimeImmutable::createFromFormat('U', floor($retryAfter)), true, $this->limit));
+                $reservation = new Reservation($now, new RateLimit($this->getAvailableTokens($window->getHitCount()), \DateTimeImmutable::createFromTimestamp((int) $retryAfter), true, $this->limit, $this->resetAt($window, $now)));
             } else {
                 $waitDuration = $window->calculateTimeForTokens($this->limit, $tokens);
 
                 if (null !== $maxTime && $waitDuration > $maxTime) {
                     // process needs to wait longer than set interval
-                    throw new MaxWaitDurationExceededException(\sprintf('The rate limiter wait time ("%d" seconds) is longer than the provided maximum time ("%d" seconds).', $waitDuration, $maxTime), new RateLimit($this->getAvailableTokens($window->getHitCount()), \DateTimeImmutable::createFromFormat('U', floor($now + $waitDuration)), false, $this->limit));
+                    throw new MaxWaitDurationExceededException(\sprintf('The rate limiter wait time ("%d" seconds) is longer than the provided maximum time ("%d" seconds).', $waitDuration, $maxTime), new RateLimit($this->getAvailableTokens($window->getHitCount()), \DateTimeImmutable::createFromTimestamp((int) ($now + $waitDuration)), false, $this->limit, $this->resetAt($window, $now)));
                 }
 
                 $window->add($tokens);
 
-                $reservation = new Reservation($now + $waitDuration, new RateLimit($this->getAvailableTokens($window->getHitCount()), \DateTimeImmutable::createFromFormat('U', floor($now + $waitDuration)), false, $this->limit));
+                $reservation = new Reservation($now + $waitDuration, new RateLimit($this->getAvailableTokens($window->getHitCount()), \DateTimeImmutable::createFromTimestamp((int) ($now + $waitDuration)), false, $this->limit, $this->resetAt($window, $now)));
             }
 
             if (0 !== $tokens) {
@@ -118,5 +118,15 @@ final class SlidingWindowLimiter implements LimiterInterface
     private function getAvailableTokens(int $hitCount): int
     {
         return $this->limit - $hitCount;
+    }
+
+    private function resetAt(SlidingWindow $window, float $now): \DateTimeImmutable
+    {
+        if (!$window->getHitCount()) {
+            return \DateTimeImmutable::createFromTimestamp((int) $now);
+        }
+
+        // the decay crosses below one hit strictly after that instant
+        return \DateTimeImmutable::createFromTimestamp((int) max($now, $window->getFullCapacityTime()) + 1);
     }
 }

--- a/src/Symfony/Component/RateLimiter/Policy/TokenBucketLimiter.php
+++ b/src/Symfony/Component/RateLimiter/Policy/TokenBucketLimiter.php
@@ -81,14 +81,14 @@ final class TokenBucketLimiter implements LimiterInterface
                     $retryAfter += $this->rate->calculateTimeForTokens(1);
                 }
 
-                $reservation = new Reservation($now, new RateLimit($bucket->getAvailableTokens($now), \DateTimeImmutable::createFromFormat('U', floor($retryAfter)), true, $this->maxBurst));
+                $reservation = new Reservation($now, new RateLimit($bucket->getAvailableTokens($now), \DateTimeImmutable::createFromTimestamp((int) $retryAfter), true, $this->maxBurst, $this->resetAt($availableTokens - $tokens, $now)));
             } else {
                 $remainingTokens = $tokens - $availableTokens;
                 $waitDuration = $this->rate->calculateTimeForTokens($remainingTokens);
 
                 if (null !== $maxTime && $waitDuration > $maxTime) {
                     // process needs to wait longer than set interval
-                    $rateLimit = new RateLimit($availableTokens, \DateTimeImmutable::createFromFormat('U', floor($now + $waitDuration)), false, $this->maxBurst);
+                    $rateLimit = new RateLimit($availableTokens, \DateTimeImmutable::createFromTimestamp((int) ($now + $waitDuration)), false, $this->maxBurst, $this->resetAt($availableTokens, $now));
 
                     throw new MaxWaitDurationExceededException(\sprintf('The rate limiter wait time ("%d" seconds) is longer than the provided maximum time ("%d" seconds).', $waitDuration, $maxTime), $rateLimit);
                 }
@@ -97,7 +97,7 @@ final class TokenBucketLimiter implements LimiterInterface
                 // so no tokens are left for other processes.
                 $bucket->setTokens($availableTokens - $tokens);
 
-                $reservation = new Reservation($now + $waitDuration, new RateLimit(0, \DateTimeImmutable::createFromFormat('U', floor($now + $waitDuration)), false, $this->maxBurst));
+                $reservation = new Reservation($now + $waitDuration, new RateLimit(0, \DateTimeImmutable::createFromTimestamp((int) ($now + $waitDuration)), false, $this->maxBurst, $this->resetAt($availableTokens - $tokens, $now)));
             }
 
             if (0 !== $tokens) {
@@ -117,5 +117,10 @@ final class TokenBucketLimiter implements LimiterInterface
         } catch (MaxWaitDurationExceededException $e) {
             return $e->getRateLimit();
         }
+    }
+
+    private function resetAt(int $availableTokens, float $now): \DateTimeImmutable
+    {
+        return \DateTimeImmutable::createFromTimestamp((int) ($now + $this->rate->calculateTimeForTokens(max(0, $this->maxBurst - $availableTokens))));
     }
 }

--- a/src/Symfony/Component/RateLimiter/RateLimit.php
+++ b/src/Symfony/Component/RateLimiter/RateLimit.php
@@ -23,6 +23,7 @@ class RateLimit
         private \DateTimeImmutable $retryAfter,
         private bool $accepted,
         private int $limit,
+        private ?\DateTimeImmutable $resetAt = null,
     ) {
     }
 
@@ -58,6 +59,14 @@ class RateLimit
     public function getLimit(): int
     {
         return $this->limit;
+    }
+
+    /**
+     * Returns when the limiter is back to its full capacity, or null if the policy has no such moment.
+     */
+    public function getResetAt(): ?\DateTimeImmutable
+    {
+        return $this->resetAt;
     }
 
     public function wait(): void

--- a/src/Symfony/Component/RateLimiter/Tests/Policy/FixedWindowLimiterTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/Policy/FixedWindowLimiterTest.php
@@ -60,6 +60,36 @@ class FixedWindowLimiterTest extends TestCase
         $this->assertEquals($retryAfter, $rateLimit->getRetryAfter());
     }
 
+    public function testResetTimeStaysConstantWithinWindow()
+    {
+        $now = time();
+        $limiter = new FixedWindowLimiter('test', 5, new \DateInterval('PT1M'), $this->storage);
+
+        // pinned to the window's end for every call within it, accepted or not
+        for ($i = 0; $i < 6; ++$i) {
+            $rateLimit = $limiter->consume();
+            $this->assertSame($now + 60, $rateLimit->getResetAt()->getTimestamp());
+        }
+    }
+
+    public function testCalendarAnchorResetTimeBoundedToPeriodEnd()
+    {
+        $utc = new \DateTimeZone('UTC');
+        $anchor = new \DateTimeImmutable('2024-01-05 00:00:00', $utc);
+
+        ClockMock::withClockMock((new \DateTimeImmutable('2026-05-10 12:00:00', $utc))->getTimestamp());
+
+        $limiter = new FixedWindowLimiter('cal', 3, new \DateInterval('P1M'), $this->storage, null, $anchor);
+
+        $rateLimit = $limiter->consume();
+        $this->assertTrue($rateLimit->isAccepted());
+        // 1 of 3 tokens used, so resetAt is the period's end
+        $this->assertEquals(
+            (new \DateTimeImmutable('2026-06-05 00:00:00', $utc))->getTimestamp(),
+            $rateLimit->getResetAt()->getTimestamp()
+        );
+    }
+
     public function testConsumeLastToken()
     {
         $now = time();

--- a/src/Symfony/Component/RateLimiter/Tests/Policy/SlidingWindowLimiterTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/Policy/SlidingWindowLimiterTest.php
@@ -69,6 +69,35 @@ class SlidingWindowLimiterTest extends TestCase
         $this->assertTrue($limiter->consume()->isAccepted());
     }
 
+    public function testResetTimeIsWhenCarriedHitsHaveFullyDecayed()
+    {
+        $limiter = new SlidingWindowLimiter('decay', 10, new \DateInterval('PT4S'), $this->storage);
+
+        $resetAt = $limiter->consume()->getResetAt()->getTimestamp();
+
+        sleep($resetAt - time() - 1);
+        $this->assertSame(9, $limiter->consume(0)->getRemainingTokens());
+
+        sleep(1);
+        $this->assertSame(10, $limiter->consume(0)->getRemainingTokens());
+    }
+
+    public function testResetTimeAfterRolloverTracksTheCarriedHits()
+    {
+        $limiter = $this->createLimiter();
+
+        $limiter->consume(3);
+        sleep(13); // the window rolls over, so the 3 hits are now the carried count
+
+        $resetAt = $limiter->consume(0)->getResetAt()->getTimestamp();
+
+        sleep($resetAt - time() - 1);
+        $this->assertSame(9, $limiter->consume(0)->getRemainingTokens());
+
+        sleep(1);
+        $this->assertSame(10, $limiter->consume(0)->getRemainingTokens());
+    }
+
     public function testConsumeLastToken()
     {
         $limiter = $this->createLimiter();

--- a/src/Symfony/Component/RateLimiter/Tests/Policy/TokenBucketLimiterTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/Policy/TokenBucketLimiterTest.php
@@ -104,6 +104,32 @@ class TokenBucketLimiterTest extends TestCase
         $this->assertSame(10, $rateLimit->getLimit());
     }
 
+    public function testResetTimeDiffersFromRetryAfterWhileTokensRemain()
+    {
+        $rate = Rate::perSecond(1);
+        $limiter = $this->createLimiter(10, $rate);
+
+        $rateLimit = $limiter->consume(5);
+        $this->assertTrue($rateLimit->isAccepted());
+        $this->assertEqualsWithDelta(time(), $rateLimit->getRetryAfter()->getTimestamp(), 1);
+        // 5 of 10 tokens used at 1/s, so the bucket is full again in 5s
+        $this->assertEqualsWithDelta(time() + 5, $rateLimit->getResetAt()->getTimestamp(), 1);
+    }
+
+    public function testResetTimeOnRejectionCountsOnlyTheMissingTokens()
+    {
+        $limiter = $this->createLimiter(10, Rate::perSecond(1));
+        $limiter->consume(10);
+
+        sleep(3); // 3 tokens back
+
+        $rateLimit = $limiter->consume(5);
+        $this->assertFalse($rateLimit->isAccepted());
+        $this->assertSame(3, $rateLimit->getRemainingTokens());
+        // 7 of 10 tokens are missing, so the bucket is full again in 7s -- not 10
+        $this->assertEqualsWithDelta(time() + 7, $rateLimit->getResetAt()->getTimestamp(), 1);
+    }
+
     public function testConsumeLastToken()
     {
         $rate = Rate::perSecond(1);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #-
| License       | MIT

Currently, `#[RateLimit]` only exposes a `Retry-After` header when a rate limit is exceeded, and a successful request tells the client nothing about its remaining quota.

This PR adds `X-RateLimit-Limit`, `X-RateLimit-Remaining` and `X-RateLimit-Reset` response headers on both accepted and rejected requests. The feature is opt-in, per attribute, via the new `$exposeHeaders` argument:

```php
#[RateLimit('api', exposeHeaders: true)]
```

```http
HTTP/1.1 200 OK
X-RateLimit-Limit: 100
X-RateLimit-Remaining: 97
X-RateLimit-Reset: 1787403071
```
```http
HTTP/1.1 429 Too Many Requests
Retry-After: 42
X-RateLimit-Limit: 100
X-RateLimit-Remaining: 0
X-RateLimit-Reset: 1787403071
```

`Retry-After` (delta in seconds, RFC 9110) is sent on rejection whatever the value of `$exposeHeaders`. `X-RateLimit-Reset` is a Unix timestamp, following the de facto convention of the `X-`-prefixed header family (GitHub, GitLab).

## New public API

- `#[RateLimit(..., exposeHeaders: true)]` in HttpKernel, default `false`
- `RateLimit::getResetAt(): ?\DateTimeImmutable` in RateLimiter: the moment the limiter is back to full capacity, or `null` when the policy has no such moment. Populated by `fixed_window` (the window's end), `sliding_window` (when the carried hit count has fully decayed) and `token_bucket` (time to refill to `max_burst`). `no_limit` returns `null`, which also makes the listener skip the headers for that policy.

## Behavior

- When several `#[RateLimit]` attributes apply, the headers come from whichever exposing limiter is closest to rejecting (fewest calls left, normalized by each attribute's `$tokens` cost). A rejecting limiter always wins; if the rejecting limiter has `exposeHeaders: false`, the response carries no `X-RateLimit-*` headers at all.
- `Limit` and `Remaining` are normalized by the attribute's own `$tokens` cost: a 10-token call against a 100-token limiter reports `X-RateLimit-Limit: 10` / `X-RateLimit-Remaining: 9`.
- The listener marks the response `private` when it adds the headers, so shared caches never store one client's counters. This also holds when `#[Cache(smaxage: ...)]` is used on the same controller: the cache attribute is processed first and the rate limit listener runs after it.
- If the response already carries any `X-RateLimit-*` header, the listener adds nothing and leaves `Cache-Control` untouched.
- Sub-requests still consume their limiters but never emit headers; only the main response does.

## For the documentation PR

- the three header names and their units: `X-RateLimit-Reset` is a Unix timestamp, `Retry-After` a delta in seconds
- `Retry-After` on the 429 is unaffected by `$exposeHeaders`
- the default (`false`) and how to opt in per attribute
- the multi-attribute rule with a worked example, including the opted-out rejecting limiter case
- the `$tokens` normalization of `Limit` and `Remaining`
- the shared-cache interaction: responses carrying the headers are forced `private`
- a security note: exposing a login-throttling limiter's remaining count tells an attacker exactly how many attempts are left, so keep `$exposeHeaders` off for sensitive limiters
