### PR TITLE
[VarExporter] Fix export of string parameter defaults containing escaped quotes

### DIFF
--- a/src/Symfony/Component/VarExporter/ProxyHelper.php
+++ b/src/Symfony/Component/VarExporter/ProxyHelper.php
@@ -510,6 +510,20 @@ final class ProxyHelper
         if (str_ends_with($default, "...'") && preg_match("/^'(?:[^'\\\\]*+(?:\\\\.)*+)*+'$/", $default)) {
             return VarExporter::export($param->getDefaultValue());
         }
+        if (str_starts_with($default, "'") && str_ends_with($default, "'")) {
+            // Reflection renders string literals without escaping quotes, which makes them
+            // impossible to re-tokenize. Export the value instead, but only when it renders
+            // back identically, which also tells literals apart from concatenations.
+            try {
+                $value = $param->getDefaultValue();
+            } catch (\Throwable) {
+                $value = null;
+            }
+
+            if (\is_string($value) && $default === self::renderString($value)) {
+                return VarExporter::export($value);
+            }
+        }
 
         $regexp = "/(\"(?:[^\"\\\\]*+(?:\\\\.)*+)*+\"|'(?:[^'\\\\]*+(?:\\\\.)*+)*+')/";
         $parts = preg_split($regexp, $default, -1, \PREG_SPLIT_DELIM_CAPTURE | \PREG_SPLIT_NO_EMPTY);
@@ -549,5 +563,19 @@ final class ProxyHelper
         }
 
         return '\\'.substr($symbol, $ns + 1);
+    }
+
+    private static function renderString(string $value): string
+    {
+        return "'".preg_replace_callback('/[\x00-\x1F\x7F-\xFF\\\\]/', static fn ($m) => match ($m[0]) {
+            '\\' => '\\\\',
+            "\t" => '\t',
+            "\n" => '\n',
+            "\v" => '\v',
+            "\f" => '\f',
+            "\r" => '\r',
+            "\e" => '\e',
+            default => \sprintf('\x%02X', \ord($m[0])),
+        }, $value)."'";
     }
 }

--- a/src/Symfony/Component/VarExporter/Tests/ProxyHelperTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/ProxyHelperTest.php
@@ -166,6 +166,24 @@ class ProxyHelperTest extends TestCase
         $this->assertSame($expected, ProxyHelper::generateLazyProxy(null, [new \ReflectionClass(TestForProxyHelperInterface1::class), new \ReflectionClass(TestForProxyHelperInterface2::class)]));
     }
 
+    public function testGenerateLazyProxyWithStringParameterDefaults()
+    {
+        $code = ProxyHelper::generateLazyProxy(null, [new \ReflectionClass(TestForProxyHelperStringDefaults::class)]);
+
+        $this->assertStringContainsString('public function singleQuote($a = \'it\\\'s a "quote" \\\\ back\')', $code);
+        $this->assertStringContainsString('public function doubleQuote($a = \'a"b\\\\c\')', $code);
+        $this->assertStringContainsString('public function concat($a = \'pre-\' . \\'.TestForProxyHelperStringDefaults::class.'::SUFFIX . \'-post\')', $code);
+
+        eval('class TestForProxyHelperStringDefaultsImpl'.$code);
+
+        foreach ((new \ReflectionClass(TestForProxyHelperStringDefaults::class))->getMethods() as $method) {
+            $expected = $method->getParameters()[0]->getDefaultValue();
+            $actual = (new \ReflectionParameter([\TestForProxyHelperStringDefaultsImpl::class, $method->name], 'a'))->getDefaultValue();
+
+            $this->assertSame($expected, $actual, $method->name);
+        }
+    }
+
     /**
      * @dataProvider classWithUnserializeMagicMethodProvider
      */
@@ -327,6 +345,23 @@ interface TestForProxyHelperInterface2
     public function foo2(?Bar $b, ...$d): self;
 
     public static function foo3(): string;
+}
+
+interface TestForProxyHelperStringDefaults
+{
+    public const SUFFIX = 'suffix';
+
+    public function singleQuote($a = 'it\'s a "quote" \ back');
+
+    public function doubleQuote($a = 'a"b\\c');
+
+    public function newLine($a = "line1\nline2");
+
+    public function nullByte($a = "nul\0byte");
+
+    public function emoji($a = "emoji \u{1F600} end");
+
+    public function concat($a = 'pre-'.self::SUFFIX.'-post');
 }
 
 class TestSignatureFQ extends \stdClass


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

`ProxyHelper::generateLazyProxy()` emits invalid PHP when a method has a string parameter default that contains a quote or a backslash. The generated class then fails to compile.

Reproduction:

```php
interface I
{
    public function singleQuote($a = 'it\'s a "quote" \ back');
    public function doubleQuote($a = 'a"b\\c');
}

echo ProxyHelper::generateLazyProxy(null, [new ReflectionClass(I::class)]);
```

Before this patch the two signatures come out as:

```php
public function singleQuote($a = 'it'\s \a "quote" \\ \back')
public function doubleQuote($a = "a"b\\c")
```

Both are parse errors.

The cause is in `ProxyHelper::exportDefault()`. It does not read the default value; it recovers it from `(string) $param`, the rendering reflection produces for a parameter. That rendering is lossy for strings: a backslash is doubled and control bytes become `\t`, `\n` or `\xNN`, but a single or double quote is emitted raw. So `'it\'s'` renders as `'it's'`, and the re-tokenizer in `exportDefault()` splits the value at the inner quote.

The fix takes the real value from `ReflectionParameter::getDefaultValue()` and exports it with `VarExporter::export()`. It accepts that value only when it renders back to exactly the string reflection produced. That check is what tells a plain string literal apart from an expression that only looks like one, such as `'a' . \DIRECTORY_SEPARATOR . 'b'`: a concatenation resolves to a value that renders differently, so it keeps the existing token-based path and stays a concatenation in the generated code. Defaults that are constants, arrays or `new` expressions are unaffected.

Known remaining gap, not covered here: an array default whose values contain quotes or backslashes is still corrupted the same way. It comes from the same lossy rendering, it is not a regression of this patch, and it needs a separate fix.
