### PR TITLE
[Mime] Reject invalid PGP recipients before passing them to gpg

### DIFF
--- a/src/Symfony/Component/Mime/Crypto/PgpProcess.php
+++ b/src/Symfony/Component/Mime/Crypto/PgpProcess.php
@@ -99,7 +99,7 @@ final class PgpProcess
     {
         foreach (array_keys($pgpKeys) as $recipient) {
             if (!\is_string($recipient) || str_starts_with($recipient, '-') || preg_match('/[\x00-\x1F\x7F]/', $recipient)) {
-                throw new InvalidArgumentException(sprintf('The PGP recipient "%s" is not a valid email address.', $recipient));
+                throw new InvalidArgumentException(\sprintf('The PGP recipient "%s" is not a valid email address.', $recipient));
             }
         }
 

--- a/src/Symfony/Component/Mime/Crypto/PgpProcess.php
+++ b/src/Symfony/Component/Mime/Crypto/PgpProcess.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Mime\Crypto;
 
+use Symfony\Component\Mime\Exception\InvalidArgumentException;
 use Symfony\Component\Mime\Exception\RuntimeException;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
@@ -96,6 +97,12 @@ final class PgpProcess
      */
     public function encrypt(string $data, array $pgpKeys, array $hiddenRecipients = []): string
     {
+        foreach (array_keys($pgpKeys) as $recipient) {
+            if (!\is_string($recipient) || str_starts_with($recipient, '-') || preg_match('/[\x00-\x1F\x7F]/', $recipient)) {
+                throw new InvalidArgumentException(sprintf('The PGP recipient "%s" is not a valid email address.', $recipient));
+            }
+        }
+
         $temporaryGnupgHome = $this->createTemporaryGnupgHome();
 
         try {

--- a/src/Symfony/Component/Mime/Tests/Crypto/PgpEncrypterTest.php
+++ b/src/Symfony/Component/Mime/Tests/Crypto/PgpEncrypterTest.php
@@ -11,7 +11,9 @@
 
 namespace Symfony\Component\Mime\Tests\Crypto;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Mime\Exception\InvalidArgumentException;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Crypto\PgpEncrypter;
 use Symfony\Component\Mime\Crypto\PgpProcess;
@@ -46,6 +48,25 @@ class PgpEncrypterTest extends TestCase
 
         $decrypted = $tester->decrypt($output, __DIR__.'/../Fixtures/pgp_test_secret_key.asc', self::KEY_PASSWORD);
         $this->assertSame('Hello there!', $decrypted);
+    }
+
+    public static function provideInvalidRecipients(): iterable
+    {
+        yield 'gpg option injection' => ['--keyserver=hkp://evil.example'];
+        yield 'output redirection' => ['--output'];
+        yield 'line feed' => ["foo\nbar@example.com"];
+        yield 'carriage return' => ["foo\rbar@example.com"];
+    }
+
+    #[DataProvider('provideInvalidRecipients')]
+    public function testPgpProcessRejectsInvalidRecipients(string $recipient)
+    {
+        $process = new PgpProcess();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('is not a valid email address');
+
+        $process->encrypt('Hello there!', [$recipient => __DIR__.'/../Fixtures/pgp_test_public_key.asc']);
     }
 
     public function testEncrypting()

--- a/src/Symfony/Component/Mime/Tests/Crypto/PgpEncrypterTest.php
+++ b/src/Symfony/Component/Mime/Tests/Crypto/PgpEncrypterTest.php
@@ -13,12 +13,12 @@ namespace Symfony\Component\Mime\Tests\Crypto;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Mime\Exception\InvalidArgumentException;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Crypto\PgpEncrypter;
 use Symfony\Component\Mime\Crypto\PgpProcess;
 use Symfony\Component\Mime\Crypto\PgpSigner;
 use Symfony\Component\Mime\Email;
+use Symfony\Component\Mime\Exception\InvalidArgumentException;
 use Symfony\Component\Mime\Message;
 use Symfony\Component\Mime\Part\Multipart\PgpEncryptedPart;
 use Symfony\Component\Mime\Part\PgpEncryptedInitializationPart;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no (only rejects input that never worked as intended)
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

`PgpEncrypter::encrypt()` documents `$recipientKeys` as "indexed by email address", but the array keys are passed verbatim as arguments to the `gpg` binary via symfony/process:

```php
foreach (array_keys($pgpKeys) as $recipient) {
    $command[] = '--recipient';
    $command[] = $recipient;
}
```

Because gpg parses leading-dash arguments as options, a caller that passes unvalidated user input as a recipient key lets that input reach gpg's option parser (e.g. `--keyserver=...`, `--output`). The process is spawned in array form, so this stays within gpg's own argument handling, but the component currently offers no guard at its boundary.

This patch validates each recipient before building the command and throws an `InvalidArgumentException` for strings that start with `-` or contain control characters. Legitimate email addresses are unaffected; only inputs that could never have worked as intended are rejected.
