### PR TITLE
[Messenger] Add an option to HandleTrait::handle() to unwrap a single handler failure

### DIFF
--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.2
 ---
 
+ * Add an option to `HandleTrait::handle()` to unwrap a `HandlerFailedException` caused by a single handler
  * Add `HandlerStartingEvent`, `HandlerSuccessEvent` and `HandlerFailureEvent`, dispatched around each handler call
  * Add `$serializedTypeNameAliases` parameter to `#[AsMessage]` to accept alternate serialized type names when decoding
  * Add `--failed-after` and `--failed-before` options to the `messenger:failed:retry`, `messenger:failed:remove` and `messenger:failed:show` commands, and a `--class-filter` option to `messenger:failed:retry`

--- a/src/Symfony/Component/Messenger/HandleTrait.php
+++ b/src/Symfony/Component/Messenger/HandleTrait.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Messenger;
 
+use Symfony\Component\Messenger\Exception\HandlerFailedException;
 use Symfony\Component\Messenger\Exception\LogicException;
 use Symfony\Component\Messenger\Stamp\HandledStamp;
 use Symfony\Component\Messenger\Stamp\StampInterface;
@@ -30,16 +31,27 @@ trait HandleTrait
      * This behavior is useful for both synchronous command & query buses,
      * the last one usually returning the handler result.
      *
-     * @param object|Envelope  $message The message or the message pre-wrapped in an envelope
-     * @param StampInterface[] $stamps  Stamps to be set on the Envelope which are used to control middleware behavior
+     * @param object|Envelope  $message                      The message or the message pre-wrapped in an envelope
+     * @param StampInterface[] $stamps                       Stamps to be set on the Envelope which are used to control middleware behavior
+     * @param bool             $unwrapHandlerFailedException Throw the handler's own exception instead of the HandlerFailedException wrapping it
      */
-    private function handle(object $message, array $stamps = []): mixed
+    private function handle(object $message, array $stamps = [], bool $unwrapHandlerFailedException = false): mixed
     {
         if (!isset($this->messageBus)) {
             throw new LogicException(\sprintf('You must provide a "%s" instance in the "%s::$messageBus" property, but that property has not been initialized yet.', MessageBusInterface::class, static::class));
         }
 
-        $envelope = $this->messageBus->dispatch($message, $stamps);
+        try {
+            $envelope = $this->messageBus->dispatch($message, $stamps);
+        } catch (HandlerFailedException $e) {
+            // Not recursive: only the envelope added by this very dispatch is removed, so
+            // nesting several buses does not collapse into a single apparent handler.
+            if (!$unwrapHandlerFailedException || 1 !== \count($wrappedExceptions = $e->getWrappedExceptions())) {
+                throw $e;
+            }
+
+            throw reset($wrappedExceptions);
+        }
         /** @var HandledStamp[] $handledStamps */
         $handledStamps = $envelope->all(HandledStamp::class);
 

--- a/src/Symfony/Component/Messenger/Tests/HandleTraitTest.php
+++ b/src/Symfony/Component/Messenger/Tests/HandleTraitTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Messenger\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\HandlerFailedException;
 use Symfony\Component\Messenger\Exception\LogicException;
 use Symfony\Component\Messenger\HandleTrait;
 use Symfony\Component\Messenger\MessageBus;
@@ -98,6 +99,86 @@ class HandleTraitTest extends TestCase
 
         $queryBus->query($query);
     }
+
+    public function testHandleUnwrapsSingleHandlerFailureWhenEnabled()
+    {
+        $bus = $this->createMock(MessageBus::class);
+        $queryBus = new TestUnwrappingQueryBus($bus);
+
+        $query = new DummyMessage('Hello');
+        $failure = new \RuntimeException('Handler blew up');
+        $bus->expects($this->once())->method('dispatch')->willThrowException(
+            new HandlerFailedException(new Envelope($query), ['DummyHandler::__invoke' => $failure])
+        );
+
+        try {
+            $queryBus->query($query);
+        } catch (\Throwable $thrown) {
+            // identity, not instanceof: HandlerFailedException extends RuntimeException
+            // and repeats the wrapped message, so a looser assertion passes either way
+            $this->assertSame($failure, $thrown);
+
+            return;
+        }
+
+        $this->fail('The handler failure should have been thrown.');
+    }
+
+    public function testHandleKeepsWrappingByDefault()
+    {
+        $bus = $this->createMock(MessageBus::class);
+        $queryBus = new TestQueryBus($bus);
+
+        $query = new DummyMessage('Hello');
+        $bus->expects($this->once())->method('dispatch')->willThrowException(
+            new HandlerFailedException(new Envelope($query), ['DummyHandler::__invoke' => new \RuntimeException('Handler blew up')])
+        );
+
+        $this->expectException(HandlerFailedException::class);
+
+        $queryBus->query($query);
+    }
+
+    public function testHandleKeepsWrappingSeveralFailuresWhenEnabled()
+    {
+        $bus = $this->createMock(MessageBus::class);
+        $queryBus = new TestUnwrappingQueryBus($bus);
+
+        $query = new DummyMessage('Hello');
+        $bus->expects($this->once())->method('dispatch')->willThrowException(
+            new HandlerFailedException(new Envelope($query), [
+                'FirstDummyHandler::__invoke' => new \RuntimeException('First'),
+                'SecondDummyHandler::__invoke' => new \RuntimeException('Second'),
+            ])
+        );
+
+        $this->expectException(HandlerFailedException::class);
+
+        $queryBus->query($query);
+    }
+
+    public function testHandleUnwrapsNestedHandlerFailureOnlyOneLevel()
+    {
+        $bus = $this->createMock(MessageBus::class);
+        $queryBus = new TestUnwrappingQueryBus($bus);
+
+        $query = new DummyMessage('Hello');
+        $innerFailure = new HandlerFailedException(new Envelope($query), ['InnerHandler::__invoke' => new \RuntimeException('Inner')]);
+        $bus->expects($this->once())->method('dispatch')->willThrowException(
+            new HandlerFailedException(new Envelope($query), ['OuterHandler::__invoke' => $innerFailure])
+        );
+
+        try {
+            $queryBus->query($query);
+        } catch (\Throwable $thrown) {
+            // one level only: a bus dispatched from within a handler keeps its own wrapper
+            $this->assertSame($innerFailure, $thrown);
+
+            return;
+        }
+
+        $this->fail('The nested handler failure should have been thrown.');
+    }
 }
 
 class TestQueryBus
@@ -114,5 +195,20 @@ class TestQueryBus
     public function query($query, array $stamps = []): string
     {
         return $this->handle($query, $stamps);
+    }
+}
+
+class TestUnwrappingQueryBus
+{
+    use HandleTrait;
+
+    public function __construct(MessageBusInterface $messageBus)
+    {
+        $this->messageBus = $messageBus;
+    }
+
+    public function query($query, array $stamps = []): string
+    {
+        return $this->handle($query, $stamps, true);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #52300
| License       | MIT

`HandleTrait` exists for command and query buses: it enforces that exactly one
handler ran and returns its result. When that single handler throws, the caller
still gets a `HandlerFailedException` wrapping the real exception. The wrapper
earns its keep when several handlers may fail; with exactly one, it only hides
the exception the caller actually wants to catch.

This adds an opt-in third argument to `HandleTrait::handle()`:

```php
public function query(object $query): mixed
{
    return $this->handle($query, unwrapHandlerFailedException: true);
}
```

The default stays `false`, so nothing changes for existing code.

Two deliberate limits:

* only a `HandlerFailedException` carrying **exactly one** wrapped exception is
  unwrapped — with several there is no single exception to throw, so the wrapper
  is kept;
* unwrapping removes **one level only**, so a bus dispatched from inside a
  handler keeps its own wrapper instead of collapsing into an apparent single
  handler. `testHandleUnwrapsNestedHandlerFailureOnlyOneLevel` pins that.

## Relation to previous attempts

This supersedes two closed PRs, and carries no code from either:

* #52952 replaced `HandleTrait` with a new `SingleHandlingTrait`. @chalasr closed
  it — the deprecation cost outweighed the benefit — and pointed at the two
  acceptable routes: *"either we address it in `HandleTrait` with BC preserved or
  we need to look at the middleware alternative instead"*.
* #52949 took the middleware route. @ro0NL objected that it *"might force users
  to split their bus into multiple buses"*, and it was closed for lack of
  traction.

This PR is the first route, the one that was never written. The problem and both
earlier explorations are @MatTheCat's; the idea of handling it inside
`HandleTrait` while preserving BC was @ro0NL's, in the #52949 thread.

An earlier draft of this used a private trait property instead of an argument.
That is not BC-safe: unlike a class property, a trait property is composed into
every consumer, so any class already declaring `$unwrapHandlerFailedException`
would fatal on upgrade — verified on PHP 8.4:

```
Consumer and T define the same property ($unwrapHandlerFailedException) in the
composition of Consumer. However, the definition differs and is considered
incompatible.
```

## Test verification (RED → GREEN)

Run against the unmodified `HandleTrait` with only the new tests applied, then
with the patch. PHP 8.4.24, PHPUnit 11.5.56.

RED:

```
......F..F                                                        10 / 10 (100%)

There were 2 failures:

1) Symfony\Component\Messenger\Tests\HandleTraitTest::testHandleUnwrapsSingleHandlerFailureWhenEnabled
Failed asserting that two variables reference the same object.

2) Symfony\Component\Messenger\Tests\HandleTraitTest::testHandleUnwrapsNestedHandlerFailureOnlyOneLevel
Failed asserting that two variables reference the same object.

Tests: 10, Assertions: 21, Failures: 2
```

GREEN:

```
..........                                                        10 / 10 (100%)

Tests: 10, Assertions: 23
```

Full Messenger suite, before and after, to show nothing else moved:

```
baseline  Tests: 705, Assertions: 2022, Errors: 1, Skipped: 19
patched   Tests: 709, Assertions: 2030, Errors: 1, Skipped: 19
```

The single error is identical in both runs and unrelated: `Class
"Symfony\Bridge\PhpUnit\ClockMock" not found` in `WorkerTest.php:847`, an
artifact of installing the component standalone rather than through the
phpunit-bridge.

The assertions use `assertSame` on purpose. `expectExceptionObject()` passes on
unpatched code here, because `HandlerFailedException` extends `\RuntimeException`
and repeats the wrapped exception's message, so only object identity actually
distinguishes the two behaviours.

I will open the docs PR against symfony/symfony-docs if you are happy with the
shape of the API.
