### PR TITLE
[HttpKernel] Capture flushed content in HttpKernelBrowser

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpKernelBrowser.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernelBrowser.php
@@ -67,12 +67,19 @@ class HttpKernelBrowser extends AbstractBrowser
         $response = $this->kernel->handle($request, HttpKernelInterface::MAIN_REQUEST, $this->catchExceptions);
 
         // the content must be sent before the kernel is terminated, as when serving a real request
-        ob_start();
+        $content = '';
+        ob_start(static function ($chunk) use (&$content) {
+            $content .= $chunk;
+
+            return '';
+        });
+
         try {
             $response->sendContent();
         } finally {
+            ob_end_clean();
             $this->sentResponse = $response;
-            $this->sentContent = ob_get_clean();
+            $this->sentContent = $content;
         }
 
         if ($this->kernel instanceof TerminableInterface) {
@@ -205,9 +212,18 @@ class HttpKernelBrowser extends AbstractBrowser
             $this->sentContent = '';
         } else {
             // this is needed to support StreamedResponse
-            ob_start();
-            $response->sendContent();
-            $content = ob_get_clean();
+            $content = '';
+            ob_start(static function ($chunk) use (&$content) {
+                $content .= $chunk;
+
+                return '';
+            });
+
+            try {
+                $response->sendContent();
+            } finally {
+                ob_end_clean();
+            }
         }
 
         return new DomResponse($content, $response->getStatusCode(), $response->headers->all());

--- a/src/Symfony/Component/HttpKernel/Tests/HttpKernelBrowserTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpKernelBrowserTest.php
@@ -74,6 +74,30 @@ class HttpKernelBrowserTest extends TestCase
         $this->assertSame('streamed content', $client->getInternalResponse()->getContent());
     }
 
+    public function testStreamedResponseThatFlushesIsCaptured()
+    {
+        $kernel = new class implements HttpKernelInterface {
+            public function handle(Request $request, int $type = self::MAIN_REQUEST, bool $catch = true): Response
+            {
+                return new StreamedResponse(static function () {
+                    foreach (['strea', 'med ', 'content'] as $chunk) {
+                        echo $chunk;
+                        @ob_flush();
+                        flush();
+                    }
+                });
+            }
+        };
+
+        $client = new HttpKernelBrowser($kernel);
+
+        $this->expectOutputString('');
+
+        $client->request('GET', '/');
+
+        $this->assertSame('streamed content', $client->getInternalResponse()->getContent());
+    }
+
     public function testGetScript()
     {
         $client = new TestClient(new TestHttpKernel());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65606
| License       | MIT

`HttpKernelBrowser` loses the body of a `StreamedResponse` whose callback calls `flush()`, and prints it to stdout instead. `getInternalResponse()->getContent()` returns `''` and PHPUnit reports "Test code or tested code printed unexpected output" on top of the failed assertion.

`StreamedResponse` documents `flush()` as supported ("The `flush()` function can also be used if needed"), and `setChunks()` on 7.3+ calls it after every chunk:

```php
$this->callback = static function () use ($chunks): void {
    foreach ($chunks as $chunk) {
        echo $chunk;
        @ob_flush();
        flush();
    }
};
```

`ob_flush()` on a buffer that has no output callback writes the buffer straight through to the parent level, so the plain `ob_start()` / `ob_get_clean()` pair used to capture the content ends up empty:

```php
$chunks = ['a', 'b', 'c'];

ob_start();
foreach ($chunks as $c) { echo $c; @ob_flush(); flush(); }
var_dump(ob_get_clean());   // prints "abc" to stdout, then string(0) ""

$content = '';
ob_start(static function ($chunk) use (&$content) { $content .= $chunk; return ''; });
foreach ($chunks as $c) { echo $c; @ob_flush(); flush(); }
ob_end_clean();
var_dump($content);         // string(3) "abc"
```

This patch uses the callback form in both places that capture the content, `doRequest()` and the `filterResponse()` fallback. The callback accumulates the chunk and returns an empty string, so a flush inside `sendContent()` is captured instead of escaping the buffer. `ob_end_clean()` moves into a `finally` block so a response that throws while sending no longer leaves an open buffer.

#62036 fixed this in `filterResponse()` on 7.3 with the same approach; #65496 then moved the sending into `doRequest()` with a plain buffer, which reintroduced it on 7.4 and up. On 6.4 `filterResponse()` never had the callback form, so the defect is older there and is not a regression — targeting 6.4 fixes both cases and merges up.

Before, on `6.4`:

```
1) Symfony\Component\HttpKernel\Tests\HttpKernelBrowserTest::testStreamedResponseThatFlushesIsCaptured
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'streamed content'
+''
```

After: `HttpKernelBrowserTest`, 10 tests, 37 assertions, all green on PHP 8.5.9.
