### PR TITLE
[Mime] Never let a PGP key path be parsed as a gpg option

### DIFF
--- a/src/Symfony/Component/Mime/Crypto/PgpProcess.php
+++ b/src/Symfony/Component/Mime/Crypto/PgpProcess.php
@@ -167,6 +167,7 @@ final class PgpProcess
         }
 
         $command[] = '--import';
+        $command[] = '--';
         $command[] = $this->convertToMsysPath($filePath);
 
         $this->execute($command, null, $gnupgHome);

--- a/src/Symfony/Component/Mime/Tests/Crypto/PgpEncrypterTest.php
+++ b/src/Symfony/Component/Mime/Tests/Crypto/PgpEncrypterTest.php
@@ -17,6 +17,7 @@ use Symfony\Component\Mime\Crypto\PgpEncrypter;
 use Symfony\Component\Mime\Crypto\PgpProcess;
 use Symfony\Component\Mime\Crypto\PgpSigner;
 use Symfony\Component\Mime\Email;
+use Symfony\Component\Mime\Exception\RuntimeException;
 use Symfony\Component\Mime\Message;
 use Symfony\Component\Mime\Part\Multipart\PgpEncryptedPart;
 use Symfony\Component\Mime\Part\PgpEncryptedInitializationPart;
@@ -46,6 +47,18 @@ class PgpEncrypterTest extends TestCase
 
         $decrypted = $tester->decrypt($output, __DIR__.'/../Fixtures/pgp_test_secret_key.asc', self::KEY_PASSWORD);
         $this->assertSame('Hello there!', $decrypted);
+    }
+
+    public function testKeyPathIsNeverParsedAsAGpgOption()
+    {
+        $process = new PgpProcess();
+
+        try {
+            $process->encrypt('Hello there!', [self::KEY_EMAIL_ADDRESS => '--version']);
+            $this->fail('Importing the key should have failed.');
+        } catch (RuntimeException $e) {
+            $this->assertStringContainsString('--import', $e->getMessage());
+        }
     }
 
     public function testEncrypting()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`PgpProcess::storeKey()` imports a public or secret key by running `gpg --import <path>`. `--import` takes positional file arguments, so gpg parses a path that starts with a dash as an option instead of opening it as a file. This adds the `--` end-of-options separator, so the path is always read as a file name.

The path comes from the application, through the values of the `$pgpKeys` map or through `PgpPublicKeyRepositoryInterface`. It is not user input, so this is not a security fix. It is a robustness fix: today a bad path can make gpg do something else entirely and still report success.

Reproduction on the current 8.2, with gpg 2.4.4:

```php
(new PgpProcess())->encrypt('Hello there!', ['pgp@pulli.dev' => '--version']);
```

That runs `'gpg' '--import' '--version'`. gpg prints its version banner, imports nothing and exits with 0, so the component believes the key was imported. The call only fails at the next step, with `gpg: pgp@pulli.dev: skipped: No public key`, which points at the recipient rather than at the path. `--list-config` and `--options=/dev/null` behave the same way.

With the separator, the same call runs `'gpg' '--import' '--' '--version'` and fails where the mistake is:

```
gpg: Note: '--version' is not considered an option
gpg: can't open '--version': No such file or directory
gpg: Total number processed: 0
```

`sign()` reaches the same code path, so it gets the same guarantee. The import file path is the only positional argument in the class. Every other value there is the argument of an option (`--recipient`, `--hidden-recipient`, `--passphrase-file`, `--cipher-algo`, `--digest-algo`, `--pinentry-mode`), and gpg consumes an option argument unconditionally, so none of them can be re-read as an option. The passphrase file path is also generated internally by `tempnam()`.

`PgpProcess` is `@internal` and `PgpSigner` and `PgpEncrypter` are `@experimental`. None of this code is in a released version yet, so there is nothing to backport and no BC surface.

Found while reviewing #65602, which looked at the recipient arguments. Thanks @iliaal for raising the area.
