### PR TITLE
[VarExporter] Fix export of array and new-expression parameter defaults containing quotes

### DIFF
--- a/src/Symfony/Component/VarExporter/ProxyHelper.php
+++ b/src/Symfony/Component/VarExporter/ProxyHelper.php
@@ -510,7 +510,9 @@ final class ProxyHelper
         if (str_ends_with($default, "...'") && preg_match("/^'(?:[^'\\\\]*+(?:\\\\.)*+)*+'$/", $default)) {
             return VarExporter::export($param->getDefaultValue());
         }
-        if (str_starts_with($default, "'") && str_ends_with($default, "'")) {
+        if ((str_starts_with($default, "'") && str_ends_with($default, "'"))
+            || (str_starts_with($default, '[') && str_ends_with($default, ']'))
+        ) {
             // Reflection renders string literals without escaping quotes, which makes them
             // impossible to re-tokenize. Export the value instead, but only when it renders
             // back identically, which also tells literals apart from concatenations.
@@ -520,8 +522,8 @@ final class ProxyHelper
                 $value = null;
             }
 
-            if (\is_string($value) && $default === self::renderString($value)) {
-                return VarExporter::export($value);
+            if ((\is_string($value) || \is_array($value)) && $default === self::renderValue($value)) {
+                return self::exportValue($value);
             }
         }
 
@@ -546,7 +548,7 @@ final class ProxyHelper
 
         return implode('', array_map(static fn ($part) => match ($part[0]) {
             '"' => $part, // for internal classes only
-            "'" => false !== strpbrk($part, "\\\0\r\n") ? '"'.substr(str_replace(['$', "\0", "\r", "\n"], ['\$', '\0', '\r', '\n'], $part), 1, -1).'"' : $part,
+            "'" => false !== strpbrk($part, "\\\0\r\n") ? '"'.self::escapeDoubleQuoted(substr($part, 1, -1)).'"' : $part,
             default => preg_replace_callback($regexp, $callback, $part),
         }, $parts));
     }
@@ -577,5 +579,80 @@ final class ProxyHelper
             "\e" => '\e',
             default => \sprintf('\x%02X', \ord($m[0])),
         }, $value)."'";
+    }
+
+    /**
+     * Reproduces how reflection renders a resolved default value, or null when it cannot.
+     */
+    private static function renderValue(mixed $value): ?string
+    {
+        if (\is_string($value)) {
+            return self::renderString($value);
+        }
+        if (\is_int($value)) {
+            return (string) $value;
+        }
+        if (\is_float($value)) {
+            $repr = (string) $value;
+
+            return is_finite($value) && !str_contains($repr, '.') && !str_contains($repr, 'E') ? $repr.'.0' : $repr;
+        }
+        if (\is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+        if (null === $value) {
+            return 'NULL';
+        }
+        if (!\is_array($value)) {
+            return null;
+        }
+
+        $isList = array_is_list($value);
+        $rendered = [];
+
+        foreach ($value as $k => $v) {
+            if (null === $part = self::renderValue($v)) {
+                return null;
+            }
+
+            $rendered[] = $isList ? $part : self::renderValue($k).' => '.$part;
+        }
+
+        return '['.implode(', ', $rendered).']';
+    }
+
+    /**
+     * Turns the inside of a single-quoted rendering into the inside of a double-quoted one.
+     *
+     * Reflection renders resolved values with \n-style escapes and unevaluated expressions with
+     * \'-style ones. Both encodings write a backslash as \\, so the two can be decoded at once.
+     */
+    private static function escapeDoubleQuoted(string $part): string
+    {
+        return preg_replace_callback('/\\\\[\\\\\']|["$\0\r\n]/', static fn ($m) => match ($m[0]) {
+            "\\'" => "'",
+            '"' => '\"',
+            '$' => '\$',
+            "\0" => '\0',
+            "\r" => '\r',
+            "\n" => '\n',
+            default => $m[0],
+        }, $part);
+    }
+
+    private static function exportValue(mixed $value): string
+    {
+        if (!\is_array($value)) {
+            return VarExporter::export($value);
+        }
+
+        $isList = array_is_list($value);
+        $exported = [];
+
+        foreach ($value as $k => $v) {
+            $exported[] = ($isList ? '' : VarExporter::export($k).' => ').self::exportValue($v);
+        }
+
+        return '['.implode(', ', $exported).']';
     }
 }

--- a/src/Symfony/Component/VarExporter/Tests/ProxyHelperTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/ProxyHelperTest.php
@@ -36,7 +36,11 @@ class ProxyHelperTest extends TestCase
 
         foreach ($methods as $method) {
             $expected = substr($source[$method->getStartLine() - 1], $method->isAbstract() ? 13 : 4, -(1 + $method->isAbstract()));
-            $expected = str_replace(['.', ' .  .  . ', '\'$a\', \'$a\n\', "\$a\n"'], [' . ', '...', '\'$a\', "\$a\\\n", "\$a\n"'], $expected);
+            $expected = str_replace(
+                ['.', ' .  .  . ', '$b = [\'$a\', \'$a\n\', "\$a\n"]', '\'$a\', \'$a\n\', "\$a\n"'],
+                [' . ', '...', '$b = [\'$a\', \'$a\\\\n\', \'$a\'."\n"]', '\'$a\', "\$a\\\n", "\$a\n"'],
+                $expected
+            );
             $expected = str_replace('Bar', '\\'.Bar::class, $expected);
             $expected = str_replace('self', '\\'.TestForProxyHelper::class, $expected);
             $expected = str_replace('= [namespace\M_PI, new M_PI()]', '= [\M_PI, new \Symfony\Component\VarExporter\Tests\M_PI()]', $expected);
@@ -181,6 +185,51 @@ class ProxyHelperTest extends TestCase
             $actual = (new \ReflectionParameter([\TestForProxyHelperStringDefaultsImpl::class, $method->name], 'a'))->getDefaultValue();
 
             $this->assertSame($expected, $actual, $method->name);
+        }
+    }
+
+    public function testGenerateLazyProxyWithArrayParameterDefaults()
+    {
+        $code = ProxyHelper::generateLazyProxy(null, [new \ReflectionClass(TestForProxyHelperArrayDefaults::class)]);
+
+        $this->assertStringContainsString('public function quotes($a = [\'it\\\'s\', \'a "quote"\', \'a \\\\ back\'])', $code);
+        $this->assertStringContainsString('public function keys($a = [\'q\\\'\' => \'v\', \'d"\' => \'w\'])', $code);
+        $this->assertStringContainsString('public function constants($a = [\\'.TestForProxyHelperArrayDefaults::class.'::SUFFIX, \\DIRECTORY_SEPARATOR])', $code);
+        $this->assertStringContainsString('public function quotesAndConstants($a = ["it\'s a \\"quote\\" \\\\ back", \\'.TestForProxyHelperArrayDefaults::class.'::SUFFIX])', $code);
+
+        eval('class TestForProxyHelperArrayDefaultsImpl'.$code);
+
+        foreach ((new \ReflectionClass(TestForProxyHelperArrayDefaults::class))->getMethods() as $method) {
+            $expected = $method->getParameters()[0]->getDefaultValue();
+            $actual = (new \ReflectionParameter([\TestForProxyHelperArrayDefaultsImpl::class, $method->name], 'a'))->getDefaultValue();
+
+            $this->assertSame($expected, $actual, $method->name);
+        }
+    }
+
+    public function testGenerateLazyProxyWithNewInParameterDefaults()
+    {
+        $code = ProxyHelper::generateLazyProxy(null, [new \ReflectionClass(TestForProxyHelperNewDefaults::class)]);
+        $new = 'new \\'.TestForProxyHelperNewInitializer::class;
+
+        $this->assertStringContainsString('public function quote($a = '.$new.'("it\'s"))', $code);
+        $this->assertStringContainsString('public function bothQuotes($a = '.$new.'("quote\\" and \'single\'"))', $code);
+        $this->assertStringContainsString('public function backslashQuote($a = '.$new.'("\\\\\'"))', $code);
+        $this->assertStringContainsString('public function nested($a = '.$new.'('.$new.'("it\'s")))', $code);
+        $this->assertStringContainsString('public function arrayArgument($a = '.$new.'([\'k\' => "it\'s"]))', $code);
+        $this->assertStringContainsString('public function namedArgument($a = '.$new.'(v: "it\'s"))', $code);
+        $this->assertStringContainsString('public function inArray($a = ['.$new.'("it\'s")])', $code);
+        $this->assertStringContainsString('public function classConstant($a = '.$new.'("a\'b", \\'.TestForProxyHelperNewDefaults::class.'::SUFFIX))', $code);
+        $this->assertStringContainsString('public function globalConstant($a = '.$new.'("a\'b", \\DIRECTORY_SEPARATOR))', $code);
+
+        // this also checks that the generated code parses
+        eval('class TestForProxyHelperNewDefaultsImpl'.$code);
+
+        foreach ((new \ReflectionClass(TestForProxyHelperNewDefaults::class))->getMethods() as $method) {
+            $expected = $method->getParameters()[0]->getDefaultValue();
+            $actual = (new \ReflectionParameter([\TestForProxyHelperNewDefaultsImpl::class, $method->name], 'a'))->getDefaultValue();
+
+            $this->assertEquals($expected, $actual, $method->name);
         }
     }
 
@@ -362,6 +411,57 @@ interface TestForProxyHelperStringDefaults
     public function emoji($a = "emoji \u{1F600} end");
 
     public function concat($a = 'pre-'.self::SUFFIX.'-post');
+}
+
+interface TestForProxyHelperArrayDefaults
+{
+    public const SUFFIX = 'suffix';
+
+    public function quotes($a = ['it\'s', 'a "quote"', 'a \\ back']);
+
+    public function keys($a = ['q\'' => 'v', 'd"' => 'w']);
+
+    public function nested($a = [['it\'s'], ['x' => ['a "quote"']]]);
+
+    public function control($a = ["nul\0byte", "line1\nline2", "emoji \u{1F600} end"]);
+
+    public function mixed($a = [5 => 'a', 'k' => 'b', 'c', true, null, 1.5, -0.0]);
+
+    public function emptyArray($a = []);
+
+    public function constants($a = [self::SUFFIX, \DIRECTORY_SEPARATOR]);
+
+    public function quotesAndConstants($a = ['it\'s a "quote" \\ back', self::SUFFIX]);
+}
+
+class TestForProxyHelperNewInitializer
+{
+    public function __construct(public mixed $v = null, public mixed $w = null)
+    {
+    }
+}
+
+interface TestForProxyHelperNewDefaults
+{
+    public const SUFFIX = 'suffix';
+
+    public function quote($a = new TestForProxyHelperNewInitializer('it\'s'));
+
+    public function bothQuotes($a = new TestForProxyHelperNewInitializer('quote" and \'single\''));
+
+    public function backslashQuote($a = new TestForProxyHelperNewInitializer('\\\''));
+
+    public function nested($a = new TestForProxyHelperNewInitializer(new TestForProxyHelperNewInitializer('it\'s')));
+
+    public function arrayArgument($a = new TestForProxyHelperNewInitializer(['k' => 'it\'s']));
+
+    public function namedArgument($a = new TestForProxyHelperNewInitializer(v: 'it\'s'));
+
+    public function inArray($a = [new TestForProxyHelperNewInitializer('it\'s')]);
+
+    public function classConstant($a = new TestForProxyHelperNewInitializer('a\'b', self::SUFFIX));
+
+    public function globalConstant($a = new TestForProxyHelperNewInitializer('a\'b', \DIRECTORY_SEPARATOR));
 }
 
 class TestSignatureFQ extends \stdClass


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`ProxyHelper::exportDefault()` recovers a parameter default from the text that reflection prints for the parameter. That text is lossy in two opposite ways, and each way corrupts a different family of defaults: array literals, and expressions that reflection keeps unevaluated, `new` in initializers in particular.

### Symptom 1, array defaults

```php
interface Options
{
    public function withQuotes($a = ['it\'s', 'a "quote"', 'a \\ back']);
}

echo ProxyHelper::generateLazyProxy(null, [new ReflectionClass(Options::class)]);
```

Today this prints:

```php
public function withQuotes($a = ['it'\s', '\a "quote"', '\a \\ \back'])
```

which is not valid PHP. Running the generated code fails with `syntax error, unexpected fully qualified name "\s"`. A lazy service whose interface has such a default cannot be built at all.

The same default mixed with a constant is worse, because it parses but changes the value:

```php
public function withConstant($a = ['it\'s', self::SUFFIX]);
```

generates `['it\'s', ...]` as `["it\'s", ...]`, so the proxy hands the method `it\'s` (four characters) where the original has `it's`.

### Symptom 2, `new` in initializers

This family is more dangerous, because in almost every case it produces no error at all. The proxy parses, loads and runs, and silently carries a different value.

```php
class Box
{
    public function __construct(public mixed $v = null)
    {
    }
}

interface Options
{
    public function withNew($a = new Box('it\'s'));
}

$code = ProxyHelper::generateLazyProxy(null, [new ReflectionClass(Options::class)]);
eval('class Impl'.$code);

var_dump((new ReflectionParameter([Impl::class, 'withNew'], 'a'))->getDefaultValue()->v);
```

Today this prints `string(5) "it\'s"` instead of `string(4) "it's"`, from this generated line:

```php
public function withNew($a = new \Box("it\'s"))
```

The same happens for a nested `new`, an array argument, a named argument, a `new` inside an array default, and a `new` next to a class or global constant. The only case that fails loudly is an argument holding both quote characters:

```php
public function withBothQuotes($a = new Box('quote" and \'single\''));
```

generates `new \Box("quote" and \'single\'")`, which fails with `syntax error, unexpected token "\"`.

### Why the current code cannot handle it

Reflection prints a parameter default in one of two ways.

When the default is already a resolved value, it prints the value: a backslash becomes `\\` and a control byte becomes `\t`, `\n` or `\xNN`, but a quote is printed raw. `['a\'b']` comes out as `['a'b']`. The regular expression that splits the text into string tokens then stops at the inner quote, and everything after it is re-tokenized as code.

When the default is an expression that is still unevaluated, such as an array holding a constant or any `new` expression, reflection prints the expression instead. There it escapes `'` and `\` correctly but prints control bytes raw. The token path assumes the first encoding, so it turns `'it\'s'` into `"it\'s"` and keeps the backslash.

Neither encoding can be told apart from the text alone, so the text is not enough.

### What the fix does

For a default printed as an array, resolve the real value with `ReflectionParameter::getDefaultValue()`, render that value back the way reflection renders resolved values, and use the resolved value only when the two texts are identical. That test is what tells a plain literal apart from an expression: `['a'.\DIRECTORY_SEPARATOR.'b']` renders back differently, so it keeps going through the token path and the constant stays a constant in the cached proxy instead of being baked in. This extends to arrays the round trip that scalar strings already use.

The renderer covers strings, integers, floats, booleans, null and nested arrays, and gives up on anything else, in which case the token path runs as before.

For the second encoding, the step that turns a single-quoted token into a double-quoted one now decodes `\'` as well. Both encodings write a backslash as `\\`, and `\'` can only come from the expression form, so one pass decodes both. That step also escapes a raw `"`, which the expression form prints unescaped. This is what fixes the `new` family, which stays on the token path from beginning to end.

### Behaviour changes

* An array default whose elements are all resolved values is now printed by `VarExporter`, so it can look different from before while holding the same value. One existing expectation in `ProxyHelperTest` moves for that reason; the values were checked to be identical byte for byte.
* A float inside such an array keeps its full precision. Reflection prints a float with the `precision` ini setting, so `[1/3]` used to reach the proxy as `0.33333333333333`.
* `getDefaultValue()` is now called for every default printed as an array, which was not the case before. When such an array holds a `new` expression, the constructor therefore runs at proxy-generation time. Measured on `$a = [new Foo()]`: zero constructor calls before, one after. The resolved value is then thrown away, because the renderer gives up on objects and the token path takes over. A `new` default that is not inside an array is unaffected: it never enters that branch, so it is still never resolved. An exception thrown by such a constructor is caught and generation continues on the token path.

### What is not covered

Reflection truncates very long string defaults of internal functions with a trailing `...`. That case was already handled separately and is untouched.

### Checks

* `ProxyHelper` was compared against reflection on 4508 generated array defaults, on PHP 8.1, 8.2, 8.3, 8.4 and 8.5, with no disagreement. The printed form is identical on all five versions.
* A grid of 51 defaults covering quotes, backslashes, control bytes, binary and unicode, integer, string and mixed keys, nested and empty arrays, floats, class constants, enum cases, `new` in initializers and constant concatenations was generated, linted and loaded, then compared with the original value. 18 were broken before, 0 after, on all five PHP versions.
* A lazy proxy was generated for every non-final non-abstract class and every interface under `src/Symfony`, plus the internal PHP classes, 2840 in total. The generated output is unchanged. The comparison was validated by mutating `ProxyHelper` on purpose, which moved 2816 lines.
* Both families have their own test. Reverting `ProxyHelper.php` and keeping the tests fails them, with the wrong signature, then the parse error, then the wrong value.
* Full `VarExporter` and `DependencyInjection` suites pass.
