### PR TITLE
[Console] Fix service arguments not resolved when a command is invoked by alias or abbreviation

### DIFF
--- a/src/Symfony/Component/Console/ArgumentResolver/ValueResolver/ServiceValueResolver.php
+++ b/src/Symfony/Component/Console/ArgumentResolver/ValueResolver/ServiceValueResolver.php
@@ -32,7 +32,9 @@ final class ServiceValueResolver implements ValueResolverInterface
 
     public function resolve(string $argumentName, InputInterface $input, ReflectionMember $member): iterable
     {
-        $command = $input->getFirstArgument();
+        // the "command" argument is normalized to the resolved command name by Command::run(),
+        // while getFirstArgument() may return an abbreviation or an alias of it
+        $command = ($input->hasArgument('command') ? $input->getArgument('command') : null) ?? $input->getFirstArgument();
 
         if ($command && $this->container->has($command)) {
             $locator = $this->container->get($command);

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -242,6 +242,14 @@ class Command implements SignalableCommandInterface
             }
         }
 
+        // The command name argument is often omitted when a command is executed directly with its run() method,
+        // and it may hold an abbreviation or an alias when the command was resolved from one (e.g. Application::find()).
+        // Normalize it to the command's actual name so it can be relied on afterwards, since it's required by the
+        // application, and so argument resolution during interact() below can already rely on it.
+        if ($input->hasArgument('command') && null !== $name = $this->getName()) {
+            $input->setArgument('command', $name);
+        }
+
         $this->initialize($input, $output);
 
         if (null !== $this->processTitle) {
@@ -266,13 +274,6 @@ class Command implements SignalableCommandInterface
             if ($this->code?->isInteractive()) {
                 $this->code->interact($input, $output);
             }
-        }
-
-        // The command name argument is often omitted when a command is executed directly with its run() method.
-        // It would fail the validation if we didn't make sure the command argument is present,
-        // since it's required by the application.
-        if ($input->hasArgument('command') && null === $input->getArgument('command')) {
-            $input->setArgument('command', $this->getName());
         }
 
         $input->validate();

--- a/src/Symfony/Component/Console/Tests/Command/InvokableCommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/InvokableCommandTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\ArgumentResolver\ArgumentResolver;
+use Symfony\Component\Console\ArgumentResolver\ValueResolver\ServiceValueResolver;
 use Symfony\Component\Console\ArgumentResolver\ValueResolver\ValueResolverInterface;
 use Symfony\Component\Console\Attribute\Argument;
 use Symfony\Component\Console\Attribute\Ask;
@@ -35,10 +36,13 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Console\Tester\ApplicationTester;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Console\Tests\Fixtures\InvokableTestCommand;
 use Symfony\Component\Console\Tests\Fixtures\InvokableWithCustomValidatorTestCommand;
 use Symfony\Component\Console\Tests\Fixtures\InvokableWithInputFileAndConstraintsTestCommand;
+use Symfony\Component\Console\Tests\Fixtures\InvokableWithServiceArgumentDuringInteractTestCommand;
+use Symfony\Component\DependencyInjection\ServiceLocator;
 
 class InvokableCommandTest extends TestCase
 {
@@ -491,6 +495,63 @@ class InvokableCommandTest extends TestCase
         });
 
         $command->run(new ArrayInput([]), new NullOutput());
+    }
+
+    public function testServiceArgumentIsResolvedWhenCommandIsInvokedByAbbreviation()
+    {
+        $service = new \stdClass();
+
+        $application = new Application();
+        $application->setArgumentResolver(new ArgumentResolver([
+            new ServiceValueResolver(new ServiceLocator([
+                'test:method' => static fn () => new ServiceLocator([
+                    's' => static fn () => $service,
+                ]),
+            ])),
+        ]));
+
+        $command = new Command('test:method');
+        $command->setCode(static function (\stdClass $s) use ($service): int {
+            Assert::assertSame($service, $s);
+
+            return 0;
+        });
+
+        $application->addCommand($command);
+        $application->setAutoExit(false);
+
+        // "t:m" is an abbreviation resolved by Application::find() to "test:method"; the service locator
+        // registered by RegisterCommandArgumentLocatorsPass is only keyed by the canonical command name,
+        // so the resolver must not key its lookup off the raw, still-abbreviated user input.
+        $tester = new ApplicationTester($application);
+        $tester->run(['command' => 't:m']);
+
+        $tester->assertCommandIsSuccessful();
+    }
+
+    public function testServiceArgumentIsResolvedDuringInteractWhenCommandIsInvokedByAbbreviation()
+    {
+        $application = new Application();
+        $application->setArgumentResolver(new ArgumentResolver([
+            new ServiceValueResolver(new ServiceLocator([
+                'test:method' => static fn () => new ServiceLocator([
+                    's' => static fn () => new \stdClass(),
+                ]),
+            ])),
+        ]));
+
+        $command = new Command('test:method');
+        $command->setCode(new InvokableWithServiceArgumentDuringInteractTestCommand());
+
+        $application->addCommand($command);
+        $application->setAutoExit(false);
+
+        // The #[Interact] method runs before Command::run() gets a chance to validate its input, so the
+        // "command" argument normalization must happen early enough to also cover this resolution pass.
+        $tester = new ApplicationTester($application);
+        $tester->run(['command' => 't:m'], ['interactive' => true]);
+
+        $tester->assertCommandIsSuccessful();
     }
 
     public function testNullableHelpersInjection()

--- a/src/Symfony/Component/Console/Tests/Fixtures/InvokableWithServiceArgumentDuringInteractTestCommand.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/InvokableWithServiceArgumentDuringInteractTestCommand.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Tests\Fixtures;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Attribute\Interact;
+use Symfony\Component\Console\Command\Command;
+
+#[AsCommand('test:method')]
+class InvokableWithServiceArgumentDuringInteractTestCommand
+{
+    // Requiring the service here forces argument resolution to run during Command::interact(),
+    // before the command has ever been validated or invoked.
+    #[Interact]
+    public function before(\stdClass $s): void
+    {
+    }
+
+    public function __invoke(\stdClass $s): int
+    {
+        return Command::SUCCESS;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65612
| License       | MIT

Invoking an invokable command by an abbreviation, or by an alias other than its primary name, breaks service-typed parameters:

```php
#[AsCommand(name: 'test:method')]
class TestCommand
{
    public function method(AutowiredService $s): int
    {
        // works: bin/console test:method
        // fails: bin/console t:m
    }
}
```

```
In ArgumentResolver.php line 140:

  Could not resolve parameter "$s" of command "App\Command\TestCommand::method()".
```

`ServiceValueResolver::resolve()` looks up the per-command service locator (built by `RegisterCommandArgumentLocatorsPass`, keyed by the command's canonical name) using `$input->getFirstArgument()`. That method returns the raw, unparsed token the user actually typed, which is only the canonical name when the user typed it in full. When the command is resolved through `Application::find()`'s abbreviation/alias matching (e.g. `t:m` for `test:method`), the raw token never gets rewritten, so the locator lookup misses, the resolver falls through to its type-based fallback, and that fails too since the service isn't publicly keyed by its class name — surfacing as "could not resolve parameter".

`Command::run()` already had a related normalization: it sets the `command` input argument to `$this->getName()`, but only when that argument was `null` (the case where a command is invoked directly via `run()` without ever going through the `command` argument at all). It didn't cover the case where the argument is already set, just to an abbreviation or alias.

The fix extends that existing normalization to always reflect the resolved command's actual name, moves it earlier in `run()` (before `initialize()`/`interact()`, not just before `validate()`, so a `#[Interact]`-annotated method that also requires a service argument resolves correctly too), and switches `ServiceValueResolver` to read the (now-reliable) `command` argument instead of the raw, pre-resolution first argument.

Added regression tests reproducing the failure both during normal invocation and during interactive prompting (`InvokableCommandTest::testServiceArgumentIsResolvedWhenCommandIsInvokedByAbbreviation` and `testServiceArgumentIsResolvedDuringInteractWhenCommandIsInvokedByAbbreviation`, both driving `ApplicationTester` through real abbreviation resolution with a wired `ServiceValueResolver`), and adjusted a few existing `ServiceValueResolverTest` cases that constructed their `ArrayInput` with a bare positional value instead of the documented `['command' => ...]` form, which was masking this exact class of bug at the unit level.