### PR TITLE
[Console] Allow dropping multiple files

### DIFF
--- a/src/Symfony/Component/Console/ArgumentResolver/ArgumentResolver.php
+++ b/src/Symfony/Component/Console/ArgumentResolver/ArgumentResolver.php
@@ -158,7 +158,7 @@ final class ArgumentResolver implements ArgumentResolverInterface
             new Resolver\UidValueResolver(),
             $inputFileResolver,
             $builtinTypeResolver,
-            new Resolver\MapInputValueResolver($builtinTypeResolver, $backedEnumResolver, $dateTimeResolver),
+            new Resolver\MapInputValueResolver($builtinTypeResolver, $backedEnumResolver, $dateTimeResolver, null, $inputFileResolver),
             $dateTimeResolver,
             new Resolver\DefaultValueResolver(),
             new Resolver\VariadicValueResolver(),

--- a/src/Symfony/Component/Console/ArgumentResolver/ValueResolver/InputFileValueResolver.php
+++ b/src/Symfony/Component/Console/ArgumentResolver/ValueResolver/InputFileValueResolver.php
@@ -15,6 +15,7 @@ use Symfony\Component\Console\Attribute\Argument;
 use Symfony\Component\Console\Attribute\Option;
 use Symfony\Component\Console\Attribute\Reflection\ReflectionMember;
 use Symfony\Component\Console\Input\File\InputFile;
+use Symfony\Component\Console\Input\File\InputFileType;
 use Symfony\Component\Console\Input\InputInterface;
 
 /**
@@ -24,21 +25,32 @@ final class InputFileValueResolver implements ValueResolverInterface
 {
     public function resolve(string $argumentName, InputInterface $input, ReflectionMember $member): iterable
     {
-        $type = $member->getType();
+        $isSingle = InputFileType::isInputFile($member);
+        $isCollection = !$isSingle && InputFileType::isInputFileCollection($member);
 
-        if (!$type instanceof \ReflectionNamedType || InputFile::class !== $type->getName()) {
+        if (!$isSingle && !$isCollection) {
             return [];
         }
 
         if ($argument = Argument::tryFrom($member->getMember())) {
-            return $this->resolveValue($input->getArgument($argument->name), $member);
+            $value = $input->getArgument($argument->name);
+        } elseif ($option = Option::tryFrom($member->getMember())) {
+            $value = $input->getOption($option->name);
+        } else {
+            return [];
         }
 
-        if ($option = Option::tryFrom($member->getMember())) {
-            return $this->resolveValue($input->getOption($option->name), $member);
+        if ($isSingle) {
+            return $this->resolveValue($value, $member);
         }
 
-        return [];
+        $files = [];
+        foreach (\is_array($value) ? $value : (null === $value ? [] : [$value]) as $file) {
+            $files[] = $file instanceof InputFile ? $file : InputFile::fromPath($file);
+        }
+
+        // A variadic parameter receives one argument per file; an array parameter receives the whole list.
+        return $member->isVariadic() ? $files : [$files];
     }
 
     private function resolveValue(mixed $value, ReflectionMember $member): iterable

--- a/src/Symfony/Component/Console/ArgumentResolver/ValueResolver/MapInputValueResolver.php
+++ b/src/Symfony/Component/Console/ArgumentResolver/ValueResolver/MapInputValueResolver.php
@@ -16,6 +16,7 @@ use Symfony\Component\Console\Attribute\MapInput;
 use Symfony\Component\Console\Attribute\Option;
 use Symfony\Component\Console\Attribute\Reflection\ReflectionMember;
 use Symfony\Component\Console\Exception\InputValidationFailedException;
+use Symfony\Component\Console\Input\File\InputFileType;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
@@ -32,6 +33,7 @@ final class MapInputValueResolver implements ValueResolverInterface
         private readonly ValueResolverInterface $backedEnumResolver,
         private readonly ValueResolverInterface $dateTimeResolver,
         private readonly ?ValidatorInterface $validator = null,
+        private readonly ?ValueResolverInterface $inputFileResolver = null,
     ) {
     }
 
@@ -102,6 +104,12 @@ final class MapInputValueResolver implements ValueResolverInterface
 
     private function resolveArgumentSpec(Argument $argument, \ReflectionProperty $property, InputInterface $input): mixed
     {
+        $member = new ReflectionMember($property);
+
+        if ($this->inputFileResolver && (InputFileType::isInputFile($member) || InputFileType::isInputFileCollection($member))) {
+            return iterator_to_array($this->inputFileResolver->resolve($property->name, $input, $member))[0] ?? null;
+        }
+
         if (is_subclass_of($argument->typeName, \BackedEnum::class)) {
             return iterator_to_array($this->backedEnumResolver->resolve($property->name, $input, new ReflectionMember($property)))[0] ?? null;
         }
@@ -115,6 +123,12 @@ final class MapInputValueResolver implements ValueResolverInterface
 
     private function resolveOptionSpec(Option $option, \ReflectionProperty $property, InputInterface $input): mixed
     {
+        $member = new ReflectionMember($property);
+
+        if ($this->inputFileResolver && (InputFileType::isInputFile($member) || InputFileType::isInputFileCollection($member))) {
+            return iterator_to_array($this->inputFileResolver->resolve($property->name, $input, $member))[0] ?? null;
+        }
+
         if (is_subclass_of($option->typeName, \BackedEnum::class)) {
             return iterator_to_array($this->backedEnumResolver->resolve($property->name, $input, new ReflectionMember($property)))[0] ?? null;
         }

--- a/src/Symfony/Component/Console/Attribute/Argument.php
+++ b/src/Symfony/Component/Console/Attribute/Argument.php
@@ -95,7 +95,9 @@ class Argument
 
         $self->interactiveAttribute = Ask::tryFrom($member, $self->name) ?? AskChoice::tryFrom($member, $self->name);
 
-        if ($self->interactiveAttribute && $isOptional) {
+        // A variadic argument is optional at the CLI but, like an array argument, collects
+        // values until an empty answer, so it stays compatible with an interactive attribute.
+        if ($self->interactiveAttribute && $isOptional && !$reflection->isVariadic()) {
             throw new LogicException(\sprintf('The %s "$%s" argument of "%s" cannot be both interactive and optional.', $reflection->getMemberName(), $self->name, $reflection->getSourceName()));
         }
 

--- a/src/Symfony/Component/Console/Attribute/Ask.php
+++ b/src/Symfony/Component/Console/Attribute/Ask.php
@@ -15,6 +15,7 @@ use Symfony\Component\Console\Attribute\Reflection\ReflectionMember;
 use Symfony\Component\Console\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Exception\LogicException;
 use Symfony\Component\Console\Input\File\InputFile;
+use Symfony\Component\Console\Input\File\InputFileType;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Console\Question\FileQuestion;
@@ -88,15 +89,18 @@ class Ask implements InteractiveAttributeInterface
             }
 
             $typeName = $type->getName();
+            $collection = InputFileType::isInputFileCollection($reflection);
 
-            if (InputFile::class === $typeName) {
-                $question = new FileQuestion($self->question);
+            // A collection keeps prompting until an empty answer, so a single call returns every
+            // file dropped at once or stacked across answers.
+            if ($collection || InputFile::class === $typeName) {
+                $question = new FileQuestion($self->question, multiple: $collection);
                 $question->setValidator($self->validator);
                 $question->setMaxAttempts($self->maxAttempts);
                 $question->setConstraints($self->constraints);
                 $value = $io->askQuestion($question);
 
-                if (null === $value && !$reflection->isNullable()) {
+                if (!$collection && null === $value && !$reflection->isNullable()) {
                     return;
                 }
 

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.2
 ---
 
+ * Allow reading several files at once through a variadic `InputFile` or `InputFile[]`-typed `#[Argument]`/`#[Option]`, the `FileQuestion` `multiple` option, and `SymfonyStyle::askFiles()`
  * Add `InputOption::HIDDEN` and `InputOption::DEPRECATED` modes
  * Allow a callable for the `description` and `help` options of `#[AsCommand]`, and for the `description` option of `#[Argument]` and `#[Option]`
  * Add `GitlabCiReporter` to emit reports in the GitLab Code Quality format

--- a/src/Symfony/Component/Console/Helper/FileInputHelper.php
+++ b/src/Symfony/Component/Console/Helper/FileInputHelper.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Console\Helper;
 
+use Symfony\Component\Console\Cursor;
 use Symfony\Component\Console\Exception\InvalidFileException;
 use Symfony\Component\Console\Exception\MissingInputException;
 use Symfony\Component\Console\Formatter\OutputFormatter;
@@ -40,66 +41,145 @@ final class FileInputHelper
     private ?ImageProtocolInterface $protocol = null;
 
     /**
-     * @param resource $inputStream
+     * @param resource        $inputStream
+     * @param callable():void $writePrompt Renders the prompt of a single-file question
+     *
+     * @return list<InputFile> A single answer may yield several files, e.g. when dragging and
+     *                         dropping multiple files at once on a multiple question
      */
-    public function readFileInput($inputStream, OutputInterface $output, FileQuestion $question): InputFile
+    public function readFileInput($inputStream, OutputInterface $output, FileQuestion $question, callable $writePrompt): array
     {
         if ($canPaste = $question->isPasteAllowed() && Terminal::supportsImageProtocol() && Terminal::hasSttyAvailable()) {
             $this->protocol = $this->detectProtocol();
+        } elseif (!$question->isPathAllowed()) {
+            throw new MissingInputException('Terminal does not support image paste and path input is disabled.');
         }
 
-        $file = null;
         $inputHelper = null;
 
         try {
+            // Configure the terminal once for the whole answer, even when several prompts are
+            // stacked, instead of re-running stty on every round.
             if ($canPaste) {
                 $inputHelper = new TerminalInputHelper($inputStream);
                 $output->write(self::BPM_ENABLE);
                 shell_exec('stty -icanon -echo');
-
-                $file = $this->readWithPasteDetection($inputStream, $output, $question, $inputHelper);
-            } elseif ($question->isPathAllowed()) {
-                $file = $this->readPathInput($inputStream);
-            } else {
-                throw new MissingInputException('Terminal does not support image paste and path input is disabled.');
             }
+
+            $read = fn (): array => $canPaste
+                ? $this->readWithPasteDetection($inputStream, $output, $question, $inputHelper)
+                : $this->readPathInput($inputStream, $question);
+
+            if ($question->isMultiple()) {
+                return $this->collectFiles($output, $question, $read, $canPaste);
+            }
+
+            $writePrompt();
+
+            $files = $read();
+
+            foreach ($files as $file) {
+                $this->assertValid($file);
+                $this->displayFile($output, $file);
+            }
+
+            return $files;
         } finally {
             if ($canPaste) {
                 $output->write(self::BPM_DISABLE);
                 $inputHelper?->finish();
             }
         }
+    }
 
+    /**
+     * Collects several files, keeping the question on a single line and a hint pinned below the
+     * growing list of files instead of repeating the prompt for every answer.
+     *
+     * @param callable():list<InputFile> $read
+     *
+     * @return list<InputFile>
+     */
+    private function collectFiles(OutputInterface $output, FileQuestion $question, callable $read, bool $canPaste): array
+    {
+        $questionLine = ' <info>'.OutputFormatter::escapeTrailingBackslash($question->getQuestion()).'</info>';
+        // A "// ..." note, like SymfonyStyle::comment(), reads as a hint rather than a value.
+        $hint = ' // Hit Enter to finish';
+        $files = [];
+
+        // Redrawing the footer needs a decorated, echo-free (paste) terminal. Otherwise fall back
+        // to a plain listing that neither repeats the question nor moves the cursor.
+        if (!$canPaste || !$output->isDecorated()) {
+            $output->writeln([$questionLine, '', $hint]);
+
+            while ($batch = $read()) {
+                foreach ($batch as $file) {
+                    $this->assertValid($file);
+                    $this->displayFile($output, $file, false, ' ');
+                    $files[] = $file;
+                }
+            }
+
+            return $files;
+        }
+
+        $cursor = new Cursor($output);
+        $output->writeln($questionLine);
+
+        while (true) {
+            // Transient footer, kept one blank line below the files collected so far.
+            $output->writeln(['', $hint]);
+            $output->write(' > ');
+
+            $batch = $read();
+
+            // Erase the footer (the prompt line, the hint line, and the blank line) before appending.
+            $cursor->clearLine()->moveUp()->clearLine()->moveUp()->clearLine()->moveToColumn(1);
+
+            if (!$batch) {
+                break;
+            }
+
+            foreach ($batch as $file) {
+                $this->assertValid($file);
+                $this->displayFile($output, $file, false, ' ');
+                $files[] = $file;
+            }
+        }
+
+        return $files;
+    }
+
+    private function assertValid(InputFile $file): void
+    {
         if (!$file->isValid()) {
             throw new InvalidFileException(\sprintf('File "%s" is not valid or readable.', $file->getPathname()));
         }
-
-        $this->displayFile($output, $file);
-
-        return $file;
     }
 
-    public function displayFile(OutputInterface $output, InputFile $file): void
+    public function displayFile(OutputInterface $output, InputFile $file, bool $thumbnail = true, string $prefix = ''): void
     {
         $path = self::sanitizeForDisplay((string) $file->getRealPath());
         $filename = self::sanitizeForDisplay($file->getFilename());
         $link = \sprintf('<href=file://%s>%s</>', OutputFormatter::escape($path), OutputFormatter::escape($filename));
 
         if ($output->isVeryVerbose()) {
-            $output->writeln(\sprintf('<info>%s</info> %s (<comment>%s, %s</comment>)', "\u{1F4CE}", $link, OutputFormatter::escape(self::sanitizeForDisplay($file->getMimeType() ?? 'unknown')), $file->getHumanReadableSize()));
+            $output->writeln(\sprintf('%s<info>%s</info> %s (<comment>%s, %s</comment>)', $prefix, "\u{1F4CE}", $link, OutputFormatter::escape(self::sanitizeForDisplay($file->getMimeType() ?? 'unknown')), $file->getHumanReadableSize()));
         } else {
-            $output->writeln(\sprintf('<info>%s</info> %s', "\u{1F4CE}", $link));
+            $output->writeln(\sprintf('%s<info>%s</info> %s', $prefix, "\u{1F4CE}", $link));
         }
 
-        if (Terminal::supportsImageProtocol() && $this->isDisplayableImage($file)) {
+        if ($thumbnail && Terminal::supportsImageProtocol() && $this->isDisplayableImage($file)) {
             $this->displayThumbnail($output, $file);
         }
     }
 
     /**
      * @param resource $inputStream
+     *
+     * @return list<InputFile>
      */
-    private function readWithPasteDetection($inputStream, OutputInterface $output, FileQuestion $question, TerminalInputHelper $inputHelper): InputFile
+    private function readWithPasteDetection($inputStream, OutputInterface $output, FileQuestion $question, TerminalInputHelper $inputHelper): array
     {
         $buffer = '';
         $inPaste = false;
@@ -164,18 +244,21 @@ final class FileInputHelper
                     throw new InvalidFileException('The pasted image could not be decoded.');
                 }
 
-                return InputFile::fromData($decoded['data'], $decoded['format']);
+                return [InputFile::fromData($decoded['data'], $decoded['format'])];
             }
 
-            $path = trim($pasteBuffer);
-            if ('' !== $path && $question->isPathAllowed()) {
-                return InputFile::fromPath($path);
+            if ([] !== $files = $this->extractPaths($pasteBuffer, $question)) {
+                return $files;
             }
         }
 
-        $path = trim($buffer);
-        if ('' !== $path && $question->isPathAllowed()) {
-            return InputFile::fromPath($path);
+        if ([] !== $files = $this->extractPaths($buffer, $question)) {
+            return $files;
+        }
+
+        // An empty answer ends the collection of a multiple question.
+        if ($question->isMultiple()) {
+            return [];
         }
 
         throw new MissingInputException('No file input provided.');
@@ -183,8 +266,10 @@ final class FileInputHelper
 
     /**
      * @param resource $inputStream
+     *
+     * @return list<InputFile>
      */
-    private function readPathInput($inputStream): InputFile
+    private function readPathInput($inputStream, FileQuestion $question): array
     {
         if (!$isBlocked = stream_get_meta_data($inputStream)['blocked'] ?? true) {
             stream_set_blocking($inputStream, true);
@@ -200,11 +285,103 @@ final class FileInputHelper
             throw new MissingInputException('Aborted.');
         }
 
-        if ('' === $path = trim($path)) {
-            throw new MissingInputException('No file path provided.');
+        if ([] !== $files = $this->extractPaths($path, $question)) {
+            return $files;
         }
 
-        return InputFile::fromPath($path);
+        // An empty answer ends the collection of a multiple question.
+        if ($question->isMultiple()) {
+            return [];
+        }
+
+        throw new MissingInputException('No file path provided.');
+    }
+
+    /**
+     * Turns a raw answer into the files it references: a single path for a regular question, or
+     * one file per whitespace-separated path for a multiple question.
+     *
+     * @return list<InputFile>
+     */
+    private function extractPaths(string $raw, FileQuestion $question): array
+    {
+        if (!$question->isPathAllowed()) {
+            return [];
+        }
+
+        if (!$question->isMultiple()) {
+            $path = trim($raw);
+
+            return '' === $path ? [] : [InputFile::fromPath($path)];
+        }
+
+        $files = [];
+        foreach (self::tokenizePaths($raw) as $path) {
+            $files[] = InputFile::fromPath($path);
+        }
+
+        return $files;
+    }
+
+    /**
+     * Splits an answer into individual paths, honoring shell-style quoting and escaping so a
+     * single drag&drop of several files - which the terminal inserts as space-separated, quoted
+     * or backslash-escaped paths - yields one entry per file.
+     *
+     * Quotes and escapes are kept in the returned tokens; InputFile::fromPath() normalizes each.
+     *
+     * @return list<string>
+     */
+    private static function tokenizePaths(string $input): array
+    {
+        $tokens = [];
+        $current = '';
+        $inToken = false;
+        $quote = null;
+        $length = \strlen($input);
+
+        for ($i = 0; $i < $length; ++$i) {
+            $char = $input[$i];
+
+            if (null !== $quote) {
+                $current .= $char;
+                if ($char === $quote) {
+                    $quote = null;
+                }
+                continue;
+            }
+
+            if ('\\' === $char && '\\' !== \DIRECTORY_SEPARATOR && $i + 1 < $length) {
+                $current .= $char.$input[++$i];
+                $inToken = true;
+                continue;
+            }
+
+            if ("'" === $char || '"' === $char) {
+                $quote = $char;
+                $current .= $char;
+                $inToken = true;
+                continue;
+            }
+
+            if (' ' === $char || "\t" === $char || "\n" === $char || "\r" === $char) {
+                if ($inToken) {
+                    $tokens[] = $current;
+                    $current = '';
+                    $inToken = false;
+                }
+                continue;
+            }
+
+            $current .= $char;
+            $inToken = true;
+        }
+
+        if ($inToken) {
+            $tokens[] = $current;
+        }
+
+        return $tokens;
     }
 
     private function detectProtocol(): ?ImageProtocolInterface

--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -114,9 +114,9 @@ class QuestionHelper extends Helper
     private function doAsk($inputStream, OutputInterface $output, Question $question): mixed
     {
         if ($question instanceof FileQuestion) {
-            $this->writePrompt($output, $question);
+            $files = (new FileInputHelper())->readFileInput($inputStream, $output, $question, fn () => $this->writePrompt($output, $question));
 
-            return (new FileInputHelper())->readFileInput($inputStream, $output, $question);
+            return $question->isMultiple() ? $files : ($files[0] ?? null);
         }
 
         $this->writePrompt($output, $question);
@@ -504,7 +504,14 @@ class QuestionHelper extends Helper
                 $value = $interviewer();
 
                 if ($constraints = $question->getConstraints()) {
-                    $this->validateConstraints($value, $constraints);
+                    if ($question instanceof FileQuestion && $question->isMultiple()) {
+                        // Validate each collected file individually rather than the whole list.
+                        foreach ($value as $file) {
+                            $this->validateConstraints($file, $constraints);
+                        }
+                    } else {
+                        $this->validateConstraints($value, $constraints);
+                    }
                 }
 
                 if ($validator = $question->getValidator()) {

--- a/src/Symfony/Component/Console/Input/File/InputFileType.php
+++ b/src/Symfony/Component/Console/Input/File/InputFileType.php
@@ -1,0 +1,267 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Input\File;
+
+use Symfony\Component\Console\Attribute\Reflection\ReflectionMember;
+
+/**
+ * Classifies a command input member (parameter or property) against the InputFile type.
+ *
+ * The "array of files" form is detected from the member's PHPDoc (`@param InputFile[] $files`,
+ * `@var list<InputFile>`, ...). Detection is self-contained: Console does not depend on
+ * symfony/type-info, so the item type is read from the doc comment and its short name is
+ * resolved against the declaring file's namespace and `use` statements.
+ *
+ * @author Robin Chalas <robin.chalas@gmail.com>
+ *
+ * @internal
+ */
+final class InputFileType
+{
+    /**
+     * A PHPDoc type expression: a name (optionally nullable, qualified or prefixed like
+     * `non-empty-`) with optional generics and array suffixes, e.g. `InputFile[]`,
+     * `?list<InputFile>`, `array<int, InputFile>`, `non-empty-list<InputFile>`, `InputFile[]|null`.
+     */
+    private const TYPE_PATTERN = '(?:null\s*\|\s*)?\??[\w\\\\-]+(?:<[^>]*>)?(?:\[\])*(?:\s*\|\s*null)?';
+
+    /** @var array<string, array{namespace: string, uses: array<string, string>}> */
+    private static array $fileContexts = [];
+
+    /**
+     * Whether the member expects a single file, e.g. `InputFile $file`.
+     */
+    public static function isInputFile(ReflectionMember $member): bool
+    {
+        $type = $member->getType();
+
+        return !$member->isVariadic() && $type instanceof \ReflectionNamedType && InputFile::class === $type->getName();
+    }
+
+    /**
+     * Whether the member expects several files, either as a variadic `InputFile ...$files`
+     * or as an array narrowed to InputFile through a PHPDoc (`@param InputFile[] $files`).
+     */
+    public static function isInputFileCollection(ReflectionMember $member): bool
+    {
+        $type = $member->getType();
+
+        if (!$type instanceof \ReflectionNamedType) {
+            return false;
+        }
+
+        if ($member->isVariadic()) {
+            return InputFile::class === $type->getName();
+        }
+
+        return 'array' === $type->getName() && self::arrayHoldsInputFiles($member);
+    }
+
+    private static function arrayHoldsInputFiles(ReflectionMember $member): bool
+    {
+        $reflector = $member->getMember();
+
+        if (null === $type = self::docBlockType($reflector)) {
+            return false;
+        }
+
+        if (null === $item = self::arrayItemType($type)) {
+            return false;
+        }
+
+        return is_a(self::resolveClassName($item, $reflector), InputFile::class, true);
+    }
+
+    /**
+     * Reads the raw PHPDoc type of a member (the `@param`/`@var` tag).
+     */
+    private static function docBlockType(\ReflectionParameter|\ReflectionProperty $reflector): ?string
+    {
+        if ($reflector instanceof \ReflectionProperty) {
+            if (null !== $type = self::varTag($reflector->getDocComment() ?: '')) {
+                return $type;
+            }
+
+            // A promoted property may instead be documented on the constructor's @param.
+            if ($reflector->isPromoted() && $constructor = $reflector->getDeclaringClass()->getConstructor()) {
+                return self::paramTag($constructor->getDocComment() ?: '', $reflector->getName());
+            }
+
+            return null;
+        }
+
+        return self::paramTag($reflector->getDeclaringFunction()->getDocComment() ?: '', $reflector->getName());
+    }
+
+    private static function paramTag(string $docComment, string $name): ?string
+    {
+        if (preg_match('{@param\s+('.self::TYPE_PATTERN.')\s+(?:&\s*)?(?:\.\.\.)?\$'.preg_quote($name, '{}').'\b}', $docComment, $matches)) {
+            return $matches[1];
+        }
+
+        return null;
+    }
+
+    private static function varTag(string $docComment): ?string
+    {
+        if (preg_match('{@var\s+('.self::TYPE_PATTERN.')}', $docComment, $matches)) {
+            return $matches[1];
+        }
+
+        return null;
+    }
+
+    /**
+     * Extracts the item type of an array shape (`Foo[]`, `list<Foo>`, `array<int, Foo>`,
+     * `non-empty-list<Foo>`, ...). `iterable<Foo>` is intentionally left out: only a member
+     * whose PHP type is `array` is treated as a collection (see isInputFileCollection()).
+     */
+    private static function arrayItemType(string $type): ?string
+    {
+        // Drop nullability so "?Foo[]", "Foo[]|null" and "null|Foo[]" are all handled.
+        $type = trim(preg_replace('{^\?|^null\s*\||\s*\|\s*null$}i', '', $type));
+
+        if (preg_match('{^([\w\\\\]+)\[\]$}', $type, $matches)) {
+            return $matches[1];
+        }
+
+        if (preg_match('{^(?:non-empty-)?(?:list|array)<[^>]*?([\w\\\\]+)>$}', $type, $matches)) {
+            return $matches[1];
+        }
+
+        return null;
+    }
+
+    /**
+     * Resolves a class name used in a doc comment to its fully-qualified form, using the
+     * declaring file's namespace and `use` statements.
+     */
+    private static function resolveClassName(string $name, \ReflectionParameter|\ReflectionProperty $reflector): string
+    {
+        if (str_starts_with($name, '\\')) {
+            return ltrim($name, '\\');
+        }
+
+        $file = $reflector instanceof \ReflectionProperty
+            ? $reflector->getDeclaringClass()->getFileName()
+            : $reflector->getDeclaringFunction()->getFileName();
+
+        if (false === $file) {
+            return $name;
+        }
+
+        ['namespace' => $namespace, 'uses' => $uses] = self::fileContext($file);
+
+        $alias = strtok($name, '\\');
+
+        if (isset($uses[strtolower($alias)])) {
+            return $uses[strtolower($alias)].substr($name, \strlen($alias));
+        }
+
+        return '' !== $namespace ? $namespace.'\\'.$name : $name;
+    }
+
+    /**
+     * @return array{namespace: string, uses: array<string, string>}
+     */
+    private static function fileContext(string $file): array
+    {
+        if (isset(self::$fileContexts[$file])) {
+            return self::$fileContexts[$file];
+        }
+
+        $namespace = '';
+        $uses = [];
+
+        if (false !== $source = @file_get_contents($file)) {
+            $tokens = \PhpToken::tokenize($source);
+            $count = \count($tokens);
+
+            for ($i = 0; $i < $count; ++$i) {
+                $id = $tokens[$i]->id;
+
+                if (\in_array($id, [\T_CLASS, \T_INTERFACE, \T_TRAIT, \T_ENUM], true)) {
+                    break; // imports always precede the type declaration
+                }
+
+                if (\T_NAMESPACE === $id) {
+                    $namespace = ltrim(self::readStatement($tokens, $i, [';', '{']), '\\');
+                } elseif (\T_USE === $id) {
+                    $statement = self::readStatement($tokens, $i, [';']);
+
+                    if (!str_starts_with($statement, 'function ') && !str_starts_with($statement, 'const ')) {
+                        self::collectUses($statement, $uses);
+                    }
+                }
+            }
+        }
+
+        return self::$fileContexts[$file] = ['namespace' => $namespace, 'uses' => $uses];
+    }
+
+    /**
+     * @param list<\PhpToken> $tokens
+     */
+    private static function readStatement(array $tokens, int &$i, array $stops): string
+    {
+        $text = '';
+
+        for (++$i; $i < \count($tokens); ++$i) {
+            if (\in_array($tokens[$i]->text, $stops, true)) {
+                break;
+            }
+
+            $text .= $tokens[$i]->text;
+        }
+
+        return trim($text);
+    }
+
+    /**
+     * @param array<string, string> $uses
+     */
+    private static function collectUses(string $statement, array &$uses): void
+    {
+        // Grouped imports: "A\B\{C, D as E}".
+        if (preg_match('{^(.+?)\\\\\{(.+)\}$}', $statement, $matches)) {
+            $prefix = trim($matches[1]).'\\';
+
+            foreach (explode(',', $matches[2]) as $part) {
+                self::addUse($prefix.trim($part), $uses);
+            }
+
+            return;
+        }
+
+        self::addUse($statement, $uses);
+    }
+
+    /**
+     * @param array<string, string> $uses
+     */
+    private static function addUse(string $import, array &$uses): void
+    {
+        if ('' === $import = ltrim(trim($import), '\\')) {
+            return;
+        }
+
+        if (preg_match('{^(.+?)\s+as\s+(\w+)$}i', $import, $matches)) {
+            $class = trim($matches[1]);
+            $alias = $matches[2];
+        } else {
+            $class = $import;
+            $alias = str_contains($import, '\\') ? substr($import, strrpos($import, '\\') + 1) : $import;
+        }
+
+        $uses[strtolower($alias)] = ltrim($class, '\\');
+    }
+}

--- a/src/Symfony/Component/Console/Question/FileQuestion.php
+++ b/src/Symfony/Component/Console/Question/FileQuestion.php
@@ -24,6 +24,7 @@ class FileQuestion extends Question
         string $question,
         private bool $allowPaste = true,
         private bool $allowPath = true,
+        private bool $multiple = false,
     ) {
         parent::__construct($question);
 
@@ -42,5 +43,14 @@ class FileQuestion extends Question
     public function isPathAllowed(): bool
     {
         return $this->allowPath;
+    }
+
+    /**
+     * Whether a single answer may provide several files at once, e.g. by dragging
+     * and dropping multiple files or by pasting space-separated paths.
+     */
+    public function isMultiple(): bool
+    {
+        return $this->multiple;
     }
 }

--- a/src/Symfony/Component/Console/Resources/config/console.php
+++ b/src/Symfony/Component/Console/Resources/config/console.php
@@ -71,6 +71,7 @@ return static function (ContainerConfigurator $container) {
                 service('console.argument_resolver.backed_enum'),
                 service('console.argument_resolver.datetime'),
                 service('validator')->nullOnInvalid(),
+                service('console.argument_resolver.input_file'),
             ])
             ->tag('console.argument_value_resolver', ['priority' => 100, 'name' => MapInputValueResolver::class])
 

--- a/src/Symfony/Component/Console/Style/SymfonyStyle.php
+++ b/src/Symfony/Component/Console/Style/SymfonyStyle.php
@@ -302,6 +302,15 @@ class SymfonyStyle extends OutputStyle
     }
 
     /**
+     * @return InputFile[] The files provided by the user, e.g. by dragging and dropping several
+     *                     files at once or by pasting space-separated paths
+     */
+    public function askFiles(string $question): array
+    {
+        return $this->askQuestion(new FileQuestion($question, multiple: true));
+    }
+
+    /**
      * @param string|null $format
      */
     public function progressStart(int $max = 0 /* , ?string $format = null */): void

--- a/src/Symfony/Component/Console/Tests/ArgumentResolver/ValueResolver/InputFileValueResolverTest.php
+++ b/src/Symfony/Component/Console/Tests/ArgumentResolver/ValueResolver/InputFileValueResolverTest.php
@@ -24,6 +24,9 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Console\Tests\Fixtures\InvokableWithInputFilesArrayTestCommand;
+use Symfony\Component\Console\Tests\Fixtures\InvokableWithInputFilesDtoTestCommand;
+use Symfony\Component\Console\Tests\Fixtures\InvokableWithInputFilesVariadicTestCommand;
 use Symfony\Component\Console\Tests\Fixtures\InvokableWithInputFileTestCommand;
 use Symfony\Component\Filesystem\Filesystem;
 
@@ -255,5 +258,109 @@ class InputFileValueResolverTest extends TestCase
         $tester->assertCommandIsSuccessful();
         $this->assertStringContainsString('Filename: InputFileValueResolverTest.php', $tester->getDisplay());
         $this->assertStringContainsString('Valid: yes', $tester->getDisplay());
+    }
+
+    public function testResolvesVariadicInputFilesFromPaths()
+    {
+        $a = $this->tempDir.'/a.txt';
+        $b = $this->tempDir.'/b.txt';
+        file_put_contents($a, 'a');
+        file_put_contents($b, 'b');
+
+        $resolver = new InputFileValueResolver();
+        $input = new ArrayInput(['files' => [$a, $b]], new InputDefinition([
+            new InputArgument('files', InputArgument::IS_ARRAY),
+        ]));
+
+        $command = new class {
+            public function __invoke(#[Argument] InputFile ...$files)
+            {
+            }
+        };
+        $member = new ReflectionMember((new \ReflectionMethod($command, '__invoke'))->getParameters()[0]);
+
+        $results = [...$resolver->resolve('files', $input, $member)];
+
+        $this->assertCount(2, $results);
+        $this->assertContainsOnlyInstancesOf(InputFile::class, $results);
+        $this->assertSame([$a, $b], [$results[0]->getPathname(), $results[1]->getPathname()]);
+    }
+
+    public function testResolvesArrayOfInputFilesNarrowedByPhpDoc()
+    {
+        $a = $this->tempDir.'/a.txt';
+        $b = $this->tempDir.'/b.txt';
+        file_put_contents($a, 'a');
+        file_put_contents($b, 'b');
+
+        $resolver = new InputFileValueResolver();
+        $input = new ArrayInput(['files' => [$a, $b]], new InputDefinition([
+            new InputArgument('files', InputArgument::IS_ARRAY),
+        ]));
+
+        $command = new class {
+            /**
+             * @param InputFile[] $files
+             */
+            public function __invoke(#[Argument] array $files)
+            {
+            }
+        };
+        $member = new ReflectionMember((new \ReflectionMethod($command, '__invoke'))->getParameters()[0]);
+
+        // A non-variadic array argument receives the whole list as a single value.
+        $results = [...$resolver->resolve('files', $input, $member)];
+
+        $this->assertCount(1, $results);
+        $this->assertContainsOnlyInstancesOf(InputFile::class, $results[0]);
+        $this->assertSame([$a, $b], [$results[0][0]->getPathname(), $results[0][1]->getPathname()]);
+    }
+
+    public function testDoesNotResolveAPlainArray()
+    {
+        $resolver = new InputFileValueResolver();
+        $input = new ArrayInput(['tags' => ['a', 'b']], new InputDefinition([
+            new InputArgument('tags', InputArgument::IS_ARRAY),
+        ]));
+
+        $command = new class {
+            public function __invoke(#[Argument] array $tags)
+            {
+            }
+        };
+        $member = new ReflectionMember((new \ReflectionMethod($command, '__invoke'))->getParameters()[0]);
+
+        $this->assertSame([], [...$resolver->resolve('tags', $input, $member)]);
+    }
+
+    public function testResolvesVariadicInputFilesInNonInteractiveMode()
+    {
+        $tester = new CommandTester(new InvokableWithInputFilesVariadicTestCommand());
+        $tester->execute(['files' => [__FILE__, __DIR__.'/../../Fixtures/InvokableWithInputFilesArrayTestCommand.php']], ['interactive' => false]);
+
+        $tester->assertCommandIsSuccessful();
+        $this->assertStringContainsString('Count: 2', $tester->getDisplay());
+        $this->assertStringContainsString('Filename: InputFileValueResolverTest.php', $tester->getDisplay());
+        $this->assertStringContainsString('Filename: InvokableWithInputFilesArrayTestCommand.php', $tester->getDisplay());
+    }
+
+    public function testResolvesArrayOfInputFilesInNonInteractiveMode()
+    {
+        $tester = new CommandTester(new InvokableWithInputFilesArrayTestCommand());
+        $tester->execute(['files' => [__FILE__, __FILE__]], ['interactive' => false]);
+
+        $tester->assertCommandIsSuccessful();
+        $this->assertStringContainsString('Count: 2', $tester->getDisplay());
+        $this->assertStringContainsString('Filename: InputFileValueResolverTest.php', $tester->getDisplay());
+    }
+
+    public function testResolvesDtoInputFilesInNonInteractiveMode()
+    {
+        $tester = new CommandTester(new InvokableWithInputFilesDtoTestCommand());
+        $tester->execute(['files' => [__FILE__, __FILE__]], ['interactive' => false]);
+
+        $tester->assertCommandIsSuccessful();
+        $this->assertStringContainsString('Count: 2', $tester->getDisplay());
+        $this->assertStringContainsString('Filename: InputFileValueResolverTest.php', $tester->getDisplay());
     }
 }

--- a/src/Symfony/Component/Console/Tests/Command/InvokableCommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/InvokableCommandTest.php
@@ -39,6 +39,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Console\Tests\Fixtures\InvokableTestCommand;
 use Symfony\Component\Console\Tests\Fixtures\InvokableWithCustomValidatorTestCommand;
 use Symfony\Component\Console\Tests\Fixtures\InvokableWithInputFileAndConstraintsTestCommand;
+use Symfony\Component\Console\Tests\Fixtures\InvokableWithInputFilesVariadicTestCommand;
 
 class InvokableCommandTest extends TestCase
 {
@@ -95,12 +96,10 @@ class InvokableCommandTest extends TestCase
     public function testCommandInputDescriptionFromCallable()
     {
         $command = new Command('foo');
-        $command->setCode(static function (
+        $command->setCode(static fn (
             #[Argument(description: [self::class, 'generateBioDescription'])] string $bio = '',
             #[Option(description: [self::class, 'generateBioDescription'])] string $summary = '',
-        ): int {
-            return 0;
-        });
+        ): int => 0);
 
         self::assertSame('Generated bio description', $command->getDefinition()->getArgument('bio')->getDescription());
         self::assertSame('Generated bio description', $command->getDefinition()->getOption('summary')->getDescription());
@@ -109,13 +108,11 @@ class InvokableCommandTest extends TestCase
     public function testCommandInputDescriptionIsNeverResolvedAsCallable()
     {
         $command = new Command('foo');
-        $command->setCode(static function (
+        $command->setCode(static fn (
             // "define" is the name of a PHP function, it must still be taken as a plain description
             #[Argument(description: 'define')] string $bio = '',
             #[Option(description: 'define')] string $summary = '',
-        ): int {
-            return 0;
-        });
+        ): int => 0);
 
         self::assertSame('define', $command->getDefinition()->getArgument('bio')->getDescription());
         self::assertSame('define', $command->getDefinition()->getOption('summary')->getDescription());
@@ -711,6 +708,28 @@ class InvokableCommandTest extends TestCase
             self::assertStringContainsString('Valid: yes', $tester->getDisplay());
         } finally {
             @unlink($tempFile);
+        }
+    }
+
+    public function testAskWithVariadicInputFilesCollectsAndStacks()
+    {
+        $a = sys_get_temp_dir().'/sf_input_files_a_'.uniqid().'.txt';
+        $b = sys_get_temp_dir().'/sf_input_files_b_'.uniqid().'.txt';
+        file_put_contents($a, 'a');
+        file_put_contents($b, 'b');
+
+        try {
+            $tester = new CommandTester(new InvokableWithInputFilesVariadicTestCommand());
+            // First answer drops two files at once, the second stacks one more, an empty answer ends.
+            $tester->setInputs(["$a $b", $a, '']);
+            $tester->execute([], ['interactive' => true]);
+            $tester->assertCommandIsSuccessful();
+
+            self::assertStringContainsString('Provide files:', $tester->getDisplay());
+            self::assertStringContainsString('Count: 3', $tester->getDisplay());
+        } finally {
+            @unlink($a);
+            @unlink($b);
         }
     }
 

--- a/src/Symfony/Component/Console/Tests/Fixtures/InputFileTypeAliasFixture.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/InputFileTypeAliasFixture.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Tests\Fixtures;
+
+use Symfony\Component\Console\Command\Command as InputFile;
+
+/**
+ * Here the "InputFile" short name resolves to a different class, so detection must read the
+ * `use` statements rather than match the short name blindly.
+ */
+class InputFileTypeAliasFixture
+{
+    /**
+     * @param InputFile[] $files
+     */
+    public function sameShortName(array $files): void
+    {
+    }
+
+    /**
+     * @param \Symfony\Component\Console\Input\File\InputFile[] $files
+     */
+    public function fullyQualified(array $files): void
+    {
+    }
+}

--- a/src/Symfony/Component/Console/Tests/Fixtures/InputFileTypeFixture.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/InputFileTypeFixture.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Tests\Fixtures;
+
+use Symfony\Component\Console\Input\File\InputFile;
+use Symfony\Component\Console\Input\File\InputFile as AliasedFile;
+
+/**
+ * Covers the PHPDoc shapes InputFileType must classify. Members are never called; only their
+ * reflection and doc comments matter.
+ */
+class InputFileTypeFixture
+{
+    /**
+     * @var InputFile[]
+     */
+    public array $propertyArray;
+
+    /**
+     * @param InputFile[] $files
+     */
+    public function arrayShortName(array $files): void
+    {
+    }
+
+    /**
+     * @param list<InputFile> $files
+     */
+    public function listGeneric(array $files): void
+    {
+    }
+
+    /**
+     * @param array<int, InputFile> $files
+     */
+    public function arrayGeneric(array $files): void
+    {
+    }
+
+    /**
+     * @param AliasedFile[] $files
+     */
+    public function aliasedImport(array $files): void
+    {
+    }
+
+    /**
+     * @param non-empty-list<InputFile> $files
+     */
+    public function nonEmptyList(array $files): void
+    {
+    }
+
+    /**
+     * @param InputFile[]|null $files
+     */
+    public function nullableArray(?array $files): void
+    {
+    }
+
+    /**
+     * A member typed `iterable` is not treated as a collection, only `array` is.
+     *
+     * @param iterable<InputFile> $files
+     */
+    public function iterableType(iterable $files): void
+    {
+    }
+
+    public function variadic(InputFile ...$files): void
+    {
+    }
+
+    public function single(InputFile $file): void
+    {
+    }
+
+    public function plainArray(array $tags): void
+    {
+    }
+
+    /**
+     * @param string[] $tags
+     */
+    public function stringArray(array $tags): void
+    {
+    }
+
+    public function __construct(
+        /** @var InputFile[] */
+        public array $promoted = [],
+    ) {
+    }
+}

--- a/src/Symfony/Component/Console/Tests/Fixtures/InvokableWithInputFilesArrayTestCommand.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/InvokableWithInputFilesArrayTestCommand.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Tests\Fixtures;
+
+use Symfony\Component\Console\Attribute\Argument;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\File\InputFile;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(name: 'app:input-files-array')]
+class InvokableWithInputFilesArrayTestCommand
+{
+    /**
+     * @param InputFile[] $files
+     */
+    public function __invoke(
+        OutputInterface $output,
+        #[Argument]
+        array $files,
+    ): int {
+        $output->writeln('Count: '.\count($files));
+
+        foreach ($files as $file) {
+            $output->writeln('Filename: '.$file->getFilename());
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Symfony/Component/Console/Tests/Fixtures/InvokableWithInputFilesDtoTestCommand.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/InvokableWithInputFilesDtoTestCommand.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Tests\Fixtures;
+
+use Symfony\Component\Console\Attribute\Argument;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Attribute\MapInput;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\File\InputFile;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(name: 'app:input-files-dto')]
+class InvokableWithInputFilesDtoTestCommand
+{
+    public function __invoke(
+        OutputInterface $output,
+        #[MapInput]
+        UploadDto $upload,
+    ): int {
+        $output->writeln('Count: '.\count($upload->files));
+
+        foreach ($upload->files as $file) {
+            $output->writeln('Filename: '.$file->getFilename());
+        }
+
+        return Command::SUCCESS;
+    }
+}
+
+final class UploadDto
+{
+    /**
+     * @var InputFile[]
+     */
+    #[Argument]
+    public array $files;
+}

--- a/src/Symfony/Component/Console/Tests/Fixtures/InvokableWithInputFilesVariadicTestCommand.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/InvokableWithInputFilesVariadicTestCommand.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Tests\Fixtures;
+
+use Symfony\Component\Console\Attribute\Argument;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Attribute\Ask;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\File\InputFile;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(name: 'app:input-files-variadic')]
+class InvokableWithInputFilesVariadicTestCommand
+{
+    public function __invoke(
+        OutputInterface $output,
+        #[Argument]
+        #[Ask('Provide files:')]
+        InputFile ...$files,
+    ): int {
+        $output->writeln('Count: '.\count($files));
+
+        foreach ($files as $file) {
+            $output->writeln('Filename: '.$file->getFilename());
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Symfony/Component/Console/Tests/Helper/FileInputHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/FileInputHelperTest.php
@@ -190,6 +190,96 @@ class FileInputHelperTest extends TestCase
         }
     }
 
+    public function testCollectFilesRedrawsTheFooterInPasteMode()
+    {
+        $a = $this->createTempFile();
+        $b = $this->createTempFile();
+
+        // One answer with two files, then an empty answer to finish.
+        $batches = [[InputFile::fromPath($a), InputFile::fromPath($b)], []];
+        $read = static function () use (&$batches): array { return array_shift($batches) ?? []; };
+
+        $output = new BufferedOutput(BufferedOutput::VERBOSITY_NORMAL, true);
+        $files = $this->invokeCollectFiles($output, new FileQuestion('Provide files:', multiple: true), $read, true);
+
+        $this->assertSame([$a, $b], array_map(static fn (InputFile $f): string => $f->getPathname(), $files));
+
+        $display = $output->fetch();
+        // The question is printed once, not repeated per answer.
+        $this->assertSame(1, substr_count($display, 'Provide files:'));
+        // The hint is pinned below and the cursor is moved up to redraw it (footer erase).
+        $this->assertStringContainsString('// Hit Enter to finish', $display);
+        $this->assertStringContainsString("\x1b[1A", $display);
+        $this->assertStringContainsString(basename($a), $display);
+        $this->assertStringContainsString(basename($b), $display);
+    }
+
+    public function testCollectFilesListsFilesWithoutCursorControlWhenNotDecorated()
+    {
+        $a = $this->createTempFile();
+
+        $batches = [[InputFile::fromPath($a)], []];
+        $read = static function () use (&$batches): array { return array_shift($batches) ?? []; };
+
+        $output = new BufferedOutput(BufferedOutput::VERBOSITY_NORMAL, false);
+        $files = $this->invokeCollectFiles($output, new FileQuestion('Provide files:', multiple: true), $read, false);
+
+        $this->assertCount(1, $files);
+
+        $display = $output->fetch();
+        $this->assertSame(1, substr_count($display, 'Provide files:'));
+        $this->assertStringContainsString('// Hit Enter to finish', $display);
+        $this->assertStringNotContainsString("\x1b[", $display);
+    }
+
+    public function testReadWithPasteDetectionReturnsSeveralPathsFromASinglePaste()
+    {
+        $a = $this->createTempFile();
+        $b = $this->createTempFile();
+
+        // Dropping several files at once inserts them as space-separated, quoted paths.
+        $input = $this->pasteMarker('PASTE_START').\sprintf("'%s' '%s'", $a, $b).$this->pasteMarker('PASTE_END');
+
+        $files = $this->readAllWithPasteDetection($this->streamOf($input), null, true);
+
+        $this->assertSame([$a, $b], array_map(static fn (InputFile $f): string => $f->getPathname(), $files));
+    }
+
+    public function testReadWithPasteDetectionReturnsSeveralPathsFromALine()
+    {
+        $a = $this->createTempFile();
+        $b = $this->createTempFile();
+
+        $files = $this->readAllWithPasteDetection($this->streamOf("$a $b\n"), null, true);
+
+        $this->assertSame([$a, $b], array_map(static fn (InputFile $f): string => $f->getPathname(), $files));
+    }
+
+    public function testReadWithPasteDetectionKeepsQuotedAndEscapedSpacesWithinEachPath()
+    {
+        if ('\\' === \DIRECTORY_SEPARATOR) {
+            $this->markTestSkipped('Backslash escaping of paths is a non-Windows convention.');
+        }
+
+        $a = sys_get_temp_dir().\DIRECTORY_SEPARATOR.'sf console '.bin2hex(random_bytes(4)).'.txt';
+        file_put_contents($a, 'x');
+        $this->tempFiles[] = $a;
+        $b = $this->createTempFile();
+
+        // First path backslash-escaped, second path quoted.
+        $input = str_replace(' ', '\ ', $a)." '$b'\n";
+
+        $files = $this->readAllWithPasteDetection($this->streamOf($input), null, true);
+
+        $this->assertSame([$a, $b], array_map(static fn (InputFile $f): string => $f->getPathname(), $files));
+    }
+
+    public function testReadWithPasteDetectionReturnsNoFileForAnEmptyMultipleAnswer()
+    {
+        // An empty answer ends the collection of a multiple question instead of aborting.
+        $this->assertSame([], $this->readAllWithPasteDetection($this->streamOf("\n"), null, true));
+    }
+
     public function testReadWithPasteDetectionRejectsAnUndecodablePastedImage()
     {
         $truncated = "\x1b_Ga=T,f=100,m=1;".base64_encode('chunk one')."\x1b\\";
@@ -240,6 +330,18 @@ class FileInputHelperTest extends TestCase
         }
     }
 
+    /**
+     * @param callable():list<InputFile> $read
+     *
+     * @return list<InputFile>
+     */
+    private function invokeCollectFiles(BufferedOutput $output, FileQuestion $question, callable $read, bool $canPaste): array
+    {
+        $method = new \ReflectionMethod(FileInputHelper::class, 'collectFiles');
+
+        return $method->invoke(new FileInputHelper(), $output, $question, $read, $canPaste);
+    }
+
     private function createTempFile(): string
     {
         $path = sys_get_temp_dir().\DIRECTORY_SEPARATOR.'sf_console_'.bin2hex(random_bytes(4)).'.txt';
@@ -270,6 +372,16 @@ class FileInputHelperTest extends TestCase
      */
     private function readWithPasteDetection($stream, ?ImageProtocolInterface $protocol = null): InputFile
     {
+        return $this->readAllWithPasteDetection($stream, $protocol)[0];
+    }
+
+    /**
+     * @param resource $stream
+     *
+     * @return list<InputFile>
+     */
+    private function readAllWithPasteDetection($stream, ?ImageProtocolInterface $protocol = null, bool $multiple = false): array
+    {
         $reflection = new \ReflectionClass(FileInputHelper::class);
         $method = $reflection->getMethod('readWithPasteDetection');
 
@@ -285,6 +397,6 @@ class FileInputHelperTest extends TestCase
             $reflection->getProperty('protocol')->setValue($helper, $protocol);
         }
 
-        return $method->invoke($helper, $stream, new BufferedOutput(), new FileQuestion('?'), $inputHelper);
+        return $method->invoke($helper, $stream, new BufferedOutput(), new FileQuestion('?', multiple: $multiple), $inputHelper);
     }
 }

--- a/src/Symfony/Component/Console/Tests/Input/File/InputFileTypeTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/File/InputFileTypeTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Tests\Input\File;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Attribute\Reflection\ReflectionMember;
+use Symfony\Component\Console\Input\File\InputFileType;
+use Symfony\Component\Console\Tests\Fixtures\InputFileTypeAliasFixture;
+use Symfony\Component\Console\Tests\Fixtures\InputFileTypeFixture;
+
+class InputFileTypeTest extends TestCase
+{
+    /**
+     * @param class-string $class
+     */
+    #[DataProvider('collectionProvider')]
+    public function testIsInputFileCollection(string $class, string $method, bool $expected)
+    {
+        $this->assertSame($expected, InputFileType::isInputFileCollection($this->member($class, $method)));
+    }
+
+    public static function collectionProvider(): iterable
+    {
+        yield 'variadic' => [InputFileTypeFixture::class, 'variadic', true];
+        yield 'short name @param InputFile[]' => [InputFileTypeFixture::class, 'arrayShortName', true];
+        yield 'list<InputFile>' => [InputFileTypeFixture::class, 'listGeneric', true];
+        yield 'array<int, InputFile>' => [InputFileTypeFixture::class, 'arrayGeneric', true];
+        yield 'non-empty-list<InputFile>' => [InputFileTypeFixture::class, 'nonEmptyList', true];
+        yield 'InputFile[]|null' => [InputFileTypeFixture::class, 'nullableArray', true];
+        yield 'aliased import' => [InputFileTypeFixture::class, 'aliasedImport', true];
+        yield 'iterable-typed member is not a collection' => [InputFileTypeFixture::class, 'iterableType', false];
+        yield 'fully-qualified name' => [InputFileTypeAliasFixture::class, 'fullyQualified', true];
+        yield 'single file is not a collection' => [InputFileTypeFixture::class, 'single', false];
+        yield 'plain array without phpdoc' => [InputFileTypeFixture::class, 'plainArray', false];
+        yield 'array of strings' => [InputFileTypeFixture::class, 'stringArray', false];
+        yield 'short name resolving to another class' => [InputFileTypeAliasFixture::class, 'sameShortName', false];
+    }
+
+    public function testIsInputFile()
+    {
+        $this->assertTrue(InputFileType::isInputFile($this->member(InputFileTypeFixture::class, 'single')));
+        $this->assertFalse(InputFileType::isInputFile($this->member(InputFileTypeFixture::class, 'variadic')));
+        $this->assertFalse(InputFileType::isInputFile($this->member(InputFileTypeFixture::class, 'arrayShortName')));
+    }
+
+    public function testDetectsPropertyVarTag()
+    {
+        $member = new ReflectionMember(new \ReflectionProperty(InputFileTypeFixture::class, 'propertyArray'));
+
+        $this->assertTrue(InputFileType::isInputFileCollection($member));
+    }
+
+    public function testDetectsPromotedProperty()
+    {
+        $member = new ReflectionMember(new \ReflectionProperty(InputFileTypeFixture::class, 'promoted'));
+
+        $this->assertTrue(InputFileType::isInputFileCollection($member));
+    }
+
+    /**
+     * @param class-string $class
+     */
+    private function member(string $class, string $method): ReflectionMember
+    {
+        return new ReflectionMember((new \ReflectionMethod($class, $method))->getParameters()[0]);
+    }
+}


### PR DESCRIPTION
| Q             | A   |
| ------------- | --- |
| Branch?       | 8.2 |
| Bug fix?      | no  |
| New feature?  | yes |
| Deprecations? | no  |
| Issues        | -   |
| License       | MIT |

Follow-up to the single-file `InputFile` support added in https://github.com/symfony/symfony/pull/63293, this lets an interactive command accept many files at once, the way you'd drop a batch onto the terminal.

3 ways to ask for them:

```php
// variadic argument (or option)
public function __invoke(#[Argument] InputFile ...$files) { }

// array narrowed by a PHPDoc — the form that also works on #[MapInput]
// DTO properties, where a variadic can't be used
/** @param InputFile[] $files */
public function __invoke(#[Argument] array $files) { }

// or programmatically
$files = $io->askFiles('Provide files:');
```

Interactively, a single drag&drop can carry many files at once, and you can keep stacking more until you submit an empty line (hit enter).

The `array` form reads the `InputFile` type from the docblock to know that a list of files is expected.
I decided not to add a soft dependency to TypeInfo component because the UX tradeoff when the component isn't available and the added complexity required for that case makes it not worth it to me. Happy to reconsider though.

The behavior is the same whether the files come from `#[Ask]`, `#[MapInput]`, or `SymfonyStyle::askFiles()` / `new FileQuestion($q, multiple: true)`.

https://github.com/user-attachments/assets/a1b3148b-2f31-446d-9cd7-84c835523d56