### PR TITLE
[FrameworkBundle] Suggest more packages for unknown commands

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/EventListener/SuggestMissingPackageSubscriber.php
+++ b/src/Symfony/Bundle/FrameworkBundle/EventListener/SuggestMissingPackageSubscriber.php
@@ -26,17 +26,57 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 final class SuggestMissingPackageSubscriber implements EventSubscriberInterface
 {
+    /**
+     * Each namespace maps to the package providing it, limited to packages having a recipe in symfony/recipes
+     * or belonging to a family of packages that do, like symfony/ux-*. A "_default" requires a namespace that
+     * no Symfony command uses and that a single package owns; otherwise the package only gets the
+     * sub-namespaces of the commands it provides.
+     */
     private const PACKAGES = [
+        'api' => [
+            '_default' => ['ApiPlatformBundle', 'api-platform/symfony'],
+        ],
+        'bazinga' => [
+            'js-translation' => ['BazingaJsTranslationBundle', 'willdurand/js-translation-bundle'],
+        ],
+        'debug' => [
+            'live-component' => ['LiveComponentBundle', 'symfony/ux-live-component'],
+            'twig-component' => ['TwigComponentBundle', 'symfony/ux-twig-component'],
+        ],
         'doctrine' => [
             'fixtures' => ['DoctrineFixturesBundle', 'doctrine/doctrine-fixtures-bundle --dev'],
+            'migrations' => ['DoctrineMigrationsBundle', 'doctrine/doctrine-migrations-bundle'],
             'mongodb' => ['DoctrineMongoDBBundle', 'doctrine/mongodb-odm-bundle'],
             '_default' => ['Doctrine ORM', 'symfony/orm-pack'],
         ],
+        'hautelook' => [
+            'fixtures' => ['HautelookAliceBundle', 'hautelook/alice-bundle --dev'],
+        ],
+        'league' => [
+            'oauth2-server' => ['LeagueOAuth2ServerBundle', 'league/oauth2-server-bundle'],
+        ],
+        'lexik' => [
+            'jwt' => ['LexikJWTAuthenticationBundle', 'lexik/jwt-authentication-bundle'],
+        ],
         'make' => [
+            'admin' => ['EasyAdminBundle', 'easycorp/easyadmin-bundle'],
             '_default' => ['MakerBundle', 'symfony/maker-bundle --dev'],
+        ],
+        'sass' => [
+            '_default' => ['SassBundle', 'symfonycasts/sass-bundle'],
         ],
         'server' => [
             '_default' => ['Debug Bundle', 'symfony/debug-bundle --dev'],
+        ],
+        'tailwind' => [
+            '_default' => ['TailwindBundle', 'symfonycasts/tailwind-bundle'],
+        ],
+        'ux' => [
+            'icons' => ['UXIconsBundle', 'symfony/ux-icons'],
+            'install' => ['UXToolkitBundle', 'symfony/ux-toolkit'],
+            'native' => ['UXNativeBundle', 'symfony/ux-native'],
+            'toolkit' => ['UXToolkitBundle', 'symfony/ux-toolkit'],
+            'translator' => ['UxTranslatorBundle', 'symfony/ux-translator'],
         ],
     ];
 
@@ -52,12 +92,10 @@ final class SuggestMissingPackageSubscriber implements EventSubscriberInterface
             return;
         }
 
-        if (isset(self::PACKAGES[$namespace][$command])) {
+        if ($exact = isset(self::PACKAGES[$namespace][$command])) {
             $suggestion = self::PACKAGES[$namespace][$command];
-            $exact = true;
-        } else {
-            $suggestion = self::PACKAGES[$namespace]['_default'];
-            $exact = false;
+        } elseif (!$suggestion = self::PACKAGES[$namespace]['_default'] ?? null) {
+            return;
         }
 
         $error = $event->getError();

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/ApplicationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/ApplicationTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\Console;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -226,6 +227,65 @@ class ApplicationTest extends TestCase
     {
         $result = $this->createEventForSuggestingPackages('server', ['server:run']);
         $this->assertDoesNotMatchRegularExpression('/You may be looking for a command provided by/', $result);
+    }
+
+    #[DataProvider('provideCommandsSuggestingAPackage')]
+    public function testSuggestingPackageForCommand(string $command, string $bundle, string $package)
+    {
+        $result = $this->createEventForSuggestingPackages($command);
+
+        $this->assertStringContainsString(\sprintf('provided by the "%s" which is currently not installed. Try running "composer require %s".', $bundle, $package), $result);
+    }
+
+    public static function provideCommandsSuggestingAPackage(): iterable
+    {
+        yield 'api:openapi:export' => ['api:openapi:export', 'ApiPlatformBundle', 'api-platform/symfony'];
+        yield 'bazinga:js-translation:dump' => ['bazinga:js-translation:dump', 'BazingaJsTranslationBundle', 'willdurand/js-translation-bundle'];
+        yield 'debug:live-component' => ['debug:live-component', 'LiveComponentBundle', 'symfony/ux-live-component'];
+        yield 'debug:twig-component' => ['debug:twig-component', 'TwigComponentBundle', 'symfony/ux-twig-component'];
+        yield 'doctrine:fixtures:load' => ['doctrine:fixtures:load', 'DoctrineFixturesBundle', 'doctrine/doctrine-fixtures-bundle --dev'];
+        yield 'doctrine:migrations:migrate' => ['doctrine:migrations:migrate', 'DoctrineMigrationsBundle', 'doctrine/doctrine-migrations-bundle'];
+        yield 'doctrine:mongodb:schema:create' => ['doctrine:mongodb:schema:create', 'DoctrineMongoDBBundle', 'doctrine/mongodb-odm-bundle'];
+        yield 'doctrine:schema:update' => ['doctrine:schema:update', 'Doctrine ORM', 'symfony/orm-pack'];
+        yield 'hautelook:fixtures:load' => ['hautelook:fixtures:load', 'HautelookAliceBundle', 'hautelook/alice-bundle --dev'];
+        yield 'league:oauth2-server:create-client' => ['league:oauth2-server:create-client', 'LeagueOAuth2ServerBundle', 'league/oauth2-server-bundle'];
+        yield 'lexik:jwt:generate-keypair' => ['lexik:jwt:generate-keypair', 'LexikJWTAuthenticationBundle', 'lexik/jwt-authentication-bundle'];
+        yield 'make:admin:dashboard' => ['make:admin:dashboard', 'EasyAdminBundle', 'easycorp/easyadmin-bundle'];
+        yield 'make:controller' => ['make:controller', 'MakerBundle', 'symfony/maker-bundle --dev'];
+        yield 'sass:build' => ['sass:build', 'SassBundle', 'symfonycasts/sass-bundle'];
+        yield 'server:dump' => ['server:dump', 'Debug Bundle', 'symfony/debug-bundle --dev'];
+        yield 'tailwind:build' => ['tailwind:build', 'TailwindBundle', 'symfonycasts/tailwind-bundle'];
+        yield 'ux:icons:import' => ['ux:icons:import', 'UXIconsBundle', 'symfony/ux-icons'];
+        yield 'ux:install' => ['ux:install', 'UXToolkitBundle', 'symfony/ux-toolkit'];
+        yield 'ux:native:build-configs' => ['ux:native:build-configs', 'UXNativeBundle', 'symfony/ux-native'];
+        yield 'ux:toolkit:create-kit' => ['ux:toolkit:create-kit', 'UXToolkitBundle', 'symfony/ux-toolkit'];
+        yield 'ux:translator:warm-cache' => ['ux:translator:warm-cache', 'UxTranslatorBundle', 'symfony/ux-translator'];
+    }
+
+    public function testNotSuggestingPackageForUnknownNamespace()
+    {
+        $result = $this->createEventForSuggestingPackages('unknown:command');
+        $this->assertStringNotContainsString('You may be looking for a command provided by', $result);
+    }
+
+    public function testNotSuggestingPackageWithoutDefaultAndPartialMatch()
+    {
+        $result = $this->createEventForSuggestingPackages('ux:unknown');
+        $this->assertStringNotContainsString('You may be looking for a command provided by', $result);
+    }
+
+    public function testNotSuggestingPackageForACommandOfACoreNamespace()
+    {
+        $result = $this->createEventForSuggestingPackages('debug:route');
+        $this->assertStringNotContainsString('You may be looking for a command provided by', $result);
+    }
+
+    public function testSuggestingPackagesWithExactMatchAndAlternatives()
+    {
+        // a partially installed namespace: DoctrineBundle is there, the fixtures bundle is not
+        $result = $this->createEventForSuggestingPackages('doctrine:fixtures:load', ['doctrine', 'doctrine:database', 'doctrine:schema']);
+
+        $this->assertStringContainsString('provided by the "DoctrineFixturesBundle"', $result);
     }
 
     private function createEventForSuggestingPackages(string $command, array $alternatives = []): string


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #59459
| License       | MIT

Following up on #59472, closed with "please submit again when you want".

This applies the limit @GromNaN proposed and @chalasr agreed on there: only packages having a recipe in `symfony/recipes`, and only when they expose a command namespace no Symfony command already uses. That rules out five of the six bundles the previous attempt proposed, which live in `symfony/recipes-contrib` or have no recipe at all. The rule is written above the constant so the next person adding an entry knows where the line is, and an entry that stops qualifying can be dropped the way `sensio/generator-bundle` and `symfony/web-server-bundle` were.

Eight namespaces are added, plus `doctrine:migrations` and `make:admin` as subkeys of existing ones. Every name was checked against the `#[AsCommand]` names upstream.

A vendor publishing several bundles under one prefix only gets its own subkey: `lexik/maintenance-bundle` and `lexik/translation-bundle` also live under `lexik:`, so mapping the whole namespace to the JWT bundle would be wrong. Five of the new entries therefore have no `_default`, which the current code cannot express, as it reads `_default` without `isset()`. Hence the `?? null`. No existing namespace is affected, all three have a `_default`.
