### PR TITLE
[PropertyInfo] Do not prefer a static named constructor as the property accessor

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -272,8 +272,16 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
             array_splice($accessorMethods, false === $getterPosition ? \count($accessorMethods) : $getterPosition + 1, 0, [$getsetter]);
         }
 
+        $staticGetsetter = null;
+
         foreach ($accessorMethods as $methodName) {
             if ($reflClass->hasMethod($methodName) && ($m = $reflClass->getMethod($methodName))->getModifiers() & $this->methodReflectionFlags && !$m->getNumberOfRequiredParameters() && !\in_array((string) $m->getReturnType(), ['void', 'never'], true)) {
+                if ($allowGetterSetter && $methodName === $getsetter && $m->isStatic()) {
+                    // a static method named after the property, e.g. a named constructor, must not win over any instance-based candidate; try it last
+                    $staticGetsetter = $m;
+                    continue;
+                }
+
                 return new PropertyReadInfo(PropertyReadInfo::TYPE_METHOD, $methodName, $this->getReadVisibilityForMethod($m), $m->isStatic(), false);
             }
         }
@@ -288,6 +296,10 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
 
         if ($allowMagicCall && $reflClass->hasMethod('__call') && ($reflClass->getMethod('__call')->getModifiers() & $this->methodReflectionFlags)) {
             return new PropertyReadInfo(PropertyReadInfo::TYPE_METHOD, 'get'.$camelProp, PropertyReadInfo::VISIBILITY_PUBLIC, false, false);
+        }
+
+        if ($staticGetsetter) {
+            return new PropertyReadInfo(PropertyReadInfo::TYPE_METHOD, $getsetter, $this->getReadVisibilityForMethod($staticGetsetter), true, false);
         }
 
         return null;

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
@@ -21,6 +21,8 @@ use Symfony\Component\PropertyInfo\Tests\Fixtures\DefaultValue;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\DummyWithGetterSetter;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\DummyWithHasser;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\DummyWithNonAsciiStaticAccessor;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\DummyWithStaticConstructorAndAccessor;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\MultiParameterAdderDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\MultiParameterAdderParentDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\MultiParameterAdderValue;
@@ -607,6 +609,41 @@ class ReflectionExtractorTest extends TestCase
 
         $this->assertSame(PropertyReadInfo::TYPE_METHOD, $readAccessor->getType());
         $this->assertSame('hasPayments', $readAccessor->getName());
+    }
+
+    public function testGetReadAccessorDoesNotPreferTheStaticNamedConstructor()
+    {
+        $readAccessor = $this->extractor->getReadInfo(DummyWithStaticConstructorAndAccessor::class, 'zero', ['enable_getter_setter_extraction' => true]);
+
+        $this->assertSame(PropertyReadInfo::TYPE_METHOD, $readAccessor->getType());
+        $this->assertSame('isZero', $readAccessor->getName());
+    }
+
+    public function testGetReadAccessorTriesTheStaticMethodNamedAfterThePropertyLast()
+    {
+        $readAccessor = $this->extractor->getReadInfo(DummyWithStaticConstructorAndAccessor::class, 'one', ['enable_getter_setter_extraction' => true]);
+
+        $this->assertSame(PropertyReadInfo::TYPE_METHOD, $readAccessor->getType());
+        $this->assertSame('one', $readAccessor->getName());
+        $this->assertTrue($readAccessor->isStatic());
+    }
+
+    public function testGetReadAccessorKeepsAConfiguredStaticAccessorWhenGetterSetterExtractionIsDisabled()
+    {
+        $extractor = new ReflectionExtractor(null, ['']);
+        $readAccessor = $extractor->getReadInfo(DummyWithNonAsciiStaticAccessor::class, 'émail');
+
+        $this->assertSame(PropertyReadInfo::TYPE_METHOD, $readAccessor->getType());
+        $this->assertSame('émail', $readAccessor->getName());
+        $this->assertTrue($readAccessor->isStatic());
+    }
+
+    public function testGetReadAccessorPrefersThePropertyOverTheStaticMethodNamedAfterIt()
+    {
+        $readAccessor = $this->extractor->getReadInfo(DummyWithStaticConstructorAndAccessor::class, 'positive', ['enable_getter_setter_extraction' => true]);
+
+        $this->assertSame(PropertyReadInfo::TYPE_PROPERTY, $readAccessor->getType());
+        $this->assertSame('positive', $readAccessor->getName());
     }
 
     /**

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/DummyWithNonAsciiStaticAccessor.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/DummyWithNonAsciiStaticAccessor.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
+
+class DummyWithNonAsciiStaticAccessor
+{
+    public static function émail(): string
+    {
+        return 'static';
+    }
+
+    public function __get($name)
+    {
+        return 'magic';
+    }
+}

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/DummyWithStaticConstructorAndAccessor.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/DummyWithStaticConstructorAndAccessor.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
+
+class DummyWithStaticConstructorAndAccessor
+{
+    public bool $positive = false;
+
+    public function __construct(private readonly int $quantity = 1)
+    {
+    }
+
+    public static function zero(): self
+    {
+        return new self(0);
+    }
+
+    public static function one(): self
+    {
+        return new self(1);
+    }
+
+    public static function positive(): self
+    {
+        return new self(2);
+    }
+
+    public function isZero(): bool
+    {
+        return 0 === $this->quantity;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65618
| License       | MIT

#65501 moved the jQuery-style bare accessor (`foo()`, only tried when `enable_getter_setter_extraction` is on) ahead of the `is`/`has`/`can` accessors in `getReadInfo()`'s priority order, without checking `isStatic()` on that bare match. A class exposing both a static named constructor and a predicate sharing the property's name, like:

```php
class Quantity
{
    public function __construct(private readonly int $quantity = 1) {}
    public static function zero(): self { return new self(0); }
    public function isZero(): bool { return $this->quantity === 0; }
}
```

had its `zero` property read through the static `zero()` factory instead of `isZero()`, returning a new instance where a bool was expected. Through the Serializer this recurses into itself and exhausts memory.

A static method cannot see the instance, so it can never report the state of the object being read. This patch therefore demotes a static method named after the property behind every instance-based candidate: the prefixed accessors, `__get()`, the property itself and `__call()`. It remains a valid last-resort accessor, so a class exposing only a static `foo()` keeps resolving to it, as it has since 5.1, and `isReadable()` still reports true for it. The demotion is scoped to the candidate added by `enable_getter_setter_extraction`: accessors found through the configured prefixes are never deferred, so prefixed accessors (`get`/`is`/`has`/`can`) and custom prefix lists may still resolve to a static method as before.

Resulting read priority for property `foo` with `enable_getter_setter_extraction` on: `getFoo()`, `foo()` if non-static, `isFoo()`, `canFoo()`, `hasFoo()`, then `__get()`, the `foo` property, `__call()`, and finally `foo()` if static.