### PR TITLE
[Notifier][Bluesky] Document the automatic rich text detection

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Bluesky/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/Bluesky/README.md
@@ -34,6 +34,27 @@ $message->options($options);
 $chatter->send($message);
 ```
 
+Automatic Rich Text Detection
+-----------------------------
+
+Bluesky posts have no markup: rich text is declared through "facets", byte
+ranges of the text that clients render as links. The transport detects them
+automatically in the message, no option is needed:
+
+ * mentions, e.g. `@nyholm.bsky.social` (the handle must resolve on the
+   configured endpoint);
+ * URLs, e.g. `https://symfony.com`;
+ * hashtags, e.g. `#symfony` (also with the fullwidth `＃` marker), which makes
+   them clickable and attaches the post to the tag feed.
+
+A hashtag needs at least one character that is neither a digit nor
+punctuation (so `#123` is left as plain text), trailing punctuation is not
+part of the tag, and a `#` inside a URL is part of the link, not a tag.
+Following the lexicon limits, a tag longer than 64 graphemes or 640 bytes is
+left as plain text instead of making the whole post fail.
+
+Hashtag facets require version 8.2 or higher of the bridge.
+
 Sponsor
 -------
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix symfony/symfony-docs#22564
| License       | MIT

Documents the rich text facets in the README of the Bluesky bridge, as asked in symfony/symfony-docs#22564: the new hashtag facets of #59784 (detection rules, fullwidth marker, lexicon limits) together with the pre-existing mention and URL detection, which was not documented either. `notifier.rst` links to this README, so nothing to add on the docs side.
