### PR TITLE
[PropertyInfo] Do not prefer a static named constructor as the property mutator

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -385,12 +385,19 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
         $getsetter = lcfirst($camelized);
         $getsetterNonCamelized = lcfirst($nonCamelized);
 
+        $staticGetsetter = null;
+
         if ($allowGetterSetter) {
             [$accessible, $methodAccessibleErrors] = $this->isMethodAccessible($reflClass, $getsetter, 1);
             if ($accessible) {
                 $method = $reflClass->getMethod($getsetter);
 
-                return new PropertyWriteInfo(PropertyWriteInfo::TYPE_METHOD, $getsetter, $this->getWriteVisibilityForMethod($method), $method->isStatic());
+                if (!$method->isStatic()) {
+                    return new PropertyWriteInfo(PropertyWriteInfo::TYPE_METHOD, $getsetter, $this->getWriteVisibilityForMethod($method), false);
+                }
+
+                // a static method named after the property, e.g. a named constructor, must not win over any instance-based candidate; try it last
+                $staticGetsetter = [$getsetter, $method];
             }
 
             $errors[] = $methodAccessibleErrors;
@@ -400,7 +407,11 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
                 if ($accessible) {
                     $method = $reflClass->getMethod($getsetterNonCamelized);
 
-                    return new PropertyWriteInfo(PropertyWriteInfo::TYPE_METHOD, $getsetterNonCamelized, $this->getWriteVisibilityForMethod($method), $method->isStatic());
+                    if (!$method->isStatic()) {
+                        return new PropertyWriteInfo(PropertyWriteInfo::TYPE_METHOD, $getsetterNonCamelized, $this->getWriteVisibilityForMethod($method), false);
+                    }
+
+                    $staticGetsetter ??= [$getsetterNonCamelized, $method];
                 }
                 $errors[] = $methodAccessibleErrors;
             }
@@ -442,6 +453,12 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
                 $reflClass->getName(),
                 implode('()", "', [$adderAccessName, $removerAccessName])
             )];
+        }
+
+        if ($staticGetsetter) {
+            [$methodName, $method] = $staticGetsetter;
+
+            return new PropertyWriteInfo(PropertyWriteInfo::TYPE_METHOD, $methodName, $this->getWriteVisibilityForMethod($method), true);
         }
 
         $noneProperty = new PropertyWriteInfo();

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
@@ -23,6 +23,7 @@ use Symfony\Component\PropertyInfo\Tests\Fixtures\DummyWithGetterSetter;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\DummyWithHasser;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\DummyWithNonAsciiStaticAccessor;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\DummyWithStaticConstructorAndAccessor;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\DummyWithStaticMutator;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\MultiParameterAdderDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\MultiParameterAdderParentDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\MultiParameterAdderValue;
@@ -726,6 +727,31 @@ class ReflectionExtractorTest extends TestCase
         self::assertNotNull($writeMutator);
         self::assertSame(PropertyWriteInfo::TYPE_NONE, $writeMutator->getType());
         self::assertSame([\sprintf('The property "baz" in class "%s" can be defined with the methods "addBaz()", "removeBaz()" but the new value must be an array or an instance of \Traversable', Php71Dummy::class)], $writeMutator->getErrors());
+    }
+
+    public function testGetWriteMutatorPrefersTheSetterOverTheStaticMethodNamedAfterTheProperty()
+    {
+        $writeMutator = $this->extractor->getWriteInfo(DummyWithStaticMutator::class, 'quantity', ['enable_getter_setter_extraction' => true]);
+
+        $this->assertSame(PropertyWriteInfo::TYPE_METHOD, $writeMutator->getType());
+        $this->assertSame('setQuantity', $writeMutator->getName());
+    }
+
+    public function testGetWriteMutatorPrefersThePropertyOverTheStaticMethodNamedAfterIt()
+    {
+        $writeMutator = $this->extractor->getWriteInfo(DummyWithStaticMutator::class, 'value', ['enable_getter_setter_extraction' => true]);
+
+        $this->assertSame(PropertyWriteInfo::TYPE_PROPERTY, $writeMutator->getType());
+        $this->assertSame('value', $writeMutator->getName());
+    }
+
+    public function testGetWriteMutatorTriesTheStaticMethodNamedAfterThePropertyLast()
+    {
+        $writeMutator = $this->extractor->getWriteInfo(DummyWithStaticMutator::class, 'amount', ['enable_getter_setter_extraction' => true]);
+
+        $this->assertSame(PropertyWriteInfo::TYPE_METHOD, $writeMutator->getType());
+        $this->assertSame('amount', $writeMutator->getName());
+        $this->assertTrue($writeMutator->isStatic());
     }
 
     public function testGetWriteInfoReadonlyProperties()

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/DummyWithStaticMutator.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/DummyWithStaticMutator.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
+
+class DummyWithStaticMutator
+{
+    public int $value = 0;
+
+    private int $quantity = 0;
+
+    public static function value(int $value): self
+    {
+        $dummy = new self();
+        $dummy->value = $value;
+
+        return $dummy;
+    }
+
+    public static function quantity(int $quantity): self
+    {
+        return self::value($quantity);
+    }
+
+    public static function amount(int $amount): self
+    {
+        return self::value($amount);
+    }
+
+    public function setQuantity(int $quantity): void
+    {
+        $this->quantity = $quantity;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Write-side follow-up to #65619. `getWriteInfo()` selects the jQuery-style bare mutator `foo($value)` (only when `enable_getter_setter_extraction` is on, which PropertyAccess always enables) before the property itself and the magic methods, without checking `isStatic()`. A static method named after the property that accepts one argument, like a named constructor:

```php
class Money
{
    public int $value = 0;

    public static function value(int $value): self
    {
        $money = new self();
        $money->value = $value;

        return $money;
    }
}
```

is picked as the mutator for `value`. A static method cannot mutate the instance and PropertyAccess discards its return value, so `$propertyAccessor->setValue($money, 'value', 42)` calls the factory, throws away the result and leaves `$money->value` untouched: the write is silently lost while a writable public property sits right there.

This patch demotes a static method named after the property behind every instance-based candidate: the prefixed mutators, the property itself, `__set()` and `__call()`. It remains a valid last-resort mutator, so a class exposing only such a static method keeps resolving to it and `isWritable()` still reports true; a static mutator can legitimately update static state. Prefixed mutators (`set`, `add`/`remove`) may still resolve to a static method as before.

Resulting write priority for property `foo` with `enable_getter_setter_extraction` on: constructor parameter, adder/remover pair, `setFoo()` and the other prefixed mutators, `foo($value)` if non-static, the `foo` property, `__set()`, `__call()`, and finally `foo($value)` if static.

With this and #65619, the read and write paths agree again on the overlap case: a public property shadowed by a same-named static method is both read from and written to directly.