### PR TITLE
[ErrorHandler] Fix what the exception page announces to assistive technologies

### DIFF
--- a/src/Symfony/Component/ErrorHandler/Resources/assets/css/exception.css
+++ b/src/Symfony/Component/ErrorHandler/Resources/assets/css/exception.css
@@ -144,6 +144,7 @@ code, pre { font: 13px/1.6 var(--font-mono); font-size-adjust: 0.5298; font-weig
 :focus-visible { outline: 2px solid var(--ring); outline-offset: 2px; }
 
 .hidden { display: none; }
+.sr-only { position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0; border: 0; overflow: hidden; clip-path: inset(50%); white-space: nowrap; }
 .break-long-words { word-wrap: break-word; overflow-wrap: break-word; -webkit-hyphens: auto; -moz-hyphens: auto; hyphens: auto; hyphenate-character: ''; min-width: 0; }
 .sf-toggle { cursor: pointer; position: relative; }
 
@@ -336,9 +337,14 @@ header .container { display: flex; align-items: center; justify-content: space-b
 .exc-detail { display: grid; grid-template-rows: 1fr; transition: grid-template-rows .25s ease; padding: 0 var(--chain-pad-x); }
 .exc-item:not(.is-expanded) .exc-detail { grid-template-rows: 0fr; }
 
-.exc-detail-inner { min-height: 0; overflow: hidden; opacity: 1; transition: opacity .2s ease; }
+.exc-detail-inner { min-height: 0; overflow: hidden; opacity: 1; visibility: visible; transition: opacity .2s ease; }
 .exc-item.is-expanded .exc-detail-inner { margin-bottom: 4px; }
-.exc-item:not(.is-expanded) .exc-detail-inner { opacity: 0; }
+.exc-item:not(.is-expanded) .exc-detail-inner { opacity: 0; visibility: hidden; transition: opacity .2s ease, visibility 0s .25s; }
+@media (prefers-reduced-motion: reduce) {
+    .exc-detail { transition: none; }
+    .exc-detail-inner,
+    .exc-item:not(.is-expanded) .exc-detail-inner { transition: none; }
+}
 
 .exc-single { margin: 15px 0 0; padding: 10px; }
 @media (min-width: 1280px) { .exc-single { padding: 15px; } }
@@ -491,8 +497,9 @@ header .container { display: flex; align-items: center; justify-content: space-b
 .trace-line a { color: var(--foreground); }
 .trace-line .icon { position: absolute; left: 10px; }
 .trace-line .icon svg { fill: var(--muted-foreground); height: 16px; width: 16px; }
-.trace-line .icon.icon-copy { position: static; margin: -3px 0; padding-left: 5px; display: none; vertical-align: middle; }
-.trace-line:hover .icon.icon-copy:not(.hidden) { display: inline-flex; }
+.trace-line .icon.icon-copy { position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0; overflow: hidden; clip-path: inset(50%); white-space: nowrap; background: none; border: 0; color: inherit; font: inherit; cursor: pointer; }
+.trace-line:hover .icon.icon-copy:not(.hidden),
+.trace-line .icon.icon-copy:not(.hidden):focus-visible { position: static; display: inline-flex; width: auto; height: auto; margin: -3px 0; padding: 0 0 0 5px; overflow: visible; clip-path: none; vertical-align: middle; }
 .trace-line .icon.icon-copy .icon-copy-default, .trace-line .icon.icon-copy .icon-copy-success { display: inline-flex; }
 .trace-line .icon.icon-copy .icon-copy-success { display: none; }
 .trace-line .icon.icon-copy.is-copied { color: var(--success); }
@@ -665,10 +672,14 @@ header .container { display: flex; align-items: center; justify-content: space-b
 
 .log-detail { display: grid; grid-template-rows: 0fr; transition: grid-template-rows .25s ease; }
 .log-line.is-expanded .log-detail { grid-template-rows: 1fr; }
-.log-detail-inner { min-height: 0; overflow: hidden; }
+.log-detail-inner { min-height: 0; overflow: hidden; visibility: visible; }
+.log-line:not(.is-expanded) .log-detail-inner { visibility: hidden; transition: visibility 0s .25s; }
 .log-json { margin: 0; padding: 2px 14px 12px; font-family: var(--font-mono); font-size: 12px; line-height: 1.5; white-space: pre-wrap; word-break: break-word; color: var(--muted-foreground); }
 .log-json-key { color: var(--code-syntax-function-title); }
 .log-json-str { color: var(--code-syntax-string); }
 .log-json-num { color: var(--code-syntax-variable-other-marker); }
 .log-json-kw { color: var(--code-syntax-keyword); }
-@media (prefers-reduced-motion: reduce) { .log-detail { transition: none; } }
+@media (prefers-reduced-motion: reduce) {
+    .log-detail { transition: none; }
+    .log-line:not(.is-expanded) .log-detail-inner { transition: none; }
+}

--- a/src/Symfony/Component/ErrorHandler/Resources/assets/js/exception.js
+++ b/src/Symfony/Component/ErrorHandler/Resources/assets/js/exception.js
@@ -29,11 +29,31 @@
         };
     }
 
+    var announcer = document.querySelector('[data-announcer]');
+
+    function announce(message) {
+        if (!announcer) {
+            return;
+        }
+        /* clearing first, then filling in a moment later, makes screen readers announce repeated copies */
+        announcer.textContent = '';
+        clearTimeout(announcer.sfAnnounceTimer);
+        announcer.sfAnnounceTimer = setTimeout(function() {
+            announcer.textContent = message;
+            announcer.sfAnnounceTimer = setTimeout(function() { announcer.textContent = ''; }, 5000);
+        }, 50);
+    }
+
     if (navigator.clipboard) {
         document.querySelectorAll('[data-clipboard-text]:not([data-processed=true])').forEach(function(element) {
             removeClass(element, 'hidden');
-            element.addEventListener('click', function() {
-                navigator.clipboard.writeText(element.getAttribute('data-clipboard-text'));
+            element.addEventListener('click', function(e) {
+                /* Prevents from disallowing clicks on "copy to clipboard" elements inside toggles */
+                e.stopPropagation();
+
+                navigator.clipboard.writeText(element.getAttribute('data-clipboard-text')).then(function() {
+                    announce('File path copied to clipboard');
+                });
                 /* briefly swap the copy glyph for a checkmark as feedback */
                 addClass(element, 'is-copied');
                 clearTimeout(element.sfCopiedTimer);
@@ -170,6 +190,7 @@
             btn.removeAttribute('hidden');
             btn.addEventListener('click', function() {
                 navigator.clipboard.writeText(buildTextContent(btn)).then(function() {
+                    announce('Copied to clipboard');
                     var label = btn.querySelector('.copy-label');
                     if (!label) { return; }
                     var previous = label.textContent;
@@ -200,7 +221,7 @@
             addEventListener(toggles[i], 'click', function(e) {
                 var toggle = e.currentTarget;
 
-                if (e.target.closest('a, span[data-clipboard-text], .sf-toggle') !== toggle) {
+                if (e.target.closest('a, .sf-toggle') !== toggle) {
                     return;
                 }
 
@@ -257,7 +278,9 @@
             var card = btn.closest('.trace-raw-card');
             var pre = card ? card.querySelector('pre') : null;
             addEventListener(btn, 'click', function() {
-                navigator.clipboard.writeText(pre ? pre.textContent.replace(/[ \t]+\n/g, '\n').trim() : '');
+                navigator.clipboard.writeText(pre ? pre.textContent.replace(/[ \t]+\n/g, '\n').trim() : '').then(function() {
+                    announce('Stack trace copied to clipboard');
+                });
                 addClass(btn, 'is-copied');
                 clearTimeout(btn.sfCopiedTimer);
                 btn.sfCopiedTimer = setTimeout(function() { removeClass(btn, 'is-copied'); }, 1500);
@@ -387,7 +410,16 @@
         });
 
         addEventListener(document, 'click', closeFilter);
-        addEventListener(document, 'keydown', function(e) { if ('Escape' === e.key) { closeFilter(); } });
+        addEventListener(document, 'keydown', function(e) {
+            if ('Escape' !== e.key || !openFilter) {
+                return;
+            }
+            /* hiding the menu drops the focus it holds, so hand it back to the trigger */
+            var trigger = openFilter.trigger;
+            var restoreFocus = openFilter.menu.contains(document.activeElement);
+            closeFilter();
+            if (restoreFocus) { trigger.focus(); }
+        });
     })();
 })();
 /*]]>*/

--- a/src/Symfony/Component/ErrorHandler/Resources/views/exception.html.php
+++ b/src/Symfony/Component/ErrorHandler/Resources/views/exception.html.php
@@ -79,3 +79,6 @@
         </div>
     <?php } ?>
 </div>
+
+<?php // the profiler scopes this fragment's stylesheet to itself, so the live region has to sit inside the fragment ?>
+<p class="sr-only" role="status" data-announcer></p>

--- a/src/Symfony/Component/ErrorHandler/Resources/views/logs.html.php
+++ b/src/Symfony/Component/ErrorHandler/Resources/views/logs.html.php
@@ -23,8 +23,8 @@ $renderLogFilter = function (string $name, string $label, array $values): void {
         return;
     } ?>
     <div class="logs-filter" data-filter="<?= $name; ?>">
-        <button type="button" class="logs-filter-trigger" aria-expanded="false" aria-haspopup="true"><?= $this->escape($label); ?> <span class="logs-filter-icon"><?= $this->include('assets/images/icon-chevrons-up-down.svg'); ?></span></button>
-        <div class="logs-filter-menu" hidden>
+        <button type="button" class="logs-filter-trigger" aria-expanded="false"><?= $this->escape($label); ?> <span class="logs-filter-icon"><?= $this->include('assets/images/icon-chevrons-up-down.svg'); ?></span></button>
+        <div class="logs-filter-menu" role="group" aria-label="Filter by <?= $this->escape($label); ?>" hidden>
             <div class="logs-filter-options">
                 <?php foreach ($values as $value) { ?>
                     <label class="logs-filter-option"><input type="checkbox" value="<?= $this->escape($value); ?>" checked><span><?= $this->escape($value); ?></span></label>
@@ -58,6 +58,7 @@ $renderLogFilter = function (string $name, string $label, array $values): void {
 
     <div class="logs-list">
         <?php
+        $logIndex = 0;
         foreach ($logs as $log) {
             if ($log['priority'] >= 400) {
                 $status = 'error';
@@ -74,13 +75,21 @@ $renderLogFilter = function (string $name, string $label, array $values): void {
             // error logs are expanded by default so the failure context is visible right away
             $expanded = $hasDetail && 'error' === $status;
             $tag = $hasDetail ? 'button' : 'div';
+            // an expandable row names its summary from its parts, so that assistive technologies
+            // read them as separate words instead of as one run-on string
+            $summaryId = $hasDetail ? 'log-'.$logIndex++ : null;
+            $labelledBy = [$summaryId.'-time', $summaryId.'-level'];
+            if ($channelIsDefined) {
+                $labelledBy[] = $summaryId.'-channel';
+            }
+            $labelledBy[] = $summaryId.'-message';
             ?>
             <div class="log-line status-<?= $status; ?><?= $hasDetail ? ' has-detail' : ''; ?><?= $expanded ? ' is-expanded' : ''; ?>"<?= $expanded ? ' data-default-expanded="1"' : ''; ?> data-level="<?= $this->escape($log['priorityName']); ?>"<?php if ($channelIsDefined) { ?> data-channel="<?= $this->escape($log['channel']); ?>"<?php } ?> data-time="<?= $this->escape($log['timestamp_rfc3339'] ?? date(\DATE_RFC3339_EXTENDED, $log['timestamp'])); ?>">
-                <<?= $tag; ?> class="log-summary"<?= $hasDetail ? ' type="button" aria-expanded="'.($expanded ? 'true' : 'false').'"' : ''; ?>>
-                    <span class="log-time"><?= date('H:i:s', $log['timestamp']); ?></span>
-                    <span class="log-level log-level-<?= $status; ?>"><?= $this->escape($log['priorityName']); ?></span>
-                    <?php if ($channelIsDefined) { ?><span class="log-channel"><?= $this->escape($log['channel']); ?></span><?php } ?>
-                    <span class="log-message break-long-words"><?= $this->formatLogMessage($log['message'], $log['context']); ?></span>
+                <<?= $tag; ?> class="log-summary"<?= $hasDetail ? ' type="button" aria-expanded="'.($expanded ? 'true' : 'false').'" aria-labelledby="'.implode(' ', $labelledBy).'"' : ''; ?>>
+                    <span class="log-time"<?= $summaryId ? ' id="'.$summaryId.'-time"' : ''; ?>><?= date('H:i:s', $log['timestamp']); ?></span>
+                    <span class="log-level log-level-<?= $status; ?>"<?= $summaryId ? ' id="'.$summaryId.'-level"' : ''; ?>><?= $this->escape($log['priorityName']); ?></span>
+                    <?php if ($channelIsDefined) { ?><span class="log-channel"<?= $summaryId ? ' id="'.$summaryId.'-channel"' : ''; ?>><?= $this->escape($log['channel']); ?></span><?php } ?>
+                    <span class="log-message break-long-words"<?= $summaryId ? ' id="'.$summaryId.'-message"' : ''; ?>><?= $this->formatLogMessage($log['message'], $log['context']); ?></span>
                     <span class="log-chevron"><?php if ($hasDetail) { echo $this->include('assets/images/chevron-right.svg'); } ?></span>
                 </<?= $tag; ?>>
                 <?php if ($hasDetail) { ?>

--- a/src/Symfony/Component/ErrorHandler/Resources/views/trace.html.php
+++ b/src/Symfony/Component/ErrorHandler/Resources/views/trace.html.php
@@ -16,10 +16,10 @@
                 <?= implode(\DIRECTORY_SEPARATOR, array_slice($filePathParts, 0, -1)).\DIRECTORY_SEPARATOR; ?><strong><?= end($filePathParts); ?></strong>
             </a>
             (line <?= $lineNumber; ?>)
-            <span class="icon icon-copy hidden" data-clipboard-text="<?php echo implode(\DIRECTORY_SEPARATOR, $filePathParts).':'.$lineNumber; ?>">
+            <button type="button" class="icon icon-copy hidden" aria-label="Copy file path" data-clipboard-text="<?php echo implode(\DIRECTORY_SEPARATOR, $filePathParts).':'.$lineNumber; ?>">
                 <span class="icon-copy-default"><?php echo $this->include('assets/images/icon-copy.svg'); ?></span>
                 <span class="icon-copy-success"><?php echo $this->include('assets/images/icon-copy-check.svg'); ?></span>
-            </span>
+            </button>
         </span>
     <?php } ?>
 </div>

--- a/src/Symfony/Component/ErrorHandler/Tests/ErrorRenderer/HtmlErrorRendererTest.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/ErrorRenderer/HtmlErrorRendererTest.php
@@ -13,7 +13,12 @@ namespace Symfony\Component\ErrorHandler\Tests\ErrorRenderer;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\AbstractLogger;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\ErrorHandler\ErrorRenderer\HtmlErrorRenderer;
+use Symfony\Component\ErrorHandler\Exception\FlattenException;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Log\DebugLoggerInterface;
 
 class HtmlErrorRendererTest extends TestCase
 {
@@ -122,6 +127,53 @@ class HtmlErrorRendererTest extends TestCase
             $rendered,
             '->render() returns the HTML content with "binary string" replacement'
         );
+    }
+
+    public function testTheCopyStatusRegionIsPartOfTheRenderedBody()
+    {
+        // the profiler embeds this fragment and scopes the stylesheet to it, so the region
+        // cannot be appended to the document from JavaScript
+        $body = (new HtmlErrorRenderer(true))->getBody(FlattenException::createFromThrowable(new \RuntimeException('Foo')));
+
+        $this->assertStringContainsString('<p class="sr-only" role="status" data-announcer></p>', $body);
+    }
+
+    public function testExpandableLogRowsNameThemselvesFromTheirParts()
+    {
+        $rendered = (new HtmlErrorRenderer(true, null, null, null, '', $this->createDebugLogger()))->render(new \RuntimeException('Foo'))->getAsString();
+
+        $this->assertStringContainsString('aria-labelledby="log-0-time log-0-level log-0-channel log-0-message"', $rendered);
+        $this->assertStringContainsString('<span class="log-time" id="log-0-time">', $rendered);
+        $this->assertStringContainsString('<span class="log-message break-long-words" id="log-0-message">', $rendered);
+
+        // a row without context is not expandable, so it has no summary to name
+        $this->assertStringNotContainsString('id="log-1-', $rendered);
+    }
+
+    private function createDebugLogger(): LoggerInterface&DebugLoggerInterface
+    {
+        return new class extends AbstractLogger implements DebugLoggerInterface {
+            public function log($level, $message, array $context = []): void
+            {
+            }
+
+            public function getLogs(?Request $request = null): array
+            {
+                return [
+                    ['timestamp' => 0, 'timestamp_rfc3339' => '1970-01-01T00:00:00.000+00:00', 'message' => 'With context', 'priority' => 200, 'priorityName' => 'INFO', 'channel' => 'request', 'context' => ['foo' => 'bar']],
+                    ['timestamp' => 0, 'timestamp_rfc3339' => '1970-01-01T00:00:00.000+00:00', 'message' => 'Without context', 'priority' => 200, 'priorityName' => 'INFO', 'channel' => 'request', 'context' => []],
+                ];
+            }
+
+            public function countErrors(?Request $request = null): int
+            {
+                return 0;
+            }
+
+            public function clear(): void
+            {
+            }
+        };
     }
 
     private function getRuntimeException(string $unusedArgument): \RuntimeException


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

The exception page redesign (#64766) gained a lot of structure, and in a few spots what
is announced to assistive technologies drifted from what the page actually does.

**Collapsed content stays in the accessibility tree.** The exception chain and the log
rows collapse with `grid-template-rows: 0fr`, which hides them visually but leaves
them readable: the summary announces `aria-expanded="false"` and a screen reader then
reads everything it claims to have collapsed. Collapsing now also flips `visibility`,
delayed to match the animation so the transition still plays, and reduced motion drops
both.

**The log filters declare themselves as menus.** `aria-haspopup="true"` promises a
menu, but what opens is a group of native checkboxes. Those checkboxes are already
fully accessible as they are, `Tab` reaches them and `Space` toggles them, so there is
nothing to build: this drops the false promise and names the group being revealed.
`Escape` closed the menu while a checkbox held the focus, which sent the focus back to
the document, so it now hands it to the trigger instead.

**Copying is silent.** The three copy controls swap an icon for 1.5s and nothing else.
A single `role="status"` region now announces each copy, and clears itself afterwards
so it does not linger in browse mode. It is rendered by `exception.html.php` rather
than injected from JavaScript: the profiler embeds this fragment and scopes the
stylesheet to it, so a region appended to `document.body` would stay unstyled there
and print its text on the page.

**The per-line copy control is mouse-only.** It was a `<span>` with no role, no
`tabindex` and no accessible name, revealed on hover. It is now a named `<button>`,
still hidden until hover, and revealed when it receives focus. The cost is one extra
tab stop per visible trace frame; hidden vendor frames are not affected.

**A log line is announced as one run-on string.** `07:50:09INFOrequestMatched
route "..."` is what NVDA announces on Chrome, while JAWS spaces the same line
correctly. Nothing guarantees that space in this context: the accname specification
leaves the case open. Composing the name with `aria-labelledby` removes the
uncertainty, since concatenation from IDREFs is specified to join with a single
space, one space for everyone, and the NVDA problem goes away.
