### PR TITLE
[Validator] #65566  Review Turkish (tr) translations

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.tr.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.tr.xlf
@@ -572,11 +572,11 @@
             </trans-unit>
             <trans-unit id="147">
                 <source>The referenced entity does not exist.</source>
-                <target state="needs-review-translation">Başvurulan varlık mevcut değil.</target>
+                <target>Referans verilen kayıt bulunamadı.</target>
             </trans-unit>
             <trans-unit id="148" resname="This is not a valid ULID.">
                 <source>This value is not a valid ULID.</source>
-                <target state="needs-review-translation">Bu değer geçerli bir ULID değildir.</target>
+                <target>Bu değer geçerli bir ULID değildir.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes/no
| New feature?  |  no
| Deprecations? | no
| Issues        | Fix #65566
| License       | MIT

  Clears the two `needs-review-translation` markers on the Turkish validator catalogue.

  | id  | source | change |
  | --- | --- | --- |
  | 147 | The referenced entity does not exist. | `Başvurulan varlık mevcut değil.` → `Referans verilen kayıt bulunamadı.` |
  | 148 | This value is not a valid ULID. | text already correct, marker removed |

  On id 147, `başvurulan` reads as "applied to" or "consulted" rather than "referenced", and `varlık` appears nowhere else in the catalogue. `bulunamadı` matches id 14, where `The file could not be found.` is already `Dosya bulunamadı.`

  The catalogue is byte-identical on 6.4, 7.4, 8.1 and 8.2, so the merge up is conflict free. No `needs-review-translation` markers are left in the file.
