### PR TITLE
[HttpKernel] Fix regression when a locale aware service is never initialized

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/LocaleAwareListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/LocaleAwareListener.php
@@ -28,6 +28,7 @@ class LocaleAwareListener implements EventSubscriberInterface
     private iterable $localeAwareServices;
     private RequestStack $requestStack;
     private array $storedLocales = [];
+    private array $initializedServices = [];
 
     /**
      * @param iterable<mixed, LocaleAwareInterface> $localeAwareServices
@@ -44,7 +45,10 @@ class LocaleAwareListener implements EventSubscriberInterface
             $locales = [];
 
             foreach ($this->localeAwareServices as $key => $service) {
-                $locales[$key] = $service->getLocale();
+                // a service the listener never set can hold no locale to restore
+                if (isset($this->initializedServices[$key])) {
+                    $locales[$key] = $service->getLocale();
+                }
             }
 
             $this->storedLocales[spl_object_id($event->getRequest())] = $locales;
@@ -86,6 +90,8 @@ class LocaleAwareListener implements EventSubscriberInterface
             } catch (\InvalidArgumentException) {
                 $service->setLocale($defaultLocale);
             }
+
+            $this->initializedServices[$key] = true;
         }
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/LocaleAwareListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/LocaleAwareListenerTest.php
@@ -148,6 +148,64 @@ class LocaleAwareListenerTest extends TestCase
         $this->assertSame('fr', $service->getLocale());
     }
 
+    public function testSubRequestDoesNotFailOnAServiceWithAnUninitializedLocale()
+    {
+        $service = new class implements LocaleAwareInterface {
+            private string $locale;
+
+            public function setLocale(string $locale): void
+            {
+                $this->locale = $locale;
+            }
+
+            public function getLocale(): string
+            {
+                return $this->locale;
+            }
+        };
+        $listener = new LocaleAwareListener(new \ArrayIterator([$service]), $this->requestStack);
+        $kernel = $this->createStub(HttpKernelInterface::class);
+
+        $this->requestStack->push($mainRequest = $this->createRequest('fr'));
+        $this->requestStack->push($subRequest = $this->createRequest('de'));
+        $listener->onKernelRequest(new RequestEvent($kernel, $subRequest, HttpKernelInterface::SUB_REQUEST));
+
+        $this->assertSame('de', $service->getLocale());
+
+        $listener->onKernelFinishRequest(new FinishRequestEvent($kernel, $subRequest, HttpKernelInterface::SUB_REQUEST));
+        $this->requestStack->pop();
+
+        $this->assertSame('fr', $service->getLocale());
+    }
+
+    public function testSubRequestDoesNotHideAnUnrelatedErrorThrownByGetLocale()
+    {
+        $service = new class implements LocaleAwareInterface {
+            private ?LocaleAwareInterface $inner = null;
+
+            public function setLocale(string $locale): void
+            {
+            }
+
+            public function getLocale(): string
+            {
+                return $this->inner->getLocale();
+            }
+        };
+        $listener = new LocaleAwareListener(new \ArrayIterator([$service]), $this->requestStack);
+        $kernel = $this->createStub(HttpKernelInterface::class);
+
+        $this->requestStack->push($mainRequest = $this->createRequest('fr'));
+        $listener->onKernelRequest(new RequestEvent($kernel, $mainRequest, HttpKernelInterface::MAIN_REQUEST));
+
+        $this->requestStack->push($subRequest = $this->createRequest('de'));
+
+        $this->expectException(\Error::class);
+        $this->expectExceptionMessage('Call to a member function getLocale() on null');
+
+        $listener->onKernelRequest(new RequestEvent($kernel, $subRequest, HttpKernelInterface::SUB_REQUEST));
+    }
+
     private function createRequest(string $locale): Request
     {
         $request = new Request();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65624
| License       | MIT

Since 6.4.44, `LocaleAwareListener::onKernelRequest()` reads `getLocale()` on every `kernel.locale_aware` service when a sub-request starts, so that it can restore each one to its own value once the sub-request ends.

A service that keeps its locale in a typed property with no default value has nothing to return until `setLocale()` has been called on it at least once. Reading it before that throws `Typed property ... must not be accessed before initialization`. That is what the reporter hit: a cache warmer running a sub-request through a kernel whose locale aware services had never been touched.

The listener now records which services it has set, and reads back only those. A service it never set holds no locale to restore, so it stays out of the stored locales for that sub-request, and the parent request's locale applies to it on `onKernelFinishRequest`, as it did before the listener started tracking per-service locales.

Errors raised by `getLocale()` for any other reason keep propagating.
