### PR TITLE
[Cache] Add sentinel_auth option to control auth forwarded to Sentinel

### DIFF
--- a/src/Symfony/Component/Cache/Traits/RedisTrait.php
+++ b/src/Symfony/Component/Cache/Traits/RedisTrait.php
@@ -47,6 +47,7 @@ trait RedisTrait
         'lazy' => null,
         'redis_cluster' => false,
         'redis_sentinel' => null,
+        'sentinel_auth' => true, // whether "auth" is also sent to the Sentinel server, not just the final Redis/Relay connection
         'dbindex' => 0,
         'failover' => 'none',
         'ssl' => null, // see https://php.net/context.ssl
@@ -241,7 +242,7 @@ trait RedisTrait
                 do {
                     $host = $hosts[$hostIndex]['host'] ?? $hosts[$hostIndex]['path'];
                     $port = $hosts[$hostIndex]['port'] ?? 0;
-                    $passAuth = null !== $params['auth'] && (!$isRedisExt || \defined('Redis::OPT_NULL_MULTIBULK_AS_NULL'));
+                    $passAuth = null !== $params['auth'] && (!$isRedisExt || \defined('Redis::OPT_NULL_MULTIBULK_AS_NULL')) && $params['sentinel_auth'];
                     $address = false;
 
                     if (isset($hosts[$hostIndex]['host']) && $tls) {

--- a/src/Symfony/Component/Cache/Traits/RedisTrait.php
+++ b/src/Symfony/Component/Cache/Traits/RedisTrait.php
@@ -207,6 +207,7 @@ trait RedisTrait
             $params['lazy'] = filter_var($params['lazy'], \FILTER_VALIDATE_BOOLEAN);
         }
         $params['redis_cluster'] = filter_var($params['redis_cluster'], \FILTER_VALIDATE_BOOLEAN);
+        $params['sentinel_auth'] = filter_var($params['sentinel_auth'], \FILTER_VALIDATE_BOOLEAN);
 
         if ($params['redis_cluster'] && isset($params['redis_sentinel'])) {
             throw new InvalidArgumentException('Cannot use both "redis_cluster" and "redis_sentinel" at the same time.');
@@ -242,7 +243,11 @@ trait RedisTrait
                 do {
                     $host = $hosts[$hostIndex]['host'] ?? $hosts[$hostIndex]['path'];
                     $port = $hosts[$hostIndex]['port'] ?? 0;
-                    $passAuth = null !== $params['auth'] && (!$isRedisExt || \defined('Redis::OPT_NULL_MULTIBULK_AS_NULL')) && $params['sentinel_auth'];
+                    // Only pass auth to the Sentinel connection when the caller opted in via
+                    // "sentinel_auth", there is actually a password configured, and the
+                    // installed phpredis version supports passing it this way.
+                    $phpredisSupportsAuthOption = !$isRedisExt || \defined('Redis::OPT_NULL_MULTIBULK_AS_NULL');
+                    $passAuth = $params['sentinel_auth'] && null !== $params['auth'] && $phpredisSupportsAuthOption;
                     $address = false;
 
                     if (isset($hosts[$hostIndex]['host']) && $tls) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | yes <!-- adds a new `sentinel_auth` option; see note below on branch targeting -->
| Deprecations? | no
| Issues        | Fix #... <!-- fill in once the bug report issue is filed -->
| License       | MIT

When connecting to Redis through a Sentinel DSN, two logically distinct connections are made: one to the Sentinel process itself (to ask "who is the current master?"), and one to the actual master (to run real commands). These commonly have different authentication requirements — many real-world deployments leave the Sentinel process unauthenticated even though the Redis master it monitors requires a password (Sentinel's own admin surface is usually protected at the network layer instead).

Today, `RedisTrait::createConnection()` uses a single shared value, `$params['auth']`, for both connections. Since #63324, this value is only populated automatically from the DSN in non-Sentinel mode — meaning in Sentinel mode, the *only* way to authenticate the final master connection is to pass `auth` explicitly via `$options`. But that same explicit value is then also sent to the Sentinel handshake itself. If the Sentinel doesn't expect a password, it rejects the connection outright (`RedisException: ... went away`), which surfaces as:
