### PR TITLE
[HttpClient] Fix GuzzleHttpHandler consuming responses out of band

### DIFF
--- a/src/Symfony/Component/HttpClient/GuzzleHttpHandler.php
+++ b/src/Symfony/Component/HttpClient/GuzzleHttpHandler.php
@@ -71,6 +71,11 @@ final class GuzzleHttpHandler
 
     private readonly bool $autoUpgradeHttpVersion;
 
+    /**
+     * Whether a stream() iterator is currently being consumed.
+     */
+    private bool $streaming = false;
+
     public function __construct(?HttpClientInterface $client = null, bool $autoUpgradeHttpVersion = true)
     {
         $this->client = $client ?? HttpClient::create();
@@ -100,7 +105,11 @@ final class GuzzleHttpHandler
         }
 
         $promise = new Promise(
-            function () use ($symfonyResponse): void {
+            function () use ($request, $symfonyResponse): void {
+                if ($this->streaming) {
+                    throw new RequestException('Cannot wait for a response from inside a callback of the same handler; the callback must return before the transfer can progress.', $request);
+                }
+
                 $this->streamPending(null, $symfonyResponse);
             },
             function () use ($symfonyResponse): void {
@@ -144,6 +153,10 @@ final class GuzzleHttpHandler
      */
     public function execute(): void
     {
+        if ($this->streaming) {
+            throw new \LogicException('Cannot run the event loop from inside a callback of the same handler; the callback must return before transfers can progress.');
+        }
+
         while ($this->pending->count()) {
             $this->streamPending(null, false);
         }
@@ -160,13 +173,35 @@ final class GuzzleHttpHandler
             return;
         }
 
-        $queue = PromiseUtils::queue();
+        if ($this->streaming) {
+            // A callback is asking for more I/O while a stream() iterator is suspended. Starting a
+            // second one over the same responses would consume them out of band, behind the back of
+            // the suspended one. The loop that is already running drives them to completion anyway.
+            return;
+        }
 
         $responses = [];
         foreach ($this->pending as $r) {
             $responses[] = $r;
         }
 
+        $this->streaming = true;
+
+        try {
+            $this->streamResponses($responses, $timeout, $breakAfter);
+        } finally {
+            $this->streaming = false;
+
+            // Run .then() callbacks now that no iterator is alive; they may add entries to $this->pending
+            PromiseUtils::queue()->run();
+        }
+    }
+
+    /**
+     * @param SymfonyResponseInterface[] $responses
+     */
+    private function streamResponses(array $responses, ?float $timeout, bool|SymfonyResponseInterface $breakAfter): void
+    {
         foreach ($this->client->stream($responses, $timeout) as $response => $chunk) {
             try {
                 if ($chunk->isTimeout()) {
@@ -232,9 +267,6 @@ final class GuzzleHttpHandler
                 if (\in_array($breakAfter, [true, $response], true)) {
                     break;
                 }
-            } finally {
-                // Run .then() callbacks; they may add new entries to $this->pending.
-                $queue->run();
             }
         }
     }
@@ -255,7 +287,7 @@ final class GuzzleHttpHandler
         }
 
         $this->fireOnStats($options, $guzzleRequest, $psrResponse, null, $response);
-        $promise->resolve($psrResponse);
+        $this->settle($promise, $psrResponse);
     }
 
     private function rejectResponse(SymfonyResponseInterface $response, TransportExceptionInterface $e): void
@@ -276,11 +308,30 @@ final class GuzzleHttpHandler
             }
 
             $this->fireOnStats($options, $guzzleRequest, $psrResponse, $e, $response);
-            $promise->reject($this->createRequestException($e->getMessage(), $guzzleRequest, $psrResponse, $e));
+            $reason = $this->createRequestException($e->getMessage(), $guzzleRequest, $psrResponse, $e);
         } else {
             // No headers received: connection-level failure.
             $this->fireOnStats($options, $guzzleRequest, null, $e, $response);
-            $promise->reject(new ConnectException($e->getMessage(), $guzzleRequest, $e));
+            $reason = new ConnectException($e->getMessage(), $guzzleRequest, $e);
+        }
+
+        $this->settle($promise, $reason);
+    }
+
+    /**
+     * Guzzle settles the promise itself when a wait callback cannot run, and an on_stats callback
+     * can do so while the transfer is still tracked here. Settling it again would throw.
+     */
+    private function settle(Promise $promise, ResponseInterface|\Throwable $outcome): void
+    {
+        if (PromiseInterface::PENDING !== $promise->getState()) {
+            return;
+        }
+
+        if ($outcome instanceof \Throwable) {
+            $promise->reject($outcome);
+        } else {
+            $promise->resolve($outcome);
         }
     }
 

--- a/src/Symfony/Component/HttpClient/Tests/GuzzleHttpHandlerTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/GuzzleHttpHandlerTest.php
@@ -14,13 +14,19 @@ namespace Symfony\Component\HttpClient\Tests;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Promise\RejectionException;
 use GuzzleHttp\Psr7\Request;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\HttpClient\DecoratorTrait;
 use Symfony\Component\HttpClient\GuzzleHttpHandler;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\HttpClient\Response\ResponseStream;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface as SymfonyResponseInterface;
+use Symfony\Contracts\HttpClient\ResponseStreamInterface;
 
 class GuzzleHttpHandlerTest extends TestCase
 {
@@ -913,6 +919,111 @@ class GuzzleHttpHandlerTest extends TestCase
 
         $this->assertSame(999, $response->getStatusCode());
         $this->assertSame('proprietary', (string) $response->getBody());
+    }
+
+    /**
+     * A .then() callback may wait on another promise, which drives the handler again. Two stream()
+     * iterators alive at once would consume the same responses out of band, so the handler must
+     * never start a second one, while still letting such a callback make progress.
+     */
+    public function testWaitingFromACallbackDoesNotConsumeASecondStream()
+    {
+        $client = new class(new MockHttpClient([new MockResponse('one'), new MockResponse('two')])) implements HttpClientInterface {
+            use DecoratorTrait;
+
+            public int $live = 0;
+            public int $maxLive = 0;
+
+            public function stream(SymfonyResponseInterface|iterable $responses, ?float $timeout = null): ResponseStreamInterface
+            {
+                $stream = $this->client->stream($responses, $timeout);
+
+                return new ResponseStream((function () use ($stream): \Generator {
+                    $this->maxLive = max($this->maxLive, ++$this->live);
+
+                    try {
+                        yield from $stream;
+                    } finally {
+                        --$this->live;
+                    }
+                })());
+            }
+        };
+
+        $handler = new GuzzleHttpHandler($client);
+
+        $p1 = $handler(new Request('GET', 'https://example.com/one'), []);
+        $p2 = $handler(new Request('GET', 'https://example.com/two'), []);
+
+        $p1->then(static function () use ($p2) { $p2->wait(); });
+
+        $this->assertSame('one', (string) $p1->wait()->getBody());
+        $this->assertSame('two', (string) $p2->wait()->getBody());
+        $this->assertSame(1, $client->maxLive);
+    }
+
+    /**
+     * on_headers and on_stats run inline from the loop, as Guzzle's contract requires, so a promise
+     * waited on from there cannot make progress. The handler must say so and stay usable: the
+     * response whose promise got rejected is still tracked, and settling it again would throw.
+     */
+    public function testWaitingFromAnInlineCallbackFailsWithoutStrandingTheHandler()
+    {
+        $handler = new GuzzleHttpHandler(new MockHttpClient([new MockResponse('one'), new MockResponse('two')]));
+
+        $p2 = null;
+        $error = null;
+        $p1 = $handler(new Request('GET', 'https://example.com/one'), ['on_headers' => static function () use (&$p2, &$error) {
+            try {
+                $p2->wait();
+            } catch (\Throwable $e) {
+                $error = $e;
+            }
+        }]);
+        $p2 = $handler(new Request('GET', 'https://example.com/two'), []);
+
+        $this->assertSame('one', (string) $p1->wait()->getBody());
+        $this->assertInstanceOf(RequestException::class, $error);
+        $this->assertSame('Cannot wait for a response from inside a callback of the same handler; the callback must return before the transfer can progress.', $error->getMessage());
+
+        $handler->execute();
+
+        $this->assertSame(PromiseInterface::REJECTED, $p2->getState());
+    }
+
+    public function testRunningTheEventLoopFromAnInlineCallbackIsRejected()
+    {
+        $handler = new GuzzleHttpHandler(new MockHttpClient([new MockResponse('one')]));
+
+        $error = null;
+        $promise = $handler(new Request('GET', 'https://example.com/one'), ['on_headers' => static function () use ($handler, &$error) {
+            try {
+                $handler->execute();
+            } catch (\Throwable $e) {
+                $error = $e;
+            }
+        }]);
+
+        $this->assertSame('one', (string) $promise->wait()->getBody());
+        $this->assertInstanceOf(\LogicException::class, $error);
+        $this->assertSame('Cannot run the event loop from inside a callback of the same handler; the callback must return before transfers can progress.', $error->getMessage());
+    }
+
+    public function testAPromiseGuzzleRejectedFromAnInlineCallbackIsNotResolvedAfterwards()
+    {
+        $handler = new GuzzleHttpHandler(new MockHttpClient([new MockResponse('one')]));
+
+        $promise = null;
+        $promise = $handler(new Request('GET', 'https://example.com/one'), ['on_stats' => static function () use (&$promise) {
+            // The wait callback has been consumed already, so Guzzle rejects the promise here
+            try {
+                $promise->wait();
+            } catch (RejectionException) {
+            }
+        }]);
+
+        $this->expectException(RejectionException::class);
+        $promise->wait();
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Follow-up to your closing note on #65306: the accurate "already consumed" exception added by #65311 did point at the real culprit, and it is the Guzzle handler.

## Problem

`streamPending()` ticks Guzzle's task queue from a `finally` **inside** its `stream()` loop, so the queue runs while the iterator is suspended. Guzzle invokes `.then()` callbacks from that queue, and such a callback may wait on another promise, which drives the handler again. The nested call then consumes a *second* `stream()` iterator over the same responses, behind the back of the suspended one.

The suspended iterator resumes with stale bookkeeping, and from `AsyncResponse`'s point of view the response was consumed out of band. Three failures follow, all reachable through the plain Guzzle API:

```
LogicException: Instance of "Symfony\Component\HttpClient\Response\CurlResponse" is already
consumed and cannot be managed by "Symfony\Component\HttpClient\NoPrivateNetworkHttpClient".
#0 [internal function]: Symfony\Component\HttpClient\Response\AsyncResponse::stream()
#1 Response/ResponseStream.php(40): Generator->next()
#2 GuzzleHttpHandler.php(170): Symfony\Component\HttpClient\Response\ResponseStream->next()
#3 GuzzleHttpHandler.php(104): Symfony\Component\HttpClient\GuzzleHttpHandler->streamPending()
#4 guzzlehttp/promises/src/Promise.php(251): {closure:GuzzleHttpHandler::__invoke():103}()
```

```
LogicException: Cannot change a rejected promise to fulfilled
#1 GuzzleHttpHandler.php(258): GuzzleHttp\Promise\Promise->resolve()
#2 GuzzleHttpHandler.php(221): Symfony\Component\HttpClient\GuzzleHttpHandler->resolveResponse()
```

plus responses stranded in `$pending`: never settled, they are garbage collected unconsumed and throw from their destructor, uncaught, with a stack starting at `AsyncResponse::__destruct()`.

This is what I have been chasing in production behind `NoPrivateNetworkHttpClient` (~10 crashes per 50k requests): a crawler driving concurrent Guzzle promises whose callbacks wait on each other.

## Reproducer

Against current 8.1 this prints 55 leaked `LogicException`s and then dies at shutdown; with the patch it prints only `done`.

<details>
<summary>repro.php</summary>

```php
<?php

require __DIR__.'/vendor/autoload.php';

use GuzzleHttp\Psr7\Request;
use Symfony\Component\HttpClient\CurlHttpClient;
use Symfony\Component\HttpClient\GuzzleHttpHandler;
use Symfony\Component\HttpClient\NoPrivateNetworkHttpClient;
use Symfony\Contracts\HttpClient\Test\TestHttpServer;

TestHttpServer::start(8057);
mt_srand(1);

$handler = new GuzzleHttpHandler(new NoPrivateNetworkHttpClient(new CurlHttpClient(), null, ['127.0.0.1']));

$urls = [
    'http://127.0.0.1:8057/302?location=http%3A%2F%2F127.0.0.1%3A8057%2F',
    'http://127.0.0.1:8057/chunked',
    'http://127.0.0.1:8057/timeout-body',
    'http://127.0.0.1:8057/json',
];

for ($round = 0; $round < 12; ++$round) {
    $promises = [];
    for ($i = 0; $i < 5; ++$i) {
        $promises[$i] = $handler(new Request('GET', $urls[array_rand($urls)]), ['timeout' => 0.2 + mt_rand(0, 4) / 10]);
    }

    // Guzzle runs these from its task queue, which the handler ticks from inside its stream() loop
    foreach ($promises as $i => $p) {
        $wait = static function () use ($promises, $i) {
            foreach (\array_slice($promises, $i + 1) as $q) {
                try {
                    $q->wait();
                } catch (\Throwable) {
                }
            }
        };
        $p->then($wait, $wait);
    }

    foreach ($promises as $p) {
        try {
            $p->wait();
        } catch (\GuzzleHttp\Exception\GuzzleException) {
            // expected: aggressive timeouts against a slow fixture server
        } catch (\Throwable $e) {
            echo 'LEAKED ', $e::class, ': ', $e->getMessage(), "\n";
        }
    }
}

echo "done\n";
```

</details>

## Fix

The task queue now runs once the iterator is gone, so a callback that waits on another promise still makes progress. It just starts its loop when none is running. A `$streaming` guard keeps a nested call from starting a second loop.

Three cases cannot make progress at all, because `on_headers` and `on_stats` are called inline from the loop, as Guzzle's contract requires. The handler now reports each of them the way Guzzle's own `CurlMultiHandler` does:

* Waiting on any promise of the same handler from such a callback throws `RequestException`, naming the cause. Without that, Guzzle rejects the promise itself with "Invoking the wait callback did not resolve the promise", which names nothing and is not even a `GuzzleException`, so callers filtering on that interface miss it.
* Calling `execute()` from such a callback throws `LogicException`, instead of returning while transfers are still outstanding, which its own docblock says it never does.
* A promise Guzzle has already rejected in that situation is left rejected. The transfer is still tracked here, so the handler used to settle it a second time when the transfer finished, and that escaped as `LogicException: Cannot change a rejected promise to fulfilled`. That one also happens without the two points above, whenever an inline callback waits on its own promise.

## Behaviour change

A promise waited on from `on_headers` or `on_stats` now fails with `RequestException` instead of silently corrupting the stream. Creating a new request from such a callback and waiting on it fails the same way. Both used to appear to work, at the cost of the corruption above.

## Test

Four tests, all `MockHttpClient`-based and deterministic, no reflection involved:

* `testWaitingFromACallbackDoesNotConsumeASecondStream` asserts the invariant directly, never two `stream()` iterators alive at once, with a `.then()` callback waiting on a sibling promise. 2 live iterators before the patch, 1 after.
* `testWaitingFromAnInlineCallbackFailsWithoutStrandingTheHandler`, `testRunningTheEventLoopFromAnInlineCallbackIsRejected` and `testAPromiseGuzzleRejectedFromAnInlineCallbackIsNotResolvedAfterwards` cover the three cases above. The last one fails on 8.1 without any of this patch.
