### PR TITLE
[Messenger] Force quit `messenger:consume` and `messenger:failed:retry` on repeated `SIGINT`

### DIFF
--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -14,6 +14,7 @@ CHANGELOG
  * Add an optional `extra` key to the encoded envelope passed to `SerializerInterface::decode()`, holding metadata added by the receiving transport
  * Add an optional `LoggingMiddleware` logging the processing time and memory usage of each message
  * Add the `messenger:show` command to list and inspect pending messages of a transport
+ * Make the `messenger:consume` and `messenger:failed:retry` commands exit immediately when a second `SIGINT` is received
 
 8.1
 ---

--- a/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
+++ b/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
@@ -47,6 +47,7 @@ class ConsumeMessagesCommand extends Command implements SignalableCommandInterfa
 {
     private const DEFAULT_KEEPALIVE_INTERVAL = 5;
 
+    private bool $shouldStop = false;
     private ?Worker $worker = null;
 
     public function __construct(
@@ -407,9 +408,16 @@ class ConsumeMessagesCommand extends Command implements SignalableCommandInterfa
             return false;
         }
 
+        if ($this->shouldStop && \SIGINT === $signal) {
+            $this->logger?->info('Received signal {signal} again, forcing exit.', ['signal' => $signal, 'transport_names' => $this->worker->getMetadata()->getTransportNames()]);
+
+            return 0 === $previousExitCode ? 128 + $signal : $previousExitCode;
+        }
+
         $this->logger?->info('Received signal {signal}.', ['signal' => $signal, 'transport_names' => $this->worker->getMetadata()->getTransportNames()]);
 
         $this->worker->stop();
+        $this->shouldStop = true;
 
         return false;
     }

--- a/src/Symfony/Component/Messenger/Command/FailedMessagesRetryCommand.php
+++ b/src/Symfony/Component/Messenger/Command/FailedMessagesRetryCommand.php
@@ -201,6 +201,12 @@ class FailedMessagesRetryCommand extends AbstractFailedMessagesCommand implement
             return false;
         }
 
+        if ($this->shouldStop && \SIGINT === $signal) {
+            $this->logger?->info('Received signal {signal} again, forcing exit.', ['signal' => $signal, 'transport_names' => $this->worker->getMetadata()->getTransportNames()]);
+
+            return 0 === $previousExitCode ? 128 + $signal : $previousExitCode;
+        }
+
         $this->logger?->info('Received signal {signal}.', ['signal' => $signal, 'transport_names' => $this->worker->getMetadata()->getTransportNames()]);
 
         $this->worker->stop();

--- a/src/Symfony/Component/Messenger/Tests/Command/ConsumeMessagesCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/ConsumeMessagesCommandTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Messenger\Tests\Command;
 
 use Amp\Parallel\Worker\ContextWorkerFactory;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LoggerTrait;
@@ -29,6 +30,7 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Messenger\Command\ConsumeMessagesCommand;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Event\WorkerRunningEvent;
+use Symfony\Component\Messenger\Event\WorkerStartedEvent;
 use Symfony\Component\Messenger\EventListener\ResetServicesListener;
 use Symfony\Component\Messenger\MessageBus;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -37,6 +39,7 @@ use Symfony\Component\Messenger\Stamp\BusNameStamp;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyReceiver;
 use Symfony\Component\Messenger\Tests\Fixtures\ResettableDummyReceiver;
 use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
+use Symfony\Component\Messenger\Worker;
 
 class ConsumeMessagesCommandTest extends TestCase
 {
@@ -699,5 +702,110 @@ class ConsumeMessagesCommandTest extends TestCase
         yield [['one', 'one_second', 'second', 'SECOND'], ['(?i)second'], ['second', 'SECOND']];
         yield [['one', 'one_second', 'second', 'SECOND', 'ssecond'], ['one', 'one.*', 'second.*'], ['one', 'one_second', 'second']];
         yield [['pone'], ['.*one'], ['pone']];
+    }
+
+    #[RequiresPhpExtension('pcntl')]
+    public function testHandleSignalWithoutRunningWorker()
+    {
+        $command = new ConsumeMessagesCommand(new RoutableMessageBus(new Container()), new Container(), new EventDispatcher());
+
+        $this->assertFalse($command->handleSignal(\SIGTERM));
+    }
+
+    #[RequiresPhpExtension('pcntl')]
+    public function testFirstSignalStopsTheWorkerGracefully()
+    {
+        $exitCodes = [];
+        $tester = $this->createSignalableCommandTester(static function (ConsumeMessagesCommand $command) use (&$exitCodes) {
+            $exitCodes[] = $command->handleSignal(\SIGTERM);
+        });
+
+        $tester->execute(['receivers' => ['dummy-receiver']]);
+
+        $this->assertSame([false], $exitCodes);
+        $tester->assertCommandIsSuccessful();
+    }
+
+    #[RequiresPhpExtension('pcntl')]
+    public function testSecondSignalForcesTheWorkerToQuit()
+    {
+        $exitCodes = [];
+        $tester = $this->createSignalableCommandTester(static function (ConsumeMessagesCommand $command) use (&$exitCodes) {
+            $exitCodes[] = $command->handleSignal(\SIGTERM);
+            $exitCodes[] = $command->handleSignal(\SIGINT);
+            $exitCodes[] = $command->handleSignal(\SIGINT, 3);
+            $exitCodes[] = $command->handleSignal(\SIGINT, false);
+        });
+
+        $tester->execute(['receivers' => ['dummy-receiver']]);
+
+        $this->assertSame([false, 128 + \SIGINT, 3, false], $exitCodes);
+    }
+
+    #[RequiresPhpExtension('pcntl')]
+    public function testOnlySigintReceivedWhileStoppingForcesTheWorkerToQuit()
+    {
+        $exitCodes = [];
+        $tester = $this->createSignalableCommandTester(static function (ConsumeMessagesCommand $command) use (&$exitCodes) {
+            $exitCodes[] = $command->handleSignal(\SIGALRM);
+            $exitCodes[] = $command->handleSignal(\SIGINT);
+            $exitCodes[] = $command->handleSignal(\SIGTERM);
+            $exitCodes[] = $command->handleSignal(\SIGQUIT);
+            $exitCodes[] = $command->handleSignal(\SIGALRM);
+            $exitCodes[] = $command->handleSignal(\SIGINT);
+        });
+
+        $tester->execute(['receivers' => ['dummy-receiver']]);
+
+        $this->assertSame([false, false, false, false, false, 128 + \SIGINT], $exitCodes);
+    }
+
+    #[RequiresPhpExtension('pcntl')]
+    public function testSignalStaysGracefulWhenTheWorkerWasStoppedWithoutASignal()
+    {
+        $exitCodes = [];
+        $tester = $this->createSignalableCommandTester(static function (ConsumeMessagesCommand $command, Worker $worker) use (&$exitCodes) {
+            $worker->stop();
+            $exitCodes[] = $command->handleSignal(\SIGINT);
+        });
+
+        $tester->execute(['receivers' => ['dummy-receiver']]);
+
+        $this->assertSame([false], $exitCodes);
+        $tester->assertCommandIsSuccessful();
+    }
+
+    private function createSignalableCommandTester(callable $onMessage): CommandTester
+    {
+        $command = null;
+        $receiver = new DummyReceiver([[new Envelope(new \stdClass(), [new BusNameStamp('dummy-bus')])]]);
+
+        $worker = null;
+
+        $bus = self::createStub(MessageBusInterface::class);
+        $bus->method('dispatch')->willReturnCallback(static function (Envelope $envelope) use (&$command, &$worker, $onMessage) {
+            $onMessage($command, $worker);
+
+            return $envelope;
+        });
+
+        $busLocator = new Container();
+        $busLocator->set('dummy-bus', $bus);
+
+        $eventDispatcher = new EventDispatcher();
+        $eventDispatcher->addListener(WorkerStartedEvent::class, static function (WorkerStartedEvent $event) use (&$worker) {
+            $worker = $event->getWorker();
+        });
+
+        $command = new ConsumeMessagesCommand(
+            new RoutableMessageBus($busLocator),
+            new ServiceLocator(['dummy-receiver' => static fn () => $receiver]),
+            $eventDispatcher
+        );
+
+        $application = new Application();
+        $application->addCommand($command);
+
+        return new CommandTester($application->get('messenger:consume'));
     }
 }

--- a/src/Symfony/Component/Messenger/Tests/Command/FailedMessagesRetryCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/FailedMessagesRetryCommandTest.php
@@ -11,7 +11,9 @@
 
 namespace Symfony\Component\Messenger\Tests\Command;
 
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Tester\CommandCompletionTester;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -19,6 +21,7 @@ use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Messenger\Command\FailedMessagesRetryCommand;
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Event\WorkerStartedEvent;
 use Symfony\Component\Messenger\Exception\InvalidArgumentException;
 use Symfony\Component\Messenger\MessageBus;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -30,6 +33,7 @@ use Symfony\Component\Messenger\Stamp\TransportMessageIdStamp;
 use Symfony\Component\Messenger\Transport\Receiver\ListableReceiverInterface;
 use Symfony\Component\Messenger\Transport\Receiver\MessageCountAwareInterface;
 use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
+use Symfony\Component\Messenger\Worker;
 
 class FailedMessagesRetryCommandTest extends TestCase
 {
@@ -577,6 +581,82 @@ class FailedMessagesRetryCommandTest extends TestCase
         $tester->execute(['--failed-after' => 'not a date']);
     }
 
+    #[RequiresPhpExtension('pcntl')]
+    public function testHandleSignalWithoutRunningWorker()
+    {
+        $command = new FailedMessagesRetryCommand(
+            'failure_receiver',
+            new ServiceLocator([]),
+            $this->createStub(MessageBusInterface::class),
+            new EventDispatcher(),
+        );
+
+        $this->assertFalse($command->handleSignal(\SIGTERM));
+    }
+
+    #[RequiresPhpExtension('pcntl')]
+    public function testFirstSignalStopsRetryingTheRemainingMessages()
+    {
+        $exitCodes = [];
+        $tester = $this->createSignalableCommandTester(static function (FailedMessagesRetryCommand $command) use (&$exitCodes) {
+            $exitCodes[] = $command->handleSignal(\SIGTERM);
+        });
+
+        $tester->execute(['id' => ['failed-id', 'other-id'], '--force' => true]);
+
+        $this->assertSame([false], $exitCodes);
+        $this->assertStringNotContainsString('[OK] All done!', $tester->getDisplay());
+    }
+
+    #[RequiresPhpExtension('pcntl')]
+    public function testSecondSignalForcesTheQuit()
+    {
+        $exitCodes = [];
+        $tester = $this->createSignalableCommandTester(static function (FailedMessagesRetryCommand $command) use (&$exitCodes) {
+            $exitCodes[] = $command->handleSignal(\SIGTERM);
+            $exitCodes[] = $command->handleSignal(\SIGINT);
+            $exitCodes[] = $command->handleSignal(\SIGINT, 3);
+            $exitCodes[] = $command->handleSignal(\SIGINT, false);
+        });
+
+        $tester->execute(['id' => ['failed-id'], '--force' => true]);
+
+        $this->assertSame([false, 128 + \SIGINT, 3, false], $exitCodes);
+    }
+
+    #[RequiresPhpExtension('pcntl')]
+    public function testOnlySigintReceivedWhileStoppingForcesTheQuit()
+    {
+        $exitCodes = [];
+        $tester = $this->createSignalableCommandTester(static function (FailedMessagesRetryCommand $command) use (&$exitCodes) {
+            $exitCodes[] = $command->handleSignal(\SIGALRM);
+            $exitCodes[] = $command->handleSignal(\SIGINT);
+            $exitCodes[] = $command->handleSignal(\SIGTERM);
+            $exitCodes[] = $command->handleSignal(\SIGQUIT);
+            $exitCodes[] = $command->handleSignal(\SIGALRM);
+            $exitCodes[] = $command->handleSignal(\SIGINT);
+        });
+
+        $tester->execute(['id' => ['failed-id'], '--force' => true]);
+
+        $this->assertSame([false, false, false, false, false, 128 + \SIGINT], $exitCodes);
+    }
+
+    #[RequiresPhpExtension('pcntl')]
+    public function testSignalStaysGracefulWhenTheWorkerWasStoppedWithoutASignal()
+    {
+        $exitCodes = [];
+        $tester = $this->createSignalableCommandTester(static function (FailedMessagesRetryCommand $command, Worker $worker) use (&$exitCodes) {
+            $worker->stop();
+            $exitCodes[] = $command->handleSignal(\SIGINT);
+        });
+
+        $tester->execute(['id' => ['failed-id'], '--force' => true]);
+
+        $this->assertSame([false], $exitCodes);
+        $this->assertStringNotContainsString('[OK] All done!', $tester->getDisplay());
+    }
+
     private function createFailedEnvelope(int $id, string $failedAt): Envelope
     {
         return new Envelope(new \stdClass(), [
@@ -619,5 +699,42 @@ class FailedMessagesRetryCommandTest extends TestCase
         );
 
         return new CommandTester($command);
+    }
+
+    private function createSignalableCommandTester(callable $onMessage): CommandTester
+    {
+        $command = null;
+
+        $receiver = $this->createMock(ListableReceiverInterface::class);
+        $receiver->expects($this->once())->method('find')->willReturn(new Envelope(new \stdClass(), [
+            new SentToFailureTransportStamp('async'),
+            new TransportMessageIdStamp('failed-id'),
+        ]));
+
+        $worker = null;
+
+        $bus = self::createStub(MessageBusInterface::class);
+        $bus->method('dispatch')->willReturnCallback(static function (Envelope $envelope) use (&$command, &$worker, $onMessage) {
+            $onMessage($command, $worker);
+
+            return $envelope;
+        });
+
+        $eventDispatcher = new EventDispatcher();
+        $eventDispatcher->addListener(WorkerStartedEvent::class, static function (WorkerStartedEvent $event) use (&$worker) {
+            $worker = $event->getWorker();
+        });
+
+        $command = new FailedMessagesRetryCommand(
+            'failure_receiver',
+            new ServiceLocator(['failure_receiver' => static fn () => $receiver]),
+            $bus,
+            $eventDispatcher,
+        );
+
+        $application = new Application();
+        $application->addCommand($command);
+
+        return new CommandTester($application->get('messenger:failed:retry'));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Currently, sending `Ctrl+C` to `messenger:consume` or `messenger:failed:retry` requests a graceful stop: the worker finishes the message it is currently processing before exiting.

That's the right behavior in most cases, but during development you sometimes just want the process gone *now*. If processing takes a while, the only way to stop it immediately is to use something like `kill -9` from another terminal.

With this PR, pressing `Ctrl+C` a second time exits immediately, following the behavior of many CLI tools: the first `Ctrl+C` requests a graceful shutdown, while the second means "stop now".
