### PR TITLE
[Cache] Fix authenticating to the master when using Redis Sentinel

### DIFF
--- a/src/Symfony/Component/Cache/Tests/Traits/RedisTraitTest.php
+++ b/src/Symfony/Component/Cache/Tests/Traits/RedisTraitTest.php
@@ -210,4 +210,159 @@ class RedisTraitTest extends TestCase
             ],
         ];
     }
+
+    /**
+     * @dataProvider providePredisMasterAuthResolution
+     */
+    public function testPredisMasterAuthResolution(string $dsn, array $options, string|array|null $expectedMasterAuth)
+    {
+        $predisClass = $this->createPredisCaptureClass();
+
+        $mock = new class {
+            use RedisTrait;
+        };
+
+        $mock::createConnection($dsn, ['class' => $predisClass] + $options);
+
+        $this->assertAuthMatchesExpected($expectedMasterAuth, $predisClass::$captured['options']['parameters'] ?? []);
+    }
+
+    public static function providePredisMasterAuthResolution(): \Generator
+    {
+        yield 'userinfo user+pass' => [
+            'redis://user:pass@localhost',
+            [],
+            ['user', 'pass'],
+        ];
+
+        yield 'userinfo with @ + query auth array' => [
+            'redis://user@pass@localhost?auth[]=otheruser&auth[]=otherpass',
+            [],
+            ['otheruser', 'otherpass'],
+        ];
+
+        yield 'query auth array' => [
+            'redis://localhost?auth[]=user&auth[]=pass',
+            [],
+            ['user', 'pass'],
+        ];
+
+        yield 'options auth array' => [
+            'redis://localhost',
+            ['auth' => ['user', 'pass']],
+            ['user', 'pass'],
+        ];
+
+        yield 'query auth beats options auth' => [
+            'redis://localhost?auth[]=query-user&auth[]=query-pass',
+            ['auth' => ['opt-user', 'opt-pass']],
+            ['query-user', 'query-pass'],
+        ];
+    }
+
+    /**
+     * @dataProvider providePredisSentinelAuthResolution
+     */
+    public function testPredisSentinelAuthResolution(string $dsn, array $options, string|array|null $expectedMasterAuth, string|array|null $expectedSentinelAuth)
+    {
+        $predisClass = $this->createPredisCaptureClass();
+
+        $mock = new class {
+            use RedisTrait;
+        };
+
+        $mock::createConnection($dsn, ['class' => $predisClass] + $options);
+
+        $this->assertAuthMatchesExpected($expectedMasterAuth, $predisClass::$captured['options']['parameters'] ?? []);
+        $this->assertAuthMatchesExpected($expectedSentinelAuth, $predisClass::$captured['parameters'][0] ?? []);
+    }
+
+    public static function providePredisSentinelAuthResolution(): \Generator
+    {
+        yield 'master userinfo, no sentinel auth' => [
+            'redis://master-user:master-pass@localhost?redis_sentinel=mymaster',
+            [],
+            ['master-user', 'master-pass'],
+            null,
+        ];
+
+        yield 'sentinel query auth, master userinfo' => [
+            'redis://master-user:master-pass@localhost?redis_sentinel=mymaster&auth[]=sentinel-user&auth[]=sentinel-pass',
+            [],
+            ['master-user', 'master-pass'],
+            ['sentinel-user', 'sentinel-pass'],
+        ];
+
+        yield 'sentinel options auth when query missing' => [
+            'redis://master-pass@localhost?redis_sentinel=mymaster',
+            ['auth' => ['sentinel-user', 'sentinel-pass']],
+            'master-pass',
+            ['sentinel-user', 'sentinel-pass'],
+        ];
+
+        yield 'sentinel query auth beats options auth' => [
+            'redis://master-pass@localhost?redis_sentinel=mymaster&auth[]=query-user&auth[]=query-pass',
+            ['auth' => ['opt-user', 'opt-pass']],
+            'master-pass',
+            ['query-user', 'query-pass'],
+        ];
+
+        yield 'auth shared by master and sentinel when no userinfo' => [
+            'redis://localhost?redis_sentinel=mymaster&auth=shared-pass',
+            [],
+            'shared-pass',
+            'shared-pass',
+        ];
+    }
+
+    private function assertAuthMatchesExpected(string|array|null $expectedAuth, array $parameters): void
+    {
+        if (null === $expectedAuth) {
+            self::assertArrayNotHasKey('username', $parameters);
+            self::assertArrayNotHasKey('password', $parameters);
+
+            return;
+        }
+
+        if (\is_array($expectedAuth)) {
+            self::assertSame($expectedAuth[0], $parameters['username'] ?? null);
+            self::assertSame($expectedAuth[1], $parameters['password'] ?? null);
+
+            return;
+        }
+
+        self::assertArrayNotHasKey('username', $parameters);
+        self::assertSame($expectedAuth, $parameters['password'] ?? null);
+    }
+
+    private function createPredisCaptureClass(): string
+    {
+        $predisClass = new class extends \Predis\Client {
+            public static array $captured = [];
+            private object $connection;
+
+            public function __construct($parameters = null, $options = null)
+            {
+                self::$captured = [
+                    'parameters' => $parameters,
+                    'options' => $options,
+                ];
+                $this->connection = new class {
+                    public function setSentinelTimeout(float $timeout): void
+                    {
+                    }
+                };
+            }
+
+            /**
+             * @return object
+             */
+            public function getConnection()
+            {
+                return $this->connection;
+            }
+        };
+
+        return $predisClass::class;
+    }
 }

--- a/src/Symfony/Component/Cache/Traits/RedisTrait.php
+++ b/src/Symfony/Component/Cache/Traits/RedisTrait.php
@@ -194,12 +194,18 @@ trait RedisTrait
 
         if (!isset($params['redis_sentinel'])) {
             $params['auth'] ??= $auth;
-        }
-
-        if (\is_array($params['auth']) && (!array_is_list($params['auth']) || 2 !== \count($params['auth']))) {
-            throw new InvalidArgumentException('Invalid Redis DSN: the "auth" parameter must be a string, or a list of exactly two elements for ACL, "[username, password]".');
+            $sentinelAuth = null;
         } elseif (!class_exists(\Predis\Client::class) && !class_exists(\RedisSentinel::class) && !class_exists(Sentinel::class)) {
             throw new CacheException('Redis Sentinel support requires one of: "predis/predis", "ext-redis >= 5.2", "ext-relay".');
+        } else {
+            $sentinelAuth = $params['auth'] ?? null;
+            $params['auth'] = $auth ?? $params['auth'];
+        }
+
+        foreach ([$params['auth'], $sentinelAuth] as $v) {
+            if (\is_array($v) && (!array_is_list($v) || 2 !== \count($v))) {
+                throw new InvalidArgumentException('Invalid Redis DSN: the "auth" parameter must be a string, or a list of exactly two elements for ACL, "[username, password]".');
+            }
         }
 
         if (isset($params['lazy'])) {
@@ -234,14 +240,14 @@ trait RedisTrait
         if ($isRedisExt || $isRelayExt) {
             $connect = $params['persistent'] || $params['persistent_id'] ? 'pconnect' : 'connect';
 
-            $initializer = static function () use ($class, $isRedisExt, $connect, $params, $hosts, $tls) {
+            $initializer = static function () use ($class, $isRedisExt, $connect, $params, $sentinelAuth, $hosts, $tls) {
                 $sentinelClass = $isRedisExt ? \RedisSentinel::class : Sentinel::class;
                 $redis = new $class();
                 $hostIndex = 0;
                 do {
                     $host = $hosts[$hostIndex]['host'] ?? $hosts[$hostIndex]['path'];
                     $port = $hosts[$hostIndex]['port'] ?? 0;
-                    $passAuth = null !== $params['auth'] && (!$isRedisExt || \defined('Redis::OPT_NULL_MULTIBULK_AS_NULL'));
+                    $passAuth = null !== $sentinelAuth && (!$isRedisExt || \defined('Redis::OPT_NULL_MULTIBULK_AS_NULL'));
                     $address = false;
 
                     if (isset($hosts[$hostIndex]['host']) && $tls) {
@@ -264,7 +270,7 @@ trait RedisTrait
                             ];
 
                             if ($passAuth) {
-                                $options['auth'] = $params['auth'];
+                                $options['auth'] = $sentinelAuth;
                             }
 
                             if (null !== $params['ssl'] && version_compare(phpversion('redis'), '6.2.0', '>=')) {
@@ -273,7 +279,7 @@ trait RedisTrait
 
                             $sentinel = new \RedisSentinel($options);
                         } else {
-                            $extra = $passAuth ? [$params['auth']] : [];
+                            $extra = $passAuth ? [$sentinelAuth] : [];
 
                             $sentinel = @new $sentinelClass($host, $port, $params['timeout'], (string) $params['persistent_id'], $params['retry_interval'], $params['read_timeout'], ...$extra);
                         }
@@ -403,6 +409,24 @@ trait RedisTrait
                 $params['parameters']['password'] = $params['auth'][1];
             } elseif (null !== $params['auth']) {
                 $params['parameters']['password'] = $params['auth'];
+            }
+
+            if (isset($params['redis_sentinel']) && null !== $sentinelAuth) {
+                if (\is_array($sentinelAuth)) {
+                    $sentinelUsername = $sentinelAuth[0];
+                    $sentinelPassword = $sentinelAuth[1];
+                } else {
+                    $sentinelUsername = null;
+                    $sentinelPassword = $sentinelAuth;
+                }
+
+                foreach ($hosts as $i => $host) {
+                    $hosts[$i]['password'] ??= $sentinelPassword;
+
+                    if (null !== $sentinelUsername) {
+                        $hosts[$i]['username'] ??= $sentinelUsername;
+                    }
+                }
             }
 
             if (isset($params['ssl'])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

A Sentinel DSN opens two connections: one to the Sentinel process, to ask for the current master, and one to that master, to run the commands. They can require different credentials, and many setups leave the Sentinel unauthenticated while the master requires a password.

`RedisTrait` resolves credentials into `$params['auth']`, which #63324 leaves empty in Sentinel mode on purpose, so that the DSN userinfo is not sent to the Sentinel. #65421 then made two code paths read `$params['auth']` where they used to read the userinfo: the Predis branch, and the `$redis->auth()` call used with phpredis below 6. In Sentinel mode both now got nothing, so the master connection was made without credentials:

```php
RedisAdapter::createConnection('redis://:p4ssw0rd@127.0.0.1:26379?redis_sentinel=mymaster');
// Redis connection failed: NOAUTH Authentication required.
```

This patch takes the resolution that 7.4 already has since #63391: the userinfo authenticates the master, the `auth` query parameter or option authenticates the Sentinel handshake, and each is applied to its own connection. For Predis, the Sentinel credentials are applied to the Sentinel hosts, as they are on 7.4.

```php
// master gets "master-pass", the Sentinel handshake gets no credentials
RedisAdapter::createConnection('redis://:master-pass@127.0.0.1:26379?redis_sentinel=mymaster');

// master gets "master-pass", the Sentinel handshake gets "sentinel-pass"
RedisAdapter::createConnection('redis://:master-pass@127.0.0.1:26379?redis_sentinel=mymaster&auth=sentinel-pass');

// no userinfo: both get "shared-pass", as before
RedisAdapter::createConnection('redis://127.0.0.1:26379?redis_sentinel=mymaster&auth=shared-pass');
```

The tests come from #63391, with the same names, so the merge-up into 7.4 resolves by keeping the 7.4 version. They cover the resolution for the master and for the Sentinel, from the userinfo, from the query string and from the options.

While doing that, the `auth` shape check added in #65421 was chained with `elseif` to the check that reports missing Sentinel support. That made `Redis Sentinel support requires one of: ...` reachable for any DSN, not only Sentinel ones, when neither predis, `RedisSentinel` nor `Relay\Sentinel` exists. Both checks now stand on their own, as they do on 7.4. The shape check also covers the Sentinel credentials now.

Checks run: the new tests fail on 6.4 for the five Sentinel cases and pass with the patch; `./phpunit src/Symfony/Component/Cache` reports the same failures with and without the patch on my machine; php-cs-fixer is clean. The fix was also verified end to end against a local master with `requirepass` and an unauthenticated Sentinel, with ext-redis 6.3 and with Predis: `NOAUTH Authentication required` before, `PONG` after. The phpredis below 6 path is fixed by the same change but was not run, since that version is not installed here.
