### PR TITLE
[Console][FrameworkBundle] Fix profiling a command stopped at ConsoleEvents::COMMAND

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/EventListener/ConsoleProfilerListener.php
+++ b/src/Symfony/Bundle/FrameworkBundle/EventListener/ConsoleProfilerListener.php
@@ -122,8 +122,17 @@ final class ConsoleProfilerListener implements EventSubscriberInterface
             }
         }
 
-        $request->command->exitCode = $event->getExitCode();
-        $request->command->interruptedBySignal = $event->getInterruptingSignal();
+        $command = $request->command;
+        $command->exitCode = $event->getExitCode();
+        $command->interruptedBySignal = $event->getInterruptingSignal();
+
+        if (!isset($command->input)) {
+            // the command was stopped before it could run and record what it was given
+            $command->input = $input = $event->getInput();
+            $command->output = $event->getOutput();
+            $command->arguments = $input->getArguments();
+            $command->options = $input->getOptions();
+        }
 
         $profile = $this->profiler->collect($request, $request->getResponse(), $error);
         $this->profiles[$request] = $profile;

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ConsoleProfilerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ConsoleProfilerTest.php
@@ -1,0 +1,108 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
+
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\ConsoleEvents;
+use Symfony\Component\Console\Event\ConsoleCommandEvent;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\HttpKernel\Profiler\Profile;
+
+class ConsoleProfilerTest extends AbstractWebTestCase
+{
+    protected function setUp(): void
+    {
+        static::bootKernel(['test_case' => 'ConsoleProfiler', 'debug' => true]);
+        static::getContainer()->get('public_profiler')->purge();
+    }
+
+    public function testProfileCommandDisabledByListener()
+    {
+        $application = $this->createApplication();
+        $this->stopCommandWith(static fn (ConsoleCommandEvent $event) => $event->disableCommand());
+
+        $exitCode = $application->run(new ArrayInput(['command' => 'app:profiled', 'name' => 'Fabien', '--profile' => true]), new NullOutput());
+
+        $this->assertSame(ConsoleCommandEvent::RETURN_CODE_DISABLED, $exitCode);
+
+        $profile = $this->loadProfile();
+
+        $this->assertStringContainsString('app:profiled', $profile->getUrl());
+        $this->assertSame(ConsoleCommandEvent::RETURN_CODE_DISABLED, $profile->getStatusCode());
+        $this->assertSame('Fabien', $profile->getCollector('command')->getArguments()['name']->getValue());
+    }
+
+    public function testProfileCommandStoppedByThrowingListener()
+    {
+        $application = $this->createApplication();
+        $this->stopCommandWith(static fn () => throw new \RuntimeException('Access denied.'));
+
+        try {
+            $application->run(new ArrayInput(['command' => 'app:profiled', 'name' => 'Fabien', '--profile' => true]), new NullOutput());
+            $this->fail('The listener should have stopped the command.');
+        } catch (\RuntimeException $e) {
+            $this->assertSame('Access denied.', $e->getMessage());
+        }
+
+        $profile = $this->loadProfile();
+
+        $this->assertSame(1, $profile->getStatusCode());
+        $this->assertSame('Fabien', $profile->getCollector('command')->getArguments()['name']->getValue());
+        $this->assertTrue($profile->getCollector('exception')->hasException());
+    }
+
+    public function testProfileCommandThatRuns()
+    {
+        $application = $this->createApplication();
+
+        $exitCode = $application->run(new ArrayInput(['command' => 'app:profiled', 'name' => 'Fabien', '--profile' => true]), new NullOutput());
+
+        $this->assertSame(Command::SUCCESS, $exitCode);
+
+        $profile = $this->loadProfile();
+
+        $this->assertSame(Command::SUCCESS, $profile->getStatusCode());
+        $this->assertSame('Fabien', $profile->getCollector('command')->getArguments()['name']->getValue());
+    }
+
+    private function createApplication(): Application
+    {
+        $command = new Command('app:profiled');
+        $command->addArgument('name', InputArgument::REQUIRED);
+        $command->setCode(static fn (): int => Command::SUCCESS);
+
+        $application = new Application(static::$kernel);
+        $application->setAutoExit(false);
+        $application->setCatchExceptions(false);
+        $application->add($command);
+
+        return $application;
+    }
+
+    private function stopCommandWith(callable $listener): void
+    {
+        static::getContainer()->get('event_dispatcher')->addListener(ConsoleEvents::COMMAND, $listener);
+    }
+
+    private function loadProfile(): Profile
+    {
+        $profiler = static::getContainer()->get('public_profiler');
+        $tokens = $profiler->find('', '', 2, '', '', '');
+
+        $this->assertCount(1, $tokens);
+
+        return $profiler->loadProfile($tokens[0]['token']);
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ConsoleProfiler/bundles.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ConsoleProfiler/bundles.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+
+return [
+    new FrameworkBundle(),
+];

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ConsoleProfiler/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ConsoleProfiler/config.yml
@@ -1,0 +1,13 @@
+imports:
+    - { resource: ../config/default.yml }
+
+framework:
+    http_method_override: false
+    profiler:
+        enabled: true
+        collect: true
+
+services:
+    public_profiler:
+        alias: profiler
+        public: true

--- a/src/Symfony/Component/Console/Debug/CliRequest.php
+++ b/src/Symfony/Component/Console/Debug/CliRequest.php
@@ -49,14 +49,12 @@ final class CliRequest extends Request
     public function getResponse(): Response
     {
         return new class($this->command->exitCode) extends Response {
-            public function __construct(private readonly int $exitCode)
+            public function __construct(int $exitCode)
             {
                 parent::__construct();
-            }
 
-            public function getStatusCode(): int
-            {
-                return $this->exitCode;
+                // getStatusCode() is final and setStatusCode() rejects an exit code
+                $this->statusCode = $exitCode;
             }
         };
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

A listener may stop a command at `ConsoleEvents::COMMAND`, by calling `$event->disableCommand()` or by throwing. The command then never runs, yet `ConsoleEvents::TERMINATE` is still dispatched and `ConsoleProfilerListener` still collects the profile.

That profile is read off the `TraceableCommand`, which records `input`, `output`, `arguments` and `options` from inside `run()`, the method that was never called. All four are typed properties with no default, so `--profile` replaces the reason the command was stopped with:

```
Error: Typed property Symfony\Component\Console\Command\TraceableCommand::$input
must not be accessed before initialization
```

thrown out of `CliRequest::getUri()`, then the same for `$arguments` out of `CommandDataCollector::collect()`. The command reports a failure that has nothing to do with why it was stopped, and no profile is saved for the very run one wanted to look at.

`ConsoleProfilerListener` already records the exit code and the interrupting signal on the `TraceableCommand` before collecting. It now also records the input, the output, the arguments and the options when the command never got to record them itself. The terminate event carries the input after it was bound to the command definition, so the profile of a stopped command lists its arguments and options the same way as the profile of a command that ran. Nothing a command that does run records is affected, since `run()` assigns all four itself and the guard then skips them.

One more thing on the same path: `CliRequest::getResponse()` returned an anonymous `Response` overriding `getStatusCode()`, which is `@final`, so every profiled command emitted a self deprecation. An exit code is not an HTTP status and does not pass the validation in `setStatusCode()`, where `0` and `113` are both rejected, so the property is written directly instead.

Three tests come with it, on a path that had no coverage until now: a command stopped by a listener that disables it, a command stopped by a listener that throws, and a command that runs.

Found while writing a console listener that denies access at `ConsoleEvents::COMMAND`.
