### PR TITLE
[Form] Allow form names to start with hyphens and colons

### DIFF
--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -12,6 +12,7 @@ CHANGELOG
  * Add `$help` parameter to `ChoiceListFactoryInterface::createView()`
  * Add the `form_id` view variable, holding the id to render on the `<form>` element of a root form when a child uses `form_attr`
  * Allow the `group_by` option of `ChoiceType` to return `TranslatableInterface` instances
+ * Allow form names to start with hyphens ("-") and colons (":")
 
 8.1
 ---

--- a/src/Symfony/Component/Form/FormConfigBuilder.php
+++ b/src/Symfony/Component/Form/FormConfigBuilder.php
@@ -632,7 +632,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     final public static function validateName(?string $name): void
     {
         if (!self::isValidName($name)) {
-            throw new InvalidArgumentException(\sprintf('The name "%s" contains illegal characters. Names should start with a letter, digit or underscore and only contain letters, digits, numbers, underscores ("_"), hyphens ("-") and colons (":").', $name));
+            throw new InvalidArgumentException(\sprintf('The name "%s" contains illegal characters. Names should only contain letters, digits, underscores ("_"), hyphens ("-") and colons (":").', $name));
         }
     }
 
@@ -642,12 +642,11 @@ class FormConfigBuilder implements FormConfigBuilderInterface
      * A name is accepted if it
      *
      *   * is empty
-     *   * starts with a letter, digit or underscore
-     *   * contains only letters, digits, numbers, underscores ("_"),
+     *   * contains only letters, digits, underscores ("_"),
      *     hyphens ("-") and colons (":")
      */
     final public static function isValidName(?string $name): bool
     {
-        return '' === $name || null === $name || preg_match('/^[a-zA-Z0-9_][a-zA-Z0-9_\-:]*$/D', $name);
+        return '' === $name || null === $name || preg_match('/^[a-zA-Z0-9_\-:][a-zA-Z0-9_\-:]*$/D', $name);
     }
 }

--- a/src/Symfony/Component/Form/Tests/ButtonBuilderTest.php
+++ b/src/Symfony/Component/Form/Tests/ButtonBuilderTest.php
@@ -41,7 +41,7 @@ class ButtonBuilderTest extends TestCase
     public function testNameContainingIllegalCharacters()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The name "button[]" contains illegal characters. Names should start with a letter, digit or underscore and only contain letters, digits, numbers, underscores ("_"), hyphens ("-") and colons (":").');
+        $this->expectExceptionMessage('The name "button[]" contains illegal characters. Names should only contain letters, digits, underscores ("_"), hyphens ("-") and colons (":").');
 
         $this->assertInstanceOf(ButtonBuilder::class, new ButtonBuilder('button[]'));
     }

--- a/src/Symfony/Component/Form/Tests/FormConfigTest.php
+++ b/src/Symfony/Component/Form/Tests/FormConfigTest.php
@@ -22,7 +22,7 @@ use Symfony\Component\Form\NativeRequestHandler;
  */
 class FormConfigTest extends TestCase
 {
-    public static function getHtml4Ids()
+    public static function getNames()
     {
         return [
             ['z0'],
@@ -37,7 +37,9 @@ class FormConfigTest extends TestCase
             ["a\t", 'Symfony\Component\Form\Exception\InvalidArgumentException'],
             ["a\n", 'Symfony\Component\Form\Exception\InvalidArgumentException'],
             ['a-'],
+            ['-a'],
             ['a_'],
+            [':a'],
             ['a:'],
             // Periods are allowed by the HTML4 spec, but disallowed by us
             // because they break the generated property paths
@@ -63,8 +65,8 @@ class FormConfigTest extends TestCase
         ];
     }
 
-    #[DataProvider('getHtml4Ids')]
-    public function testNameAcceptsOnlyNamesValidAsIdsInHtml4($name, $expectedException = null)
+    #[DataProvider('getNames')]
+    public function testNameValidation($name, $expectedException = null)
     {
         if (null !== $expectedException) {
             $this->expectException($expectedException);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #53977
| License       | MIT

Form field names can already contain hyphens (`-`) and colons (`:`), but they currently cannot start with them.

This allows form names to start with a hyphen or colon while keeping the existing allowed character set unchanged.

Before:

```php
FormConfigBuilder::validateName('-field');
FormConfigBuilder::validateName(':field');
```

Both throw an `InvalidArgumentException`.

After this change, both names are accepted.

The change intentionally only relaxes the first-character restriction. It does not change the handling of other characters, form IDs, `isindex`, `_charset_`, or property paths.
