### PR TITLE
[Serializer] Let DISABLE_TYPE_ENFORCEMENT keep strings that cannot be converted

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -469,6 +469,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
         $extraAttributesException = null;
         $missingConstructorArgumentsException = null;
         $filterBoolFailed = false;
+        $enforceTypes = !($context[self::DISABLE_TYPE_ENFORCEMENT] ?? $this->defaultContext[self::DISABLE_TYPE_ENFORCEMENT] ?? false);
 
         $types = match (true) {
             $type instanceof IntersectionType => throw new LogicException('Unable to handle intersection type.'),
@@ -528,14 +529,14 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                             } elseif ($context[self::FILTER_BOOL] ?? false) {
                                 // defer to the FILTER_BOOL handling below, which accepts more representations (e.g. "on"/"off")
                                 break;
-                            } else {
+                            } elseif ($enforceTypes) {
                                 throw NotNormalizableValueException::createForUnexpectedDataType(\sprintf('The type of the "%s" attribute for class "%s" must be bool ("%s" given).', $attribute, $currentClass, $data), $data, [Type::bool()], $context['deserialization_path'] ?? null);
                             }
                             break;
                         case TypeIdentifier::INT:
                             if (ctype_digit(isset($data[0]) && '-' === $data[0] ? substr($data, 1) : $data)) {
                                 $data = (int) $data;
-                            } else {
+                            } elseif ($enforceTypes) {
                                 throw NotNormalizableValueException::createForUnexpectedDataType(\sprintf('The type of the "%s" attribute for class "%s" must be int ("%s" given).', $attribute, $currentClass, $data), $data, [Type::int()], $context['deserialization_path'] ?? null);
                             }
                             break;
@@ -544,12 +545,13 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                                 return (float) $data;
                             }
 
-                            return match ($data) {
+                            $data = match ($data) {
                                 'NaN' => \NAN,
                                 'INF' => \INF,
                                 '-INF' => -\INF,
-                                default => throw NotNormalizableValueException::createForUnexpectedDataType(\sprintf('The type of the "%s" attribute for class "%s" must be float ("%s" given).', $attribute, $currentClass, $data), $data, [Type::float()], $context['deserialization_path'] ?? null),
+                                default => $enforceTypes ? throw NotNormalizableValueException::createForUnexpectedDataType(\sprintf('The type of the "%s" attribute for class "%s" must be float ("%s" given).', $attribute, $currentClass, $data), $data, [Type::float()], $context['deserialization_path'] ?? null) : $data,
                             };
+                            break;
                     }
                 }
 
@@ -763,7 +765,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
             throw $e;
         }
 
-        if ($context[self::DISABLE_TYPE_ENFORCEMENT] ?? $this->defaultContext[self::DISABLE_TYPE_ENFORCEMENT] ?? false) {
+        if (!$enforceTypes) {
             return $data;
         }
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
@@ -1512,6 +1512,28 @@ class AbstractObjectNormalizerTest extends TestCase
         $this->assertSame([1, 'nope'], $dummy->ints);
     }
 
+    #[DataProvider('denormalizeBasicTypePropertiesConversionDataProvider')]
+    public function testDenormalizeKeepsUnconvertibleScalarCollectionElementsWhenTypeEnforcementIsDisabled(string $format, array $context)
+    {
+        $normalizer = new AbstractObjectNormalizerWithMetadataAndPropertyTypeExtractors();
+
+        $dummy = $normalizer->denormalize(['ints' => ['1', 'nope', '']], ScalarCollectionsDummy::class, $format, $context + [AbstractObjectNormalizer::DISABLE_TYPE_ENFORCEMENT => true]);
+
+        $this->assertSame([1, 'nope', ''], $dummy->ints);
+    }
+
+    #[DataProvider('denormalizeBasicTypePropertiesConversionDataProvider')]
+    public function testDenormalizeKeepsUnconvertibleBasicTypePropertiesWhenTypeEnforcementIsDisabled(string $format, array $context)
+    {
+        $normalizer = new AbstractObjectNormalizerWithMetadataAndPropertyTypeExtractors();
+
+        $object = $normalizer->denormalize(['boolTrue1' => 'maybe', 'int1' => 'nope', 'float1' => 'nope'], ObjectWithBasicProperties::class, $format, $context + [AbstractObjectNormalizer::DISABLE_TYPE_ENFORCEMENT => true]);
+
+        $this->assertSame('maybe', $object->boolTrue1);
+        $this->assertSame('nope', $object->int1);
+        $this->assertSame('nope', $object->float1);
+    }
+
     public function testDenormalizeCollectionOfUnionTypesPropertyWithPhpDocExtractor()
     {
         $normalizer = new AbstractObjectNormalizerWithMetadataAndPropertyTypeExtractors();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65623
| License       | MIT

For formats where every value is a string (XML, CSV, and the query string or form data mapped by `#[MapQueryString]` and `#[MapRequestPayload]`), `AbstractObjectNormalizer` converts the string to the declared `bool`, `int` or `float`. When the conversion is impossible, it throws a `NotNormalizableValueException` before it reads `DISABLE_TYPE_ENFORCEMENT`, so the option has no effect on those formats. Since #65291 the same applies to the elements of a scalar collection, which is the case of #65623: the values of a `list<int>` property used to reach the validator, they now stop at the serializer, and the validator never runs.

This PR makes `DISABLE_TYPE_ENFORCEMENT` cover those conversions: a string that cannot be converted is kept as is, the same as for formats without conversion. The default behavior does not change. Without the option, the same exception is thrown, with the same message and path.

For the DTO of #65623, the property keeps its `list<positive-int>` type and the validator is in charge of the values:

```php
#[MapQueryString(serializationContext: [AbstractObjectNormalizer::DISABLE_TYPE_ENFORCEMENT => true])] QueryString $queryString
```

With `?ids[]=foo`, the resolver reports the messages of the `Assert\All` constraints instead of "This value should be of type int.".

The option keeps its existing trap: values are set as is, so it only helps for properties that can hold the string (`mixed`, `array`, or a docblock type on an untyped property). A property with a native `int` type still fails at the constructor or the setter, the same as it does for JSON today.

Checks run: `./phpunit src/Symfony/Component/Serializer` (1403 tests, green) and `./phpunit src/Symfony/Component/HttpKernel` (1677 tests, green; its resolver uses the csv path). The two new tests fail on 8.1 with the conversion exception. The scenario of the issue was also run end to end through `RequestPayloadValueResolver`: custom messages with the option, unchanged type message without it. No test was added to HttpKernel on purpose: its lowest-dependency job would run it against a released Serializer that does not have the fix.
