### PR TITLE
[Messenger] Add claim check support

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add the `framework.webhook.no_private_network` and `framework.webhook.http_client` options
+ * Add the `claim_check` option to Messenger transports
  * Add the `framework.asset_mapper.importmap_entries` option to limit the rendered import map to the entries reachable from the rendered entrypoints
  * Add the `http_cache.cache_status` option to emit the RFC 9211 `Cache-Status` header
  * Add the `framework.mailer.tracking` option to set default open/click tracking for every outgoing message

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -199,6 +199,23 @@ class Configuration implements ConfigurationInterface
         $this->addRemoteEventSection($rootNode, $enableIfStandalone);
         $this->addJsonStreamerSection($rootNode, $enableIfStandalone);
 
+        $rootNode
+            ->validate()
+                ->always(static function (array $config): array {
+                    foreach ($config['messenger']['transports'] ?? [] as $name => $transport) {
+                        if (null === $pool = $transport['claim_check']['cache_pool'] ?? null) {
+                            continue;
+                        }
+                        if (isset($config['cache']['pools'][$pool]) && !isset($config['cache']['pools'][$pool]['default_lifetime'])) {
+                            throw new InvalidConfigurationException(\sprintf('The cache pool "%s" used by Messenger transport "%s" for claim checks must define a "default_lifetime".', $pool, $name));
+                        }
+                    }
+
+                    return $config;
+                })
+            ->end()
+        ;
+
         return $treeBuilder;
     }
 
@@ -1925,6 +1942,12 @@ class Configuration implements ConfigurationInterface
                                 ->children()
                                     ->scalarNode('dsn')->end()
                                     ->scalarNode('serializer')->defaultNull()->info('Service id of a custom serializer to use.')->end()
+                                    ->arrayNode('claim_check')
+                                        ->children()
+                                            ->scalarNode('cache_pool')->isRequired()->cannotBeEmpty()->info('Service id of the dedicated cache pool used to store claims. Pools declared under "framework.cache.pools" must define a "default_lifetime".')->end()
+                                            ->integerNode('max_size')->isRequired()->min(1)->info('Maximum encoded message size in bytes before using a claim check.')->end()
+                                        ->end()
+                                    ->end()
                                     ->arrayNode('options', 'option')
                                         ->useAttributeAsKey('key')
                                         ->normalizeKeys(false)

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -132,6 +132,7 @@ use Symfony\Component\Messenger\MessageBus;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Messenger\Middleware\DecodeFailedMessageMiddleware;
 use Symfony\Component\Messenger\Middleware\RouterContextMiddleware;
+use Symfony\Component\Messenger\Transport\Serialization\ClaimCheckSerializer;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 use Symfony\Component\Messenger\Transport\TransportFactoryInterface as MessengerTransportFactoryInterface;
 use Symfony\Component\Messenger\Transport\TransportInterface;
@@ -2608,18 +2609,32 @@ class FrameworkExtension extends Extension
         $serializerIds = [];
         foreach ($config['transports'] as $name => $transport) {
             $serializerId = $transport['serializer'] ?? 'messenger.default_serializer';
+            $transportSerializerId = $serializerId;
             $tags = [
                 'alias' => $name,
                 'is_failure_transport' => \in_array($name, $failureTransports, true),
                 'priority' => $transport['priority'],
             ];
-            $serializerReferencesByTransport[$name] = new Reference($serializerId);
+            if ($transport['claim_check'] ?? null) {
+                if (!class_exists(ClaimCheckSerializer::class)) {
+                    throw new LogicException('Claim checks require symfony/messenger 8.2 or higher.');
+                }
+
+                $container->setDefinition($transportSerializerId = '.messenger.transport.'.$name.'.claim_check_serializer', (new Definition(ClaimCheckSerializer::class))
+                    ->setArguments([
+                        new Reference($serializerId),
+                        new Reference($transport['claim_check']['cache_pool']),
+                        $transport['claim_check']['max_size'],
+                    ]));
+            }
+
+            $serializerReferencesByTransport[$name] = new Reference($transportSerializerId);
             if (str_starts_with($transport['dsn'], 'sync://')) {
                 $tags['is_consumable'] = false;
             }
             $transportDefinition = (new Definition(TransportInterface::class))
                 ->setFactory([new Reference('messenger.transport_factory'), 'createTransport'])
-                ->setArguments([$transport['dsn'], $transport['options'] + ['transport_name' => $name], new Reference($serializerId)])
+                ->setArguments([$transport['dsn'], $transport['options'] + ['transport_name' => $name], new Reference($transportSerializerId)])
                 ->addTag('messenger.receiver', $tags)
             ;
             $container->setDefinition($transportId = 'messenger.transport.'.$name, $transportDefinition);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -685,6 +685,56 @@ class ConfigurationTest extends TestCase
         ]);
     }
 
+    public function testMessengerClaimCheckConfiguration()
+    {
+        $processor = new Processor();
+        $config = $processor->processConfiguration(new Configuration(true), [[
+            'messenger' => [
+                'transports' => [
+                    'async' => [
+                        'dsn' => 'in-memory:///',
+                        'claim_check' => [
+                            'cache_pool' => 'app.claim_check_pool',
+                            'max_size' => 200000,
+                        ],
+                    ],
+                ],
+            ],
+        ]]);
+
+        $this->assertSame([
+            'cache_pool' => 'app.claim_check_pool',
+            'max_size' => 200000,
+        ], $config['messenger']['transports']['async']['claim_check']);
+    }
+
+    public function testMessengerClaimCheckCachePoolRequiresDefaultLifetime()
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('The cache pool "app.claim_check_pool" used by Messenger transport "async" for claim checks must define a "default_lifetime".');
+
+        (new Processor())->processConfiguration(new Configuration(true), [[
+            'cache' => [
+                'pools' => [
+                    'app.claim_check_pool' => [
+                        'adapter' => 'cache.adapter.pdo',
+                    ],
+                ],
+            ],
+            'messenger' => [
+                'transports' => [
+                    'async' => [
+                        'dsn' => 'in-memory:///',
+                        'claim_check' => [
+                            'cache_pool' => 'app.claim_check_pool',
+                            'max_size' => 200000,
+                        ],
+                    ],
+                ],
+            ],
+        ]]);
+    }
+
     public function testBusMiddlewareDontMerge()
     {
         $processor = new Processor();

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_claim_check.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_claim_check.php
@@ -1,0 +1,23 @@
+<?php
+
+$container->loadFromExtension('framework', [
+    'cache' => [
+        'pools' => [
+            'app.claim_check_pool' => [
+                'adapters' => ['cache.adapter.pdo'],
+                'default_lifetime' => 604800,
+            ],
+        ],
+    ],
+    'messenger' => [
+        'transports' => [
+            'async' => [
+                'dsn' => 'in-memory:///',
+                'claim_check' => [
+                    'cache_pool' => 'app.claim_check_pool',
+                    'max_size' => 200000,
+                ],
+            ],
+        ],
+    ],
+]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_claim_check.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_claim_check.yml
@@ -1,0 +1,13 @@
+framework:
+    cache:
+        pools:
+            app.claim_check_pool:
+                adapter: cache.adapter.pdo
+                default_lifetime: 604800
+    messenger:
+        transports:
+            async:
+                dsn: 'in-memory:///'
+                claim_check:
+                    cache_pool: app.claim_check_pool
+                    max_size: 200000

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -96,6 +96,7 @@ use Symfony\Component\Messenger\DependencyInjection\MessengerPass;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Messenger\Middleware\DecodeFailedMessageMiddleware;
 use Symfony\Component\Messenger\Middleware\DeduplicateMiddleware;
+use Symfony\Component\Messenger\Transport\Serialization\ClaimCheckSerializer;
 use Symfony\Component\Messenger\Transport\TransportFactory;
 use Symfony\Component\Mime\Crypto\PgpEncrypter;
 use Symfony\Component\Mime\Crypto\PgpSigner;
@@ -1435,6 +1436,32 @@ abstract class FrameworkExtensionTestCase extends TestCase
             'customised' => new Reference('limiter.customised_worker'),
         ];
         $this->assertEquals($expectedRateLimitersByRateLimitedTransports, $rateLimitedTransports);
+    }
+
+    public function testMessengerClaimCheckSerializer()
+    {
+        if (!class_exists(ClaimCheckSerializer::class)) {
+            $this->markTestSkipped('Claim checks require symfony/messenger 8.2 or higher.');
+        }
+
+        $container = $this->createContainerFromFile('messenger_claim_check');
+
+        $transport = $container->getDefinition('messenger.transport.async');
+        $this->assertSame('.messenger.transport.async.claim_check_serializer', (string) $transport->getArgument(2));
+
+        $serializer = $container->getDefinition('.messenger.transport.async.claim_check_serializer');
+        $this->assertSame(ClaimCheckSerializer::class, $serializer->getClass());
+        $this->assertSame('messenger.default_serializer', (string) $serializer->getArgument(0));
+        $this->assertSame('app.claim_check_pool', (string) $serializer->getArgument(1));
+        $this->assertSame(200000, $serializer->getArgument(2));
+
+        $serializers = $container->getDefinition('messenger.transport.serializer_locator')->getArgument(0);
+        $this->assertSame('.messenger.transport.async.claim_check_serializer', (string) $serializers['async']);
+
+        // signing must decorate the inner serializer, never the claim check wrapper
+        $eligible = $container->getDefinition('messenger.signing_serializer')->getArgument(2)['*'];
+        $this->assertContains('messenger.default_serializer', $eligible);
+        $this->assertNotContains('.messenger.transport.async.claim_check_serializer', $eligible);
     }
 
     #[Group('legacy')]

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/config/schema.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/config/schema.json
@@ -2518,6 +2518,25 @@
                                                             "default": null,
                                                             "description": "Service id of a custom serializer to use."
                                                         },
+                                                        "claim_check": {
+                                                            "$ref": "#/$defs/types/object_null",
+                                                            "properties": {
+                                                                "cache_pool": {
+                                                                    "$ref": "#/$defs/types/scalar",
+                                                                    "description": "Service id of the dedicated cache pool used to store claims. Pools declared under \"framework.cache.pools\" must define a \"default_lifetime\"."
+                                                                },
+                                                                "max_size": {
+                                                                    "$ref": "#/$defs/types/integer",
+                                                                    "minimum": 1,
+                                                                    "description": "Maximum encoded message size in bytes before using a claim check."
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "cache_pool",
+                                                                "max_size"
+                                                            ],
+                                                            "additionalProperties": false
+                                                        },
                                                         "options": {
                                                             "$ref": "#/$defs/types/object_null",
                                                             "additionalProperties": {

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.2
 ---
 
+ * Add claim check support with `ClaimCheckSerializer` and PSR-6 cache pools
  * Add `HandlerStartingEvent`, `HandlerSuccessEvent` and `HandlerFailureEvent`, dispatched around each handler call
  * Add `$serializedTypeNameAliases` parameter to `#[AsMessage]` to accept alternate serialized type names when decoding
  * Add `--failed-after` and `--failed-before` options to the `messenger:failed:retry`, `messenger:failed:remove` and `messenger:failed:show` commands, and a `--class-filter` option to `messenger:failed:retry`

--- a/src/Symfony/Component/Messenger/Exception/ClaimCheckNotFoundException.php
+++ b/src/Symfony/Component/Messenger/Exception/ClaimCheckNotFoundException.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Exception;
+
+class ClaimCheckNotFoundException extends RuntimeException
+{
+    public function __construct(string $id)
+    {
+        parent::__construct(\sprintf('Claim check "%s" was not found.', $id));
+    }
+}

--- a/src/Symfony/Component/Messenger/Exception/ClaimCheckStorageException.php
+++ b/src/Symfony/Component/Messenger/Exception/ClaimCheckStorageException.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Exception;
+
+class ClaimCheckStorageException extends RuntimeException
+{
+}

--- a/src/Symfony/Component/Messenger/Tests/Transport/Serialization/ClaimCheckSerializerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Serialization/ClaimCheckSerializerTest.php
@@ -1,0 +1,242 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Transport\Serialization;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\ClaimCheckNotFoundException;
+use Symfony\Component\Messenger\Exception\ClaimCheckStorageException;
+use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Messenger\Transport\Serialization\ClaimCheckSerializer;
+use Symfony\Component\Messenger\Transport\Serialization\MessageTypeAwareSerializerInterface;
+use Symfony\Component\Messenger\Transport\Serialization\PhpSerializer;
+use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
+use Symfony\Component\Messenger\Transport\Serialization\SigningSerializer;
+
+class ClaimCheckSerializerTest extends TestCase
+{
+    public function testSmallEncodedEnvelopeIsReturnedUnchanged()
+    {
+        $inner = new PhpSerializer();
+        $pool = $this->createMock(CacheItemPoolInterface::class);
+        $pool->expects($this->never())->method('getItem');
+        $serializer = new ClaimCheckSerializer($inner, $pool, 10000);
+        $envelope = new Envelope(new DummyMessage('hello'));
+
+        $this->assertSame($inner->encode($envelope), $serializer->encode($envelope));
+    }
+
+    public function testLargeEncodedEnvelopeIsStoredAndRestored()
+    {
+        $values = [];
+        $serializer = new ClaimCheckSerializer(new PhpSerializer(), $this->createCachePool($values), 512);
+        $envelope = new Envelope(new DummyMessage(str_repeat('a', 1000)));
+
+        $encoded = $serializer->encode($envelope);
+
+        $this->assertSame('1', $encoded['headers']['X-Symfony-Messenger-Claim-Check'] ?? null);
+        $claim = json_decode($encoded['body'], true, flags: \JSON_THROW_ON_ERROR);
+        $this->assertNotEmpty($values[$claim['id']]);
+        $this->assertEquals($envelope, $serializer->decode($encoded));
+    }
+
+    public function testTransportMetadataIsForwardedToTheInnerSerializer()
+    {
+        $values = [];
+        $phpSerializer = new PhpSerializer();
+        $envelope = new Envelope(new DummyMessage(str_repeat('a', 1000)));
+        $inner = $this->createMock(SerializerInterface::class);
+        $inner->method('encode')->willReturn($phpSerializer->encode($envelope));
+        $inner->expects($this->once())->method('decode')
+            ->with($this->callback(static fn (array $encodedEnvelope): bool => ['routing_key' => 'urgent'] === $encodedEnvelope['extra']))
+            ->willReturn($envelope);
+        $serializer = new ClaimCheckSerializer($inner, $this->createCachePool($values), 512);
+        $encoded = $serializer->encode($envelope);
+        $encoded['extra'] = ['routing_key' => 'urgent'];
+
+        $serializer->decode($encoded);
+    }
+
+    public function testMissingClaimProducesDecodingFailure()
+    {
+        $values = [];
+        $serializer = new ClaimCheckSerializer(new PhpSerializer(), $this->createCachePool($values), 512);
+        $encoded = $serializer->encode(new Envelope(new DummyMessage(str_repeat('a', 1000))));
+        $claim = json_decode($encoded['body'], true, flags: \JSON_THROW_ON_ERROR);
+        unset($values[$claim['id']]);
+
+        $decoded = $serializer->decode($encoded);
+
+        $this->assertInstanceOf(MessageDecodingFailedException::class, $decoded->getMessage());
+        $this->assertSame($encoded, $decoded->getMessage()->encodedEnvelope);
+        $this->assertInstanceOf(ClaimCheckNotFoundException::class, $decoded->getMessage()->getPrevious());
+    }
+
+    public function testChangedClaimProducesDecodingFailure()
+    {
+        $values = [];
+        $serializer = new ClaimCheckSerializer(new PhpSerializer(), $this->createCachePool($values), 512);
+        $encoded = $serializer->encode(new Envelope(new DummyMessage(str_repeat('a', 1000))));
+        $claim = json_decode($encoded['body'], true, flags: \JSON_THROW_ON_ERROR);
+        $values[$claim['id']] = 'changed';
+
+        $decoded = $serializer->decode($encoded);
+
+        $this->assertInstanceOf(MessageDecodingFailedException::class, $decoded->getMessage());
+        $this->assertStringContainsString('integrity', $decoded->getMessage()->getMessage());
+    }
+
+    public function testMessageTypeDoesNotRetrieveClaim()
+    {
+        $values = [];
+        $serializer = new ClaimCheckSerializer(new PhpSerializer(), $this->createCachePool($values), 512);
+        $encoded = $serializer->encode(new Envelope(new DummyMessage(str_repeat('a', 1000))));
+        $claim = json_decode($encoded['body'], true, flags: \JSON_THROW_ON_ERROR);
+        unset($values[$claim['id']]);
+
+        $this->assertInstanceOf(MessageTypeAwareSerializerInterface::class, $serializer);
+        $this->assertSame(DummyMessage::class, $serializer->getMessageType($encoded));
+    }
+
+    public function testMessageTypeIsDelegatedForRegularEnvelope()
+    {
+        $serializer = new ClaimCheckSerializer(new PhpSerializer(), $this->createStub(CacheItemPoolInterface::class), 10000);
+        $encoded = $serializer->encode(new Envelope(new DummyMessage('hello')));
+
+        $this->assertSame(DummyMessage::class, $serializer->getMessageType($encoded));
+    }
+
+    public function testComposesWithSigningSerializer()
+    {
+        $values = [];
+        $serializer = new ClaimCheckSerializer(
+            new SigningSerializer(new PhpSerializer(), 'secret', [DummyMessage::class]),
+            $this->createCachePool($values),
+            512,
+        );
+        $envelope = new Envelope(new DummyMessage(str_repeat('a', 1000)));
+
+        $encoded = $serializer->encode($envelope);
+        $claim = json_decode($encoded['body'], true, flags: \JSON_THROW_ON_ERROR);
+
+        $this->assertArrayNotHasKey('Body-Sign', $encoded['headers']);
+        $this->assertStringContainsString('Body-Sign', $values[$claim['id']]);
+        $this->assertEquals($envelope, $serializer->decode($encoded));
+    }
+
+    public function testReferenceThatExceedsMaximumSizeIsRemoved()
+    {
+        $values = [];
+        $serializer = new ClaimCheckSerializer(new PhpSerializer(), $this->createCachePool($values), 1);
+
+        try {
+            $serializer->encode(new Envelope(new DummyMessage(str_repeat('a', 1000))));
+            $this->fail('An oversized claim check reference was returned.');
+        } catch (ClaimCheckStorageException $e) {
+            $this->assertSame([], $values);
+            $this->assertStringContainsString('reference is larger', $e->getMessage());
+        }
+    }
+
+    public function testCacheSaveFailureThrowsStorageException()
+    {
+        $item = $this->createMock(CacheItemInterface::class);
+        $item->expects($this->never())->method('isHit');
+        $item->method('set')->willReturnSelf();
+        $pool = $this->createStub(CacheItemPoolInterface::class);
+        $pool->method('getItem')->willReturn($item);
+        $pool->method('save')->willReturn(false);
+        $serializer = new ClaimCheckSerializer(new PhpSerializer(), $pool, 512);
+
+        $this->expectException(ClaimCheckStorageException::class);
+        $this->expectExceptionMessage('Unable to store the claim check');
+
+        $serializer->encode(new Envelope(new DummyMessage(str_repeat('a', 1000))));
+    }
+
+    public function testReferenceSizeErrorIsReportedWhenCleanupFails()
+    {
+        $item = $this->createStub(CacheItemInterface::class);
+        $item->method('set')->willReturnSelf();
+        $pool = $this->createStub(CacheItemPoolInterface::class);
+        $pool->method('getItem')->willReturn($item);
+        $pool->method('save')->willReturn(true);
+        $pool->method('deleteItem')->willThrowException(new \RuntimeException('Cleanup failed.'));
+        $serializer = new ClaimCheckSerializer(new PhpSerializer(), $pool, 1);
+
+        $this->expectException(ClaimCheckStorageException::class);
+        $this->expectExceptionMessage('reference is larger');
+
+        $serializer->encode(new Envelope(new DummyMessage(str_repeat('a', 1000))));
+    }
+
+    public function testReferenceSizeErrorIsReportedWhenCleanupReturnsFalse()
+    {
+        $item = $this->createStub(CacheItemInterface::class);
+        $item->method('set')->willReturnSelf();
+        $pool = $this->createStub(CacheItemPoolInterface::class);
+        $pool->method('getItem')->willReturn($item);
+        $pool->method('save')->willReturn(true);
+        $pool->method('deleteItem')->willReturn(false);
+        $serializer = new ClaimCheckSerializer(new PhpSerializer(), $pool, 1);
+
+        $this->expectException(ClaimCheckStorageException::class);
+        $this->expectExceptionMessage('reference is larger');
+
+        $serializer->encode(new Envelope(new DummyMessage(str_repeat('a', 1000))));
+    }
+
+    public function testRejectsInvalidMaximumSize()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('maximum size must be greater than zero');
+
+        new ClaimCheckSerializer(new PhpSerializer(), $this->createStub(CacheItemPoolInterface::class), 0);
+    }
+
+    /** @param array<string, mixed> $values */
+    private function createCachePool(array &$values): CacheItemPoolInterface
+    {
+        $pool = $this->createStub(CacheItemPoolInterface::class);
+        $pool->method('getItem')->willReturnCallback(function (string $id) use (&$values): CacheItemInterface {
+            $item = $this->createStub(CacheItemInterface::class);
+            $value = $values[$id] ?? null;
+            $item->method('getKey')->willReturn($id);
+            $item->method('get')->willReturnCallback(static function () use (&$value): mixed {
+                return $value;
+            });
+            $item->method('isHit')->willReturnCallback(static fn (): bool => null !== $value);
+            $item->method('set')->willReturnCallback(static function (mixed $newValue) use (&$value, $item): CacheItemInterface {
+                $value = $newValue;
+
+                return $item;
+            });
+
+            return $item;
+        });
+        $pool->method('save')->willReturnCallback(static function (CacheItemInterface $item) use (&$values): bool {
+            $values[$item->getKey()] = $item->get();
+
+            return true;
+        });
+        $pool->method('deleteItem')->willReturnCallback(static function (string $id) use (&$values): bool {
+            unset($values[$id]);
+
+            return true;
+        });
+
+        return $pool;
+    }
+}

--- a/src/Symfony/Component/Messenger/Transport/Serialization/ClaimCheckSerializer.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/ClaimCheckSerializer.php
@@ -1,0 +1,188 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Transport\Serialization;
+
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\ClaimCheckNotFoundException;
+use Symfony\Component\Messenger\Exception\ClaimCheckStorageException;
+use Symfony\Component\Messenger\Exception\InvalidArgumentException;
+use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
+
+/**
+ * Stores oversized encoded envelopes in a cache pool.
+ *
+ * When using a SigningSerializer, pass it as the inner serializer. Wrapping this serializer in a SigningSerializer
+ * would sign only the claim reference. The stored envelope would remain unsigned, allowing a spoofed type header
+ * to bypass signature verification.
+ */
+final class ClaimCheckSerializer implements SerializerInterface, MessageTypeAwareSerializerInterface
+{
+    private const HEADER = 'X-Symfony-Messenger-Claim-Check';
+    private const TYPE_HEADER = 'X-Symfony-Messenger-Claim-Check-Type';
+
+    /**
+     * @param CacheItemPoolInterface $pool    Dedicated pool configured to retain claims for the complete message lifetime
+     * @param int                    $maxSize Maximum encoded envelope size in bytes
+     */
+    public function __construct(
+        private SerializerInterface $inner,
+        private CacheItemPoolInterface $pool,
+        private int $maxSize,
+    ) {
+        if (0 >= $maxSize) {
+            throw new InvalidArgumentException('The claim check maximum size must be greater than zero.');
+        }
+    }
+
+    public function encode(Envelope $envelope): array
+    {
+        $encodedEnvelope = $this->inner->encode($envelope);
+        if ($this->getSize($encodedEnvelope) <= $this->maxSize) {
+            return $encodedEnvelope;
+        }
+
+        $data = serialize($encodedEnvelope);
+        $id = $this->storeClaim($data);
+        $claim = [
+            'body' => json_encode(['id' => $id, 'digest' => hash('sha256', $data)], \JSON_THROW_ON_ERROR),
+            'headers' => [self::HEADER => '1', self::TYPE_HEADER => $envelope->getMessage()::class],
+        ];
+
+        if ($this->getSize($claim) > $this->maxSize) {
+            $this->removeClaim($id);
+
+            throw new ClaimCheckStorageException(\sprintf('The claim check reference is larger than the configured maximum size of %d bytes.', $this->maxSize));
+        }
+
+        return $claim;
+    }
+
+    public function decode(array $encodedEnvelope): Envelope
+    {
+        if ('1' !== ($encodedEnvelope['headers'][self::HEADER] ?? null)) {
+            return $this->inner->decode($encodedEnvelope);
+        }
+
+        try {
+            $claim = json_decode($encodedEnvelope['body'], true, flags: \JSON_THROW_ON_ERROR);
+            if (!\is_array($claim) || !\is_string($claim['id'] ?? null) || !\is_string($claim['digest'] ?? null)) {
+                throw new ClaimCheckStorageException('The claim check reference is invalid.');
+            }
+
+            $data = $this->retrieveClaim($claim['id']);
+            if (!hash_equals(hash('sha256', $data), $claim['digest'])) {
+                throw new ClaimCheckStorageException('The claim check integrity check failed.');
+            }
+
+            $claimedEnvelope = $this->decodeClaim($data);
+        } catch (\Throwable $e) {
+            return MessageDecodingFailedException::wrap($encodedEnvelope, $e->getMessage(), (int) $e->getCode(), $e);
+        }
+
+        if (isset($encodedEnvelope['extra'])) {
+            $claimedEnvelope['extra'] = $encodedEnvelope['extra'];
+        }
+
+        return $this->inner->decode($claimedEnvelope);
+    }
+
+    public function getMessageType(array $encodedEnvelope): ?string
+    {
+        if ('1' === ($encodedEnvelope['headers'][self::HEADER] ?? null)) {
+            $type = $encodedEnvelope['headers'][self::TYPE_HEADER] ?? null;
+
+            return \is_string($type) ? $type : null;
+        }
+
+        return $this->inner instanceof MessageTypeAwareSerializerInterface ? $this->inner->getMessageType($encodedEnvelope) : null;
+    }
+
+    /**
+     * @param array{body: string, headers?: array<string, string>} $encodedEnvelope
+     */
+    private function getSize(array $encodedEnvelope): int
+    {
+        $size = \strlen($encodedEnvelope['body'] ?? '');
+        foreach ($encodedEnvelope['headers'] ?? [] as $name => $value) {
+            $size += \strlen($name) + \strlen($value);
+        }
+
+        return $size;
+    }
+
+    private function storeClaim(string $data): string
+    {
+        try {
+            $id = bin2hex(random_bytes(16));
+            if (!$this->pool->save($this->pool->getItem($id)->set($data))) {
+                throw new ClaimCheckStorageException('Unable to store the claim check.');
+            }
+
+            return $id;
+        } catch (ClaimCheckStorageException $e) {
+            throw $e;
+        } catch (\Throwable $e) {
+            throw new ClaimCheckStorageException('Unable to store the claim check.', previous: $e);
+        }
+    }
+
+    private function retrieveClaim(string $id): string
+    {
+        try {
+            $item = $this->pool->getItem($id);
+            if (!$item->isHit()) {
+                throw new ClaimCheckNotFoundException($id);
+            }
+
+            if (!\is_string($data = $item->get())) {
+                throw new ClaimCheckStorageException('The claimed data is invalid.');
+            }
+
+            return $data;
+        } catch (ClaimCheckNotFoundException|ClaimCheckStorageException $e) {
+            throw $e;
+        } catch (\Throwable $e) {
+            throw new ClaimCheckStorageException('Unable to retrieve the claim check.', previous: $e);
+        }
+    }
+
+    private function removeClaim(string $id): void
+    {
+        try {
+            $this->pool->deleteItem($id);
+        } catch (\Throwable) {
+        }
+    }
+
+    /**
+     * @return array{body: string, headers?: array<string, string>}
+     */
+    private function decodeClaim(string $data): array
+    {
+        $encodedEnvelope = @unserialize($data, ['allowed_classes' => false]);
+        if (!\is_array($encodedEnvelope) || !\is_string($encodedEnvelope['body'] ?? null)) {
+            throw new ClaimCheckStorageException('The claimed envelope is invalid.');
+        }
+        if (isset($encodedEnvelope['headers']) && !\is_array($encodedEnvelope['headers'])) {
+            throw new ClaimCheckStorageException('The claimed envelope is invalid.');
+        }
+
+        foreach ($encodedEnvelope['headers'] ?? [] as $name => $value) {
+            if (!\is_string($name) || !\is_string($value)) {
+                throw new ClaimCheckStorageException('The claimed envelope is invalid.');
+            }
+        }
+
+        return $encodedEnvelope;
+    }
+}


### PR DESCRIPTION
| Q             | A                 |
| ------------- | ----------------- |
| Branch?       | 8.2               |
| Bug fix?      | no                |
| New feature?  | yes               |
| Deprecations? | no                |
| Issues        | Fix #60390 |
| License       | MIT               |

Message transports commonly impose payload-size limits. This PR adds transport-agnostic support for the claim check pattern at the serializer level.

Messages below the configured limit are sent unchanged. When an encoded envelope exceeds the limit, Messenger stores it in a dedicated PSR-6 cache pool and sends a small reference through the transport. Consumers transparently retrieve and decode the original envelope.

The feature is configured per transport because each broker and transport can have a different payload limit:

```yaml
framework:
    cache:
        pools:
            app.messenger_claim_check_pool:
                adapter: cache.adapter.pdo
                default_lifetime: 604800 # One week

    messenger:
        transports:
            async:
                dsn: '%env(MESSENGER_TRANSPORT_DSN)%'
                claim_check:
                    cache_pool: app.messenger_claim_check_pool
                    max_size: 200000
```

The `max_size` option measures the encoded body and headers. It should be set below the limit imposed by the configured broker.

Using a PSR-6 cache pool avoids introducing a Messenger-specific storage abstraction. Applications can use the existing Symfony cache adapters for filesystem, Redis, Valkey, Memcached, PDO, Doctrine DBAL and other supported backends.

The cache pool should be dedicated to claim checks and configured so that claims cannot be evicted or cleared before the complete message lifecycle has elapsed. Its `default_lifetime` must cover broker retention, retry delays, failure transports, operational recovery and possible redelivery after a worker crash. A pool declared under `framework.cache.pools` must define a `default_lifetime`, and the configuration throws otherwise: PSR-6 gives no way to read a pool's default, and a pool without a lifetime keeps claims forever.

Claims are deliberately not removed immediately after decoding. The same broker message may need to retrieve its claim again if the worker crashes before acknowledgement or the broker redelivers it.

Backends with native expiration, such as Redis, can remove expired claims automatically. Storing large claims on the filesystem is possible, but not through a `cache.adapter.filesystem` pool declared under `framework.cache.pools`: such pools live under `kernel.cache_dir`, so `cache:clear` deletes in-flight claims. Declare a plain `FilesystemAdapter` service with an explicit directory outside the cache directory instead; this also keeps the pool out of `cache:pool:clear --all`, which clears every pool declared under `framework.cache.pools`, Redis and PDO included. Filesystem cache entries are not necessarily removed from disk when they expire, so applications using a pruneable cache adapter should run Symfony’s existing cache-pruning command regularly:

```console
php bin/console cache:pool:prune
```

For example, an application can run it from cron or its regular maintenance process:

```cron
*/15 * * * * php /path/to/project/bin/console cache:pool:prune
```

This command prunes expired entries from all configured pruneable cache pools. Backends that handle expiration natively do not require manual pruning.

Missing, expired, corrupted or inaccessible claims produce a normal Messenger decoding failure. They can consequently follow the existing retry and failure-transport path.

The serializer stores the complete encoded envelope, so it composes with custom serializers and message signing. The reference contains a digest used to detect corrupted or mismatched stored data. Transport metadata added during receipt is forwarded to the inner serializer.

A Flysystem-backed implementation could be added later by exposing a `CacheItemPoolInterface` backed by a `FilesystemOperator`. Such an adapter would need to store expiration metadata and define its cleanup strategy, while Messenger itself would require no additional integration. This could support S3 and the other Flysystem adapters, but probably belongs in a separate PR.

This PR is also intended to start a discussion about the lifecycle of stored claims and whether claim check support could eventually become a default Messenger capability.

Every asynchronous transport has a payload limit, even though the exact limit depends on the transport, broker and its configuration. Except for transports backed directly by a database, applications generally cannot assume that arbitrarily large messages can be sent.

The difficult part is retention. Symfony cannot infer how long a claim must remain available. It depends on broker retention, retry delays, failure transports, operational recovery and possible redelivery after a worker crash.

Deleting a claim immediately after decoding is unsafe because the broker has not acknowledged the message yet. Keeping claims indefinitely creates unbounded storage growth.

The current proposal therefore keeps claim check support explicit, requires a dedicated cache pool and delegates retention to that pool. Applications configure an appropriate lifetime, while cleanup is handled through native expiration, external lifecycle policies or Symfony’s existing cache-pruning command.

I considered several alternatives:

- Define a default retention period in Symfony.
- Prune expired claims on every write.
- Run probabilistic pruning during writes.
- Remove expired claims when they are read.
- Remove claims after successful broker acknowledgement.

Each option has limitations. Pruning on read is ineffective for claims that are normally read only once. Pruning on every write can become expensive. Probabilistic pruning cannot guarantee cleanup after traffic stops.

Deleting after handling is currently unsafe because `WorkerMessageHandledEvent` runs before transport acknowledgement and Messenger has no post-acknowledgement hook. Such a hook would make eager cleanup possible after a successful acknowledgement, but expiration would still be required as a safety net for messages that are never acknowledged.

Interested in hearing the community’s thoughts 😊

---

Notes for the documentation:

- Every retry and every send to the failure transport stores a new claim, so up to `1 + max_retries + 1` copies of one message can exist in the pool at the same time. Size the pool and its lifetime accordingly.
- A failure transport without its own `claim_check` option receives the full payload.
- A storage backend outage reads as a cache miss: the cache adapters log the error and report a miss, so the message follows the normal retry and failure-transport path instead of crashing the worker.
- `max_size` counts the encoded body plus header names and values. Brokers count message size differently, so keep a margin below the broker limit.
- When combining with `SigningSerializer`, the signing serializer must be the inner one, so that the stored envelope carries the signature. The bundle wires this order automatically.
