### PR TITLE
[Notifier] Add `TelegramOptions::disableMarkdownV2Escaping()`

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Telegram/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.2
 ---
 
+ * Add `TelegramOptions::disableMarkdownV2Escaping()` to send MarkdownV2 text as is
  * Add support for editing media messages via the `editMessageMedia` and `editMessageCaption` API methods
 
 8.1

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/README.md
@@ -91,6 +91,38 @@ $telegramOptions = (new TelegramOptions())
 The keyboard above shows "Yes" and "No" side by side on the first row, and the
 link alone on the second one.
 
+Escaping MarkdownV2 Text
+------------------------
+
+The `TelegramOptions::disableMarkdownV2Escaping()` method was introduced in Symfony 8.2.
+
+When the parse mode is not set or is `MarkdownV2`, the transport escapes the
+special characters that do not come in pairs, such as `.`, `!` and `-`, before
+sending the message. This lets plain text through, while paired markup such as
+`*bold*`, `_italic_` and `` `code` `` is kept as written. The escaped characters
+include `>`, `|` and `~`, which prevents using block quotations, spoilers and
+strikethrough.
+
+Call `disableMarkdownV2Escaping()` to send the message text exactly as written.
+The text must then be valid MarkdownV2, so any special character that is not
+part of the markup must be escaped by hand.
+
+```php
+use Symfony\Component\Notifier\Bridge\Telegram\TelegramOptions;
+use Symfony\Component\Notifier\Message\ChatMessage;
+
+$chatMessage = new ChatMessage(">Quoted text\n||Spoiler||\n~Strikethrough~\nVersion 1\\.2");
+
+$telegramOptions = (new TelegramOptions())
+    ->chatId('@symfonynotifierdev')
+    ->parseMode(TelegramOptions::PARSE_MODE_MARKDOWN_V2)
+    ->disableMarkdownV2Escaping();
+
+$chatMessage->options($telegramOptions);
+
+$chatter->send($chatMessage);
+```
+
 Adding files to a Message
 -------------------------
 

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramOptions.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramOptions.php
@@ -68,6 +68,13 @@ final class TelegramOptions implements MessageOptionsInterface
         return $this;
     }
 
+    public function disableMarkdownV2Escaping(bool $bool = true): static
+    {
+        $this->options['disable_markdown_v2_escaping'] = $bool;
+
+        return $this;
+    }
+
     /**
      * @return $this
      */

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramTransport.php
@@ -96,8 +96,9 @@ final class TelegramTransport extends AbstractTransport
         $options['chat_id'] ??= $message->getRecipientId() ?: $this->chatChannel;
         $text = $message->getSubject();
 
-        if (!isset($options['parse_mode']) || TelegramOptions::PARSE_MODE_MARKDOWN_V2 === $options['parse_mode']) {
-            $options['parse_mode'] = TelegramOptions::PARSE_MODE_MARKDOWN_V2;
+        $options['parse_mode'] ??= TelegramOptions::PARSE_MODE_MARKDOWN_V2;
+
+        if (TelegramOptions::PARSE_MODE_MARKDOWN_V2 === $options['parse_mode'] && empty($options['disable_markdown_v2_escaping'])) {
             /*
              * Just replace the obvious chars according to Telegram documentation.
              * Do not try to find pairs or replace chars, that occur in pairs like
@@ -113,6 +114,7 @@ final class TelegramTransport extends AbstractTransport
              */
             $text = preg_replace('/([.!#>+-=|{}~])/', '\\\\$1', $text);
         }
+        unset($options['disable_markdown_v2_escaping']);
 
         if (isset($options['upload'])) {
             foreach ($options['upload'] as $option => $path) {

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/Tests/TelegramOptionsTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/Tests/TelegramOptionsTest.php
@@ -124,6 +124,18 @@ final class TelegramOptionsTest extends TestCase
         $this->assertSame('123456', $options->getRecipientId());
     }
 
+    public function testDisableMarkdownV2Escaping()
+    {
+        $options = new TelegramOptions();
+
+        $this->assertSame($options, $options->disableMarkdownV2Escaping());
+        $this->assertSame(['disable_markdown_v2_escaping' => true], $options->toArray());
+
+        $options->disableMarkdownV2Escaping(false);
+
+        $this->assertSame(['disable_markdown_v2_escaping' => false], $options->toArray());
+    }
+
     public function testParseModeConstants()
     {
         $this->assertSame('HTML', TelegramOptions::PARSE_MODE_HTML);

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/Tests/TelegramTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/Tests/TelegramTransportTest.php
@@ -487,6 +487,53 @@ final class TelegramTransportTest extends TransportTestCase
         $transport->send(new ChatMessage('I contain special characters _ * [ ] ( ) ~ ` > # + - = | { } . ! \\ to send.'));
     }
 
+    public function testSendWithMarkdownV2EscapingDisabledSendsTextAsIs()
+    {
+        $text = "*Bold*\n>Quote\n||Spoiler||\n~Strike~\nVersion 1\\.2\\.3\\!";
+        $expectedBody = [
+            'chat_id' => 'testChannel',
+            'text' => $text,
+            'parse_mode' => 'MarkdownV2',
+        ];
+
+        $client = new MockHttpClient(function (string $method, string $url, array $options = []) use ($expectedBody): ResponseInterface {
+            $this->assertEqualsCanonicalizing($expectedBody, json_decode($options['body'], true));
+
+            return new JsonMockResponse(['ok' => true, 'result' => ['message_id' => 1]]);
+        });
+
+        $transport = self::createTransport($client, 'testChannel');
+        $options = (new TelegramOptions())
+            ->parseMode(TelegramOptions::PARSE_MODE_MARKDOWN_V2)
+            ->disableMarkdownV2Escaping();
+
+        $sentMessage = $transport->send(new ChatMessage($text, $options));
+
+        $this->assertSame('1', $sentMessage->getMessageId());
+    }
+
+    public function testSendWithMarkdownV2EscapingExplicitlyEnabledEscapesText()
+    {
+        $expectedBody = [
+            'chat_id' => 'testChannel',
+            'text' => '\>Quote \|\|Spoiler\|\| \~Strike\~',
+            'parse_mode' => 'MarkdownV2',
+        ];
+
+        $client = new MockHttpClient(function (string $method, string $url, array $options = []) use ($expectedBody): ResponseInterface {
+            $this->assertEqualsCanonicalizing($expectedBody, json_decode($options['body'], true));
+
+            return new JsonMockResponse(['ok' => true, 'result' => ['message_id' => 1]]);
+        });
+
+        $transport = self::createTransport($client, 'testChannel');
+        $options = (new TelegramOptions())->disableMarkdownV2Escaping(false);
+
+        $sentMessage = $transport->send(new ChatMessage('>Quote ||Spoiler|| ~Strike~', $options));
+
+        $this->assertSame('1', $sentMessage->getMessageId());
+    }
+
     /**
      * @return array<array<string, array{messageOptions: TelegramOptions, endpoint: string, expectedBody: array<mixed>, responseContent: array<mixed>}>>
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #65626
| License       | MIT

When the parse mode is not set or is `MarkdownV2`, `TelegramTransport` escapes the characters `. ! # > + - = | { } ~` in the message text before sending it. This makes plain text work without any care from the caller. But `>`, `||` and `~` are MarkdownV2 markup (block quotation, spoiler, strikethrough), so these three formats cannot be used at all. Text that is already escaped by hand breaks too: `1\.2` is turned into `1\\.2`, which Telegram rejects as an unescaped `.` after a literal backslash.

This PR adds `TelegramOptions::disableMarkdownV2Escaping(bool $bool = true)`. When it is set, the transport sends the message text exactly as written. The text must then be valid MarkdownV2, including the escaping of the special characters that are not part of the markup. The default behavior is unchanged. The option is consumed by the transport and is not sent to the Telegram API. It has no effect with the `HTML` and `Markdown` parse modes, which are never escaped.

```php
use Symfony\Component\Notifier\Bridge\Telegram\TelegramOptions;
use Symfony\Component\Notifier\Message\ChatMessage;

$options = (new TelegramOptions())
    ->parseMode(TelegramOptions::PARSE_MODE_MARKDOWN_V2)
    ->disableMarkdownV2Escaping();

$chatter->send(new ChatMessage(">Quote\n||Spoiler||\n~Strikethrough~\nVersion 1\\.2", $options));
```

Why an opt-out rather than a change of the escaped set: the set was already reshaped twice as a bug fix (#42721, #58636), and each change broke messages that relied on the previous behavior. Removing `>`, `|` and `~` from it would make a plain `a > b` or `~5 min` fail with a 400 from Telegram after a patch release, and the same change would be needed again for every syntax Telegram adds (block quotations and spoilers were added to the Bot API after the escaping was written). The transport cannot tell markup from plain text; with this option, the caller decides.

Alternatives with the existing API, checked before adding the method:

- `parseMode('markdownv2')` in lowercase, reported as a workaround in #51330, skips the escaping only because the transport compares the mode case-sensitively. It relies on an implementation detail and on Telegram accepting the value regardless of case.
- `parseMode(TelegramOptions::PARSE_MODE_HTML)` supports `<blockquote>`, `<tg-spoiler>` and `<s>` and is never escaped, but it does not help anyone who writes MarkdownV2.

Checks run:

- `./phpunit src/Symfony/Component/Notifier/Bridge/Telegram`: OK (101 tests, 221 assertions).
- Revert-verify: with the source changes reverted and the new tests kept, the 3 new tests error on the undefined method. With only the `TelegramOptions` method present, the two transport tests fail on the escaped text and on the option leaking into the request body.
- `php-cs-fixer fix --dry-run` on the touched files: clean.

Not covered: no call to the real Telegram API was made.

For the documentation: the README of the bridge gets a section in this PR. `notifier.rst` has nothing on Telegram escaping today; it should get the same points: the default escaping and its character set, `disableMarkdownV2Escaping()`, and the rule that the text must then be valid MarkdownV2.
