### PR TITLE
[Notifier] Fix escaping of MarkdownV2 markup in TelegramTransport

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramTransport.php
@@ -90,19 +90,14 @@ final class TelegramTransport extends AbstractTransport
         if (!isset($options['parse_mode']) || TelegramOptions::PARSE_MODE_MARKDOWN_V2 === $options['parse_mode']) {
             $options['parse_mode'] = TelegramOptions::PARSE_MODE_MARKDOWN_V2;
             /*
-             * Just replace the obvious chars according to Telegram documentation.
-             * Do not try to find pairs or replace chars, that occur in pairs like
-             *  - *bold text*
-             *  - _italic text_
-             *  - __underlined text__
-             *  - various notations of images, f. ex. [title](url)
-             *  - `code samples`.
-             *
-             * These formats should be taken care of when the message is constructed.
+             * Escape the reserved characters that Telegram would reject and leave the markup alone:
+             * paired markers (*bold*, _italic_, `code`, ~strikethrough~, ||spoiler||, [link](url)),
+             * block quotations (">" at the start of a line) and custom emojis ("![").
+             * Characters that are already escaped are kept as they are.
              *
              * @see https://core.telegram.org/bots/api#markdownv2-style
              */
-            $text = preg_replace('/([.!#>+-=|{}~])/', '\\\\$1', $text);
+            $text = preg_replace_callback('/\\\\[\x01-\x7E]|\|\||^(?:\*\*)?>|!\[|([.!#+\-=|{}>])/m', static fn (array $m) => isset($m[1]) ? '\\'.$m[1] : $m[0], $text);
         }
 
         if (isset($options['upload'])) {

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/Tests/TelegramTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/Tests/TelegramTransportTest.php
@@ -250,7 +250,7 @@ final class TelegramTransportTest extends TransportTestCase
 
         $expectedBody = [
             'chat_id' => 'testChannel',
-            'text' => 'I contain special characters _ * [ ] ( ) \~ ` \> \# \+ \- \= \| \{ \} \. \! \ to send\.',
+            'text' => 'I contain special characters _ * [ ] ( ) ~ ` \> \# \+ \- \= \| \{ \} \. \! \ to send\.',
             'parse_mode' => 'MarkdownV2',
         ];
 
@@ -263,6 +263,32 @@ final class TelegramTransportTest extends TransportTestCase
         $transport = self::createTransport($client, 'testChannel');
 
         $transport->send(new ChatMessage('I contain special characters _ * [ ] ( ) ~ ` > # + - = | { } . ! \\ to send.'));
+    }
+
+    public function testSendWithMarkdownEscapesReservedCharactersButNotMarkup()
+    {
+        $cases = [
+            'plain text' => ['Hello world. Cost: 10 EUR!', 'Hello world\. Cost: 10 EUR\!'],
+            'digits and unreserved punctuation' => ['v1.2.3 at 10:30, a/b; x<y', 'v1\.2\.3 at 10:30, a/b; x<y'],
+            'already escaped' => ['Version 1\.2 and \\\\.', 'Version 1\.2 and \\\\\.'],
+            'paired markup' => ['*bold* _italic_ __underline__ `code` ~strike~ ||spoiler|| [link](https://symfony.com/)', '*bold* _italic_ __underline__ `code` ~strike~ ||spoiler|| [link](https://symfony\.com/)'],
+            'block quotation' => [">Quote\n>More\n**>Expandable\n>Last line||", ">Quote\n>More\n**>Expandable\n>Last line||"],
+            'reserved characters outside markup' => ['a > b, a | b, a ! b, **> c', 'a \> b, a \| b, a \! b, **\> c'],
+            'custom emoji' => ['![👍](tg://emoji?id=5368324170671202286)', '![👍](tg://emoji?id\=5368324170671202286)'],
+        ];
+
+        foreach ($cases as $case => [$subject, $expectedText]) {
+            $sentText = null;
+            $client = new MockHttpClient(static function (string $method, string $url, array $options = []) use (&$sentText): ResponseInterface {
+                $sentText = json_decode($options['body'], true)['text'];
+
+                return new JsonMockResponse(['ok' => true, 'result' => ['message_id' => 1]]);
+            });
+
+            self::createTransport($client, 'testChannel')->send(new ChatMessage($subject));
+
+            $this->assertSame($expectedText, $sentText, $case);
+        }
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65626
| License       | MIT

When the parse mode is not set or is `MarkdownV2`, `TelegramTransport` escapes reserved characters in the message text before sending it. The list of characters it escapes was adjusted by hand three times (#41600, #42721, #58636) and still contains three markup markers of MarkdownV2: `~` (strikethrough), `|` (`||spoiler||`) and `>` (block quotation). These formats cannot be used at all. Text that is already escaped by hand is escaped a second time (`1\.2` becomes `1\\.2`), which Telegram rejects.

This PR replaces the character list with the rule that Telegram's own parser applies: a reserved character is escaped when Telegram would reject it, and the markup is left alone.

- Paired markers are never escaped: `*bold*`, `_italic_`, `__underline__`, `` `code` ``, `~strikethrough~`, `||spoiler||`, `[link](url)`. The first five were already left alone since #58636; `~` and `||` now follow the same rule.
- `>` is left alone at the start of a line, where it starts a block quotation, including the `**>` form of expandable quotations. It is escaped anywhere else.
- `!` is left alone in front of `[`, where it starts a custom emoji or a date-time entity. It is escaped anywhere else.
- A character that is already escaped is kept as it is, so a message written as valid MarkdownV2 is sent unchanged.
- `.`, `#`, `+`, `-`, `=`, `{`, `}` and a single `|` are escaped as before.

It also fixes the character class of the old pattern: `+-=` was read as a range from `+` to `=`, so digits, `,`, `/`, `:`, `;` and `<` were escaped too. Telegram accepts a backslash in front of any of them, so nothing was visible in the chat, but every digit counted twice towards the 4096-character limit.

Behavior change for plain-text senders: a message with an unescaped `~` or `||`, or a line starting with `>`, is now sent as markup, the same way `*` and `_` are since #58636. Plain text is sent as before when these characters are escaped in the message, or with the `HTML` parse mode.

Checks run:

- `./phpunit src/Symfony/Component/Notifier/Bridge/Telegram` on 6.4: OK, 70 tests, 161 assertions, 1 skipped (pre-existing).
- Before the fix, the new case table fails on its first case and the existing escaping test fails on `\~`; both pass after it.
- `php-cs-fixer fix --dry-run` on the touched files: clean.

Not covered: no call to the real Telegram API was made. The rules follow the MarkdownV2 section of the Bot API documentation.

Replaces #65643.
