### PR TITLE
[Validator] Review Bulgarian (bg) translations

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.bg.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.bg.xlf
@@ -568,15 +568,15 @@
             </trans-unit>
             <trans-unit id="146">
                 <source>This value is not a valid cron expression.</source>
-                <target state="needs-review-translation">Тази стойност не е валиден cron израз.</target>
+                <target>Тази стойност не е валиден cron израз.</target>
             </trans-unit>
             <trans-unit id="147">
                 <source>The referenced entity does not exist.</source>
-                <target state="needs-review-translation">Обектът, към който се препраща, не съществува.</target>
+                <target>Обектът, към който се препраща, не съществува.</target>
             </trans-unit>
             <trans-unit id="148" resname="This is not a valid ULID.">
                 <source>This value is not a valid ULID.</source>
-                <target state="needs-review-translation">Стойността не е валиден ULID.</target>
+                <target>Стойността не е валиден ULID.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64678
| License       | MIT

I am a native Bulgarian speaker and reviewed the three translations reported in #64678 .

The existing translations are correct and match the style of the Bulgarian catalog, so this PR only removes the `needs-review-translation` markers.

For unit 147, `Обектът, към който се препраща, не съществува.` could also be written as `Посоченият обект не съществува.`, which sounds slightly more natural in Bulgarian. However, the current translation is grammatically correct and accurately conveys the original meaning, so I kept it unchanged instead of making a purely stylistic change.

Tests:
- `./phpunit src/Symfony/Component/Validator/Tests/Resources/TranslationFilesTest.php`
- `php src/Symfony/Component/Translation/Resources/bin/translation-status.php -v`
- `php .github/sync-translations.php`