### PR TITLE
[Serializer] Fix max depth counting for subclasses that inherit MaxDepth metadata

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -762,7 +762,18 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
             return false;
         }
 
-        $key = \sprintf(self::DEPTH_KEY_PATTERN, $class, $attribute);
+        $keyClass = $class;
+        if ($this->classMetadataFactory) {
+            while (false !== $parent = get_parent_class($keyClass)) {
+                $parentAttributes = $this->classMetadataFactory->getMetadataFor($parent)->getAttributesMetadata();
+                if (($parentAttributes[$attribute] ?? null)?->getMaxDepth() !== $maxDepth) {
+                    break;
+                }
+                $keyClass = $parent;
+            }
+        }
+
+        $key = \sprintf(self::DEPTH_KEY_PATTERN, $keyClass, $attribute);
         if (!isset($context[$key])) {
             $context[$key] = 1;
 

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/MaxDepthRecursiveDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/MaxDepthRecursiveDummy.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures\Attributes;
+
+use Symfony\Component\Serializer\Attribute\MaxDepth;
+
+class MaxDepthRecursiveDummy
+{
+    public $name;
+
+    #[MaxDepth(1)]
+    public $linked;
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function getLinked()
+    {
+        return $this->linked;
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/MaxDepthRecursiveDummyProxy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/MaxDepthRecursiveDummyProxy.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures\Attributes;
+
+class MaxDepthRecursiveDummyProxy extends MaxDepthRecursiveDummy
+{
+}

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/Features/MaxDepthTestTrait.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/Features/MaxDepthTestTrait.php
@@ -13,6 +13,8 @@ namespace Symfony\Component\Serializer\Tests\Normalizer\Features;
 
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\Tests\Fixtures\Attributes\MaxDepthDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\Attributes\MaxDepthRecursiveDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\Attributes\MaxDepthRecursiveDummyProxy;
 
 /**
  * Covers AbstractObjectNormalizer::ENABLE_MAX_DEPTH and AbstractObjectNormalizer::MAX_DEPTH_HANDLER.
@@ -58,6 +60,31 @@ trait MaxDepthTestTrait
         ];
 
         $this->assertEquals($expected, $result);
+    }
+
+    public function testMaxDepthWithSubclassInheritingMetadata()
+    {
+        $normalizer = $this->getNormalizerForMaxDepth();
+
+        $level1 = new MaxDepthRecursiveDummy();
+        $level1->name = 'level1';
+
+        $level2 = new MaxDepthRecursiveDummyProxy();
+        $level2->name = 'level2';
+        $level1->linked = $level2;
+
+        $level3 = new MaxDepthRecursiveDummy();
+        $level3->name = 'level3';
+        $level2->linked = $level3;
+
+        $result = $normalizer->normalize($level1, null, ['enable_max_depth' => true]);
+
+        $this->assertEquals([
+            'name' => 'level1',
+            'linked' => [
+                'name' => 'level2',
+            ],
+        ], $result);
     }
 
     public function testMaxDepthHandler()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #58526
| License       | MIT

`MaxDepth` is counted per runtime class name. A Doctrine proxy is a subclass of the entity, so it gets its own counter. With `max_depth: 1`, a graph of entity → proxy → entity is serialized two levels deep instead of one.

The depth key now uses the parent class when that parent declares the same `MaxDepth` value. A proxy and its entity then share one counter.

```php
$a = new Dossier();
$b = new DossierProxy(); // subclass, same MaxDepth metadata
$c = new Dossier();
$a->linkedDossiers = $b;
$b->linkedDossiers = $c;

$normalizer->normalize($a, null, ['enable_max_depth' => true]);
// before: A → B → C
// after:  A → B
