### PR TITLE
[Validator] Remove needs-review-translation state from Spanish translations

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.es.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.es.xlf
@@ -572,11 +572,11 @@
             </trans-unit>
             <trans-unit id="147">
                 <source>The referenced entity does not exist.</source>
-                <target state="needs-review-translation">La entidad referenciada no existe.</target>
+                <target>La entidad referenciada no existe.</target>
             </trans-unit>
             <trans-unit id="148" resname="This is not a valid ULID.">
                 <source>This value is not a valid ULID.</source>
-                <target state="needs-review-translation">Este valor no es un ULID válido.</target>
+                <target>Este valor no es un ULID válido.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65564
| License       | MIT

As a native Spanish (es) speaker, I reviewed the two pending translations in `validators.es.xlf` and confirm they are correct, so I removed their `needs-review-translation` state:

- id 147: `The referenced entity does not exist.` → `La entidad referenciada no existe.`
- id 148: `This value is not a valid ULID.` → `Este valor no es un ULID válido.`

Both follow the existing style and tone of the file. In particular, id 148 mirrors the already approved id 83 (`This value is not a valid UUID.` → `Este valor no es un UUID válido.`), and both are consistent with the already reviewed `pt_BR` and `fr` translations of the same units.

No translated text was changed, only the review state.
