### PR TITLE
[Security] Apply "signature_properties" when a remember-me token provider is used

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RememberMeFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RememberMeFactory.php
@@ -61,6 +61,10 @@ class RememberMeFactory implements AuthenticatorFactoryInterface, PrependExtensi
             throw new InvalidConfigurationException(\sprintf('You cannot use both "service" and "token_provider" in "security.firewalls.%s.remember_me".', $firewallName));
         }
 
+        if (isset($config['service']) && $config['signature_properties']) {
+            throw new InvalidConfigurationException(\sprintf('You cannot use both "service" and "signature_properties" in "security.firewalls.%s.remember_me" because the custom handler signs the cookies itself and the option would have no effect.', $firewallName));
+        }
+
         if (isset($config['service'])) {
             $container->register($rememberMeHandlerId, DecoratedRememberMeHandler::class)
                 ->addArgument(new Reference($config['service']))
@@ -73,11 +77,12 @@ class RememberMeFactory implements AuthenticatorFactoryInterface, PrependExtensi
                 ->replaceArgument(1, new Reference($userProviderId))
                 ->replaceArgument(3, $config)
                 ->replaceArgument(5, $tokenVerifier)
+                ->replaceArgument(6, $config['signature_properties'] ?: null)
                 ->addTag('security.remember_me_handler', ['firewall' => $firewallName]);
         } else {
             $signatureHasherId = 'security.authenticator.remember_me_signature_hasher.'.$firewallName;
             $container->setDefinition($signatureHasherId, new ChildDefinition('security.authenticator.remember_me_signature_hasher'))
-                ->replaceArgument(1, $config['signature_properties'])
+                ->replaceArgument(1, $config['signature_properties'] ?: ['password'])
                 ->replaceArgument(2, $config['secret'])
             ;
 
@@ -146,9 +151,8 @@ class RememberMeFactory implements AuthenticatorFactoryInterface, PrependExtensi
             ->arrayNode('signature_properties')
                 ->prototype('scalar')->end()
                 ->requiresAtLeastOneElement()
-                ->info('An array of properties on your User that are used to sign the remember-me cookie. If any of these change, all existing cookies will become invalid.')
+                ->info('An array of properties on your User. All existing cookies become invalid when one of them changes. Defaults to ["password"], which a "token_provider" skips when the user class does not expose it. A property listed here explicitly must exist on the user class. Cannot be combined with a custom "service".')
                 ->example(['email', 'password'])
-                ->defaultValue(['password'])
             ->end()
             ->arrayNode('token_provider')
                 ->beforeNormalization()

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator_remember_me.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator_remember_me.php
@@ -55,6 +55,8 @@ return static function (ContainerConfigurator $container) {
                 abstract_arg('options'),
                 service('logger')->nullOnInvalid(),
                 abstract_arg('token verifier'),
+                abstract_arg('signature properties'),
+                service('property_accessor')->nullOnInvalid(),
             ])
             ->tag('monolog.logger', ['channel' => 'security'])
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
@@ -692,6 +692,126 @@ class SecurityExtensionTest extends TestCase
         $this->assertSame('very', $handler->getArgument(2));
     }
 
+    public function testRememberMeSignaturePropertiesDefaultToPassword()
+    {
+        $container = $this->getRawContainer();
+
+        $container->loadFromExtension('security', [
+            'firewalls' => [
+                'default' => [
+                    'remember_me' => ['secret' => 'very'],
+                ],
+            ],
+        ]);
+
+        $container->compile();
+
+        $hasher = $container->getDefinition('security.authenticator.remember_me_signature_hasher.default');
+        $this->assertSame(['password'], $hasher->getArgument(1));
+    }
+
+    public function testRememberMeSignaturePropertiesAreImplicitByDefaultWithATokenProvider()
+    {
+        $container = $this->getRawContainer();
+
+        $container->register('custom_token_provider', \stdClass::class);
+        $container->loadFromExtension('security', [
+            'firewalls' => [
+                'default' => [
+                    'remember_me' => ['token_provider' => 'custom_token_provider'],
+                ],
+            ],
+        ]);
+
+        $container->compile();
+
+        $handler = $container->getDefinition('security.authenticator.remember_me_handler.default');
+        $this->assertNull($handler->getArgument(6));
+    }
+
+    public function testRememberMeSignaturePropertiesAreBoundToTokensWhenConfigured()
+    {
+        $container = $this->getRawContainer();
+
+        $container->register('custom_token_provider', \stdClass::class);
+        $container->loadFromExtension('security', [
+            'firewalls' => [
+                'default' => [
+                    'remember_me' => [
+                        'token_provider' => 'custom_token_provider',
+                        'signature_properties' => ['email', 'password'],
+                    ],
+                ],
+            ],
+        ]);
+
+        $container->compile();
+
+        $handler = $container->getDefinition('security.authenticator.remember_me_handler.default');
+        $this->assertSame(['email', 'password'], $handler->getArgument(6));
+    }
+
+    public function testRememberMeSignaturePropertiesCannotBeUsedWithACustomHandler()
+    {
+        $container = $this->getRawContainer();
+
+        $container->register('custom_remember_me', \stdClass::class);
+        $container->loadFromExtension('security', [
+            'firewalls' => [
+                'default' => [
+                    'remember_me' => [
+                        'service' => 'custom_remember_me',
+                        'signature_properties' => ['password'],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('You cannot use both "service" and "signature_properties" in "security.firewalls.default.remember_me" because the custom handler signs the cookies itself and the option would have no effect.');
+        $container->compile();
+    }
+
+    public function testCustomRememberMeHandlerWithATokenProviderReportsTheTokenProviderConflict()
+    {
+        $container = $this->getRawContainer();
+
+        $container->register('custom_remember_me', \stdClass::class);
+        $container->register('custom_token_provider', \stdClass::class);
+        $container->loadFromExtension('security', [
+            'firewalls' => [
+                'default' => [
+                    'remember_me' => [
+                        'service' => 'custom_remember_me',
+                        'token_provider' => 'custom_token_provider',
+                        'signature_properties' => ['password'],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('You cannot use both "service" and "token_provider" in "security.firewalls.default.remember_me".');
+        $container->compile();
+    }
+
+    public function testRememberMeSignaturePropertiesCannotBeEmpty()
+    {
+        $container = $this->getRawContainer();
+
+        $container->loadFromExtension('security', [
+            'firewalls' => [
+                'default' => [
+                    'remember_me' => ['signature_properties' => []],
+                ],
+            ],
+        ]);
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('The path "security.firewalls.default.remember_me.signature_properties" should have at least 1 element(s) defined.');
+        $container->compile();
+    }
+
     public static function sessionConfigurationProvider(): array
     {
         return [

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/RememberMeTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/RememberMeTest.php
@@ -73,6 +73,34 @@ class RememberMeTest extends AbstractWebTestCase
         $this->assertRedirect($client->getResponse(), '/login');
     }
 
+    /**
+     * @dataProvider provideClearOnChangeConfigs
+     */
+    public function testUserChangeInvalidatesRememberMeCookie(string $rootConfig)
+    {
+        $client = $this->createClient(['test_case' => 'RememberMe', 'root_config' => $rootConfig]);
+
+        $client->request('POST', '/login', [
+            '_username' => 'johannes',
+            '_password' => 'test',
+        ]);
+
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
+        $cookieJar = $client->getCookieJar();
+        $this->assertNotNull($cookieJar->get('REMEMBERME'));
+
+        // clear the session, only the remember-me cookie is left to authenticate
+        $cookieJar->expire('MOCKSESSID');
+
+        UserChangingUserProvider::$changePassword = true;
+
+        $client->request('GET', '/profile');
+        $this->assertRedirect($client->getResponse(), '/login');
+
+        // the failed login clears the cookie, which is what deletes the token
+        $this->assertNull($cookieJar->get('REMEMBERME'));
+    }
+
     public function testSessionLessRememberMeLogout()
     {
         $client = $this->createClient(['test_case' => 'RememberMe', 'root_config' => 'stateless_config.yml']);
@@ -97,5 +125,12 @@ class RememberMeTest extends AbstractWebTestCase
     {
         yield [['root_config' => 'config_session.yml']];
         yield [['root_config' => 'config_persistent.yml']];
+    }
+
+    public static function provideClearOnChangeConfigs(): iterable
+    {
+        yield ['clear_on_change_config.yml'];
+        yield ['clear_on_change_persistent_config.yml'];
+        yield ['clear_on_change_explicit_persistent_config.yml'];
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/RememberMe/clear_on_change_explicit_persistent_config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/RememberMe/clear_on_change_explicit_persistent_config.yml
@@ -1,0 +1,8 @@
+imports:
+    - { resource: ./clear_on_change_persistent_config.yml }
+
+security:
+    firewalls:
+        default:
+            remember_me:
+                signature_properties: [password]

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/RememberMe/clear_on_change_persistent_config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/RememberMe/clear_on_change_persistent_config.yml
@@ -1,0 +1,9 @@
+imports:
+    - { resource: ./config.yml }
+    - { resource: ./config_persistent.yml }
+
+services:
+    Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\RememberMeBundle\Security\UserChangingUserProvider:
+        public: true
+        decorates: security.user.provider.concrete.in_memory
+        arguments: ['@.inner']

--- a/src/Symfony/Component/Security/Http/RememberMe/PersistentRememberMeHandler.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/PersistentRememberMeHandler.php
@@ -13,7 +13,10 @@ namespace Symfony\Component\Security\Http\RememberMe;
 
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\Security\Core\Authentication\RememberMe\PersistentToken;
+use Symfony\Component\Security\Core\Authentication\RememberMe\PersistentTokenInterface;
 use Symfony\Component\Security\Core\Authentication\RememberMe\TokenProviderInterface;
 use Symfony\Component\Security\Core\Authentication\RememberMe\TokenVerifierInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
@@ -32,17 +35,31 @@ use Symfony\Component\Security\Core\User\UserProviderInterface;
  */
 final class PersistentRememberMeHandler extends AbstractRememberMeHandler
 {
+    /**
+     * Marks a stored token value as bound to the signature properties of the user.
+     *
+     * Base64 encoded values never start with this character, which tells bound
+     * values apart from the ones stored before the properties were bound.
+     */
+    private const SIGNATURE_MARKER = '~';
+
     private TokenProviderInterface $tokenProvider;
     private ?TokenVerifierInterface $tokenVerifier;
+    private UserProviderInterface $userProvider;
+    private ?array $signatureProperties;
+    private PropertyAccessorInterface $propertyAccessor;
 
     /**
-     * @param UserProviderInterface       $userProvider
-     * @param RequestStack                $requestStack
-     * @param array                       $options
-     * @param LoggerInterface|null        $logger
-     * @param TokenVerifierInterface|null $tokenVerifier
+     * @param UserProviderInterface          $userProvider
+     * @param RequestStack                   $requestStack
+     * @param array                          $options
+     * @param LoggerInterface|null           $logger
+     * @param TokenVerifierInterface|null    $tokenVerifier
+     * @param array|null                     $signatureProperties Properties of the User; the stored token is invalidated when these properties change.
+     *                                                            Defaults to ["password"], with the properties the user does not expose being skipped
+     * @param PropertyAccessorInterface|null $propertyAccessor
      */
-    public function __construct(TokenProviderInterface $tokenProvider, #[\SensitiveParameter] $userProvider, $requestStack, $options, $logger = null, $tokenVerifier = null)
+    public function __construct(TokenProviderInterface $tokenProvider, #[\SensitiveParameter] $userProvider, $requestStack, $options, $logger = null, $tokenVerifier = null, $signatureProperties = null, $propertyAccessor = null)
     {
         if (\is_string($userProvider)) {
             trigger_deprecation('symfony/security-http', '6.3', 'Calling "%s()" with the secret as the second argument is deprecated. The argument will be dropped in 7.0.', __CLASS__);
@@ -52,6 +69,8 @@ final class PersistentRememberMeHandler extends AbstractRememberMeHandler
             $options = $logger;
             $logger = $tokenVerifier;
             $tokenVerifier = \func_num_args() > 6 ? func_get_arg(6) : null;
+            $signatureProperties = \func_num_args() > 7 ? func_get_arg(7) : null;
+            $propertyAccessor = \func_num_args() > 8 ? func_get_arg(8) : null;
         }
 
         if (!$userProvider instanceof UserProviderInterface) {
@@ -74,6 +93,14 @@ final class PersistentRememberMeHandler extends AbstractRememberMeHandler
             throw new \TypeError(\sprintf('Argument 6 passed to "%s()" must be an instance of "%s", "%s" given.', __CLASS__, TokenVerifierInterface::class, get_debug_type($userProvider)));
         }
 
+        if (null !== $signatureProperties && !\is_array($signatureProperties)) {
+            throw new \TypeError(\sprintf('Argument 7 passed to "%s()" must be an array, "%s" given.', __CLASS__, get_debug_type($signatureProperties)));
+        }
+
+        if (null !== $propertyAccessor && !$propertyAccessor instanceof PropertyAccessorInterface) {
+            throw new \TypeError(\sprintf('Argument 8 passed to "%s()" must be an instance of "%s", "%s" given.', __CLASS__, PropertyAccessorInterface::class, get_debug_type($propertyAccessor)));
+        }
+
         parent::__construct($userProvider, $requestStack, $options, $logger);
 
         if (!$tokenVerifier && $tokenProvider instanceof TokenVerifierInterface) {
@@ -81,6 +108,9 @@ final class PersistentRememberMeHandler extends AbstractRememberMeHandler
         }
         $this->tokenProvider = $tokenProvider;
         $this->tokenVerifier = $tokenVerifier;
+        $this->userProvider = $userProvider;
+        $this->signatureProperties = $signatureProperties;
+        $this->propertyAccessor = $propertyAccessor ?? PropertyAccess::createPropertyAccessor();
     }
 
     public function createRememberMeCookie(UserInterface $user): void
@@ -88,12 +118,17 @@ final class PersistentRememberMeHandler extends AbstractRememberMeHandler
         $series = random_bytes(66);
         $tokenValue = strtr(base64_encode(substr($series, 33)), '+/=', '-_~');
         $series = strtr(base64_encode(substr($series, 0, 33)), '+/=', '-_~');
-        $token = new PersistentToken($user::class, $user->getUserIdentifier(), $series, $tokenValue, new \DateTimeImmutable());
+        $token = new PersistentToken($user::class, $user->getUserIdentifier(), $series, $this->hashTokenValue($tokenValue, $user), new \DateTimeImmutable());
 
         $this->tokenProvider->createNewToken($token);
-        $this->createCookie(RememberMeDetails::fromPersistentToken($token, time() + $this->options['lifetime']));
+        $this->createCookie(new RememberMeDetails($user::class, $user->getUserIdentifier(), time() + $this->options['lifetime'], $series.':'.$tokenValue));
     }
 
+    /**
+     * This does not call the parent method: checking the signature properties requires the user, and the
+     * user is loaded from the identifier of the persistent token rather than from the untrusted cookie,
+     * which also keeps the number of user lookups to one.
+     */
     public function consumeRememberMeCookie(RememberMeDetails $rememberMeDetails): UserInterface
     {
         if (!str_contains($rememberMeDetails->getValue(), ':')) {
@@ -110,12 +145,18 @@ final class PersistentRememberMeHandler extends AbstractRememberMeHandler
         // content of $rememberMeDetails is not trustable. this prevents use of this class
         unset($rememberMeDetails);
 
-        if ($this->tokenVerifier) {
-            $isTokenValid = $this->tokenVerifier->verifyToken($persistentToken, $tokenValue);
-        } else {
-            $isTokenValid = hash_equals($persistentToken->getTokenValue(), $tokenValue);
+        $user = $this->userProvider->loadUserByIdentifier($persistentToken->getUserIdentifier());
+
+        if (!$user instanceof UserInterface) {
+            throw new \LogicException(\sprintf('The UserProviderInterface implementation must return an instance of UserInterface, but returned "%s".', get_debug_type($user)));
         }
-        if (!$isTokenValid) {
+
+        $storedTokenValue = $this->hashTokenValue($tokenValue, $user);
+
+        // a token stored before the signature properties were bound to it is accepted once, then bound
+        $bindToken = $storedTokenValue !== $tokenValue && !str_starts_with($persistentToken->getTokenValue(), self::SIGNATURE_MARKER);
+
+        if (!$this->verifyTokenValue($persistentToken, $bindToken ? $tokenValue : $storedTokenValue)) {
             throw new CookieTheftException('This token was already used. The account is possibly compromised.');
         }
 
@@ -124,12 +165,21 @@ final class PersistentRememberMeHandler extends AbstractRememberMeHandler
             throw new AuthenticationException('The cookie has expired.');
         }
 
-        return parent::consumeRememberMeCookie(new RememberMeDetails(
+        // when the token is about to be regenerated, binding it here would be a needless extra write
+        if ($bindToken && $this->isTokenFresh($persistentToken)) {
+            $this->tokenProvider->updateToken($series, $storedTokenValue, \DateTime::createFromInterface($persistentToken->getLastUsed()));
+        }
+
+        $this->processRememberMe(new RememberMeDetails(
             $persistentToken->getClass(),
             $persistentToken->getUserIdentifier(),
             $expires,
-            $persistentToken->getLastUsed()->getTimestamp().':'.$series.':'.$tokenValue.':'.$persistentToken->getClass()
-        ));
+            $persistentToken->getLastUsed()->getTimestamp().':'.$series.':'.$storedTokenValue.':'.$persistentToken->getClass()
+        ), $user);
+
+        $this->logger?->info('Remember-me cookie accepted.');
+
+        return $user;
     }
 
     public function processRememberMe(RememberMeDetails $rememberMeDetails, UserInterface $user): void
@@ -137,16 +187,15 @@ final class PersistentRememberMeHandler extends AbstractRememberMeHandler
         [$lastUsed, $series, $tokenValue, $class] = explode(':', $rememberMeDetails->getValue(), 4);
         $persistentToken = new PersistentToken($class, $rememberMeDetails->getUserIdentifier(), $series, $tokenValue, new \DateTimeImmutable('@'.$lastUsed));
 
-        // if a token was regenerated less than a minute ago, there is no need to regenerate it
-        // if multiple concurrent requests reauthenticate a user we do not want to update the token several times
-        if ($persistentToken->getLastUsed()->getTimestamp() + 60 >= time()) {
+        if ($this->isTokenFresh($persistentToken)) {
             return;
         }
 
         $tokenValue = strtr(base64_encode(random_bytes(33)), '+/=', '-_~');
+        $storedTokenValue = $this->hashTokenValue($tokenValue, $user);
         $tokenLastUsed = new \DateTime();
-        $this->tokenVerifier?->updateExistingToken($persistentToken, $tokenValue, $tokenLastUsed);
-        $this->tokenProvider->updateToken($series, $tokenValue, $tokenLastUsed);
+        $this->tokenVerifier?->updateExistingToken($persistentToken, $storedTokenValue, $tokenLastUsed);
+        $this->tokenProvider->updateToken($series, $storedTokenValue, $tokenLastUsed);
 
         $this->createCookie($rememberMeDetails->withValue($series.':'.$tokenValue));
     }
@@ -176,5 +225,65 @@ final class PersistentRememberMeHandler extends AbstractRememberMeHandler
     public function getTokenProvider(): TokenProviderInterface
     {
         return $this->tokenProvider;
+    }
+
+    /**
+     * A token regenerated less than a minute ago does not need to be regenerated again.
+     *
+     * This keeps concurrent requests that reauthenticate the same user from updating the token several times.
+     */
+    private function isTokenFresh(PersistentTokenInterface $persistentToken): bool
+    {
+        return $persistentToken->getLastUsed()->getTimestamp() + 60 >= time();
+    }
+
+    private function verifyTokenValue(PersistentTokenInterface $persistentToken, #[\SensitiveParameter] string $tokenValue): bool
+    {
+        if ($this->tokenVerifier) {
+            return $this->tokenVerifier->verifyToken($persistentToken, $tokenValue);
+        }
+
+        return hash_equals($persistentToken->getTokenValue(), $tokenValue);
+    }
+
+    /**
+     * Binds the signature properties of the user to the token value that is stored by the token provider.
+     *
+     * The cookie carries the plain token value only, so that the stored value cannot be replayed and
+     * changing one of the signature properties makes every token of that user unusable.
+     *
+     * Properties the user does not expose are skipped when the list was not configured explicitly. The
+     * token value is then returned unchanged, which is what keeps user classes without any of the default
+     * properties working as they did before the properties were bound.
+     */
+    private function hashTokenValue(#[\SensitiveParameter] string $tokenValue, UserInterface $user): string
+    {
+        $isDefaultList = null === $this->signatureProperties;
+        $signature = hash_init('sha256');
+        $isBound = false;
+
+        foreach ($this->signatureProperties ?? ['password'] as $property) {
+            if ($isDefaultList && !$this->propertyAccessor->isReadable($user, $property)) {
+                continue;
+            }
+
+            $value = $this->propertyAccessor->getValue($user, $property) ?? '';
+            if ($value instanceof \DateTimeInterface) {
+                $value = $value->format('c');
+            }
+
+            if (!\is_scalar($value) && !$value instanceof \Stringable) {
+                throw new \InvalidArgumentException(\sprintf('The property path "%s" on the user object "%s" must return a value that can be cast to a string, but "%s" was returned.', $property, $user::class, get_debug_type($value)));
+            }
+
+            hash_update($signature, ':'.base64_encode($value));
+            $isBound = true;
+        }
+
+        if (!$isBound) {
+            return $tokenValue;
+        }
+
+        return self::SIGNATURE_MARKER.strtr(base64_encode(hash('sha256', $tokenValue.'|'.hash_final($signature), true)), '+/=', '-_~');
     }
 }

--- a/src/Symfony/Component/Security/Http/Tests/Fixtures/PasswordlessUser.php
+++ b/src/Symfony/Component/Security/Http/Tests/Fixtures/PasswordlessUser.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Tests\Fixtures;
+
+use Symfony\Component\Security\Core\User\UserInterface;
+
+final class PasswordlessUser implements UserInterface
+{
+    public function __construct(
+        private string $identifier,
+        private string $email = '',
+    ) {
+    }
+
+    public function getEmail(): string
+    {
+        return $this->email;
+    }
+
+    public function getRoles(): array
+    {
+        return ['ROLE_USER'];
+    }
+
+    public function getUserIdentifier(): string
+    {
+        return $this->identifier;
+    }
+
+    public function eraseCredentials(): void
+    {
+    }
+}

--- a/src/Symfony/Component/Security/Http/Tests/RememberMe/PersistentRememberMeHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/RememberMe/PersistentRememberMeHandlerTest.php
@@ -12,20 +12,27 @@
 namespace Symfony\Component\Security\Http\Tests\RememberMe;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
+use Symfony\Component\Security\Core\Authentication\RememberMe\CacheTokenVerifier;
 use Symfony\Component\Security\Core\Authentication\RememberMe\InMemoryTokenProvider;
 use Symfony\Component\Security\Core\Authentication\RememberMe\PersistentToken;
 use Symfony\Component\Security\Core\Authentication\RememberMe\TokenProviderInterface;
 use Symfony\Component\Security\Core\Authentication\RememberMe\TokenVerifierInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Exception\CookieTheftException;
+use Symfony\Component\Security\Core\Exception\TokenNotFoundException;
 use Symfony\Component\Security\Core\User\InMemoryUser;
 use Symfony\Component\Security\Core\User\InMemoryUserProvider;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Symfony\Component\Security\Http\RememberMe\PersistentRememberMeHandler;
 use Symfony\Component\Security\Http\RememberMe\RememberMeDetails;
 use Symfony\Component\Security\Http\RememberMe\ResponseListener;
+use Symfony\Component\Security\Http\Tests\Fixtures\PasswordlessUser;
 
 class PersistentRememberMeHandlerTest extends TestCase
 {
@@ -33,6 +40,8 @@ class PersistentRememberMeHandlerTest extends TestCase
     private InMemoryUserProvider $userProvider;
     private RequestStack $requestStack;
     private Request $request;
+    private string $password;
+    private string $email;
 
     protected function setUp(): void
     {
@@ -42,6 +51,8 @@ class PersistentRememberMeHandlerTest extends TestCase
         $this->requestStack = new RequestStack();
         $this->request = Request::create('/login');
         $this->requestStack->push($this->request);
+        $this->password = 'p4ssw0rd';
+        $this->email = 'wouter@example.com';
     }
 
     public function testCreateRememberMeCookie()
@@ -217,5 +228,223 @@ class PersistentRememberMeHandlerTest extends TestCase
         $rememberMeDetails = new RememberMeDetails(InMemoryUser::class, 'wouter', 360, 'series1:tokenvalue');
         $rememberMeDetails = RememberMeDetails::fromRawCookie(base64_encode($rememberMeDetails->toString()));
         (new PersistentRememberMeHandler($tokenProvider, $this->userProvider, $this->requestStack, []))->consumeRememberMeCookie($rememberMeDetails);
+    }
+
+    public function testConsumeRememberMeCookieBindsThePasswordByDefault()
+    {
+        $handler = $this->createHandler(null, $this->createChangingUserProvider());
+        $handler->createRememberMeCookie(new InMemoryUser('wouter', $this->password));
+
+        [$series, $tokenValue] = $this->readCookieValue();
+
+        $this->assertNotSame($tokenValue, $this->tokenProvider->loadTokenBySeries($series)->getTokenValue());
+
+        $this->password = 'n3wp4ssw0rd';
+
+        $this->expectException(CookieTheftException::class);
+        $handler->consumeRememberMeCookie(new RememberMeDetails(InMemoryUser::class, 'wouter', 360, $series.':'.$tokenValue));
+    }
+
+    public function testConsumeRememberMeCookieSkipsThePasswordTheUserDoesNotExpose()
+    {
+        $handler = $this->createHandler(null, $this->createPasswordlessUserProvider());
+        $handler->createRememberMeCookie(new PasswordlessUser('wouter', $this->email));
+
+        [$series, $tokenValue] = $this->readCookieValue();
+
+        $this->assertSame($tokenValue, $this->tokenProvider->loadTokenBySeries($series)->getTokenValue());
+
+        $this->email = 'wouter@example.org';
+
+        $user = $handler->consumeRememberMeCookie(new RememberMeDetails(PasswordlessUser::class, 'wouter', 360, $series.':'.$tokenValue));
+
+        $this->assertSame('wouter', $user->getUserIdentifier());
+    }
+
+    public function testConsumeRememberMeCookieBindsThePasswordByDefaultToAnUnboundToken()
+    {
+        $handler = $this->createHandler(null, $this->createChangingUserProvider());
+        $this->tokenProvider->createNewToken(new PersistentToken(InMemoryUser::class, 'wouter', 'series1', 'tokenvalue', new \DateTimeImmutable()));
+
+        $handler->consumeRememberMeCookie(new RememberMeDetails(InMemoryUser::class, 'wouter', 360, 'series1:tokenvalue'));
+
+        $this->assertNotSame('tokenvalue', $this->tokenProvider->loadTokenBySeries('series1')->getTokenValue());
+
+        $this->password = 'n3wp4ssw0rd';
+
+        $this->expectException(CookieTheftException::class);
+        $handler->consumeRememberMeCookie(new RememberMeDetails(InMemoryUser::class, 'wouter', 360, 'series1:tokenvalue'));
+    }
+
+    public function testCreateRememberMeCookieWithAnExplicitPropertyTheUserDoesNotExpose()
+    {
+        $handler = $this->createHandler(['ipAddress'], $this->createChangingUserProvider());
+
+        $this->expectException(NoSuchPropertyException::class);
+        $handler->createRememberMeCookie(new InMemoryUser('wouter', $this->password));
+    }
+
+    public function testConsumeRememberMeCookieWithAnExplicitPropertyTheUserDoesNotExpose()
+    {
+        $handler = $this->createHandler(['ipAddress'], $this->createChangingUserProvider());
+        $this->tokenProvider->createNewToken(new PersistentToken(InMemoryUser::class, 'wouter', 'series1', 'tokenvalue', new \DateTimeImmutable()));
+
+        $this->expectException(NoSuchPropertyException::class);
+        $handler->consumeRememberMeCookie(new RememberMeDetails(InMemoryUser::class, 'wouter', 360, 'series1:tokenvalue'));
+    }
+
+    public function testCreateRememberMeCookieWithAnExplicitPasswordTheUserDoesNotExpose()
+    {
+        $handler = $this->createHandler(['password'], $this->createPasswordlessUserProvider());
+
+        $this->expectException(NoSuchPropertyException::class);
+        $handler->createRememberMeCookie(new PasswordlessUser('wouter'));
+    }
+
+    public function testConsumeRememberMeCookieRejectsABoundTokenWhenThePropertyBecomesUnreadable()
+    {
+        $isReadable = true;
+        $propertyAccessor = $this->createStub(PropertyAccessorInterface::class);
+        $propertyAccessor->method('isReadable')->willReturnCallback(static function () use (&$isReadable) { return $isReadable; });
+        $propertyAccessor->method('getValue')->willReturnCallback(fn () => $this->password);
+
+        $handler = $this->createHandler(null, $this->createChangingUserProvider(), null, $propertyAccessor);
+        $handler->createRememberMeCookie(new InMemoryUser('wouter', $this->password));
+
+        [$series, $tokenValue] = $this->readCookieValue();
+
+        $isReadable = false;
+
+        $this->expectException(CookieTheftException::class);
+        $handler->consumeRememberMeCookie(new RememberMeDetails(InMemoryUser::class, 'wouter', 360, $series.':'.$tokenValue));
+    }
+
+    public function testConsumeRememberMeCookieWithUnchangedSignatureProperties()
+    {
+        $handler = $this->createSignedHandler();
+        $handler->createRememberMeCookie(new InMemoryUser('wouter', $this->password));
+
+        [$series, $tokenValue] = $this->readCookieValue();
+
+        $this->assertNotSame($tokenValue, $this->tokenProvider->loadTokenBySeries($series)->getTokenValue());
+
+        $user = $handler->consumeRememberMeCookie(new RememberMeDetails(InMemoryUser::class, 'wouter', 360, $series.':'.$tokenValue));
+
+        $this->assertSame('wouter', $user->getUserIdentifier());
+    }
+
+    public function testConsumeRememberMeCookieWithChangedSignatureProperties()
+    {
+        $handler = $this->createSignedHandler();
+        $handler->createRememberMeCookie(new InMemoryUser('wouter', $this->password));
+
+        [$series, $tokenValue] = $this->readCookieValue();
+        $rememberMeDetails = new RememberMeDetails(InMemoryUser::class, 'wouter', 360, $series.':'.$tokenValue);
+        $this->request->cookies->set('REMEMBERME', $rememberMeDetails->toString());
+
+        $this->password = 'n3wp4ssw0rd';
+
+        try {
+            $handler->consumeRememberMeCookie($rememberMeDetails);
+            $this->fail('The remember-me cookie should be rejected after a signature property changed.');
+        } catch (CookieTheftException) {
+        }
+
+        // the failed login clears the cookie, which is what deletes the token
+        $handler->clearRememberMeCookie();
+
+        $this->expectException(TokenNotFoundException::class);
+        $this->tokenProvider->loadTokenBySeries($series);
+    }
+
+    public function testConsumeRememberMeCookieBindsSignaturePropertiesToUnboundToken()
+    {
+        $handler = $this->createSignedHandler();
+        $this->tokenProvider->createNewToken(new PersistentToken(InMemoryUser::class, 'wouter', 'series1', 'tokenvalue', new \DateTimeImmutable()));
+
+        $handler->consumeRememberMeCookie(new RememberMeDetails(InMemoryUser::class, 'wouter', 360, 'series1:tokenvalue'));
+
+        $this->assertNotSame('tokenvalue', $this->tokenProvider->loadTokenBySeries('series1')->getTokenValue());
+
+        $this->password = 'n3wp4ssw0rd';
+
+        $this->expectException(CookieTheftException::class);
+        $handler->consumeRememberMeCookie(new RememberMeDetails(InMemoryUser::class, 'wouter', 360, 'series1:tokenvalue'));
+    }
+
+    public function testConsumeRememberMeCookieRejectsStoredTokenValue()
+    {
+        $handler = $this->createSignedHandler();
+        $handler->createRememberMeCookie(new InMemoryUser('wouter', $this->password));
+
+        [$series] = $this->readCookieValue();
+        $storedTokenValue = $this->tokenProvider->loadTokenBySeries($series)->getTokenValue();
+
+        $this->expectException(CookieTheftException::class);
+        $handler->consumeRememberMeCookie(new RememberMeDetails(InMemoryUser::class, 'wouter', 360, $series.':'.$storedTokenValue));
+    }
+
+    public function testConsumeRememberMeCookieRejectsUnboundTokenValueAfterRotation()
+    {
+        $handler = $this->createSignedHandler();
+        $this->tokenProvider->createNewToken(new PersistentToken(InMemoryUser::class, 'wouter', 'series1', 'tokenvalue', new \DateTimeImmutable('-10 min')));
+
+        $handler->consumeRememberMeCookie(new RememberMeDetails(InMemoryUser::class, 'wouter', 360, 'series1:tokenvalue'));
+
+        $this->expectException(CookieTheftException::class);
+        $handler->consumeRememberMeCookie(new RememberMeDetails(InMemoryUser::class, 'wouter', 360, 'series1:tokenvalue'));
+    }
+
+    public function testConsumeRememberMeCookieAcceptsOutdatedTokenValue()
+    {
+        $handler = $this->createSignedHandler(new CacheTokenVerifier(new ArrayAdapter()));
+        $handler->createRememberMeCookie(new InMemoryUser('wouter', $this->password));
+
+        [$series, $tokenValue] = $this->readCookieValue();
+
+        $token = $this->tokenProvider->loadTokenBySeries($series);
+        $this->tokenProvider->createNewToken(new PersistentToken($token->getClass(), $token->getUserIdentifier(), $series, $token->getTokenValue(), new \DateTimeImmutable('-10 min')));
+
+        $rememberMeDetails = new RememberMeDetails(InMemoryUser::class, 'wouter', 360, $series.':'.$tokenValue);
+        $handler->consumeRememberMeCookie($rememberMeDetails);
+
+        // a concurrent request still carries the previous token value
+        $user = $handler->consumeRememberMeCookie($rememberMeDetails);
+
+        $this->assertSame('wouter', $user->getUserIdentifier());
+    }
+
+    private function createSignedHandler(?TokenVerifierInterface $tokenVerifier = null): PersistentRememberMeHandler
+    {
+        return $this->createHandler(['password'], $this->createChangingUserProvider(), $tokenVerifier);
+    }
+
+    private function createHandler(?array $signatureProperties, UserProviderInterface $userProvider, ?TokenVerifierInterface $tokenVerifier = null, ?PropertyAccessorInterface $propertyAccessor = null): PersistentRememberMeHandler
+    {
+        return new PersistentRememberMeHandler($this->tokenProvider, $userProvider, $this->requestStack, [], null, $tokenVerifier, $signatureProperties, $propertyAccessor);
+    }
+
+    private function createChangingUserProvider(): UserProviderInterface
+    {
+        $userProvider = $this->createStub(UserProviderInterface::class);
+        $userProvider->method('loadUserByIdentifier')->willReturnCallback(fn (string $identifier) => new InMemoryUser($identifier, $this->password));
+
+        return $userProvider;
+    }
+
+    private function createPasswordlessUserProvider(): UserProviderInterface
+    {
+        $userProvider = $this->createStub(UserProviderInterface::class);
+        $userProvider->method('loadUserByIdentifier')->willReturnCallback(fn (string $identifier) => new PasswordlessUser($identifier, $this->email));
+
+        return $userProvider;
+    }
+
+    private function readCookieValue(): array
+    {
+        /** @var Cookie $cookie */
+        $cookie = $this->request->attributes->get(ResponseListener::COOKIE_ATTR_NAME);
+
+        return explode(':', explode(':', $cookie->getValue(), 4)[3], 2);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

## The bug

`remember_me.signature_properties` is accepted and silently ignored as soon as a `token_provider` is configured.

`RememberMeFactory::createAuthenticator()` branches three ways. It reads `$config['signature_properties']` only in the branch that builds `SignatureRememberMeHandler`. The `token_provider` branch builds `PersistentRememberMeHandler`, which never constructs a `SignatureHasher` and never reads a user property. So changing a listed property does not invalidate an already issued remember-me cookie. The default value of the option is `['password']`, so an application that never writes the option still loses password-change revocation the moment it turns on `token_provider`. The `->info()` string printed by `config:dump-reference security` promises the opposite, with no caveat.

Present since 5.3, unchanged in every maintained branch. What fails is the automatic revocation of a cookie whose holder already has it, not authentication itself: signature validation is simply not part of the persistent strategy, so no implemented check is being bypassed.

The gap survived since 5.3 because it was never exercised. `RememberMeTest::testUserChangeClearsCookie()` runs only against the signature config, and `config_persistent.yml` is only used by `testRememberMe()`, which never changes a user property.

## Solution

Secure by default, with no BC break, no schema change and no new cookie part.

### Implicit is lenient, explicit is strict

With a token provider and no `signature_properties` written, the handler binds the default `['password']` and skips the properties the user class does not expose. So a user class with a password gets revocation on a password change, and a user class without one, from an OIDC or magic-link setup, binds nothing and keeps behaving exactly as it does today. This is what makes the change safe to apply by default: the leniency, not an opt-in.

With `signature_properties` written, every listed property must exist and be readable. A missing one raises `NoSuchPropertyException`, exactly as the signature strategy does today. Writing the option is an assertion that those fields exist, so they are not silently skipped, and that holds even when the list happens to be `['password']`.

The two cases are told apart at the container level. The option no longer carries a `['password']` default in the config tree, so an unset node yields the empty array that `PrototypedArrayNode` gives it, and the factory passes `null` to the handler for that case and the array otherwise. The handler then reads `$this->signatureProperties ?? ['password']` and treats `null` as the lenient case.

`->requiresAtLeastOneElement()` did not need reworking. `ArrayNode::finalizeValue()` injects a child default and moves on without finalizing it, so `minNumberOfElements` never sees the default, while an explicitly written `signature_properties: []` or `signature_properties: ~` is still rejected.

The signature strategy is untouched. It applies the `['password']` fallback itself, in the branch that builds the hasher, and resolves to the same value as before in every case.

The new `->info()` string is:

> An array of properties on your User. All existing cookies become invalid when one of them changes. Defaults to ["password"], which a "token_provider" skips when the user class does not expose it. A property listed here explicitly must exist on the user class. Cannot be combined with a custom "service".

### A custom handler refuses the option instead of ignoring it

A custom `remember_me.service` replaces the handler entirely, so `signature_properties` has never had any effect there. Leaving it accepted and inert is the same defect this pull request is about, only in another branch of the same method, so it is now refused at container-compile time:

```
You cannot use both "service" and "signature_properties" in "security.firewalls.main.remember_me" because the custom handler signs the cookies itself and the option would have no effect.
```

The check only fires on an explicitly written list, never on the implicit default, so an application using a custom handler and never touching the option keeps compiling exactly as before. It sits right after the existing `service` and `token_provider` conflict check, which therefore still reports first when all three are configured.

This is a compile-time consideration for anyone currently setting both, since that combination used to be accepted and silently did nothing. The fix is to remove the option from that firewall.

### How the binding works

A new database column was considered and rejected. `DoctrineTokenProvider::configureSchema()` returns early when the `rememberme_token` table already exists, so a new column would never be autogenerated for existing installations. That gap is being fixed separately, and this fix should not depend on it.

A new cookie part was considered and rejected too. Anything the cookie carries next to the token value can be stripped by whoever holds the cookie, and the server would then have to choose between refusing every cookie issued before the upgrade or accepting the stripped one. The second choice is a downgrade: revocation would be defeated by deleting a field.

So the values of the properties are bound to the value that the token provider already stores, where there is nothing to strip:

- `PersistentRememberMeHandler` gained two optional trailing constructor arguments, `$signatureProperties` and `$propertyAccessor`. `RememberMeFactory` passes them in the `token_provider` branch, and the abstract service declares `property_accessor` as an optional dependency.
- The cookie keeps its exact format, `series:tokenValue`, with the same random token value as before. What is stored is now `'~'.base64url(sha256($tokenValue.'|'.$propertiesHash))`.
- On consume, the handler loads the user first, recomputes that value from the freshly loaded user, and compares it with the stored one through the same `TokenVerifierInterface` or `hash_equals()` path as before. When a bound property changed, the value no longer matches and the cookie is refused with the same `CookieTheftException` a stale token already raises. The row itself is deleted by the existing path: the failed login dispatches `LoginFailureEvent`, `RememberMeListener` calls `clearRememberMeCookie()`, and that method reads the raw cookie and deletes the series. So revocation ends with the row gone, through the route 6.4 already used for theft.
- Because the hash covers user state and not per-series state, this gives user-wide invalidation for free. A password change makes every series of that user stale at once, which matters because `TokenProviderInterface` exposes no `deleteTokensByUser()`.

The same code path computes the value when storing and when verifying, so the leniency applies identically on both sides. A property that was readable when the cookie was issued and is not any more simply produces a different value, the comparison fails, and the cookie is refused. A shrinking property set cannot weaken an existing binding.

Rows written before the upgrade are accepted once, without opening a downgrade path. The fallback is the old direct comparison against the stored value, and it is only reached for a row that is not bound yet. On success the row is rewritten in bound form, with the same token value and the same `lastUsed`, so the window closes on first use and the user is not logged out. When the token is about to be regenerated anyway, that write is left to the regeneration, so the token provider is still written to at most once per request.

The `'~'` marker is what makes the fallback one-way. Base64 encoded values never start with it, so a bound row never takes the fallback again, and a stored bound value can never be replayed as a cookie value. Without the marker, presenting the stored value of a bound row passes the fallback comparison; that needs read access to the database, which already grants a login today, but it is free to close.

`SignatureHasher` was not reusable. It folds `$expires` into the keyed part of its output, and the persistent handler recomputes `$expires` on every rotation from `lastUsed + lifetime` while treating the incoming one as untrusted, so the two never line up. Its only expiry-free component is the plain unkeyed `fieldsHash`. The handler therefore hashes the properties itself, with the same rules as `SignatureHasher::computeSignatureHash()` for `null`, `\DateTimeInterface` and non-stringable values.

The hash is not keyed with the application secret, and the key would not be load-bearing here: the derived value never leaves the server, and the cookie carries only the random token value.

`TokenVerifierInterface` is fed consistently. `verifyToken()`, `updateExistingToken()` and `updateToken()` all receive the bound value, so `CacheTokenVerifier` keeps the bound value of the previous token and concurrent requests carrying the previous cookie still authenticate.

### Consequences

- The cookie format is unchanged by design, so a mixed-version rollout is a non-event: an older and a newer instance read the same cookie. What changes is the stored value, and a row written by an older instance is accepted and bound by a newer one.
- Applications that never wrote the option start binding the password on the first use of each row. That is the point of the fix, and nobody is logged out by it.
- A property written in `signature_properties` that the user class does not expose raises `NoSuchPropertyException`, exactly as the signature strategy does today. Only applications that wrote the option are concerned.
- Writing `signature_properties` together with a custom `service` now fails at compile time, where it used to be accepted and do nothing.
- Nothing changes for the signature strategy.

## Tests

`./phpunit src/Symfony/Component/Security/Http`, `./phpunit src/Symfony/Bundle/SecurityBundle` and `./phpunit src/Symfony/Bridge/Doctrine` were green on the base commit and are green with the change.

| Suite | Base | With the change |
| --- | --- | --- |
| `Component/Security/Http` | 534 tests, 1002 assertions | 547 tests, 1020 assertions |
| `Bundle/SecurityBundle` | 360 tests, 1104 assertions, 1 skipped | 369 tests, 1128 assertions, 1 skipped |
| `Bridge/Doctrine` | 454 tests, 1055 assertions, 22 skipped | unchanged |

Added to `PersistentRememberMeHandlerTest`:

- nothing configured, user with a password: the password is bound and a password change revokes the cookie
- nothing configured, user class without a password: nothing is bound, no exception is raised, and a change to another field leaves the cookie valid
- nothing configured, row stored without the binding: bound on first use, then revoked by a password change
- an explicit property the user class does not expose: raises when storing and when verifying
- an explicit `['password']` on a user class without a password: raises, so an explicit list is strict even when it repeats the default
- a bound row whose property stops being readable: refused, so a shrinking property set cannot weaken the binding
- an explicit list, unchanged properties: the cookie is accepted and what is stored is not what the cookie carries
- an explicit list, a changed property: the cookie is rejected, and the row is gone once `clearRememberMeCookie()` has run
- the stored value is rejected when replayed as a cookie value
- the unbound comparison is not reachable any more once the row was bound
- a concurrent request carrying the previous cookie still authenticates, through `CacheTokenVerifier`

Added to `SecurityExtensionTest`:

- with no `token_provider` and nothing configured, the signature hasher still receives `['password']`
- with a `token_provider` and nothing configured, the handler receives `null`, which is the lenient case
- with a `token_provider` and an explicit list, the handler receives that list
- an explicitly configured empty array is still rejected by the config tree
- an explicit list together with a custom `service` fails to compile
- all three of `service`, `token_provider` and an explicit list still report the pre-existing `service` and `token_provider` conflict

`RememberMeTest::testUserChangeInvalidatesRememberMeCookie()` runs over `clear_on_change_config.yml`, `clear_on_change_persistent_config.yml` and `clear_on_change_explicit_persistent_config.yml`: log in, drop the session so that only the remember-me cookie is left, change the password through the user provider, and expect a redirect to the login page and a cleared remember-me cookie, which is the listener path that deletes the row. On the base branch the signature config redirects and both persistent configs answer `johannes`, which is the reported bug.

Reverting the three source files and keeping the tests fails ten handler tests, the two container tests that read the new argument, the container test for the custom handler refusal, and both persistent data sets of the functional test. The other new tests pass on the base branch by design: they pin the behavior that must not move, namely the `['password']` fallback of the signature strategy, the rejection of an empty array, the untouched behavior for a user class without a password, and the one-way fallback.

The compiled container was compared between the base commit and this change, over seven firewall configurations, including a custom handler with the option left unset. Every case resolves byte-identically, the signature hasher arguments and the handler options included.

Checked with a `DoctrineTokenProvider` on SQLite, end to end, with the properties both implicit and explicit: binding on creation, acceptance and rotation, refusal after a password change followed by the row being deleted by `clearRememberMeCookie()`, the one-shot binding of a row written by the pre-fix code, and the refusal of both the stored value and a rotated cookie.

Not covered: the lenient case is not exercised through the functional application. Its firewall authenticates with `form_login`, which needs a user carrying a password, so a user class without one cannot reach the point where a remember-me cookie is issued. That case is covered at the component level instead. The PostgreSQL variant of the Doctrine token provider tests is skipped in this environment for unrelated reasons.



