### PR TITLE
[Security] Apply "signature_properties" when a remember-me token provider is used

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RememberMeFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RememberMeFactory.php
@@ -61,6 +61,10 @@ class RememberMeFactory implements AuthenticatorFactoryInterface, PrependExtensi
             throw new InvalidConfigurationException(\sprintf('You cannot use both "service" and "token_provider" in "security.firewalls.%s.remember_me".', $firewallName));
         }
 
+        if (isset($config['service']) && $config['signature_properties']) {
+            throw new InvalidConfigurationException(\sprintf('You cannot use both "service" and "signature_properties" in "security.firewalls.%s.remember_me" because the custom handler signs the cookies itself and the option would have no effect.', $firewallName));
+        }
+
         if (isset($config['service'])) {
             $container->register($rememberMeHandlerId, DecoratedRememberMeHandler::class)
                 ->addArgument(new Reference($config['service']))
@@ -73,11 +77,12 @@ class RememberMeFactory implements AuthenticatorFactoryInterface, PrependExtensi
                 ->replaceArgument(1, new Reference($userProviderId))
                 ->replaceArgument(3, $config)
                 ->replaceArgument(5, $tokenVerifier)
+                ->replaceArgument(6, $config['signature_properties'] ?: null)
                 ->addTag('security.remember_me_handler', ['firewall' => $firewallName]);
         } else {
             $signatureHasherId = 'security.authenticator.remember_me_signature_hasher.'.$firewallName;
             $container->setDefinition($signatureHasherId, new ChildDefinition('security.authenticator.remember_me_signature_hasher'))
-                ->replaceArgument(1, $config['signature_properties'])
+                ->replaceArgument(1, $config['signature_properties'] ?: ['password'])
                 ->replaceArgument(2, $config['secret'])
             ;
 
@@ -146,9 +151,8 @@ class RememberMeFactory implements AuthenticatorFactoryInterface, PrependExtensi
             ->arrayNode('signature_properties')
                 ->prototype('scalar')->end()
                 ->requiresAtLeastOneElement()
-                ->info('An array of properties on your User that are used to sign the remember-me cookie. If any of these change, all existing cookies will become invalid.')
+                ->info('An array of properties on your User. All existing cookies become invalid when one of them changes. Defaults to ["password"], which a "token_provider" skips when the user class does not expose it. A property listed here explicitly must exist on the user class. Cannot be combined with a custom "service".')
                 ->example(['email', 'password'])
-                ->defaultValue(['password'])
             ->end()
             ->arrayNode('token_provider')
                 ->beforeNormalization()

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator_remember_me.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator_remember_me.php
@@ -55,6 +55,8 @@ return static function (ContainerConfigurator $container) {
                 abstract_arg('options'),
                 service('logger')->nullOnInvalid(),
                 abstract_arg('token verifier'),
+                abstract_arg('signature properties'),
+                service('property_accessor')->nullOnInvalid(),
             ])
             ->tag('monolog.logger', ['channel' => 'security'])
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
@@ -692,6 +692,126 @@ class SecurityExtensionTest extends TestCase
         $this->assertSame('very', $handler->getArgument(2));
     }
 
+    public function testRememberMeSignaturePropertiesDefaultToPassword()
+    {
+        $container = $this->getRawContainer();
+
+        $container->loadFromExtension('security', [
+            'firewalls' => [
+                'default' => [
+                    'remember_me' => ['secret' => 'very'],
+                ],
+            ],
+        ]);
+
+        $container->compile();
+
+        $hasher = $container->getDefinition('security.authenticator.remember_me_signature_hasher.default');
+        $this->assertSame(['password'], $hasher->getArgument(1));
+    }
+
+    public function testRememberMeSignaturePropertiesAreImplicitByDefaultWithATokenProvider()
+    {
+        $container = $this->getRawContainer();
+
+        $container->register('custom_token_provider', \stdClass::class);
+        $container->loadFromExtension('security', [
+            'firewalls' => [
+                'default' => [
+                    'remember_me' => ['token_provider' => 'custom_token_provider'],
+                ],
+            ],
+        ]);
+
+        $container->compile();
+
+        $handler = $container->getDefinition('security.authenticator.remember_me_handler.default');
+        $this->assertNull($handler->getArgument(6));
+    }
+
+    public function testRememberMeSignaturePropertiesAreBoundToTokensWhenConfigured()
+    {
+        $container = $this->getRawContainer();
+
+        $container->register('custom_token_provider', \stdClass::class);
+        $container->loadFromExtension('security', [
+            'firewalls' => [
+                'default' => [
+                    'remember_me' => [
+                        'token_provider' => 'custom_token_provider',
+                        'signature_properties' => ['email', 'password'],
+                    ],
+                ],
+            ],
+        ]);
+
+        $container->compile();
+
+        $handler = $container->getDefinition('security.authenticator.remember_me_handler.default');
+        $this->assertSame(['email', 'password'], $handler->getArgument(6));
+    }
+
+    public function testRememberMeSignaturePropertiesCannotBeUsedWithACustomHandler()
+    {
+        $container = $this->getRawContainer();
+
+        $container->register('custom_remember_me', \stdClass::class);
+        $container->loadFromExtension('security', [
+            'firewalls' => [
+                'default' => [
+                    'remember_me' => [
+                        'service' => 'custom_remember_me',
+                        'signature_properties' => ['password'],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('You cannot use both "service" and "signature_properties" in "security.firewalls.default.remember_me" because the custom handler signs the cookies itself and the option would have no effect.');
+        $container->compile();
+    }
+
+    public function testCustomRememberMeHandlerWithATokenProviderReportsTheTokenProviderConflict()
+    {
+        $container = $this->getRawContainer();
+
+        $container->register('custom_remember_me', \stdClass::class);
+        $container->register('custom_token_provider', \stdClass::class);
+        $container->loadFromExtension('security', [
+            'firewalls' => [
+                'default' => [
+                    'remember_me' => [
+                        'service' => 'custom_remember_me',
+                        'token_provider' => 'custom_token_provider',
+                        'signature_properties' => ['password'],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('You cannot use both "service" and "token_provider" in "security.firewalls.default.remember_me".');
+        $container->compile();
+    }
+
+    public function testRememberMeSignaturePropertiesCannotBeEmpty()
+    {
+        $container = $this->getRawContainer();
+
+        $container->loadFromExtension('security', [
+            'firewalls' => [
+                'default' => [
+                    'remember_me' => ['signature_properties' => []],
+                ],
+            ],
+        ]);
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('The path "security.firewalls.default.remember_me.signature_properties" should have at least 1 element(s) defined.');
+        $container->compile();
+    }
+
     public static function sessionConfigurationProvider(): array
     {
         return [

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/RememberMeTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/RememberMeTest.php
@@ -73,6 +73,34 @@ class RememberMeTest extends AbstractWebTestCase
         $this->assertRedirect($client->getResponse(), '/login');
     }
 
+    /**
+     * @dataProvider provideClearOnChangeConfigs
+     */
+    public function testUserChangeInvalidatesRememberMeCookie(string $rootConfig)
+    {
+        $client = $this->createClient(['test_case' => 'RememberMe', 'root_config' => $rootConfig]);
+
+        $client->request('POST', '/login', [
+            '_username' => 'johannes',
+            '_password' => 'test',
+        ]);
+
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
+        $cookieJar = $client->getCookieJar();
+        $this->assertNotNull($cookieJar->get('REMEMBERME'));
+
+        // clear the session, only the remember-me cookie is left to authenticate
+        $cookieJar->expire('MOCKSESSID');
+
+        UserChangingUserProvider::$changePassword = true;
+
+        $client->request('GET', '/profile');
+        $this->assertRedirect($client->getResponse(), '/login');
+
+        // the failed login clears the cookie, which is what deletes the token
+        $this->assertNull($cookieJar->get('REMEMBERME'));
+    }
+
     public function testSessionLessRememberMeLogout()
     {
         $client = $this->createClient(['test_case' => 'RememberMe', 'root_config' => 'stateless_config.yml']);
@@ -97,5 +125,12 @@ class RememberMeTest extends AbstractWebTestCase
     {
         yield [['root_config' => 'config_session.yml']];
         yield [['root_config' => 'config_persistent.yml']];
+    }
+
+    public static function provideClearOnChangeConfigs(): iterable
+    {
+        yield ['clear_on_change_config.yml'];
+        yield ['clear_on_change_persistent_config.yml'];
+        yield ['clear_on_change_explicit_persistent_config.yml'];
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/RememberMeTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/RememberMeTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
 
 use Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\RememberMeBundle\Security\UserChangingUserProvider;
+use Symfony\Component\Security\Http\RememberMe\PersistentRememberMeHandler;
 
 class RememberMeTest extends AbstractWebTestCase
 {
@@ -73,6 +74,38 @@ class RememberMeTest extends AbstractWebTestCase
         $this->assertRedirect($client->getResponse(), '/login');
     }
 
+    /**
+     * @dataProvider provideClearOnChangeConfigs
+     */
+    public function testUserChangeInvalidatesRememberMeCookie(string $rootConfig, bool $usesTokenProvider)
+    {
+        if ($usesTokenProvider && !self::persistentHandlerBindsSignatureProperties()) {
+            $this->markTestSkipped('Requires symfony/security-http 6.4 or higher.');
+        }
+
+        $client = $this->createClient(['test_case' => 'RememberMe', 'root_config' => $rootConfig]);
+
+        $client->request('POST', '/login', [
+            '_username' => 'johannes',
+            '_password' => 'test',
+        ]);
+
+        $this->assertSame(302, $client->getResponse()->getStatusCode());
+        $cookieJar = $client->getCookieJar();
+        $this->assertNotNull($cookieJar->get('REMEMBERME'));
+
+        // clear the session, only the remember-me cookie is left to authenticate
+        $cookieJar->expire('MOCKSESSID');
+
+        UserChangingUserProvider::$changePassword = true;
+
+        $client->request('GET', '/profile');
+        $this->assertRedirect($client->getResponse(), '/login');
+
+        // the failed login clears the cookie, which is what deletes the token
+        $this->assertNull($cookieJar->get('REMEMBERME'));
+    }
+
     public function testSessionLessRememberMeLogout()
     {
         $client = $this->createClient(['test_case' => 'RememberMe', 'root_config' => 'stateless_config.yml']);
@@ -97,5 +130,23 @@ class RememberMeTest extends AbstractWebTestCase
     {
         yield [['root_config' => 'config_session.yml']];
         yield [['root_config' => 'config_persistent.yml']];
+    }
+
+    public static function provideClearOnChangeConfigs(): iterable
+    {
+        yield ['clear_on_change_config.yml', false];
+        yield ['clear_on_change_persistent_config.yml', true];
+        yield ['clear_on_change_explicit_persistent_config.yml', true];
+    }
+
+    private static function persistentHandlerBindsSignatureProperties(): bool
+    {
+        foreach ((new \ReflectionMethod(PersistentRememberMeHandler::class, '__construct'))->getParameters() as $parameter) {
+            if ('signatureProperties' === $parameter->getName()) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/RememberMe/clear_on_change_explicit_persistent_config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/RememberMe/clear_on_change_explicit_persistent_config.yml
@@ -1,0 +1,8 @@
+imports:
+    - { resource: ./clear_on_change_persistent_config.yml }
+
+security:
+    firewalls:
+        default:
+            remember_me:
+                signature_properties: [password]

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/RememberMe/clear_on_change_persistent_config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/RememberMe/clear_on_change_persistent_config.yml
@@ -1,0 +1,9 @@
+imports:
+    - { resource: ./config.yml }
+    - { resource: ./config_persistent.yml }
+
+services:
+    Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\RememberMeBundle\Security\UserChangingUserProvider:
+        public: true
+        decorates: security.user.provider.concrete.in_memory
+        arguments: ['@.inner']

--- a/src/Symfony/Component/Security/Http/RememberMe/PersistentRememberMeHandler.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/PersistentRememberMeHandler.php
@@ -13,6 +13,8 @@ namespace Symfony\Component\Security\Http\RememberMe;
 
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\Security\Core\Authentication\RememberMe\PersistentToken;
 use Symfony\Component\Security\Core\Authentication\RememberMe\TokenProviderInterface;
 use Symfony\Component\Security\Core\Authentication\RememberMe\TokenVerifierInterface;
@@ -32,17 +34,30 @@ use Symfony\Component\Security\Core\User\UserProviderInterface;
  */
 final class PersistentRememberMeHandler extends AbstractRememberMeHandler
 {
+    /**
+     * Separates the random part of a token value from the digest of the signature properties of the user.
+     *
+     * Token values are base64 encoded, so they never contain this character: a stored
+     * value without it was written before the properties were bound to the token.
+     */
+    private const DIGEST_SEPARATOR = '.';
+
     private TokenProviderInterface $tokenProvider;
     private ?TokenVerifierInterface $tokenVerifier;
+    private ?array $signatureProperties;
+    private PropertyAccessorInterface $propertyAccessor;
 
     /**
-     * @param UserProviderInterface       $userProvider
-     * @param RequestStack                $requestStack
-     * @param array                       $options
-     * @param LoggerInterface|null        $logger
-     * @param TokenVerifierInterface|null $tokenVerifier
+     * @param UserProviderInterface          $userProvider
+     * @param RequestStack                   $requestStack
+     * @param array                          $options
+     * @param LoggerInterface|null           $logger
+     * @param TokenVerifierInterface|null    $tokenVerifier
+     * @param array|null                     $signatureProperties Properties of the User; the stored token is invalidated when these properties change.
+     *                                                            Defaults to ["password"], with the properties the user does not expose being skipped
+     * @param PropertyAccessorInterface|null $propertyAccessor
      */
-    public function __construct(TokenProviderInterface $tokenProvider, #[\SensitiveParameter] $userProvider, $requestStack, $options, $logger = null, $tokenVerifier = null)
+    public function __construct(TokenProviderInterface $tokenProvider, #[\SensitiveParameter] $userProvider, $requestStack, $options, $logger = null, $tokenVerifier = null, $signatureProperties = null, $propertyAccessor = null)
     {
         if (\is_string($userProvider)) {
             trigger_deprecation('symfony/security-http', '6.3', 'Calling "%s()" with the secret as the second argument is deprecated. The argument will be dropped in 7.0.', __CLASS__);
@@ -52,6 +67,8 @@ final class PersistentRememberMeHandler extends AbstractRememberMeHandler
             $options = $logger;
             $logger = $tokenVerifier;
             $tokenVerifier = \func_num_args() > 6 ? func_get_arg(6) : null;
+            $signatureProperties = \func_num_args() > 7 ? func_get_arg(7) : null;
+            $propertyAccessor = \func_num_args() > 8 ? func_get_arg(8) : null;
         }
 
         if (!$userProvider instanceof UserProviderInterface) {
@@ -74,6 +91,14 @@ final class PersistentRememberMeHandler extends AbstractRememberMeHandler
             throw new \TypeError(\sprintf('Argument 6 passed to "%s()" must be an instance of "%s", "%s" given.', __CLASS__, TokenVerifierInterface::class, get_debug_type($userProvider)));
         }
 
+        if (null !== $signatureProperties && !\is_array($signatureProperties)) {
+            throw new \TypeError(\sprintf('Argument 7 passed to "%s()" must be an array, "%s" given.', __CLASS__, get_debug_type($signatureProperties)));
+        }
+
+        if (null !== $propertyAccessor && !$propertyAccessor instanceof PropertyAccessorInterface) {
+            throw new \TypeError(\sprintf('Argument 8 passed to "%s()" must be an instance of "%s", "%s" given.', __CLASS__, PropertyAccessorInterface::class, get_debug_type($propertyAccessor)));
+        }
+
         parent::__construct($userProvider, $requestStack, $options, $logger);
 
         if (!$tokenVerifier && $tokenProvider instanceof TokenVerifierInterface) {
@@ -81,6 +106,8 @@ final class PersistentRememberMeHandler extends AbstractRememberMeHandler
         }
         $this->tokenProvider = $tokenProvider;
         $this->tokenVerifier = $tokenVerifier;
+        $this->signatureProperties = $signatureProperties;
+        $this->propertyAccessor = $propertyAccessor ?? PropertyAccess::createPropertyAccessor();
     }
 
     public function createRememberMeCookie(UserInterface $user): void
@@ -88,6 +115,9 @@ final class PersistentRememberMeHandler extends AbstractRememberMeHandler
         $series = random_bytes(66);
         $tokenValue = strtr(base64_encode(substr($series, 33)), '+/=', '-_~');
         $series = strtr(base64_encode(substr($series, 0, 33)), '+/=', '-_~');
+        if (null !== $digest = $this->hashSignatureProperties($user)) {
+            $tokenValue .= self::DIGEST_SEPARATOR.$digest;
+        }
         $token = new PersistentToken($user::class, $user->getUserIdentifier(), $series, $tokenValue, new \DateTimeImmutable());
 
         $this->tokenProvider->createNewToken($token);
@@ -128,7 +158,7 @@ final class PersistentRememberMeHandler extends AbstractRememberMeHandler
             $persistentToken->getClass(),
             $persistentToken->getUserIdentifier(),
             $expires,
-            $persistentToken->getLastUsed()->getTimestamp().':'.$series.':'.$tokenValue.':'.$persistentToken->getClass()
+            $persistentToken->getLastUsed()->getTimestamp().':'.$series.':'.$persistentToken->getTokenValue().':'.$persistentToken->getClass()
         ));
     }
 
@@ -137,6 +167,13 @@ final class PersistentRememberMeHandler extends AbstractRememberMeHandler
         [$lastUsed, $series, $tokenValue, $class] = explode(':', $rememberMeDetails->getValue(), 4);
         $persistentToken = new PersistentToken($class, $rememberMeDetails->getUserIdentifier(), $series, $tokenValue, new \DateTimeImmutable('@'.$lastUsed));
 
+        $digest = $this->hashSignatureProperties($user);
+        $storedDigest = false === ($i = strpos($tokenValue, self::DIGEST_SEPARATOR)) ? null : substr($tokenValue, $i + 1);
+
+        if (null !== $storedDigest && (null === $digest || !hash_equals($storedDigest, $digest))) {
+            throw new AuthenticationException('The cookie\'s hash is invalid.');
+        }
+
         // if a token was regenerated less than a minute ago, there is no need to regenerate it
         // if multiple concurrent requests reauthenticate a user we do not want to update the token several times
         if ($persistentToken->getLastUsed()->getTimestamp() + 60 >= time()) {
@@ -144,6 +181,9 @@ final class PersistentRememberMeHandler extends AbstractRememberMeHandler
         }
 
         $tokenValue = strtr(base64_encode(random_bytes(33)), '+/=', '-_~');
+        if (null !== $digest) {
+            $tokenValue .= self::DIGEST_SEPARATOR.$digest;
+        }
         $tokenLastUsed = new \DateTime();
         $this->tokenVerifier?->updateExistingToken($persistentToken, $tokenValue, $tokenLastUsed);
         $this->tokenProvider->updateToken($series, $tokenValue, $tokenLastUsed);
@@ -176,5 +216,43 @@ final class PersistentRememberMeHandler extends AbstractRememberMeHandler
     public function getTokenProvider(): TokenProviderInterface
     {
         return $this->tokenProvider;
+    }
+
+    /**
+     * Returns a digest of the signature properties of the user, or null when there is nothing to bind.
+     *
+     * Properties the user does not expose are skipped when the list was not configured explicitly,
+     * which keeps user classes without any of the default properties working as before.
+     */
+    private function hashSignatureProperties(UserInterface $user): ?string
+    {
+        $isDefaultList = null === $this->signatureProperties;
+        $digest = hash_init('sha256');
+        $isBound = false;
+
+        foreach ($this->signatureProperties ?? ['password'] as $property) {
+            if ($isDefaultList && !$this->propertyAccessor->isReadable($user, $property)) {
+                continue;
+            }
+
+            $value = $this->propertyAccessor->getValue($user, $property) ?? '';
+            if ($value instanceof \DateTimeInterface) {
+                $value = $value->format('c');
+            }
+
+            if (!\is_scalar($value) && !$value instanceof \Stringable) {
+                throw new \InvalidArgumentException(\sprintf('The property path "%s" on the user object "%s" must return a value that can be cast to a string, but "%s" was returned.', $property, $user::class, get_debug_type($value)));
+            }
+
+            hash_update($digest, ':'.base64_encode($value));
+            $isBound = true;
+        }
+
+        if (!$isBound) {
+            return null;
+        }
+
+        // 24 bytes keep the token value within the 88 characters of the documented "rememberme_token.value" column
+        return strtr(base64_encode(substr(hash_final($digest, true), 0, 24)), '+/', '-_');
     }
 }

--- a/src/Symfony/Component/Security/Http/RememberMe/PersistentRememberMeHandler.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/PersistentRememberMeHandler.php
@@ -13,7 +13,10 @@ namespace Symfony\Component\Security\Http\RememberMe;
 
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\Security\Core\Authentication\RememberMe\PersistentToken;
+use Symfony\Component\Security\Core\Authentication\RememberMe\PersistentTokenInterface;
 use Symfony\Component\Security\Core\Authentication\RememberMe\TokenProviderInterface;
 use Symfony\Component\Security\Core\Authentication\RememberMe\TokenVerifierInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
@@ -32,17 +35,31 @@ use Symfony\Component\Security\Core\User\UserProviderInterface;
  */
 final class PersistentRememberMeHandler extends AbstractRememberMeHandler
 {
+    /**
+     * Marks a stored token value as bound to the signature properties of the user.
+     *
+     * Base64 encoded values never start with this character, which tells bound
+     * values apart from the ones stored before the properties were bound.
+     */
+    private const SIGNATURE_MARKER = '~';
+
     private TokenProviderInterface $tokenProvider;
     private ?TokenVerifierInterface $tokenVerifier;
+    private UserProviderInterface $userProvider;
+    private ?array $signatureProperties;
+    private PropertyAccessorInterface $propertyAccessor;
 
     /**
-     * @param UserProviderInterface       $userProvider
-     * @param RequestStack                $requestStack
-     * @param array                       $options
-     * @param LoggerInterface|null        $logger
-     * @param TokenVerifierInterface|null $tokenVerifier
+     * @param UserProviderInterface          $userProvider
+     * @param RequestStack                   $requestStack
+     * @param array                          $options
+     * @param LoggerInterface|null           $logger
+     * @param TokenVerifierInterface|null    $tokenVerifier
+     * @param array|null                     $signatureProperties Properties of the User; the stored token is invalidated when these properties change.
+     *                                                            Defaults to ["password"], with the properties the user does not expose being skipped
+     * @param PropertyAccessorInterface|null $propertyAccessor
      */
-    public function __construct(TokenProviderInterface $tokenProvider, #[\SensitiveParameter] $userProvider, $requestStack, $options, $logger = null, $tokenVerifier = null)
+    public function __construct(TokenProviderInterface $tokenProvider, #[\SensitiveParameter] $userProvider, $requestStack, $options, $logger = null, $tokenVerifier = null, $signatureProperties = null, $propertyAccessor = null)
     {
         if (\is_string($userProvider)) {
             trigger_deprecation('symfony/security-http', '6.3', 'Calling "%s()" with the secret as the second argument is deprecated. The argument will be dropped in 7.0.', __CLASS__);
@@ -52,6 +69,8 @@ final class PersistentRememberMeHandler extends AbstractRememberMeHandler
             $options = $logger;
             $logger = $tokenVerifier;
             $tokenVerifier = \func_num_args() > 6 ? func_get_arg(6) : null;
+            $signatureProperties = \func_num_args() > 7 ? func_get_arg(7) : null;
+            $propertyAccessor = \func_num_args() > 8 ? func_get_arg(8) : null;
         }
 
         if (!$userProvider instanceof UserProviderInterface) {
@@ -74,6 +93,14 @@ final class PersistentRememberMeHandler extends AbstractRememberMeHandler
             throw new \TypeError(\sprintf('Argument 6 passed to "%s()" must be an instance of "%s", "%s" given.', __CLASS__, TokenVerifierInterface::class, get_debug_type($userProvider)));
         }
 
+        if (null !== $signatureProperties && !\is_array($signatureProperties)) {
+            throw new \TypeError(\sprintf('Argument 7 passed to "%s()" must be an array, "%s" given.', __CLASS__, get_debug_type($signatureProperties)));
+        }
+
+        if (null !== $propertyAccessor && !$propertyAccessor instanceof PropertyAccessorInterface) {
+            throw new \TypeError(\sprintf('Argument 8 passed to "%s()" must be an instance of "%s", "%s" given.', __CLASS__, PropertyAccessorInterface::class, get_debug_type($propertyAccessor)));
+        }
+
         parent::__construct($userProvider, $requestStack, $options, $logger);
 
         if (!$tokenVerifier && $tokenProvider instanceof TokenVerifierInterface) {
@@ -81,6 +108,9 @@ final class PersistentRememberMeHandler extends AbstractRememberMeHandler
         }
         $this->tokenProvider = $tokenProvider;
         $this->tokenVerifier = $tokenVerifier;
+        $this->userProvider = $userProvider;
+        $this->signatureProperties = $signatureProperties;
+        $this->propertyAccessor = $propertyAccessor ?? PropertyAccess::createPropertyAccessor();
     }
 
     public function createRememberMeCookie(UserInterface $user): void
@@ -88,12 +118,17 @@ final class PersistentRememberMeHandler extends AbstractRememberMeHandler
         $series = random_bytes(66);
         $tokenValue = strtr(base64_encode(substr($series, 33)), '+/=', '-_~');
         $series = strtr(base64_encode(substr($series, 0, 33)), '+/=', '-_~');
-        $token = new PersistentToken($user::class, $user->getUserIdentifier(), $series, $tokenValue, new \DateTimeImmutable());
+        $token = new PersistentToken($user::class, $user->getUserIdentifier(), $series, $this->hashTokenValue($tokenValue, $user), new \DateTimeImmutable());
 
         $this->tokenProvider->createNewToken($token);
-        $this->createCookie(RememberMeDetails::fromPersistentToken($token, time() + $this->options['lifetime']));
+        $this->createCookie(new RememberMeDetails($user::class, $user->getUserIdentifier(), time() + $this->options['lifetime'], $series.':'.$tokenValue));
     }
 
+    /**
+     * This does not call the parent method: checking the signature properties requires the user, and the
+     * user is loaded from the identifier of the persistent token rather than from the untrusted cookie,
+     * which also keeps the number of user lookups to one.
+     */
     public function consumeRememberMeCookie(RememberMeDetails $rememberMeDetails): UserInterface
     {
         if (!str_contains($rememberMeDetails->getValue(), ':')) {
@@ -110,12 +145,18 @@ final class PersistentRememberMeHandler extends AbstractRememberMeHandler
         // content of $rememberMeDetails is not trustable. this prevents use of this class
         unset($rememberMeDetails);
 
-        if ($this->tokenVerifier) {
-            $isTokenValid = $this->tokenVerifier->verifyToken($persistentToken, $tokenValue);
-        } else {
-            $isTokenValid = hash_equals($persistentToken->getTokenValue(), $tokenValue);
+        $user = $this->userProvider->loadUserByIdentifier($persistentToken->getUserIdentifier());
+
+        if (!$user instanceof UserInterface) {
+            throw new \LogicException(\sprintf('The UserProviderInterface implementation must return an instance of UserInterface, but returned "%s".', get_debug_type($user)));
         }
-        if (!$isTokenValid) {
+
+        $storedTokenValue = $this->hashTokenValue($tokenValue, $user);
+
+        // a token stored before the signature properties were bound to it is accepted once, then bound
+        $bindToken = $storedTokenValue !== $tokenValue && !str_starts_with($persistentToken->getTokenValue(), self::SIGNATURE_MARKER);
+
+        if (!$this->verifyTokenValue($persistentToken, $bindToken ? $tokenValue : $storedTokenValue)) {
             throw new CookieTheftException('This token was already used. The account is possibly compromised.');
         }
 
@@ -124,12 +165,21 @@ final class PersistentRememberMeHandler extends AbstractRememberMeHandler
             throw new AuthenticationException('The cookie has expired.');
         }
 
-        return parent::consumeRememberMeCookie(new RememberMeDetails(
+        // when the token is about to be regenerated, binding it here would be a needless extra write
+        if ($bindToken && $this->isTokenFresh($persistentToken)) {
+            $this->tokenProvider->updateToken($series, $storedTokenValue, \DateTime::createFromInterface($persistentToken->getLastUsed()));
+        }
+
+        $this->processRememberMe(new RememberMeDetails(
             $persistentToken->getClass(),
             $persistentToken->getUserIdentifier(),
             $expires,
-            $persistentToken->getLastUsed()->getTimestamp().':'.$series.':'.$tokenValue.':'.$persistentToken->getClass()
-        ));
+            $persistentToken->getLastUsed()->getTimestamp().':'.$series.':'.$storedTokenValue.':'.$persistentToken->getClass()
+        ), $user);
+
+        $this->logger?->info('Remember-me cookie accepted.');
+
+        return $user;
     }
 
     public function processRememberMe(RememberMeDetails $rememberMeDetails, UserInterface $user): void
@@ -137,16 +187,15 @@ final class PersistentRememberMeHandler extends AbstractRememberMeHandler
         [$lastUsed, $series, $tokenValue, $class] = explode(':', $rememberMeDetails->getValue(), 4);
         $persistentToken = new PersistentToken($class, $rememberMeDetails->getUserIdentifier(), $series, $tokenValue, new \DateTimeImmutable('@'.$lastUsed));
 
-        // if a token was regenerated less than a minute ago, there is no need to regenerate it
-        // if multiple concurrent requests reauthenticate a user we do not want to update the token several times
-        if ($persistentToken->getLastUsed()->getTimestamp() + 60 >= time()) {
+        if ($this->isTokenFresh($persistentToken)) {
             return;
         }
 
         $tokenValue = strtr(base64_encode(random_bytes(33)), '+/=', '-_~');
+        $storedTokenValue = $this->hashTokenValue($tokenValue, $user);
         $tokenLastUsed = new \DateTime();
-        $this->tokenVerifier?->updateExistingToken($persistentToken, $tokenValue, $tokenLastUsed);
-        $this->tokenProvider->updateToken($series, $tokenValue, $tokenLastUsed);
+        $this->tokenVerifier?->updateExistingToken($persistentToken, $storedTokenValue, $tokenLastUsed);
+        $this->tokenProvider->updateToken($series, $storedTokenValue, $tokenLastUsed);
 
         $this->createCookie($rememberMeDetails->withValue($series.':'.$tokenValue));
     }
@@ -176,5 +225,65 @@ final class PersistentRememberMeHandler extends AbstractRememberMeHandler
     public function getTokenProvider(): TokenProviderInterface
     {
         return $this->tokenProvider;
+    }
+
+    /**
+     * A token regenerated less than a minute ago does not need to be regenerated again.
+     *
+     * This keeps concurrent requests that reauthenticate the same user from updating the token several times.
+     */
+    private function isTokenFresh(PersistentTokenInterface $persistentToken): bool
+    {
+        return $persistentToken->getLastUsed()->getTimestamp() + 60 >= time();
+    }
+
+    private function verifyTokenValue(PersistentTokenInterface $persistentToken, #[\SensitiveParameter] string $tokenValue): bool
+    {
+        if ($this->tokenVerifier) {
+            return $this->tokenVerifier->verifyToken($persistentToken, $tokenValue);
+        }
+
+        return hash_equals($persistentToken->getTokenValue(), $tokenValue);
+    }
+
+    /**
+     * Binds the signature properties of the user to the token value that is stored by the token provider.
+     *
+     * The cookie carries the plain token value only, so that the stored value cannot be replayed and
+     * changing one of the signature properties makes every token of that user unusable.
+     *
+     * Properties the user does not expose are skipped when the list was not configured explicitly. The
+     * token value is then returned unchanged, which is what keeps user classes without any of the default
+     * properties working as they did before the properties were bound.
+     */
+    private function hashTokenValue(#[\SensitiveParameter] string $tokenValue, UserInterface $user): string
+    {
+        $isDefaultList = null === $this->signatureProperties;
+        $signature = hash_init('sha256');
+        $isBound = false;
+
+        foreach ($this->signatureProperties ?? ['password'] as $property) {
+            if ($isDefaultList && !$this->propertyAccessor->isReadable($user, $property)) {
+                continue;
+            }
+
+            $value = $this->propertyAccessor->getValue($user, $property) ?? '';
+            if ($value instanceof \DateTimeInterface) {
+                $value = $value->format('c');
+            }
+
+            if (!\is_scalar($value) && !$value instanceof \Stringable) {
+                throw new \InvalidArgumentException(\sprintf('The property path "%s" on the user object "%s" must return a value that can be cast to a string, but "%s" was returned.', $property, $user::class, get_debug_type($value)));
+            }
+
+            hash_update($signature, ':'.base64_encode($value));
+            $isBound = true;
+        }
+
+        if (!$isBound) {
+            return $tokenValue;
+        }
+
+        return self::SIGNATURE_MARKER.strtr(base64_encode(hash('sha256', $tokenValue.'|'.hash_final($signature), true)), '+/=', '-_~');
     }
 }

--- a/src/Symfony/Component/Security/Http/Tests/Fixtures/PasswordlessUser.php
+++ b/src/Symfony/Component/Security/Http/Tests/Fixtures/PasswordlessUser.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Tests\Fixtures;
+
+use Symfony\Component\Security\Core\User\UserInterface;
+
+final class PasswordlessUser implements UserInterface
+{
+    public function __construct(
+        private string $identifier,
+        private string $email = '',
+    ) {
+    }
+
+    public function getEmail(): string
+    {
+        return $this->email;
+    }
+
+    public function getRoles(): array
+    {
+        return ['ROLE_USER'];
+    }
+
+    public function getUserIdentifier(): string
+    {
+        return $this->identifier;
+    }
+
+    public function eraseCredentials(): void
+    {
+    }
+}

--- a/src/Symfony/Component/Security/Http/Tests/RememberMe/PersistentRememberMeHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/RememberMe/PersistentRememberMeHandlerTest.php
@@ -12,20 +12,27 @@
 namespace Symfony\Component\Security\Http\Tests\RememberMe;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
+use Symfony\Component\Security\Core\Authentication\RememberMe\CacheTokenVerifier;
 use Symfony\Component\Security\Core\Authentication\RememberMe\InMemoryTokenProvider;
 use Symfony\Component\Security\Core\Authentication\RememberMe\PersistentToken;
 use Symfony\Component\Security\Core\Authentication\RememberMe\TokenProviderInterface;
 use Symfony\Component\Security\Core\Authentication\RememberMe\TokenVerifierInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Exception\CookieTheftException;
+use Symfony\Component\Security\Core\Exception\TokenNotFoundException;
 use Symfony\Component\Security\Core\User\InMemoryUser;
 use Symfony\Component\Security\Core\User\InMemoryUserProvider;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Symfony\Component\Security\Http\RememberMe\PersistentRememberMeHandler;
 use Symfony\Component\Security\Http\RememberMe\RememberMeDetails;
 use Symfony\Component\Security\Http\RememberMe\ResponseListener;
+use Symfony\Component\Security\Http\Tests\Fixtures\PasswordlessUser;
 
 class PersistentRememberMeHandlerTest extends TestCase
 {
@@ -33,6 +40,8 @@ class PersistentRememberMeHandlerTest extends TestCase
     private InMemoryUserProvider $userProvider;
     private RequestStack $requestStack;
     private Request $request;
+    private string $password;
+    private string $email;
 
     protected function setUp(): void
     {
@@ -42,6 +51,8 @@ class PersistentRememberMeHandlerTest extends TestCase
         $this->requestStack = new RequestStack();
         $this->request = Request::create('/login');
         $this->requestStack->push($this->request);
+        $this->password = 'p4ssw0rd';
+        $this->email = 'wouter@example.com';
     }
 
     public function testCreateRememberMeCookie()
@@ -217,5 +228,240 @@ class PersistentRememberMeHandlerTest extends TestCase
         $rememberMeDetails = new RememberMeDetails(InMemoryUser::class, 'wouter', 360, 'series1:tokenvalue');
         $rememberMeDetails = RememberMeDetails::fromRawCookie(base64_encode($rememberMeDetails->toString()));
         (new PersistentRememberMeHandler($tokenProvider, $this->userProvider, $this->requestStack, []))->consumeRememberMeCookie($rememberMeDetails);
+    }
+
+    public function testCreateRememberMeCookieBindsThePasswordByDefault()
+    {
+        $handler = $this->createHandler(null, $this->createChangingUserProvider());
+        $handler->createRememberMeCookie(new InMemoryUser('wouter', $this->password));
+
+        [$series, $tokenValue] = $this->readCookieValue();
+
+        // the cookie carries the stored value, so that a version that does not bind properties accepts it
+        $this->assertStringContainsString('.', $tokenValue);
+        $this->assertSame($tokenValue, $this->tokenProvider->loadTokenBySeries($series)->getTokenValue());
+
+        $this->password = 'n3wp4ssw0rd';
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('The cookie\'s hash is invalid.');
+        $handler->consumeRememberMeCookie(new RememberMeDetails(InMemoryUser::class, 'wouter', 360, $series.':'.$tokenValue));
+    }
+
+    public function testConsumeRememberMeCookieSkipsThePasswordTheUserDoesNotExpose()
+    {
+        $handler = $this->createHandler(null, $this->createPasswordlessUserProvider());
+        $handler->createRememberMeCookie(new PasswordlessUser('wouter', $this->email));
+
+        [$series, $tokenValue] = $this->readCookieValue();
+
+        $this->assertStringNotContainsString('.', $tokenValue);
+        $this->assertSame($tokenValue, $this->tokenProvider->loadTokenBySeries($series)->getTokenValue());
+
+        $this->email = 'wouter@example.org';
+
+        $user = $handler->consumeRememberMeCookie(new RememberMeDetails(PasswordlessUser::class, 'wouter', 360, $series.':'.$tokenValue));
+
+        $this->assertSame('wouter', $user->getUserIdentifier());
+    }
+
+    public function testConsumeRememberMeCookieBindsThePasswordByDefaultToAnUnboundToken()
+    {
+        $handler = $this->createHandler(null, $this->createChangingUserProvider());
+        $this->tokenProvider->createNewToken(new PersistentToken(InMemoryUser::class, 'wouter', 'series1', 'tokenvalue', new \DateTimeImmutable('-10 min')));
+
+        $handler->consumeRememberMeCookie(new RememberMeDetails(InMemoryUser::class, 'wouter', 360, 'series1:tokenvalue'));
+
+        // the token is bound when it is regenerated
+        [$series, $tokenValue] = $this->readCookieValue();
+        $this->assertSame('series1', $series);
+        $this->assertStringContainsString('.', $tokenValue);
+        $this->assertSame($tokenValue, $this->tokenProvider->loadTokenBySeries('series1')->getTokenValue());
+
+        $this->password = 'n3wp4ssw0rd';
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('The cookie\'s hash is invalid.');
+        $handler->consumeRememberMeCookie(new RememberMeDetails(InMemoryUser::class, 'wouter', 360, $series.':'.$tokenValue));
+    }
+
+    public function testCreateRememberMeCookieWithAnExplicitPropertyTheUserDoesNotExpose()
+    {
+        $handler = $this->createHandler(['ipAddress'], $this->createChangingUserProvider());
+
+        $this->expectException(NoSuchPropertyException::class);
+        $handler->createRememberMeCookie(new InMemoryUser('wouter', $this->password));
+    }
+
+    public function testConsumeRememberMeCookieWithAnExplicitPropertyTheUserDoesNotExpose()
+    {
+        $handler = $this->createHandler(['ipAddress'], $this->createChangingUserProvider());
+        $this->tokenProvider->createNewToken(new PersistentToken(InMemoryUser::class, 'wouter', 'series1', 'tokenvalue', new \DateTimeImmutable()));
+
+        $this->expectException(NoSuchPropertyException::class);
+        $handler->consumeRememberMeCookie(new RememberMeDetails(InMemoryUser::class, 'wouter', 360, 'series1:tokenvalue'));
+    }
+
+    public function testCreateRememberMeCookieWithAnExplicitPasswordTheUserDoesNotExpose()
+    {
+        $handler = $this->createHandler(['password'], $this->createPasswordlessUserProvider());
+
+        $this->expectException(NoSuchPropertyException::class);
+        $handler->createRememberMeCookie(new PasswordlessUser('wouter'));
+    }
+
+    public function testConsumeRememberMeCookieRejectsABoundTokenWhenThePropertyBecomesUnreadable()
+    {
+        $isReadable = true;
+        $propertyAccessor = $this->createStub(PropertyAccessorInterface::class);
+        $propertyAccessor->method('isReadable')->willReturnCallback(static function () use (&$isReadable) { return $isReadable; });
+        $propertyAccessor->method('getValue')->willReturnCallback(fn () => $this->password);
+
+        $handler = $this->createHandler(null, $this->createChangingUserProvider(), null, $propertyAccessor);
+        $handler->createRememberMeCookie(new InMemoryUser('wouter', $this->password));
+
+        [$series, $tokenValue] = $this->readCookieValue();
+
+        $isReadable = false;
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('The cookie\'s hash is invalid.');
+        $handler->consumeRememberMeCookie(new RememberMeDetails(InMemoryUser::class, 'wouter', 360, $series.':'.$tokenValue));
+    }
+
+    public function testConsumeRememberMeCookieWithUnchangedSignatureProperties()
+    {
+        $handler = $this->createSignedHandler();
+        $handler->createRememberMeCookie(new InMemoryUser('wouter', $this->password));
+
+        [$series, $tokenValue] = $this->readCookieValue();
+
+        $this->assertStringContainsString('.', $tokenValue);
+        $this->assertSame($tokenValue, $this->tokenProvider->loadTokenBySeries($series)->getTokenValue());
+
+        $user = $handler->consumeRememberMeCookie(new RememberMeDetails(InMemoryUser::class, 'wouter', 360, $series.':'.$tokenValue));
+
+        $this->assertSame('wouter', $user->getUserIdentifier());
+    }
+
+    public function testConsumeRememberMeCookieWithChangedSignatureProperties()
+    {
+        $handler = $this->createSignedHandler();
+        $handler->createRememberMeCookie(new InMemoryUser('wouter', $this->password));
+
+        [$series, $tokenValue] = $this->readCookieValue();
+        $rememberMeDetails = new RememberMeDetails(InMemoryUser::class, 'wouter', 360, $series.':'.$tokenValue);
+        $this->request->cookies->set('REMEMBERME', $rememberMeDetails->toString());
+
+        $this->password = 'n3wp4ssw0rd';
+
+        try {
+            $handler->consumeRememberMeCookie($rememberMeDetails);
+            $this->fail('The remember-me cookie should be rejected after a signature property changed.');
+        } catch (AuthenticationException $e) {
+            $this->assertSame('The cookie\'s hash is invalid.', $e->getMessage());
+        }
+
+        // the failed login clears the cookie, which is what deletes the token
+        $handler->clearRememberMeCookie();
+
+        $this->expectException(TokenNotFoundException::class);
+        $this->tokenProvider->loadTokenBySeries($series);
+    }
+
+    public function testConsumeRememberMeCookieRejectsAnotherTokenValueAsTheft()
+    {
+        $handler = $this->createSignedHandler();
+        $handler->createRememberMeCookie(new InMemoryUser('wouter', $this->password));
+
+        [$series, $tokenValue] = $this->readCookieValue();
+        [$random, $digest] = explode('.', $tokenValue);
+        $random = substr_replace($random, 'a' === $random[0] ? 'b' : 'a', 0, 1);
+
+        $this->expectException(CookieTheftException::class);
+        $handler->consumeRememberMeCookie(new RememberMeDetails(InMemoryUser::class, 'wouter', 360, $series.':'.$random.'.'.$digest));
+    }
+
+    public function testConsumeRememberMeCookieBindsSignaturePropertiesToUnboundToken()
+    {
+        $handler = $this->createSignedHandler();
+        $this->tokenProvider->createNewToken(new PersistentToken(InMemoryUser::class, 'wouter', 'series1', 'tokenvalue', new \DateTimeImmutable('-10 min')));
+
+        $handler->consumeRememberMeCookie(new RememberMeDetails(InMemoryUser::class, 'wouter', 360, 'series1:tokenvalue'));
+
+        [$series, $tokenValue] = $this->readCookieValue();
+        $this->assertSame('series1', $series);
+        $this->assertStringContainsString('.', $tokenValue);
+        $this->assertSame($tokenValue, $this->tokenProvider->loadTokenBySeries('series1')->getTokenValue());
+
+        $this->password = 'n3wp4ssw0rd';
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('The cookie\'s hash is invalid.');
+        $handler->consumeRememberMeCookie(new RememberMeDetails(InMemoryUser::class, 'wouter', 360, $series.':'.$tokenValue));
+    }
+
+    public function testConsumeRememberMeCookieRejectsUnboundTokenValueAfterRotation()
+    {
+        $handler = $this->createSignedHandler();
+        $this->tokenProvider->createNewToken(new PersistentToken(InMemoryUser::class, 'wouter', 'series1', 'tokenvalue', new \DateTimeImmutable('-10 min')));
+
+        $handler->consumeRememberMeCookie(new RememberMeDetails(InMemoryUser::class, 'wouter', 360, 'series1:tokenvalue'));
+
+        $this->expectException(CookieTheftException::class);
+        $handler->consumeRememberMeCookie(new RememberMeDetails(InMemoryUser::class, 'wouter', 360, 'series1:tokenvalue'));
+    }
+
+    public function testConsumeRememberMeCookieAcceptsOutdatedTokenValue()
+    {
+        $handler = $this->createSignedHandler(new CacheTokenVerifier(new ArrayAdapter()));
+        $handler->createRememberMeCookie(new InMemoryUser('wouter', $this->password));
+
+        [$series, $tokenValue] = $this->readCookieValue();
+
+        $token = $this->tokenProvider->loadTokenBySeries($series);
+        $this->tokenProvider->createNewToken(new PersistentToken($token->getClass(), $token->getUserIdentifier(), $series, $token->getTokenValue(), new \DateTimeImmutable('-10 min')));
+
+        $rememberMeDetails = new RememberMeDetails(InMemoryUser::class, 'wouter', 360, $series.':'.$tokenValue);
+        $handler->consumeRememberMeCookie($rememberMeDetails);
+
+        // a concurrent request still carries the previous token value
+        $user = $handler->consumeRememberMeCookie($rememberMeDetails);
+
+        $this->assertSame('wouter', $user->getUserIdentifier());
+    }
+
+    private function createSignedHandler(?TokenVerifierInterface $tokenVerifier = null): PersistentRememberMeHandler
+    {
+        return $this->createHandler(['password'], $this->createChangingUserProvider(), $tokenVerifier);
+    }
+
+    private function createHandler(?array $signatureProperties, UserProviderInterface $userProvider, ?TokenVerifierInterface $tokenVerifier = null, ?PropertyAccessorInterface $propertyAccessor = null): PersistentRememberMeHandler
+    {
+        return new PersistentRememberMeHandler($this->tokenProvider, $userProvider, $this->requestStack, [], null, $tokenVerifier, $signatureProperties, $propertyAccessor);
+    }
+
+    private function createChangingUserProvider(): UserProviderInterface
+    {
+        $userProvider = $this->createStub(UserProviderInterface::class);
+        $userProvider->method('loadUserByIdentifier')->willReturnCallback(fn (string $identifier) => new InMemoryUser($identifier, $this->password));
+
+        return $userProvider;
+    }
+
+    private function createPasswordlessUserProvider(): UserProviderInterface
+    {
+        $userProvider = $this->createStub(UserProviderInterface::class);
+        $userProvider->method('loadUserByIdentifier')->willReturnCallback(fn (string $identifier) => new PasswordlessUser($identifier, $this->email));
+
+        return $userProvider;
+    }
+
+    private function readCookieValue(): array
+    {
+        /** @var Cookie $cookie */
+        $cookie = $this->request->attributes->get(ResponseListener::COOKIE_ATTR_NAME);
+
+        return explode(':', explode(':', $cookie->getValue(), 4)[3], 2);
     }
 }

--- a/src/Symfony/Component/Security/Http/Tests/RememberMe/PersistentRememberMeHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/RememberMe/PersistentRememberMeHandlerTest.php
@@ -12,20 +12,27 @@
 namespace Symfony\Component\Security\Http\Tests\RememberMe;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
+use Symfony\Component\Security\Core\Authentication\RememberMe\CacheTokenVerifier;
 use Symfony\Component\Security\Core\Authentication\RememberMe\InMemoryTokenProvider;
 use Symfony\Component\Security\Core\Authentication\RememberMe\PersistentToken;
 use Symfony\Component\Security\Core\Authentication\RememberMe\TokenProviderInterface;
 use Symfony\Component\Security\Core\Authentication\RememberMe\TokenVerifierInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Exception\CookieTheftException;
+use Symfony\Component\Security\Core\Exception\TokenNotFoundException;
 use Symfony\Component\Security\Core\User\InMemoryUser;
 use Symfony\Component\Security\Core\User\InMemoryUserProvider;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Symfony\Component\Security\Http\RememberMe\PersistentRememberMeHandler;
 use Symfony\Component\Security\Http\RememberMe\RememberMeDetails;
 use Symfony\Component\Security\Http\RememberMe\ResponseListener;
+use Symfony\Component\Security\Http\Tests\Fixtures\PasswordlessUser;
 
 class PersistentRememberMeHandlerTest extends TestCase
 {
@@ -33,6 +40,8 @@ class PersistentRememberMeHandlerTest extends TestCase
     private InMemoryUserProvider $userProvider;
     private RequestStack $requestStack;
     private Request $request;
+    private string $password;
+    private string $email;
 
     protected function setUp(): void
     {
@@ -42,6 +51,8 @@ class PersistentRememberMeHandlerTest extends TestCase
         $this->requestStack = new RequestStack();
         $this->request = Request::create('/login');
         $this->requestStack->push($this->request);
+        $this->password = 'p4ssw0rd';
+        $this->email = 'wouter@example.com';
     }
 
     public function testCreateRememberMeCookie()
@@ -217,5 +228,223 @@ class PersistentRememberMeHandlerTest extends TestCase
         $rememberMeDetails = new RememberMeDetails(InMemoryUser::class, 'wouter', 360, 'series1:tokenvalue');
         $rememberMeDetails = RememberMeDetails::fromRawCookie(base64_encode($rememberMeDetails->toString()));
         (new PersistentRememberMeHandler($tokenProvider, $this->userProvider, $this->requestStack, []))->consumeRememberMeCookie($rememberMeDetails);
+    }
+
+    public function testConsumeRememberMeCookieBindsThePasswordByDefault()
+    {
+        $handler = $this->createHandler(null, $this->createChangingUserProvider());
+        $handler->createRememberMeCookie(new InMemoryUser('wouter', $this->password));
+
+        [$series, $tokenValue] = $this->readCookieValue();
+
+        $this->assertNotSame($tokenValue, $this->tokenProvider->loadTokenBySeries($series)->getTokenValue());
+
+        $this->password = 'n3wp4ssw0rd';
+
+        $this->expectException(CookieTheftException::class);
+        $handler->consumeRememberMeCookie(new RememberMeDetails(InMemoryUser::class, 'wouter', 360, $series.':'.$tokenValue));
+    }
+
+    public function testConsumeRememberMeCookieSkipsThePasswordTheUserDoesNotExpose()
+    {
+        $handler = $this->createHandler(null, $this->createPasswordlessUserProvider());
+        $handler->createRememberMeCookie(new PasswordlessUser('wouter', $this->email));
+
+        [$series, $tokenValue] = $this->readCookieValue();
+
+        $this->assertSame($tokenValue, $this->tokenProvider->loadTokenBySeries($series)->getTokenValue());
+
+        $this->email = 'wouter@example.org';
+
+        $user = $handler->consumeRememberMeCookie(new RememberMeDetails(PasswordlessUser::class, 'wouter', 360, $series.':'.$tokenValue));
+
+        $this->assertSame('wouter', $user->getUserIdentifier());
+    }
+
+    public function testConsumeRememberMeCookieBindsThePasswordByDefaultToAnUnboundToken()
+    {
+        $handler = $this->createHandler(null, $this->createChangingUserProvider());
+        $this->tokenProvider->createNewToken(new PersistentToken(InMemoryUser::class, 'wouter', 'series1', 'tokenvalue', new \DateTimeImmutable()));
+
+        $handler->consumeRememberMeCookie(new RememberMeDetails(InMemoryUser::class, 'wouter', 360, 'series1:tokenvalue'));
+
+        $this->assertNotSame('tokenvalue', $this->tokenProvider->loadTokenBySeries('series1')->getTokenValue());
+
+        $this->password = 'n3wp4ssw0rd';
+
+        $this->expectException(CookieTheftException::class);
+        $handler->consumeRememberMeCookie(new RememberMeDetails(InMemoryUser::class, 'wouter', 360, 'series1:tokenvalue'));
+    }
+
+    public function testCreateRememberMeCookieWithAnExplicitPropertyTheUserDoesNotExpose()
+    {
+        $handler = $this->createHandler(['ipAddress'], $this->createChangingUserProvider());
+
+        $this->expectException(NoSuchPropertyException::class);
+        $handler->createRememberMeCookie(new InMemoryUser('wouter', $this->password));
+    }
+
+    public function testConsumeRememberMeCookieWithAnExplicitPropertyTheUserDoesNotExpose()
+    {
+        $handler = $this->createHandler(['ipAddress'], $this->createChangingUserProvider());
+        $this->tokenProvider->createNewToken(new PersistentToken(InMemoryUser::class, 'wouter', 'series1', 'tokenvalue', new \DateTimeImmutable()));
+
+        $this->expectException(NoSuchPropertyException::class);
+        $handler->consumeRememberMeCookie(new RememberMeDetails(InMemoryUser::class, 'wouter', 360, 'series1:tokenvalue'));
+    }
+
+    public function testCreateRememberMeCookieWithAnExplicitPasswordTheUserDoesNotExpose()
+    {
+        $handler = $this->createHandler(['password'], $this->createPasswordlessUserProvider());
+
+        $this->expectException(NoSuchPropertyException::class);
+        $handler->createRememberMeCookie(new PasswordlessUser('wouter'));
+    }
+
+    public function testConsumeRememberMeCookieRejectsABoundTokenWhenThePropertyBecomesUnreadable()
+    {
+        $isReadable = true;
+        $propertyAccessor = $this->createStub(PropertyAccessorInterface::class);
+        $propertyAccessor->method('isReadable')->willReturnCallback(static function () use (&$isReadable) { return $isReadable; });
+        $propertyAccessor->method('getValue')->willReturnCallback(fn () => $this->password);
+
+        $handler = $this->createHandler(null, $this->createChangingUserProvider(), null, $propertyAccessor);
+        $handler->createRememberMeCookie(new InMemoryUser('wouter', $this->password));
+
+        [$series, $tokenValue] = $this->readCookieValue();
+
+        $isReadable = false;
+
+        $this->expectException(CookieTheftException::class);
+        $handler->consumeRememberMeCookie(new RememberMeDetails(InMemoryUser::class, 'wouter', 360, $series.':'.$tokenValue));
+    }
+
+    public function testConsumeRememberMeCookieWithUnchangedSignatureProperties()
+    {
+        $handler = $this->createSignedHandler();
+        $handler->createRememberMeCookie(new InMemoryUser('wouter', $this->password));
+
+        [$series, $tokenValue] = $this->readCookieValue();
+
+        $this->assertNotSame($tokenValue, $this->tokenProvider->loadTokenBySeries($series)->getTokenValue());
+
+        $user = $handler->consumeRememberMeCookie(new RememberMeDetails(InMemoryUser::class, 'wouter', 360, $series.':'.$tokenValue));
+
+        $this->assertSame('wouter', $user->getUserIdentifier());
+    }
+
+    public function testConsumeRememberMeCookieWithChangedSignatureProperties()
+    {
+        $handler = $this->createSignedHandler();
+        $handler->createRememberMeCookie(new InMemoryUser('wouter', $this->password));
+
+        [$series, $tokenValue] = $this->readCookieValue();
+        $rememberMeDetails = new RememberMeDetails(InMemoryUser::class, 'wouter', 360, $series.':'.$tokenValue);
+        $this->request->cookies->set('REMEMBERME', $rememberMeDetails->toString());
+
+        $this->password = 'n3wp4ssw0rd';
+
+        try {
+            $handler->consumeRememberMeCookie($rememberMeDetails);
+            $this->fail('The remember-me cookie should be rejected after a signature property changed.');
+        } catch (CookieTheftException) {
+        }
+
+        // the failed login clears the cookie, which is what deletes the token
+        $handler->clearRememberMeCookie();
+
+        $this->expectException(TokenNotFoundException::class);
+        $this->tokenProvider->loadTokenBySeries($series);
+    }
+
+    public function testConsumeRememberMeCookieBindsSignaturePropertiesToUnboundToken()
+    {
+        $handler = $this->createSignedHandler();
+        $this->tokenProvider->createNewToken(new PersistentToken(InMemoryUser::class, 'wouter', 'series1', 'tokenvalue', new \DateTimeImmutable()));
+
+        $handler->consumeRememberMeCookie(new RememberMeDetails(InMemoryUser::class, 'wouter', 360, 'series1:tokenvalue'));
+
+        $this->assertNotSame('tokenvalue', $this->tokenProvider->loadTokenBySeries('series1')->getTokenValue());
+
+        $this->password = 'n3wp4ssw0rd';
+
+        $this->expectException(CookieTheftException::class);
+        $handler->consumeRememberMeCookie(new RememberMeDetails(InMemoryUser::class, 'wouter', 360, 'series1:tokenvalue'));
+    }
+
+    public function testConsumeRememberMeCookieRejectsStoredTokenValue()
+    {
+        $handler = $this->createSignedHandler();
+        $handler->createRememberMeCookie(new InMemoryUser('wouter', $this->password));
+
+        [$series] = $this->readCookieValue();
+        $storedTokenValue = $this->tokenProvider->loadTokenBySeries($series)->getTokenValue();
+
+        $this->expectException(CookieTheftException::class);
+        $handler->consumeRememberMeCookie(new RememberMeDetails(InMemoryUser::class, 'wouter', 360, $series.':'.$storedTokenValue));
+    }
+
+    public function testConsumeRememberMeCookieRejectsUnboundTokenValueAfterRotation()
+    {
+        $handler = $this->createSignedHandler();
+        $this->tokenProvider->createNewToken(new PersistentToken(InMemoryUser::class, 'wouter', 'series1', 'tokenvalue', new \DateTimeImmutable('-10 min')));
+
+        $handler->consumeRememberMeCookie(new RememberMeDetails(InMemoryUser::class, 'wouter', 360, 'series1:tokenvalue'));
+
+        $this->expectException(CookieTheftException::class);
+        $handler->consumeRememberMeCookie(new RememberMeDetails(InMemoryUser::class, 'wouter', 360, 'series1:tokenvalue'));
+    }
+
+    public function testConsumeRememberMeCookieAcceptsOutdatedTokenValue()
+    {
+        $handler = $this->createSignedHandler(new CacheTokenVerifier(new ArrayAdapter()));
+        $handler->createRememberMeCookie(new InMemoryUser('wouter', $this->password));
+
+        [$series, $tokenValue] = $this->readCookieValue();
+
+        $token = $this->tokenProvider->loadTokenBySeries($series);
+        $this->tokenProvider->createNewToken(new PersistentToken($token->getClass(), $token->getUserIdentifier(), $series, $token->getTokenValue(), new \DateTimeImmutable('-10 min')));
+
+        $rememberMeDetails = new RememberMeDetails(InMemoryUser::class, 'wouter', 360, $series.':'.$tokenValue);
+        $handler->consumeRememberMeCookie($rememberMeDetails);
+
+        // a concurrent request still carries the previous token value
+        $user = $handler->consumeRememberMeCookie($rememberMeDetails);
+
+        $this->assertSame('wouter', $user->getUserIdentifier());
+    }
+
+    private function createSignedHandler(?TokenVerifierInterface $tokenVerifier = null): PersistentRememberMeHandler
+    {
+        return $this->createHandler(['password'], $this->createChangingUserProvider(), $tokenVerifier);
+    }
+
+    private function createHandler(?array $signatureProperties, UserProviderInterface $userProvider, ?TokenVerifierInterface $tokenVerifier = null, ?PropertyAccessorInterface $propertyAccessor = null): PersistentRememberMeHandler
+    {
+        return new PersistentRememberMeHandler($this->tokenProvider, $userProvider, $this->requestStack, [], null, $tokenVerifier, $signatureProperties, $propertyAccessor);
+    }
+
+    private function createChangingUserProvider(): UserProviderInterface
+    {
+        $userProvider = $this->createStub(UserProviderInterface::class);
+        $userProvider->method('loadUserByIdentifier')->willReturnCallback(fn (string $identifier) => new InMemoryUser($identifier, $this->password));
+
+        return $userProvider;
+    }
+
+    private function createPasswordlessUserProvider(): UserProviderInterface
+    {
+        $userProvider = $this->createStub(UserProviderInterface::class);
+        $userProvider->method('loadUserByIdentifier')->willReturnCallback(fn (string $identifier) => new PasswordlessUser($identifier, $this->email));
+
+        return $userProvider;
+    }
+
+    private function readCookieValue(): array
+    {
+        /** @var Cookie $cookie */
+        $cookie = $this->request->attributes->get(ResponseListener::COOKIE_ATTR_NAME);
+
+        return explode(':', explode(':', $cookie->getValue(), 4)[3], 2);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`remember_me.signature_properties` is accepted and silently ignored as soon as a `token_provider` is configured. `RememberMeFactory::createAuthenticator()` reads the option only in the branch that builds `SignatureRememberMeHandler`. The `token_provider` branch builds `PersistentRememberMeHandler`, which never constructs a `SignatureHasher` and never reads a user property, so changing a listed property does not invalidate an already issued cookie. The default value is `['password']`, so an application that never writes the option loses password-change revocation the moment it turns on `token_provider`, while `config:dump-reference security` keeps promising the opposite. This has been the case since 5.3. `RememberMeTest::testUserChangeClearsCookie()` only ever ran against the signature config, which is why it went unnoticed.

A digest of the configured properties is now appended to the token value, in the store and in the cookie alike: `<random>.<digest>`, 77 characters, within the 88 of the documented `rememberme_token.value` column. On consume, the token value is verified as before (`TokenVerifierInterface` or `hash_equals()`), then the digest is recomputed from the loaded user and compared with the stored one. A changed property is refused with `The cookie's hash is invalid.`, the same failure as the signature strategy, and the existing `clearRememberMeCookie()` path on login failure deletes the row; a mismatch of the random part keeps raising `CookieTheftException`, so a stolen token and a changed property stay distinguishable in the logs. The digest covers user state rather than per-series state, so one password change invalidates every series of that user at once, which the provider cannot otherwise express: `TokenProviderInterface` exposes no `deleteTokensByUser()`.

Rows written before the upgrade have no digest: they are accepted as before and bound when the token is next regenerated, that is on the first use more than a minute after the previous one. Because the stored value stays equal to the cookie value, a node running the previous release accepts a bound row and a bound cookie unchanged, so a rolling deploy or a rollback logs nobody out; such a node regenerates the token without a digest, and the next consume on an upgraded node binds it again.

Two behaviors change. An unset option stays lenient: the default `['password']` is bound, and a property the user class does not expose is skipped, so user classes without a password keep working. A written list is strict, as it already is for the signature strategy, and a missing property raises `NoSuchPropertyException`. And `signature_properties` written together with a custom `service` is now refused at compile time instead of being accepted and doing nothing, since a custom handler signs the cookies itself.

`RememberMeTest::testUserChangeInvalidatesRememberMeCookie()` now runs over the persistent configs as well as the signature one.

