### PR TITLE
[Tui] Fix Tailwind font-weight and font-family utilities being treated as FIGlet fonts

### DIFF
--- a/src/Symfony/Component/Tui/Style/TailwindStylesheet.php
+++ b/src/Symfony/Component/Tui/Style/TailwindStylesheet.php
@@ -165,6 +165,19 @@ class TailwindStylesheet extends StyleSheet
         950 => 90,
     ];
 
+    /**
+     * Standard Tailwind `font-{weight|family}` utilities.
+     *
+     * These share the `font-` prefix with Tui's FIGlet font directive
+     * (`font-{name}`), so they must be excluded from that match: a widget
+     * styled with a plain `font-bold`/`font-sans` should not be treated as
+     * requesting a (nonexistent) FIGlet font named "bold" or "sans".
+     */
+    private const FONT_UTILITY_KEYWORDS = [
+        'thin', 'extralight', 'light', 'normal', 'medium', 'semibold', 'bold', 'extrabold', 'black',
+        'sans', 'serif', 'mono',
+    ];
+
     protected function getCssClasses(AbstractWidget $widget): array
     {
         return $this->partitionClasses($widget)['css'];
@@ -334,7 +347,7 @@ class TailwindStylesheet extends StyleSheet
         }
 
         // === FONT ===
-        if (preg_match('/^font-(.+)$/', $class, $m)) {
+        if (preg_match('/^font-(.+)$/', $class, $m) && !\in_array($m[1], self::FONT_UTILITY_KEYWORDS, true)) {
             return ['font' => $m[1]];
         }
 

--- a/src/Symfony/Component/Tui/Style/TailwindStylesheet.php
+++ b/src/Symfony/Component/Tui/Style/TailwindStylesheet.php
@@ -67,6 +67,11 @@ use Symfony\Component\Tui\Widget\AbstractWidget;
  * ### Font
  *     font-{name}           FIGlet font (big, small, slant, standard, mini, or path)
  *
+ *     The standard Tailwind font-weight (font-thin … font-black) and
+ *     font-family (font-sans, font-serif, font-mono) utilities are reserved
+ *     and never treated as a FIGlet font name, even if a font of that name
+ *     is registered.
+ *
  * ### Layout
  *     flex-row              Horizontal direction
  *     flex-col              Vertical direction

--- a/src/Symfony/Component/Tui/Style/TailwindStylesheet.php
+++ b/src/Symfony/Component/Tui/Style/TailwindStylesheet.php
@@ -67,6 +67,10 @@ use Symfony\Component\Tui\Widget\AbstractWidget;
  * ### Font
  *     font-{name}           FIGlet font (big, small, slant, standard, mini, or path)
  *
+ *     The Tailwind font-weight (font-thin to font-black) and font-family
+ *     (font-sans, font-serif, font-mono) utilities never name a FIGlet font:
+ *     they are plain CSS classes, even when a font of that name is registered.
+ *
  * ### Layout
  *     flex-row              Horizontal direction
  *     flex-col              Vertical direction
@@ -163,6 +167,15 @@ class TailwindStylesheet extends StyleSheet
         800 => 60,
         900 => 80,
         950 => 90,
+    ];
+
+    /**
+     * Tailwind font-weight and font-family keywords. They share the "font-"
+     * prefix with the FIGlet font directive and must not name a font.
+     */
+    private const FONT_UTILITY_KEYWORDS = [
+        'thin', 'extralight', 'light', 'normal', 'medium', 'semibold', 'bold', 'extrabold', 'black',
+        'sans', 'serif', 'mono',
     ];
 
     protected function getCssClasses(AbstractWidget $widget): array
@@ -334,7 +347,7 @@ class TailwindStylesheet extends StyleSheet
         }
 
         // === FONT ===
-        if (preg_match('/^font-(.+)$/', $class, $m)) {
+        if (preg_match('/^font-(.+)$/', $class, $m) && !\in_array($m[1], self::FONT_UTILITY_KEYWORDS, true)) {
             return ['font' => $m[1]];
         }
 

--- a/src/Symfony/Component/Tui/Tests/Style/TailwindStylesheetTest.php
+++ b/src/Symfony/Component/Tui/Tests/Style/TailwindStylesheetTest.php
@@ -405,7 +405,9 @@ class TailwindStylesheetTest extends TestCase
      */
     public static function fontUtilityKeywordProvider(): iterable
     {
-        foreach (['thin', 'extralight', 'light', 'normal', 'medium', 'semibold', 'bold', 'extrabold', 'black', 'sans', 'serif', 'mono'] as $keyword) {
+        $keywords = (new \ReflectionClass(TailwindStylesheet::class))->getConstant('FONT_UTILITY_KEYWORDS');
+
+        foreach ($keywords as $keyword) {
             yield $keyword => ["font-{$keyword}"];
         }
     }

--- a/src/Symfony/Component/Tui/Tests/Style/TailwindStylesheetTest.php
+++ b/src/Symfony/Component/Tui/Tests/Style/TailwindStylesheetTest.php
@@ -400,6 +400,26 @@ class TailwindStylesheetTest extends TestCase
         $this->assertSame('mini', $stylesheet->resolve($widget)->getFont());
     }
 
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function fontUtilityKeywordProvider(): iterable
+    {
+        foreach (['thin', 'extralight', 'light', 'normal', 'medium', 'semibold', 'bold', 'extrabold', 'black', 'sans', 'serif', 'mono'] as $keyword) {
+            yield $keyword => ["font-{$keyword}"];
+        }
+    }
+
+    #[DataProvider('fontUtilityKeywordProvider')]
+    public function testStandardFontUtilityIsNotTreatedAsFigletFont(string $utilityClass)
+    {
+        $stylesheet = new TailwindStylesheet();
+        $widget = new TextWidget('Hello');
+        $widget->addStyleClass($utilityClass);
+
+        $this->assertNull($stylesheet->resolve($widget)->getFont());
+    }
+
     // --- Align ---
 
     /**

--- a/src/Symfony/Component/Tui/Tests/Style/TailwindStylesheetTest.php
+++ b/src/Symfony/Component/Tui/Tests/Style/TailwindStylesheetTest.php
@@ -400,6 +400,40 @@ class TailwindStylesheetTest extends TestCase
         $this->assertSame('mini', $stylesheet->resolve($widget)->getFont());
     }
 
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function tailwindFontUtilityProvider(): iterable
+    {
+        yield 'thin' => ['font-thin'];
+        yield 'extralight' => ['font-extralight'];
+        yield 'light' => ['font-light'];
+        yield 'normal' => ['font-normal'];
+        yield 'medium' => ['font-medium'];
+        yield 'semibold' => ['font-semibold'];
+        yield 'bold' => ['font-bold'];
+        yield 'extrabold' => ['font-extrabold'];
+        yield 'black' => ['font-black'];
+        yield 'sans' => ['font-sans'];
+        yield 'serif' => ['font-serif'];
+        yield 'mono' => ['font-mono'];
+    }
+
+    #[DataProvider('tailwindFontUtilityProvider')]
+    public function testTailwindFontUtilityIsACssClassNotAFigletFont(string $class)
+    {
+        $stylesheet = new TailwindStylesheet();
+        $stylesheet->addRule('.'.$class, new Style()->withItalic());
+
+        $widget = new TextWidget('Hello');
+        $widget->addStyleClass($class);
+
+        $resolved = $stylesheet->resolve($widget);
+
+        $this->assertNull($resolved->getFont());
+        $this->assertTrue($resolved->getItalic());
+    }
+
     // --- Align ---
 
     /**

--- a/src/Symfony/Component/Tui/Tests/Widget/FigletTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/FigletTest.php
@@ -177,6 +177,21 @@ class FigletTest extends TestCase
         $this->assertCount(4, $lines);
     }
 
+    public function testTailwindFontUtilityDoesNotSelectAFigletFont()
+    {
+        $renderer = new Renderer(new TailwindStylesheet());
+
+        $root = new ContainerWidget();
+        $widget = new TextWidget('Hello');
+        $widget->addStyleClass('font-bold');
+        $root->add($widget);
+
+        $lines = $renderer->render($root, 80, 24);
+
+        $this->assertCount(1, $lines);
+        $this->assertStringContainsString('Hello', AnsiUtils::stripAnsiCodes($lines[0]));
+    }
+
     public function testInstanceStyleFontOverridesStylesheet()
     {
         $stylesheet = new StyleSheet([


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`TailwindStylesheet` turned every `font-{name}` class into a FIGlet font name, so a widget styled with a standard Tailwind utility such as `font-bold`, `font-sans` or `font-mono` made `TextWidget` ask the `FontRegistry` for a font called "bold" or "sans", which throws at render time:

```
InvalidArgumentException: Font "bold" is not registered. Available fonts: "big", "small", "slant", "standard", "mini".
```

The Tailwind font-weight (`font-thin` to `font-black`) and font-family (`font-sans`, `font-serif`, `font-mono`) keywords are now excluded from the FIGlet match and handled as plain CSS classes, like any other class the stylesheet does not recognize. Bundled and custom FIGlet fonts (`font-big`, `font-my-title`, `font-/path/to/font.flf`) are unchanged.
