### PR TITLE
[Security] Clarify AuthenticatorManager constructor docblock for deprecated eraseCredentials argument

### DIFF
--- a/src/Symfony/Component/Security/Http/Authentication/AuthenticatorManager.php
+++ b/src/Symfony/Component/Security/Http/Authentication/AuthenticatorManager.php
@@ -48,7 +48,7 @@ class AuthenticatorManager implements AuthenticatorManagerInterface, UserAuthent
 {
     /**
      * @param iterable<mixed, AuthenticatorInterface> $authenticators
-     * @param ExposeSecurityLevel                     $exposeSecurityErrors Passing a bool is deprecated since Symfony 8.1
+     * @param ExposeSecurityLevel                     $exposeSecurityErrors Passing the removed "bool $eraseCredentials" as 6th argument (pre-8.1 signature) is deprecated since Symfony 8.1
      * @param string[]                                $requiredBadges
      */
     public function __construct(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65648
| License       | MIT

Since Symfony 8.1, the 6th argument of `AuthenticatorManager::__construct()` is `$exposeSecurityErrors`: the former `bool $eraseCredentials` argument is gone from the signature and the arguments after it moved one position to the left. A bool in that position is only accepted as the removed `$eraseCredentials` of the pre-8.1 signature, which triggers the deprecation and re-reads `$exposeSecurityErrors` and `$requiredBadges` from the next two arguments. The docblock described this as "passing a bool is deprecated", which made it look like a deprecated form of `$exposeSecurityErrors`; it now says which argument the bool is and where it comes from.
