### PR TITLE
[Tui] Fix standard Tailwind font-{weight|family} utilities crashing a…

### DIFF
--- a/src/Symfony/Component/Tui/Style/TailwindStylesheet.php
+++ b/src/Symfony/Component/Tui/Style/TailwindStylesheet.php
@@ -165,6 +165,19 @@ class TailwindStylesheet extends StyleSheet
         950 => 90,
     ];
 
+    /**
+     * Standard Tailwind `font-{weight|family}` utilities.
+     *
+     * These share the `font-` prefix with Tui's FIGlet font directive
+     * (`font-{name}`), so they must be excluded from that match: a widget
+     * styled with a plain `font-bold`/`font-sans` should not be treated as
+     * requesting a (nonexistent) FIGlet font named "bold" or "sans".
+     */
+    private const FONT_UTILITY_KEYWORDS = [
+        'thin', 'extralight', 'light', 'normal', 'medium', 'semibold', 'bold', 'extrabold', 'black',
+        'sans', 'serif', 'mono',
+    ];
+
     protected function getCssClasses(AbstractWidget $widget): array
     {
         return $this->partitionClasses($widget)['css'];
@@ -334,7 +347,7 @@ class TailwindStylesheet extends StyleSheet
         }
 
         // === FONT ===
-        if (preg_match('/^font-(.+)$/', $class, $m)) {
+        if (preg_match('/^font-(.+)$/', $class, $m) && !\in_array($m[1], self::FONT_UTILITY_KEYWORDS, true)) {
             return ['font' => $m[1]];
         }
 

--- a/src/Symfony/Component/Tui/Style/TailwindStylesheet.php
+++ b/src/Symfony/Component/Tui/Style/TailwindStylesheet.php
@@ -67,6 +67,11 @@ use Symfony\Component\Tui\Widget\AbstractWidget;
  * ### Font
  *     font-{name}           FIGlet font (big, small, slant, standard, mini, or path)
  *
+ *     The standard Tailwind font-weight (font-thin … font-black) and
+ *     font-family (font-sans, font-serif, font-mono) utilities are reserved
+ *     and never treated as a FIGlet font name, even if a font of that name
+ *     is registered.
+ *
  * ### Layout
  *     flex-row              Horizontal direction
  *     flex-col              Vertical direction

--- a/src/Symfony/Component/Tui/Tests/Style/TailwindStylesheetTest.php
+++ b/src/Symfony/Component/Tui/Tests/Style/TailwindStylesheetTest.php
@@ -405,7 +405,9 @@ class TailwindStylesheetTest extends TestCase
      */
     public static function fontUtilityKeywordProvider(): iterable
     {
-        foreach (['thin', 'extralight', 'light', 'normal', 'medium', 'semibold', 'bold', 'extrabold', 'black', 'sans', 'serif', 'mono'] as $keyword) {
+        $keywords = (new \ReflectionClass(TailwindStylesheet::class))->getConstant('FONT_UTILITY_KEYWORDS');
+
+        foreach ($keywords as $keyword) {
             yield $keyword => ["font-{$keyword}"];
         }
     }

--- a/src/Symfony/Component/Tui/Tests/Style/TailwindStylesheetTest.php
+++ b/src/Symfony/Component/Tui/Tests/Style/TailwindStylesheetTest.php
@@ -400,6 +400,26 @@ class TailwindStylesheetTest extends TestCase
         $this->assertSame('mini', $stylesheet->resolve($widget)->getFont());
     }
 
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function fontUtilityKeywordProvider(): iterable
+    {
+        foreach (['thin', 'extralight', 'light', 'normal', 'medium', 'semibold', 'bold', 'extrabold', 'black', 'sans', 'serif', 'mono'] as $keyword) {
+            yield $keyword => ["font-{$keyword}"];
+        }
+    }
+
+    #[DataProvider('fontUtilityKeywordProvider')]
+    public function testStandardFontUtilityIsNotTreatedAsFigletFont(string $utilityClass)
+    {
+        $stylesheet = new TailwindStylesheet();
+        $widget = new TextWidget('Hello');
+        $widget->addStyleClass($utilityClass);
+
+        $this->assertNull($stylesheet->resolve($widget)->getFont());
+    }
+
     // --- Align ---
 
     /**


### PR DESCRIPTION
…s FIGlet fonts

TailwindStylesheet::parseSingleUtility() matched any "font-{name}" class as the FIGlet font directive, with no distinction from Tailwind's own font-{weight|family} utility namespace (font-bold, font-sans, font-mono, etc.). Styling any TextWidget with one of these common utility classes made TextWidget::renderFiglet() call FontRegistry::get() with the weight/family keyword as a font name, throwing InvalidArgumentException at render time.

Exclude the standard Tailwind font-weight and font-family keywords from the FIGlet font match so they fall through to plain CSS class handling instead.

| Q             | A
| ------------- | ---
| Branch?       | 8.2 for features / 6.4, 7.4, 8.1 for bug fixes
| Bug fix?      | yes/no
| New feature?  | yes/no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | yes/no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

<!--
🛠️ Replace this text with a concise explanation of your change:
- What it does and why it's needed
- A simple example of how it works (include PHP, YAML, etc.)
- If it modifies existing behavior, include a before/after comparison

Contributor guidelines:
- ✅ Add tests and ensure they pass
- 🐞 Bug fixes must target the **lowest maintained** branch where they apply
  https://symfony.com/releases#maintained-symfony-branches
- ✨ New features and deprecations must target the **feature** branch
  and must add an entry to the changelog file of the patched component:
  https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
- 🔒 Do not break backward compatibility:
  https://symfony.com/bc
-->
