### PR TITLE
[Cache] Respect max_execution_time in LockRegistry's wait loop

### DIFF
--- a/src/Symfony/Component/Cache/LockRegistry.php
+++ b/src/Symfony/Component/Cache/LockRegistry.php
@@ -127,6 +127,17 @@ final class LockRegistry
                 $logger?->info('Item "{key}" is locked, waiting for it to be released', ['key' => $item->getKey()]);
 
                 $deadline = microtime(true) + 30.0;
+
+                // max_execution_time counts wall time on Windows, on Apple Silicon and on ZTS builds with zend-max-execution-timers
+                // (e.g. FrankenPHP): stop waiting 1s before that limit, to leave time for evicting the slot and computing the value.
+                // A limit that is already past means the timer counts CPU time or was restarted by set_time_limit(): ignore it then.
+                if (0 < $limit = (int) \ini_get('max_execution_time')) {
+                    $end = ($_SERVER['REQUEST_TIME_FLOAT'] ?? microtime(true)) + $limit;
+
+                    if (microtime(true) < $end) {
+                        $deadline = min($deadline, $end - 1.0);
+                    }
+                }
                 $acquired = false;
                 do {
                     if ($acquired = flock($lock, \LOCK_SH | \LOCK_NB)) {

--- a/src/Symfony/Component/Cache/Tests/LockRegistryTest.php
+++ b/src/Symfony/Component/Cache/Tests/LockRegistryTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Cache\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Log\AbstractLogger;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Cache\LockRegistry;
 
@@ -46,5 +47,86 @@ class LockRegistryTest extends TestCase
 
         $this->assertSame('bar', $pool->get('foo', static fn () => 'bar'));
         $this->assertSame([], $logger->messages);
+    }
+
+    public function testWaitLoopEndsBeforeMaxExecutionTime()
+    {
+        $elapsed = $this->computeWhileSlotIsLocked(requestAge: 0.0);
+
+        $this->assertGreaterThan(0.5, $elapsed, 'The wait loop should use the time budget that is left');
+        $this->assertLessThan(2.0, $elapsed, 'The wait loop should end before max_execution_time');
+    }
+
+    public function testWaitLoopEndsAtOnceWhenMaxExecutionTimeIsNear()
+    {
+        $elapsed = $this->computeWhileSlotIsLocked(requestAge: 1.5);
+
+        $this->assertLessThan(0.5, $elapsed, 'The wait loop should end before max_execution_time');
+    }
+
+    /**
+     * Calls LockRegistry::compute() while another process holds the lock of the item,
+     * with a max_execution_time of 2 seconds of which $requestAge seconds are already spent.
+     *
+     * @return float The number of seconds it took for the callback to run
+     */
+    private function computeWhileSlotIsLocked(float $requestAge): float
+    {
+        if ('\\' === \DIRECTORY_SEPARATOR) {
+            $this->markTestSkipped('LockRegistry is disabled on Windows');
+        }
+        if (!\function_exists('proc_open')) {
+            $this->markTestSkipped('proc_open() is required');
+        }
+
+        $logger = new class extends AbstractLogger {
+            public array $messages = [];
+
+            public function log($level, $message, array $context = []): void
+            {
+                $this->messages[] = $message;
+            }
+        };
+
+        $files = [tempnam(sys_get_temp_dir(), 'sf_lock'), tempnam(sys_get_temp_dir(), 'sf_lock')];
+        $pool = new ArrayAdapter();
+        $item = $pool->getItem('foo');
+
+        $script = 'flock($h = fopen($argv[1], "r+"), LOCK_EX) || exit(1); echo "locked\n"; fgets(STDIN);';
+        $process = proc_open([\PHP_BINARY, '-n', '-r', $script, '--', $files[abs(crc32($item->getKey())) % 2]], [['pipe', 'r'], ['pipe', 'w'], ['redirect', 1]], $pipes);
+        $this->assertSame("locked\n", fgets($pipes[1]));
+
+        $previousFiles = LockRegistry::setFiles($files);
+        $previousLimit = (int) \ini_get('max_execution_time');
+        $previousRequestTime = $_SERVER['REQUEST_TIME_FLOAT'] ?? null;
+        $save = true;
+
+        try {
+            $_SERVER['REQUEST_TIME_FLOAT'] = microtime(true) - $requestAge;
+            set_time_limit(2);
+            $start = microtime(true);
+
+            $this->assertSame('bar', LockRegistry::compute(static fn () => 'bar', $item, $save, $pool, null, $logger));
+            $this->assertSame([
+                'Item "{key}" is locked, waiting for it to be released',
+                'Lock on item "{key}" timed out, evicting slot',
+                'Lock acquired, now computing item "{key}"',
+            ], $logger->messages);
+
+            return microtime(true) - $start;
+        } finally {
+            set_time_limit($previousLimit);
+            if (null === $previousRequestTime) {
+                unset($_SERVER['REQUEST_TIME_FLOAT']);
+            } else {
+                $_SERVER['REQUEST_TIME_FLOAT'] = $previousRequestTime;
+            }
+            LockRegistry::setFiles($previousFiles);
+            fclose($pipes[0]);
+            fclose($pipes[1]);
+            proc_terminate($process);
+            proc_close($process);
+            array_map('unlink', $files);
+        }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65659
| License       | MIT

`LockRegistry::compute()` waits up to 30 seconds for the process that computes a cache item, sleeping 100 ms between lock attempts. Whether that wait counts against `max_execution_time` depends on the PHP build: NTS builds on Linux count CPU time, so sleeping is free, but ZTS builds with zend-max-execution-timers (the FrankenPHP builds), Windows and Apple Silicon count wall time. With the default limit of 30 seconds the request is then killed inside the wait loop, with a `MaxExecutionTimeError` that points at `LockRegistry`.

The wait is now capped on the time the request has left: `$_SERVER['REQUEST_TIME_FLOAT'] + max_execution_time`, minus one second so that the slot can be evicted and the value computed. A limit that is already past is ignored, since on a wall-time build the request would be dead already: it means the timer counts CPU time, or that it was restarted by `set_time_limit()`. Requests without a limit keep the 30 second cap. On CPU-time builds this can evict a slot before the 30 second cap when a request is near the end of its wall budget; the eviction then behaves as it did after 30 seconds.

The test holds the slot from a child process, sets a 2 second limit, and checks that the callback runs within the remaining budget instead of after 30 seconds.
