### PR TITLE
[HtmlSanitizer] Accept percent-encoded line breaks and tabs in the query of hostless URLs

### DIFF
--- a/src/Symfony/Component/HtmlSanitizer/Tests/HtmlSanitizerAllTest.php
+++ b/src/Symfony/Component/HtmlSanitizer/Tests/HtmlSanitizerAllTest.php
@@ -345,6 +345,10 @@ class HtmlSanitizerAllTest extends TestCase
                 '<a href="mailto:test&#64;gmail.com" title="Link title">Lorem ipsum</a>',
             ],
             [
+                '<a href="mailto:infobot@example.com?body=send%20current-issue%0D%0Asend%20index" title="Link title">Lorem ipsum</a>',
+                '<a href="mailto:infobot&#64;example.com?body&#61;send%20current-issue%0D%0Asend%20index" title="Link title">Lorem ipsum</a>',
+            ],
+            [
                 '<blockquote>Lorem ipsum</blockquote>',
                 '<blockquote>Lorem ipsum</blockquote>',
             ],

--- a/src/Symfony/Component/HtmlSanitizer/Tests/TextSanitizer/UrlSanitizerTest.php
+++ b/src/Symfony/Component/HtmlSanitizer/Tests/TextSanitizer/UrlSanitizerTest.php
@@ -881,6 +881,28 @@ class UrlSanitizerTest extends TestCase
             'http://example.com/foo%C2%A0bar' => null,
             'http://example.com/%E2%80%A8bar' => null,
             'http://example.com/%E3%80%80bar' => null,
+
+            // Percent-encoded line breaks and tabs are legitimate in the query and
+            // fragment of hostless schemes (RFC 6068 requires %0D%0A in a mailto body)
+            'mailto:infobot@example.com?body=send%20current-issue%0D%0Asend%20index' => ['scheme' => 'mailto', 'host' => null],
+            'mailto:x@example.com?body=line1%0d%0aline2' => ['scheme' => 'mailto', 'host' => null],
+            'mailto:x@example.com?body=col1%09col2' => ['scheme' => 'mailto', 'host' => null],
+            'mailto:x@example.com#line1%0D%0Aline2' => ['scheme' => 'mailto', 'host' => null],
+            'sms:+15105550101?body=line1%0D%0Aline2' => ['scheme' => 'sms', 'host' => null],
+            'mailto:x%0D%0Ay@example.com' => null,
+            'mailto:x@example.com?subject=%E2%80%AE' => null,
+            'mailto:x@example.com#%E2%81%A6' => null,
+            'mailto:x@example.com?subject=a%C2%A0b' => null,
+            'mailto:x@example.com?subject=a%E2%80%A8b' => null,
+            'mailto:x@example.com?subject=a%0Bb' => null,
+            'mailto:x@example.com?subject=a%0Cb' => null,
+            'mailto:x@example.com?body=line1%0D%0Aline2%E2%80%AE' => null,
+            "mailto:x@example.com?body=line1\nline2" => null,
+            "mailto:x@example.com?body=col1\tcol2" => null,
+            'http://example.com/?q=line1%0D%0Aline2' => null,
+            'http://example.com/?q=col1%09col2' => null,
+            'http://example.com/#line1%0Aline2' => null,
+            'http://example.com/?q=a%C2%A0b' => null,
         ];
 
         foreach ($urls as $url => $expected) {

--- a/src/Symfony/Component/HtmlSanitizer/TextSanitizer/UrlSanitizer.php
+++ b/src/Symfony/Component/HtmlSanitizer/TextSanitizer/UrlSanitizer.php
@@ -24,7 +24,7 @@ final class UrlSanitizer
      * formatting marks plus Unicode whitespace and the zero-width no-break
      * space. ASCII space is tolerated and percent-encoded by parse().
      */
-    private const DENIED_CHARS_PATTERN = '/[\t\n\v\f\r\x{0085}\x{00A0}\x{1680}\x{2000}-\x{200A}\x{2028}\x{2029}\x{202F}\x{205F}\x{3000}\x{FEFF}\x{202A}-\x{202E}\x{2066}-\x{2069}]/u';
+    private const DENIED_CHARS_PATTERN = '/[\t\n\x0B\f\r\x{0085}\x{00A0}\x{1680}\x{2000}-\x{200A}\x{2028}\x{2029}\x{202F}\x{205F}\x{3000}\x{FEFF}\x{202A}-\x{202E}\x{2066}-\x{2069}]/u';
 
     /**
      * Sanitizes a given URL string.
@@ -149,8 +149,22 @@ final class UrlSanitizer
 
             // Reject denied characters reachable via percent-encoding in any
             // component; otherwise the upfront check is bypassed by encoding.
+            // Percent-encoded line breaks and tabs are legitimate in the query
+            // and fragment of hostless schemes: RFC 6068 requires %0D%0A for
+            // line breaks in the body of a mailto URL.
+            $isHostless = self::isHostlessScheme($parsedUrl['scheme']);
             foreach (['user', 'pass', 'host', 'path', 'query', 'fragment'] as $part) {
-                if (isset($parsedUrl[$part]) && preg_match(self::DENIED_CHARS_PATTERN, rawurldecode($parsedUrl[$part]))) {
+                if (!isset($parsedUrl[$part])) {
+                    continue;
+                }
+
+                $decoded = rawurldecode($parsedUrl[$part]);
+
+                if ($isHostless && ('query' === $part || 'fragment' === $part)) {
+                    $decoded = str_replace(["\r", "\n", "\t"], '', $decoded);
+                }
+
+                if (preg_match(self::DENIED_CHARS_PATTERN, $decoded)) {
                     return null;
                 }
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65650
| License       | MIT

Since the percent-decoded check for denied characters was added to `UrlSanitizer::parse()`, a `mailto:` URL with a multi-line body was rejected and the link lost its `href` silently. RFC 6068 requires line breaks in the body to be encoded as `%0D%0A`, so a URL that follows the scheme's own specification was dropped.

The check now ignores percent-encoded CR, LF and TAB in the query and fragment of hostless schemes (`mailto`, `sms`, `tel`, ...). Everything else is unchanged: those characters stay rejected in every other component, for every scheme with an authority (`https://example.org/a?x=1%0A2` is still rejected), and the BiDi marks and Unicode whitespace stay rejected everywhere, encoded or not. The output keeps the percent-encoded form.

Before: `<a href="mailto:infobot@example.com?body=send%20current-issue%0D%0Asend%20index">contact</a>` became `<a>contact</a>`.
After: `<a href="mailto:infobot&#64;example.com?body&#61;send%20current-issue%0D%0Asend%20index">contact</a>`.

The `\v` escape in the denied-characters pattern is PCRE's vertical whitespace class, not the vertical tab; it is replaced by `\x0B`. This changes nothing, since every character `\v` matches is listed explicitly in the pattern.
