### PR TITLE
[HtmlSanitizer] Keep rejecting denied URL characters when percent-decoding yields malformed UTF-8

### DIFF
--- a/src/Symfony/Component/HtmlSanitizer/Tests/HtmlSanitizerAllTest.php
+++ b/src/Symfony/Component/HtmlSanitizer/Tests/HtmlSanitizerAllTest.php
@@ -349,6 +349,10 @@ class HtmlSanitizerAllTest extends TestCase
                 '<a href="mailto:infobot&#64;example.com?body&#61;send%20current-issue%0D%0Asend%20index" title="Link title">Lorem ipsum</a>',
             ],
             [
+                '<a href="https://trusted.com/?q=%E2%80%AD%80" title="Link title">Lorem ipsum</a>',
+                '<a title="Link title">Lorem ipsum</a>',
+            ],
+            [
                 '<blockquote>Lorem ipsum</blockquote>',
                 '<blockquote>Lorem ipsum</blockquote>',
             ],

--- a/src/Symfony/Component/HtmlSanitizer/Tests/TextSanitizer/UrlSanitizerTest.php
+++ b/src/Symfony/Component/HtmlSanitizer/Tests/TextSanitizer/UrlSanitizerTest.php
@@ -337,6 +337,61 @@ class UrlSanitizerTest extends TestCase
             'allowRelative' => false,
             'expected' => null,
         ];
+
+        // view-source URLs wrap another URL, which must pass the same checks
+        yield [
+            'input' => 'view-source:https://trusted.com/index.html',
+            'allowedSchemes' => ['https', 'view-source'],
+            'allowedHosts' => ['trusted.com'],
+            'forceHttps' => false,
+            'allowRelative' => false,
+            'expected' => 'view-source:https://trusted.com/index.html',
+        ];
+
+        yield [
+            'input' => 'view-source:https://untrusted.com/index.html',
+            'allowedSchemes' => ['https', 'view-source'],
+            'allowedHosts' => ['trusted.com'],
+            'forceHttps' => false,
+            'allowRelative' => false,
+            'expected' => null,
+        ];
+
+        yield [
+            'input' => 'view-source:https://untrusted.com/index.html',
+            'allowedSchemes' => ['https', 'view-source'],
+            'allowedHosts' => ['trusted.com'],
+            'forceHttps' => false,
+            'allowRelative' => true,
+            'expected' => null,
+        ];
+
+        yield [
+            'input' => 'view-source:http://trusted.com/index.html',
+            'allowedSchemes' => ['http', 'https', 'view-source'],
+            'allowedHosts' => null,
+            'forceHttps' => true,
+            'allowRelative' => false,
+            'expected' => 'view-source:https://trusted.com/index.html',
+        ];
+
+        yield [
+            'input' => 'view-source:javascript:alert(1)',
+            'allowedSchemes' => ['https', 'view-source'],
+            'allowedHosts' => null,
+            'forceHttps' => false,
+            'allowRelative' => false,
+            'expected' => null,
+        ];
+
+        yield [
+            'input' => 'view-source:view-source:https://trusted.com/index.html',
+            'allowedSchemes' => ['https', 'view-source'],
+            'allowedHosts' => ['trusted.com'],
+            'forceHttps' => false,
+            'allowRelative' => false,
+            'expected' => null,
+        ];
     }
 
     /**

--- a/src/Symfony/Component/HtmlSanitizer/Tests/TextSanitizer/UrlSanitizerTest.php
+++ b/src/Symfony/Component/HtmlSanitizer/Tests/TextSanitizer/UrlSanitizerTest.php
@@ -903,6 +903,19 @@ class UrlSanitizerTest extends TestCase
             'http://example.com/?q=col1%09col2' => null,
             'http://example.com/#line1%0Aline2' => null,
             'http://example.com/?q=a%C2%A0b' => null,
+
+            // A stray byte next to a denied character must not disable the check
+            'http://example.com/?q=%E2%80%AD%80' => null,
+            'http://example.com/#%E2%80%AE%80' => null,
+            'http://example.com/%E2%81%A6%80/x' => null,
+            'http://%E2%80%AE%80@example.com/' => null,
+            'http://example.com/?q=%C2%A0%80' => null,
+            'mailto:x@example.com?subject=%E2%80%AE%80' => null,
+            "http://example.com/foo\u{202E}bar\x80" => null,
+
+            // Percent-encoded bytes that are not UTF-8 are accepted when no character is denied
+            'http://example.com/%80' => ['scheme' => 'http', 'host' => 'example.com'],
+            'http://example.com/?name=Fran%E7ois' => ['scheme' => 'http', 'host' => 'example.com'],
         ];
 
         foreach ($urls as $url => $expected) {

--- a/src/Symfony/Component/HtmlSanitizer/TextSanitizer/UrlSanitizer.php
+++ b/src/Symfony/Component/HtmlSanitizer/TextSanitizer/UrlSanitizer.php
@@ -73,6 +73,18 @@ final class UrlSanitizer
             return null;
         }
 
+        // A view-source URL wraps another URL, which has to pass the same checks;
+        // browsers reject a view-source URL wrapped in another one
+        if ('view-source' === $url['scheme']) {
+            $nested = substr($input, \strlen('view-source:'));
+
+            if (0 === strncasecmp($nested, 'view-source:', 12) || null === $nested = self::sanitize($nested, $allowedSchemes, $forceHttps, $allowedHosts, $allowRelative)) {
+                return null;
+            }
+
+            return 'view-source:'.$nested;
+        }
+
         // If the scheme used is not supposed to have a host, do not check the host
         if (!self::isHostlessScheme($url['scheme'])) {
             // No host and relative not allowed
@@ -187,7 +199,7 @@ final class UrlSanitizer
 
     private static function isHostlessScheme(?string $scheme): bool
     {
-        return \in_array($scheme, ['blob', 'chrome', 'data', 'file', 'geo', 'mailto', 'maps', 'tel', 'sms', 'view-source'], true);
+        return \in_array($scheme, ['blob', 'chrome', 'data', 'file', 'geo', 'mailto', 'maps', 'tel', 'sms'], true);
     }
 
     private static function isAllowedHost(?string $host, array $allowedHosts): bool

--- a/src/Symfony/Component/HtmlSanitizer/TextSanitizer/UrlSanitizer.php
+++ b/src/Symfony/Component/HtmlSanitizer/TextSanitizer/UrlSanitizer.php
@@ -23,8 +23,18 @@ final class UrlSanitizer
      * Characters with no legitimate place in a URL: explicit-direction BiDi
      * formatting marks plus Unicode whitespace and the zero-width no-break
      * space. ASCII space is tolerated and percent-encoded by parse().
+     *
+     * The characters are matched as UTF-8 byte sequences: with the "u" modifier,
+     * preg_match() returns false on malformed UTF-8, which percent-decoding can
+     * produce, and the check would then be skipped.
      */
-    private const DENIED_CHARS_PATTERN = '/[\t\n\x0B\f\r\x{0085}\x{00A0}\x{1680}\x{2000}-\x{200A}\x{2028}\x{2029}\x{202F}\x{205F}\x{3000}\x{FEFF}\x{202A}-\x{202E}\x{2066}-\x{2069}]/u';
+    private const DENIED_CHARS_PATTERN = '/[\t\n\x0B\f\r]'
+        .'|\xC2[\x85\xA0]'                // U+0085, U+00A0
+        .'|\xE1\x9A\x80'                  // U+1680
+        .'|\xE2\x80[\x80-\x8A\xA8-\xAF]'  // U+2000-U+200A, U+2028-U+202F
+        .'|\xE2\x81[\x9F\xA6-\xA9]'       // U+205F, U+2066-U+2069
+        .'|\xE3\x80\x80'                  // U+3000
+        .'|\xEF\xBB\xBF/';                // U+FEFF
 
     /**
      * Sanitizes a given URL string.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`UrlSanitizer::parse()` rejects BiDi formatting marks and Unicode whitespace in every URL component, raw and percent-decoded. The pattern used the `u` modifier, and with that modifier `preg_match()` returns `false` on malformed UTF-8, which the check read as "no match". Percent-decoding produces malformed UTF-8 as soon as one encoded byte does not complete a sequence, so a stray byte next to a denied character switched the check off for that component:

```php
UrlSanitizer::sanitize('http://example.com/?q=%E2%80%AD');     // null
UrlSanitizer::sanitize('http://example.com/?q=%E2%80%AD%80');  // 'http://example.com/?q=%E2%80%AD%80'
```

The denied characters are now matched as UTF-8 byte sequences, without the `u` modifier, so the match works on any input; the set is unchanged (verified against the previous pattern over every code point). Percent-encoded bytes that are not UTF-8 stay accepted when no denied character is present (`http://example.com/?name=Fran%E7ois`, `http://example.com/%80`), as before.

Second commit: `view-source` was in the hostless-scheme list, so when an application allows that scheme, the URL after `view-source:` was never checked against the allowed hosts or schemes and never forced to HTTPS (`view-source:https://untrusted.com/` passed `allowLinkHosts(['trusted.com'])`). The wrapped URL now goes through `sanitize()` with the same constraints.
