### PR TITLE
[VarDumper] Account for PHP 8.6 deprecating `SplFileObject::getCsvControl()`

### DIFF
--- a/src/Symfony/Component/VarDumper/Caster/SplCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/SplCaster.php
@@ -160,7 +160,6 @@ class SplCaster
     public static function castFileObject(\SplFileObject $c, array $a, Stub $stub, bool $isNested)
     {
         static $map = [
-            'csvControl' => 'getCsvControl',
             'flags' => 'getFlags',
             'maxLineLen' => 'getMaxLineLen',
             'fstat' => 'fstat',
@@ -169,6 +168,16 @@ class SplCaster
         ];
 
         $prefix = Caster::PREFIX_VIRTUAL;
+
+        if (\PHP_VERSION_ID < 90000) {
+            set_error_handler(static fn () => true, \E_DEPRECATED);
+            try {
+                $a[$prefix.'csvControl'] = $c->getCsvControl();
+            } catch (\Exception) {
+            } finally {
+                restore_error_handler();
+            }
+        }
 
         foreach ($map as $key => $accessor) {
             try {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT
