### PR TITLE
 Upgrade twig-cs-fixer to version 4.0

### DIFF
--- a/.github/workflows/twig-cs-fixer.yml
+++ b/.github/workflows/twig-cs-fixer.yml
@@ -41,7 +41,7 @@ jobs:
           COMPOSER_HOME="$(composer config home)"
           ([ -d "$COMPOSER_HOME" ] || mkdir "$COMPOSER_HOME") && cp .github/composer-config.json "$COMPOSER_HOME/config.json"
           export COMPOSER_ROOT_VERSION=$(grep ' VERSION = ' src/Symfony/Component/HttpKernel/Kernel.php | grep -P -o '[0-9]+\.[0-9]+').x-dev
-          composer require --dev vincentlanglet/twig-cs-fixer:^3.9.0
+          composer require --dev vincentlanglet/twig-cs-fixer:^4.0
 
       - name: Run Twig CS Fixer Lint
         run: vendor/bin/twig-cs-fixer lint --config=.twig-cs-fixer.dist.php --report=github

--- a/src/Symfony/Bundle/DebugBundle/Resources/views/Profiler/dump.html.twig
+++ b/src/Symfony/Bundle/DebugBundle/Resources/views/Profiler/dump.html.twig
@@ -1,4 +1,4 @@
-{% extends '@WebProfiler/Profiler/layout.html.twig' %}
+{%  extends '@WebProfiler/Profiler/layout.html.twig' %}
 
 {% block toolbar %}
     {% if collector.dumpsCount %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2 or 6.4, tbd
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| License       | MIT

Bump the twig cs fixer tool to its latest major version
linked to https://github.com/symfony-tools/fabbot/pull/20

ℹ️ the second commit is to be reverted, was just added to test ci on GitHub ✅ ([via](https://github.com/symfony/symfony/actions/runs/33150520305/job/98781179377))