### PR TITLE
[Serializer] Fix deep_object_to_populate for collections of objects

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/ArrayDenormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ArrayDenormalizer.php
@@ -71,9 +71,19 @@ class ArrayDenormalizer implements ContextAwareDenormalizerInterface, Denormaliz
             }
         }
 
+        if (\is_array($objectsToPopulate = $context[AbstractNormalizer::OBJECT_TO_POPULATE] ?? null)) {
+            unset($context[AbstractNormalizer::OBJECT_TO_POPULATE]);
+        } else {
+            $objectsToPopulate = [];
+        }
+
         foreach ($data as $key => $value) {
             $subContext = $context;
             $subContext['deserialization_path'] = ($context['deserialization_path'] ?? false) ? \sprintf('%s[%s]', $context['deserialization_path'], $key) : "[$key]";
+
+            if (\is_object($objectsToPopulate[$key] ?? null) || \is_array($objectsToPopulate[$key] ?? null)) {
+                $subContext[AbstractNormalizer::OBJECT_TO_POPULATE] = $objectsToPopulate[$key];
+            }
 
             $this->validateKeyType($builtinTypes, $key, $subContext['deserialization_path']);
 

--- a/src/Symfony/Component/Serializer/Tests/DeserializeNestedArrayOfObjectsTest.php
+++ b/src/Symfony/Component/Serializer/Tests/DeserializeNestedArrayOfObjectsTest.php
@@ -54,6 +54,33 @@ class DeserializeNestedArrayOfObjectsTest extends TestCase
         self::assertInstanceOf(Animal::class, $zoo->getAnimals()[0]);
     }
 
+    public function testPropertyPhpDocWithDeepObjectToPopulate()
+    {
+        $json = <<<EOF
+            {
+                "animals": [
+                    {"name": "Bug"}
+                ]
+            }
+            EOF;
+        $serializer = new Serializer([
+            new ObjectNormalizer(null, null, null, new PhpDocExtractor()),
+            new ArrayDenormalizer(),
+        ], ['json' => new JsonEncoder()]);
+
+        $zoo = new Zoo();
+        $zoo->setAnimals([$animal = new Animal()]);
+
+        $serializer->deserialize($json, Zoo::class, 'json', [
+            'object_to_populate' => $zoo,
+            'deep_object_to_populate' => true,
+        ]);
+
+        self::assertCount(1, $zoo->getAnimals());
+        self::assertSame($animal, $zoo->getAnimals()[0]);
+        self::assertSame('Bug', $animal->getName());
+    }
+
     public function testPropertyPhpDocWithKeyTypes()
     {
         $json = <<<EOF

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ArrayDenormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ArrayDenormalizerTest.php
@@ -54,6 +54,37 @@ class ArrayDenormalizerTest extends TestCase
         );
     }
 
+    public function testDenormalizeSplitsObjectToPopulatePerItem()
+    {
+        $first = new ArrayDummy('one', 'two');
+        $nested = [new ArrayDummy('three', 'four')];
+        $contexts = [];
+
+        $nestedDenormalizer = $this->createMock(DenormalizerInterface::class);
+        $nestedDenormalizer->expects($this->exactly(4))
+            ->method('denormalize')
+            ->willReturnCallback(static function ($data, $type, $format, $context) use (&$contexts) {
+                $contexts[] = $context;
+
+                return $data;
+            })
+        ;
+
+        $denormalizer = new ArrayDenormalizer();
+        $denormalizer->setDenormalizer($nestedDenormalizer);
+        $denormalizer->denormalize(
+            ['a' => [], 'b' => [], 'c' => [], 'd' => []],
+            __NAMESPACE__.'\ArrayDummy[]',
+            null,
+            ['object_to_populate' => ['a' => $first, 'b' => $nested, 'c' => 'scalar']]
+        );
+
+        $this->assertSame($first, $contexts[0]['object_to_populate']);
+        $this->assertSame($nested, $contexts[1]['object_to_populate']);
+        $this->assertArrayNotHasKey('object_to_populate', $contexts[2]);
+        $this->assertArrayNotHasKey('object_to_populate', $contexts[3]);
+    }
+
     public function testSupportsValidArray()
     {
         $nestedDenormalizer = $this->createMock(DenormalizerInterface::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65669
| License       | MIT

With `deep_object_to_populate`, a nested object attribute is populated in place, but a nested collection of objects is not: `AbstractObjectNormalizer` hands the whole existing array down as `object_to_populate`, and `ArrayDenormalizer` copies that array into every item's context, where `extractObjectToPopulate()` ignores it because it is not an object of the item type. Each item is then built from scratch and everything the payload does not mention is lost.

This gives each item the existing entry at the same key instead, so collection items keep their identity and their untouched properties, like nested objects already do. Items with no existing counterpart are still created fresh. The issue lists 7.4 and up, but 6.4 has the same behavior, so I targeted it here.

```php
$invoice->lines = [$line];  // $line->id = 1
$serializer->denormalize(
    ['lines' => [['description' => 'first']]],
    Invoice::class,
    context: [
        AbstractNormalizer::OBJECT_TO_POPULATE => $invoice,
        AbstractObjectNormalizer::DEEP_OBJECT_TO_POPULATE => true,
    ],
);

// before: $invoice->lines[0] is a new Line, its id is null
// after:  $invoice->lines[0] === $line, its id is still 1
```
