### PR TITLE
[Mailer] Use the configured secret to authenticate Postmark webhooks

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Postmark/Tests/Webhook/PostmarkRequestParserTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/Tests/Webhook/PostmarkRequestParserTest.php
@@ -25,11 +25,17 @@ class PostmarkRequestParserTest extends AbstractRequestParserTestCase
         return new PostmarkRequestParser(new PostmarkPayloadConverter());
     }
 
+    protected function getSecret(): string
+    {
+        return 'symfony:top-secret';
+    }
+
     protected function createRequest(string $payload): Request
     {
         return Request::create('/', 'POST', [], [], [], [
             'Content-Type' => 'application/json',
             'REMOTE_ADDR' => '3.134.147.250',
+            'HTTP_Authorization' => 'Basic '.base64_encode('symfony:top-secret'),
         ], $payload);
     }
 
@@ -61,5 +67,34 @@ class PostmarkRequestParserTest extends AbstractRequestParserTestCase
         ], $payload);
 
         $this->assertNotNull($parser->parse($request, ''));
+    }
+
+    public function testRejectMissingCredentials()
+    {
+        $parser = new PostmarkRequestParser(new PostmarkPayloadConverter());
+        $payload = file_get_contents(__DIR__.'/Fixtures/delivery.json');
+        $request = Request::create('/', 'POST', [], [], [], [
+            'Content-Type' => 'application/json',
+            'REMOTE_ADDR' => '3.134.147.250',
+        ], $payload);
+
+        $this->expectException(RejectWebhookException::class);
+        $this->expectExceptionMessage('Invalid credentials.');
+        $parser->parse($request, 'symfony:top-secret');
+    }
+
+    public function testRejectWrongSecret()
+    {
+        $parser = new PostmarkRequestParser(new PostmarkPayloadConverter());
+        $payload = file_get_contents(__DIR__.'/Fixtures/delivery.json');
+        $request = Request::create('/', 'POST', [], [], [], [
+            'Content-Type' => 'application/json',
+            'REMOTE_ADDR' => '3.134.147.250',
+            'HTTP_Authorization' => 'Basic '.base64_encode('symfony:wrong-secret'),
+        ], $payload);
+
+        $this->expectException(RejectWebhookException::class);
+        $this->expectExceptionMessage('Invalid credentials.');
+        $parser->parse($request, 'symfony:top-secret');
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/Webhook/PostmarkRequestParser.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/Webhook/PostmarkRequestParser.php
@@ -45,6 +45,10 @@ final class PostmarkRequestParser extends AbstractRequestParser
 
     protected function doParse(Request $request, #[\SensitiveParameter] string $secret): ?AbstractMailerEvent
     {
+        if ($secret && !hash_equals('Basic '.base64_encode($secret), $request->headers->get('Authorization', ''))) {
+            throw new RejectWebhookException(403, 'Invalid credentials.');
+        }
+
         $payload = $request->toArray();
         if (
             !isset($payload['RecordType'])


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`PostmarkRequestParser::doParse()` receives the secret configured on the webhook route and never looks at it. The only authenticating check is the `IpsRequestMatcher` returned by `getRequestMatcher()`, which compares `Request::getClientIp()`, and that value comes from `X-Forwarded-For` when the connecting address is inside `trusted_proxies`. An application trusting a range wider than its own proxies therefore accepts a forged event, and the secret it configured buys nothing.

Postmark does not sign webhook payloads. Its documented way to protect the endpoint is HTTP Basic authentication, set either in the webhook URL or through the `HttpAuth` fields of the Webhooks API. The secret is now read the way `BrevoRequestParser` already reads it on this branch: when it is not empty, the request must carry `Authorization: Basic <base64 of the secret>`, compared with `hash_equals()`, and anything else is rejected with a 403. The secret is the whole `username:password` pair, since that is what the provider encodes.

An empty secret, which is the default, keeps the current behaviour. A route that carries a secret today and has no credentials set on the Postmark side starts getting 403 responses; the fix for such a setup is to set the same pair in Postmark, or to drop the secret from the configuration.
