### PR TITLE
[Mailer][Notifier] Reject webhook requests with a stale timestamp

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/AhaSend/Tests/Webhook/AhaSendRequestParserTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/AhaSend/Tests/Webhook/AhaSendRequestParserTest.php
@@ -11,15 +11,53 @@
 
 namespace Symfony\Component\Mailer\Bridge\AhaSend\Tests\Webhook;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use Symfony\Bridge\PhpUnit\ClockMock;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Mailer\Bridge\AhaSend\RemoteEvent\AhaSendPayloadConverter;
 use Symfony\Component\Mailer\Bridge\AhaSend\Webhook\AhaSendRequestParser;
 use Symfony\Component\Webhook\Client\RequestParserInterface;
+use Symfony\Component\Webhook\Exception\RejectWebhookException;
 use Symfony\Component\Webhook\Test\AbstractRequestParserTestCase;
 
+#[Group('time-sensitive')]
 class AhaSendRequestParserTest extends AbstractRequestParserTestCase
 {
     private const SECRET = 'nxLe:L:fZLb7J_Wb3uFeWX/&z4Ed#9&DxPL%Ud&:jhpAW1gLaR%AEFwfKnwp60cC';
+
+    public static function getStaleClockOffsets(): iterable
+    {
+        yield 'too old' => [301];
+        yield 'too far in the future' => [-301];
+    }
+
+    #[DataProvider('getStaleClockOffsets')]
+    public function testRejectSignedRequestWithStaleTimestamp(int $offset)
+    {
+        $request = $this->createRequest(file_get_contents(__DIR__.'/Fixtures/delivered.json'));
+        ClockMock::withClockMock((int) $request->headers->get('webhook-timestamp') + $offset);
+
+        $this->expectException(RejectWebhookException::class);
+        $this->expectExceptionMessage('Timestamp is outside the allowed time window.');
+
+        $this->createRequestParser()->parse($request, self::SECRET);
+    }
+
+    public static function getToleratedClockOffsets(): iterable
+    {
+        yield 'at the past edge' => [300];
+        yield 'at the future edge' => [-300];
+    }
+
+    #[DataProvider('getToleratedClockOffsets')]
+    public function testAcceptSignedRequestWithinTolerance(int $offset)
+    {
+        $request = $this->createRequest(file_get_contents(__DIR__.'/Fixtures/delivered.json'));
+        ClockMock::withClockMock((int) $request->headers->get('webhook-timestamp') + $offset);
+
+        $this->assertNotNull($this->createRequestParser()->parse($request, self::SECRET));
+    }
 
     protected function createRequestParser(): RequestParserInterface
     {
@@ -43,6 +81,8 @@ class AhaSendRequestParserTest extends AbstractRequestParserTestCase
             }
         }
         $payload = json_encode($payloadArray, \JSON_UNESCAPED_SLASHES);
+
+        ClockMock::withClockMock((int) $server['HTTP_webhook-timestamp']);
 
         return Request::create('/', 'POST', [], [], [], $server, $payload);
     }

--- a/src/Symfony/Component/Mailer/Bridge/AhaSend/Webhook/AhaSendRequestParser.php
+++ b/src/Symfony/Component/Mailer/Bridge/AhaSend/Webhook/AhaSendRequestParser.php
@@ -24,6 +24,8 @@ use Symfony\Component\Webhook\Exception\RejectWebhookException;
 
 final class AhaSendRequestParser extends AbstractRequestParser
 {
+    private const TIMESTAMP_TOLERANCE = 300;
+
     public function __construct(
         private readonly AhaSendPayloadConverter $converter,
     ) {
@@ -48,6 +50,9 @@ final class AhaSendRequestParser extends AbstractRequestParser
         }
         if (!is_numeric($timestamp) || \is_float($timestamp + 0) || (int) $timestamp != $timestamp || (int) $timestamp <= 0) {
             throw new RejectWebhookException(406, 'Invalid timestamp.');
+        }
+        if (abs(time() - (int) $timestamp) > self::TIMESTAMP_TOLERANCE) {
+            throw new RejectWebhookException(406, 'Timestamp is outside the allowed time window.');
         }
         $expectedSignature = $this->sign($eventID, $timestamp, $request->getContent(), $secret);
         if (!hash_equals($expectedSignature, $signature)) {

--- a/src/Symfony/Component/Mailer/Bridge/Resend/Tests/Webhook/ResendRequestParserTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Resend/Tests/Webhook/ResendRequestParserTest.php
@@ -11,14 +11,52 @@
 
 namespace Symfony\Component\Mailer\Bridge\Resend\Tests\Webhook;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use Symfony\Bridge\PhpUnit\ClockMock;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Mailer\Bridge\Resend\RemoteEvent\ResendPayloadConverter;
 use Symfony\Component\Mailer\Bridge\Resend\Webhook\ResendRequestParser;
 use Symfony\Component\Webhook\Client\RequestParserInterface;
+use Symfony\Component\Webhook\Exception\RejectWebhookException;
 use Symfony\Component\Webhook\Test\AbstractRequestParserTestCase;
 
+#[Group('time-sensitive')]
 class ResendRequestParserTest extends AbstractRequestParserTestCase
 {
+    public static function getStaleClockOffsets(): iterable
+    {
+        yield 'too old' => [301];
+        yield 'too far in the future' => [-301];
+    }
+
+    #[DataProvider('getStaleClockOffsets')]
+    public function testRejectSignedRequestWithStaleTimestamp(int $offset)
+    {
+        $request = $this->createRequest(file_get_contents(__DIR__.'/Fixtures/sent.json'));
+        ClockMock::withClockMock((int) $request->headers->get('svix-timestamp') + $offset);
+
+        $this->expectException(RejectWebhookException::class);
+        $this->expectExceptionMessage('Timestamp is outside the allowed time window.');
+
+        $this->createRequestParser()->parse($request, $this->getSecret());
+    }
+
+    public static function getToleratedClockOffsets(): iterable
+    {
+        yield 'at the past edge' => [300];
+        yield 'at the future edge' => [-300];
+    }
+
+    #[DataProvider('getToleratedClockOffsets')]
+    public function testAcceptSignedRequestWithinTolerance(int $offset)
+    {
+        $request = $this->createRequest(file_get_contents(__DIR__.'/Fixtures/sent.json'));
+        ClockMock::withClockMock((int) $request->headers->get('svix-timestamp') + $offset);
+
+        $this->assertNotNull($this->createRequestParser()->parse($request, $this->getSecret()));
+    }
+
     protected function createRequestParser(): RequestParserInterface
     {
         return new ResendRequestParser(new ResendPayloadConverter());
@@ -31,6 +69,8 @@ class ResendRequestParserTest extends AbstractRequestParserTestCase
 
     protected function createRequest(string $payload): Request
     {
+        ClockMock::withClockMock(1712569389);
+
         return Request::create('/', 'POST', [], [], [], [
             'Content-Type' => 'application/json',
             'HTTP_svix-id' => '172c41ce-ba6d-4281-8a7a-541faa725748',

--- a/src/Symfony/Component/Mailer/Bridge/Resend/Webhook/ResendRequestParser.php
+++ b/src/Symfony/Component/Mailer/Bridge/Resend/Webhook/ResendRequestParser.php
@@ -27,6 +27,8 @@ use Symfony\Component\Webhook\Exception\RejectWebhookException;
 
 final class ResendRequestParser extends AbstractRequestParser
 {
+    private const TIMESTAMP_TOLERANCE = 300;
+
     public function __construct(
         private readonly ResendPayloadConverter $converter,
     ) {
@@ -81,6 +83,10 @@ final class ResendRequestParser extends AbstractRequestParser
         $messageId = $headers->get('svix-id');
         $messageTimestamp = (int) $headers->get('svix-timestamp');
         $messageSignature = $headers->get('svix-signature');
+
+        if (abs(time() - $messageTimestamp) > self::TIMESTAMP_TOLERANCE) {
+            throw new RejectWebhookException(406, 'Timestamp is outside the allowed time window.');
+        }
 
         $signature = $this->sign($secret, $messageId, $messageTimestamp, $payload);
         $expectedSignature = explode(',', $signature, 2)[1];

--- a/src/Symfony/Component/Mailer/Bridge/Sweego/Tests/Webhook/SweegoSignedRequestParserTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sweego/Tests/Webhook/SweegoSignedRequestParserTest.php
@@ -11,19 +11,19 @@
 
 namespace Symfony\Component\Mailer\Bridge\Sweego\Tests\Webhook;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use Symfony\Bridge\PhpUnit\ClockMock;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Mailer\Bridge\Sweego\RemoteEvent\SweegoPayloadConverter;
 use Symfony\Component\Mailer\Bridge\Sweego\Webhook\SweegoRequestParser;
 use Symfony\Component\Webhook\Client\RequestParserInterface;
+use Symfony\Component\Webhook\Exception\RejectWebhookException;
 use Symfony\Component\Webhook\Test\AbstractRequestParserTestCase;
 
+#[Group('time-sensitive')]
 class SweegoSignedRequestParserTest extends AbstractRequestParserTestCase
 {
-    protected function createRequestParser(): RequestParserInterface
-    {
-        return new SweegoRequestParser(new SweegoPayloadConverter());
-    }
-
     public static function getPayloads(): iterable
     {
         $filename = 'delivered.json';
@@ -35,6 +35,44 @@ class SweegoSignedRequestParserTest extends AbstractRequestParserTestCase
         ];
     }
 
+    public static function getStaleClockOffsets(): iterable
+    {
+        yield 'too old' => [301];
+        yield 'too far in the future' => [-301];
+    }
+
+    #[DataProvider('getStaleClockOffsets')]
+    public function testRejectSignedRequestWithStaleTimestamp(int $offset)
+    {
+        $request = $this->createRequest(file_get_contents(__DIR__.'/Fixtures/delivered.json'));
+        ClockMock::withClockMock((int) $request->headers->get('webhook-timestamp') + $offset);
+
+        $this->expectException(RejectWebhookException::class);
+        $this->expectExceptionMessage('Timestamp is outside the allowed time window.');
+
+        $this->createRequestParser()->parse($request, $this->getSecret());
+    }
+
+    public static function getToleratedClockOffsets(): iterable
+    {
+        yield 'at the past edge' => [300];
+        yield 'at the future edge' => [-300];
+    }
+
+    #[DataProvider('getToleratedClockOffsets')]
+    public function testAcceptSignedRequestWithinTolerance(int $offset)
+    {
+        $request = $this->createRequest(file_get_contents(__DIR__.'/Fixtures/delivered.json'));
+        ClockMock::withClockMock((int) $request->headers->get('webhook-timestamp') + $offset);
+
+        $this->assertNotNull($this->createRequestParser()->parse($request, $this->getSecret()));
+    }
+
+    protected function createRequestParser(): RequestParserInterface
+    {
+        return new SweegoRequestParser(new SweegoPayloadConverter());
+    }
+
     protected function getSecret(): string
     {
         return 'GvLY88Uyj70jQm3fUwYyWmAaiz98wWim';
@@ -42,6 +80,8 @@ class SweegoSignedRequestParserTest extends AbstractRequestParserTestCase
 
     protected function createRequest(string $payload): Request
     {
+        ClockMock::withClockMock(1723737959);
+
         return Request::create('/', 'POST', [], [], [], [
             'Content-Type' => 'application/json',
             'HTTP_webhook-id' => '9f26b9d0-13d7-410c-ba04-5019cd30e6d0',

--- a/src/Symfony/Component/Mailer/Bridge/Sweego/Tests/Webhook/SweegoWrongSignatureRequestParserTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sweego/Tests/Webhook/SweegoWrongSignatureRequestParserTest.php
@@ -49,7 +49,7 @@ class SweegoWrongSignatureRequestParserTest extends AbstractRequestParserTestCas
         return Request::create('/', 'POST', [], [], [], [
             'Content-Type' => 'application/json',
             'HTTP_webhook-id' => '9f26b9d0-13d7-410c-ba04-5019cd30e6d0',
-            'HTTP_webhook-timestamp' => '1723737959',
+            'HTTP_webhook-timestamp' => (string) time(),
             'HTTP_webhook-signature' => 'wrong_signature',
         ], $payload);
     }

--- a/src/Symfony/Component/Mailer/Bridge/Sweego/Webhook/SweegoRequestParser.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sweego/Webhook/SweegoRequestParser.php
@@ -25,6 +25,8 @@ use Symfony\Component\Webhook\Exception\RejectWebhookException;
 
 final class SweegoRequestParser extends AbstractRequestParser
 {
+    private const TIMESTAMP_TOLERANCE = 300;
+
     public function __construct(
         private readonly SweegoPayloadConverter $converter,
     ) {
@@ -73,10 +75,16 @@ final class SweegoRequestParser extends AbstractRequestParser
 
     private function validateSignature(Request $request, string $secret): void
     {
+        $timestamp = $request->headers->get('webhook-timestamp');
+
+        if (abs(time() - (int) $timestamp) > self::TIMESTAMP_TOLERANCE) {
+            throw new RejectWebhookException(403, 'Timestamp is outside the allowed time window.');
+        }
+
         $contentToSign = \sprintf(
             '%s.%s.%s',
             $request->headers->get('webhook-id'),
-            $request->headers->get('webhook-timestamp'),
+            $timestamp,
             $request->getContent(),
         );
 

--- a/src/Symfony/Component/Notifier/Bridge/Sweego/Tests/Webhook/SweegoRequestParserTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sweego/Tests/Webhook/SweegoRequestParserTest.php
@@ -11,13 +11,51 @@
 
 namespace Symfony\Component\Notifier\Bridge\Sweego\Tests\Webhook;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use Symfony\Bridge\PhpUnit\ClockMock;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Notifier\Bridge\Sweego\Webhook\SweegoRequestParser;
 use Symfony\Component\Webhook\Client\RequestParserInterface;
+use Symfony\Component\Webhook\Exception\RejectWebhookException;
 use Symfony\Component\Webhook\Test\AbstractRequestParserTestCase;
 
+#[Group('time-sensitive')]
 class SweegoRequestParserTest extends AbstractRequestParserTestCase
 {
+    public static function getStaleClockOffsets(): iterable
+    {
+        yield 'too old' => [301];
+        yield 'too far in the future' => [-301];
+    }
+
+    #[DataProvider('getStaleClockOffsets')]
+    public function testRejectSignedRequestWithStaleTimestamp(int $offset)
+    {
+        $request = $this->createRequest(file_get_contents(__DIR__.'/Fixtures/sent.json'));
+        ClockMock::withClockMock((int) $request->headers->get('webhook-timestamp') + $offset);
+
+        $this->expectException(RejectWebhookException::class);
+        $this->expectExceptionMessage('Timestamp is outside the allowed time window.');
+
+        $this->createRequestParser()->parse($request, $this->getSecret());
+    }
+
+    public static function getToleratedClockOffsets(): iterable
+    {
+        yield 'at the past edge' => [300];
+        yield 'at the future edge' => [-300];
+    }
+
+    #[DataProvider('getToleratedClockOffsets')]
+    public function testAcceptSignedRequestWithinTolerance(int $offset)
+    {
+        $request = $this->createRequest(file_get_contents(__DIR__.'/Fixtures/sent.json'));
+        ClockMock::withClockMock((int) $request->headers->get('webhook-timestamp') + $offset);
+
+        $this->assertNotNull($this->createRequestParser()->parse($request, $this->getSecret()));
+    }
+
     protected function createRequestParser(): RequestParserInterface
     {
         return new SweegoRequestParser();
@@ -25,6 +63,8 @@ class SweegoRequestParserTest extends AbstractRequestParserTestCase
 
     protected function createRequest(string $payload): Request
     {
+        ClockMock::withClockMock(1725290740);
+
         return Request::create('/', 'POST', [], [], [], [
             'Content-Type' => 'application/json',
             'HTTP_webhook-id' => 'a5ccc627-6e43-4012-bb29-f1bfe3a3d13e',

--- a/src/Symfony/Component/Notifier/Bridge/Sweego/Tests/Webhook/SweegoWrongSignatureRequestParserTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sweego/Tests/Webhook/SweegoWrongSignatureRequestParserTest.php
@@ -32,7 +32,7 @@ class SweegoWrongSignatureRequestParserTest extends AbstractRequestParserTestCas
         return Request::create('/', 'POST', [], [], [], [
             'Content-Type' => 'application/json',
             'HTTP_webhook-id' => 'a5ccc627-6e43-4012-bb29-f1bfe3a3d13e',
-            'HTTP_webhook-timestamp' => '1725290740',
+            'HTTP_webhook-timestamp' => (string) time(),
             'HTTP_webhook-signature' => 'wrong_signature',
         ], $payload);
     }

--- a/src/Symfony/Component/Notifier/Bridge/Sweego/Webhook/SweegoRequestParser.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sweego/Webhook/SweegoRequestParser.php
@@ -28,6 +28,8 @@ use Symfony\Component\Webhook\Exception\RejectWebhookException;
  */
 final class SweegoRequestParser extends AbstractRequestParser
 {
+    private const TIMESTAMP_TOLERANCE = 300;
+
     protected function getRequestMatcher(): RequestMatcherInterface
     {
         return new ChainRequestMatcher([
@@ -60,10 +62,16 @@ final class SweegoRequestParser extends AbstractRequestParser
 
     private function validateSignature(Request $request, string $secret): void
     {
+        $timestamp = $request->headers->get('webhook-timestamp');
+
+        if (abs(time() - (int) $timestamp) > self::TIMESTAMP_TOLERANCE) {
+            throw new RejectWebhookException(403, 'Timestamp is outside the allowed time window.');
+        }
+
         $contentToSign = \sprintf(
             '%s.%s.%s',
             $request->headers->get('webhook-id'),
-            $request->headers->get('webhook-timestamp'),
+            $timestamp,
             $request->getContent(),
         );
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The AhaSend, Resend and Sweego webhook parsers verify an HMAC over `<id>.<timestamp>.<body>`. The signature covers the body, but nothing tied the request to a point in time, so a captured request stayed valid forever and replaying it re-dispatches a real `RemoteEvent` into consumers that may not be idempotent.

Each parser now rejects a request whose timestamp header is more than five minutes away from the current time. Resend reads `svix-timestamp`, the three others read `webhook-timestamp`. The specification asks for "some allowable tolerance" without naming a value; five minutes is what the svix libraries default to. A host whose clock is off by more than that already fails TLS and other time-based checks.

The window is a constant rather than a constructor argument. These parsers are container services built with fixed arguments, so an adjustable window would also need a configuration option to be reachable, and that belongs on the development branch. The guard is repeated in each parser rather than shared: the four classes sit in four separate packages whose only common dependency is `symfony/webhook`, where a helper would mean new protected API and a constraint bump, and both Sweego bridges still allow `symfony/webhook: ^6.4`. Each parser keeps its own failure mode, so a stale timestamp is rejected with the status code that parser already uses for a bad signature.
