### PR TITLE
[Lock] Delete a DynamoDb lock only when the caller holds it

### DIFF
--- a/src/Symfony/Component/Lock/Bridge/DynamoDb/Store/DynamoDbStore.php
+++ b/src/Symfony/Component/Lock/Bridge/DynamoDb/Store/DynamoDbStore.php
@@ -174,12 +174,23 @@ class DynamoDbStore implements PersistingStoreInterface
 
     public function delete(Key $key): void
     {
-        $this->client->deleteItem(new DeleteItemInput([
-            'TableName' => $this->tableName,
-            'Key' => [
-                $this->idAttr => new AttributeValue(['S' => $this->getHashedKey($key)]),
-            ],
-        ]));
+        try {
+            $this->client->deleteItem(new DeleteItemInput([
+                'TableName' => $this->tableName,
+                'Key' => [
+                    $this->idAttr => new AttributeValue(['S' => $this->getHashedKey($key)]),
+                ],
+                'ConditionExpression' => '#token = :token',
+                'ExpressionAttributeNames' => [
+                    '#token' => $this->tokenAttr,
+                ],
+                'ExpressionAttributeValues' => [
+                    ':token' => new AttributeValue(['S' => $this->getUniqueToken($key)]),
+                ],
+            ]));
+        } catch (ConditionalCheckFailedException) {
+            // the lock is held by someone else, or it doesn't exist anymore
+        }
     }
 
     public function exists(Key $key): bool

--- a/src/Symfony/Component/Lock/Bridge/DynamoDb/Tests/Store/DynamoDbStoreTest.php
+++ b/src/Symfony/Component/Lock/Bridge/DynamoDb/Tests/Store/DynamoDbStoreTest.php
@@ -15,7 +15,9 @@ use AsyncAws\DynamoDb\DynamoDbClient;
 use PHPUnit\Framework\Attributes\Before;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Lock\Bridge\DynamoDb\Store\DynamoDbStore;
+use Symfony\Component\Lock\Key;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 class DynamoDbStoreTest extends TestCase
@@ -157,5 +159,45 @@ class DynamoDbStoreTest extends TestCase
         $this->expectExceptionMessageMatches('|Unknown option found: \[bar\]\. Allowed options are \[session_token, |');
 
         new DynamoDbStore('dynamodb://default?foo=foo', ['bar' => 'bar']);
+    }
+
+    public function testDeleteIsScopedToTheOwnerToken()
+    {
+        $requests = [];
+        $httpClient = new MockHttpClient(static function (string $method, string $url, array $options) use (&$requests) {
+            $requests[] = json_decode($options['body'], true);
+
+            return new MockResponse('{}', ['response_headers' => ['content-type' => 'application/x-amz-json-1.0']]);
+        });
+
+        $store = new DynamoDbStore($this->createClient($httpClient), ['table_name' => 'table']);
+
+        $key = new Key(__METHOD__);
+        $store->save($key);
+        $store->delete($key);
+
+        $this->assertCount(2, $requests);
+        $this->assertSame('#token = :token', $requests[1]['ConditionExpression']);
+        $this->assertSame(['#token' => 'key_token'], $requests[1]['ExpressionAttributeNames']);
+        $this->assertSame($requests[0]['Item']['key_token']['S'], $requests[1]['ExpressionAttributeValues'][':token']['S']);
+    }
+
+    public function testDeleteOfALockHeldBySomeoneElseIsIgnored()
+    {
+        $httpClient = new MockHttpClient(new MockResponse(json_encode([
+            '__type' => 'com.amazonaws.dynamodb.v20120810#ConditionalCheckFailedException',
+            'message' => 'The conditional request failed',
+        ]), ['http_code' => 400, 'response_headers' => ['content-type' => 'application/x-amz-json-1.0']]));
+
+        $store = new DynamoDbStore($this->createClient($httpClient), ['table_name' => 'table']);
+
+        $store->delete(new Key(__METHOD__));
+
+        $this->addToAssertionCount(1);
+    }
+
+    private function createClient(HttpClientInterface $httpClient): DynamoDbClient
+    {
+        return new DynamoDbClient(['region' => 'us-east-1', 'accessKeyId' => 'key', 'accessKeySecret' => 'secret'], null, $httpClient);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`DynamoDbStore::delete()` sends a `DeleteItem` keyed on the hashed resource id alone, with no condition on the owner token, so knowing the resource name is enough to drop a lock somebody else holds. Every other store scopes its delete: `PdoStore` and `DoctrineDbalStore` match on id and token, the `RedisStore` script asserts `ZSCORE key uniqueToken` before the `ZREM`, `MongoDbStore` filters the bulk delete on the token, `MemcachedStore` compares the stored value, and `PostgreSqlStore` and `ZookeeperStore` go through `exists()` first. `DynamoDbStore` itself already compares the token in `putOffExpiration()` and in `exists()`, so `delete()` was the one place that did not.

The `DeleteItem` now carries `ConditionExpression: '#token = :token'`, and a failed condition is ignored. A caller that does not hold the lock gets the same silent no-op as with the other stores, and `Lock::release()` still reports success afterwards because `exists()` already returns false for a non-holder.

What makes the omission reachable is the Messenger transport: `DeduplicateStamp` is sendable, `LockKeyNormalizer` rebuilds the `Key` from the wire, and `DeduplicateMiddleware`, added to every bus when `framework.lock` is enabled, calls `release()` on it. The token is what keeps that path safe, since the producer acquires the lock and only a consumer carrying the token the store generated can release it.

Guarding `RedisStore::getUniqueToken()` against a key state of `__write__`, which releases the write sentinel and lets readers in under a live write lock, is a separate defect on a more widely used store and deserves its own pull request.
