### PR TITLE
[Security] Reject OIDC discovery endpoints that downgrade to plain HTTP

### DIFF
--- a/src/Symfony/Component/Security/Http/AccessToken/Oidc/OidcTokenHandler.php
+++ b/src/Symfony/Component/Security/Http/AccessToken/Oidc/OidcTokenHandler.php
@@ -160,16 +160,13 @@ final class OidcTokenHandler implements AccessTokenHandlerInterface
             $jwkSetResponses = [];
 
             foreach ($clients as $client) {
-                $configResponses[] = [$client, $client->request('GET', '.well-known/openid-configuration')];
+                $configResponses[] = [$client, $client->request('GET', '.well-known/openid-configuration', ['max_redirects' => 0])];
             }
 
             foreach ($configResponses as [$client, $response]) {
                 $config = $response->toArray();
 
-                $jwksUri = $config['jwks_uri'] ?? null;
-                if (!\is_string($jwksUri) || '' === $jwksUri) {
-                    throw new \RuntimeException('The "jwks_uri" is missing from the OIDC discovery document.');
-                }
+                $jwksUri = self::checkDiscoveredEndpoint($config['jwks_uri'] ?? null, 'jwks_uri', $response->getInfo('url'));
 
                 $jwkSetResponses[] = $client->request('GET', $jwksUri);
             }

--- a/src/Symfony/Component/Security/Http/AccessToken/Oidc/OidcTrait.php
+++ b/src/Symfony/Component/Security/Http/AccessToken/Oidc/OidcTrait.php
@@ -16,7 +16,7 @@ use Symfony\Component\Security\Core\User\OidcUser;
 use function Symfony\Component\String\u;
 
 /**
- * Creates {@see OidcUser} from claims.
+ * Creates {@see OidcUser} from claims and validates the endpoints advertised by the discovery document.
  *
  * @internal
  */
@@ -49,5 +49,24 @@ trait OidcTrait
         }
 
         return new OidcUser(...$claims);
+    }
+
+    /**
+     * The discovery specification requires the endpoints it advertises to use the "https" scheme.
+     * They are rejected here when they downgrade the transport that carried the discovery document.
+     */
+    private static function checkDiscoveredEndpoint(mixed $endpoint, string $key, ?string $discoveryUrl): string
+    {
+        if (!\is_string($endpoint) || '' === $endpoint) {
+            throw new \RuntimeException(\sprintf('The "%s" is missing from the OIDC discovery document.', $key));
+        }
+
+        $scheme = parse_url($endpoint, \PHP_URL_SCHEME);
+
+        if ($scheme && 'https' !== strtolower($scheme) && str_starts_with($discoveryUrl ?? '', 'https://')) {
+            throw new \RuntimeException(\sprintf('The "%s" found in the OIDC discovery document must use the "https" scheme, "%s" given.', $key, $scheme));
+        }
+
+        return $endpoint;
     }
 }

--- a/src/Symfony/Component/Security/Http/AccessToken/Oidc/OidcUserInfoTokenHandler.php
+++ b/src/Symfony/Component/Security/Http/AccessToken/Oidc/OidcUserInfoTokenHandler.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Security\Http\AccessToken\Oidc;
 
+use Psr\Cache\CacheItemInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\Security\Http\AccessToken\AccessTokenHandlerInterface;
@@ -45,15 +46,35 @@ final class OidcUserInfoTokenHandler implements AccessTokenHandlerInterface
 
     public function getUserBadgeFrom(string $accessToken): UserBadge
     {
+        $userInfoEndpoint = '';
+
         if (null !== $this->discoveryCache) {
             try {
                 // Call OIDC discovery to retrieve userinfo endpoint
                 // OIDC configuration is stored in cache
-                $oidcConfiguration = json_decode($this->discoveryCache->get($this->oidcConfigurationCacheKey, function (): string {
-                    $response = $this->client->request('GET', '.well-known/openid-configuration');
+                $discover = function (CacheItemInterface $item, bool &$save): array {
+                    $response = $this->client->request('GET', '.well-known/openid-configuration', ['max_redirects' => 0]);
+                    $config = $response->toArray();
+                    $discoveryUrl = $response->getInfo('url');
 
-                    return $response->getContent();
-                }), true, 512, \JSON_THROW_ON_ERROR);
+                    self::checkDiscoveredEndpoint($config['userinfo_endpoint'] ?? null, 'userinfo_endpoint', $discoveryUrl);
+
+                    // A cached configuration does not tell which URL served it, so store only what has been checked against that URL
+                    $save = null !== $discoveryUrl && '' !== $discoveryUrl;
+
+                    return $config;
+                };
+
+                $oidcConfiguration = $this->discoveryCache->get($this->oidcConfigurationCacheKey, $discover);
+
+                if (!\is_array($oidcConfiguration)) {
+                    // Raw JSON was cached before the discovered endpoints were checked, refresh it to get it checked
+                    $this->discoveryCache->delete($this->oidcConfigurationCacheKey);
+                    $oidcConfiguration = $this->discoveryCache->get($this->oidcConfigurationCacheKey, $discover);
+                }
+
+                // The endpoint was checked against the discovery URL before the configuration was stored
+                $userInfoEndpoint = self::checkDiscoveredEndpoint($oidcConfiguration['userinfo_endpoint'] ?? null, 'userinfo_endpoint', null);
             } catch (\Throwable $e) {
                 $this->logger?->error('An error occurred while requesting OIDC configuration.', [
                     'error' => $e->getMessage(),
@@ -67,7 +88,7 @@ final class OidcUserInfoTokenHandler implements AccessTokenHandlerInterface
         try {
             // Call the OIDC server to retrieve the user info
             // If the token is invalid or expired, the OIDC server will return an error
-            $claims = $this->client->request('GET', $this->discoveryCache ? $oidcConfiguration['userinfo_endpoint'] : '', [
+            $claims = $this->client->request('GET', $userInfoEndpoint, [
                 'auth_bearer' => $accessToken,
             ])->toArray();
 

--- a/src/Symfony/Component/Security/Http/Tests/AccessToken/Oidc/OidcTokenHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/AccessToken/Oidc/OidcTokenHandlerTest.php
@@ -24,6 +24,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\JsonMockResponse;
+use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\Security\Core\User\OidcUser;
 use Symfony\Component\Security\Http\AccessToken\Oidc\OidcTokenHandler;
@@ -445,6 +446,85 @@ class OidcTokenHandlerTest extends TestCase
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('No OIDC discovery client configured.');
         $handler->computeDiscoveryKeys($item);
+    }
+
+    public function testDiscoveryDoesNotFollowRedirects()
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options) {
+            $this->assertSame(0, $options['max_redirects']);
+
+            return new MockResponse('', ['http_code' => 301, 'response_headers' => ['location' => 'https://other.example.com/.well-known/openid-configuration']]);
+        });
+
+        $cache = new ArrayAdapter();
+        $handler = new OidcTokenHandler(
+            new AlgorithmManager([new ES256()]),
+            null,
+            self::AUDIENCE,
+            ['https://www.example.com']
+        );
+        $handler->enableDiscovery($cache, $httpClient, 'oidc_redirected_discovery');
+
+        $item = $this->createMock(ItemInterface::class);
+        $item->expects($this->never())->method('expiresAfter');
+
+        try {
+            $handler->computeDiscoveryKeys($item);
+            $this->fail('A BadCredentialsException should have been thrown.');
+        } catch (BadCredentialsException) {
+        }
+
+        $this->assertSame(1, $httpClient->getRequestsCount());
+    }
+
+    public function testDiscoveryRejectsJwksUriDowngradedToHttp()
+    {
+        $httpClient = new MockHttpClient([
+            new JsonMockResponse(['jwks_uri' => 'http://169.254.169.254/latest/meta-data/']),
+            new JsonMockResponse(['keys' => [array_merge(self::getJWK()->all(), ['use' => 'sig'])]]),
+        ]);
+
+        $cache = new ArrayAdapter();
+        $handler = new OidcTokenHandler(
+            new AlgorithmManager([new ES256()]),
+            null,
+            self::AUDIENCE,
+            ['https://www.example.com']
+        );
+        $handler->enableDiscovery($cache, $httpClient, 'oidc_insecure_jwks_uri');
+
+        $item = $this->createMock(ItemInterface::class);
+        $item->expects($this->never())->method('expiresAfter');
+
+        try {
+            $handler->computeDiscoveryKeys($item);
+            $this->fail('A BadCredentialsException should have been thrown.');
+        } catch (BadCredentialsException) {
+        }
+
+        $this->assertSame(1, $httpClient->getRequestsCount());
+    }
+
+    public function testDiscoveryFollowsJwksUriOfAnIssuerServedOverHttp()
+    {
+        $httpClient = new MockHttpClient([
+            new JsonMockResponse(['jwks_uri' => 'http://www.example.com/jwks.json']),
+            new JsonMockResponse(['keys' => [array_merge(self::getJWK()->all(), ['use' => 'sig'])]]),
+        ], 'http://www.example.com');
+
+        $cache = new ArrayAdapter();
+        $handler = new OidcTokenHandler(
+            new AlgorithmManager([new ES256()]),
+            null,
+            self::AUDIENCE,
+            ['http://www.example.com']
+        );
+        $handler->enableDiscovery($cache, $httpClient, 'oidc_http_issuer');
+
+        $item = $this->createMock(ItemInterface::class);
+        $item->expects($this->never())->method('expiresAfter');
+
+        $this->assertCount(1, $handler->computeDiscoveryKeys($item));
     }
 
     public function testDiscoveryThrowsWhenJwksUriIsMissing()

--- a/src/Symfony/Component/Security/Http/Tests/AccessToken/Oidc/OidcUserInfoTokenHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/AccessToken/Oidc/OidcUserInfoTokenHandlerTest.php
@@ -14,6 +14,10 @@ namespace Symfony\Component\Security\Http\Tests\AccessToken\Oidc;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\JsonMockResponse;
+use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\Security\Core\User\OidcUser;
 use Symfony\Component\Security\Http\AccessToken\Oidc\OidcUserInfoTokenHandler;
@@ -83,5 +87,161 @@ class OidcUserInfoTokenHandlerTest extends TestCase
         $this->expectExceptionMessage('Invalid credentials.');
 
         $handler->getUserBadgeFrom('a-secret-token');
+    }
+
+    public function testDiscoveryFollowsUserInfoEndpointHostedOnAnotherDomain()
+    {
+        $claims = ['sub' => 'e21bf182-1538-406e-8ccb-e25a17aba39f'];
+        $userInfoResponse = new JsonMockResponse($claims);
+        $httpClient = new MockHttpClient([
+            new JsonMockResponse(['userinfo_endpoint' => 'https://openidconnect.example.net/v1/userinfo']),
+            $userInfoResponse,
+        ]);
+
+        $handler = new OidcUserInfoTokenHandler($httpClient);
+        $handler->enableDiscovery(new ArrayAdapter(), 'oidc_config');
+
+        $userBadge = $handler->getUserBadgeFrom('a-secret-token');
+
+        $this->assertSame('e21bf182-1538-406e-8ccb-e25a17aba39f', $userBadge->getUserIdentifier());
+        $this->assertSame('https://openidconnect.example.net/v1/userinfo', $userInfoResponse->getRequestUrl());
+        $this->assertContains('Authorization: Bearer a-secret-token', $userInfoResponse->getRequestOptions()['headers']);
+    }
+
+    public function testDiscoveryDoesNotFollowRedirects()
+    {
+        $httpClient = new MockHttpClient(function (string $method, string $url, array $options) {
+            $this->assertSame(0, $options['max_redirects']);
+
+            return new MockResponse('', ['http_code' => 301, 'response_headers' => ['location' => 'https://other.example.com/.well-known/openid-configuration']]);
+        }, 'https://oidc.example.com');
+
+        $handler = new OidcUserInfoTokenHandler($httpClient);
+        $handler->enableDiscovery(new ArrayAdapter(), 'oidc_config');
+
+        try {
+            $handler->getUserBadgeFrom('a-secret-token');
+            $this->fail('A BadCredentialsException should have been thrown.');
+        } catch (BadCredentialsException) {
+        }
+
+        $this->assertSame(1, $httpClient->getRequestsCount());
+    }
+
+    public function testDiscoveryRejectsUserInfoEndpointDowngradedToHttp()
+    {
+        $httpClient = new MockHttpClient([
+            new JsonMockResponse(['userinfo_endpoint' => 'http://169.254.169.254/latest/meta-data/']),
+            new JsonMockResponse(['sub' => 'e21bf182-1538-406e-8ccb-e25a17aba39f']),
+        ]);
+
+        $handler = new OidcUserInfoTokenHandler($httpClient);
+        $handler->enableDiscovery(new ArrayAdapter(), 'oidc_config');
+
+        try {
+            $handler->getUserBadgeFrom('a-secret-token');
+            $this->fail('A BadCredentialsException should have been thrown.');
+        } catch (BadCredentialsException) {
+        }
+
+        $this->assertSame(1, $httpClient->getRequestsCount());
+    }
+
+    public function testDiscoveryDoesNotCacheADowngradedUserInfoEndpoint()
+    {
+        $requestedUrls = [];
+        $httpClient = new MockHttpClient(static function (string $method, string $url) use (&$requestedUrls) {
+            $requestedUrls[] = $url;
+
+            return new JsonMockResponse(['userinfo_endpoint' => 'http://169.254.169.254/latest/meta-data/']);
+        });
+
+        $handler = new OidcUserInfoTokenHandler($httpClient);
+        $handler->enableDiscovery(new ArrayAdapter(), 'oidc_config');
+
+        for ($i = 0; $i < 2; ++$i) {
+            try {
+                $handler->getUserBadgeFrom('a-secret-token');
+                $this->fail('A BadCredentialsException should have been thrown.');
+            } catch (BadCredentialsException) {
+            }
+        }
+
+        $this->assertSame([
+            'https://example.com/.well-known/openid-configuration',
+            'https://example.com/.well-known/openid-configuration',
+        ], $requestedUrls);
+    }
+
+    public function testDiscoveryIsNotCachedWhenTheDiscoveryUrlIsUnknown()
+    {
+        $configResponse = $this->createStub(ResponseInterface::class);
+        $configResponse->method('toArray')->willReturn(['userinfo_endpoint' => 'https://oidc.example.com/userinfo']);
+        $configResponse->method('getInfo')->willReturn(null);
+
+        $userInfoResponse = $this->createStub(ResponseInterface::class);
+        $userInfoResponse->method('toArray')->willReturn(['sub' => 'e21bf182-1538-406e-8ccb-e25a17aba39f']);
+
+        $requestedUrls = [];
+        $clientMock = $this->createStub(HttpClientInterface::class);
+        $clientMock->method('request')->willReturnCallback(static function (string $method, string $url) use (&$requestedUrls, $configResponse, $userInfoResponse) {
+            $requestedUrls[] = $url;
+
+            return '.well-known/openid-configuration' === $url ? $configResponse : $userInfoResponse;
+        });
+
+        $handler = new OidcUserInfoTokenHandler($clientMock);
+        $handler->enableDiscovery(new ArrayAdapter(), 'oidc_config');
+
+        $handler->getUserBadgeFrom('a-secret-token');
+        $handler->getUserBadgeFrom('a-secret-token');
+
+        $this->assertSame([
+            '.well-known/openid-configuration',
+            'https://oidc.example.com/userinfo',
+            '.well-known/openid-configuration',
+            'https://oidc.example.com/userinfo',
+        ], $requestedUrls);
+    }
+
+    public function testDiscoveryRefreshesAConfigurationCachedAsRawJson()
+    {
+        $cache = new ArrayAdapter();
+        // an entry written before the discovered endpoints were checked
+        $cache->get('oidc_config', static fn () => json_encode(['userinfo_endpoint' => 'http://169.254.169.254/latest/meta-data/']));
+
+        $userInfoResponse = new JsonMockResponse(['sub' => 'e21bf182-1538-406e-8ccb-e25a17aba39f']);
+        $httpClient = new MockHttpClient([
+            new JsonMockResponse(['userinfo_endpoint' => 'https://oidc.example.com/userinfo']),
+            $userInfoResponse,
+        ]);
+
+        $handler = new OidcUserInfoTokenHandler($httpClient);
+        $handler->enableDiscovery($cache, 'oidc_config');
+
+        $userBadge = $handler->getUserBadgeFrom('a-secret-token');
+
+        $this->assertSame('e21bf182-1538-406e-8ccb-e25a17aba39f', $userBadge->getUserIdentifier());
+        $this->assertSame('https://oidc.example.com/userinfo', $userInfoResponse->getRequestUrl());
+        $this->assertIsArray($cache->getItem('oidc_config')->get());
+    }
+
+    public function testDiscoveryRejectsMissingUserInfoEndpoint()
+    {
+        $httpClient = new MockHttpClient([
+            new JsonMockResponse(['issuer' => 'https://example.com']),
+            new JsonMockResponse(['sub' => 'e21bf182-1538-406e-8ccb-e25a17aba39f']),
+        ]);
+
+        $handler = new OidcUserInfoTokenHandler($httpClient);
+        $handler->enableDiscovery(new ArrayAdapter(), 'oidc_config');
+
+        try {
+            $handler->getUserBadgeFrom('a-secret-token');
+            $this->fail('A BadCredentialsException should have been thrown.');
+        } catch (BadCredentialsException) {
+        }
+
+        $this->assertSame(1, $httpClient->getRequestsCount());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

When OIDC discovery is enabled, both token handlers fetch `.well-known/openid-configuration` from the configured issuer and then request the `userinfo_endpoint` and `jwks_uri` found in that document. The user-info handler sends the caller's access token to that URL. An absolute URL replaces the host of the client's `base_uri`, so a discovery document advertising `http://` sends the access token in clear text, or makes the application fetch signing keys over an unauthenticated channel, and reaches hosts that are only served over plain HTTP such as cloud metadata services.

The discovery specification requires both endpoints to use the `https` scheme, so a discovered endpoint whose scheme is not `https` is now rejected when the discovery document itself was fetched over `https`. A provider served over plain HTTP keeps working, since nothing is downgraded there. The user-info handler also validates that `userinfo_endpoint` is present and is a string, the way the token handler already does for `jwks_uri`: a document without it passes the missing value to `HttpClientInterface::request()` and raises an uncaught `TypeError` instead of `BadCredentialsException`.

The user-info handler caches the discovery document, and a cache hit does not say which URL served it, so the check runs inside the cache callback and the configuration is stored only once checked. The cached value is now the decoded configuration rather than the raw JSON, which also makes an entry written by an older version recognisable: it was never checked, so it is fetched again rather than trusted. During a rolling deploy, an instance still running the old code cannot decode the new cached value and rejects authentication until it is upgraded.

Pinning the endpoints to the origin of the issuer is not applied: the specification lets them live anywhere, and `https://accounts.google.com` advertises `https://openidconnect.googleapis.com/v1/userinfo` and `https://www.googleapis.com/oauth2/v3/certs`. Dropping the bearer token when the user-info endpoint is not same-origin fails for the same reason.


The discovery request itself no longer follows redirects (`max_redirects` is set to 0). The specification requires the document to be served directly at the issuer URL, and the `issuer` value it carries must be identical to the URL it was retrieved from, so a redirect there is a misconfiguration. Following it would also open a window that the scheme check cannot see: a plain-HTTP hop in the chain lets a third party on the path choose where the rest of the chain goes. A provider that redirects its well-known URL now fails at the first request, with the "An error occurred while requesting OIDC configuration" log entry; pointing the issuer at the final location fixes it.
