### PR TITLE
[SecurityBundle] Make the remember-me cookie follow the session cookie defaults

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RememberMeFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RememberMeFactory.php
@@ -37,9 +37,9 @@ class RememberMeFactory implements AuthenticatorFactoryInterface, PrependExtensi
         'lifetime' => 31536000,
         'path' => '/',
         'domain' => null,
-        'secure' => false,
+        'secure' => 'auto',
         'httponly' => true,
-        'samesite' => null,
+        'samesite' => Cookie::SAMESITE_LAX,
         'always_remember_me' => false,
         'remember_me_parameter' => '_remember_me',
     ];
@@ -162,7 +162,7 @@ class RememberMeFactory implements AuthenticatorFactoryInterface, PrependExtensi
 
         foreach ($this->options as $name => $value) {
             if ('secure' === $name) {
-                $builder->enumNode($name)->values([true, false, 'auto'])->defaultValue('auto' === $value ? null : $value);
+                $builder->enumNode($name)->values([true, false, 'auto'])->defaultValue($value);
             } elseif ('samesite' === $name) {
                 $builder->enumNode($name)->values([null, Cookie::SAMESITE_LAX, Cookie::SAMESITE_STRICT, Cookie::SAMESITE_NONE])->defaultValue($value);
             } elseif (\is_bool($value)) {
@@ -219,21 +219,15 @@ class RememberMeFactory implements AuthenticatorFactoryInterface, PrependExtensi
 
     public function prepend(ContainerBuilder $container): void
     {
-        $rememberMeSecureDefault = false;
-        $rememberMeSameSiteDefault = null;
-
         if (!isset($container->getExtensions()['framework'])) {
             return;
         }
 
         foreach ($container->getExtensionConfig('framework') as $config) {
             if (isset($config['session']) && \is_array($config['session'])) {
-                $rememberMeSecureDefault = $config['session']['cookie_secure'] ?? $rememberMeSecureDefault;
-                $rememberMeSameSiteDefault = \array_key_exists('cookie_samesite', $config['session']) ? $config['session']['cookie_samesite'] : $rememberMeSameSiteDefault;
+                $this->options['secure'] = $config['session']['cookie_secure'] ?? $this->options['secure'];
+                $this->options['samesite'] = \array_key_exists('cookie_samesite', $config['session']) ? $config['session']['cookie_samesite'] : $this->options['samesite'];
             }
         }
-
-        $this->options['secure'] = $rememberMeSecureDefault;
-        $this->options['samesite'] = $rememberMeSameSiteDefault;
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/RememberMeFactoryTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/RememberMeFactoryTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\DependencyInjection\Security\Factory;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\FrameworkExtension;
+use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\RememberMeFactory;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpFoundation\Cookie;
+
+class RememberMeFactoryTest extends TestCase
+{
+    public function testCookieFollowsTheSessionCookieDefaults()
+    {
+        $options = $this->createHandlerOptions(['session' => ['enabled' => true]]);
+
+        $this->assertNull($options['secure']);
+        $this->assertSame(Cookie::SAMESITE_LAX, $options['samesite']);
+    }
+
+    public function testCookieFollowsTheConfiguredSessionCookie()
+    {
+        $options = $this->createHandlerOptions(['session' => ['enabled' => true, 'cookie_secure' => false, 'cookie_samesite' => null]]);
+
+        $this->assertFalse($options['secure']);
+        $this->assertNull($options['samesite']);
+    }
+
+    public function testCookieDefaultsWithoutFrameworkBundle()
+    {
+        $options = $this->createHandlerOptions(null);
+
+        $this->assertNull($options['secure']);
+        $this->assertSame(Cookie::SAMESITE_LAX, $options['samesite']);
+    }
+
+    public function testFirewallConfigWinsOverTheSessionCookie()
+    {
+        $options = $this->createHandlerOptions(['session' => ['enabled' => true]], ['secure' => false, 'samesite' => null]);
+
+        $this->assertFalse($options['secure']);
+        $this->assertNull($options['samesite']);
+    }
+
+    public function testSecureDefaultIsAnAllowedValue()
+    {
+        $factory = new RememberMeFactory();
+        $factory->addConfiguration($nodeDefinition = new ArrayNodeDefinition('remember_me'));
+        $node = $nodeDefinition->getNode();
+
+        $config = $node->finalize($node->normalize(['secret' => 'very']));
+
+        $this->assertSame('auto', $config['secure']);
+        $this->assertSame('auto', $node->finalize($node->normalize(['secret' => 'very', 'secure' => $config['secure']]))['secure']);
+    }
+
+    private function createHandlerOptions(?array $frameworkConfig, array $rememberMeConfig = []): array
+    {
+        $container = new ContainerBuilder();
+
+        if (null !== $frameworkConfig) {
+            $container->registerExtension(new FrameworkExtension());
+            $container->loadFromExtension('framework', $frameworkConfig);
+        }
+
+        $factory = new RememberMeFactory();
+        $factory->prepend($container);
+
+        $factory->addConfiguration($nodeDefinition = new ArrayNodeDefinition('remember_me'));
+        $node = $nodeDefinition->getNode();
+        $config = $node->finalize($node->normalize($rememberMeConfig + ['secret' => 'very']));
+
+        $factory->createAuthenticator($container, 'main', $config, 'security.user.provider.concrete.default');
+
+        return $container->getDefinition('security.authenticator.remember_me_handler.main')->getArgument(3);
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/RememberMeCookieTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/RememberMeCookieTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 
 class RememberMeCookieTest extends AbstractWebTestCase
@@ -30,6 +31,23 @@ class RememberMeCookieTest extends AbstractWebTestCase
 
         $cookies = $client->getResponse()->headers->getCookies(ResponseHeaderBag::COOKIES_ARRAY);
         $this->assertSame($expectedSecureFlag, $cookies['']['/']['REMEMBERME']->isSecure());
+    }
+
+    #[DataProvider('getSessionRememberMeSecureCookieFlagAutoHttpsMap')]
+    public function testRememberMeCookieDefaults($https, $expectedSecureFlag)
+    {
+        $client = $this->createClient(['test_case' => 'RememberMeCookie', 'root_config' => 'config_defaults.yml']);
+
+        $client->request('POST', '/login', [
+            '_username' => 'test',
+            '_password' => 'test',
+        ], [], [
+            'HTTPS' => (int) $https,
+        ]);
+
+        $cookies = $client->getResponse()->headers->getCookies(ResponseHeaderBag::COOKIES_ARRAY);
+        $this->assertSame($expectedSecureFlag, $cookies['']['/']['REMEMBERME']->isSecure());
+        $this->assertSame(Cookie::SAMESITE_LAX, $cookies['']['/']['REMEMBERME']->getSameSite());
     }
 
     public static function getSessionRememberMeSecureCookieFlagAutoHttpsMap()

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/RememberMeCookie/config_defaults.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/RememberMeCookie/config_defaults.yml
@@ -1,0 +1,29 @@
+framework:
+    secret: test
+    router: { resource: "%kernel.project_dir%/%kernel.test_case%/routing.yml" }
+    test: ~
+    session:
+        handler_id: null
+        storage_factory_id: session.storage.factory.mock_file
+
+services:
+    logger: { class: Psr\Log\NullLogger }
+
+security:
+    password_hashers:
+        Symfony\Component\Security\Core\User\InMemoryUser: plaintext
+
+    providers:
+        in_memory:
+            memory:
+                users:
+                    test: { password: test, roles: [ROLE_USER] }
+
+    firewalls:
+        default:
+            form_login:
+                check_path: login
+            remember_me:
+                always_remember_me: true
+                secret: key
+            logout: ~


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`RememberMeFactory::prepend()` exists so that the remember-me cookie follows `framework.session.cookie_secure` and `cookie_samesite`. It reads the raw extension config, so it sees those keys only when the application writes them, and falls back to `false` and `null` otherwise. Those fallbacks matched FrameworkBundle until 7.0, where `cookie_secure` started defaulting to `auto` and `cookie_samesite` to `lax`. Since then, an application that leaves its session block alone gets a session cookie that is `Secure` on HTTPS and `SameSite=Lax`, and a one-year remember-me credential cookie with neither.

The fallbacks now carry the same values as the session cookie, and `prepend()` writes only the keys it actually finds. `secure: auto` resolves to `null`, which `AbstractRememberMeHandler` already turns into `$request->isSecure()`, so nothing gains a `Secure` flag over plain HTTP and development setups are unchanged. An application that wants the previous attributes writes `secure: false` and `samesite: ~` under its `remember_me` block, which still wins.

6.4 is not affected: `cookie_secure` has no default there and `cookie_samesite` defaults to `null`, so its session cookie and its remember-me cookie already agree.
