### PR TITLE
[Messenger] Cover the headers that describe the message with the SigningSerializer signature

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/Transport/Serialization/SigningSerializerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Serialization/SigningSerializerTest.php
@@ -14,11 +14,13 @@ namespace Symfony\Component\Messenger\Tests\Transport\Serialization;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\InvalidMessageSignatureException;
+use Symfony\Component\Messenger\Stamp\BusNameStamp;
 use Symfony\Component\Messenger\Tests\Fixtures\ChildDummyMessage;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessageInterface;
 use Symfony\Component\Messenger\Transport\Serialization\MessageTypeAwareSerializerInterface;
 use Symfony\Component\Messenger\Transport\Serialization\PhpSerializer;
+use Symfony\Component\Messenger\Transport\Serialization\Serializer;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 use Symfony\Component\Messenger\Transport\Serialization\SigningSerializer;
 
@@ -113,6 +115,17 @@ class SigningSerializerTest extends TestCase
         }
 
         $this->assertFalse($inner->decoded, 'The inner serializer must not be invoked when a signed message has an invalid signature.');
+    }
+
+    public function testDecodeRejectsNonStringSignature()
+    {
+        $serializer = $this->createSerializer([DummyMessage::class]);
+        $envelope = new Envelope(new DummyMessage('hello'));
+        $encoded = $serializer->encode($envelope);
+        $encoded['headers']['Body-Sign'] = [$encoded['headers']['Body-Sign']];
+
+        $this->expectException(InvalidMessageSignatureException::class);
+        $serializer->decode($encoded);
     }
 
     public function testDecodeRejectsMissingSignatureBeforeInvokingTypeAwareInnerSerializer()
@@ -287,10 +300,7 @@ class SigningSerializerTest extends TestCase
 
         $serializer = new SigningSerializer($inner, 'secret-key', [DummyMessage::class]);
 
-        $decoded = $serializer->decode([
-            'body' => 'the-body',
-            'headers' => ['Body-Sign' => hash_hmac('sha256', 'the-body', 'secret-key'), 'Sign-Algo' => 'sha256'],
-        ]);
+        $decoded = $serializer->decode($serializer->encode(new Envelope(new DummyMessage('hello'))));
         $this->assertInstanceOf(DummyMessage::class, $decoded->getMessage());
     }
 
@@ -320,8 +330,125 @@ class SigningSerializerTest extends TestCase
         $serializer->decode($encoded);
     }
 
+    public function testDecodeRejectsATamperedTypeHeader()
+    {
+        $serializer = $this->createJsonSerializer([DummyMessage::class]);
+        $encoded = $serializer->encode(new Envelope(new DummyMessage('hello')));
+        $encoded['headers']['type'] = ChildDummyMessage::class;
+
+        $this->expectException(InvalidMessageSignatureException::class);
+        $serializer->decode($encoded);
+    }
+
+    public function testDecodeRejectsAGraftedStampHeader()
+    {
+        $serializer = $this->createJsonSerializer([DummyMessage::class]);
+        $encoded = $serializer->encode(new Envelope(new DummyMessage('hello')));
+        $encoded['headers']['X-Message-Stamp-'.BusNameStamp::class] = '[{"busName":"other_bus"}]';
+
+        $this->expectException(InvalidMessageSignatureException::class);
+        $serializer->decode($encoded);
+    }
+
+    public function testDecodeIgnoresHeadersThatDoNotDescribeTheMessage()
+    {
+        $serializer = $this->createJsonSerializer([DummyMessage::class]);
+        $encoded = $serializer->encode(new Envelope(new DummyMessage('hello')));
+        $encoded['headers']['Content-Type'] = 'application/x-something-else';
+        $encoded['headers']['x-death'] = 'added by the broker';
+
+        $decoded = $serializer->decode($encoded);
+
+        $this->assertSame('hello', $decoded->getMessage()->getMessage());
+    }
+
+    public function testDecodeAcceptsSignedHeadersInAnyOrder()
+    {
+        $serializer = $this->createJsonSerializer([DummyMessage::class]);
+        $encoded = $serializer->encode(new Envelope(new DummyMessage('hello'), [new BusNameStamp('the_bus')]));
+        $encoded['headers'] = array_reverse($encoded['headers'], true);
+
+        $decoded = $serializer->decode($encoded);
+
+        $this->assertSame('the_bus', $decoded->last(BusNameStamp::class)->getBusName());
+    }
+
+    public function testEncodeMarksTheSignatureAsCoveringTheHeaders()
+    {
+        $serializer = $this->createJsonSerializer([DummyMessage::class]);
+
+        $encoded = $serializer->encode(new Envelope(new DummyMessage('hello')));
+
+        $this->assertStringStartsWith('v2:', $encoded['headers']['Body-Sign']);
+    }
+
+    public function testDecodeAcceptsABodyOnlySignature()
+    {
+        $inner = new Serializer();
+        $serializer = new SigningSerializer($inner, 'secret-key', [DummyMessage::class]);
+
+        $decoded = $serializer->decode($this->signBodyOnly($inner->encode(new Envelope(new DummyMessage('hello')))));
+
+        $this->assertSame('hello', $decoded->getMessage()->getMessage());
+    }
+
+    public function testDecodeAcceptsTamperedHeadersOnABodyOnlySignature()
+    {
+        $inner = new Serializer();
+        $serializer = new SigningSerializer($inner, 'secret-key', [DummyMessage::class]);
+        $encoded = $this->signBodyOnly($inner->encode(new Envelope(new DummyMessage('hello'))));
+        $encoded['headers']['type'] = ChildDummyMessage::class;
+
+        // messages signed before the headers were covered keep working, headers included
+        $decoded = $serializer->decode($encoded);
+
+        $this->assertInstanceOf(ChildDummyMessage::class, $decoded->getMessage());
+    }
+
+    public function testDecodeRejectsASignatureStrippedOfItsMarker()
+    {
+        $serializer = $this->createJsonSerializer([DummyMessage::class]);
+        $encoded = $serializer->encode(new Envelope(new DummyMessage('hello')));
+        $encoded['headers']['Body-Sign'] = substr($encoded['headers']['Body-Sign'], \strlen('v2:'));
+        $encoded['headers']['type'] = ChildDummyMessage::class;
+
+        $this->expectException(InvalidMessageSignatureException::class);
+        $serializer->decode($encoded);
+    }
+
+    public function testDecodeRejectsAHeaderCoveringSignatureReplayedAsBodyOnly()
+    {
+        $serializer = $this->createJsonSerializer([DummyMessage::class]);
+        $encoded = $serializer->encode(new Envelope(new DummyMessage('hello')));
+
+        // the signed payload is built from public data: replay it as the body of a message bearing a body-only signature
+        $forged = [
+            'body' => serialize([$encoded['body'], ['type' => $encoded['headers']['type']]]),
+            'headers' => [
+                'type' => ChildDummyMessage::class,
+                'Body-Sign' => substr($encoded['headers']['Body-Sign'], \strlen('v2:')),
+            ],
+        ];
+
+        $this->expectException(InvalidMessageSignatureException::class);
+        $serializer->decode($forged);
+    }
+
     private function createSerializer(array $signedTypes): SerializerInterface
     {
         return new SigningSerializer(new PhpSerializer(), 'secret-key', $signedTypes);
+    }
+
+    private function createJsonSerializer(array $signedTypes): SerializerInterface
+    {
+        return new SigningSerializer(new Serializer(), 'secret-key', $signedTypes);
+    }
+
+    private function signBodyOnly(array $encoded): array
+    {
+        $encoded['headers']['Body-Sign'] = hash_hmac('sha256', $encoded['body'] ?? '', 'secret-key');
+        $encoded['headers']['Sign-Algo'] = 'sha256';
+
+        return $encoded;
     }
 }

--- a/src/Symfony/Component/Messenger/Transport/Serialization/SigningSerializer.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/SigningSerializer.php
@@ -19,6 +19,14 @@ use Symfony\Component\Messenger\Exception\InvalidMessageSignatureException;
  */
 final class SigningSerializer implements SerializerInterface
 {
+    private const STAMP_HEADER_PREFIX = 'X-Message-Stamp-';
+
+    // Tells apart a signature that covers the headers from an older one that covers the body alone.
+    // HMACs are written in lowercase hexadecimal, so no older signature can ever start with this marker.
+    // The marker also derives the key of the newer scheme, so that a signature stripped of it cannot
+    // be replayed as a body-only signature over its own payload.
+    private const SIGNATURE_MARKER = 'v2:';
+
     /**
      * @param list<class-string> $signedMessageTypes
      */
@@ -36,7 +44,7 @@ final class SigningSerializer implements SerializerInterface
         $type = $envelope->getMessage()::class;
 
         if ($this->shouldSign($type)) {
-            $encoded['headers']['Body-Sign'] = hash_hmac($this->algorithm, $encoded['body'] ?? '', $this->signingKey);
+            $encoded['headers']['Body-Sign'] = self::SIGNATURE_MARKER.hash_hmac($this->algorithm, self::getSignedPayload($encoded), $this->getSigningKey(false));
             $encoded['headers']['Sign-Algo'] = $this->algorithm;
         }
 
@@ -52,13 +60,21 @@ final class SigningSerializer implements SerializerInterface
 
         $headers = $encodedEnvelope['headers'] ?? [];
         $sign = $headers['Body-Sign'] ?? null;
+        $sign = \is_string($sign) ? $sign : null;
 
-        if ($sign && hash_equals(hash_hmac($this->algorithm, $encodedEnvelope['body'] ?? '', $this->signingKey), $sign)) {
-            // A valid signature authenticates the message whatever its type: decode it without peeking.
-            // The algorithm is implied by the HMAC itself, so the "Sign-Algo" header isn't consulted here.
-            unset($encodedEnvelope['headers']['Body-Sign'], $encodedEnvelope['headers']['Sign-Algo']);
+        if ($sign) {
+            // signatures written before the headers were covered carry no marker and authenticate the body alone
+            $bodyOnly = !str_starts_with($sign, self::SIGNATURE_MARKER);
+            $payload = $bodyOnly ? ($encodedEnvelope['body'] ?? '') : self::getSignedPayload($encodedEnvelope);
+            $expected = ($bodyOnly ? '' : self::SIGNATURE_MARKER).hash_hmac($this->algorithm, $payload, $this->getSigningKey($bodyOnly));
 
-            return $this->inner->decode($encodedEnvelope);
+            if (hash_equals($expected, $sign)) {
+                // A valid signature authenticates the message whatever its type: decode it without peeking.
+                // The algorithm is implied by the HMAC itself, so the "Sign-Algo" header isn't consulted here.
+                unset($encodedEnvelope['headers']['Body-Sign'], $encodedEnvelope['headers']['Sign-Algo']);
+
+                return $this->inner->decode($encodedEnvelope);
+            }
         }
 
         $envelope = null;
@@ -94,5 +110,32 @@ final class SigningSerializer implements SerializerInterface
         }
 
         return false;
+    }
+
+    private function getSigningKey(bool $bodyOnly): string
+    {
+        return $bodyOnly ? $this->signingKey : hash_hmac($this->algorithm, self::SIGNATURE_MARKER, $this->signingKey);
+    }
+
+    /**
+     * Returns the payload the signature covers: the body, plus the headers that
+     * decide how the body is turned into an envelope. Transports add headers of
+     * their own, so signing every header would break as soon as one of them does.
+     */
+    private static function getSignedPayload(array $encodedEnvelope): string
+    {
+        $headers = [];
+
+        foreach ($encodedEnvelope['headers'] ?? [] as $name => $value) {
+            if ('type' === $name || str_starts_with($name, self::STAMP_HEADER_PREFIX)) {
+                $headers[$name] = $value;
+            }
+        }
+
+        // transports are free to reorder headers, so the order must not matter
+        ksort($headers, \SORT_STRING);
+
+        // serialize() gives an unambiguous encoding of the pair; it is never read back
+        return serialize([$encodedEnvelope['body'] ?? '', $headers]);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`SigningSerializer::encode()` computed the HMAC over `$encoded['body']`, so the signature covered the body and nothing else. The headers travelled unauthenticated, and the headers are what turn a body into an envelope: `Serializer::decode()` reads `type` to pick the class the body is denormalized into, and every `X-Message-Stamp-*` header to build the stamps. A valid body signature was therefore treated as authenticating the whole message, while relabelling `type` decodes the same body as another class and grafting a `BusNameStamp` header routes it to another bus.

The signature now covers the body together with the headers that describe the message, which are `type` and `X-Message-Stamp-*`, serialized with the header names sorted. Signing every header would be wrong, since transports add their own after `encode()` has returned: RabbitMQ writes an `x-death` entry when a delayed message comes back through its dead-letter exchange, and Amazon SQS reorders them by splitting them between message attributes and a JSON blob.

The signature value says which scheme produced it. `encode()` writes `v2:` in front of the new HMAC, and a value without that prefix is read as the older body-only signature, so messages already in the queue keep working across the upgrade, which matters because `DelayStamp` and AMQP delay exchanges can hold a message for days. HMACs are lowercase hexadecimal, so the two forms cannot be confused, and the marker cannot be stripped to force a downgrade: what is left must still verify as a body-only HMAC over that exact body, which takes the signing key. What stays open is bounded to a message captured before the upgrade, and the component cannot refuse the old path on its own because it cannot tell a finished rollout from one in progress. A deprecation on the development branch once this merges up is what will move operators off it.
