### PR TITLE
[Lock] Declare symfony/http-client in the DynamoDb bridge

### DIFF
--- a/src/Symfony/Component/Lock/Bridge/DynamoDb/composer.json
+++ b/src/Symfony/Component/Lock/Bridge/DynamoDb/composer.json
@@ -21,6 +21,9 @@
         "async-aws/dynamo-db": "^3.0",
         "symfony/lock": "^7.4|^8.0"
     },
+    "require-dev": {
+        "symfony/http-client": "^6.4|^7.0|^8.0"
+    },
     "conflict": {
         "symfony/polyfill-uuid": "<1.15"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The DynamoDb lock bridge has no `require-dev` section, while `Tests/Store/DynamoDbStoreTest.php` builds a `MockHttpClient`. The class is resolvable only because `async-aws/core` lists `symfony/http-client` in its own `require`, so the split package cannot install what its tests need. The bridge now asks for the package itself, with the constraint the other packages of the branch use.
