### PR TITLE
[HttpKernel] Strip cache-internal headers from backend responses in HttpCache

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
@@ -481,6 +481,12 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
         // always a "master" request (as the real master request can be in cache)
         $response = SubRequestHandler::handle($this->kernel, $request, HttpKernelInterface::MAIN_REQUEST, $catch);
 
+        // These headers drive how the body is restored before sending the response.
+        // Only the store and the surrogate may set them, never the backend.
+        $response->headers->remove('X-Body-File');
+        $response->headers->remove('X-Body-Eval');
+        $response->headers->remove('X-Content-Digest');
+
         /*
          * Support stale-if-error given on Responses or as a config option.
          * RFC 7234 summarizes in Section 4.2.4 (but also mentions with the individual

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTest.php
@@ -1359,6 +1359,55 @@ class HttpCacheTest extends HttpCacheTestCase
         $this->assertEquals(12, $this->response->headers->get('Content-Length'));
     }
 
+    public function testBackendCannotSetBodyFileHeader()
+    {
+        $file = sys_get_temp_dir().'/http_cache_local_file.txt';
+        file_put_contents($file, 'contents of a local file');
+
+        try {
+            $this->setNextResponse(200, ['X-Body-File' => $file], 'backend body');
+            $this->request('GET', '/');
+
+            $this->assertSame('backend body', $this->response->getContent());
+            $this->assertFalse($this->response->headers->has('X-Body-File'));
+        } finally {
+            @unlink($file);
+        }
+    }
+
+    public function testBackendCannotSetBodyEvalHeader()
+    {
+        $boundary = str_repeat('b', HttpCache::BODY_EVAL_BOUNDARY_LENGTH);
+        $body = $boundary.'start'.$boundary."/embedded\n\n\nend".$boundary;
+
+        $this->setNextResponses([
+            [
+                'status' => 200,
+                'body' => $body,
+                'headers' => ['X-Body-Eval' => 'ESI'],
+            ],
+            [
+                'status' => 200,
+                'body' => 'embedded content',
+                'headers' => [],
+            ],
+        ]);
+
+        $this->request('GET', '/', [], [], true);
+
+        $this->assertSame($body, $this->response->getContent());
+        $this->assertFalse($this->response->headers->has('X-Body-Eval'));
+    }
+
+    public function testBackendCannotSetContentDigestHeader()
+    {
+        $this->setNextResponse(200, ['X-Content-Digest' => 'from-the-backend'], 'backend body');
+        $this->request('GET', '/');
+
+        $this->assertSame('backend body', $this->response->getContent());
+        $this->assertFalse($this->response->headers->has('X-Content-Digest'));
+    }
+
     public function testClientIpIsAlwaysLocalhostForForwardedRequests()
     {
         $this->setNextResponse();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`HttpCache::forward()` returns the response of the backend unchanged, and `handle()` then calls `restoreResponseBody()` on it. That method has an `X-Body-File` branch which reads the path named by the header, and an `X-Body-Eval` branch which runs surrogate handling on the body. Both are cache-internal headers, so a backend sitting in a separate trust domain, which is the case in a gateway or a multi-tenant setup, can have the cache serve any local file it names, or make it fetch a URI of its choosing with the client's cookies. The persistence path is already guarded, since `Store::write()` throws unless an `X-Body-File` equals its own `getPath($digest)` and overwrites `X-Content-Digest`, so this is a per-request substitution rather than cache poisoning.

`X-Body-File`, `X-Body-Eval` and `X-Content-Digest` are now removed from the backend response, right after `SubRequestHandler::handle()` and before the surrogate that legitimately sets `X-Body-Eval` a few lines below. Everything else reaching `restoreResponseBody()` comes from `Store`. `HttpClientKernel::handle()` already removes the same three headers, so this extends an existing rule rather than inventing one.

This targets 5.4 on purpose. The change is hardening rather than a security fix, and 5.4 takes security fixes only, so a hardening change would normally start on the lowest branch that still receives bug fixes. It is proposed here deliberately, so that the long term support branch does not keep a defect that the maintained branches are having fixed.
