### PR TITLE
[HttpFoundation] Ignore session ids that are not usable as file names in MockFileSessionStorage

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/MockFileSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/MockFileSessionStorage.php
@@ -84,6 +84,20 @@ class MockFileSessionStorage extends MockArraySessionStorage
     /**
      * {@inheritdoc}
      */
+    public function setId(string $id)
+    {
+        // the id is turned into a file name, so keep it to the charset PHP allows for session ids
+        // and to the 255 bytes a file name can hold once the ".mocksess" suffix is added
+        if ('' !== $id && !preg_match('/^[a-zA-Z0-9,-]{1,246}$/D', $id)) {
+            $id = '';
+        }
+
+        parent::setId($id);
+    }
+
+    /**
+     * @return void
+     */
     public function save()
     {
         if (!$this->started) {

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/MockFileSessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/MockFileSessionStorageTest.php
@@ -114,6 +114,36 @@ class MockFileSessionStorageTest extends TestCase
         $storage1->save();
     }
 
+    public function testSetIdIgnoresAnIdThatIsNotUsableAsAFileName()
+    {
+        $this->storage->setId('../'.basename($this->sessionDir).'/planted');
+
+        $this->assertSame('', $this->storage->getId());
+    }
+
+    public function testSetIdIgnoresAnIdThatIsTooLongForAFileName()
+    {
+        $this->storage->setId($id = str_repeat('a', 246));
+        $this->assertSame($id, $this->storage->getId());
+
+        $this->storage->setId(str_repeat('a', 247));
+        $this->assertSame('', $this->storage->getId());
+    }
+
+    public function testAnIdThatIsNotUsableAsAFileNameStartsANewSession()
+    {
+        $planted = $this->sessionDir.'/planted.mocksess';
+        file_put_contents($planted, serialize(['_sf2_attributes' => ['foo' => 'bar']]));
+
+        $this->storage->setId('../'.basename($this->sessionDir).'/planted');
+        $this->storage->start();
+        $this->storage->getBag('attributes')->set('new', '108');
+        $this->storage->save();
+
+        $this->assertNull($this->storage->getBag('attributes')->get('foo'));
+        $this->assertSame(['_sf2_attributes' => ['foo' => 'bar']], unserialize(file_get_contents($planted)));
+    }
+
     private function getStorage(): MockFileSessionStorage
     {
         $storage = new MockFileSessionStorage($this->sessionDir);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`MockArraySessionStorage::setId()` stores whatever it is given, and `MockFileSessionStorage::getFilePath()` builds `$savePath.'/'.$id.'.mocksess'` from it, so an id carrying traversal segments resolves outside the save path. `read()` then unserializes whatever file that is, `save()` writes there and `destroy()` unlinks there. `AbstractSessionListener` copies the session cookie into `setId()`, so the id is not always something the application chose.

A session id that cannot be used as a file name is now ignored, so the storage keeps working with the ids it generates and stops following a hostile one.

These are the mock storages used by the functional test helpers, which is why this is robustness rather than a fix for something reachable in production: `session.storage.factory.mock_file` is wired in the test environment only.

This targets 5.4 on purpose. The change is hardening rather than a security fix, and 5.4 takes security fixes only, so a hardening change would normally start on the lowest branch that still receives bug fixes. It is proposed here deliberately, so that the long term support branch does not keep a defect that the maintained branches are having fixed.
