### PR TITLE
[HttpFoundation] Allow-list the values of the "X-Sendfile-Type" header

### DIFF
--- a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
+++ b/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
@@ -25,6 +25,13 @@ use Symfony\Component\HttpFoundation\File\File;
  */
 class BinaryFileResponse extends Response
 {
+    // Values accepted for the "X-Sendfile-Type" header, mapped to the response header to send
+    private const SENDFILE_TYPES = [
+        'x-sendfile' => 'X-Sendfile',
+        'x-accel-redirect' => 'X-Accel-Redirect',
+        'x-lighttpd-send-file' => 'X-LIGHTTPD-send-file',
+    ];
+
     protected static $trustXSendfileTypeHeader = false;
 
     /**
@@ -234,15 +241,17 @@ class BinaryFileResponse extends Response
             $this->headers->set('Accept-Ranges', $request->isMethodSafe() ? 'bytes' : 'none');
         }
 
-        if (self::$trustXSendfileTypeHeader && $request->headers->has('X-Sendfile-Type')) {
+        $sendfileType = self::$trustXSendfileTypeHeader ? $request->headers->get('X-Sendfile-Type') : null;
+        $type = self::SENDFILE_TYPES[strtolower($sendfileType ?? '')] ?? null;
+
+        if (null !== $type) {
             // Use X-Sendfile, do not send any content.
-            $type = $request->headers->get('X-Sendfile-Type');
             $path = $this->file->getRealPath();
             // Fall back to scheme://path for stream wrapped locations.
             if (false === $path) {
                 $path = $this->file->getPathname();
             }
-            if ('x-accel-redirect' === strtolower($type)) {
+            if ('X-Accel-Redirect' === $type) {
                 // Do X-Accel-Mapping substitutions.
                 // @link https://github.com/rack/rack/blob/main/lib/rack/sendfile.rb
                 // @link https://mattbrictson.com/blog/accelerated-rails-downloads

--- a/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
@@ -320,6 +320,60 @@ class BinaryFileResponseTest extends ResponseTestCase
     }
 
     /**
+     * @dataProvider provideSupportedXSendfileTypes
+     */
+    public function testSupportedXSendfileTypes(string $type, string $header)
+    {
+        $request = Request::create('/');
+        $request->headers->set('X-Sendfile-Type', $type);
+
+        BinaryFileResponse::trustXSendfileTypeHeader();
+        $response = new BinaryFileResponse(__DIR__.'/../README.md', 200, ['Content-Type' => 'application/octet-stream']);
+        $response->prepare($request);
+
+        $this->expectOutputString('');
+        $response->sendContent();
+
+        $this->assertArrayHasKey($header, $response->headers->allPreserveCase());
+        $this->assertStringContainsString('README.md', $response->headers->get($header));
+    }
+
+    public static function provideSupportedXSendfileTypes()
+    {
+        return [
+            ['X-Sendfile', 'X-Sendfile'],
+            ['x-sendfile', 'X-Sendfile'],
+            ['X-LIGHTTPD-send-file', 'X-LIGHTTPD-send-file'],
+        ];
+    }
+
+    /**
+     * @dataProvider provideUnsupportedXSendfileTypes
+     */
+    public function testUnsupportedXSendfileTypeIsIgnored(string $type)
+    {
+        $request = Request::create('/');
+        $request->headers->set('X-Sendfile-Type', $type);
+
+        BinaryFileResponse::trustXSendfileTypeHeader();
+        $response = new BinaryFileResponse(__DIR__.'/File/Fixtures/test.gif', 200, ['Content-Type' => 'application/octet-stream']);
+        $response->prepare($request);
+
+        $this->assertFalse($response->headers->has($type));
+
+        $this->expectOutputString(file_get_contents(__DIR__.'/File/Fixtures/test.gif'));
+        $response->sendContent();
+    }
+
+    public static function provideUnsupportedXSendfileTypes()
+    {
+        return [
+            ['X-Leak-Path'],
+            ['Location'],
+        ];
+    }
+
+    /**
      * @dataProvider getSampleXAccelMappings
      */
     public function testXAccelMapping($realpath, $mapping, $virtual)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

When an application calls `trustXSendfileTypeHeader()`, `BinaryFileResponse::prepare()` reads the `X-Sendfile-Type` request header and uses its value as the name of a response header. A client therefore chooses which header the server emits, and the value of that header is the internal path of the file being served. It can also overwrite a header that is already there: `X-Sendfile-Type: Content-Type` replaces the content type with the file path, and `Content-Disposition` goes the same way.

The value is now looked up in a map of the three types the feature supports, `X-Sendfile`, `X-Accel-Redirect` and `X-LIGHTTPD-send-file`, and the header emitted is one of those constants rather than the string received. Matching stays case insensitive. An unknown value is ignored instead of being trusted, so the response is what it would have been without the header: PHP streams the file and the `Range` branch applies again, where previously any value skipped it and produced an empty body.

The `X-Accel-Mapping` header is still read from the request. It is how the mapping legitimately reaches the application, since nginx sets it with `proxy_set_header` next to `X-Sendfile-Type`, and there is no server-side alternative in the component today. Replacing it with a configured mapping means new public API, so it belongs on the development branch.

This targets 5.4 on purpose. The change is hardening rather than a security fix, and 5.4 takes security fixes only, so a hardening change would normally start on the lowest branch that still receives bug fixes. It is proposed here deliberately, so that the long term support branch does not keep a defect that the maintained branches are having fixed.
