### PR TITLE
[Cache][HttpFoundation] Do not unmarshall values that SodiumMarshaller cannot decrypt

### DIFF
--- a/src/Symfony/Component/Cache/Marshaller/SodiumMarshaller.php
+++ b/src/Symfony/Component/Cache/Marshaller/SodiumMarshaller.php
@@ -68,13 +68,17 @@ class SodiumMarshaller implements MarshallerInterface
      */
     public function unmarshall(string $value)
     {
+        if ('' === $value) {
+            // an empty value carries no payload and tells session handlers that no session exists
+            return $this->marshaller->unmarshall($value);
+        }
+
         foreach ($this->decryptionKeys as $k) {
             if (false !== $decryptedValue = @sodium_crypto_box_seal_open($value, $k)) {
-                $value = $decryptedValue;
-                break;
+                return $this->marshaller->unmarshall($decryptedValue);
             }
         }
 
-        return $this->marshaller->unmarshall($value);
+        throw new \DomainException('Failed to decrypt value.');
     }
 }

--- a/src/Symfony/Component/Cache/Tests/Marshaller/SodiumMarshallerTest.php
+++ b/src/Symfony/Component/Cache/Tests/Marshaller/SodiumMarshallerTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Cache\Tests\Marshaller;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Cache\Marshaller\DefaultMarshaller;
+use Symfony\Component\Cache\Marshaller\MarshallerInterface;
 use Symfony\Component\Cache\Marshaller\SodiumMarshaller;
 
 /**
@@ -51,14 +52,62 @@ class SodiumMarshallerTest extends TestCase
         $failed = [];
 
         $sodiumResult = $sodiumMarshaller->marshall($values, $failed);
-        $defaultResult = $defaultMarshaller->marshall($values, $failed);
 
         $this->assertSame($values['a'], $sodiumMarshaller->unmarshall($sodiumResult['a']));
-        $this->assertSame($values['a'], $sodiumMarshaller->unmarshall($defaultResult['a']));
 
         $sodiumMarshaller = new SodiumMarshaller([sodium_crypto_box_keypair(), $this->decryptionKey], $defaultMarshaller);
 
         $this->assertSame($values['a'], $sodiumMarshaller->unmarshall($sodiumResult['a']));
-        $this->assertSame($values['a'], $sodiumMarshaller->unmarshall($defaultResult['a']));
+    }
+
+    public function testUnmarshallThrowsOnUnencryptedValues()
+    {
+        $defaultMarshaller = new DefaultMarshaller();
+        $sodiumMarshaller = new SodiumMarshaller([$this->decryptionKey], $defaultMarshaller);
+
+        $failed = [];
+        $defaultResult = $defaultMarshaller->marshall(['a' => '123'], $failed);
+
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessage('Failed to decrypt value.');
+
+        $sodiumMarshaller->unmarshall($defaultResult['a']);
+    }
+
+    public function testUnmarshallThrowsWhenNoKeyMatches()
+    {
+        $defaultMarshaller = new DefaultMarshaller();
+
+        $failed = [];
+        $otherResult = (new SodiumMarshaller([sodium_crypto_box_keypair()], $defaultMarshaller))->marshall(['a' => '123'], $failed);
+
+        $sodiumMarshaller = new SodiumMarshaller([$this->decryptionKey], $defaultMarshaller);
+
+        $this->expectException(\DomainException::class);
+        $this->expectExceptionMessage('Failed to decrypt value.');
+
+        $sodiumMarshaller->unmarshall($otherResult['a']);
+    }
+
+    public function testUnmarshallDoesNotForwardUndecryptedValues()
+    {
+        $marshaller = $this->createMock(MarshallerInterface::class);
+        $marshaller->expects($this->never())->method('unmarshall');
+
+        $sodiumMarshaller = new SodiumMarshaller([$this->decryptionKey], $marshaller);
+
+        $this->expectException(\DomainException::class);
+
+        $sodiumMarshaller->unmarshall(serialize(new \ArrayObject(['a' => '123'])));
+    }
+
+    public function testUnmarshallForwardsEmptyValues()
+    {
+        $marshaller = $this->createMock(MarshallerInterface::class);
+        $marshaller->expects($this->once())->method('unmarshall')->with('')->willReturn('');
+
+        $sodiumMarshaller = new SodiumMarshaller([$this->decryptionKey], $marshaller);
+
+        $this->assertSame('', $sodiumMarshaller->unmarshall(''));
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MarshallingSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MarshallingSessionHandler.php
@@ -69,7 +69,14 @@ class MarshallingSessionHandler implements \SessionHandlerInterface, \SessionUpd
     #[\ReturnTypeWillChange]
     public function read($sessionId)
     {
-        return $this->marshaller->unmarshall($this->handler->read($sessionId));
+        $data = $this->handler->read($sessionId);
+
+        try {
+            return $this->marshaller->unmarshall($data);
+        } catch (\DomainException $e) {
+            // data that cannot be unmarshalled is treated as a missing session, as PHP does with data it cannot decode
+            return '';
+        }
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MarshallingSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MarshallingSessionHandlerTest.php
@@ -91,6 +91,19 @@ class MarshallingSessionHandlerTest extends TestCase
         $this->assertEquals('unmarshalled_data', $result);
     }
 
+    public function testReadReturnsEmptyStringWhenUnmarshallingFails()
+    {
+        $marshallingSessionHandler = new MarshallingSessionHandler($this->handler, $this->marshaller);
+
+        $this->handler->expects($this->once())->method('read')->with('session_id')
+            ->willReturn('data');
+        $this->marshaller->expects($this->once())->method('unmarshall')->with('data')
+            ->willThrowException(new \DomainException('Failed to decrypt value.'))
+        ;
+
+        $this->assertSame('', $marshallingSessionHandler->read('session_id'));
+    }
+
     public function testWrite()
     {
         $marshallingSessionHandler = new MarshallingSessionHandler($this->handler, $this->marshaller);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`SodiumMarshaller::unmarshall()` tries each decryption key in turn, and when none of them opens the sealed box it leaves `$value` holding the raw stored bytes and hands them to the inner marshaller, which unserializes them. The class exists to keep a cache or session backend that somebody else can write to from being trusted, and that fall-through gives exactly that trust away: a plain serialized payload, written by whoever has access to the backend, is unserialized as if it had been produced by the application.

A value that no key decrypts is now rejected with a `\DomainException`, and the raw bytes never reach the inner marshaller. `DefaultMarshaller::unmarshall()` already throws that same exception for a value it cannot read, and the adapters catch `\Exception` around `doFetch()`, so this degrades to a logged cache miss rather than a fatal error, and one `catch` keeps covering both marshallers.

The empty string is still forwarded unchanged. `AbstractSessionHandler::read()` returns `''` when no session exists and `MarshallingSessionHandler::read()` passes it straight to the marshaller with no `try`, so rejecting it would fail every new session for anyone encrypting them. An empty value cannot carry a payload either way.

This targets 5.4 on purpose. The change is hardening rather than a security fix, and 5.4 takes security fixes only, so a hardening change would normally start on the lowest branch that still receives bug fixes. It is proposed here deliberately, so that the long term support branch does not keep a defect that the maintained branches are having fixed.

The second commit makes `MarshallingSessionHandler::read()` treat data that the marshaller cannot unmarshall as a missing session, the way PHP handles session data it cannot decode. Without it, a session record that no configured key can decrypt (for example after an old key was dropped from the list) would make `session_start()` throw on every request that carries the cookie, since the record is never rewritten.
