### PR TITLE
[Security] Narrow the race that lets a login link exceed max_uses

### DIFF
--- a/src/Symfony/Component/Security/Core/Signature/ExpiredSignatureStorage.php
+++ b/src/Symfony/Component/Security/Core/Signature/ExpiredSignatureStorage.php
@@ -37,7 +37,10 @@ final class ExpiredSignatureStorage
         return $this->cache->getItem($key)->get();
     }
 
-    public function incrementUsages(string $hash): void
+    /**
+     * @return int The number of usages once this one is accounted for
+     */
+    public function incrementUsages(string $hash): int
     {
         $item = $this->cache->getItem(rawurlencode($hash));
 
@@ -45,7 +48,10 @@ final class ExpiredSignatureStorage
             $item->expiresAfter($this->lifetime);
         }
 
-        $item->set($this->countUsages($hash) + 1);
+        $usages = ($item->get() ?? 0) + 1;
+        $item->set($usages);
         $this->cache->save($item);
+
+        return $usages;
     }
 }

--- a/src/Symfony/Component/Security/Core/Signature/ExpiredSignatureStorage.php
+++ b/src/Symfony/Component/Security/Core/Signature/ExpiredSignatureStorage.php
@@ -43,13 +43,11 @@ final class ExpiredSignatureStorage
     public function incrementUsages(string $hash): int
     {
         $item = $this->cache->getItem(rawurlencode($hash));
-
-        if (!$item->isHit()) {
-            $item->expiresAfter($this->lifetime);
-        }
-
         $usages = ($item->get() ?? 0) + 1;
+
+        // a fetched item does not carry its expiration, it has to be set on every save
         $item->set($usages);
+        $item->expiresAfter($this->lifetime);
         $this->cache->save($item);
 
         return $usages;

--- a/src/Symfony/Component/Security/Core/Signature/SignatureHasher.php
+++ b/src/Symfony/Component/Security/Core/Signature/SignatureHasher.php
@@ -87,12 +87,8 @@ class SignatureHasher
             throw new InvalidSignatureException('Invalid or expired signature.');
         }
 
-        if ($this->expiredSignaturesStorage && $this->maxUses) {
-            if ($this->expiredSignaturesStorage->countUsages($hash) >= $this->maxUses) {
-                throw new ExpiredSignatureException(sprintf('Signature can only be used "%d" times.', $this->maxUses));
-            }
-
-            $this->expiredSignaturesStorage->incrementUsages($hash);
+        if ($this->expiredSignaturesStorage && $this->maxUses && $this->expiredSignaturesStorage->incrementUsages($hash) > $this->maxUses) {
+            throw new ExpiredSignatureException(sprintf('Signature can only be used "%d" times.', $this->maxUses));
         }
     }
 

--- a/src/Symfony/Component/Security/Core/Tests/Signature/ExpiredSignatureStorageTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Signature/ExpiredSignatureStorageTest.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\Security\Core\Tests\Signature;
 
 use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Security\Core\Signature\ExpiredSignatureStorage;
 
@@ -34,5 +36,22 @@ class ExpiredSignatureStorageTest extends TestCase
         $this->assertSame(1, $storage->incrementUsages('hash+more'));
         $this->assertSame(2, $storage->incrementUsages('hash+more'));
         $this->assertSame(1, $storage->incrementUsages('another+hash'));
+    }
+
+    public function testIncrementUsagesAlwaysSetsAnExpiry()
+    {
+        // the counter already exists: an item fetched from the pool does not carry its expiration
+        $item = $this->createMock(CacheItemInterface::class);
+        $item->method('isHit')->willReturn(true);
+        $item->method('get')->willReturn(1);
+        $item->expects($this->once())->method('expiresAfter')->with(600);
+
+        $cache = $this->createMock(CacheItemPoolInterface::class);
+        $cache->method('getItem')->with(rawurlencode('hash+more'))->willReturn($item);
+        $cache->expects($this->once())->method('save')->with($item);
+
+        $storage = new ExpiredSignatureStorage($cache, 600);
+
+        $this->assertSame(2, $storage->incrementUsages('hash+more'));
     }
 }

--- a/src/Symfony/Component/Security/Core/Tests/Signature/ExpiredSignatureStorageTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Signature/ExpiredSignatureStorageTest.php
@@ -26,4 +26,13 @@ class ExpiredSignatureStorageTest extends TestCase
         $storage->incrementUsages('hash+more');
         $this->assertSame(1, $storage->countUsages('hash+more'));
     }
+
+    public function testIncrementUsagesReturnsTheResultingCount()
+    {
+        $storage = new ExpiredSignatureStorage(new ArrayAdapter(), 600);
+
+        $this->assertSame(1, $storage->incrementUsages('hash+more'));
+        $this->assertSame(2, $storage->incrementUsages('hash+more'));
+        $this->assertSame(1, $storage->incrementUsages('another+hash'));
+    }
 }

--- a/src/Symfony/Component/Security/Http/Tests/LoginLink/LoginLinkHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/LoginLink/LoginLinkHandlerTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Security\Http\Tests\LoginLink;
 use PHPUnit\Framework\Constraint\Constraint;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\HttpFoundation\Request;
@@ -191,6 +192,27 @@ class LoginLinkHandlerTest extends TestCase
         $linker->consumeLoginLink($request);
     }
 
+    public function testConsumeLoginLinkExceedsMaxUsageWhenConsumedConcurrently()
+    {
+        $expires = time() + 500;
+        $signature = $this->createSignatureHash('weaverryan', $expires);
+        $request = Request::create(sprintf('/login/verify?user=weaverryan&hash=%s&expires=%d', $signature, $expires));
+
+        $user = new TestLoginLinkHandlerUser('weaverryan', 'ryan@symfonycasts.com', 'pwhash');
+        $this->userProvider->createUser($user);
+
+        $linker = null;
+        // consume the same link a second time while the first consumption reads the usage counter
+        $this->expiredLinkCache = new TestLoginLinkConcurrentCache(new ArrayAdapter(), static function () use (&$linker, $request) {
+            $linker->consumeLoginLink($request);
+        });
+        $this->expiredLinkStorage = new ExpiredSignatureStorage($this->expiredLinkCache, 360);
+        $linker = $this->createLinker(['max_uses' => 1]);
+
+        $this->expectException(ExpiredLoginLinkException::class);
+        $linker->consumeLoginLink($request);
+    }
+
     public function testConsumeLoginLinkWithMissingHash()
     {
         $user = new TestLoginLinkHandlerUser('weaverryan', 'ryan@symfonycasts.com', 'pwhash');
@@ -231,6 +253,71 @@ class LoginLinkHandlerTest extends TestCase
         ], $options);
 
         return new LoginLinkHandler($this->router, $this->userProvider, new SignatureHasher($this->propertyAccessor, $extraProperties, 's3cret', $this->expiredLinkStorage, $options['max_uses'] ?? null), $options);
+    }
+}
+
+/**
+ * Runs a concurrent request the first time an item is read from the pool.
+ */
+class TestLoginLinkConcurrentCache implements CacheItemPoolInterface
+{
+    private $pool;
+    private $concurrentRequest;
+
+    public function __construct(CacheItemPoolInterface $pool, callable $concurrentRequest)
+    {
+        $this->pool = $pool;
+        $this->concurrentRequest = \Closure::fromCallable($concurrentRequest);
+    }
+
+    public function getItem($key): CacheItemInterface
+    {
+        if ($concurrentRequest = $this->concurrentRequest) {
+            $this->concurrentRequest = null;
+            $concurrentRequest();
+        }
+
+        return $this->pool->getItem($key);
+    }
+
+    public function getItems(array $keys = []): iterable
+    {
+        return $this->pool->getItems($keys);
+    }
+
+    public function hasItem($key): bool
+    {
+        return $this->pool->hasItem($key);
+    }
+
+    public function clear(): bool
+    {
+        return $this->pool->clear();
+    }
+
+    public function deleteItem($key): bool
+    {
+        return $this->pool->deleteItem($key);
+    }
+
+    public function deleteItems(array $keys): bool
+    {
+        return $this->pool->deleteItems($keys);
+    }
+
+    public function save(CacheItemInterface $item): bool
+    {
+        return $this->pool->save($item);
+    }
+
+    public function saveDeferred(CacheItemInterface $item): bool
+    {
+        return $this->pool->saveDeferred($item);
+    }
+
+    public function commit(): bool
+    {
+        return $this->pool->commit();
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`SignatureHasher::verifySignatureHash()` reads the use counter, compares it to `max_uses`, and then increments it, while `ExpiredSignatureStorage::incrementUsages()` does its own read, add and save against the cache with nothing serializing them. Two requests presenting the same login link at the same time both read the same count, both pass the guard, and both authenticate, so a link meant to be usable once is usable more than once. `SignatureRememberMeHandler` reaches the same code.

`incrementUsages()` now returns the count including the usage it just recorded, and the caller compares that instead of doing a separate read first. The storage also reuses the item it already fetched rather than reading it a second time, so the sequence costs two cache round trips instead of three.

This narrows the window rather than closing it. Two requests that both read before either writes still see the same value, and that window is now the storage's own fetch and save rather than the wider check-then-act above it. Closing it needs an atomic increment, which `CacheItemPoolInterface` cannot express, so it would mean changing what the constructor accepts.

One behaviour change follows: an attempt that is rejected now also increments the counter, so it can climb above `max_uses` until the entry expires. Reaching that code needs a signature that is otherwise valid, and the outcome stays a rejection.

This targets 5.4 on purpose. The change is hardening rather than a security fix, and 5.4 takes security fixes only, so a hardening change would normally start on the lowest branch that still receives bug fixes. It is proposed here deliberately, so that the long term support branch does not keep a defect that the maintained branches are having fixed.

Merging up into 6.4 conflicts in `SignatureHasher.php`, because the file has moved on since 5.4. Take the 6.4 side and re-apply the single comparison against the count returned by `incrementUsages()`, dropping the separate `countUsages()` read.
