### PR TITLE
[Serializer] Check the denormalized class is a Mime part in MimeMessageNormalizer

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/MimeMessageNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/MimeMessageNormalizer.php
@@ -18,6 +18,7 @@ use Symfony\Component\Mime\Header\UnstructuredHeader;
 use Symfony\Component\Mime\Message;
 use Symfony\Component\Mime\Part\AbstractPart;
 use Symfony\Component\Mime\RawMessage;
+use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
 use Symfony\Component\Serializer\SerializerAwareInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 
@@ -95,7 +96,13 @@ final class MimeMessageNormalizer implements NormalizerInterface, DenormalizerIn
         }
 
         if (AbstractPart::class === $type) {
-            $type = $data['class'];
+            $class = $data['class'] ?? null;
+
+            if (!\is_string($class) || !is_a($class, AbstractPart::class, true)) {
+                throw NotNormalizableValueException::createForUnexpectedDataType(sprintf('Expected a subclass of "%s", got "%s".', AbstractPart::class, \is_string($class) ? $class : get_debug_type($class)), $data, [AbstractPart::class], $context['deserialization_path'] ?? null);
+            }
+
+            $type = $class;
             unset($data['class']);
             $data['headers'] = $this->serializer->denormalize($data['headers'], Headers::class, $format, $context);
         }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/MimeMessageNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/MimeMessageNormalizerTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Normalizer;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Mime\Part\AbstractPart;
+use Symfony\Component\Mime\Part\TextPart;
+use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
+use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
+use Symfony\Component\Serializer\Normalizer\MimeMessageNormalizer;
+use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
+use Symfony\Component\Serializer\Normalizer\PropertyNormalizer;
+use Symfony\Component\Serializer\Serializer;
+
+class MimeMessageNormalizerTestForeignClass
+{
+    public $marker = '';
+}
+
+class MimeMessageNormalizerTest extends TestCase
+{
+    public function testDenormalizePartRoundTrip()
+    {
+        $serializer = $this->createMimeSerializer();
+
+        $part = new TextPart('Text content');
+        $part->getHeaders()->addHeader('foo', 'bar');
+
+        $normalized = $serializer->normalize($part);
+        $this->assertSame(TextPart::class, $normalized['class']);
+
+        $this->assertEquals($part, $serializer->denormalize($normalized, AbstractPart::class));
+    }
+
+    public function testDenormalizeRejectsForeignClassInPart()
+    {
+        $serializer = $this->createMimeSerializer();
+
+        $this->expectException(NotNormalizableValueException::class);
+        $this->expectExceptionMessage('Expected a subclass of "Symfony\Component\Mime\Part\AbstractPart", got "Symfony\Component\Serializer\Tests\Normalizer\MimeMessageNormalizerTestForeignClass".');
+
+        $serializer->denormalize(['class' => MimeMessageNormalizerTestForeignClass::class, 'marker' => 'foo', 'headers' => []], AbstractPart::class);
+    }
+
+    public function testDenormalizeRejectsNonStringClassInPart()
+    {
+        $serializer = $this->createMimeSerializer();
+
+        $this->expectException(NotNormalizableValueException::class);
+        $this->expectExceptionMessage('Expected a subclass of "Symfony\Component\Mime\Part\AbstractPart", got "array".');
+
+        $serializer->denormalize(['class' => [], 'headers' => []], AbstractPart::class);
+    }
+
+    public function testDenormalizeRejectsNonArrayDataInPart()
+    {
+        $serializer = $this->createMimeSerializer();
+
+        $this->expectException(NotNormalizableValueException::class);
+        $this->expectExceptionMessage('Expected a subclass of "Symfony\Component\Mime\Part\AbstractPart", got "null".');
+
+        $serializer->denormalize('a string', AbstractPart::class);
+    }
+
+    private function createMimeSerializer(): Serializer
+    {
+        $extractor = new PhpDocExtractor();
+        $propertyNormalizer = new PropertyNormalizer(null, null, $extractor);
+
+        return new Serializer([
+            new ArrayDenormalizer(),
+            new MimeMessageNormalizer($propertyNormalizer),
+            new ObjectNormalizer(null, null, null, $extractor),
+            $propertyNormalizer,
+        ], [new JsonEncoder()]);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

This backports #65025 to 5.4.

`MimeMessageNormalizer::denormalize()` ignores the type the caller asked for and re-derives the class to instantiate from the `class` key of the payload. Nothing checks that the resulting class is a Mime part, so denormalizing into the fixed and trusted `AbstractPart::class` still ends up with whatever class the payload names, constructed and populated by the wrapped `PropertyNormalizer`. The payload is now rejected with a `NotNormalizableValueException` unless the `class` key is a string and `is_a($class, AbstractPart::class, true)` holds, before anything is instantiated. `normalize()` writes the `class` key from an `AbstractPart` instance, so every legitimate round trip satisfies the check.

This targets 5.4 on purpose. The change is hardening rather than a security fix, and 5.4 takes security fixes only, so a hardening change would normally start on the lowest branch that still receives bug fixes. It is proposed here deliberately, so that the long term support branch does not keep a defect that the maintained branches have fixed.

Merging up into 6.4 conflicts in `MimeMessageNormalizer.php` and its test, because 6.4 already carries #65025 in a different shape: take the 6.4 side for both files.
