### PR TITLE
[HttpKernel] Validate the profiler token before using it as a file name

### DIFF
--- a/src/Symfony/Component/HttpKernel/Profiler/FileProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/FileProfilerStorage.php
@@ -198,9 +198,15 @@ class FileProfilerStorage implements ProfilerStorageInterface
      * Gets filename to store data, associated to the token.
      *
      * @return string
+     *
+     * @throws \InvalidArgumentException when the token cannot be used as a file name
      */
     protected function getFilename(string $token)
     {
+        if (!self::isValidToken($token)) {
+            throw new \InvalidArgumentException(sprintf('The profiler token "%s" is invalid: only letters, digits, dashes and underscores are allowed.', $token));
+        }
+
         // Uses 4 last characters, because first are mostly the same.
         $folderA = substr($token, -2, 2);
         $folderB = substr($token, -4, 2);
@@ -294,7 +300,7 @@ class FileProfilerStorage implements ProfilerStorageInterface
 
     private function doRead($token, ?Profile $profile = null): ?Profile
     {
-        if (!$token || !file_exists($file = $this->getFilename($token))) {
+        if (!$token || !self::isValidToken($token) || !file_exists($file = $this->getFilename($token))) {
             return null;
         }
 
@@ -313,5 +319,10 @@ class FileProfilerStorage implements ProfilerStorageInterface
         }
 
         return $this->createProfileFromData($token, $data, $profile);
+    }
+
+    private static function isValidToken(string $token): bool
+    {
+        return preg_match('/^[a-zA-Z0-9_-]++$/D', $token);
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/Profiler/FileProfilerStorageTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Profiler/FileProfilerStorageTest.php
@@ -139,6 +139,75 @@ class FileProfilerStorageTest extends TestCase
         $this->assertCount(1, $this->storage->find('', '', 1000, ''), '->find() does not return the same profile twice');
     }
 
+    public function testStoreTokenWithDash()
+    {
+        $profile = new Profile('a-token');
+        $profile->setUrl('http://example.com/');
+        $profile->setIp('127.0.0.1');
+        $profile->setStatusCode(200);
+        $profile->setMethod('GET');
+
+        $this->assertTrue($this->storage->write($profile));
+        $this->assertSame('http://example.com/', $this->storage->read('a-token')->getUrl());
+    }
+
+    public function testReadDoesNotLeaveTheStorageFolder()
+    {
+        $outside = \dirname($this->tmpDir).'/sf_profiler_outside';
+        file_put_contents($outside, serialize([
+            'token' => 'outside',
+            'parent' => null,
+            'children' => [],
+            'data' => [],
+            'ip' => '127.0.0.1',
+            'method' => 'GET',
+            'url' => 'http://example.com/',
+            'time' => time(),
+            'status_code' => 200,
+            'virtual_type' => 'request',
+        ]));
+
+        // the sharding folders must exist for the ".." segments to resolve
+        mkdir($this->tmpDir.'/de/si', 0777, true);
+
+        try {
+            $this->assertNull($this->storage->read('../../../sf_profiler_outside'));
+        } finally {
+            unlink($outside);
+        }
+    }
+
+    /**
+     * @dataProvider provideInvalidTokens
+     */
+    public function testReadInvalidToken(string $token)
+    {
+        $this->assertNull($this->storage->read($token));
+    }
+
+    /**
+     * @dataProvider provideInvalidTokens
+     */
+    public function testWriteInvalidToken(string $token)
+    {
+        $profile = new Profile($token);
+        $profile->setIp('127.0.0.1');
+        $profile->setMethod('GET');
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->storage->write($profile);
+    }
+
+    public static function provideInvalidTokens()
+    {
+        yield 'slash' => ['../../../evil'];
+        yield 'backslash' => ['..\\..\\..\\evil'];
+        yield 'dot' => ['evil.token'];
+        yield 'null byte' => ["evil\0token"];
+        yield 'trailing new line' => ["eviltoken\n"];
+    }
+
     public function testRetrieveByIp()
     {
         $profile = new Profile('token');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`FileProfilerStorage::getFilename()` interpolates the token into `<folder>/<last two>/<previous two>/<token>` without looking at it, and `doRead()` unserializes whatever that path resolves to. The profiler routes declare no requirement for `{token}`, so the compiled pattern is `[^/]++`, which rejects a forward slash and accepts a backslash. On Windows that is a directory separator, so a token of `..\..\..\Temp\payload` resolves outside the profiler folder and the file found there is unserialized.

`getFilename()` now rejects a token that is not made of the characters the profiler generates, `doRead()` returns `null` for such a token so an unknown token still lands on the "token not found" page rather than an error, and `removeExpiredProfiles()` skips index entries it cannot validate so an index written before this change cannot make a later `write()` throw.

`write()` now rejects a token outside that set, for example `evil.token`, which used to be stored. Nothing in Symfony produces one: tokens come from `Profiler::collect()`, and the only other values in play are the `latest` and `empty` sentinels of the profiler controller.

WebProfilerBundle is a development tool, so this is robustness rather than a fix for something reachable in production.

This targets 5.4 on purpose. The change is hardening rather than a security fix, and 5.4 takes security fixes only, so a hardening change would normally start on the lowest branch that still receives bug fixes. It is proposed here deliberately, so that the long term support branch does not keep a defect that the maintained branches are having fixed.

Merging up into 6.4 conflicts in `FileProfilerStorage.php`, because the file has moved on since 5.4. Take the 6.4 side and re-apply the token check in `getFilename()`, the early return in `doRead()` and the skip in `removeExpiredProfiles()`.
