### PR TITLE
[Yaml] Bound recursion depth in the inline lexer

### DIFF
--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -1275,6 +1275,18 @@ class Parser
 
     private function lexInlineStructure(int &$cursor, string $closingTag): string
     {
+        $state = $this->getState();
+        $state->enterNestingLevel($this->getRealCurrentLineNb() + 1, $this->currentLine, $this->filename);
+
+        try {
+            return $this->doLexInlineStructure($cursor, $closingTag);
+        } finally {
+            $state->leaveNestingLevel();
+        }
+    }
+
+    private function doLexInlineStructure(int &$cursor, string $closingTag): string
+    {
         $value = $this->currentLine[$cursor];
         ++$cursor;
 

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -2967,6 +2967,34 @@ YAML;
         $this->parser->parse($yaml);
     }
 
+    public function testParseRejectsUnterminatedInlineSequencesThatExceedTheNestingDepth()
+    {
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage('Maximum nesting depth of 128 exceeded');
+
+        $this->parser->parse(str_repeat('[', Parser::DEFAULT_MAX_NESTING_LEVEL + 1));
+    }
+
+    public function testParseRejectsUnterminatedInlineMappingsThatExceedTheNestingDepth()
+    {
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage('Maximum nesting depth of 128 exceeded');
+
+        $this->parser->parse(str_repeat('{', Parser::DEFAULT_MAX_NESTING_LEVEL + 1));
+    }
+
+    public function testParseAcceptsInlineSequencesAtTheNestingDepth()
+    {
+        $expected = [];
+        for ($i = 1; $i < Parser::DEFAULT_MAX_NESTING_LEVEL; ++$i) {
+            $expected = [$expected];
+        }
+
+        $yaml = str_repeat('[', Parser::DEFAULT_MAX_NESTING_LEVEL).str_repeat(']', Parser::DEFAULT_MAX_NESTING_LEVEL);
+
+        $this->assertSame($expected, $this->parser->parse($yaml));
+    }
+
     public function testParseRejectsDocumentsThatExceedTheConfiguredCollectionAliasLimit()
     {
         $parser = new Parser(Parser::DEFAULT_MAX_NESTING_LEVEL, 5);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`Parser::lexInlineStructure()` recurses through `lexInlineMapping()` and `lexInlineSequence()` on `{` and `[` without entering the nesting level that the rest of the parser counts. The `maxNestingLevel` guard covers the block subparser and the semantic parse in `Inline`, and both of those run after the lexer has already returned, so neither of them can stop a deeply nested inline document: a balanced input of a couple of hundred levels hits the guard as expected, while one of a few hundred thousand exhausts memory in the lexer before the guard is ever reached.

The lexer now enters and leaves the shared nesting level, at the entry of `lexInlineStructure()` rather than around the two recursive calls, so the outermost structure is counted too and the bound matches the one the semantic parse applies. Beyond the configured depth the parser raises the same "maximum nesting depth" error it already raises for block structures.

This targets 5.4 on purpose. The change is hardening rather than a security fix, and 5.4 takes security fixes only, so a hardening change would normally start on the lowest branch that still receives bug fixes. It is proposed here deliberately, so that the long term support branch does not keep a defect that the maintained branches are having fixed.
