### PR TITLE
[SecurityBundle] Use a lock for login throttling by default

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/LoginThrottlingFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/LoginThrottlingFactory.php
@@ -16,8 +16,10 @@ use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpFoundation\RateLimiter\RequestRateLimiterInterface;
+use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\RateLimiter\RateLimiterFactory;
 use Symfony\Component\Security\Http\RateLimiter\DefaultLoginRateLimiter;
 
@@ -60,7 +62,7 @@ class LoginThrottlingFactory implements AuthenticatorFactoryInterface, SecurityF
                 ->scalarNode('limiter')->info(sprintf('A service id implementing "%s".', RequestRateLimiterInterface::class))->end()
                 ->integerNode('max_attempts')->defaultValue(5)->end()
                 ->scalarNode('interval')->defaultValue('1 minute')->end()
-                ->scalarNode('lock_factory')->info('The service ID of the lock factory used by the login rate limiter (or null to disable locking)')->defaultNull()->end()
+                ->scalarNode('lock_factory')->info('The service ID of the lock factory used by the login rate limiter ("auto" to use the default one when the Lock component is configured, or null to disable locking)')->defaultValue('auto')->end()
             ->end();
     }
 
@@ -79,12 +81,19 @@ class LoginThrottlingFactory implements AuthenticatorFactoryInterface, SecurityF
                 'policy' => 'fixed_window',
                 'limit' => $config['max_attempts'],
                 'interval' => $config['interval'],
-                'lock_factory' => $config['lock_factory'],
+                'lock_factory' => 'auto' === $config['lock_factory'] ? null : $config['lock_factory'],
             ];
             FrameworkExtension::registerRateLimiter($container, $localId = '_login_local_'.$firewallName, $limiterOptions);
 
             $limiterOptions['limit'] = 5 * $config['max_attempts'];
             FrameworkExtension::registerRateLimiter($container, $globalId = '_login_global_'.$firewallName, $limiterOptions);
+
+            if ('auto' === $config['lock_factory'] && class_exists(LockFactory::class)) {
+                // resolved when the container is compiled, so that the order in which extensions are loaded does not matter
+                $lockFactory = new Reference('lock.factory', ContainerInterface::NULL_ON_INVALID_REFERENCE);
+                $container->getDefinition('limiter.'.$localId)->replaceArgument(2, $lockFactory);
+                $container->getDefinition('limiter.'.$globalId)->replaceArgument(2, $lockFactory);
+            }
 
             $container->register($config['limiter'] = 'security.login_throttling.'.$firewallName.'.limiter', DefaultLoginRateLimiter::class)
                 ->addArgument(new Reference('limiter.'.$globalId))

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/LoginThrottlingFactoryTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/LoginThrottlingFactoryTest.php
@@ -1,0 +1,128 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\DependencyInjection\Security\Factory;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\FrameworkExtension;
+use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\LoginThrottlingFactory;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\DependencyInjection\Alias;
+use Symfony\Component\DependencyInjection\Compiler\ResolveChildDefinitionsPass;
+use Symfony\Component\DependencyInjection\Compiler\ResolveInvalidReferencesPass;
+use Symfony\Component\DependencyInjection\Compiler\ResolveReferencesToAliasesPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
+use Symfony\Component\Security\Http\EventListener\LoginThrottlingListener;
+
+class LoginThrottlingFactoryTest extends TestCase
+{
+    public function testTheDefaultLockFactoryIsUsedWhenItIsAvailable()
+    {
+        $this->skipIfLockIsNotInstalled();
+
+        $container = $this->createContainer(true);
+        $this->createAuthenticator($container, []);
+        $this->resolveDefinitions($container);
+
+        $this->assertSame('lock.default.factory', (string) $container->getDefinition('limiter._login_local_main')->getArgument(2));
+        $this->assertSame('lock.default.factory', (string) $container->getDefinition('limiter._login_global_main')->getArgument(2));
+    }
+
+    public function testNoLockIsUsedWhenTheDefaultLockFactoryIsNotAvailable()
+    {
+        $container = $this->createContainer(false);
+        $this->createAuthenticator($container, []);
+        $this->resolveDefinitions($container);
+
+        $this->assertNull($container->getDefinition('limiter._login_local_main')->getArgument(2));
+        $this->assertNull($container->getDefinition('limiter._login_global_main')->getArgument(2));
+    }
+
+    public function testLockingCanBeTurnedOff()
+    {
+        $container = $this->createContainer(true);
+        $this->createAuthenticator($container, ['lock_factory' => null]);
+        $this->resolveDefinitions($container);
+
+        $this->assertNull($container->getDefinition('limiter._login_local_main')->getArgument(2));
+        $this->assertNull($container->getDefinition('limiter._login_global_main')->getArgument(2));
+    }
+
+    public function testAnExplicitLockFactoryIsUsed()
+    {
+        $this->skipIfLockIsNotInstalled();
+
+        if (!(new \ReflectionClass(FrameworkExtension::class))->hasProperty('lockConfigEnabled')) {
+            $this->markTestSkipped('This test requires symfony/framework-bundle 5.x.');
+        }
+
+        $container = $this->createContainer(true);
+        $container->register('app.lock_factory', LockFactory::class);
+
+        // FrameworkExtension::registerRateLimiter() accepts an explicit lock factory only when the lock configuration is enabled
+        $setLockConfigEnabled = \Closure::bind(static function (bool $enabled) { self::$lockConfigEnabled = $enabled; }, null, FrameworkExtension::class);
+        $setLockConfigEnabled(true);
+
+        try {
+            $this->createAuthenticator($container, ['lock_factory' => 'app.lock_factory']);
+        } finally {
+            $setLockConfigEnabled(false);
+        }
+
+        $this->resolveDefinitions($container);
+
+        $this->assertSame('app.lock_factory', (string) $container->getDefinition('limiter._login_local_main')->getArgument(2));
+        $this->assertSame('app.lock_factory', (string) $container->getDefinition('limiter._login_global_main')->getArgument(2));
+    }
+
+    private function createContainer(bool $withLockFactory): ContainerBuilder
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('kernel.secret', 's3cr3t');
+        $container->setDefinition('limiter', (new Definition(RateLimiterFactory::class))->setAbstract(true)->setArguments([null, null, null]));
+        $container->setDefinition('security.listener.login_throttling', (new Definition(LoginThrottlingListener::class))->setAbstract(true)->setArguments([null, null]));
+        $container->register('cache.rate_limiter');
+
+        if ($withLockFactory) {
+            $container->register('lock.default.factory', LockFactory::class);
+            $container->setAlias('lock.factory', new Alias('lock.default.factory', false));
+        }
+
+        return $container;
+    }
+
+    private function createAuthenticator(ContainerBuilder $container, array $config): void
+    {
+        $factory = new LoginThrottlingFactory();
+
+        $factory->addConfiguration($nodeDefinition = new ArrayNodeDefinition('login_throttling'));
+        $node = $nodeDefinition->getNode();
+
+        $factory->createAuthenticator($container, 'main', $node->finalize($node->normalize($config)), 'user_provider');
+    }
+
+    private function resolveDefinitions(ContainerBuilder $container): void
+    {
+        (new ResolveChildDefinitionsPass())->process($container);
+        (new ResolveReferencesToAliasesPass())->process($container);
+        (new ResolveInvalidReferencesPass())->process($container);
+    }
+
+    private function skipIfLockIsNotInstalled(): void
+    {
+        if (!class_exists(LockFactory::class)) {
+            $this->markTestSkipped('This test requires symfony/lock.');
+        }
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The rate limiter policies acquire a lock, fetch the state, compute and save it. When no lock is configured that sequence is not serialized, so requests arriving together all read the same state and each writes back its own increment, and a burst of failed logins consumes roughly one attempt instead of one each. `login_throttling` is exactly that case: `lock_factory` defaulted to `null`, so the limiter protecting `/login` ran without a lock unless the application named a service.

The option now defaults to `auto`, resolved as a reference to `lock.factory` that becomes `null` when the Lock component is not configured. The resolution happens when the container is compiled, so the order in which the extensions are loaded does not matter. `lock_factory: null` still disables locking, and an explicit service id still wins.

This is inert unless `framework.lock` is configured, so an application without the Lock component behaves exactly as before, and the race stays open there. Where a lock is wired, the default store serializes one machine, so deployments spread over several servers still need a shared store to close it fully.

This targets 5.4 on purpose. The change is hardening rather than a security fix, and 5.4 takes security fixes only, so a hardening change would normally start on the lowest branch that still receives bug fixes. It is proposed here deliberately, so that the long term support branch does not keep a defect that the maintained branches are having fixed.

Merging up into 6.4 needs a rewrite rather than a replay. On 5.4 the factory delegates to `FrameworkExtension::registerRateLimiter()`, which is why the lock is injected here by replacing the third argument of the two limiter definitions. From 6.4 the factory registers the limiters itself, so the same result is obtained by setting the reference directly where those definitions are built. The config node and the `auto` sentinel carry over unchanged. From 7.4 the surrounding method also gained `cache_pool` and `storage_service` nodes, so keep that shape and add the `auto` branch ahead of the existing null check.
