### PR TITLE
[ExpressionLanguage] Bound the nesting level of parsed expressions

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/Parser.php
+++ b/src/Symfony/Component/ExpressionLanguage/Parser.php
@@ -26,12 +26,15 @@ class Parser
     public const OPERATOR_LEFT = 1;
     public const OPERATOR_RIGHT = 2;
 
+    private const MAX_NESTING_LEVEL = 256;
+
     private $stream;
     private $unaryOperators;
     private $binaryOperators;
     private $functions;
     private $names;
     private $lint;
+    private $nestingLevel = 0;
 
     public function __construct(array $functions)
     {
@@ -118,6 +121,7 @@ class Parser
     {
         $this->stream = $stream;
         $this->names = $names;
+        $this->nestingLevel = 0;
 
         $node = $this->parseExpression();
         if (!$stream->isEOF()) {
@@ -132,23 +136,31 @@ class Parser
 
     public function parseExpression(int $precedence = 0)
     {
-        $expr = $this->getPrimary();
-        $token = $this->stream->current;
-        while ($token->test(Token::OPERATOR_TYPE) && isset($this->binaryOperators[$token->value]) && $this->binaryOperators[$token->value]['precedence'] >= $precedence) {
-            $op = $this->binaryOperators[$token->value];
-            $this->stream->next();
+        $nestingLevel = $this->nestingLevel;
+        $this->enterNestingLevel();
 
-            $expr1 = $this->parseExpression(self::OPERATOR_LEFT === $op['associativity'] ? $op['precedence'] + 1 : $op['precedence']);
-            $expr = new Node\BinaryNode($token->value, $expr, $expr1);
-
+        try {
+            $expr = $this->getPrimary();
             $token = $this->stream->current;
-        }
+            while ($token->test(Token::OPERATOR_TYPE) && isset($this->binaryOperators[$token->value]) && $this->binaryOperators[$token->value]['precedence'] >= $precedence) {
+                $this->enterNestingLevel();
+                $op = $this->binaryOperators[$token->value];
+                $this->stream->next();
 
-        if (0 === $precedence) {
-            return $this->parseConditionalExpression($expr);
-        }
+                $expr1 = $this->parseExpression(self::OPERATOR_LEFT === $op['associativity'] ? $op['precedence'] + 1 : $op['precedence']);
+                $expr = new Node\BinaryNode($token->value, $expr, $expr1);
 
-        return $expr;
+                $token = $this->stream->current;
+            }
+
+            if (0 === $precedence) {
+                return $this->parseConditionalExpression($expr);
+            }
+
+            return $expr;
+        } finally {
+            $this->nestingLevel = $nestingLevel;
+        }
     }
 
     protected function getPrimary()
@@ -177,6 +189,7 @@ class Parser
     protected function parseConditionalExpression(Node\Node $expr)
     {
         while ($this->stream->current->test(Token::PUNCTUATION_TYPE, '?')) {
+            $this->enterNestingLevel();
             $this->stream->next();
             if (!$this->stream->current->test(Token::PUNCTUATION_TYPE, ':')) {
                 $expr2 = $this->parseExpression();
@@ -336,6 +349,7 @@ class Parser
         $token = $this->stream->current;
         while (Token::PUNCTUATION_TYPE == $token->type) {
             if ('.' === $token->value) {
+                $this->enterNestingLevel();
                 $this->stream->next();
                 $token = $this->stream->current;
                 $this->stream->next();
@@ -373,6 +387,7 @@ class Parser
 
                 $node = new Node\GetAttrNode($node, $arg, $arguments, $type);
             } elseif ('[' === $token->value) {
+                $this->enterNestingLevel();
                 $this->stream->next();
                 $arg = $this->parseExpression();
                 $this->stream->expect(Token::PUNCTUATION_TYPE, ']');
@@ -405,5 +420,20 @@ class Parser
         $this->stream->expect(Token::PUNCTUATION_TYPE, ')', 'A list of arguments must be closed by a parenthesis');
 
         return new Node\Node($args);
+    }
+
+    /**
+     * Accounts for one more node on the branch being built.
+     *
+     * The nesting level bounds the depth of the resulting node tree. Beyond a few
+     * thousand levels, destroying such a tree overflows the native stack.
+     *
+     * @throws SyntaxError
+     */
+    private function enterNestingLevel(): void
+    {
+        if (self::MAX_NESTING_LEVEL < ++$this->nestingLevel) {
+            throw new SyntaxError(sprintf('Expression is nested too deeply, the maximum nesting level is %d', self::MAX_NESTING_LEVEL), $this->stream->current->cursor, $this->stream->getExpression());
+        }
     }
 }

--- a/src/Symfony/Component/ExpressionLanguage/Tests/ParserTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/ParserTest.php
@@ -344,4 +344,35 @@ class ParserTest extends TestCase
             ],
         ];
     }
+
+    /**
+     * @dataProvider getDeeplyNestedExpressions
+     */
+    public function testDeeplyNestedExpressionIsRejected(string $expression)
+    {
+        $this->expectException(SyntaxError::class);
+        $this->expectExceptionMessage('Expression is nested too deeply, the maximum nesting level is 256');
+
+        (new Parser([]))->lint((new Lexer())->tokenize($expression), null);
+    }
+
+    public static function getDeeplyNestedExpressions(): iterable
+    {
+        yield 'unary operators' => [str_repeat('!', 300).'1'];
+        yield 'signs' => [str_repeat('-', 300).'1'];
+        yield 'parentheses' => [str_repeat('(', 300).'1'.str_repeat(')', 300)];
+        yield 'arrays' => [str_repeat('[', 300).'1'.str_repeat(']', 300)];
+        yield 'hashes' => [str_repeat('{a:', 300).'1'.str_repeat('}', 300)];
+        yield 'binary operators' => [str_repeat('1+', 300).'1'];
+        yield 'properties' => ['a'.str_repeat('.b', 300)];
+        yield 'array accesses' => ['a'.str_repeat('[0]', 300)];
+        yield 'ternaries' => [str_repeat('1?', 300).'1'.str_repeat(':1', 300)];
+    }
+
+    public function testDeepButReasonableExpressionIsAccepted()
+    {
+        (new Parser([]))->lint((new Lexer())->tokenize(str_repeat('(', 100).'a'.str_repeat(' + 1)', 100)), ['a']);
+
+        $this->expectNotToPerformAssertions();
+    }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/ExpressionLanguageSyntaxValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ExpressionLanguageSyntaxValidatorTest.php
@@ -65,4 +65,20 @@ class ExpressionLanguageSyntaxValidatorTest extends ConstraintValidatorTestCase
             ->setCode(ExpressionLanguageSyntax::EXPRESSION_LANGUAGE_SYNTAX_ERROR)
             ->assertRaised();
     }
+
+    public function testDeeplyNestedExpressionIsNotValid()
+    {
+        $expression = str_repeat('!', 300).'1';
+
+        $this->validator->validate($expression, new ExpressionLanguageSyntax([
+            'message' => 'myMessage',
+            'allowedVariables' => [],
+        ]));
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ syntax_error }}', sprintf('"Expression is nested too deeply, the maximum nesting level is 256 around position 257 for expression `%s`."', $expression))
+            ->setInvalidValue($expression)
+            ->setCode(ExpressionLanguageSyntax::EXPRESSION_LANGUAGE_SYNTAX_ERROR)
+            ->assertRaised();
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The expression parser builds its node tree with no bound on how deep it goes, and a deep enough tree crashes the process while it is being freed rather than while it is being built. An input of tens of thousands of nested unary operators, array literals, binary operators or property accesses parses successfully and then segfaults on teardown.

Counting the recursive descent is not enough. Four of those shapes fold iteratively rather than recursively: the binary operator loop in `parseExpression()`, the `.` and `[…]` loops in `parsePostfixExpression()`, and the `??` and `?:` loops in `parseConditionalExpression()`. Each turn of those loops deepens the tree while the call depth stays where it was, so a counter placed on the descent alone leaves `1+1+1+…` and `a.b.b.b…` crashing.

The bound therefore counts the nodes stacked on the branch currently being built. It is saved and restored around `parseExpression()`, so sibling subtrees do not accumulate, and it is incremented at the four fold sites as well. Beyond the limit the parser raises a `SyntaxError`, which callers already handle. The limit is 256; the deepest expression anywhere in this repository is 9.

This targets 5.4 on purpose. The change is hardening rather than a security fix, and 5.4 takes security fixes only, so a hardening change would normally start on the lowest branch that still receives bug fixes. It is proposed here deliberately, so that the long term support branch does not keep a defect that the maintained branches are having fixed.

Merging up into 6.4 conflicts in `Parser.php`, because the file has moved on since 5.4. Take the 6.4 side and re-apply the nesting counter, keeping it saved and restored around `parseExpression()` and incremented at the four fold sites, since a counter placed only on the recursive descent does not bound the iterative folds.
