### PR TITLE
[VarDumper] Escape context strings in HtmlDescriptor

### DIFF
--- a/src/Symfony/Component/VarDumper/Command/Descriptor/HtmlDescriptor.php
+++ b/src/Symfony/Component/VarDumper/Command/Descriptor/HtmlDescriptor.php
@@ -45,11 +45,11 @@ class HtmlDescriptor implements DumpDescriptorInterface
         if (isset($context['request'])) {
             $request = $context['request'];
             $controller = "<span class='dumped-tag'>{$this->dumper->dump($request['controller'], true, ['maxDepth' => 0])}</span>";
-            $title = sprintf('<code>%s</code> <a href="%s">%s</a>', $request['method'], $uri = $request['uri'], $uri);
-            $dedupIdentifier = $request['identifier'];
+            $title = sprintf('<code>%s</code> <a href="%s">%s</a>', self::escape($request['method']), $uri = self::escape($request['uri']), $uri);
+            $dedupIdentifier = self::escape($request['identifier']);
         } elseif (isset($context['cli'])) {
-            $title = '<code>$ </code>'.$context['cli']['command_line'];
-            $dedupIdentifier = $context['cli']['identifier'];
+            $title = '<code>$ </code>'.self::escape($context['cli']['command_line']);
+            $dedupIdentifier = self::escape($context['cli']['identifier']);
         } else {
             $dedupIdentifier = uniqid('', true);
         }
@@ -57,10 +57,10 @@ class HtmlDescriptor implements DumpDescriptorInterface
         $sourceDescription = '';
         if (isset($context['source'])) {
             $source = $context['source'];
-            $projectDir = $source['project_dir'] ?? null;
-            $sourceDescription = sprintf('%s on line %d', $source['name'], $source['line']);
+            $projectDir = isset($source['project_dir']) ? self::escape($source['project_dir']) : null;
+            $sourceDescription = sprintf('%s on line %d', self::escape($source['name']), $source['line']);
             if (isset($source['file_link'])) {
-                $sourceDescription = sprintf('<a href="%s">%s</a>', $source['file_link'], $sourceDescription);
+                $sourceDescription = sprintf('<a href="%s">%s</a>', self::escape($source['file_link']), $sourceDescription);
             }
         }
 
@@ -115,5 +115,10 @@ HTML
     </ul>
 </div>
 HTML;
+    }
+
+    private static function escape(string $value): string
+    {
+        return htmlspecialchars($value, \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8');
     }
 }

--- a/src/Symfony/Component/VarDumper/Tests/Command/Descriptor/HtmlDescriptorTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Command/Descriptor/HtmlDescriptorTest.php
@@ -48,6 +48,80 @@ class HtmlDescriptorTest extends TestCase
         $this->assertDoesNotMatchRegularExpression('#<style>(.*?)</style><script>(.*?)</script>(.*)#', $output->fetch(), 'styles & scripts are output only once');
     }
 
+    public function testItEscapesContextStrings()
+    {
+        $output = new BufferedOutput();
+        $dumper = $this->createMock(HtmlDumper::class);
+        $dumper->method('dump')->willReturn('[DUMPED]');
+        $descriptor = new HtmlDescriptor($dumper);
+
+        $descriptor->describe($output, new Data([[123]]), ['timestamp' => 1544804268.3668], 1);
+        $output->fetch();
+
+        $descriptor->describe($output, new Data([[123]]), [
+            'timestamp' => 1544804268.3668,
+            'request' => [
+                'identifier' => 'id"><script>alert(1)</script>',
+                'controller' => new Data([['FooController.php']]),
+                'method' => 'GET<script>alert(2)</script>',
+                'uri' => 'http://localhost/"><script>alert(3)</script>',
+            ],
+            'source' => [
+                'name' => 'Foo<script>alert(4)</script>.php',
+                'line' => 30,
+                'project_dir' => '/app"><script>alert(5)</script>',
+                'file_link' => 'phpstorm://open"><script>alert(6)</script>',
+            ],
+        ], 1);
+
+        $dump = $output->fetch();
+
+        $this->assertStringNotContainsString('<script>', $dump);
+        $this->assertStringContainsString('data-dedup-id="id&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;"', $dump);
+        $this->assertStringContainsString('<code>GET&lt;script&gt;alert(2)&lt;/script&gt;</code>', $dump);
+        $this->assertStringContainsString('<a href="http://localhost/&quot;&gt;&lt;script&gt;alert(3)&lt;/script&gt;">http://localhost/&quot;&gt;&lt;script&gt;alert(3)&lt;/script&gt;</a>', $dump);
+        $this->assertStringContainsString('<a href="phpstorm://open&quot;&gt;&lt;script&gt;alert(6)&lt;/script&gt;">Foo&lt;script&gt;alert(4)&lt;/script&gt;.php on line 30</a>', $dump);
+        $this->assertStringContainsString('<li><span class="badge">project dir</span>/app&quot;&gt;&lt;script&gt;alert(5)&lt;/script&gt;</li>', $dump);
+    }
+
+    public function testItKeepsContextStringsThatAreNotValidUtf8()
+    {
+        $output = new BufferedOutput();
+        $dumper = $this->createMock(HtmlDumper::class);
+        $dumper->method('dump')->willReturn('[DUMPED]');
+        $descriptor = new HtmlDescriptor($dumper);
+
+        $descriptor->describe($output, new Data([[123]]), [
+            'timestamp' => 1544804268.3668,
+            'cli' => [
+                'identifier' => 'd8bece1c',
+                'command_line' => "bin/phpunit \xB1",
+            ],
+        ], 1);
+
+        $this->assertStringContainsString('<code>$ </code>bin/phpunit ', $output->fetch());
+    }
+
+    public function testItKeepsTheDumpedControllerAsMarkup()
+    {
+        $output = new BufferedOutput();
+        $dumper = $this->createMock(HtmlDumper::class);
+        $dumper->method('dump')->willReturn('<span class=sf-dump-str>App\\Controller\\FooController</span>');
+        $descriptor = new HtmlDescriptor($dumper);
+
+        $descriptor->describe($output, new Data([[123]]), [
+            'timestamp' => 1544804268.3668,
+            'request' => [
+                'identifier' => 'd8bece1c',
+                'controller' => new Data([['FooController.php']]),
+                'method' => 'GET',
+                'uri' => 'http://localhost/foo',
+            ],
+        ], 1);
+
+        $this->assertStringContainsString('<span class=\'dumped-tag\'><span class=sf-dump-str>App\\Controller\\FooController</span></span>', $output->fetch());
+    }
+
     /**
      * @dataProvider provideContext
      */
@@ -122,7 +196,7 @@ TXT
     </header>
     <section class="body">
         <p class="text-small">
-            <a href="phpstorm://open?file=/Users/ogi/symfony/src/Symfony/Component/VarDumper/Tests/Command/Descriptor/CliDescriptorTest.php&line=30">CliDescriptorTest.php on line 30</a>
+            <a href="phpstorm://open?file=/Users/ogi/symfony/src/Symfony/Component/VarDumper/Tests/Command/Descriptor/CliDescriptorTest.php&amp;line=30">CliDescriptorTest.php on line 30</a>
         </p>
         [DUMPED]
     </section>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`HtmlDescriptor::describe()` writes an HTML document and interpolates several context strings into it without escaping: the request method and URI, the command line of a CLI run, the name and the link of the source, the project directory and the deduplication identifier. The dump server accepts those values from a socket and passes them on unchanged, so they are whatever the process that produced the dump put there, and the document is then opened in a browser.

Each of those values is now escaped where it enters the document. The tags are not escaped as a whole, because one of them holds the controller as HTML that the dumper has just produced, and escaping that would print the dump as literal text.

`ENT_SUBSTITUTE` is set along with `ENT_QUOTES`: without it, a single invalid UTF-8 byte in one of those strings makes `htmlspecialchars()` return an empty string and the field disappears from the output.

This targets 5.4 on purpose. The change is hardening rather than a security fix, and 5.4 takes security fixes only, so a hardening change would normally start on the lowest branch that still receives bug fixes. It is proposed here deliberately, so that the long term support branch does not keep a defect that the maintained branches are having fixed.

Merging up into 6.4 conflicts in `HtmlDescriptor.php` and its test, because the file has moved on since 5.4. Take the 6.4 side and re-apply the escaping at each point where a context string enters the document. Note that on 6.4 the dump identifier is a hash rather than `spl_object_hash()`, so that field does not need escaping there.
