### PR TITLE
[Console][MonologBridge][VarDumper] Escape context strings written to the terminal

### DIFF
--- a/src/Symfony/Bridge/Monolog/Formatter/ConsoleFormatter.php
+++ b/src/Symfony/Bridge/Monolog/Formatter/ConsoleFormatter.php
@@ -105,13 +105,13 @@ class ConsoleFormatter implements FormatterInterface
         $record = $this->replacePlaceHolder($record);
 
         if (!$this->options['ignore_empty_context_and_extra'] || !empty($record['context'])) {
-            $context = ($this->options['multiline'] ? "\n" : ' ').$this->dumpData($record['context']);
+            $context = ($this->options['multiline'] ? "\n" : ' ').OutputFormatter::escape($this->dumpData($record['context']));
         } else {
             $context = '';
         }
 
         if (!$this->options['ignore_empty_context_and_extra'] || !empty($record['extra'])) {
-            $extra = ($this->options['multiline'] ? "\n" : ' ').$this->dumpData($record['extra']);
+            $extra = ($this->options['multiline'] ? "\n" : ' ').OutputFormatter::escape($this->dumpData($record['extra']));
         } else {
             $extra = '';
         }
@@ -119,12 +119,12 @@ class ConsoleFormatter implements FormatterInterface
         $formatted = strtr($this->options['format'], [
             '%datetime%' => $record['datetime'] instanceof \DateTimeInterface
                 ? $record['datetime']->format($this->options['date_format'])
-                : $record['datetime'],
+                : self::escape($record['datetime']),
             '%start_tag%' => sprintf('<%s>', self::LEVEL_COLOR_MAP[$record['level']]),
-            '%level_name%' => sprintf($this->options['level_name_format'], $record['level_name']),
+            '%level_name%' => sprintf($this->options['level_name_format'], self::escape($record['level_name'])),
             '%end_tag%' => '</>',
-            '%channel%' => $record['channel'],
-            '%message%' => $this->replacePlaceHolder($record)['message'],
+            '%channel%' => self::escape($record['channel']),
+            '%message%' => $record['message'],
             '%context%' => $context,
             '%extra%' => $extra,
         ]);
@@ -161,7 +161,7 @@ class ConsoleFormatter implements FormatterInterface
 
     private function replacePlaceHolder(array $record): array
     {
-        $message = $record['message'];
+        $message = $record['message'] = self::escape($record['message']);
 
         if (!str_contains($message, '{')) {
             return $record;
@@ -205,5 +205,10 @@ class ConsoleFormatter implements FormatterInterface
         ftruncate($this->outputBuffer, 0);
 
         return rtrim($dump);
+    }
+
+    private static function escape(string $value): string
+    {
+        return OutputFormatter::escape(preg_replace('/[\x00-\x08\x0B-\x1F\x7F]|\xC2[\x80-\x9F]/', '', $value));
     }
 }

--- a/src/Symfony/Bridge/Monolog/Tests/Formatter/ConsoleFormatterTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Formatter/ConsoleFormatterTest.php
@@ -62,6 +62,41 @@ class ConsoleFormatterTest extends TestCase
         ];
     }
 
+    public function testItEscapesTheRecordFields()
+    {
+        $formatter = new ConsoleFormatter(['colors' => false]);
+
+        $record = self::createRecord([
+            'message' => "SELECT * FROM t WHERE a < 1 AND b > 2\033[2J\u{9b}2J",
+            'channel' => '<fg=red>app</>',
+        ]);
+
+        $output = $formatter->format($record);
+
+        $this->assertStringNotContainsString("\033", $output);
+        $this->assertStringNotContainsString("\u{9b}", $output);
+        $this->assertStringContainsString('[\<fg=red\>app\</\>]', $output);
+        $this->assertStringContainsString('SELECT * FROM t WHERE a \< 1 AND b \> 2', $output);
+    }
+
+    public function testItEscapesTheDumpedContext()
+    {
+        $formatter = new ConsoleFormatter(['colors' => false]);
+
+        $record = self::createRecord(['context' => ['user' => '<fg=red>alice</>']]);
+
+        $this->assertStringContainsString('"user" =\> "\<fg=red\>alice\</\>"', $formatter->format($record));
+    }
+
+    public function testItKeepsTheMarkupAroundReplacedPlaceholders()
+    {
+        $formatter = new ConsoleFormatter(['colors' => false]);
+
+        $record = self::createRecord(['message' => 'Hello {user}', 'context' => ['user' => '<fg=red>alice</>']]);
+
+        $this->assertStringContainsString('Hello <comment>\<fg=red\>alice\</\></>', $formatter->format($record));
+    }
+
     public function testPlaceholderInMessageWithDataContext()
     {
         $context = (new VarCloner())->cloneVar(['user' => 'alice']);
@@ -78,5 +113,18 @@ class ConsoleFormatterTest extends TestCase
         ]);
 
         self::assertStringContainsString('Hello <comment>alice</>', $output);
+    }
+
+    private static function createRecord(array $record): array
+    {
+        return $record + [
+            'message' => 'test',
+            'context' => [],
+            'level' => Logger::WARNING,
+            'level_name' => Logger::getLevelName(Logger::WARNING),
+            'channel' => 'test',
+            'datetime' => new \DateTime(),
+            'extra' => [],
+        ];
     }
 }

--- a/src/Symfony/Component/Console/Formatter/OutputFormatter.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatter.php
@@ -42,7 +42,7 @@ class OutputFormatter implements WrappableOutputFormatterInterface
      */
     public static function escape(string $text)
     {
-        $text = preg_replace('/([^\\\\]|^)([<>])/', '$1\\\\$2', $text);
+        $text = str_replace(['<', '>'], ['\\<', '\\>'], $text);
 
         return self::escapeTrailingBackslash($text);
     }

--- a/src/Symfony/Component/Console/Tests/Formatter/OutputFormatterTest.php
+++ b/src/Symfony/Component/Console/Tests/Formatter/OutputFormatterTest.php
@@ -33,14 +33,24 @@ class OutputFormatterTest extends TestCase
         $this->assertEquals("foo << \033[32mbar \\ baz\033[39m \\", $formatter->format('foo << <info>bar \\ baz</info> \\'));
         $this->assertEquals('<info>some info</info>', $formatter->format('\\<info>some info\\</info>'));
         $this->assertEquals('\\<info\\>some info\\</info\\>', OutputFormatter::escape('<info>some info</info>'));
-        // every < and > gets escaped if not already escaped, but already escaped ones do not get escaped again
-        // and escaped backslashes remain as such, same with backslashes escaping non-special characters
-        $this->assertEquals('foo \\< bar \\< baz \\\\< foo \\> bar \\> baz \\\\> \\x', OutputFormatter::escape('foo < bar \\< baz \\\\< foo > bar \\> baz \\\\> \\x'));
+        // every < and > gets escaped, backslashes are left as they are
+        $this->assertEquals('foo \\< bar \\\\< baz \\\\\\< foo \\> bar \\\\> baz \\\\\\> \\x', OutputFormatter::escape('foo < bar \\< baz \\\\< foo > bar \\> baz \\\\> \\x'));
 
         $this->assertEquals(
             "\033[33mSymfony\\Component\\Console does work very well!\033[39m",
             $formatter->format('<comment>Symfony\Component\Console does work very well!</comment>')
         );
+    }
+
+    public function testFormatRestoresEscapedText()
+    {
+        $formatter = new OutputFormatter(true);
+
+        $this->assertEquals('foo \\<bar', $formatter->format(OutputFormatter::escape('foo \\<bar')));
+        $this->assertEquals('foo \\>bar', $formatter->format(OutputFormatter::escape('foo \\>bar')));
+        $this->assertEquals('foo \\\\<bar>', $formatter->format(OutputFormatter::escape('foo \\\\<bar>')));
+        $this->assertEquals('foo \\<info>bar\\</info>', $formatter->format(OutputFormatter::escape('foo \\<info>bar\\</info>')));
+        $this->assertEquals('foo \\', $formatter->format(OutputFormatter::escape('foo \\')));
     }
 
     public function testBundledStyles()
@@ -105,7 +115,7 @@ class OutputFormatterTest extends TestCase
         $formatter = new OutputFormatter(true);
 
         $this->assertEquals(
-            "(\033[32mz>=2.0,<<<a2.3\\\033[39m)",
+            "(\033[32mz>=2.0,<\\<<a2.3\\\033[39m)",
             $formatter->format('(<info>'.$formatter->escape('z>=2.0,<\\<<a2.3\\').'</info>)')
         );
 

--- a/src/Symfony/Component/VarDumper/Command/Descriptor/CliDescriptor.php
+++ b/src/Symfony/Component/VarDumper/Command/Descriptor/CliDescriptor.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\VarDumper\Command\Descriptor;
 
+use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
@@ -47,13 +48,13 @@ class CliDescriptor implements DumpDescriptorInterface
         if (isset($context['request'])) {
             $request = $context['request'];
             $this->lastIdentifier = $request['identifier'];
-            $section = sprintf('%s %s', $request['method'], $request['uri']);
+            $section = sprintf('%s %s', self::escape($request['method']), self::escape($request['uri']));
             if ($controller = $request['controller']) {
-                $rows[] = ['controller', rtrim($this->dumper->dump($controller, true), "\n")];
+                $rows[] = ['controller', OutputFormatter::escape(rtrim($this->dumper->dump($controller, true), "\n"))];
             }
         } elseif (isset($context['cli'])) {
             $this->lastIdentifier = $context['cli']['identifier'];
-            $section = '$ '.$context['cli']['command_line'];
+            $section = '$ '.self::escape($context['cli']['command_line']);
         }
 
         if ($this->lastIdentifier !== $lastIdentifier) {
@@ -62,18 +63,23 @@ class CliDescriptor implements DumpDescriptorInterface
 
         if (isset($context['source'])) {
             $source = $context['source'];
-            $sourceInfo = sprintf('%s on line %d', $source['name'], $source['line']);
+            $sourceInfo = sprintf('%s on line %d', self::escape($source['name']), $source['line']);
             if ($fileLink = $source['file_link'] ?? null) {
-                $sourceInfo = sprintf('<href=%s>%s</>', $fileLink, $sourceInfo);
+                $sourceInfo = sprintf('<href=%s>%s</>', self::escape($fileLink), $sourceInfo);
             }
             $rows[] = ['source', $sourceInfo];
             $file = $source['file_relative'] ?? $source['file'];
-            $rows[] = ['file', $file];
+            $rows[] = ['file', self::escape($file)];
         }
 
         $io->table([], $rows);
 
         $this->dumper->dump($data);
         $io->newLine();
+    }
+
+    private static function escape(string $value): string
+    {
+        return OutputFormatter::escape(preg_replace('/[\x00-\x08\x0B-\x1F\x7F]|\xC2[\x80-\x9F]/', '', $value));
     }
 }

--- a/src/Symfony/Component/VarDumper/Tests/Command/Descriptor/CliDescriptorTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Command/Descriptor/CliDescriptorTest.php
@@ -38,6 +38,86 @@ class CliDescriptorTest extends TestCase
         putenv('TERMINAL_EMULATOR'.(self::$prevTerminalEmulator ? '='.self::$prevTerminalEmulator : ''));
     }
 
+    public function testItEscapesContextStrings()
+    {
+        $output = new BufferedOutput();
+        $descriptor = new CliDescriptor(new CliDumper(function ($s) {
+            return $s;
+        }));
+
+        $descriptor->describe($output, new Data([[123]]), [
+            'timestamp' => 1544804268.3668,
+            'request' => [
+                'identifier' => 'd8bece1c',
+                'controller' => new Data([['FooController.php']]),
+                'method' => 'GET',
+                'uri' => "http://localhost/<comment>pwned</>\033[2J\u{9b}2J",
+            ],
+            'source' => [
+                'name' => '<href=http://evil.example>Foo.php',
+                'line' => 30,
+                'file' => "/app/<info>Foo</info>.php\033[2J",
+            ],
+        ], 1);
+
+        $dump = $output->fetch();
+
+        $this->assertStringNotContainsString("\033", $dump);
+        $this->assertStringNotContainsString("\u{9b}", $dump);
+        $this->assertStringContainsString('GET http://localhost/<comment>pwned</>', $dump);
+        $this->assertStringContainsString('<href=http://evil.example>Foo.php on line 30', $dump);
+        $this->assertStringContainsString('/app/<info>Foo</info>.php', $dump);
+    }
+
+    public function testItEscapesTheDumpedController()
+    {
+        $output = new BufferedOutput();
+        $output->setDecorated(true);
+        $descriptor = new CliDescriptor(new CliDumper(function ($s) {
+            return $s;
+        }));
+
+        $descriptor->describe($output, new Data([[123]]), [
+            'timestamp' => 1544804268.3668,
+            'request' => [
+                'identifier' => 'd8bece1c',
+                'controller' => new Data([["<fg=red>pwned</>\033[2J"]]),
+                'method' => 'GET',
+                'uri' => 'http://localhost/',
+            ],
+        ], 1);
+
+        $dump = $output->fetch();
+
+        $this->assertStringNotContainsString("\033[31m", $dump);
+        $this->assertStringNotContainsString("\033[2J", $dump);
+        $this->assertStringContainsString('<fg=red>pwned</>', $dump);
+    }
+
+    public function testItEscapesTheFileLink()
+    {
+        $output = new BufferedOutput();
+        $output->setDecorated(true);
+        $descriptor = new CliDescriptor(new CliDumper(function ($s) {
+            return $s;
+        }));
+
+        $descriptor->describe($output, new Data([[123]]), [
+            'timestamp' => 1544804268.3668,
+            'source' => [
+                'name' => 'Foo.php',
+                'line' => 30,
+                'file_relative' => 'src/Foo.php',
+                'file_link' => 'phpstorm://open?file=/app/Foo.php><fg=red>',
+            ],
+        ], 1);
+
+        $dump = $output->fetch();
+
+        $this->assertStringContainsString("\033]8;;phpstorm://open?file=/app/Foo.php><fg=red>\033\\Foo.php on line 30\033]8;;\033\\", $dump);
+        $this->assertStringNotContainsString("\033[31m", $dump);
+    }
+
     /**
      * @dataProvider provideContext
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`CliDescriptor::describe()` writes context strings straight to the terminal, and `ConsoleFormatter::format()` does the same with the channel and the message template of a record. Neither passes them through `OutputFormatter::escape()`, so a value carrying console markup is interpreted rather than printed, and a value carrying escape sequences reaches the terminal as is. A file link rendered that way becomes a hyperlink whose visible text and target disagree.

Those values are now escaped. The dumped context and extra fields are escaped too: they go through the dumper, which strips control bytes but leaves console tags alone, so a value such as `<fg=red>alice</>` still reached the formatter as live markup. The record's level name and the string form of its date are interpolated the same way and are escaped as well.

The second `replacePlaceHolder()` call is removed. It escaped the message a second time, and it expanded a placeholder that had itself come out of a context value.

This targets 5.4 on purpose. The change is hardening rather than a security fix, and 5.4 takes security fixes only, so a hardening change would normally start on the lowest branch that still receives bug fixes. It is proposed here deliberately, so that the long term support branch does not keep a defect that the maintained branches are having fixed.

Merging up into 6.4: the Console commit is already there and drops out. `CliDescriptor.php` and `ConsoleFormatter.php` conflict on the lines where 6.4 writes `\sprintf`: keep the 6.4 side and wrap the same arguments in `self::escape()` as on 5.4 (method, uri, command line, source name, file link, datetime, level name). Everything else merges cleanly. Then run php-cs-fixer on `CliDescriptorTest.php`: the 6.4 ruleset turns the three `function ($s) { return $s; }` closures into `static fn ($s) => $s`. Verified with a cherry-pick on 6.4: VarDumper and Monolog bridge suites green.

The first commit is the fix for `OutputFormatter::escape()` that already shipped on 6.4: on 5.4 the regexp consumes the character before each bracket, so the second of two adjacent brackets stays unescaped and a context value such as `a><fg=red;>` still reaches the formatter as a tag. The escaping above depends on it.

The dumped controller is escaped too, and UTF-8 encoded C1 control characters (U+0080 to U+009F) are stripped along with the C0 ones, since xterm-like terminals in UTF-8 mode honor them.

