### PR TITLE
[Messenger] Restrict what "X-Message-Stamp-*" headers can put in an envelope

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/Transport/Serialization/SerializerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Serialization/SerializerTest.php
@@ -15,12 +15,19 @@ use PHPUnit\Framework\Constraint\Constraint;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
+use Symfony\Component\Messenger\Stamp\BusNameStamp;
 use Symfony\Component\Messenger\Stamp\NonSendableStampInterface;
+use Symfony\Component\Messenger\Stamp\ReceivedStamp;
 use Symfony\Component\Messenger\Stamp\SerializerStamp;
+use Symfony\Component\Messenger\Stamp\StampInterface;
 use Symfony\Component\Messenger\Stamp\ValidationStamp;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Messenger\Transport\Serialization\Serializer;
 use Symfony\Component\Serializer as SerializerComponent;
+use Symfony\Component\Serializer\Encoder\XmlEncoder;
+use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
+use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
+use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Symfony\Component\Serializer\SerializerInterface as SerializerComponentInterface;
 
@@ -251,6 +258,61 @@ class SerializerTest extends TestCase
             ],
         ]);
     }
+
+    public function testDecodingFailsWithAStampHeaderThatIsNotAStamp()
+    {
+        $serializer = new Serializer();
+
+        $this->expectException(MessageDecodingFailedException::class);
+        $this->expectExceptionMessage(sprintf('Could not decode stamp: "%s" is not a "%s".', DummyMessage::class, StampInterface::class));
+
+        $serializer->decode([
+            'body' => '{"message":"hello"}',
+            'headers' => [
+                'type' => DummyMessage::class,
+                'X-Message-Stamp-'.DummyMessage::class => '[{"message":"injected"}]',
+            ],
+        ]);
+    }
+
+    public function testDecodedSkipsNonSendableStamps()
+    {
+        $serializer = new Serializer();
+
+        $envelope = $serializer->decode([
+            'body' => '{"message":"hello"}',
+            'headers' => [
+                'type' => DummyMessage::class,
+                'X-Message-Stamp-'.ReceivedStamp::class => '[{"transportName":"injected"}]',
+                'X-Message-Stamp-'.BusNameStamp::class => '[{"busName":"the_bus"}]',
+            ],
+        ]);
+
+        $this->assertNull($envelope->last(ReceivedStamp::class));
+        $this->assertEquals([new BusNameStamp('the_bus')], $envelope->all(BusNameStamp::class));
+    }
+
+    public function testDecodedSerializerStampSkipsCodeAffectingContextOptions()
+    {
+        $serializer = new Serializer();
+
+        $envelope = $serializer->decode([
+            'body' => '{"message":"hello"}',
+            'headers' => [
+                'type' => DummyMessage::class,
+                'X-Message-Stamp-'.SerializerStamp::class => json_encode([['context' => [
+                    AbstractNormalizer::CALLBACKS => ['message' => [DummySymfonySerializerCallback::class, 'shout']],
+                    AbstractNormalizer::CIRCULAR_REFERENCE_HANDLER => [DummySymfonySerializerCallback::class, 'shout'],
+                    AbstractObjectNormalizer::MAX_DEPTH_HANDLER => [DummySymfonySerializerCallback::class, 'shout'],
+                    XmlEncoder::LOAD_OPTIONS => \LIBXML_NOENT,
+                    DateTimeNormalizer::FORMAT_KEY => 'Y-m-d',
+                ]]]),
+            ],
+        ]);
+
+        $this->assertSame('hello', $envelope->getMessage()->getMessage());
+        $this->assertSame([DateTimeNormalizer::FORMAT_KEY => 'Y-m-d'], $envelope->last(SerializerStamp::class)->getContext());
+    }
 }
 class DummySymfonySerializerNonSendableStamp implements NonSendableStampInterface
 {
@@ -259,5 +321,12 @@ class DummySymfonySerializerInvalidConstructor
 {
     public function __construct(string $missingArgument)
     {
+    }
+}
+class DummySymfonySerializerCallback
+{
+    public static function shout(...$arguments): string
+    {
+        return strtoupper($arguments[0]);
     }
 }

--- a/src/Symfony/Component/Messenger/Transport/Serialization/Serializer.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/Serializer.php
@@ -20,6 +20,8 @@ use Symfony\Component\Messenger\Stamp\StampInterface;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Encoder\XmlEncoder;
 use Symfony\Component\Serializer\Exception\ExceptionInterface;
+use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
+use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
@@ -33,6 +35,14 @@ class Serializer implements SerializerInterface
 {
     public const MESSENGER_SERIALIZATION_CONTEXT = 'messenger_serialization';
     private const STAMP_HEADER_PREFIX = 'X-Message-Stamp-';
+
+    // these options hold a callable, or let the XML parser resolve external entities
+    private const CODE_AFFECTING_CONTEXT_OPTIONS = [
+        AbstractNormalizer::CALLBACKS => true,
+        AbstractNormalizer::CIRCULAR_REFERENCE_HANDLER => true,
+        AbstractObjectNormalizer::MAX_DEPTH_HANDLER => true,
+        XmlEncoder::LOAD_OPTIONS => true,
+    ];
 
     private $serializer;
     private $format;
@@ -117,14 +127,31 @@ class Serializer implements SerializerInterface
                 continue;
             }
 
+            $class = substr($name, \strlen(self::STAMP_HEADER_PREFIX));
+
+            if (!is_subclass_of($class, StampInterface::class)) {
+                throw new MessageDecodingFailedException(sprintf('Could not decode stamp: "%s" is not a "%s".', $class, StampInterface::class));
+            }
+
+            // encoding strips these stamps, so they never come from a transport
+            if (is_subclass_of($class, NonSendableStampInterface::class)) {
+                continue;
+            }
+
             try {
-                $stamps[] = $this->serializer->deserialize($value, substr($name, \strlen(self::STAMP_HEADER_PREFIX)).'[]', $this->format, $this->context);
+                $stamps[] = $this->serializer->deserialize($value, $class.'[]', $this->format, $this->context);
             } catch (ExceptionInterface $e) {
                 throw new MessageDecodingFailedException('Could not decode stamp: '.$e->getMessage(), $e->getCode(), $e);
             }
         }
         if ($stamps) {
             $stamps = array_merge(...$stamps);
+        }
+
+        foreach ($stamps as $i => $stamp) {
+            if ($stamp instanceof SerializerStamp) {
+                $stamps[$i] = new SerializerStamp(array_diff_key($stamp->getContext(), self::CODE_AFFECTING_CONTEXT_OPTIONS));
+            }
         }
 
         return $stamps;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`Serializer::decodeStamps()` turns every `X-Message-Stamp-*` header into a class name and deserializes it with no check on what that class is, and the stamps it produces are then trusted by the rest of the pipeline. Three of them matter: a class that is not a stamp at all ends up in the envelope, a `SerializerStamp` arriving from the wire has its context merged into the denormalization context, which is how `callbacks` reaches `AbstractNormalizer::applyCallbacks()`, and a stamp implementing `NonSendableStampInterface` is stripped when encoding but nothing rejects it when decoding.

A header naming a class that does not implement `StampInterface` now fails the decode, before anything is deserialized. A class implementing `NonSendableStampInterface` is skipped, since those are added locally by the framework at receive or handle time and `encode()` already strips them, so no producer can lose one. A decoded `SerializerStamp` is rebuilt without the context keys that carry code, which are `callbacks`, `circular_reference_handler`, `max_depth_handler` and `load_options`; the keys that describe the message, such as the groups and the attributes, are why the stamp is on the wire and are kept.

Failing rather than dropping an unusable header puts the message on the failure transport, where it can be read, instead of leaving nothing behind.

This targets 5.4 on purpose. The change is hardening rather than a security fix, and 5.4 takes security fixes only, so a hardening change would normally start on the lowest branch that still receives bug fixes. It is proposed here deliberately, so that the long term support branch does not keep a defect that the maintained branches are having fixed.

Merging up into 6.4 conflicts in `Serializer.php` and `SerializerTest.php`, because those files have moved on since 5.4. Take the 6.4 side of the surrounding code and re-apply the three guards on the decoded stamps.
