### PR TITLE
[Cache] Fix fatal error when a cache file references a missing class

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/PhpFilesAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/PhpFilesAdapter.php
@@ -109,19 +109,23 @@ class PhpFilesAdapter extends AbstractAdapter implements PruneableInterface
         $getExpiry = false;
 
         foreach ($ids as $id) {
-            if (null === $value = $this->values[$id] ?? null) {
-                $missingIds[] = $id;
-            } elseif ('N;' === $value) {
-                $values[$id] = null;
-            } elseif (!\is_object($value)) {
-                $values[$id] = $value;
-            } elseif ($value instanceof CachedValueInterface) {
-                $values[$id] = $value->getValue();
-            } elseif (!$value instanceof LazyValue) {
-                $values[$id] = $value;
-            } elseif (false === $values[$id] = include $value->file) {
-                unset($values[$id], $this->values[$id]);
-                $missingIds[] = $id;
+            try {
+                if (null === $value = $this->values[$id] ?? null) {
+                    $missingIds[] = $id;
+                } elseif ('N;' === $value) {
+                    $values[$id] = null;
+                } elseif (!\is_object($value)) {
+                    $values[$id] = $value;
+                } elseif ($value instanceof CachedValueInterface) {
+                    $values[$id] = $value->getValue();
+                } elseif (!$value instanceof LazyValue) {
+                    $values[$id] = $value;
+                } elseif (false === $values[$id] = include $value->file) {
+                    unset($values[$id], $this->values[$id]);
+                    $missingIds[] = $id;
+                }
+            } catch (\Throwable) {
+                unset($values[$id], $this->values[$id], self::$valuesCache[$this->files[$id] ?? '']);
             }
             if (!$this->appendOnly) {
                 unset($this->values[$id]);

--- a/src/Symfony/Component/Cache/Tests/Adapter/PhpFilesAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PhpFilesAdapterTest.php
@@ -34,6 +34,27 @@ class PhpFilesAdapterTest extends AdapterTestCase
         (new Filesystem())->remove(sys_get_temp_dir().'/symfony-cache');
     }
 
+    public function testFileReferencingAMissingClassIsAMiss()
+    {
+        $pool = new PhpFilesAdapter('sf-cache-stale', 0, null, true);
+        $pool->save($pool->getItem('foo')->set(new \ArrayObject()));
+
+        $content = <<<'EOPHP'
+            <?php //foo
+
+            return [\PHP_INT_MAX, new class() implements \Symfony\Component\Cache\Traits\CachedValueInterface {
+                public function getValue(): mixed { return \Symfony\Component\Cache\Tests\Adapter\MissingClass::hydrate(); }
+            }];
+
+            EOPHP;
+
+        foreach (new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator(sys_get_temp_dir().'/symfony-cache/sf-cache-stale', \FilesystemIterator::SKIP_DOTS)) as $file) {
+            file_put_contents($file, $content);
+        }
+
+        $this->assertFalse((new PhpFilesAdapter('sf-cache-stale', 0, null, true))->getItem('foo')->isHit());
+    }
+
     protected function isPruned(CacheItemPoolInterface $cache, string $name): bool
     {
         $getFileMethod = (new \ReflectionObject($cache))->getMethod('getFile');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65694
| License       | MIT

Upgrading from 8.0 to 8.1 without wiping `var/cache` kills the app with `Class "Symfony\Component\VarExporter\Internal\Hydrator" not found`. The files already sitting in `pools/system` were written by VarExporter 8.0 and call that class, which 8.1 replaced with `deepclone_from_array()`. Nothing invalidates those files: the pool namespace is seeded from the project dir, the container class and the adapter class, and `createSystemCache()` passes its `$version` to `ApcuAdapter` only. The report is about `#[IsGranted(new Expression(...))]` because the parsed expression is read back from such a file, but every pool built on `cache.system` is affected.

`PhpFilesAdapter` already treats a file it cannot include as a miss, though only for `ErrorException`. A file that includes fine and then references a symbol that is gone throws an `Error`, which nothing catches. Turning it into a miss like `PhpArrayAdapter` does lets the next `save()` overwrite the stale file, so the app recovers on its own instead of dying. Reported on 8.1, but the unguarded code is the same down to 6.4.
