### PR TITLE
[VarExporter] Fix fatal error when loading code exported by versions < 8.1

### DIFF
--- a/src/Symfony/Component/VarExporter/Internal/Hydrator.php
+++ b/src/Symfony/Component/VarExporter/Internal/Hydrator.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarExporter\Internal;
+
+use Symfony\Component\VarExporter\Exception\LogicException;
+
+/**
+ * Code exported by versions < 8.1 calls this class. Throwing instead of failing with
+ * a fatal error lets callers such as cache pools treat that code as a miss and regenerate it.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ *
+ * @internal
+ */
+final class Hydrator
+{
+    public static function hydrate(): never
+    {
+        throw new LogicException('Code exported by symfony/var-exporter < 8.1 cannot be loaded anymore and must be regenerated.');
+    }
+}

--- a/src/Symfony/Component/VarExporter/Tests/Fixtures/legacy-exported-code.php
+++ b/src/Symfony/Component/VarExporter/Tests/Fixtures/legacy-exported-code.php
@@ -1,0 +1,17 @@
+<?php
+
+return \Symfony\Component\VarExporter\Internal\Hydrator::hydrate(
+    $o = [
+        clone (\Symfony\Component\VarExporter\Internal\Registry::$prototypes['stdClass'] ?? \Symfony\Component\VarExporter\Internal\Registry::p('stdClass')),
+    ],
+    null,
+    [
+        'stdClass' => [
+            'foo' => [
+                'bar',
+            ],
+        ],
+    ],
+    $o[0],
+    []
+);

--- a/src/Symfony/Component/VarExporter/Tests/VarExporterTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/VarExporterTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\VarDumper\Test\VarDumperTestTrait;
 use Symfony\Component\VarExporter\Exception\ClassNotFoundException;
+use Symfony\Component\VarExporter\Exception\LogicException;
 use Symfony\Component\VarExporter\Exception\NotInstantiableTypeException;
 use Symfony\Component\VarExporter\Internal\Registry;
 use Symfony\Component\VarExporter\Tests\Fixtures\BackedProperty;
@@ -67,6 +68,14 @@ class VarExporterTest extends TestCase
         } finally {
             $this->assertSame('var_dump', ini_set('unserialize_callback_func', $unserializeCallback));
         }
+    }
+
+    public function testLoadingLegacyExportedCodeThrows()
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Code exported by symfony/var-exporter < 8.1 cannot be loaded anymore and must be regenerated.');
+
+        include __DIR__.'/Fixtures/legacy-exported-code.php';
     }
 
     #[DataProvider('provideFailingSerialization')]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65694
| License       | MIT

Code exported by `VarExporter::export()` before 8.1 calls `\Symfony\Component\VarExporter\Internal\Hydrator::hydrate(...)`. 8.1 removed that class, since exported code now calls `\deepclone_from_array()`. Loading old code therefore fails with `Class "Symfony\Component\VarExporter\Internal\Hydrator" not found`. That is an `Error`, and the cache pools catch `Exception` only, so an app upgraded to 8.1 without clearing `var/cache/` dies on every stale file of `cache.system`. The report is about the parsed expression of `#[IsGranted(new Expression(...))]`, but every pool built on `cache.system` is affected, and nothing invalidates those files on upgrade.

This PR reintroduces `Internal\Hydrator` as a stub whose `hydrate()` method throws a `LogicException`. Every other symbol the old exported code references (`Registry::$prototypes`, `Registry::p()`, `Registry::$factories`, `Registry::f()` and `Registry::unserialize()`) still exists on 8.1, so old code now loads and throws an exception instead of a fatal error. `PhpFilesAdapter` and `PhpArrayAdapter` already turn an exception raised while reading a value into a logged miss, so the next `save()` overwrites the stale file with the new format and the app heals itself. No change is needed in the Cache component.

Checked with pools written by 8.0 and read by 8.1 with this patch: an append-only `PhpFilesAdapter` as used by `cache.system`, a regular `PhpFilesAdapter`, and a `PhpArrayAdapter` warmup file. Each stale item reports a miss, a warning `Failed to fetch key "..."` is logged, and the item is a hit again after `save()`.

A stub returning a value instead of throwing does not work: `PhpFilesAdapter` returns whatever `CachedValueInterface::getValue()` returns as a hit, so `ExpressionLanguage::parse()` then fails with a `TypeError`, and in non-append-only mode a `false` returned by the included file makes `doFetch()` loop forever.

This is an alternative to #65696, which catches every `Throwable` raised by a cached value in `PhpFilesAdapter::doFetch()`.
