### PR TITLE
[Mailer] Reject Mailomat webhook requests with a stale timestamp

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Mailomat/Tests/Webhook/MailomatRequestParserTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailomat/Tests/Webhook/MailomatRequestParserTest.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\Mailer\Bridge\Mailomat\Tests\Webhook;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use Symfony\Bridge\PhpUnit\ClockMock;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Mailer\Bridge\Mailomat\RemoteEvent\MailomatPayloadConverter;
 use Symfony\Component\Mailer\Bridge\Mailomat\Webhook\MailomatRequestParser;
@@ -19,8 +21,42 @@ use Symfony\Component\Webhook\Client\RequestParserInterface;
 use Symfony\Component\Webhook\Exception\RejectWebhookException;
 use Symfony\Component\Webhook\Test\AbstractRequestParserTestCase;
 
+#[Group('time-sensitive')]
 class MailomatRequestParserTest extends AbstractRequestParserTestCase
 {
+    public static function getStaleClockOffsets(): iterable
+    {
+        yield 'too old' => [301];
+        yield 'too far in the future' => [-301];
+    }
+
+    #[DataProvider('getStaleClockOffsets')]
+    public function testRejectSignedRequestWithStaleTimestamp(int $offset)
+    {
+        $request = $this->createRequest(file_get_contents(__DIR__.'/Fixtures/delivered.json'));
+        ClockMock::withClockMock((int) $request->headers->get('X-MOM-Webhook-Timestamp') + $offset);
+
+        $this->expectException(RejectWebhookException::class);
+        $this->expectExceptionMessage('Timestamp is outside the allowed time window.');
+
+        $this->createRequestParser()->parse($request, $this->getSecret());
+    }
+
+    public static function getToleratedClockOffsets(): iterable
+    {
+        yield 'at the past edge' => [300];
+        yield 'at the future edge' => [-300];
+    }
+
+    #[DataProvider('getToleratedClockOffsets')]
+    public function testAcceptSignedRequestWithinTolerance(int $offset)
+    {
+        $request = $this->createRequest(file_get_contents(__DIR__.'/Fixtures/delivered.json'));
+        ClockMock::withClockMock((int) $request->headers->get('X-MOM-Webhook-Timestamp') + $offset);
+
+        $this->assertNotNull($this->createRequestParser()->parse($request, $this->getSecret()));
+    }
+
     protected function createRequestParser(): RequestParserInterface
     {
         return new MailomatRequestParser(new MailomatPayloadConverter());
@@ -33,6 +69,8 @@ class MailomatRequestParserTest extends AbstractRequestParserTestCase
 
     protected function createRequest(string $payload): Request
     {
+        ClockMock::withClockMock(1718004211);
+
         return Request::create('/', 'POST', [], [], [], [
             'Content-Type' => 'application/json',
             'HTTP_X-MOM-Webhook-Event' => 'delivered',
@@ -49,6 +87,7 @@ class MailomatRequestParserTest extends AbstractRequestParserTestCase
         $data = '1d958822-0934-4c6a-abc8-5defec4baa64.delivered.1718004211';
         $payload = file_get_contents(__DIR__.'/Fixtures/delivered.json');
 
+        ClockMock::withClockMock(1718004211);
         $request = Request::create('/', 'POST', [], [], [], [
             'Content-Type' => 'application/json',
             'HTTP_X-MOM-Webhook-Event' => 'delivered',
@@ -58,6 +97,8 @@ class MailomatRequestParserTest extends AbstractRequestParserTestCase
         ], str_replace("\n", "\r\n", $payload));
 
         $this->expectException(RejectWebhookException::class);
+        $this->expectExceptionMessage('Signature is wrong.');
+
         $this->createRequestParser()->parse($request, $secret);
     }
 

--- a/src/Symfony/Component/Mailer/Bridge/Mailomat/Webhook/MailomatRequestParser.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailomat/Webhook/MailomatRequestParser.php
@@ -31,6 +31,7 @@ final class MailomatRequestParser extends AbstractRequestParser
     private const HEADER_ID = 'X-MOM-Webhook-Id';
     private const HEADER_TIMESTAMP = 'X-MOM-Webhook-Timestamp';
     private const HEADER_SIGNATURE = 'X-MOM-Webhook-Signature';
+    private const TIMESTAMP_TOLERANCE = 300;
 
     public function __construct(
         private readonly MailomatPayloadConverter $converter,
@@ -67,6 +68,10 @@ final class MailomatRequestParser extends AbstractRequestParser
             || !isset($content['recipient'])
         ) {
             throw new RejectWebhookException(406, 'Payload is malformed.');
+        }
+
+        if (abs(time() - (int) $request->headers->get(self::HEADER_TIMESTAMP)) > self::TIMESTAMP_TOLERANCE) {
+            throw new RejectWebhookException(406, 'Timestamp is outside the allowed time window.');
         }
 
         $this->validateSignature($request->headers, $secret);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The Mailomat webhook parser verifies an HMAC over `<id>.<event>.<timestamp>`, as described in the [vendor documentation](https://api.mailomat.swiss/docs/#tag/webhook-security). Nothing tied a request to a point in time, so a captured signed request stayed valid forever and could be replayed into consumers that are not idempotent.

The parser now rejects a request whose `X-MOM-Webhook-Timestamp` header (a unix timestamp in seconds) is more than five minutes away from the current time, before the signature is checked. The vendor asks integrations to compare that header with the current time within a tolerance of their choice and gives no number, so this uses the 300 second window that the other timestamped webhook parsers use. The header is part of the signed data, so an attacker cannot refresh it. The rejection reuses the exception and the 406 status the parser already returns for a bad signature.

Traps:
- The server clock must be accurate to within the window; a skewed clock rejects every delivery.
- Mailomat retries failed deliveries at 2, 5, 15, 30, 60, 120 and 240 minutes, only on 429 and 5xx statuses, so a 406 causes no retry loop. Whether a retry carries a fresh timestamp is not documented.
- The vendor scheme signs only the id, event and timestamp headers, not the body. A replay within the window with a modified body is not detected by the signature; this is a limitation of the vendor scheme. The vendor also recommends storing the received `X-MOM-Webhook-Id` values and rejecting duplicates within the window; that de-duplication is left to the application.

Same change as #65675 for the AhaSend, Resend and Sweego parsers.
