### PR TITLE
[Mailer][Notifier] Reject Mailgun, SendGrid and Vonage webhook requests with a stale timestamp

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Webhook/MailgunRequestParserTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Webhook/MailgunRequestParserTest.php
@@ -11,17 +11,67 @@
 
 namespace Symfony\Component\Mailer\Bridge\Mailgun\Tests\Webhook;
 
+use Symfony\Bridge\PhpUnit\ClockMock;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Mailer\Bridge\Mailgun\RemoteEvent\MailgunPayloadConverter;
 use Symfony\Component\Mailer\Bridge\Mailgun\Webhook\MailgunRequestParser;
 use Symfony\Component\Webhook\Client\RequestParserInterface;
 use Symfony\Component\Webhook\Exception\RejectWebhookException;
 use Symfony\Component\Webhook\Test\AbstractRequestParserTestCase;
 
+/**
+ * @group time-sensitive
+ */
 class MailgunRequestParserTest extends AbstractRequestParserTestCase
 {
+    public static function getStaleClockOffsets(): iterable
+    {
+        yield 'too old' => [301];
+        yield 'too far in the future' => [-301];
+    }
+
+    /**
+     * @dataProvider getStaleClockOffsets
+     */
+    public function testRejectSignedRequestWithStaleTimestamp(int $offset)
+    {
+        $request = $this->createRequest(file_get_contents(__DIR__.'/Fixtures/delivered_messages.json'));
+        ClockMock::withClockMock($request->toArray()['signature']['timestamp'] + $offset);
+
+        $this->expectException(RejectWebhookException::class);
+        $this->expectExceptionMessage('Timestamp is outside the allowed time window.');
+
+        $this->createRequestParser()->parse($request, $this->getSecret());
+    }
+
+    public static function getToleratedClockOffsets(): iterable
+    {
+        yield 'at the past edge' => [300];
+        yield 'at the future edge' => [-300];
+    }
+
+    /**
+     * @dataProvider getToleratedClockOffsets
+     */
+    public function testAcceptSignedRequestWithinTolerance(int $offset)
+    {
+        $request = $this->createRequest(file_get_contents(__DIR__.'/Fixtures/delivered_messages.json'));
+        ClockMock::withClockMock($request->toArray()['signature']['timestamp'] + $offset);
+
+        $this->assertNotNull($this->createRequestParser()->parse($request, $this->getSecret()));
+    }
+
     protected function createRequestParser(): RequestParserInterface
     {
         return new MailgunRequestParser(new MailgunPayloadConverter());
+    }
+
+    protected function createRequest(string $payload): Request
+    {
+        $request = parent::createRequest($payload);
+        ClockMock::withClockMock($request->toArray()['signature']['timestamp'] ?? 0);
+
+        return $request;
     }
 
     protected function getSecret(): string

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Webhook/MailgunRequestParser.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Webhook/MailgunRequestParser.php
@@ -25,6 +25,8 @@ use Symfony\Component\Webhook\Exception\RejectWebhookException;
 
 final class MailgunRequestParser extends AbstractRequestParser
 {
+    private const TIMESTAMP_TOLERANCE = 300;
+
     public function __construct(
         private readonly MailgunPayloadConverter $converter,
     ) {
@@ -52,6 +54,10 @@ final class MailgunRequestParser extends AbstractRequestParser
             || !isset($content['event-data']['event'])
         ) {
             throw new RejectWebhookException(406, 'Payload is malformed.');
+        }
+
+        if (abs(time() - (int) $content['signature']['timestamp']) > self::TIMESTAMP_TOLERANCE) {
+            throw new RejectWebhookException(406, 'Timestamp is outside the allowed time window.');
         }
 
         $this->validateSignature($content['signature'], $secret);

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Webhook/SendgridStaleTimestampRequestParserTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Webhook/SendgridStaleTimestampRequestParserTest.php
@@ -16,45 +16,33 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Mailer\Bridge\Sendgrid\RemoteEvent\SendgridPayloadConverter;
 use Symfony\Component\Mailer\Bridge\Sendgrid\Webhook\SendgridRequestParser;
 use Symfony\Component\Webhook\Client\RequestParserInterface;
+use Symfony\Component\Webhook\Exception\RejectWebhookException;
 use Symfony\Component\Webhook\Test\AbstractRequestParserTestCase;
 
 /**
- * @author WoutervanderLoop.nl <info@woutervanderloop.nl>
- *
- * @requires extension openssl
- *
  * @group time-sensitive
  */
-class SendgridSignedRequestParserTest extends AbstractRequestParserTestCase
+class SendgridStaleTimestampRequestParserTest extends AbstractRequestParserTestCase
 {
-    public static function getToleratedClockOffsets(): iterable
-    {
-        yield 'at the past edge' => [300];
-        yield 'at the future edge' => [-300];
-    }
-
-    /**
-     * @dataProvider getToleratedClockOffsets
-     */
-    public function testAcceptSignedRequestWithinTolerance(int $offset)
+    public function testRejectSignedRequestFromTheFuture()
     {
         $request = $this->createRequest(file_get_contents(__DIR__.'/Fixtures/webhook.json'));
-        ClockMock::withClockMock((int) $request->headers->get('X-Twilio-Email-Event-Webhook-Timestamp') + $offset);
+        ClockMock::withClockMock((int) $request->headers->get('X-Twilio-Email-Event-Webhook-Timestamp') - 301);
 
-        $this->assertNotNull($this->createRequestParser()->parse($request, $this->getSecret()));
+        $this->createRequestParser()->parse($request, $this->getSecret());
     }
 
     protected function createRequestParser(): RequestParserInterface
     {
-        return new SendgridRequestParser(new SendgridPayloadConverter(), true);
+        $this->expectException(RejectWebhookException::class);
+        $this->expectExceptionMessage('Timestamp is outside the allowed time window.');
+
+        return new SendgridRequestParser(new SendgridPayloadConverter());
     }
 
-    /**
-     * @see https://github.com/sendgrid/sendgrid-php/blob/9335dca98bc64456a72db73469d1dd67db72f6ea/test/unit/EventWebhookTest.php#L20
-     */
     protected function createRequest(string $payload): Request
     {
-        ClockMock::withClockMock(1600112502);
+        ClockMock::withClockMock(1600112502 + 301);
 
         return Request::create('/', 'POST', [], [], [], [
             'Content-Type' => 'application/json',

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Webhook/SendgridWrongSecretRequestParserTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Webhook/SendgridWrongSecretRequestParserTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Mailer\Bridge\Sendgrid\Tests\Webhook;
 
+use Symfony\Bridge\PhpUnit\ClockMock;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Mailer\Bridge\Sendgrid\RemoteEvent\SendgridPayloadConverter;
 use Symfony\Component\Mailer\Bridge\Sendgrid\Webhook\SendgridRequestParser;
@@ -22,6 +23,8 @@ use Symfony\Component\Webhook\Test\AbstractRequestParserTestCase;
  * @author WoutervanderLoop.nl <info@woutervanderloop.nl>
  *
  * @requires extension openssl
+ *
+ * @group time-sensitive
  */
 class SendgridWrongSecretRequestParserTest extends AbstractRequestParserTestCase
 {
@@ -38,6 +41,8 @@ class SendgridWrongSecretRequestParserTest extends AbstractRequestParserTestCase
      */
     protected function createRequest(string $payload): Request
     {
+        ClockMock::withClockMock(1600112502);
+
         return Request::create('/', 'POST', [], [], [], [
             'Content-Type' => 'application/json',
             'HTTP_X-Twilio-Email-Event-Webhook-Signature' => 'MEUCIGHQVtGj+Y3LkG9fLcxf3qfI10QysgDWmMOVmxG0u6ZUAiEAyBiXDWzM+uOe5W0JuG+luQAbPIqHh89M15TluLtEZtM=',

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Webhook/SendgridWrongSignatureRequestParserTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Webhook/SendgridWrongSignatureRequestParserTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Mailer\Bridge\Sendgrid\Tests\Webhook;
 
+use Symfony\Bridge\PhpUnit\ClockMock;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Mailer\Bridge\Sendgrid\RemoteEvent\SendgridPayloadConverter;
 use Symfony\Component\Mailer\Bridge\Sendgrid\Webhook\SendgridRequestParser;
@@ -22,6 +23,8 @@ use Symfony\Component\Webhook\Test\AbstractRequestParserTestCase;
  * @author WoutervanderLoop.nl <info@woutervanderloop.nl>
  *
  * @requires extension openssl
+ *
+ * @group time-sensitive
  */
 class SendgridWrongSignatureRequestParserTest extends AbstractRequestParserTestCase
 {
@@ -38,6 +41,8 @@ class SendgridWrongSignatureRequestParserTest extends AbstractRequestParserTestC
      */
     protected function createRequest(string $payload): Request
     {
+        ClockMock::withClockMock(1600112502);
+
         return Request::create('/', 'POST', [], [], [], [
             'Content-Type' => 'application/json',
             'HTTP_X-Twilio-Email-Event-Webhook-Signature' => 'incorrect',

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Webhook/SendgridRequestParser.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Webhook/SendgridRequestParser.php
@@ -28,6 +28,8 @@ use Symfony\Component\Webhook\Exception\RejectWebhookException;
  */
 final class SendgridRequestParser extends AbstractRequestParser
 {
+    private const TIMESTAMP_TOLERANCE = 300;
+
     public function __construct(
         private readonly SendgridPayloadConverter $converter,
     ) {
@@ -58,6 +60,10 @@ final class SendgridRequestParser extends AbstractRequestParser
                 || !$request->headers->get('X-Twilio-Email-Event-Webhook-Timestamp')
             ) {
                 throw new RejectWebhookException(406, 'Signature is required.');
+            }
+
+            if (abs(time() - (int) $request->headers->get('X-Twilio-Email-Event-Webhook-Timestamp')) > self::TIMESTAMP_TOLERANCE) {
+                throw new RejectWebhookException(406, 'Timestamp is outside the allowed time window.');
             }
 
             $this->validateSignature(

--- a/src/Symfony/Component/Notifier/Bridge/Vonage/Tests/Webhook/VonageRequestParserTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Vonage/Tests/Webhook/VonageRequestParserTest.php
@@ -11,14 +11,55 @@
 
 namespace Symfony\Component\Notifier\Bridge\Vonage\Tests\Webhook;
 
+use Symfony\Bridge\PhpUnit\ClockMock;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Notifier\Bridge\Vonage\Webhook\VonageRequestParser;
 use Symfony\Component\Webhook\Client\RequestParserInterface;
 use Symfony\Component\Webhook\Exception\RejectWebhookException;
 use Symfony\Component\Webhook\Test\AbstractRequestParserTestCase;
 
+/**
+ * @group time-sensitive
+ */
 class VonageRequestParserTest extends AbstractRequestParserTestCase
 {
+    public static function getStaleClockOffsets(): iterable
+    {
+        yield 'too old' => [301];
+        yield 'too far in the future' => [-301];
+    }
+
+    /**
+     * @dataProvider getStaleClockOffsets
+     */
+    public function testRejectSignedRequestWithStaleTimestamp(int $offset)
+    {
+        $request = $this->createRequest(file_get_contents(__DIR__.'/Fixtures/delivered.json'));
+        ClockMock::withClockMock(self::getIssuedAt($request) + $offset);
+
+        $this->expectException(RejectWebhookException::class);
+        $this->expectExceptionMessage('Timestamp is outside the allowed time window.');
+
+        $this->createRequestParser()->parse($request, $this->getSecret());
+    }
+
+    public static function getToleratedClockOffsets(): iterable
+    {
+        yield 'at the past edge' => [300];
+        yield 'at the future edge' => [-300];
+    }
+
+    /**
+     * @dataProvider getToleratedClockOffsets
+     */
+    public function testAcceptSignedRequestWithinTolerance(int $offset)
+    {
+        $request = $this->createRequest(file_get_contents(__DIR__.'/Fixtures/delivered.json'));
+        ClockMock::withClockMock(self::getIssuedAt($request) + $offset);
+
+        $this->assertNotNull($this->createRequestParser()->parse($request, $this->getSecret()));
+    }
+
     public function testMissingAuthorizationTokenThrows()
     {
         $request = $this->createRequest('{}');
@@ -55,6 +96,7 @@ class VonageRequestParserTest extends AbstractRequestParserTestCase
 
         $request = parent::createRequest($payload);
         $request->headers->set('Authorization', 'Bearer '.$jwt);
+        ClockMock::withClockMock(self::getIssuedAt($request));
 
         return $request;
     }
@@ -62,5 +104,12 @@ class VonageRequestParserTest extends AbstractRequestParserTestCase
     protected function getSecret(): string
     {
         return 'secret-key';
+    }
+
+    private static function getIssuedAt(Request $request): int
+    {
+        $claims = explode('.', substr($request->headers->get('Authorization'), \strlen('Bearer ')))[1];
+
+        return json_decode(base64_decode(strtr($claims, '-_', '+/')), true)['iat'];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Vonage/Webhook/VonageRequestParser.php
+++ b/src/Symfony/Component/Notifier/Bridge/Vonage/Webhook/VonageRequestParser.php
@@ -23,6 +23,8 @@ use Symfony\Component\Webhook\Exception\RejectWebhookException;
 
 final class VonageRequestParser extends AbstractRequestParser
 {
+    private const TIMESTAMP_TOLERANCE = 300;
+
     protected function getRequestMatcher(): RequestMatcherInterface
     {
         return new ChainRequestMatcher([
@@ -86,6 +88,11 @@ final class VonageRequestParser extends AbstractRequestParser
         $expected = $this->base64EncodeUrl(hash_hmac('sha256', $header.'.'.$payload, $secret, true));
         if (!hash_equals($expected, $signature)) {
             throw new RejectWebhookException(406, 'Signature is wrong.');
+        }
+
+        $claims = json_decode(base64_decode(strtr($payload, '-_', '+/')), true);
+        if (abs(time() - (int) ($claims['iat'] ?? 0)) > self::TIMESTAMP_TOLERANCE) {
+            throw new RejectWebhookException(406, 'Timestamp is outside the allowed time window.');
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The Mailgun, SendGrid and Vonage webhook parsers verify a signature that covers a timestamp: Mailgun signs `timestamp.token` with HMAC-SHA256, SendGrid signs `timestamp + body` with ECDSA, and Vonage signs a JWT whose `iat` claim is the issue time (Vonage JWTs carry no `exp` claim). None of the parsers checked that this timestamp is recent, so a captured request stayed valid forever and could be replayed into consumers that are not idempotent.

Each parser now rejects a request whose signed timestamp is more than five minutes away from the current time, with the same `RejectWebhookException(406, ...)` already used for a wrong signature. The unit is seconds for all three vendors. Mailgun's documentation recommends this check ("check if the timestamp is not too far from the current time") without giving a number, and SendGrid and Vonage give no guidance, so the 300 second symmetric window of the Standard Webhooks specification and of the AhaSend, Resend and Sweego parsers is used. For SendGrid the check runs before the signature is verified, so it does not depend on ext-openssl. For Vonage the `iat` claim is read only after the HMAC has been verified; a token without `iat` is rejected.

Traps:
- A receiver whose clock is off by more than five minutes rejects every request; keep the clock synchronised.
- SendGrid and Vonage retry failed deliveries for up to 24 hours and Mailgun for 8 hours. A retry that is signed when it is sent passes the check; a retry that keeps the original timestamp is rejected once the window has passed. The vendor documentation does not say which it is.
- The Vonage parser still does not compare the `payload_hash` claim with the request body; that is a separate gap.

The tests keep the requests recorded from the vendors, signatures included, freeze the clock at the recorded timestamp, and cover the +300/-300 edge (accepted) and +301/-301 (rejected).

Same change as #65675 for the AhaSend, Resend and Sweego parsers, and #65699 for Mailomat.
