### PR TITLE
[HtmlSanitizer] Compare schemes and hosts case-insensitively

### DIFF
--- a/src/Symfony/Component/HtmlSanitizer/Tests/TextSanitizer/UrlSanitizerTest.php
+++ b/src/Symfony/Component/HtmlSanitizer/Tests/TextSanitizer/UrlSanitizerTest.php
@@ -26,6 +26,62 @@ class UrlSanitizerTest extends TestCase
 
     public static function provideSanitize(): iterable
     {
+        // Schemes are case-insensitive
+        yield [
+            'input' => 'HTTPS://trusted.com/link',
+            'allowedSchemes' => ['https'],
+            'allowedHosts' => ['trusted.com'],
+            'forceHttps' => false,
+            'allowRelative' => false,
+            'expected' => 'https://trusted.com/link',
+        ];
+
+        yield [
+            'input' => 'HTTP://trusted.com/link',
+            'allowedSchemes' => ['http', 'https'],
+            'allowedHosts' => ['trusted.com'],
+            'forceHttps' => true,
+            'allowRelative' => false,
+            'expected' => 'https://trusted.com/link',
+        ];
+
+        yield [
+            'input' => 'MAILTO:john@trusted.com?body=line1%0D%0Aline2',
+            'allowedSchemes' => ['mailto'],
+            'allowedHosts' => null,
+            'forceHttps' => false,
+            'allowRelative' => false,
+            'expected' => 'mailto:john@trusted.com?body=line1%0D%0Aline2',
+        ];
+
+        // Hosts are case-insensitive
+        yield [
+            'input' => 'https://Trusted.COM/link',
+            'allowedSchemes' => ['https'],
+            'allowedHosts' => ['trusted.com'],
+            'forceHttps' => false,
+            'allowRelative' => false,
+            'expected' => 'https://Trusted.COM/link',
+        ];
+
+        yield [
+            'input' => 'https://trusted.com/link',
+            'allowedSchemes' => ['https'],
+            'allowedHosts' => ['Trusted.com'],
+            'forceHttps' => false,
+            'allowRelative' => false,
+            'expected' => 'https://trusted.com/link',
+        ];
+
+        yield [
+            'input' => 'https://Untrusted.COM/link',
+            'allowedSchemes' => ['https'],
+            'allowedHosts' => ['trusted.com'],
+            'forceHttps' => false,
+            'allowRelative' => false,
+            'expected' => null,
+        ];
+
         // Simple accepted cases
         yield [
             'input' => '',
@@ -364,6 +420,7 @@ class UrlSanitizerTest extends TestCase
 
             // Simple tests
             'https://trusted.com/link.php' => ['scheme' => 'https', 'host' => 'trusted.com'],
+            'HTTPS://trusted.com/link.php' => ['scheme' => 'https', 'host' => 'trusted.com'],
             'https://trusted.com/link.php?query=1#foo' => ['scheme' => 'https', 'host' => 'trusted.com'],
             'https://subdomain.trusted.com/link' => ['scheme' => 'https', 'host' => 'subdomain.trusted.com'],
             '//trusted.com/link.php' => ['scheme' => null, 'host' => 'trusted.com'],

--- a/src/Symfony/Component/HtmlSanitizer/TextSanitizer/UrlSanitizer.php
+++ b/src/Symfony/Component/HtmlSanitizer/TextSanitizer/UrlSanitizer.php
@@ -142,6 +142,9 @@ final class UrlSanitizer
             }
 
             $parsedUrl = UriString::parse($url);
+            if (isset($parsedUrl['scheme'])) {
+                $parsedUrl['scheme'] = strtolower($parsedUrl['scheme']);
+            }
 
             if (isset($parsedUrl['host']) && self::decodeUnreservedCharacters($parsedUrl['host']) !== $parsedUrl['host']) {
                 return null;
@@ -186,10 +189,10 @@ final class UrlSanitizer
             return \in_array(null, $allowedHosts, true);
         }
 
-        $parts = array_reverse(explode('.', $host));
+        $parts = array_reverse(explode('.', strtolower($host)));
 
         foreach ($allowedHosts as $allowedHost) {
-            if (self::matchAllowedHostParts($parts, array_reverse(explode('.', $allowedHost)))) {
+            if (self::matchAllowedHostParts($parts, array_reverse(explode('.', strtolower($allowedHost))))) {
                 return true;
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`UrlSanitizer` compares the scheme and the host of a URL with the configured lists byte for byte, while both are case-insensitive (RFC 3986 sections 3.1 and 3.2.2). `HTTPS://trusted.com/` is rejected by the default `allowedLinkSchemes`, and `https://Trusted.COM/` is rejected by an `allowLinkHosts(['trusted.com'])` configuration, although browsers follow both. The same comparison decides whether a scheme is hostless and whether `forceHttpsUrls()` applies, so a direct caller of `UrlSanitizer::sanitize()` that allows every scheme gets `HTTP://` links left unupgraded and `MAILTO:` line breaks handled as if the scheme had a host.

The parsed scheme is now lowercased before any check, so the sanitized URL carries a lowercase scheme. Hosts are compared case-insensitively on both sides, so an allowed host written with capitals keeps matching, and the host is returned as written in the URL, as `parse()` did before. Links that were dropped for their case only are now kept.

Checks run: `./phpunit src/Symfony/Component/HtmlSanitizer` (773 tests green), php-cs-fixer on the two files. The new sanitize and parse cases fail on the current code (7 failures), the `Untrusted.COM` case passes on both states.
