### PR TITLE
[Mailer] Reject Scaleway webhook requests with a stale timestamp

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Scaleway/Tests/Webhook/ScalewayRequestParserSignatureTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Scaleway/Tests/Webhook/ScalewayRequestParserSignatureTest.php
@@ -12,7 +12,9 @@
 namespace Symfony\Component\Mailer\Bridge\Scaleway\Tests\Webhook;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ClockMock;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
@@ -24,8 +26,28 @@ use Symfony\Component\Webhook\Exception\RejectWebhookException;
 use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
+#[Group('time-sensitive')]
 class ScalewayRequestParserSignatureTest extends TestCase
 {
+    public static function getMalformedTimestamps(): iterable
+    {
+        yield 'no milliseconds' => ['2026-01-15T10:30:01Z'];
+        yield 'no timezone' => ['2026-01-15T10:30:01.000'];
+        yield 'unix time' => ['1768473001'];
+        yield 'relative' => ['now'];
+    }
+
+    #[DataProvider('getMalformedTimestamps')]
+    public function testRejectsMalformedTimestamp(string $timestamp)
+    {
+        $envelope = $this->createSignedEnvelope(timestamp: $timestamp);
+        $parser = $this->createParser($this->createCertClient());
+
+        $this->expectException(RejectWebhookException::class);
+        $this->expectExceptionMessage('Payload is malformed.');
+        $parser->parse($this->createRequest($envelope), '');
+    }
+
     public function testRejectsTamperedPayload()
     {
         $envelope = $this->createSignedEnvelope();
@@ -195,14 +217,14 @@ class ScalewayRequestParserSignatureTest extends TestCase
         return new MockHttpClient(static fn () => new MockResponse(file_get_contents(__DIR__.'/Fixtures/signing.crt')));
     }
 
-    private function createSignedEnvelope(string $type = 'Notification', string $key = __DIR__.'/Fixtures/signing.key', string $certUrl = 'https://messaging.s3.fr-par.scw.cloud/certs/cert-11111111.pem', string $signatureVersion = '2'): array
+    private function createSignedEnvelope(string $type = 'Notification', string $key = __DIR__.'/Fixtures/signing.key', string $certUrl = 'https://messaging.s3.fr-par.scw.cloud/certs/cert-11111111.pem', string $signatureVersion = '2', string $timestamp = '2026-01-15T10:30:01.000Z'): array
     {
         $envelope = [
             'Type' => $type,
             'MessageId' => '9ae5c56c-6c9c-42e5-b0b1-0fe0f8bbdbf7',
             'TopicArn' => 'arn:scw:sns:fr-par:project-8c8bfa06:mailer-events',
             'Message' => json_encode(['type' => 'email_delivered', 'id' => 'af5c1aac-cf1b-4d4d-9e46-e6d0cd40b81c', 'email_id' => 'd4fbec9d-eed9-44d5-af47-c1126467a5ca', 'created_at' => '2026-01-15T10:30:00Z', 'email_to' => 'recipient@example.com']),
-            'Timestamp' => '2026-01-15T10:30:01.000Z',
+            'Timestamp' => $timestamp,
             'SignatureVersion' => $signatureVersion,
             'SigningCertURL' => $certUrl,
         ];
@@ -229,6 +251,8 @@ class ScalewayRequestParserSignatureTest extends TestCase
 
     private function createRequest(array $envelope): Request
     {
+        ClockMock::withClockMock(1768473001);
+
         return Request::create('/', 'POST', [], [], [], ['CONTENT_TYPE' => 'text/plain; charset=UTF-8'], json_encode($envelope));
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Scaleway/Tests/Webhook/ScalewayRequestParserTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Scaleway/Tests/Webhook/ScalewayRequestParserTest.php
@@ -11,16 +11,54 @@
 
 namespace Symfony\Component\Mailer\Bridge\Scaleway\Tests\Webhook;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use Symfony\Bridge\PhpUnit\ClockMock;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Mailer\Bridge\Scaleway\RemoteEvent\ScalewayPayloadConverter;
 use Symfony\Component\Mailer\Bridge\Scaleway\Webhook\ScalewayRequestParser;
 use Symfony\Component\Webhook\Client\RequestParserInterface;
+use Symfony\Component\Webhook\Exception\RejectWebhookException;
 use Symfony\Component\Webhook\Test\AbstractRequestParserTestCase;
 
+#[Group('time-sensitive')]
 class ScalewayRequestParserTest extends AbstractRequestParserTestCase
 {
+    public static function getStaleClockOffsets(): iterable
+    {
+        yield 'too old' => [28801];
+        yield 'too far in the future' => [-28801];
+    }
+
+    #[DataProvider('getStaleClockOffsets')]
+    public function testRejectSignedRequestWithStaleTimestamp(int $offset)
+    {
+        $request = $this->createRequest(file_get_contents(__DIR__.'/Fixtures/email_delivered.json'));
+        ClockMock::withClockMock(1768473001 + $offset);
+
+        $this->expectException(RejectWebhookException::class);
+        $this->expectExceptionMessage('Timestamp is outside the allowed time window.');
+
+        $this->createRequestParser()->parse($request, $this->getSecret());
+    }
+
+    public static function getToleratedClockOffsets(): iterable
+    {
+        yield 'at the past edge' => [28800];
+        yield 'at the future edge' => [-28800];
+    }
+
+    #[DataProvider('getToleratedClockOffsets')]
+    public function testAcceptSignedRequestWithinTolerance(int $offset)
+    {
+        $request = $this->createRequest(file_get_contents(__DIR__.'/Fixtures/email_delivered.json'));
+        ClockMock::withClockMock(1768473001 + $offset);
+
+        $this->assertNotNull($this->createRequestParser()->parse($request, $this->getSecret()));
+    }
+
     protected function createRequestParser(): RequestParserInterface
     {
         return new ScalewayRequestParser(
@@ -33,6 +71,8 @@ class ScalewayRequestParserTest extends AbstractRequestParserTestCase
 
     protected function createRequest(string $payload): Request
     {
+        ClockMock::withClockMock(1768473001);
+
         $envelope = [
             'Type' => 'Notification',
             'MessageId' => '9ae5c56c-6c9c-42e5-b0b1-0fe0f8bbdbf7',

--- a/src/Symfony/Component/Mailer/Bridge/Scaleway/Webhook/ScalewayRequestParser.php
+++ b/src/Symfony/Component/Mailer/Bridge/Scaleway/Webhook/ScalewayRequestParser.php
@@ -38,6 +38,9 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 final class ScalewayRequestParser extends AbstractRequestParser
 {
     private const SIGNING_CERT_URL = '{^https://messaging\.s3\.[a-z]{2}-[a-z]{3}\.scw\.cloud/}i';
+    private const TIMESTAMP_FORMAT = 'Y-m-d\TH:i:s.v\Z';
+    // retried deliveries keep the timestamp of the original publication
+    private const TIMESTAMP_TOLERANCE = 8 * 3600;
 
     private const SIGNED_KEYS = [
         'Notification' => ['Message', 'MessageId', 'Subject', 'Timestamp', 'TopicArn', 'Type'],
@@ -74,6 +77,14 @@ final class ScalewayRequestParser extends AbstractRequestParser
             if (!\is_string($payload[$key] ?? null)) {
                 throw new RejectWebhookException(406, 'Payload is malformed.');
             }
+        }
+
+        if (!$timestamp = \DateTimeImmutable::createFromFormat(self::TIMESTAMP_FORMAT, $payload['Timestamp'], new \DateTimeZone('UTC'))) {
+            throw new RejectWebhookException(406, 'Payload is malformed.');
+        }
+
+        if (abs(time() - $timestamp->getTimestamp()) > self::TIMESTAMP_TOLERANCE) {
+            throw new RejectWebhookException(406, 'Timestamp is outside the allowed time window.');
         }
 
         $this->verifySignature($payload);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The Scaleway webhook parser verifies an SNS-style signature over the Message, MessageId, Timestamp, TopicArn and Type fields (plus SubscribeURL and Token for confirmations). The signature proves who sent the request, but nothing checked when it was published: a captured request stayed valid for as long as the signing certificate was trusted and could be replayed into consumers that are not idempotent.

The parser now parses the `Timestamp` field with the SNS format (ISO 8601 with milliseconds and a `Z` suffix, e.g. `2026-01-15T10:30:01.000Z`, always UTC) and rejects the request with a 406 when:

- the value does not match that format (`Payload is malformed.`), or
- it is more than eight hours before or after the server clock (`Timestamp is outside the allowed time window.`).

The check runs before the signature is verified, so a stale request costs no certificate fetch. The timestamp is part of the signed string, so an attacker cannot refresh it without breaking the signature.

Why eight hours and not the five minutes of the other timestamped parsers: SNS defines `Timestamp` as the time the notification was published, not the time of the delivery attempt, so retried deliveries keep the original value. The window therefore has to cover the retry span of a briefly unreachable endpoint rather than the latency of one request. Neither AWS nor Scaleway documents a maximum retry span; SNS HTTP/S delivery policies retry for up to an hour, and eight hours leaves room for a longer outage while still bounding replay.

Trap: a server whose clock drifts by more than eight hours rejects legitimate requests.

The tests keep the test PKI and sign their fixtures at test time; they freeze the clock at the fixture timestamp and add cases at the two edges of the window, one second beyond them, and for malformed timestamp values.

Same change as #65675 (AhaSend, Resend, Sweego), #65699 (Mailomat) and #65700 (Mailgun, SendGrid, Vonage), with a wider window for the reason above.
