### PR TITLE
[HttpClient] Drop credentials when a redirect changes the scheme

### DIFF
--- a/src/Symfony/Component/HttpClient/CurlHttpClient.php
+++ b/src/Symfony/Component/HttpClient/CurlHttpClient.php
@@ -319,7 +319,7 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
             }
         }
 
-        return $pushedResponse ?? new CurlResponse($multi, $ch, $options, $this->logger, $method, self::createRedirectResolver($options, $host), CurlClientState::$curlVersion['version_number']);
+        return $pushedResponse ?? new CurlResponse($multi, $ch, $options, $this->logger, $method, self::createRedirectResolver($options, $scheme, $host), CurlClientState::$curlVersion['version_number']);
     }
 
     /**
@@ -405,10 +405,11 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
      *
      * Work around CVE-2018-1000007: Authorization and Cookie headers should not follow redirects - fixed in Curl 7.64
      */
-    private static function createRedirectResolver(array $options, string $host): \Closure
+    private static function createRedirectResolver(array $options, string $scheme, string $host): \Closure
     {
         $redirectHeaders = [];
         if (0 < $options['max_redirects']) {
+            $redirectHeaders['scheme'] = $scheme;
             $redirectHeaders['host'] = $host;
             $redirectHeaders['with_auth'] = $redirectHeaders['no_auth'] = array_filter($options['headers'], static function ($h) {
                 return 0 !== stripos($h, 'Host:');
@@ -439,7 +440,8 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
             }
 
             if ($redirectHeaders && isset($location['authority'])) {
-                $requestHeaders = parse_url($location['authority'], \PHP_URL_HOST) === $redirectHeaders['host'] ? $redirectHeaders['with_auth'] : $redirectHeaders['no_auth'];
+                // Authorization and Cookie headers MUST NOT follow except for the initial scheme and host name
+                $requestHeaders = $url['scheme'] === $redirectHeaders['scheme'] && parse_url($url['authority'], \PHP_URL_HOST) === $redirectHeaders['host'] ? $redirectHeaders['with_auth'] : $redirectHeaders['no_auth'];
                 curl_setopt($ch, \CURLOPT_HTTPHEADER, $requestHeaders);
             } elseif ($noContent && $redirectHeaders) {
                 curl_setopt($ch, \CURLOPT_HTTPHEADER, $redirectHeaders['with_auth']);

--- a/src/Symfony/Component/HttpClient/NativeHttpClient.php
+++ b/src/Symfony/Component/HttpClient/NativeHttpClient.php
@@ -257,7 +257,7 @@ final class NativeHttpClient implements HttpClientInterface, LoggerAwareInterfac
                 $url['authority'] = substr_replace($url['authority'], $ip, -\strlen($host) - \strlen($port), \strlen($host));
             }
 
-            return [self::createRedirectResolver($options, $host, $proxy, $info, $onProgress), implode('', $url)];
+            return [self::createRedirectResolver($options, $url['scheme'], $host, $proxy, $info, $onProgress), implode('', $url)];
         };
 
         return new NativeResponse($this->multi, $context, implode('', $url), $options, $info, $resolver, $onProgress, $this->logger);
@@ -360,11 +360,11 @@ final class NativeHttpClient implements HttpClientInterface, LoggerAwareInterfac
     /**
      * Handles redirects - the native logic is too buggy to be used.
      */
-    private static function createRedirectResolver(array $options, string $host, ?array $proxy, array &$info, ?\Closure $onProgress): \Closure
+    private static function createRedirectResolver(array $options, string $scheme, string $host, ?array $proxy, array &$info, ?\Closure $onProgress): \Closure
     {
         $redirectHeaders = [];
         if (0 < $maxRedirects = $options['max_redirects']) {
-            $redirectHeaders = ['host' => $host];
+            $redirectHeaders = ['scheme' => $scheme, 'host' => $host];
             $redirectHeaders['with_auth'] = $redirectHeaders['no_auth'] = array_filter($options['headers'], static function ($h) {
                 return 0 !== stripos($h, 'Host:');
             });
@@ -428,8 +428,8 @@ final class NativeHttpClient implements HttpClientInterface, LoggerAwareInterfac
             [$host, $port] = self::parseHostPort($url, $info);
 
             if ($locationHasHost) {
-                // Authorization and Cookie headers MUST NOT follow except for the initial host name
-                $requestHeaders = $redirectHeaders['host'] === $host ? $redirectHeaders['with_auth'] : $redirectHeaders['no_auth'];
+                // Authorization and Cookie headers MUST NOT follow except for the initial scheme and host name
+                $requestHeaders = $url['scheme'] === $redirectHeaders['scheme'] && $redirectHeaders['host'] === $host ? $redirectHeaders['with_auth'] : $redirectHeaders['no_auth'];
                 $requestHeaders[] = 'Host: '.$host.$port;
                 $dnsResolve = !self::configureHeadersAndProxy($context, $host, $requestHeaders, $proxy, 'https:' === $url['scheme']);
             } else {

--- a/src/Symfony/Component/HttpClient/NoPrivateNetworkHttpClient.php
+++ b/src/Symfony/Component/HttpClient/NoPrivateNetworkHttpClient.php
@@ -100,6 +100,7 @@ final class NoPrivateNetworkHttpClient implements HttpClientInterface, LoggerAwa
         [$url, $options] = self::prepareRequest($method, $url, $options, $this->defaultOptions, true);
 
         $redirectHeaders = parse_url($url['authority']);
+        $redirectHeaders['scheme'] = $url['scheme'];
         $host = $redirectHeaders['host'];
         $url = implode('', $url);
         $dnsCache = $this->dnsCache;
@@ -170,8 +171,8 @@ final class NoPrivateNetworkHttpClient implements HttpClientInterface, LoggerAwa
                 }
             }
 
-            // Authorization and Cookie headers MUST NOT follow except for the initial host name
-            $options['headers'] = $redirectHeaders['host'] === $host ? $redirectHeaders['with_auth'] : $redirectHeaders['no_auth'];
+            // Authorization and Cookie headers MUST NOT follow except for the initial scheme and host name
+            $options['headers'] = parse_url($url, \PHP_URL_SCHEME).':' === $redirectHeaders['scheme'] && $redirectHeaders['host'] === $host ? $redirectHeaders['with_auth'] : $redirectHeaders['no_auth'];
 
             static $redirectCount = 0;
             $context->setInfo('redirect_count', ++$redirectCount);

--- a/src/Symfony/Component/HttpClient/Response/AmpResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/AmpResponse.php
@@ -360,7 +360,7 @@ final class AmpResponse implements ResponseInterface, StreamableInterface
                 $request->addHeader($name, $value);
             }
 
-            if ($request->getUri()->getAuthority() !== $originRequest->getUri()->getAuthority()) {
+            if ($request->getUri()->getScheme() !== $originRequest->getUri()->getScheme() || $request->getUri()->getAuthority() !== $originRequest->getUri()->getAuthority()) {
                 $request->removeHeader('authorization');
                 $request->removeHeader('cookie');
                 $request->removeHeader('host');

--- a/src/Symfony/Component/HttpClient/Tests/Fixtures/tls/redirect-server.php
+++ b/src/Symfony/Component/HttpClient/Tests/Fixtures/tls/redirect-server.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+// Serves both TLS and plain HTTP on one port: TLS requests are redirected to the
+// plain URL of the same host and port, plain requests echo their headers as JSON.
+
+$port = (int) ($argv[1] ?? 8059);
+$context = stream_context_create(['ssl' => ['local_cert' => __DIR__.'/server.crt', 'local_pk' => __DIR__.'/server.key']]);
+$server = stream_socket_server('tcp://127.0.0.1:'.$port, $errno, $errstr, \STREAM_SERVER_BIND | \STREAM_SERVER_LISTEN, $context);
+
+while ($conn = @stream_socket_accept($server, 30)) {
+    $tls = "\x16" === stream_socket_recvfrom($conn, 1, \STREAM_PEEK);
+
+    if ($tls && !@stream_socket_enable_crypto($conn, true, \STREAM_CRYPTO_METHOD_TLS_SERVER)) {
+        fclose($conn);
+        continue;
+    }
+
+    $headers = [];
+    while (false !== ($line = fgets($conn)) && '' !== ($line = trim($line))) {
+        if (false !== $i = strpos($line, ':')) {
+            $headers[strtolower(substr($line, 0, $i))] = trim(substr($line, $i + 1));
+        }
+    }
+
+    if ($tls) {
+        fwrite($conn, "HTTP/1.1 301 Moved Permanently\r\nLocation: http://127.0.0.1:$port/\r\nContent-Length: 0\r\nConnection: close\r\n\r\n");
+    } else {
+        $body = json_encode($headers);
+        fwrite($conn, "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: ".strlen($body)."\r\nConnection: close\r\n\r\n".$body);
+    }
+
+    fclose($conn);
+}

--- a/src/Symfony/Component/HttpClient/Tests/HttpClientTestCase.php
+++ b/src/Symfony/Component/HttpClient/Tests/HttpClientTestCase.php
@@ -44,6 +44,28 @@ abstract class HttpClientTestCase extends BaseHttpClientTestCase
         parent::testTimeoutOnDestruct();
     }
 
+    /**
+     * @requires extension openssl
+     */
+    public function testRedirectToADifferentSchemeDropsCredentials()
+    {
+        TestRedirectServer::start();
+        $client = $this->getHttpClient(__FUNCTION__);
+
+        $response = $client->request('GET', 'https://127.0.0.1:8059/', [
+            'auth_basic' => 'foo:bar',
+            'headers' => ['Cookie' => 'a=b', 'X-Custom' => 'kept'],
+            'verify_peer' => false,
+            'verify_host' => false,
+        ]);
+        $headers = $response->toArray();
+
+        $this->assertSame('http://127.0.0.1:8059/', $response->getInfo('url'));
+        $this->assertSame('kept', $headers['x-custom']);
+        $this->assertArrayNotHasKey('authorization', $headers);
+        $this->assertArrayNotHasKey('cookie', $headers);
+    }
+
     public function testAcceptHeader()
     {
         $client = $this->getHttpClient(__FUNCTION__);

--- a/src/Symfony/Component/HttpClient/Tests/NoPrivateNetworkHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/NoPrivateNetworkHttpClientTest.php
@@ -16,6 +16,7 @@ use Symfony\Bridge\PhpUnit\DnsMock;
 use Symfony\Component\HttpClient\Exception\InvalidArgumentException;
 use Symfony\Component\HttpClient\Exception\TransportException;
 use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\NativeHttpClient;
 use Symfony\Component\HttpClient\NoPrivateNetworkHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
 
@@ -176,6 +177,28 @@ class NoPrivateNetworkHttpClientTest extends TestCase
 
         $client = new NoPrivateNetworkHttpClient(new MockHttpClient());
         $client->request('GET', $url, ['on_progress' => $customCallback]);
+    }
+
+    /**
+     * @requires extension openssl
+     */
+    public function testRedirectToADifferentSchemeDropsCredentials()
+    {
+        TestRedirectServer::start();
+        $client = new NoPrivateNetworkHttpClient(new NativeHttpClient(), '10.0.0.0/8');
+
+        $response = $client->request('GET', 'https://127.0.0.1:8059/', [
+            'auth_basic' => 'foo:bar',
+            'headers' => ['Cookie' => 'a=b', 'X-Custom' => 'kept'],
+            'verify_peer' => false,
+            'verify_host' => false,
+        ]);
+        $headers = $response->toArray();
+
+        $this->assertSame('http://127.0.0.1:8059/', $response->getInfo('url'));
+        $this->assertSame('kept', $headers['x-custom']);
+        $this->assertArrayNotHasKey('authorization', $headers);
+        $this->assertArrayNotHasKey('cookie', $headers);
     }
 
     public function testConstructor()

--- a/src/Symfony/Component/HttpClient/Tests/TestRedirectServer.php
+++ b/src/Symfony/Component/HttpClient/Tests/TestRedirectServer.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\Tests;
+
+use Symfony\Component\Process\PhpExecutableFinder;
+use Symfony\Component\Process\Process;
+
+/**
+ * Starts a server that redirects TLS requests to the plain URL of the same host and port.
+ */
+class TestRedirectServer
+{
+    private static $process;
+
+    public static function start(): void
+    {
+        if (self::$process) {
+            return;
+        }
+
+        $finder = new PhpExecutableFinder();
+        $process = new Process(array_merge([$finder->find(false)], $finder->findArguments(), [__DIR__.'/Fixtures/tls/redirect-server.php', '8059']));
+        $process->start();
+        self::$process = $process;
+        register_shutdown_function([$process, 'stop']);
+
+        do {
+            usleep(50000);
+        } while ($process->isRunning() && !@fsockopen('127.0.0.1', 8059));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

When a response redirects to another host, the redirect handling of every client drops the `Authorization` and `Cookie` headers before following it. It kept them when the host was the same but the scheme changed, so an `https://` request redirected to `http://` on the same host sent the credentials in clear text. Browsers and the Fetch standard strip these headers on any change of origin, and the scheme is part of the origin.

The scheme is now compared next to the host in the four places that make this decision: `CurlHttpClient`, `NativeHttpClient`, `AmpResponse` and `NoPrivateNetworkHttpClient`. Other custom headers keep following the redirect as before, and a redirect to the same scheme and host still carries the credentials.

The test starts a small server that serves TLS and plain HTTP on the same port, using the certificate already in the fixtures: a TLS request is redirected to the plain URL of the same host and port, and a plain request echoes the headers it received. The test runs for the curl, native, Amp and mock clients through `HttpClientTestCase`, and once more with `NoPrivateNetworkHttpClient`. With the fix reverted, the native, Amp and `NoPrivateNetwork` clients fail it with `Failed asserting that an array does not have the key 'authorization'`. The curl client passes it on both states: libcurl 8.5.0 drops the headers itself on a scheme change, so the change in `CurlHttpClient` aligns the code path for the libcurl versions that do not.

Not covered: the port stays out of the comparison on this branch, as before (a redirect to another port of the same host keeps the credentials). Windows was not tested locally.

This targets 5.4 on purpose, as a hardening change: it fixes a credential leak that exists in the same shape on every maintained branch.

Checks run: `./phpunit src/Symfony/Component/HttpClient` (804 tests, 26 skipped, no failures) and php-cs-fixer on the changed files.
