### PR TITLE
[Translation] Fix Persian (fa) translations for Form and Validator components

### DIFF
--- a/src/Symfony/Component/Form/Resources/translations/validators.fa.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.fa.xlf
@@ -128,7 +128,7 @@
             </trans-unit>
             <trans-unit id="127">
                 <source>Please select a valid range.</source>
-                <target>لطفاً یک محدوده‌ معتبر انتخاب کنید.</target>
+                <target>لطفاً یک بازه‌ معتبر انتخاب کنید.</target>
             </trans-unit>
             <trans-unit id="128">
                 <source>Please enter a valid week.</source>
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="129">
                 <source>Please enter a valid UUID.</source>
-                <target state="needs-review-translation">لطفاً یک UUID معتبر وارد کنید.</target>
+                <target>لطفاً یک UUID معتبر وارد کنید.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.fa.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.fa.xlf
@@ -556,27 +556,27 @@
             </trans-unit>
             <trans-unit id="143">
                 <source>This value is not valid XML.</source>
-                <target state="needs-review-translation">این مقدار یک XML معتبر نیست.</target>
+                <target>این مقدار یک XML معتبر نیست.</target>
             </trans-unit>
             <trans-unit id="144">
                 <source>This value does not conform to the expected XSD schema.</source>
-                <target state="needs-review-translation">این مقدار با طرح‌وارهٔ XSD مورد انتظار مطابقت ندارد.</target>
+                <target>این مقدار با طرحواره (اسکیما) XSD مورد انتظار مطابقت ندارد.</target>
             </trans-unit>
             <trans-unit id="145">
                 <source>This XML payload is too large ({{ size }} bytes): it exceeds the limit of {{ limit }} bytes.</source>
-                <target state="needs-review-translation">این محتوای XML بیش از حد بزرگ است ({{ size }} بایت): از محدودیت {{ limit }} بایت فراتر می‌رود.</target>
+                <target>این محتوای XML بیش از حد بزرگ است ({{ size }} بایت): از محدودیت {{ limit }} بایت فراتر می‌رود.</target>
             </trans-unit>
             <trans-unit id="146">
                 <source>This value is not a valid cron expression.</source>
-                <target state="needs-review-translation">این مقدار یک عبارت cron معتبر نیست.</target>
+                <target>این مقدار یک عبارت cron معتبر نیست.</target>
             </trans-unit>
             <trans-unit id="147">
                 <source>The referenced entity does not exist.</source>
-                <target state="needs-review-translation">موجودیت ارجاع‌شده وجود ندارد.</target>
+                <target>موجودیت ارجاع داده شده وجود ندارد.</target>
             </trans-unit>
             <trans-unit id="148" resname="This is not a valid ULID.">
                 <source>This value is not a valid ULID.</source>
-                <target state="needs-review-translation">این مقدار یک ULID معتبر نیست.</target>
+                <target>این مقدار یک ULID معتبر نیست.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no 
| Issues        | Fix #64508 
| License       | MIT

This PR completes the requested Persian (fa) translations in:
- `src/Symfony/Component/Form/Resources/translations/validators.fa.xlf`
- `src/Symfony/Component/Validator/Resources/translations/validators.fa.xlf`

As a native Persian speaker, I reviewed all strings flagged "Needs review" and confirmed/corrected them to match natural Persian phrasing and the existing tone of the file.

I also corrected one string that was not flagged as "Needs review" but used a less natural term: "range" was translated as "محدوده", which I changed to "بازه" — the more standard term in this context.
