### PR TITLE
[Mailer][Mailchimp] Sign the webhook URL as sent and reject a non-string mandrill_events parameter

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Webhook/MailchimpSignatureRequestParserTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Webhook/MailchimpSignatureRequestParserTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\Mailchimp\Tests\Webhook;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Mailer\Bridge\Mailchimp\RemoteEvent\MailchimpPayloadConverter;
+use Symfony\Component\Mailer\Bridge\Mailchimp\Webhook\MailchimpRequestParser;
+use Symfony\Component\Webhook\Exception\RejectWebhookException;
+
+class MailchimpSignatureRequestParserTest extends TestCase
+{
+    private const SECRET = 'key-0p6mqbf74lb20gzq9f4dhpn9rg3zyk26';
+
+    public function testMissingSignatureIsRejected()
+    {
+        $this->expectException(RejectWebhookException::class);
+        $this->expectExceptionMessage('Signature is wrong.');
+
+        $this->parse($this->createRequest(['mandrill_events' => $this->events()]));
+    }
+
+    public function testForgedSignatureIsRejected()
+    {
+        $request = $this->createRequest(['mandrill_events' => $this->events()]);
+        $request->headers->set('X-Mandrill-Signature', base64_encode(hash_hmac('sha1', 'http://localhost/mandrill_events'.$this->events(), 'wrong-secret', true)));
+
+        $this->expectException(RejectWebhookException::class);
+        $this->expectExceptionMessage('Signature is wrong.');
+
+        $this->parse($request);
+    }
+
+    public function testEmptyCheckSignedWithTheRealSecretIsRejected()
+    {
+        $request = $this->createRequest(['mandrill_events' => '[]']);
+        $request->headers->set('X-Mandrill-Signature', base64_encode(hash_hmac('sha1', 'http://localhost/mandrill_events[]', self::SECRET, true)));
+
+        $this->expectException(RejectWebhookException::class);
+        $this->expectExceptionMessage('Signature is wrong.');
+
+        $this->parse($request);
+    }
+
+    public function testNonStringEventsParameterIsRejected()
+    {
+        $this->expectException(RejectWebhookException::class);
+        $this->expectExceptionMessage('Payload malformed.');
+
+        $this->parse($this->createRequest(['mandrill_events' => ['[]']]));
+    }
+
+    private function events(): string
+    {
+        return '[{"event":"send","msg":{"_id":"1","email":"foo@example.com","ts":1365109999}}]';
+    }
+
+    private function createRequest(array $params): Request
+    {
+        return Request::create('/', 'POST', $params, [], [], ['CONTENT_TYPE' => 'application/x-www-form-urlencoded']);
+    }
+
+    private function parse(Request $request): mixed
+    {
+        return (new MailchimpRequestParser(new MailchimpPayloadConverter()))->parse($request, self::SECRET);
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Webhook/MailchimpSignatureRequestParserTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Webhook/MailchimpSignatureRequestParserTest.php
@@ -59,9 +59,17 @@ class MailchimpSignatureRequestParserTest extends TestCase
         $this->parse($this->createRequest(['mandrill_events' => ['[]']]));
     }
 
+    public function testUrlIsSignedAsSentAndNotNormalized()
+    {
+        $request = Request::create('/hook?foo=1&bar=2', 'POST', ['mandrill_events' => $this->events()], [], [], ['CONTENT_TYPE' => 'application/x-www-form-urlencoded']);
+        $request->headers->set('X-Mandrill-Signature', base64_encode(hash_hmac('sha1', 'http://localhost/hook?foo=1&bar=2mandrill_events'.$this->events(), self::SECRET, true)));
+
+        $this->assertCount(1, $this->parse($request));
+    }
+
     private function events(): string
     {
-        return '[{"event":"send","msg":{"_id":"1","email":"foo@example.com","ts":1365109999}}]';
+        return json_encode(json_decode(file_get_contents(__DIR__.'/Fixtures/send.json'), true)['mandrill_events'], \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE);
     }
 
     private function createRequest(array $params): Request

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Webhook/MailchimpRequestParser.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Webhook/MailchimpRequestParser.php
@@ -38,7 +38,7 @@ final class MailchimpRequestParser extends AbstractRequestParser
     protected function doParse(Request $request, #[\SensitiveParameter] string $secret): RemoteEvent|array|null
     {
         $content = $request->request->all();
-        if (!isset($content['mandrill_events'])) {
+        if (!\is_string($content['mandrill_events'] ?? null)) {
             throw new RejectWebhookException(400, 'Payload malformed.');
         }
 

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Webhook/MailchimpRequestParser.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Webhook/MailchimpRequestParser.php
@@ -44,7 +44,7 @@ final class MailchimpRequestParser extends AbstractRequestParser
 
         // Mailchimp sends an empty array to verify the webhook URL is reachable.
         if ([] === $events = json_decode($content['mandrill_events'], true)) {
-            $this->validateSignature($content, $secret, $request->getUri(), $request->headers->get('X-Mandrill-Signature'));
+            $this->validateSignature($content, $secret, $this->getWebhookUrl($request), $request->headers->get('X-Mandrill-Signature'));
 
             return null;
         }
@@ -53,13 +53,26 @@ final class MailchimpRequestParser extends AbstractRequestParser
             throw new RejectWebhookException(400, 'Payload malformed.');
         }
 
-        $this->validateSignature($content, $secret, $request->getUri(), $request->headers->get('X-Mandrill-Signature'));
+        $this->validateSignature($content, $secret, $this->getWebhookUrl($request), $request->headers->get('X-Mandrill-Signature'));
 
         try {
             return array_map($this->converter->convert(...), $events);
         } catch (ParseException $e) {
             throw new RejectWebhookException(406, $e->getMessage(), $e);
         }
+    }
+
+    /**
+     * Mandrill signs the webhook URL as configured, so the query string must be used as sent, not normalized.
+     */
+    private function getWebhookUrl(Request $request): string
+    {
+        $url = $request->getSchemeAndHttpHost().$request->getBaseUrl().$request->getPathInfo();
+        if ('' !== ($queryString = $request->server->get('QUERY_STRING', '')) && null !== $queryString) {
+            $url .= '?'.$queryString;
+        }
+
+        return $url;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Two defects in the Mandrill webhook parser of the Mailchimp mailer bridge.

**Signature computed on a normalized URL.** Mandrill signs `base64(HMAC-SHA1(url + sorted key/value pairs, key))`, where `url` is the webhook URL exactly as configured in the Mandrill account (https://mailchimp.com/developer/transactional/guides/track-respond-activity-webhooks/#authenticating-webhook-requests). The parser used `Request::getUri()`, which re-sorts and re-encodes the query string. Any webhook URL with a query string whose keys are not already sorted (`?foo=1&bar=2`) produced a different string, so every valid request was rejected with "Signature is wrong.". The parser now builds the URL from the scheme, host, base URL, path info and the raw `QUERY_STRING`.

**Non-string `mandrill_events` parameter.** A request sending `mandrill_events[]=x` passed the `isset()` check, then `json_decode()` threw a `TypeError` (500). The parser now requires a string and rejects anything else with the existing 400 "Payload malformed.".

Not changed: the signing algorithm, the `test-webhook` key used for the empty verification ping, and the accepted payload shape.

Checks run:
- `MailchimpSignatureRequestParserTest`: each new test fails with its fix hunk reverted (signature rejected on `/hook?foo=1&bar=2`; `TypeError` from `json_decode()`), and passes with the fix.
- `./phpunit src/Symfony/Component/Mailer/Bridge/Mailchimp`: OK (52 tests, 103 assertions).
- `php .github/sa-tools/check-hardening-tests.php`: convention satisfied.
