### PR TITLE
[Mailer][Scaleway] Reject non-string signed fields instead of raising a warning

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Scaleway/Tests/Webhook/ScalewayRequestParserSignatureTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Scaleway/Tests/Webhook/ScalewayRequestParserSignatureTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Mailer\Bridge\Scaleway\Tests\Webhook;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\HttpClient\MockHttpClient;
@@ -34,6 +35,26 @@ class ScalewayRequestParserSignatureTest extends TestCase
         $this->expectException(RejectWebhookException::class);
         $this->expectExceptionMessage('Signature is invalid.');
         $parser->parse($this->createRequest($envelope), '');
+    }
+
+    #[DataProvider('provideNonStringSignedFields')]
+    public function testRejectsNonStringSignedField(string $type, string $field)
+    {
+        $envelope = $this->createSignedEnvelope(type: $type);
+        $envelope[$field] = ['not a string'];
+        $parser = $this->createParser($this->createCertClient());
+
+        $this->expectException(RejectWebhookException::class);
+        $this->expectExceptionMessage('Payload is malformed.');
+        $parser->parse($this->createRequest($envelope), '');
+    }
+
+    public static function provideNonStringSignedFields(): iterable
+    {
+        yield ['Notification', 'Message'];
+        yield ['Notification', 'Subject'];
+        yield ['SubscriptionConfirmation', 'SubscribeURL'];
+        yield ['SubscriptionConfirmation', 'Token'];
     }
 
     public function testRejectsCertificateNotIssuedByTrustedCA()

--- a/src/Symfony/Component/Mailer/Bridge/Scaleway/Webhook/ScalewayRequestParser.php
+++ b/src/Symfony/Component/Mailer/Bridge/Scaleway/Webhook/ScalewayRequestParser.php
@@ -121,9 +121,15 @@ final class ScalewayRequestParser extends AbstractRequestParser
 
         $signedString = '';
         foreach ($signedKeys as $key) {
-            if (isset($payload[$key])) {
-                $signedString .= $key."\n".$payload[$key]."\n";
+            if (!isset($payload[$key])) {
+                continue;
             }
+
+            if (!\is_string($payload[$key])) {
+                throw new RejectWebhookException(406, 'Payload is malformed.');
+            }
+
+            $signedString .= $key."\n".$payload[$key]."\n";
         }
 
         $certUrl = $payload['SigningCertURL'];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Scaleway webhooks use the SNS signing scheme: the `Message`, `Subject`, `Token` and `SubscribeURL` fields are joined into a string, and that string is checked against the signature. See https://www.scaleway.com/en/docs/topics-and-events/reference-content/verifying-webhooks/ and https://docs.aws.amazon.com/sns/latest/dg/sns-verify-signature-of-message.html. Those fields are strings by definition.

`ScalewayRequestParser` concatenated them without a type check. A payload where one of them is a JSON array (for example `"Message": ["x"]`) raised an "Array to string conversion" warning during concatenation, before the signature was verified. With the usual error handler that is a 500 for anyone who posts such a body to the webhook endpoint.

The fix rejects a non-string signed field with a 406 `RejectWebhookException` ("Payload is malformed."), which is how the parser already reports other malformed payloads. Missing fields are still skipped, as before, since the SNS scheme only signs the fields that are present. Valid payloads are not affected.

Checks:
- Revert-verify: with the parser hunk reverted, the four new test cases fail with "Array to string conversion".
- `./phpunit src/Symfony/Component/Mailer/Bridge/Scaleway`: OK (40 tests, 69 assertions).
- `php .github/sa-tools/check-hardening-tests.php`: convention satisfied.
