### PR TITLE
[Mailer][Resend] Reject a versioned signature entry without a value instead of raising a warning

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Resend/Tests/Webhook/ResendRequestParserTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Resend/Tests/Webhook/ResendRequestParserTest.php
@@ -78,4 +78,34 @@ class ResendRequestParserTest extends AbstractRequestParserTestCase
             'HTTP_svix-signature' => 'v1,4wjuRp64yC/2itgCQwl2xPePVwSPTdPbXLIY6IxGLTA=',
         ], str_replace("\n", "\r\n", $payload));
     }
+
+    #[DataProvider('provideInvalidSignatureHeaders')]
+    public function testRejectsInvalidSignatureHeader(string $signature)
+    {
+        $request = $this->createRequest(file_get_contents(__DIR__.'/Fixtures/sent.json'));
+        $request->headers->set('svix-signature', $signature);
+
+        $this->expectException(RejectWebhookException::class);
+        $this->expectExceptionMessage('No signatures found matching the expected signature.');
+        $this->createRequestParser()->parse($request, $this->getSecret());
+    }
+
+    public static function provideInvalidSignatureHeaders(): iterable
+    {
+        yield 'forged' => ['v1,AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA='];
+        yield 'empty' => [''];
+        yield 'no version' => ['4wjuRp64yC/2itgCQwl2xPePVwSPTdPbXLIY6IxGLTA='];
+        yield 'version only' => ['v1'];
+        yield 'unknown version' => ['v2,4wjuRp64yC/2itgCQwl2xPePVwSPTdPbXLIY6IxGLTA='];
+    }
+
+    public function testRejectsMissingSignatureHeader()
+    {
+        $request = $this->createRequest(file_get_contents(__DIR__.'/Fixtures/sent.json'));
+        $request->headers->remove('svix-signature');
+
+        $this->expectException(RejectWebhookException::class);
+        $this->expectExceptionMessage('Request does not match.');
+        $this->createRequestParser()->parse($request, $this->getSecret());
+    }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Resend/Webhook/ResendRequestParser.php
+++ b/src/Symfony/Component/Mailer/Bridge/Resend/Webhook/ResendRequestParser.php
@@ -94,14 +94,11 @@ final class ResendRequestParser extends AbstractRequestParser
         $signatureFound = false;
 
         foreach ($passedSignatures as $versionedSignature) {
-            $signatureParts = explode(',', $versionedSignature, 2);
-            $version = $signatureParts[0];
+            [$version, $passedSignature] = explode(',', $versionedSignature, 2) + [1 => ''];
 
             if ('v1' !== $version) {
                 continue;
             }
-
-            $passedSignature = $signatureParts[1];
 
             if (hash_equals($expectedSignature, $passedSignature)) {
                 $signatureFound = true;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The Resend webhook parser verifies the `svix-signature` header. Per the Svix scheme (https://docs.svix.com/receiving/verifying-payloads/how-manual), the header holds space-separated entries, each of the form `<version>,<base64 signature>`.

An entry with a version but no value, for example `v1` alone, made the parser read a missing array key. That raised an "Undefined array key 1" warning, which the error handler turns into a 500 response. A malformed header should be rejected with a 406 like any other bad signature.

The fix pads the exploded entry with an empty signature. An entry without a value then fails the constant-time comparison and the request is rejected with "No signatures found matching the expected signature."

Nothing else changes: valid entries, unknown versions and forged signatures behave as before. Only the warning path is removed.

Checks:
- With the fix reverted, the new `version only` case fails with "Undefined array key 1" at `ResendRequestParser.php:104`.
- `./phpunit src/Symfony/Component/Mailer/Bridge/Resend`: OK (33 tests, 75 assertions).
- `php .github/sa-tools/check-hardening-tests.php`: convention satisfied.
