### PR TITLE
[Mailer][Mailgun] Reject non-string signature fields instead of throwing a TypeError

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Webhook/MailgunRequestParserTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Webhook/MailgunRequestParserTest.php
@@ -90,6 +90,23 @@ class MailgunRequestParserTest extends AbstractRequestParserTestCase
         $this->createRequestParser()->parse($this->createRequest($payload), $this->getSecret());
     }
 
+    /**
+     * @dataProvider provideNonStringSignatureFields
+     */
+    public function testNonStringSignatureFieldsAreRejected(string $payload)
+    {
+        $this->expectException(RejectWebhookException::class);
+        $this->createRequestParser()->parse($this->createRequest($payload), $this->getSecret());
+    }
+
+    public static function provideNonStringSignatureFields(): iterable
+    {
+        yield 'int signature' => ['{"signature":{"timestamp":"1","token":"token","signature":123},"event-data":{"event":"delivered"}}'];
+        yield 'array signature' => ['{"signature":{"timestamp":"1","token":"token","signature":["wrong"]},"event-data":{"event":"delivered"}}'];
+        yield 'array timestamp' => ['{"signature":{"timestamp":["1"],"token":"token","signature":"wrong"},"event-data":{"event":"delivered"}}'];
+        yield 'array token' => ['{"signature":{"timestamp":"1","token":["token"],"signature":"wrong"},"event-data":{"event":"delivered"}}'];
+    }
+
     public function testMalformedPayloadIsRejected()
     {
         $this->expectException(RejectWebhookException::class);

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Webhook/MailgunRequestParser.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Webhook/MailgunRequestParser.php
@@ -48,9 +48,9 @@ final class MailgunRequestParser extends AbstractRequestParser
 
         $content = $request->toArray();
         if (
-            !isset($content['signature']['timestamp'])
-            || !isset($content['signature']['token'])
-            || !isset($content['signature']['signature'])
+            !\is_string($content['signature']['timestamp'] ?? null)
+            || !\is_string($content['signature']['token'] ?? null)
+            || !\is_string($content['signature']['signature'] ?? null)
             || !isset($content['event-data']['event'])
         ) {
             throw new RejectWebhookException(406, 'Payload is malformed.');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`MailgunRequestParser` reads `signature.timestamp`, `signature.token` and `signature.signature` from the JSON body and passes them to `hash_equals()` and to string concatenation. It only checked that the keys are set. A body with a number or an array in one of these fields passed that check and reached `hash_equals()`, which threw a `TypeError` (a 500 response) instead of the `406` rejection used for every other malformed payload. An array in `signature.token` also raised an "Array to string conversion" warning.

Mailgun documents these three fields as strings (https://documentation.mailgun.com/docs/mailgun/user-manual/webhooks/securing-webhooks), so a non-string value is a malformed payload and never a valid signed request.

This PR replaces the `isset()` checks with `is_string()` checks on the three signature fields. Such bodies now get the same `RejectWebhookException(406, 'Payload is malformed.')` as a body with a missing field. Valid payloads, the timestamp tolerance and the signature comparison are unchanged.

Checks run:
- The new test with the fix reverted: 1 error ("Array to string conversion") and 2 failures (`TypeError` from `hash_equals()` instead of `RejectWebhookException`).
- `./phpunit src/Symfony/Component/Mailer/Bridge/Mailgun`: OK (58 tests, 130 assertions).
- `php .github/sa-tools/check-hardening-tests.php`: convention satisfied.
