### PR TITLE
[Notifier][Twilio] Sign the query string as sent instead of the normalized one

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Twilio/Tests/Webhook/TwilioRequestParserTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Twilio/Tests/Webhook/TwilioRequestParserTest.php
@@ -59,6 +59,27 @@ class TwilioRequestParserTest extends AbstractRequestParserTestCase
         $this->assertSame('SM1234', $event->getId());
     }
 
+    public function testQueryStringIsSignedAsSent()
+    {
+        $secret = 's3cret-token';
+        $params = [
+            'MessageSid' => 'SM1234',
+            'MessageStatus' => 'delivered',
+            'To' => '+15555550100',
+        ];
+        $url = 'https://example.com/webhook?foo=1&bar=2';
+        $signature = $this->computeTwilioSignature($url, $params, $secret);
+
+        $request = Request::create($url, 'POST', $params, [], [], [
+            'Content-Type' => 'application/x-www-form-urlencoded',
+            'HTTP_X-Twilio-Signature' => $signature,
+        ]);
+
+        $event = (new TwilioRequestParser())->parse($request, $secret);
+        $this->assertNotNull($event);
+        $this->assertSame('SM1234', $event->getId());
+    }
+
     public function testMissingSignatureHeaderIsRejected()
     {
         $request = Request::create('https://example.com/webhook', 'POST', [

--- a/src/Symfony/Component/Notifier/Bridge/Twilio/Webhook/TwilioRequestParser.php
+++ b/src/Symfony/Component/Notifier/Bridge/Twilio/Webhook/TwilioRequestParser.php
@@ -79,7 +79,11 @@ final class TwilioRequestParser extends AbstractRequestParser
         }
 
         ksort($payload);
-        $data = $request->getUri();
+        // the query string must be signed as sent, getUri() would normalize it
+        $data = $request->getSchemeAndHttpHost().$request->getBaseUrl().$request->getPathInfo();
+        if ('' !== $qs = (string) $request->server->get('QUERY_STRING')) {
+            $data .= '?'.$qs;
+        }
         foreach ($payload as $key => $value) {
             $data .= $key.$value;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Twilio signs its webhooks over the full URL as configured in the console, followed by the POST parameters sorted by key (see https://www.twilio.com/docs/usage/webhooks/webhooks-security). The query string is part of that URL exactly as Twilio sent it.

`TwilioRequestParser` rebuilt the URL with `Request::getUri()`. That method normalizes the query string: it parses it, sorts the keys and re-encodes it. Any webhook URL whose query parameters are not already in sorted order, for example the `?foo=1&bar=2` shape used in the vendor documentation, produces a different string than the one Twilio signed, and the webhook is rejected with "Signature is invalid."

The fix builds the URL from scheme, host, base URL and path info, and appends the raw `QUERY_STRING` as received. The signature formula itself is unchanged, and URLs without a query string are signed exactly as before.

Checks:
- New test `testQueryStringIsSignedAsSent` fails before the fix (`RejectWebhookException: Signature is invalid.` at `TwilioRequestParser.php:90`) and passes after.
- `./phpunit src/Symfony/Component/Notifier/Bridge/Twilio`: `Tests: 57, Assertions: 121, Skipped: 1`.
- `php .github/sa-tools/check-hardening-tests.php`: convention satisfied.
- A PHP probe of the vendor documentation shape, `https://example.com/myapp.php?foo=1&bar=2` with token `12345` and a signature computed with the documented formula: `getUri()` returns `https://example.com/myapp.php?bar=2&foo=1` and the parser rejects the request before the fix; it accepts it after the fix.
