### PR TITLE
[Mailer] Add forged and missing signature tests to the AhaSend and Mailomat webhook parsers

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/AhaSend/Tests/Webhook/AhaSendWrongSignatureRequestParserTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/AhaSend/Tests/Webhook/AhaSendWrongSignatureRequestParserTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\AhaSend\Tests\Webhook;
+
+use PHPUnit\Framework\Attributes\Group;
+use Symfony\Bridge\PhpUnit\ClockMock;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Mailer\Bridge\AhaSend\RemoteEvent\AhaSendPayloadConverter;
+use Symfony\Component\Mailer\Bridge\AhaSend\Webhook\AhaSendRequestParser;
+use Symfony\Component\Webhook\Client\RequestParserInterface;
+use Symfony\Component\Webhook\Exception\RejectWebhookException;
+use Symfony\Component\Webhook\Test\AbstractRequestParserTestCase;
+
+#[Group('time-sensitive')]
+class AhaSendWrongSignatureRequestParserTest extends AbstractRequestParserTestCase
+{
+    protected function createRequestParser(): RequestParserInterface
+    {
+        $this->expectException(RejectWebhookException::class);
+        $this->expectExceptionMessage('Invalid signature');
+
+        return new AhaSendRequestParser(new AhaSendPayloadConverter());
+    }
+
+    public static function getPayloads(): iterable
+    {
+        $payload = '{"type":"message.delivered","timestamp":"2024-01-01T00:00:00Z","data":{}}';
+
+        yield 'forged signature' => [$payload, []];
+        yield 'signed with another secret' => [$payload, []];
+    }
+
+    protected function getSecret(): string
+    {
+        return 'nxLe:L:fZLb7J_Wb3uFeWX/&z4Ed#9&DxPL%Ud&:jhpAW1gLaR%AEFwfKnwp60cC';
+    }
+
+    protected function createRequest(string $payload): Request
+    {
+        $signature = 'forged signature' === $this->dataName() ? 'v1,'.base64_encode(random_bytes(32)) : 'v1,'.base64_encode(hash_hmac('sha256', "id.1730057850.$payload", 'another-secret', true));
+
+        ClockMock::withClockMock(1730057850);
+
+        return Request::create('/', 'POST', [], [], [], [
+            'CONTENT_TYPE' => 'application/json',
+            'HTTP_webhook-id' => 'id',
+            'HTTP_webhook-timestamp' => '1730057850',
+            'HTTP_webhook-signature' => $signature,
+        ], $payload);
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/Mailomat/Tests/Webhook/MailomatRequestParserTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailomat/Tests/Webhook/MailomatRequestParserTest.php
@@ -80,6 +80,27 @@ class MailomatRequestParserTest extends AbstractRequestParserTestCase
         ], str_replace("\n", "\r\n", $payload));
     }
 
+    public function testRejectsForgedSignature()
+    {
+        $request = $this->createRequest(file_get_contents(__DIR__.'/Fixtures/delivered.json'));
+        $request->headers->set('X-MOM-Webhook-Signature', 'sha256='.hash_hmac('sha256', '1d958822-0934-4c6a-abc8-5defec4baa64.delivered.1718004211', 'another-secret'));
+
+        $this->expectException(RejectWebhookException::class);
+        $this->expectExceptionMessage('Signature is wrong.');
+
+        $this->createRequestParser()->parse($request, $this->getSecret());
+    }
+
+    public function testRejectsMissingSignature()
+    {
+        $request = $this->createRequest(file_get_contents(__DIR__.'/Fixtures/delivered.json'));
+        $request->headers->remove('X-MOM-Webhook-Signature');
+
+        $this->expectException(RejectWebhookException::class);
+
+        $this->createRequestParser()->parse($request, $this->getSecret());
+    }
+
     #[DataProvider('provideNonSha256Algorithms')]
     public function testRejectsNonSha256Algorithm(string $algo)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The AhaSend and Mailomat webhook parsers compare the request signature with `hash_equals()` against an HMAC computed from the secret. That code is correct. Their test suites only covered the happy path and the stale-timestamp case: no test sent a request with a forged signature, one signed with another secret, or no signature at all. Disabling the `hash_equals()` check left both suites green.

This PR adds those cases:

- AhaSend: a new `AhaSendWrongSignatureRequestParserTest` sends a random signature and a signature computed with another secret. Both must be rejected with `Invalid signature`.
- Mailomat: `testRejectsForgedSignature` sends a signature computed with another secret and expects `Signature is wrong.`; `testRejectsMissingSignature` drops the signature header and expects a `RejectWebhookException`.

Tests only. No parser code changes, no changelog entry. The tests pin the reject path so that `.github/sa-tools/check-hardening-tests.php` keeps covering it.

Checks:

- With the `hash_equals()` condition replaced by `false` in each parser, the new tests fail (AhaSend: both forged cases reach the converter; Mailomat: `testRejectsForgedSignature` raises no exception). With the check restored, they pass.
- `./phpunit src/Symfony/Component/Mailer/Bridge/AhaSend`: OK (42 tests, 93 assertions).
- `./phpunit src/Symfony/Component/Mailer/Bridge/Mailomat`: OK (32 tests, 62 assertions).
- `php .github/sa-tools/check-hardening-tests.php`: convention satisfied, 0 allow-listed gaps.
