### PR TITLE
[Mailer][Postmark] Check basic auth credentials against the webhook secret

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Postmark/Tests/Webhook/PostmarkRequestParserTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/Tests/Webhook/PostmarkRequestParserTest.php
@@ -25,11 +25,17 @@ class PostmarkRequestParserTest extends AbstractRequestParserTestCase
         return new PostmarkRequestParser(new PostmarkPayloadConverter());
     }
 
+    protected function getSecret(): string
+    {
+        return 'symfony:top-secret';
+    }
+
     protected function createRequest(string $payload): Request
     {
         return Request::create('/', 'POST', [], [], [], [
             'Content-Type' => 'application/json',
             'REMOTE_ADDR' => '3.134.147.250',
+            'HTTP_Authorization' => 'Basic '.base64_encode('symfony:top-secret'),
         ], $payload);
     }
 
@@ -61,5 +67,34 @@ class PostmarkRequestParserTest extends AbstractRequestParserTestCase
         ], $payload);
 
         $this->assertNotNull($parser->parse($request, ''));
+    }
+
+    public function testRejectMissingCredentials()
+    {
+        $parser = new PostmarkRequestParser(new PostmarkPayloadConverter());
+        $payload = file_get_contents(__DIR__.'/Fixtures/delivery.json');
+        $request = Request::create('/', 'POST', [], [], [], [
+            'Content-Type' => 'application/json',
+            'REMOTE_ADDR' => '3.134.147.250',
+        ], $payload);
+
+        $this->expectException(RejectWebhookException::class);
+        $this->expectExceptionMessage('Invalid credentials.');
+        $parser->parse($request, 'symfony:top-secret');
+    }
+
+    public function testRejectWrongSecret()
+    {
+        $parser = new PostmarkRequestParser(new PostmarkPayloadConverter());
+        $payload = file_get_contents(__DIR__.'/Fixtures/delivery.json');
+        $request = Request::create('/', 'POST', [], [], [], [
+            'Content-Type' => 'application/json',
+            'REMOTE_ADDR' => '3.134.147.250',
+            'HTTP_Authorization' => 'Basic '.base64_encode('symfony:wrong-secret'),
+        ], $payload);
+
+        $this->expectException(RejectWebhookException::class);
+        $this->expectExceptionMessage('Invalid credentials.');
+        $parser->parse($request, 'symfony:top-secret');
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/Webhook/PostmarkRequestParser.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/Webhook/PostmarkRequestParser.php
@@ -45,6 +45,10 @@ final class PostmarkRequestParser extends AbstractRequestParser
 
     protected function doParse(Request $request, #[\SensitiveParameter] string $secret): ?AbstractMailerEvent
     {
+        if ($secret && !hash_equals('Basic '.base64_encode($secret), $request->headers->get('Authorization', ''))) {
+            throw new RejectWebhookException(403, 'Invalid credentials.');
+        }
+
         $payload = $request->toArray();
         if (
             !isset($payload['RecordType'])


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

`PostmarkRequestParser` authenticates webhook requests by IP allowlist only. The `$secret` passed to `parse()` is ignored, so configuring one in the webhook settings has no effect.

Postmark does not sign webhook payloads. Its documentation states that HMAC signature verification is not supported, and recommends HTTP basic auth credentials in the webhook URL (`https://<username>:<password>@example.com/webhook`) combined with the IP allowlist: https://postmarkapp.com/developer/webhooks/webhooks-overview

This PR makes the parser check the `Authorization` header against the configured secret, the same way the Mailjet and Brevo parsers do: when the secret is not empty, the header must equal `Basic base64("user:password")`, compared with `hash_equals()`. A missing or wrong header is rejected with a 403 before the payload is read. The IP allowlist is unchanged and still applies.

Behavior change for operators: a secret that was set to an arbitrary value was silently ignored so far. It must now be set to the `user:password` pair configured in the Postmark webhook URL, or left empty to keep IP-only authentication.

Checks:
- `./phpunit src/Symfony/Component/Mailer/Bridge/Postmark`: OK (47 tests, 89 assertions); the two new reject tests fail without the parser change
- `php .github/sa-tools/check-hardening-tests.php`: satisfied
