### PR TITLE
[Mailer][Scaleway] Pin the SigningCertURL host of webhook notifications

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Scaleway/Tests/Webhook/ScalewayRequestParserSignatureTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Scaleway/Tests/Webhook/ScalewayRequestParserSignatureTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Mailer\Bridge\Scaleway\Tests\Webhook;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\HttpClient\MockHttpClient;
@@ -47,14 +48,37 @@ class ScalewayRequestParserSignatureTest extends TestCase
         $parser->parse($this->createRequest($envelope), '');
     }
 
-    public function testRejectsNonHttpsSigningCertUrl()
+    #[DataProvider('provideForeignSigningCertUrls')]
+    public function testRejectsSigningCertUrlOnForeignHostWithoutFetchingIt(string $certUrl)
     {
-        $envelope = $this->createSignedEnvelope(certUrl: 'http://messaging.s3.fr-par.scw.cloud/certs/cert-11111111.pem');
-        $parser = $this->createParser($this->createCertClient());
+        $envelope = $this->createSignedEnvelope(certUrl: $certUrl);
+        $parser = $this->createParser(new MockHttpClient(static fn () => throw new \LogicException('The certificate must not be fetched.')));
 
         $this->expectException(RejectWebhookException::class);
-        $this->expectExceptionMessage('The signing certificate URL must use HTTPS.');
+        $this->expectExceptionMessage('The signing certificate URL must point to Scaleway over HTTPS.');
         $parser->parse($this->createRequest($envelope), '');
+    }
+
+    public static function provideForeignSigningCertUrls(): iterable
+    {
+        yield 'plain http' => ['http://messaging.s3.fr-par.scw.cloud/certs/cert-11111111.pem'];
+        yield 'other domain' => ['https://example.com/cert.pem'];
+        yield 'other bucket on Scaleway object storage' => ['https://attacker.s3.fr-par.scw.cloud/cert.pem'];
+        yield 'lookalike domain' => ['https://messaging.s3.fr-par.scw.cloud.example.com/cert.pem'];
+        yield 'userinfo trick' => ['https://messaging.s3.fr-par.scw.cloud@example.com/cert.pem'];
+        yield 'private address' => ['https://169.254.169.254/latest/meta-data/'];
+        yield 'explicit port' => ['https://messaging.s3.fr-par.scw.cloud:8443/cert.pem'];
+        yield 'backslash after host' => ['https://messaging.s3.fr-par.scw.cloud\\@example.com/cert.pem'];
+        yield 'host without path' => ['https://messaging.s3.fr-par.scw.cloud'];
+        yield 'leading whitespace' => [' https://messaging.s3.fr-par.scw.cloud/cert.pem'];
+    }
+
+    public function testAcceptsSigningCertUrlOnEveryScalewayRegion()
+    {
+        $envelope = $this->createSignedEnvelope(certUrl: 'https://messaging.s3.nl-ams.scw.cloud/nl-ams/sns/sns_certificate_123.crt');
+        $parser = $this->createParser($this->createCertClient());
+
+        $this->assertInstanceOf(MailerDeliveryEvent::class, $parser->parse($this->createRequest($envelope), ''));
     }
 
     public function testRejectsUnsupportedSignatureVersion()

--- a/src/Symfony/Component/Mailer/Bridge/Scaleway/Webhook/ScalewayRequestParser.php
+++ b/src/Symfony/Component/Mailer/Bridge/Scaleway/Webhook/ScalewayRequestParser.php
@@ -37,6 +37,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 final class ScalewayRequestParser extends AbstractRequestParser
 {
+    private const SIGNING_CERT_URL = '{^https://messaging\.s3\.[a-z]{2}-[a-z]{3}\.scw\.cloud/}i';
+
     private const SIGNED_KEYS = [
         'Notification' => ['Message', 'MessageId', 'Subject', 'Timestamp', 'TopicArn', 'Type'],
         'SubscriptionConfirmation' => ['Message', 'MessageId', 'SubscribeURL', 'Timestamp', 'Token', 'TopicArn', 'Type'],
@@ -127,8 +129,8 @@ final class ScalewayRequestParser extends AbstractRequestParser
         }
 
         $certUrl = $payload['SigningCertURL'];
-        if ('https' !== strtolower((string) parse_url($certUrl, \PHP_URL_SCHEME))) {
-            throw new RejectWebhookException(406, 'The signing certificate URL must use HTTPS.');
+        if (!preg_match(self::SIGNING_CERT_URL, $certUrl)) {
+            throw new RejectWebhookException(406, 'The signing certificate URL must point to Scaleway over HTTPS.');
         }
 
         $cacheKey = 'scaleway_sns_cert.'.hash('xxh128', $certUrl);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`ScalewayRequestParser` fetches the certificate named by the `SigningCertURL` field of the notification. The only check on that URL was the `https` scheme. The field comes from the request body, before the signature is verified, so anyone who can reach the webhook endpoint could make the application send a GET request to any HTTPS host. The CA chain check still rejects the response, so this cannot forge a signature. It is an unauthenticated request to an attacker-chosen host, nothing more.

This PR rejects the message before any request is made unless `SigningCertURL` starts with the literal `https://messaging.s3.<region>.scw.cloud/`. The check is a prefix match on the raw string, not a `parse_url()` call: a literal scheme and host followed by `/` leaves no room for userinfo, ports, backslashes or any other input where PHP's parser and the HTTP client could disagree on the host. It also subsumes the previous HTTPS-only check. This mirrors what the AWS SDKs do for SNS, where the host must match `sns.<region>.amazonaws.com`.

Evidence for the host:
- Scaleway's [Topics and Events code samples](https://www.scaleway.com/en/docs/topics-and-events/api-cli/python-node-topics-events/) show a real envelope with `"SigningCertURL": "https://messaging.s3.fr-par.scw.cloud/fr-par/sns/sns_certificate_[certSerialNumber].crt"`.
- The [webhook verification guide](https://www.scaleway.com/en/docs/topics-and-events/reference-content/verifying-webhooks/) serves the CA trust chain of both regions (fr-par and nl-ams) from the same host, `messaging.s3.fr-par.scw.cloud`. The region is kept variable in the pattern in case other regions get their own bucket.
- No Scaleway document shows any other host. The lowercase `<xx>-<yyy>` region shape covers every Scaleway region today.

No public API is added. An allowed-host constructor parameter was considered and dropped: the host is a property of the provider, not of the application, and if Scaleway moves the certificates the fix belongs in the bridge for every user at once.

What does not change:
- The signature and CA chain checks are the same as before.
- `SubscribeURL` is still only checked for `https`. It is part of the signed string, so it is only followed after the signature has been verified with a certificate issued by the Scaleway CA.
- The cache key was already a hash of the URL, so its length is bounded.

Checks:
- `./phpunit src/Symfony/Component/Mailer/Bridge/Scaleway`: OK (42 tests, 72 assertions)
- The new `testRejectsSigningCertUrlOnForeignHostWithoutFetchingIt` cases fail without the fix, with the mock client reporting an attempted fetch.
- `php .github/sa-tools/check-hardening-tests.php`: Hardening-test convention satisfied (0 allow-listed gap(s)).
- php-cs-fixer: no change.

