### PR TITLE
[Notifier][Lox24] Match JSON webhook requests only

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Lox24/Tests/Webhook/Lox24RequestParserTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Lox24/Tests/Webhook/Lox24RequestParserTest.php
@@ -375,8 +375,30 @@ class Lox24RequestParserTest extends TestCase
         $this->assertSame($payload, $event->getPayload());
     }
 
+    public function testFormEncodedRequestIsRejected()
+    {
+        $this->expectException(RejectWebhookException::class);
+        $this->expectExceptionMessage('Request does not match.');
+
+        $request = Request::create('/test', 'POST', [
+            'id' => 'webhook-id',
+            'name' => 'sms.delivery',
+            'data' => ['id' => '123', 'status_code' => 100],
+        ]);
+        $this->parser->parse($request, '');
+    }
+
+    public function testNonObjectJsonBodyIsRejected()
+    {
+        $this->expectException(RejectWebhookException::class);
+        $this->expectExceptionMessage('The payload must be a JSON object.');
+
+        $request = Request::create('/test', 'POST', [], [], [], ['CONTENT_TYPE' => 'application/json'], '"not an object"');
+        $this->parser->parse($request, '');
+    }
+
     private function getRequest(array $data, array $server = []): Request
     {
-        return Request::create('/test', 'POST', $data, [], [], $server);
+        return Request::create('/test', 'POST', [], [], [], ['CONTENT_TYPE' => 'application/json'] + $server, json_encode($data));
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Lox24/Webhook/Lox24RequestParser.php
+++ b/src/Symfony/Component/Notifier/Bridge/Lox24/Webhook/Lox24RequestParser.php
@@ -11,7 +11,10 @@
 
 namespace Symfony\Component\Notifier\Bridge\Lox24\Webhook;
 
+use Symfony\Component\HttpFoundation\ChainRequestMatcher;
+use Symfony\Component\HttpFoundation\Exception\JsonException;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcher\IsJsonRequestMatcher;
 use Symfony\Component\HttpFoundation\RequestMatcher\MethodRequestMatcher;
 use Symfony\Component\HttpFoundation\RequestMatcherInterface;
 use Symfony\Component\RemoteEvent\Event\Sms\SmsEvent;
@@ -28,7 +31,10 @@ final class Lox24RequestParser extends AbstractRequestParser
 {
     protected function getRequestMatcher(): RequestMatcherInterface
     {
-        return new MethodRequestMatcher('POST');
+        return new ChainRequestMatcher([
+            new MethodRequestMatcher('POST'),
+            new IsJsonRequestMatcher(),
+        ]);
     }
 
     /**
@@ -43,7 +49,12 @@ final class Lox24RequestParser extends AbstractRequestParser
             }
         }
 
-        $payload = $request->getPayload()->all();
+        try {
+            $payload = $request->toArray();
+        } catch (JsonException) {
+            throw new RejectWebhookException(406, 'The payload must be a JSON object.');
+        }
+
         $name = $payload['name'] ?? null;
         $data = $payload['data'] ?? null;
         $id = $payload['id'] ?? null;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Follow-up to #65712, which made the Lox24 webhook parser read the JSON body.

The LOX24 OpenAPI spec (https://doc.lox24.eu/openapi-en.json) declares `application/json` as the only content type of every `webhooks.*` callback, and the `notifications` tag states that the JSON is sent as the request body with `Content-Type: application/json`. This PR aligns the request matcher with that contract:

- `getRequestMatcher()` now chains `MethodRequestMatcher('POST')` with `IsJsonRequestMatcher()`, the same shape as the Mailtrap parser. A form-encoded request is rejected with "Request does not match." before the token check.
- With a JSON-only matcher the form fallback of `getPayload()` is unused code, so the payload is read with `toArray()`. A JSON body that is not an object is rejected with a 406 instead of leaking the `JsonException` thrown by `toArray()`.
- The test helper now sends JSON bodies so every existing case exercises the real path; two rejection tests were added (form-encoded request, non-object JSON body). Both failed before the change.

Checks: `./phpunit src/Symfony/Component/Notifier/Bridge/Lox24` returns `OK (62 tests, 169 assertions)`; `php .github/sa-tools/check-hardening-tests.php` is satisfied. The matchers exist since HttpFoundation 6.2 and reach the bridge through `symfony/webhook ^6.4`, so no constraint change.
