### PR TITLE
[Psalm] Disable the Override attribute check

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -10,6 +10,7 @@
     findUnusedBaselineEntry="false"
     findUnusedCode="false"
     findUnusedIssueHandlerSuppression="false"
+    ensureOverrideAttribute="false"
 >
     <projectFiles>
         <directory name="src" />


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Psalm reports `MissingOverrideAttribute` for every overriding method it sees, and CI generates the baseline from the base branch at run time, so the report shows up for any pull request that touches a file with an override, whether or not the change is related. 5.4 supports PHP 7.2, so the `#[\Override]` attribute cannot be added. 6.4 and up carry `ensureOverrideAttribute="false"` since b188dccd491; this sets the same flag on 5.4.

Checked locally with Psalm 6.16.1 on `BinaryFileResponse.php`: the three `MissingOverrideAttribute` errors go away, the remaining reports are the ones already covered by the generated baseline.
