### PR TITLE
[VarDumper] Escape UTF-8 encoded C1 control characters

### DIFF
--- a/src/Symfony/Component/VarDumper/Dumper/CliDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/CliDumper.php
@@ -42,7 +42,7 @@ class CliDumper extends AbstractDumper
         'index' => '38;5;38',
     ];
 
-    protected static $controlCharsRx = '/[\x00-\x1F\x7F]+/';
+    protected static $controlCharsRx = '/(?:[\x00-\x1F\x7F]|\xC2[\x80-\x9F])+/';
     protected static $controlCharsMap = [
         "\t" => '\t',
         "\n" => '\n',

--- a/src/Symfony/Component/VarDumper/Tests/Dumper/CliDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/CliDumperTest.php
@@ -29,6 +29,13 @@ class CliDumperTest extends TestCase
 {
     use VarDumperTestTrait;
 
+    public function testC1ControlCharsAreEscaped()
+    {
+        $this->assertDumpEquals('"a\xC2\x9Bb"', "a\u{9B}b");
+        $this->assertDumpEquals('"\e\xC2\x9B\xC2\x80"', "\e\u{9B}\u{80}");
+        $this->assertDumpEquals("\"\u{A0}\u{E9}\"", "\u{A0}\u{E9}");
+    }
+
     public function testGet()
     {
         require __DIR__.'/../Fixtures/dumb-var.php';

--- a/src/Symfony/Component/VarDumper/Tests/Dumper/HtmlDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/HtmlDumperTest.php
@@ -21,6 +21,18 @@ use Symfony\Component\VarDumper\Dumper\HtmlDumper;
  */
 class HtmlDumperTest extends TestCase
 {
+    public function testC1ControlCharsAreEscaped()
+    {
+        $dumper = new HtmlDumper('php://output');
+        $dumper->setDumpHeader('<foo></foo>');
+        $dumper->setDumpBoundaries('<bar>', '</bar>');
+        $cloner = new VarCloner();
+
+        $out = $dumper->dump($cloner->cloneVar("a\u{9B}b"), true);
+
+        $this->assertStringContainsString('a<span class="sf-dump-default">\xC2\x9B</span>b', $out);
+    }
+
     public function testGet()
     {
         if (\ini_get('xdebug.file_link_format') || get_cfg_var('xdebug.file_link_format')) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`CliDumper` renders C0 control characters and DEL as escape sequences such as `\e` or `\x01`, so that a dumped string cannot drive the terminal. The C1 control characters (U+0080 to U+009F) were left as is. In UTF-8 mode, xterm-like terminals interpret them the same way as their 7-bit ESC forms: U+009B is CSI and U+009D is OSC, so a string coming from user input and dumped on a terminal (with `dump()` in a CLI, or through `server:dump`) could move the cursor, clear the screen or set a spoofed hyperlink.

They are now rendered the way C0 characters are, as the bytes of their UTF-8 encoding: U+009B shows as `\xC2\x9B`. The non-breaking space (U+00A0) and every other non-ASCII character are unchanged. The pattern is shared with `HtmlDumper`, which now shows the same escaped form inside a `sf-dump-default` span instead of an invisible numeric entity, consistent with how it shows C0 characters.

This targets 5.4 on purpose. The change is hardening rather than a security fix, and 5.4 takes security fixes only, so a hardening change would normally start on the lowest branch that still receives bug fixes. It is proposed here deliberately, so that the long term support branch does not keep a defect that the maintained branches are having fixed.

Checks: the new tests fail on the current code (the character passes through, `"ab"`), and pass with the change; the VarDumper suite is green (php 8.4). The pattern line is identical on 6.4 and, with a `string` type, on 7.4 and 8.2, so the merge-up applies as is.
