### PR TITLE
[HttpClient][MonologBridge][Security][Validator][VarDumper] Fix the tests that depend on unreleased siblings and the redirect test server

### DIFF
--- a/src/Symfony/Bridge/Monolog/Tests/Formatter/ConsoleFormatterTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Formatter/ConsoleFormatterTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Bridge\Monolog\Tests\Formatter;
 use Monolog\Logger;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Monolog\Formatter\ConsoleFormatter;
+use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\VarDumper\Cloner\VarCloner;
 
 class ConsoleFormatterTest extends TestCase
@@ -75,8 +76,8 @@ class ConsoleFormatterTest extends TestCase
 
         $this->assertStringNotContainsString("\033", $output);
         $this->assertStringNotContainsString("\u{9b}", $output);
-        $this->assertStringContainsString('[\<fg=red\>app\</\>]', $output);
-        $this->assertStringContainsString('SELECT * FROM t WHERE a \< 1 AND b \> 2', $output);
+        $this->assertStringContainsString('['.OutputFormatter::escape('<fg=red>app</>').']', $output);
+        $this->assertStringContainsString(OutputFormatter::escape('SELECT * FROM t WHERE a < 1 AND b > 2'), $output);
     }
 
     public function testItEscapesTheDumpedContext()
@@ -85,7 +86,7 @@ class ConsoleFormatterTest extends TestCase
 
         $record = self::createRecord(['context' => ['user' => '<fg=red>alice</>']]);
 
-        $this->assertStringContainsString('"user" =\> "\<fg=red\>alice\</\>"', $formatter->format($record));
+        $this->assertStringContainsString(OutputFormatter::escape('"user" => "<fg=red>alice</>"'), $formatter->format($record));
     }
 
     public function testItKeepsTheMarkupAroundReplacedPlaceholders()
@@ -94,7 +95,7 @@ class ConsoleFormatterTest extends TestCase
 
         $record = self::createRecord(['message' => 'Hello {user}', 'context' => ['user' => '<fg=red>alice</>']]);
 
-        $this->assertStringContainsString('Hello <comment>\<fg=red\>alice\</\></>', $formatter->format($record));
+        $this->assertStringContainsString('Hello <comment>'.OutputFormatter::escape('<fg=red>alice</>').'</>', $formatter->format($record));
     }
 
     public function testPlaceholderInMessageWithDataContext()

--- a/src/Symfony/Component/HttpClient/Tests/Fixtures/tls/redirect-server.php
+++ b/src/Symfony/Component/HttpClient/Tests/Fixtures/tls/redirect-server.php
@@ -16,7 +16,11 @@ $port = (int) ($argv[1] ?? 8059);
 $context = stream_context_create(['ssl' => ['local_cert' => __DIR__.'/server.crt', 'local_pk' => __DIR__.'/server.key']]);
 $server = stream_socket_server('tcp://127.0.0.1:'.$port, $errno, $errstr, \STREAM_SERVER_BIND | \STREAM_SERVER_LISTEN, $context);
 
-while ($conn = @stream_socket_accept($server, 30)) {
+while (true) {
+    if (!$conn = @stream_socket_accept($server, 30)) {
+        continue;
+    }
+
     $tls = "\x16" === stream_socket_recvfrom($conn, 1, \STREAM_PEEK);
 
     if ($tls && !@stream_socket_enable_crypto($conn, true, \STREAM_CRYPTO_METHOD_TLS_SERVER)) {

--- a/src/Symfony/Component/HttpClient/Tests/TestRedirectServer.php
+++ b/src/Symfony/Component/HttpClient/Tests/TestRedirectServer.php
@@ -23,7 +23,7 @@ class TestRedirectServer
 
     public static function start(): void
     {
-        if (self::$process) {
+        if (self::$process && self::$process->isRunning()) {
             return;
         }
 

--- a/src/Symfony/Component/Security/Core/Tests/Signature/SignatureHasherTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Signature/SignatureHasherTest.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Tests\Signature;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\Security\Core\Signature\Exception\ExpiredSignatureException;
+use Symfony\Component\Security\Core\Signature\ExpiredSignatureStorage;
+use Symfony\Component\Security\Core\Signature\SignatureHasher;
+use Symfony\Component\Security\Core\User\InMemoryUser;
+
+class SignatureHasherTest extends TestCase
+{
+    public function testVerifySignatureHashRejectsAConcurrentUsageBeyondMaxUses()
+    {
+        $user = new InMemoryUser('john', 'pa$$word');
+        $expires = time() + 500;
+        $hasher = null;
+        $hash = null;
+
+        // the same hash is verified a second time while the first verification reads the usage counter
+        $cache = new ConcurrentUsageCache(new ArrayAdapter(), static function () use (&$hasher, &$hash, $user, $expires) {
+            $hasher->verifySignatureHash($user, $expires, $hash);
+        });
+        $hasher = new SignatureHasher(PropertyAccess::createPropertyAccessor(), ['password'], 's3cret', new ExpiredSignatureStorage($cache, 360), 1);
+        $hash = $hasher->computeSignatureHash($user, $expires);
+
+        $this->expectException(ExpiredSignatureException::class);
+        $hasher->verifySignatureHash($user, $expires, $hash);
+    }
+}
+
+class ConcurrentUsageCache implements CacheItemPoolInterface
+{
+    private $pool;
+    private $concurrentUsage;
+
+    public function __construct(CacheItemPoolInterface $pool, callable $concurrentUsage)
+    {
+        $this->pool = $pool;
+        $this->concurrentUsage = \Closure::fromCallable($concurrentUsage);
+    }
+
+    public function getItem($key): CacheItemInterface
+    {
+        if ($concurrentUsage = $this->concurrentUsage) {
+            $this->concurrentUsage = null;
+            $concurrentUsage();
+        }
+
+        return $this->pool->getItem($key);
+    }
+
+    public function getItems(array $keys = []): iterable
+    {
+        return $this->pool->getItems($keys);
+    }
+
+    public function hasItem($key): bool
+    {
+        return $this->pool->hasItem($key);
+    }
+
+    public function clear(): bool
+    {
+        return $this->pool->clear();
+    }
+
+    public function deleteItem($key): bool
+    {
+        return $this->pool->deleteItem($key);
+    }
+
+    public function deleteItems(array $keys): bool
+    {
+        return $this->pool->deleteItems($keys);
+    }
+
+    public function save(CacheItemInterface $item): bool
+    {
+        return $this->pool->save($item);
+    }
+
+    public function saveDeferred(CacheItemInterface $item): bool
+    {
+        return $this->pool->saveDeferred($item);
+    }
+
+    public function commit(): bool
+    {
+        return $this->pool->commit();
+    }
+}

--- a/src/Symfony/Component/Security/Core/composer.json
+++ b/src/Symfony/Component/Security/Core/composer.json
@@ -31,6 +31,7 @@
         "symfony/expression-language": "^4.4|^5.0|^6.0",
         "symfony/http-foundation": "^5.3|^6.0",
         "symfony/ldap": "^4.4|^5.0|^6.0",
+        "symfony/property-access": "^5.4|^6.0",
         "symfony/translation": "^5.4.35|~6.3.12|^6.4.3",
         "symfony/validator": "^5.2|^6.0",
         "psr/log": "^1|^2|^3"

--- a/src/Symfony/Component/Security/Http/Tests/LoginLink/LoginLinkHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/LoginLink/LoginLinkHandlerTest.php
@@ -14,7 +14,6 @@ namespace Symfony\Component\Security\Http\Tests\LoginLink;
 use PHPUnit\Framework\Constraint\Constraint;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\HttpFoundation\Request;
@@ -192,26 +191,6 @@ class LoginLinkHandlerTest extends TestCase
         $linker->consumeLoginLink($request);
     }
 
-    public function testConsumeLoginLinkExceedsMaxUsageWhenConsumedConcurrently()
-    {
-        $expires = time() + 500;
-        $signature = $this->createSignatureHash('weaverryan', $expires);
-        $request = Request::create(sprintf('/login/verify?user=weaverryan&hash=%s&expires=%d', $signature, $expires));
-
-        $user = new TestLoginLinkHandlerUser('weaverryan', 'ryan@symfonycasts.com', 'pwhash');
-        $this->userProvider->createUser($user);
-
-        $linker = null;
-        // consume the same link a second time while the first consumption reads the usage counter
-        $this->expiredLinkCache = new TestLoginLinkConcurrentCache(new ArrayAdapter(), static function () use (&$linker, $request) {
-            $linker->consumeLoginLink($request);
-        });
-        $this->expiredLinkStorage = new ExpiredSignatureStorage($this->expiredLinkCache, 360);
-        $linker = $this->createLinker(['max_uses' => 1]);
-
-        $this->expectException(ExpiredLoginLinkException::class);
-        $linker->consumeLoginLink($request);
-    }
 
     public function testConsumeLoginLinkWithMissingHash()
     {
@@ -259,68 +238,6 @@ class LoginLinkHandlerTest extends TestCase
 /**
  * Runs a concurrent request the first time an item is read from the pool.
  */
-class TestLoginLinkConcurrentCache implements CacheItemPoolInterface
-{
-    private $pool;
-    private $concurrentRequest;
-
-    public function __construct(CacheItemPoolInterface $pool, callable $concurrentRequest)
-    {
-        $this->pool = $pool;
-        $this->concurrentRequest = \Closure::fromCallable($concurrentRequest);
-    }
-
-    public function getItem($key): CacheItemInterface
-    {
-        if ($concurrentRequest = $this->concurrentRequest) {
-            $this->concurrentRequest = null;
-            $concurrentRequest();
-        }
-
-        return $this->pool->getItem($key);
-    }
-
-    public function getItems(array $keys = []): iterable
-    {
-        return $this->pool->getItems($keys);
-    }
-
-    public function hasItem($key): bool
-    {
-        return $this->pool->hasItem($key);
-    }
-
-    public function clear(): bool
-    {
-        return $this->pool->clear();
-    }
-
-    public function deleteItem($key): bool
-    {
-        return $this->pool->deleteItem($key);
-    }
-
-    public function deleteItems(array $keys): bool
-    {
-        return $this->pool->deleteItems($keys);
-    }
-
-    public function save(CacheItemInterface $item): bool
-    {
-        return $this->pool->save($item);
-    }
-
-    public function saveDeferred(CacheItemInterface $item): bool
-    {
-        return $this->pool->saveDeferred($item);
-    }
-
-    public function commit(): bool
-    {
-        return $this->pool->commit();
-    }
-}
-
 class TestLoginLinkHandlerUser implements UserInterface
 {
     public $username;

--- a/src/Symfony/Component/Validator/Tests/Constraints/ExpressionLanguageSyntaxValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ExpressionLanguageSyntaxValidatorTest.php
@@ -66,19 +66,4 @@ class ExpressionLanguageSyntaxValidatorTest extends ConstraintValidatorTestCase
             ->assertRaised();
     }
 
-    public function testDeeplyNestedExpressionIsNotValid()
-    {
-        $expression = str_repeat('!', 300).'1';
-
-        $this->validator->validate($expression, new ExpressionLanguageSyntax([
-            'message' => 'myMessage',
-            'allowedVariables' => [],
-        ]));
-
-        $this->buildViolation('myMessage')
-            ->setParameter('{{ syntax_error }}', sprintf('"Expression is nested too deeply, the maximum nesting level is 256 around position 257 for expression `%s`."', $expression))
-            ->setInvalidValue($expression)
-            ->setCode(ExpressionLanguageSyntax::EXPRESSION_LANGUAGE_SYNTAX_ERROR)
-            ->assertRaised();
-    }
 }

--- a/src/Symfony/Component/VarDumper/Tests/Command/Descriptor/CliDescriptorTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Command/Descriptor/CliDescriptorTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\VarDumper\Tests\Command\Descriptor;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\VarDumper\Cloner\Data;
@@ -96,6 +97,10 @@ class CliDescriptorTest extends TestCase
 
     public function testItEscapesTheFileLink()
     {
+        if ('\<\>' !== OutputFormatter::escape('<>')) {
+            $this->markTestSkipped('The installed symfony/console does not escape adjacent brackets.');
+        }
+
         $output = new BufferedOutput();
         $output->setDecorated(true);
         $descriptor = new CliDescriptor(new CliDumper(function ($s) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Fixes the four failures the 5.4 branch shows since today's merges, one commit each:

- The Monolog bridge and VarDumper tests added by #65692 expected the output of the fixed `OutputFormatter::escape()`, which the low-deps job cannot see: the bridge allows `symfony/console ^4.4`, and 4.4 only escapes `<`. The expectations are now computed with the installed `escape()`, which is what the code under test applies, and the file-link test skips when the installed console does not escape adjacent brackets, since no href can be correct there.
- The Validator copy of the ExpressionLanguage nesting-depth test from #65690 fails on low-deps and high-deps until an ExpressionLanguage release carries the limit; the component's own `ParserTest` covers it, and the validator turns any `SyntaxError` into a violation without special code, so the copy is removed.
- The concurrent `max_uses` test from #65685 lived in Security/Http but exercises `SignatureHasher` and `ExpiredSignatureStorage` from Security/Core, so it failed on low-deps and high-deps with a released security-core. It now lives in Security/Core, where it fails on the previous `SignatureHasher` (verified) and passes on the current one; `symfony/property-access` is added to Core's require-dev, since `SignatureHasher` takes a `PropertyAccessorInterface`.
- The TLS redirect server from the HttpClient hardening exits after 30 seconds without a request, and `TestRedirectServer::start()` did not restart a dead server, so on the Windows job the second test class got "connection actively refused". The server now keeps accepting, and `start()` restarts it when it is gone.

Checks: Monolog bridge 114 tests, VarDumper Command tests 17, Validator constraint test 4, Security/Core signature test 1 (and 1 failure on the previous hasher), Security/Http LoginLink 11, the three HttpClient scheme-redirect tests 6: all green locally (php 8.4). The Windows behavior is reasoned from the server loop, not reproduced.
