### PR TITLE
[AssetMapper][Tui] Fix the tests failing on the 8.2 branch

### DIFF
--- a/src/Symfony/Component/AssetMapper/Tests/Command/AssetMapperCompileCommandTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/Command/AssetMapperCompileCommandTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\AssetMapper\Event\PreAssetsCompileEvent;
 use Symfony\Component\AssetMapper\Tests\Fixtures\AssetMapperTestAppKernel;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -115,6 +116,13 @@ class AssetMapperCompileCommandTest extends TestCase
     public function testReachableEntrypointMetadataIsCompiledWhenTheImportMapIsLimitedToIt()
     {
         $this->kernel = new AssetMapperTestAppKernel('reachable_entries', true);
+
+        try {
+            $this->kernel->boot();
+        } catch (InvalidConfigurationException) {
+            $this->markTestSkipped('The installed FrameworkBundle has no "importmap_entries" option.');
+        }
+
         $application = new Application($this->kernel);
 
         $targetBuildDir = $this->kernel->getProjectDir().'/public/assets';

--- a/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapGeneratorTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/ImportMap/ImportMapGeneratorTest.php
@@ -126,7 +126,7 @@ class ImportMapGeneratorTest extends TestCase
     public function testGetImportMapDataLimitedToTheReachableEntriesUsesTheCompiledMetadata()
     {
         $this->compiledConfigReader = $this->createMock(CompiledAssetMapperConfigReader::class);
-        $this->compiledConfigReader->expects($this->any())
+        $this->compiledConfigReader
             ->method('configExists')
             ->willReturnCallback(static fn (string $file) => 'entrypoint.reachable.app.json' === $file);
         $this->compiledConfigReader->expects($this->once())

--- a/src/Symfony/Component/Tui/Tests/Widget/FigletTest.php
+++ b/src/Symfony/Component/Tui/Tests/Widget/FigletTest.php
@@ -186,7 +186,7 @@ class FigletTest extends TestCase
         $widget->addStyleClass('font-bold');
         $root->add($widget);
 
-        $lines = $renderer->render($root, 80, 24);
+        $lines = $renderer->renderFrame($root, 80, 24)->toArray();
 
         $this->assertCount(1, $lines);
         $this->assertStringContainsString('Hello', AnsiUtils::stripAnsiCodes($lines[0]));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Fixes the two failures every Unit Tests job of the 8.2 branch shows, plus a PHPUnit deprecation in the same component:

- `FigletTest::testTailwindFontUtilityDoesNotSelectAFigletFont` came from 8.1 with the merge-up and still calls `Renderer::render()`, which 8.2 replaced with `renderFrame()`. It now renders like its sibling test in the same file.
- `AssetMapperCompileCommandTest::testReachableEntrypointMetadataIsCompiledWhenTheImportMapIsLimitedToIt` boots a kernel that sets `framework.asset_mapper.importmap_entries`, an option FrameworkBundle only has on 8.2, while the AssetMapper test suite allows `symfony/framework-bundle ^7.4|^8.0`; the low-deps job installs 7.4.0 and the kernel refuses the option. The test now skips when the installed bundle does not know it, and keeps running everywhere else.
- `ImportMapGeneratorTest` configured a mock with an `any()` invocation count expectation, which PHPUnit 13 reports as deprecated; the return value is configured without an expectation now.

Checks: Tui suite 1860 tests and AssetMapper suite 441 tests green locally (php 8.5, PHPUnit 13), no PHPUnit deprecation left in AssetMapper.
