### PR TITLE
[Lock] Never take the reserved "__write__" member as a Redis lock token

### DIFF
--- a/src/Symfony/Component/Lock/Store/RedisStore.php
+++ b/src/Symfony/Component/Lock/Store/RedisStore.php
@@ -294,7 +294,8 @@ class RedisStore implements SharedLockStoreInterface
 
     private function getUniqueToken(Key $key): string
     {
-        if (!$key->hasState(__CLASS__)) {
+        // "__write__" is the reserved member that marks a write lock, so it can never be a token
+        if (!$key->hasState(__CLASS__) || '__write__' === $key->getState(__CLASS__)) {
             $token = base64_encode(random_bytes(32));
             $key->setState(__CLASS__, $token);
         }

--- a/src/Symfony/Component/Lock/Tests/Store/AbstractRedisStoreTestCase.php
+++ b/src/Symfony/Component/Lock/Tests/Store/AbstractRedisStoreTestCase.php
@@ -64,6 +64,53 @@ abstract class AbstractRedisStoreTestCase extends AbstractStoreTestCase
         $this->expectException(LockConflictedException::class);
         $newStore->save($key2);
     }
+
+    public function testWriteMemberIsNotOwnedByTheKeyThatNamesIt()
+    {
+        $store = $this->getStore();
+
+        $resource = uniqid(__METHOD__, true);
+        $key1 = new Key($resource);
+        $store->save($key1);
+
+        $key2 = new Key($resource);
+        $key2->setState(RedisStore::class, '__write__');
+
+        $this->assertFalse($store->exists($key2));
+    }
+
+    public function testWriteMemberDoesNotGrantASecondWriteLock()
+    {
+        $store = $this->getStore();
+
+        $resource = uniqid(__METHOD__, true);
+        $key1 = new Key($resource);
+        $store->save($key1);
+
+        $key2 = new Key($resource);
+        $key2->setState(RedisStore::class, '__write__');
+
+        $this->expectException(LockConflictedException::class);
+        $store->save($key2);
+    }
+
+    public function testWriteMemberCannotBeDeletedByAnotherKey()
+    {
+        $store = $this->getStore();
+
+        $resource = uniqid(__METHOD__, true);
+        $key1 = new Key($resource);
+        $store->save($key1);
+
+        $key2 = new Key($resource);
+        $key2->setState(RedisStore::class, '__write__');
+        $store->delete($key2);
+
+        $this->assertTrue($store->exists($key1));
+
+        $this->expectException(LockConflictedException::class);
+        $store->saveRead(new Key($resource));
+    }
 }
 
 class Symfony51Store


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`RedisStore` keeps a lock in a sorted set and reserves the member `__write__` to mark a write lock, so `saveRead()` admits a reader only while that member is absent. `getUniqueToken()` returned the state carried by the `Key` verbatim, so a key whose state is that reserved member passes every `ZSCORE key uniqueToken` assertion of the Lua scripts while somebody else holds the write lock: `exists()` answers true, `save()` grants a second write lock on the same resource, and `delete()` removes the reserved member and lets readers in under the live write lock.

`getUniqueToken()` now generates a fresh token when the state names the reserved member, exactly as it already does for a key carrying no state. Such a key owns nothing, which is what it really means, so it acquires, releases and reports like any other key with no prior state.

Rejecting the value outright was considered and dropped: it would throw from `getUniqueToken()`, so from `exists()`, so from `Lock::__destruct()`, turning a crafted key into a fatal error during shutdown. Namespacing the members so the reserved one cannot collide was dropped too, since it changes what is stored: during a rolling deploy the two versions read a different marker on the same sorted set and stop excluding each other, and a token serialized by one version no longer releases the lock through the other.

`Key::setState()` is public, and from 7.4 a `Key` also reaches the store from the wire through `LockKeyNormalizer` and `DeduplicateMiddleware`. The collision comes from the sorted-set format introduced in 5.2, so every branch carrying that format is affected.

This targets 5.4 on purpose. The change is hardening rather than a security fix, and 5.4 takes security fixes only, so a hardening change would normally start on the lowest branch that still receives bug fixes. It is proposed here deliberately, so that the long term support branch does not keep a defect that the maintained branches are having fixed.

The merge up carries no conflict: `getUniqueToken()` is identical on 5.4 and 6.4.
