### PR TITLE
[CI] Restore .twig-cs-fixer.dist.php, which Fabbot still needs

### DIFF
--- a/.twig-cs-fixer.dist.php
+++ b/.twig-cs-fixer.dist.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+if (!file_exists(__DIR__.'/src')) {
+    exit(0);
+}
+
+$ruleset = new TwigCsFixer\Ruleset\Ruleset();
+$ruleset->addStandard(new TwigCsFixer\Standard\TwigCsFixer());
+
+$finder = new TwigCsFixer\File\Finder();
+$finder->in('src/');
+$finder->exclude('Symfony/Contracts/');
+$finder->exclude('Fixtures');
+
+$config = new TwigCsFixer\Config\Config();
+$config->setCacheFile('.twig-cs-fixer.cache');
+$config->setRuleset($ruleset);
+$config->setFinder($finder);
+
+return $config;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Follows #65698
| License       | MIT

#65698 removed both the standalone Twig CS Fixer job and `.twig-cs-fixer.dist.php`. Only the job was meant to go: Fabbot reads that config file, so removing it turned the Twig style check off instead of moving it to Fabbot.

In [Fabbot](https://github.com/symfony-tools/fabbot/blob/main/.github/workflows/fabbot.yml), the config is both the gate for the step and the ruleset the run picks up:

```yaml
[ -e o/.twig-cs-fixer.dist.php ] && cp -a {o,a}/.twig-cs-fixer.dist.php
...
- name: Check Twig code style
  if: always() && hashFiles(o/.twig-cs-fixer.dist.php) != 
```

This PR restores the file, with one addition: the `src/` guard that `.php-cs-fixer.dist.php` already has. Fabbot runs in a tree that holds only the files changed by the PR, so without the guard `$finder->in(src/)` fails on any PR that touches no file under `src/`:

```
Error: The "src/" directory does not exist.
```

Checked with `vincentlanglet/twig-cs-fixer:^4`, the version Fabbot installs, on a tree holding a single misformatted Twig file (reported and fixed) and on a tree without `src/` (exit code 0).