### PR TITLE
[SecurityBundle] Un-skip the explicit lock factory login throttling test

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/LoginThrottlingFactoryTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/LoginThrottlingFactoryTest.php
@@ -12,7 +12,6 @@
 namespace Symfony\Bundle\SecurityBundle\Tests\DependencyInjection\Security\Factory;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Bundle\FrameworkBundle\DependencyInjection\FrameworkExtension;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\LoginThrottlingFactory;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\DependencyInjection\Alias;
@@ -63,23 +62,9 @@ class LoginThrottlingFactoryTest extends TestCase
     {
         $this->skipIfLockIsNotInstalled();
 
-        if (!(new \ReflectionClass(FrameworkExtension::class))->hasProperty('lockConfigEnabled')) {
-            $this->markTestSkipped('This test requires symfony/framework-bundle 5.x.');
-        }
-
         $container = $this->createContainer(true);
         $container->register('app.lock_factory', LockFactory::class);
-
-        // FrameworkExtension::registerRateLimiter() accepts an explicit lock factory only when the lock configuration is enabled
-        $setLockConfigEnabled = \Closure::bind(static function (bool $enabled) { self::$lockConfigEnabled = $enabled; }, null, FrameworkExtension::class);
-        $setLockConfigEnabled(true);
-
-        try {
-            $this->createAuthenticator($container, ['lock_factory' => 'app.lock_factory']);
-        } finally {
-            $setLockConfigEnabled(false);
-        }
-
+        $this->createAuthenticator($container, ['lock_factory' => 'app.lock_factory']);
         $this->resolveDefinitions($container);
 
         $this->assertSame('app.lock_factory', (string) $container->getDefinition('limiter._login_local_main')->getArgument(2));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`LoginThrottlingFactoryTest::testAnExplicitLockFactoryIsUsed()` guards itself on `FrameworkExtension::$lockConfigEnabled`, a property that exists only on 5.4, so it has been skipped on every branch since. That guard was needed only because the 5.x code path went through `FrameworkExtension::registerRateLimiter()`; here the factory registers the limiter itself and an explicit `lock_factory` simply lands as argument 2 of the limiter definition. The test can therefore be written directly, like its three siblings in the same file.

Checked by breaking the `replaceArgument(2, ...)` wiring in `LoginThrottlingFactory::registerRateLimiter()`: the test turns red, so it does assert something.
