### PR TITLE
 Declare the polyfills needed by the code on PHP 7.2

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -27,6 +27,7 @@
         "symfony/http-foundation": "^5.4.24|^6.2.11",
         "symfony/http-kernel": "^5.4|^6.0",
         "symfony/polyfill-mbstring": "~1.0",
+        "symfony/polyfill-php73": "^1.9",
         "symfony/polyfill-php80": "^1.16",
         "symfony/polyfill-php81": "^1.22",
         "symfony/filesystem": "^4.4|^5.0|^6.0",

--- a/src/Symfony/Component/Dotenv/composer.json
+++ b/src/Symfony/Component/Dotenv/composer.json
@@ -17,7 +17,8 @@
     ],
     "require": {
         "php": ">=7.2.5",
-        "symfony/deprecation-contracts": "^2.1|^3"
+        "symfony/deprecation-contracts": "^2.1|^3",
+        "symfony/polyfill-php80": "^1.16"
     },
     "require-dev": {
         "symfony/console": "^4.4|^5.0|^6.0",

--- a/src/Symfony/Component/ExpressionLanguage/composer.json
+++ b/src/Symfony/Component/ExpressionLanguage/composer.json
@@ -18,6 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/cache": "^4.4|^5.0|^6.0",
+        "symfony/polyfill-php80": "^1.16",
         "symfony/service-contracts": "^1.1|^2|^3"
     },
     "autoload": {

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/composer.json
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/composer.json
@@ -18,7 +18,8 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/deprecation-contracts": "^2.1|^3",
-        "symfony/messenger": "^5.3|^6.0"
+        "symfony/messenger": "^5.3|^6.0",
+        "symfony/polyfill-php80": "^1.16"
     },
     "require-dev": {
         "symfony/event-dispatcher": "^4.4|^5.0|^6.0",

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/composer.json
@@ -18,6 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/messenger": "^5.1|^6.0",
+        "symfony/polyfill-php80": "^1.16",
         "symfony/service-contracts": "^1.1|^2|^3"
     },
     "require-dev": {

--- a/src/Symfony/Component/Notifier/Bridge/Mercure/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Mercure/composer.json
@@ -20,6 +20,7 @@
         "ext-json": "*",
         "symfony/mercure": "^0.5.2|^0.6",
         "symfony/notifier": "^5.4.21|^6.2.7",
+        "symfony/polyfill-php80": "^1.16",
         "symfony/service-contracts": "^1.10|^2|^3"
     },
     "autoload": {

--- a/src/Symfony/Component/Semaphore/composer.json
+++ b/src/Symfony/Component/Semaphore/composer.json
@@ -21,7 +21,8 @@
     ],
     "require": {
         "php": ">=7.2.5",
-        "psr/log": "^1|^2|^3"
+        "psr/log": "^1|^2|^3",
+        "symfony/polyfill-php80": "^1.16"
     },
     "require-dev": {
         "predis/predis": "^1.1|^2.0"

--- a/src/Symfony/Contracts/HttpClient/Test/HttpClientTestCase.php
+++ b/src/Symfony/Contracts/HttpClient/Test/HttpClientTestCase.php
@@ -1153,7 +1153,7 @@ abstract class HttpClientTestCase extends TestCase
     {
         $client = $this->getHttpClient(__FUNCTION__);
         if (!method_exists($client, 'withOptions')) {
-            $this->markTestSkipped(sprintf('Not implementing "%s::withOptions()" is deprecated.', get_debug_type($client)));
+            $this->markTestSkipped(sprintf('Not implementing "%s::withOptions()" is deprecated.', \get_class($client)));
         }
 
         $client2 = $client->withOptions(['base_uri' => 'http://localhost:8057/']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Seven packages support PHP 7.2.5 but call functions that PHP provides only from 7.3 or 8.0 on, without requiring the polyfill that defines them:

| Package | Call | Needs |
| --- | --- | --- |
| `symfony/framework-bundle` | `array_key_first()` in `EventDispatcherDebugCommand` | `polyfill-php73` |
| `symfony/dotenv` | `str_starts_with()`, `str_ends_with()` in `DebugCommand` | `polyfill-php80` |
| `symfony/expression-language` | `get_debug_type()` in `GetAttrNode` | `polyfill-php80` |
| `symfony/amqp-messenger` | `get_debug_type()` in `Connection` | `polyfill-php80` |
| `symfony/doctrine-messenger` | `get_debug_type()` in `Connection`, `DoctrineTransportFactory` | `polyfill-php80` |
| `symfony/mercure-notifier` | `get_debug_type()` in `MercureOptions`, `MercureTransport` | `polyfill-php80` |
| `symfony/semaphore` | `get_debug_type()` in `RedisStore` | `polyfill-php80` |

Each one fatals with `Call to undefined function` on PHP 7.2 (7.2 or 7.3 for `array_key_first()`) when the split package is installed on its own. The monorepo never sees it: the root `composer.json` requires every polyfill, so the test suite always has them loaded.

`symfony/http-client-contracts` has the same problem, through `get_debug_type()` in the shipped `HttpClientTestCase`. Contracts packages deliberately depend on nothing but PHP, so this one uses `get_class()` instead, which is all that is needed for an object.

Checked and not affected: `mb_str_split()` in `Console\Helper\Table` is provided by `polyfill-mbstring`, which Console already requires; `array_is_list()` in `VarCloner` is behind `\PHP_VERSION_ID >= 80100`; `FILTER_VALIDATE_BOOL` in Cache and Runtime is defined by `polyfill-php80`, which both already require; every other use of `\JSON_THROW_ON_ERROR` on this branch is guarded by `\PHP_VERSION_ID >= 70300`.
