### PR TITLE
[Yaml] Fix a TypeError when "!!binary" is given an unparsable value

### DIFF
--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -796,6 +796,8 @@ class Inline
     {
         $parsedBinaryData = self::parseScalar(preg_replace('/\s/', '', $scalar));
 
+        $parsedBinaryData = (string) $parsedBinaryData;
+
         if (0 !== (\strlen($parsedBinaryData) % 4)) {
             throw new ParseException(sprintf('The normalized base64 encoded data (data without whitespace characters) length must be a multiple of four (%d bytes given).', \strlen($parsedBinaryData)), self::$parsedLineNumber + 1, $scalar, self::$parsedFilename);
         }

--- a/src/Symfony/Component/Yaml/Tests/InlineTest.php
+++ b/src/Symfony/Component/Yaml/Tests/InlineTest.php
@@ -651,6 +651,7 @@ class InlineTest extends TestCase
             'invalid characters' => ['!!binary "SGVsbG8#d29ybGQ="', '/The base64 encoded data \(.*\) contains invalid characters/'],
             'too many equals characters' => ['!!binary "SGVsbG8gd29yb==="', '/The base64 encoded data \(.*\) contains invalid characters/'],
             'misplaced equals character' => ['!!binary "SGVsbG8gd29ybG=Q"', '/The base64 encoded data \(.*\) contains invalid characters/'],
+            'unparsable scalar value' => ['!!binary !php/object a', '/The base64 encoded data \(\) contains invalid characters/'],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Partial backport of #64196 (cherry-pick of 0e59018abb2) to 5.4.

The crash the original PR fixes is real on 5.4: `Inline::parse('!!binary !php/object a')` gets `null` back from `parseScalar()` and dies with `TypeError: preg_match(): Argument #2 ($subject) must be of type string`, plus a `strlen(): Passing null` deprecation, instead of the documented `ParseException`. The `(string)` cast fixes it and the added test case covers it.

The `!\is_scalar(...)` guard of the original patch is not backported: on 5.4 `evaluateBinaryScalar()` calls `parseScalar()` without flags, so a `TaggedValue` can never come back here. Everything that would reach that branch (`!!binary [1, 2]`, `!!binary {a: b}`, `!!binary !foo bar`, and direct calls to the public `evaluateBinaryScalar()`) is already rejected by "The built-in tag "!!binary" is not implemented", "unsupported built-in tag" or the base64 checks, so the guard would be unused code here, and with it the `get_debug_type()` call it contains.
