### PR TITLE
[HttpKernel] Fix TypeError in UriSigner when the hash parameter is not a string

### DIFF
--- a/src/Symfony/Component/HttpKernel/Tests/UriSignerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/UriSignerTest.php
@@ -41,6 +41,23 @@ class UriSignerTest extends TestCase
         $this->assertSame($signer->sign('http://example.com/foo?foo=bar&bar=foo'), $signer->sign('http://example.com/foo?bar=foo&foo=bar'));
     }
 
+    public function testCheckWithNonStringHash()
+    {
+        $signer = new UriSigner('foobar');
+
+        $this->assertFalse($signer->check('http://example.com/foo?_hash[]=y'));
+        $this->assertFalse($signer->check('http://example.com/foo?_hash[k]=y'));
+        $this->assertFalse($signer->check('http://example.com/foo?foo=bar&_hash[]='));
+    }
+
+    public function testCheckRequestWithNonStringHash()
+    {
+        $signer = new UriSigner('foobar');
+
+        $this->assertFalse($signer->checkRequest(Request::create('http://example.com/foo?_path=x&_hash[]=y')));
+        $this->assertFalse($signer->checkRequest(Request::create('http://example.com/foo?_hash[k]=y')));
+    }
+
     public function testCheckWithDifferentArgSeparator()
     {
         $initialSeparatorOutput = ini_set('arg_separator.output', '&amp;');

--- a/src/Symfony/Component/HttpKernel/UriSigner.php
+++ b/src/Symfony/Component/HttpKernel/UriSigner.php
@@ -70,11 +70,10 @@ class UriSigner
             $params = [];
         }
 
-        if (empty($params[$this->parameter])) {
+        if (!\is_string($hash = $params[$this->parameter] ?? null) || '' === $hash) {
             return false;
         }
 
-        $hash = $params[$this->parameter];
         unset($params[$this->parameter]);
 
         return hash_equals($this->computeHash($this->buildUrl($url, $params)), $hash);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Backport of #65022 (cherry-pick of e8b166c8075) to 5.4.

Adapted for 5.4: ported by hand: on 5.4 `UriSigner` still lives in HttpKernel, and `check()` is the only entry point that reads the parameter.
