### PR TITLE
[HttpClient] Don't send the original Host header on cross-authority redirects

### DIFF
--- a/src/Symfony/Component/HttpClient/CurlHttpClient.php
+++ b/src/Symfony/Component/HttpClient/CurlHttpClient.php
@@ -416,7 +416,7 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
             });
 
             if (isset($options['normalized_headers']['authorization'][0]) || isset($options['normalized_headers']['cookie'][0])) {
-                $redirectHeaders['no_auth'] = array_filter($options['headers'], static function ($h) {
+                $redirectHeaders['no_auth'] = array_filter($redirectHeaders['no_auth'], static function ($h) {
                     return 0 !== stripos($h, 'Authorization:') && 0 !== stripos($h, 'Cookie:');
                 });
             }

--- a/src/Symfony/Component/HttpClient/Tests/AmpHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/AmpHttpClientTest.php
@@ -24,6 +24,16 @@ class AmpHttpClientTest extends HttpClientTestCase
         return new AmpHttpClient(['verify_peer' => false, 'verify_host' => false, 'timeout' => 5]);
     }
 
+    public static function getRedirectWithHostHeaderTests()
+    {
+        // unlike curl and the native client, amphp keeps the user-provided Host header when the authority doesn't change
+        return [
+            'same host and port' => ['url' => 'http://localhost:8057/custom', 'redirectWithAuth' => true, 'expectedHost' => 'foo.example.com'],
+            'other port' => ['url' => 'http://localhost:8067/custom', 'redirectWithAuth' => false, 'expectedHost' => 'localhost:8057'],
+            'other host' => ['url' => 'http://127.0.0.1:8057/custom', 'redirectWithAuth' => false, 'expectedHost' => 'localhost:8057'],
+        ];
+    }
+
     public function testProxy()
     {
         $this->markTestSkipped('A real proxy server would be needed.');

--- a/src/Symfony/Component/HttpClient/Tests/CurlHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/CurlHttpClientTest.php
@@ -115,6 +115,16 @@ class CurlHttpClientTest extends HttpClientTestCase
         ]);
     }
 
+    public static function getRedirectWithHostHeaderTests()
+    {
+        // curl itself drops the credentials when the port changes
+        return [
+            'same host and port' => ['url' => 'http://localhost:8057/custom', 'redirectWithAuth' => true, 'expectedHost' => 'localhost:8057'],
+            'other port' => ['url' => 'http://localhost:8067/custom', 'redirectWithAuth' => false, 'expectedHost' => 'localhost:8057'],
+            'other host' => ['url' => 'http://127.0.0.1:8057/custom', 'redirectWithAuth' => false, 'expectedHost' => 'localhost:8057'],
+        ];
+    }
+
     public function testKeepAuthorizationHeaderOnRedirectToSameHostWithConfiguredHostToIpAddressMapping()
     {
         $httpClient = $this->getHttpClient(__FUNCTION__);

--- a/src/Symfony/Component/HttpClient/Tests/HttpClientTestCase.php
+++ b/src/Symfony/Component/HttpClient/Tests/HttpClientTestCase.php
@@ -24,6 +24,7 @@ use Symfony\Component\Process\Process;
 use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\Test\HttpClientTestCase as BaseHttpClientTestCase;
+use Symfony\Contracts\HttpClient\Test\TestHttpServer;
 
 /*
 Tests for HTTP2 Push need a recent version of both PHP and curl. This docker command should run them:
@@ -623,5 +624,50 @@ abstract class HttpClientTestCase extends BaseHttpClientTestCase
         $response = $client->request('GET', 'http://localhost:8057/302?location=http:localhost');
 
         $this->assertSame(302, $response->getStatusCode());
+    }
+
+    /**
+     * @dataProvider getRedirectWithHostHeaderTests
+     */
+    public function testRedirectWithHostHeader(string $url, bool $redirectWithAuth, string $expectedHost)
+    {
+        $p = TestHttpServer::start(8067);
+
+        try {
+            $client = $this->getHttpClient(__FUNCTION__);
+
+            $response = $client->request('GET', $url, [
+                'query' => [
+                    'status' => 302,
+                    'headers' => ['Location: http://localhost:8057/'],
+                ],
+                'headers' => [
+                    'Host' => 'foo.example.com',
+                    'Authorization' => 'Basic Zm9vOmJhcg==',
+                ],
+            ]);
+            $body = $response->toArray();
+        } finally {
+            $p->stop();
+        }
+
+        $this->assertSame('http://localhost:8057/', $response->getInfo('url'));
+        $this->assertSame($expectedHost, $body['HTTP_HOST']);
+
+        if ($redirectWithAuth) {
+            $this->assertSame('Basic Zm9vOmJhcg==', $body['HTTP_AUTHORIZATION']);
+        } else {
+            $this->assertArrayNotHasKey('HTTP_AUTHORIZATION', $body);
+        }
+    }
+
+    public static function getRedirectWithHostHeaderTests()
+    {
+        // the native client keeps the credentials when only the port changes
+        return [
+            'same host and port' => ['url' => 'http://localhost:8057/custom', 'redirectWithAuth' => true, 'expectedHost' => 'localhost:8057'],
+            'other port' => ['url' => 'http://localhost:8067/custom', 'redirectWithAuth' => true, 'expectedHost' => 'localhost:8057'],
+            'other host' => ['url' => 'http://127.0.0.1:8057/custom', 'redirectWithAuth' => false, 'expectedHost' => 'localhost:8057'],
+        ];
     }
 }

--- a/src/Symfony/Contracts/HttpClient/Test/Fixtures/web/index.php
+++ b/src/Symfony/Contracts/HttpClient/Test/Fixtures/web/index.php
@@ -198,6 +198,17 @@ switch (parse_url($vars['REQUEST_URI'], \PHP_URL_PATH)) {
         ]);
 
         exit;
+
+    case '/custom':
+        if (isset($_GET['status'])) {
+            http_response_code((int) $_GET['status']);
+        }
+        if (isset($_GET['headers']) && is_array($_GET['headers'])) {
+            foreach ($_GET['headers'] as $header) {
+                header($header);
+            }
+        }
+        break;
 }
 
 header('Content-Type: application/json', true);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Backport of #65004 (cherry-pick of b8d0f1fc6c5) to 5.4.

Adapted for 5.4: ported by hand, and the `/custom` endpoint was added to the test fixture. The expected values differ per client because 5.4 compares only the host on redirects: curl drops the credentials itself when the port changes, the native client keeps them, and amphp compares the whole authority.
