### PR TITLE
[Security] Remove the legacy nested unserialize() call from token and exception classes

### DIFF
--- a/src/Symfony/Component/Security/Core/Authentication/Token/AnonymousToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AnonymousToken.php
@@ -73,7 +73,6 @@ class AnonymousToken extends AbstractToken
     public function __unserialize(array $data): void
     {
         [$this->secret, $parentData] = $data;
-        $parentData = \is_array($parentData) ? $parentData : unserialize($parentData);
         parent::__unserialize($parentData);
     }
 }

--- a/src/Symfony/Component/Security/Core/Authentication/Token/PreAuthenticatedToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/PreAuthenticatedToken.php
@@ -108,7 +108,6 @@ class PreAuthenticatedToken extends AbstractToken
     public function __unserialize(array $data): void
     {
         [$this->credentials, $this->firewallName, $parentData] = $data;
-        $parentData = \is_array($parentData) ? $parentData : unserialize($parentData);
         parent::__unserialize($parentData);
     }
 }

--- a/src/Symfony/Component/Security/Core/Authentication/Token/RememberMeToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/RememberMeToken.php
@@ -112,7 +112,6 @@ class RememberMeToken extends AbstractToken
     public function __unserialize(array $data): void
     {
         [$this->secret, $this->firewallName, $parentData] = $data;
-        $parentData = \is_array($parentData) ? $parentData : unserialize($parentData);
         parent::__unserialize($parentData);
     }
 }

--- a/src/Symfony/Component/Security/Core/Authentication/Token/SwitchUserToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/SwitchUserToken.php
@@ -81,7 +81,6 @@ class SwitchUserToken extends UsernamePasswordToken
         } else {
             [$this->originalToken, $this->originatedFromUri, $parentData] = $data;
         }
-        $parentData = \is_array($parentData) ? $parentData : unserialize($parentData);
         parent::__unserialize($parentData);
     }
 }

--- a/src/Symfony/Component/Security/Core/Authentication/Token/UsernamePasswordToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/UsernamePasswordToken.php
@@ -119,7 +119,6 @@ class UsernamePasswordToken extends AbstractToken
     public function __unserialize(array $data): void
     {
         [$this->credentials, $this->firewallName, $parentData] = $data;
-        $parentData = \is_array($parentData) ? $parentData : unserialize($parentData);
         parent::__unserialize($parentData);
     }
 }

--- a/src/Symfony/Component/Security/Core/Exception/AccountStatusException.php
+++ b/src/Symfony/Component/Security/Core/Exception/AccountStatusException.php
@@ -53,7 +53,6 @@ abstract class AccountStatusException extends AuthenticationException
     public function __unserialize(array $data): void
     {
         [$this->user, $parentData] = $data;
-        $parentData = \is_array($parentData) ? $parentData : unserialize($parentData);
         parent::__unserialize($parentData);
     }
 }

--- a/src/Symfony/Component/Security/Core/Exception/CustomUserMessageAuthenticationException.php
+++ b/src/Symfony/Component/Security/Core/Exception/CustomUserMessageAuthenticationException.php
@@ -69,7 +69,6 @@ class CustomUserMessageAuthenticationException extends AuthenticationException
     public function __unserialize(array $data): void
     {
         [$parentData, $this->messageKey, $this->messageData] = $data;
-        $parentData = \is_array($parentData) ? $parentData : unserialize($parentData);
         parent::__unserialize($parentData);
     }
 }

--- a/src/Symfony/Component/Security/Core/Exception/TooManyLoginAttemptsAuthenticationException.php
+++ b/src/Symfony/Component/Security/Core/Exception/TooManyLoginAttemptsAuthenticationException.php
@@ -59,7 +59,6 @@ class TooManyLoginAttemptsAuthenticationException extends AuthenticationExceptio
     public function __unserialize(array $data): void
     {
         [$this->threshold, $parentData] = $data;
-        $parentData = \is_array($parentData) ? $parentData : unserialize($parentData);
         parent::__unserialize($parentData);
     }
 }

--- a/src/Symfony/Component/Security/Core/Exception/UserNotFoundException.php
+++ b/src/Symfony/Component/Security/Core/Exception/UserNotFoundException.php
@@ -89,7 +89,6 @@ class UserNotFoundException extends AuthenticationException
     public function __unserialize(array $data): void
     {
         [$this->identifier, $parentData] = $data;
-        $parentData = \is_array($parentData) ? $parentData : unserialize($parentData);
         parent::__unserialize($parentData);
     }
 }

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Token/RememberMeTokenTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Token/RememberMeTokenTest.php
@@ -48,6 +48,18 @@ class RememberMeTokenTest extends TestCase
         );
     }
 
+    public function testUnserializeRejectsLegacyStringParentData()
+    {
+        $token = new RememberMeToken($this->getUser(), 'fookey', 'foo');
+        $data = $token->__serialize();
+        $data[2] = serialize($data[2]);
+
+        $token = new RememberMeToken($this->getUser(), 'fookey', 'foo');
+
+        $this->expectException(\TypeError::class);
+        $token->__unserialize($data);
+    }
+
     protected function getUser($roles = ['ROLE_FOO'])
     {
         $user = $this->createMock(UserInterface::class);

--- a/src/Symfony/Component/Security/Guard/Token/PostAuthenticationGuardToken.php
+++ b/src/Symfony/Component/Security/Guard/Token/PostAuthenticationGuardToken.php
@@ -92,7 +92,6 @@ class PostAuthenticationGuardToken extends AbstractToken implements GuardTokenIn
     public function __unserialize(array $data): void
     {
         [$this->providerKey, $parentData] = $data;
-        $parentData = \is_array($parentData) ? $parentData : unserialize($parentData);
         parent::__unserialize($parentData);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Backport of #64195 (cherry-pick of 7b916314118) to 5.4.

Adapted for 5.4: the backport also covers two classes that exist only on 5.4 and therefore had no counterpart in the original patch: `Security\Core\Authentication\Token\AnonymousToken` and `Security\Guard\Token\PostAuthenticationGuardToken`.
