### PR TITLE
[Security] Reject malformed login link parameters instead of throwing a TypeError

### DIFF
--- a/src/Symfony/Component/Security/Http/LoginLink/LoginLinkHandler.php
+++ b/src/Symfony/Component/Security/Http/LoginLink/LoginLinkHandler.php
@@ -87,8 +87,15 @@ final class LoginLinkHandler implements LoginLinkHandlerInterface
         if (!$hash = $request->get('hash')) {
             throw new InvalidLoginLinkException('Missing "hash" parameter.');
         }
+        if (!is_string($hash)) {
+            throw new InvalidLoginLinkException('Invalid "hash" parameter.');
+        }
+
         if (!$expires = $request->get('expires')) {
             throw new InvalidLoginLinkException('Missing "expires" parameter.');
+        }
+        if (preg_match('/^\d+$/', $expires) !== 1) {
+            throw new InvalidLoginLinkException('Invalid "expires" parameter.');
         }
 
         try {

--- a/src/Symfony/Component/Security/Http/LoginLink/LoginLinkHandler.php
+++ b/src/Symfony/Component/Security/Http/LoginLink/LoginLinkHandler.php
@@ -83,18 +83,24 @@ final class LoginLinkHandler implements LoginLinkHandlerInterface
     public function consumeLoginLink(Request $request): UserInterface
     {
         $userIdentifier = $request->get('user');
+        if (null === $userIdentifier || '' === $userIdentifier) {
+            throw new InvalidLoginLinkException('Missing "user" parameter.');
+        }
+        if (!\is_string($userIdentifier)) {
+            throw new InvalidLoginLinkException('Invalid "user" parameter.');
+        }
 
         if (!$hash = $request->get('hash')) {
             throw new InvalidLoginLinkException('Missing "hash" parameter.');
         }
-        if (!is_string($hash)) {
+        if (!\is_string($hash)) {
             throw new InvalidLoginLinkException('Invalid "hash" parameter.');
         }
 
         if (!$expires = $request->get('expires')) {
             throw new InvalidLoginLinkException('Missing "expires" parameter.');
         }
-        if (preg_match('/^\d+$/', $expires) !== 1) {
+        if (!\is_string($expires) || !preg_match('/^\d+$/', $expires)) {
             throw new InvalidLoginLinkException('Invalid "expires" parameter.');
         }
 

--- a/src/Symfony/Component/Security/Http/Tests/LoginLink/LoginLinkHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/LoginLink/LoginLinkHandlerTest.php
@@ -216,6 +216,36 @@ class LoginLinkHandlerTest extends TestCase
         $linker->consumeLoginLink($request);
     }
 
+    public function testConsumeLoginLinkWithMissingUser()
+    {
+        $this->expectException(InvalidLoginLinkException::class);
+        $this->expectExceptionMessage('Missing "user" parameter.');
+        $request = Request::create('/login/verify?hash=thehash&expires='.(time() + 500));
+
+        $linker = $this->createLinker();
+        $linker->consumeLoginLink($request);
+    }
+
+    public function testConsumeLoginLinkWithArrayUser()
+    {
+        $this->expectException(InvalidLoginLinkException::class);
+        $this->expectExceptionMessage('Invalid "user" parameter.');
+        $request = Request::create('/login/verify?user[]=weaverryan&hash=thehash&expires='.(time() + 500));
+
+        $linker = $this->createLinker();
+        $linker->consumeLoginLink($request);
+    }
+
+    public function testConsumeLoginLinkWithArrayExpiration()
+    {
+        $this->expectException(InvalidLoginLinkException::class);
+        $this->expectExceptionMessage('Invalid "expires" parameter.');
+        $request = Request::create('/login/verify?user=weaverryan&hash=thehash&expires[]=1000000000');
+
+        $linker = $this->createLinker();
+        $linker->consumeLoginLink($request);
+    }
+
     public function testConsumeLoginLinkWithInvalidExpiration()
     {
         $user = new TestLoginLinkHandlerUser('weaverryan', 'ryan@symfonycasts.com', 'pwhash');

--- a/src/Symfony/Component/Security/Http/Tests/LoginLink/LoginLinkHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/LoginLink/LoginLinkHandlerTest.php
@@ -216,6 +216,30 @@ class LoginLinkHandlerTest extends TestCase
         $linker->consumeLoginLink($request);
     }
 
+    public function testConsumeLoginLinkWithInvalidExpiration()
+    {
+        $user = new TestLoginLinkHandlerUser('weaverryan', 'ryan@symfonycasts.com', 'pwhash');
+        $this->userProvider->createUser($user);
+
+        $this->expectException(InvalidLoginLinkException::class);
+        $request = Request::create('/login/verify?user=weaverryan&hash=thehash&expires=%E2%80%AA1000000000%E2%80%AC');
+
+        $linker = $this->createLinker();
+        $linker->consumeLoginLink($request);
+    }
+
+    public function testConsumeLoginLinkWithInvalidHash()
+    {
+        $user = new TestLoginLinkHandlerUser('weaverryan', 'ryan@symfonycasts.com', 'pwhash');
+        $this->userProvider->createUser($user);
+
+        $this->expectException(InvalidLoginLinkException::class);
+        $request = Request::create('/login/verify?user=weaverryan&hash[]=an&hash[]=array&expires=1000000000');
+
+        $linker = $this->createLinker();
+        $linker->consumeLoginLink($request);
+    }
+
     private function createSignatureHash(string $username, int $expires, array $extraFields = ['emailProperty' => 'ryan@symfonycasts.com', 'passwordProperty' => 'pwhash']): string
     {
         $hasher = new SignatureHasher($this->propertyAccessor, array_keys($extraFields), 's3cret');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Backport of #60350 and #65422 (cherry-pick of 0dc4d0b98b5, 176e82f054b) to 5.4.

Adapted for 5.4: two commits, the second builds on the first.
