### PR TITLE
[Security] Avoid failing when PersistentRememberMeHandler handles a malformed cookie

### DIFF
--- a/src/Symfony/Component/Security/Http/RememberMe/PersistentRememberMeHandler.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/PersistentRememberMeHandler.php
@@ -131,7 +131,12 @@ final class PersistentRememberMeHandler extends AbstractRememberMeHandler
             return;
         }
 
-        $rememberMeDetails = RememberMeDetails::fromRawCookie($cookie);
+        try {
+            $rememberMeDetails = RememberMeDetails::fromRawCookie($cookie);
+        } catch (AuthenticationException $e) {
+            // malformed cookie should not fail the response and can be simply ignored
+            return;
+        }
         [$series] = explode(':', $rememberMeDetails->getValue());
         $this->tokenProvider->deleteTokenBySeries($series);
     }

--- a/src/Symfony/Component/Security/Http/Tests/RememberMe/PersistentRememberMeHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/RememberMe/PersistentRememberMeHandlerTest.php
@@ -75,6 +75,22 @@ class PersistentRememberMeHandlerTest extends TestCase
         $this->assertNull($cookie->getValue());
     }
 
+    public function testClearRememberMeCookieMalformedCookie()
+    {
+        $this->tokenProvider->expects($this->exactly(0))
+            ->method('deleteTokenBySeries');
+
+        $this->request->cookies->set('REMEMBERME', 'malformed');
+
+        $this->handler->clearRememberMeCookie();
+
+        $this->assertTrue($this->request->attributes->has(ResponseListener::COOKIE_ATTR_NAME));
+
+        /** @var Cookie $cookie */
+        $cookie = $this->request->attributes->get(ResponseListener::COOKIE_ATTR_NAME);
+        $this->assertNull($cookie->getValue());
+    }
+
     public function testConsumeRememberMeCookieValid()
     {
         $this->tokenProvider->expects($this->any())


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Backport of #60379 (cherry-pick of 2eaa7ee0fd9) to 5.4.

Adapted for 5.4: `catch (AuthenticationException $e)`, PHP 7.2 requires the variable.
