### PR TITLE
[HttpKernel] Ignore the session id that PHP kept from a previous request

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/AbstractSessionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/AbstractSessionListener.php
@@ -79,6 +79,8 @@ abstract class AbstractSessionListener implements EventSubscriberInterface, Rese
             $sess = null;
             $request->setSessionFactory(function () use (&$sess, $request) {
                 if (!$sess) {
+                    // PHP keeps the id of the previous request when it cannot be reset, e.g. once some output has been sent
+                    $previousSessionId = session_id();
                     $sess = $this->getSession();
                     $request->setSession($sess);
 
@@ -89,7 +91,12 @@ abstract class AbstractSessionListener implements EventSubscriberInterface, Rese
                      * Do not set it when a native php session is active.
                      */
                     if ($sess && !$sess->isStarted() && \PHP_SESSION_ACTIVE !== session_status()) {
-                        $sessionId = $sess->getId() ?: $request->cookies->get($sess->getName(), '');
+                        $sessionId = $sess->getId();
+
+                        if (!$sessionId || $previousSessionId === $sessionId) {
+                            $sessionId = $request->cookies->get($sess->getName(), '');
+                        }
+
                         $sess->setId($sessionId);
                     }
                 }

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/SessionListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/SessionListenerTest.php
@@ -26,6 +26,7 @@ use Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage;
 use Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorageFactory;
 use Symfony\Component\HttpFoundation\Session\Storage\PhpBridgeSessionStorageFactory;
 use Symfony\Component\HttpFoundation\Session\Storage\SessionStorageFactoryInterface;
+use Symfony\Component\HttpFoundation\Session\Storage\SessionStorageInterface;
 use Symfony\Component\HttpKernel\DataCollector\RequestDataCollector;
 use Symfony\Component\HttpKernel\Event\FinishRequestEvent;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
@@ -219,16 +220,54 @@ class SessionListenerTest extends TestCase
     /**
      * @runInSeparateProcess
      */
+    public function testSessionIdKeptByPhpFromAPreviousRequestIsIgnored()
+    {
+        $previousSessionId = $this->createValidSessionId();
+
+        $this->assertSame($previousSessionId, session_id());
+
+        $request = new Request();
+        $request->cookies->set('PHPSESSID', 'REQUEST-SESSION-ID');
+
+        $listener = $this->createListener($request, new NativeSessionStorageFactory());
+
+        $kernel = $this->createStub(HttpKernelInterface::class);
+        $listener->onKernelRequest(new RequestEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST));
+
+        $this->assertSame('REQUEST-SESSION-ID', $request->getSession()->getId());
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
     public function testNewSessionIdIsNotOverwritten()
     {
         $newSessionId = $this->createValidSessionId();
 
         $this->assertNotEmpty($newSessionId);
 
+        // the id comes from the storage factory below, not from the state PHP kept from a previous request
+        session_id('');
+
         $request = new Request();
         $request->cookies->set('PHPSESSID', 'OLD-SESSION-ID');
 
-        $listener = $this->createListener($request, new NativeSessionStorageFactory());
+        $listener = $this->createListener($request, new class($newSessionId) implements SessionStorageFactoryInterface {
+            private $sessionId;
+
+            public function __construct(string $sessionId)
+            {
+                $this->sessionId = $sessionId;
+            }
+
+            public function createStorage(?Request $request): SessionStorageInterface
+            {
+                $storage = new NativeSessionStorage();
+                $storage->setId($this->sessionId);
+
+                return $storage;
+            }
+        });
 
         $kernel = $this->createMock(HttpKernelInterface::class);
         $listener->onKernelRequest(new RequestEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Backport of #65512 (cherry-pick of 0d8a11c51bb) to 5.4.

Adapted for 5.4: `Session::getId()` can return null with the 5.4 test doubles, so the check is a falsy test; the test uses a plain constructor, PHP 7.2 has no promotion.
