### PR TITLE
[HttpKernel][Security] Add allowed_classes => false to unserialize() in CacheWarmerAggregate, LoggerDataCollector, and HttpCache Store

### DIFF
--- a/src/Symfony/Component/HttpKernel/CacheWarmer/CacheWarmerAggregate.php
+++ b/src/Symfony/Component/HttpKernel/CacheWarmer/CacheWarmerAggregate.php
@@ -103,7 +103,7 @@ class CacheWarmerAggregate implements CacheWarmerInterface
                 restore_error_handler();
 
                 if (is_file($this->deprecationLogsFilepath)) {
-                    $previousLogs = unserialize(file_get_contents($this->deprecationLogsFilepath));
+                    $previousLogs = unserialize(file_get_contents($this->deprecationLogsFilepath), ['allowed_classes' => false]);
                     if (\is_array($previousLogs)) {
                         $collectedLogs = array_merge($previousLogs, $collectedLogs);
                     }

--- a/src/Symfony/Component/HttpKernel/DataCollector/LoggerDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/LoggerDataCollector.php
@@ -207,7 +207,7 @@ class LoggerDataCollector extends DataCollector implements LateDataCollectorInte
 
         $bootTime = filemtime($file);
         $logs = [];
-        foreach (unserialize($logContent) as $log) {
+        foreach (unserialize($logContent, ['allowed_classes' => false]) as $log) {
             $log['context'] = ['exception' => new SilencedErrorContext($log['type'], $log['file'], $log['line'], $log['trace'], $log['count'])];
             $log['timestamp'] = $bootTime;
             $log['timestamp_rfc3339'] = (new \DateTimeImmutable())->setTimestamp($bootTime)->format(\DateTimeInterface::RFC3339_EXTENDED);

--- a/src/Symfony/Component/HttpKernel/HttpCache/Store.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/Store.php
@@ -314,7 +314,7 @@ class Store implements StoreInterface
             return [];
         }
 
-        return unserialize($entries) ?: [];
+        return unserialize($entries, ['allowed_classes' => false]) ?: [];
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Backport of #64419 (cherry-pick of 1c75e36baf4) to 5.4.
