### PR TITLE
[Process] Ignore invalid env var names and non-scalar env values

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -341,7 +341,7 @@ class Process implements \IteratorAggregate
 
         $envPairs = [];
         foreach ($env as $k => $v) {
-            if (false !== $v && false === \in_array($k, ['argc', 'argv', 'ARGC', 'ARGV'], true)) {
+            if (false !== $v && !\in_array($k = (string) $k, ['', 'argc', 'argv', 'ARGC', 'ARGV'], true) && !str_contains($k, '=') && !str_contains($k, "\0")) {
                 $envPairs[] = $k.'='.$v;
             }
         }

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -341,6 +341,10 @@ class Process implements \IteratorAggregate
 
         $envPairs = [];
         foreach ($env as $k => $v) {
+            if (!\is_scalar($v ?? '') && !(\is_object($v) && method_exists($v, '__toString'))) {
+                continue;
+            }
+
             if (false !== $v && !\in_array($k = (string) $k, ['', 'argc', 'argv', 'ARGC', 'ARGV'], true) && !str_contains($k, '=') && !str_contains($k, "\0")) {
                 $envPairs[] = $k.'='.$v;
             }

--- a/src/Symfony/Component/Process/Tests/ProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessTest.php
@@ -1541,6 +1541,46 @@ class ProcessTest extends TestCase
         $this->assertSame($env, $p->getEnv());
     }
 
+    public function testEnvVarNamesCastToString()
+    {
+        $process = $this->getProcess('echo hello');
+        $process->setEnv([123 => 'value']);
+
+        $process->run();
+
+        $this->assertSame('hello'.\PHP_EOL, $process->getOutput());
+    }
+
+    public function testEnvVarNamesWithEqualsSigns()
+    {
+        $process = $this->getProcess('echo hello');
+        $process->setEnv(['VAR=NAME' => 'value']);
+
+        $process->run();
+
+        $this->assertSame('hello'.\PHP_EOL, $process->getOutput());
+    }
+
+    public function testEnvVarNamesWithNullBytes()
+    {
+        $process = $this->getProcess('echo hello');
+        $process->setEnv(["VAR\0NAME" => 'value']);
+
+        $process->run();
+
+        $this->assertSame('hello'.\PHP_EOL, $process->getOutput());
+    }
+
+    public function testEnvVarNamesEmpty()
+    {
+        $process = $this->getProcess('echo hello');
+        $process->setEnv(['' => 'value']);
+
+        $process->run();
+
+        $this->assertSame('hello'.\PHP_EOL, $process->getOutput());
+    }
+
     public function testWaitStoppedDeadProcess()
     {
         $process = $this->getProcess(self::$phpBin.' '.__DIR__.'/ErrorProcessInitiator.php -e '.self::$phpBin);

--- a/src/Symfony/Component/Process/Tests/ProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessTest.php
@@ -1541,6 +1541,21 @@ class ProcessTest extends TestCase
         $this->assertSame($env, $p->getEnv());
     }
 
+    public function testEnvNonScalarValuesAreIgnored()
+    {
+        $_ENV['BAD_ARRAY_ENV'] = ['foo', 'bar'];
+        $_ENV['BAD_OBJECT_ENV'] = new \stdClass();
+
+        try {
+            $process = $this->getProcessForCode('echo "OK";');
+            $process->mustRun();
+
+            $this->assertSame('OK', $process->getOutput());
+        } finally {
+            unset($_ENV['BAD_ARRAY_ENV'], $_ENV['BAD_OBJECT_ENV']);
+        }
+    }
+
     public function testEnvVarNamesCastToString()
     {
         $process = $this->getProcess('echo hello');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Backport of #63004 and #64058 (cherry-pick of da9e3d9a44d, d5123b5323b) to 5.4.

Adapted for 5.4: two commits touching the same loop; the `\Stringable` check is written with `method_exists()`, the interface does not exist on PHP 7.2.
