### PR TITLE
[HttpClient] Reject https:// proxies that curl would connect to in cleartext

### DIFF
--- a/src/Symfony/Component/HttpClient/CurlHttpClient.php
+++ b/src/Symfony/Component/HttpClient/CurlHttpClient.php
@@ -105,6 +105,8 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
         $authority = $url['authority'];
         $host = parse_url($authority, \PHP_URL_HOST);
         $proxy = self::getProxyUrl($options['proxy'], $url);
+        $noProxy = $options['no_proxy'] ?? $_SERVER['no_proxy'] ?? $_SERVER['NO_PROXY'] ?? '';
+        self::checkHttpsProxySupport($proxy, $url, $noProxy);
         $url = implode('', $url);
 
         if (!isset($options['normalized_headers']['user-agent'])) {
@@ -120,8 +122,9 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
             \CURLOPT_MAXREDIRS => 0 < $options['max_redirects'] ? $options['max_redirects'] : 0,
             \CURLOPT_COOKIEFILE => '', // Keep track of cookies during redirects
             \CURLOPT_TIMEOUT => 0,
-            \CURLOPT_PROXY => $proxy,
-            \CURLOPT_NOPROXY => $options['no_proxy'] ?? $_SERVER['no_proxy'] ?? $_SERVER['NO_PROXY'] ?? '',
+            // Always set, so that curl doesn't resolve the proxy from its own environment
+            \CURLOPT_PROXY => $proxy ?? '',
+            \CURLOPT_NOPROXY => $noProxy,
             \CURLOPT_SSL_VERIFYPEER => $options['verify_peer'],
             \CURLOPT_SSL_VERIFYHOST => $options['verify_host'] ? 2 : 0,
             \CURLOPT_CAINFO => $options['cafile'],
@@ -319,7 +322,7 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
             }
         }
 
-        return $pushedResponse ?? new CurlResponse($multi, $ch, $options, $this->logger, $method, self::createRedirectResolver($options, $scheme, $host), CurlClientState::$curlVersion['version_number']);
+        return $pushedResponse ?? new CurlResponse($multi, $ch, $options, $this->logger, $method, self::createRedirectResolver($options, $scheme, $host, $noProxy), CurlClientState::$curlVersion['version_number']);
     }
 
     /**
@@ -407,7 +410,7 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
      *
      * Work around CVE-2018-1000007: Authorization and Cookie headers should not follow redirects - fixed in Curl 7.64
      */
-    private static function createRedirectResolver(array $options, string $scheme, string $host): \Closure
+    private static function createRedirectResolver(array $options, string $scheme, string $host, string $noProxy): \Closure
     {
         $redirectHeaders = [];
         if (0 < $options['max_redirects']) {
@@ -424,7 +427,7 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
             }
         }
 
-        return static function ($ch, string $location, bool $noContent) use (&$redirectHeaders, $options) {
+        return static function ($ch, string $location, bool $noContent) use (&$redirectHeaders, $options, $noProxy) {
             try {
                 $location = self::parseUrl($location);
                 $url = self::parseUrl(curl_getinfo($ch, \CURLINFO_EFFECTIVE_URL));
@@ -449,10 +452,40 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
                 curl_setopt($ch, \CURLOPT_HTTPHEADER, $redirectHeaders['with_auth']);
             }
 
-            curl_setopt($ch, \CURLOPT_PROXY, self::getProxyUrl($options['proxy'], $url));
+            $proxy = self::getProxyUrl($options['proxy'], $url);
+            self::checkHttpsProxySupport($proxy, $url, $noProxy);
+            curl_setopt($ch, \CURLOPT_PROXY, $proxy ?? '');
 
             return implode('', $url);
         };
+    }
+
+    /**
+     * Rejects "https://" proxies that curl cannot connect to over TLS.
+     *
+     * Curl older than 7.50.2 connects to them in cleartext instead, leaking the proxy
+     * credentials and the CONNECT metadata on the wire.
+     */
+    private static function checkHttpsProxySupport(?string $proxy, array $url, string $noProxy): void
+    {
+        if (null === $proxy || 0 !== stripos($proxy, 'https://')) {
+            return;
+        }
+
+        if (CurlClientState::$curlVersion['features'] & (\defined('CURL_VERSION_HTTPS_PROXY') ? \CURL_VERSION_HTTPS_PROXY : 1 << 21)) {
+            return;
+        }
+
+        $host = parse_url($url['authority'], \PHP_URL_HOST);
+
+        // Matching "no_proxy" should follow the behavior of curl
+        foreach (preg_split('/[\s,]+/', $noProxy, -1, \PREG_SPLIT_NO_EMPTY) as $rule) {
+            if ('*' === $rule || $host === $rule || str_ends_with($host, '.'.ltrim($rule, '.'))) {
+                return;
+            }
+        }
+
+        throw new TransportException('Cannot use an "https://" proxy: the installed curl does not support HTTPS proxies and could connect to it in cleartext; curl 7.52 or higher is required.');
     }
 
     private function ensureState(): CurlClientState

--- a/src/Symfony/Component/HttpClient/Response/CurlResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/CurlResponse.php
@@ -430,7 +430,17 @@ final class CurlResponse implements ResponseInterface, StreamableInterface
                 curl_setopt($ch, \CURLOPT_CUSTOMREQUEST, $info['http_method']);
             }
 
-            if (null === $info['redirect_url'] = $resolveRedirect($ch, $location, $noContent)) {
+            try {
+                $info['redirect_url'] = $resolveRedirect($ch, $location, $noContent);
+            } catch (TransportException $e) {
+                // Exceptions must be reported through the response, they cannot escape a curl callback
+                $multi->handlesActivity[$id][] = null;
+                $multi->handlesActivity[$id][] = $e;
+
+                return 0;
+            }
+
+            if (null === $info['redirect_url']) {
                 $options['max_redirects'] = curl_getinfo($ch, \CURLINFO_REDIRECT_COUNT);
                 curl_setopt($ch, \CURLOPT_FOLLOWLOCATION, false);
                 curl_setopt($ch, \CURLOPT_MAXREDIRS, $options['max_redirects']);

--- a/src/Symfony/Component/HttpClient/Tests/CurlHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/CurlHttpClientTest.php
@@ -13,6 +13,8 @@ namespace Symfony\Component\HttpClient\Tests;
 
 use Symfony\Component\HttpClient\CurlHttpClient;
 use Symfony\Component\HttpClient\Exception\InvalidArgumentException;
+use Symfony\Component\HttpClient\Exception\TransportException;
+use Symfony\Component\HttpClient\Internal\CurlClientState;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
@@ -21,6 +23,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 class CurlHttpClientTest extends HttpClientTestCase
 {
+    private const HTTPS_PROXY_ERROR = 'Cannot use an "https://" proxy: the installed curl does not support HTTPS proxies and could connect to it in cleartext; curl 7.52 or higher is required.';
+
     protected function getHttpClient(string $testCase): HttpClientInterface
     {
         if (!str_contains($testCase, 'Push')) {
@@ -125,6 +129,82 @@ class CurlHttpClientTest extends HttpClientTestCase
         ];
     }
 
+    public function testHttpsProxyIsRejectedWhenCurlLacksSupport()
+    {
+        $client = $this->getHttpClient(__FUNCTION__);
+
+        $this->withProxyEnvironment([], [], false, function () use ($client) {
+            $this->expectException(TransportException::class);
+            $this->expectExceptionMessage(self::HTTPS_PROXY_ERROR);
+
+            $client->request('GET', 'http://127.0.0.1:8057/', ['proxy' => 'https://127.0.0.1:8057']);
+        });
+    }
+
+    public function testHttpsProxyFromServerVarsIsRejectedWhenCurlLacksSupport()
+    {
+        $client = $this->getHttpClient(__FUNCTION__);
+
+        $this->withProxyEnvironment(['https_proxy' => 'https://127.0.0.1:8057'], [], false, function () use ($client) {
+            $this->expectException(TransportException::class);
+            $this->expectExceptionMessage(self::HTTPS_PROXY_ERROR);
+
+            $client->request('GET', 'https://127.0.0.1:8057/');
+        });
+    }
+
+    public function testProxyFromProcessEnvIsNotUsed()
+    {
+        $client = $this->getHttpClient(__FUNCTION__);
+
+        // Only curl reads the process environment, and it must not do so behind our back
+        $this->withProxyEnvironment([], ['http_proxy' => 'http://127.0.0.1:9'], true, function () use ($client) {
+            $response = $client->request('GET', 'http://127.0.0.1:8057/');
+
+            $this->assertSame(200, $response->getStatusCode());
+        });
+    }
+
+    public function testHttpsProxyIsRejectedOnRedirectWhenCurlLacksSupport()
+    {
+        $client = $this->getHttpClient(__FUNCTION__);
+
+        $this->withProxyEnvironment(['https_proxy' => 'https://127.0.0.1:8057'], [], false, function () use ($client) {
+            $response = $client->request('GET', 'http://127.0.0.1:8057/302?location=https://127.0.0.1:8057/');
+
+            $this->expectException(TransportException::class);
+            $this->expectExceptionMessage(self::HTTPS_PROXY_ERROR);
+
+            $response->getStatusCode();
+        });
+    }
+
+    public function testHttpsProxyIsNotRejectedWhenNoProxyMatches()
+    {
+        $client = $this->getHttpClient(__FUNCTION__);
+
+        $this->withProxyEnvironment([], [], false, function () use ($client) {
+            $response = $client->request('GET', 'http://127.0.0.1:8057/', [
+                'proxy' => 'https://127.0.0.1:8057',
+                'no_proxy' => '127.0.0.1',
+            ]);
+
+            $this->assertSame(200, $response->getStatusCode());
+        });
+    }
+
+    public function testHttpsProxyIsNotRejectedWhenCurlSupportsIt()
+    {
+        $client = $this->getHttpClient(__FUNCTION__);
+
+        $this->withProxyEnvironment([], [], true, function () use ($client) {
+            $response = $client->request('GET', 'http://127.0.0.1:8057/', ['proxy' => 'https://127.0.0.1:8057']);
+            $response->cancel();
+
+            $this->addToAssertionCount(1);
+        });
+    }
+
     public function testKeepAuthorizationHeaderOnRedirectToSameHostWithConfiguredHostToIpAddressMapping()
     {
         $httpClient = $this->getHttpClient(__FUNCTION__);
@@ -167,6 +247,48 @@ class CurlHttpClientTest extends HttpClientTestCase
                 $response->getContent();
 
                 self::assertSame($expectedResult[$i], str_contains($response->getInfo('debug'), 'Re-using existing connection'));
+            }
+        }
+    }
+
+    /**
+     * Runs $test with a controlled proxy environment and a curl that pretends to support HTTPS proxies or not.
+     */
+    private function withProxyEnvironment(array $server, array $env, bool $httpsProxySupport, \Closure $test): void
+    {
+        $backup = [];
+
+        foreach (['http_proxy', 'HTTP_PROXY', 'https_proxy', 'HTTPS_PROXY', 'all_proxy', 'ALL_PROXY', 'no_proxy', 'NO_PROXY'] as $name) {
+            $backup[$name] = [\array_key_exists($name, $_SERVER) ? $_SERVER[$name] : null, getenv($name, true)];
+            unset($_SERVER[$name]);
+            putenv($name);
+        }
+
+        foreach ($server as $name => $value) {
+            $_SERVER[$name] = $value;
+        }
+
+        foreach ($env as $name => $value) {
+            putenv($name.'='.$value);
+        }
+
+        $curlVersion = CurlClientState::$curlVersion ?? curl_version();
+        $httpsProxyFeature = \defined('CURL_VERSION_HTTPS_PROXY') ? \CURL_VERSION_HTTPS_PROXY : 1 << 21;
+        CurlClientState::$curlVersion = ['features' => $httpsProxySupport ? $curlVersion['features'] | $httpsProxyFeature : $curlVersion['features'] & ~$httpsProxyFeature] + $curlVersion;
+
+        try {
+            $test();
+        } finally {
+            CurlClientState::$curlVersion = $curlVersion;
+
+            foreach ($backup as $name => [$serverValue, $envValue]) {
+                if (null === $serverValue) {
+                    unset($_SERVER[$name]);
+                } else {
+                    $_SERVER[$name] = $serverValue;
+                }
+
+                false === $envValue ? putenv($name) : putenv($name.'='.$envValue);
             }
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Backport of #65028 (cherry-pick of 8896a7c2f92) to 5.4.

Adapted for 5.4: ported by hand: `createRedirectResolver()` has a different signature on 5.4.
