### PR TITLE
[Mime] Reject an unquoted "@" in the local part of an email address

### DIFF
--- a/src/Symfony/Component/Mime/Address.php
+++ b/src/Symfony/Component/Mime/Address.php
@@ -56,7 +56,7 @@ final class Address
             throw new InvalidArgumentException('Email address contains control characters.');
         }
 
-        if (!self::$validator->isValid($this->address, class_exists(MessageIDValidation::class) ? new MessageIDValidation() : new RFCValidation())) {
+        if (!self::isValidAddrSpec($this->address)) {
             throw new RfcComplianceException(sprintf('Email "%s" does not comply with addr-spec of RFC 2822.', $address));
         }
     }
@@ -149,5 +149,20 @@ final class Address
         }
 
         return new self($matches['addrSpec'], trim($matches['displayName'], ' \'"'));
+    }
+
+    private static function isValidAddrSpec(string $address): bool
+    {
+        // the message id validation is needed as this class also holds the ids of the Message-ID,
+        // In-Reply-To and References headers, but it accepts an unquoted "@" in the local part
+        if (!self::$validator->isValid($address, class_exists(MessageIDValidation::class) ? new MessageIDValidation() : new RFCValidation())) {
+            return false;
+        }
+
+        if (substr_count($address, '@') < 2) {
+            return true;
+        }
+
+        return self::$validator->isValid(substr($address, 0, strrpos($address, '@')).'@example.com', new RFCValidation());
     }
 }

--- a/src/Symfony/Component/Mime/Tests/AddressTest.php
+++ b/src/Symfony/Component/Mime/Tests/AddressTest.php
@@ -38,6 +38,19 @@ class AddressTest extends TestCase
         new Address('fab   pot@symfony.com');
     }
 
+    public function testConstructorWithUnquotedAtSignInLocalPart()
+    {
+        $this->expectException(RfcComplianceException::class);
+        $this->expectExceptionMessage('Email "em@il@example.test" does not comply with addr-spec of RFC 2822.');
+        new Address('em@il@example.test');
+    }
+
+    public function testConstructorWithQuotedAtSignInLocalPart()
+    {
+        $a = new Address('"em@il"@example.test');
+        $this->assertSame('"em@il"@example.test', $a->getAddress());
+    }
+
     /**
      * @dataProvider provideAddressesWithControlCharacters
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Backport of #65509 (cherry-pick of 0fd64d06617) to 5.4.

Adapted for 5.4: the deprecated `fromString()` method is kept.
