### PR TITLE
[Messenger] Drop trace args from FlattenException normalization

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/Stamp/ErrorDetailsStampTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Stamp/ErrorDetailsStampTest.php
@@ -56,6 +56,18 @@ class ErrorDetailsStampTest extends TestCase
     {
         $exception = new \Exception('exception message');
         $stamp = ErrorDetailsStamp::create($exception);
+
+        // FlattenExceptionNormalizer drops trace args, mirror that on the expected stamp
+        $flattenException = $stamp->getFlattenException();
+        $trace = array_map(static function (array $frame): array {
+            unset($frame['args']);
+
+            return $frame;
+        }, $flattenException->getTrace());
+        $traceProperty = new \ReflectionProperty(FlattenException::class, 'trace');
+        $traceProperty->setAccessible(true);
+        $traceProperty->setValue($flattenException, $trace);
+
         $serializer = new Serializer(
             new SymfonySerializer([
                 new ArrayDenormalizer(),

--- a/src/Symfony/Component/Messenger/Tests/Transport/Serialization/Normalizer/FlattenExceptionNormalizerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Serialization/Normalizer/FlattenExceptionNormalizerTest.php
@@ -58,7 +58,12 @@ class FlattenExceptionNormalizerTest extends TestCase
         $this->assertSame($exception->getFile(), $normalized['file']);
         $this->assertSame($exception->getLine(), $normalized['line']);
         $this->assertSame($previous, $normalized['previous']);
-        $this->assertSame($exception->getTrace(), $normalized['trace']);
+        $expectedTrace = array_map(static function (array $frame): array {
+            unset($frame['args']);
+
+            return $frame;
+        }, $exception->getTrace());
+        $this->assertSame($expectedTrace, $normalized['trace']);
         $this->assertSame($exception->getTraceAsString(), $normalized['trace_as_string']);
         $this->assertSame($exception->getStatusText(), $normalized['status_text']);
     }
@@ -70,6 +75,32 @@ class FlattenExceptionNormalizerTest extends TestCase
             'instance with previous exception' => [FlattenException::createFromThrowable(new \RuntimeException('foo', 42, new \Exception()))],
             'instance with headers' => [FlattenException::createFromThrowable(new \RuntimeException('foo', 42), 404, ['Foo' => 'Bar'])],
         ];
+    }
+
+    public function testNormalizeStripsTraceArgs()
+    {
+        $exception = FlattenException::createFromThrowable(new \RuntimeException('boom'));
+
+        $trace = $exception->getTrace();
+        $trace[] = [
+            'namespace' => '', 'short_class' => '', 'class' => '', 'type' => '',
+            'function' => 'fromPdf', 'file' => 'foo.php', 'line' => 1,
+            'args' => [
+                ['string', 'valid utf8'],
+                ['string', "\x80\x81\xfe"],
+            ],
+        ];
+        $traceProperty = new \ReflectionProperty(FlattenException::class, 'trace');
+        $traceProperty->setAccessible(true);
+        $traceProperty->setValue($exception, $trace);
+
+        $normalized = $this->normalizer->normalize($exception, null, $this->getMessengerContext());
+
+        foreach ($normalized['trace'] as $frame) {
+            $this->assertArrayNotHasKey('args', $frame);
+        }
+
+        $this->assertNotFalse(json_encode($normalized));
     }
 
     public function testSupportsDenormalization()

--- a/src/Symfony/Component/Messenger/Transport/Serialization/Normalizer/FlattenExceptionNormalizer.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/Normalizer/FlattenExceptionNormalizer.php
@@ -44,7 +44,7 @@ final class FlattenExceptionNormalizer implements DenormalizerInterface, Context
             'previous' => null === $object->getPrevious() ? null : $this->normalize($object->getPrevious(), $format, $context),
             'status' => $object->getStatusCode(),
             'status_text' => $object->getStatusText(),
-            'trace' => $object->getTrace(),
+            'trace' => self::sanitizeTrace($object->getTrace()),
             'trace_as_string' => $object->getTraceAsString(),
         ];
 
@@ -96,5 +96,16 @@ final class FlattenExceptionNormalizer implements DenormalizerInterface, Context
     public function supportsDenormalization($data, string $type, ?string $format = null, array $context = []): bool
     {
         return FlattenException::class === $type && ($context[Serializer::MESSENGER_SERIALIZATION_CONTEXT] ?? false);
+    }
+
+    private static function sanitizeTrace(array $trace): array
+    {
+        foreach ($trace as &$frame) {
+            if (isset($frame['args'])) {
+                unset($frame['args']);
+            }
+        }
+
+        return $trace;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Backport of #64153 and #64176 (cherry-pick of f367ca616e1, c357bfcef89) to 5.4.

Adapted for 5.4: two commits, the second is the test fix that followed; the tests call `ReflectionProperty::setAccessible(true)` before writing a private property, skipping it only works from PHP 8.1 on.
