### PR TITLE
[RateLimiter] Cap the burst size and the duration computed from it

### DIFF
--- a/src/Symfony/Component/RateLimiter/Policy/Rate.php
+++ b/src/Symfony/Component/RateLimiter/Policy/Rate.php
@@ -20,6 +20,11 @@ use Symfony\Component\RateLimiter\Util\TimeUtil;
  */
 final class Rate
 {
+    /**
+     * ~68 years, the largest duration that still fits an int on 32-bit platforms.
+     */
+    private const MAX_SECONDS = 2147483647;
+
     private $refillTime;
     private $refillAmount;
 
@@ -71,12 +76,15 @@ final class Rate
 
     /**
      * Calculates the time needed to free up the provided number of tokens in seconds.
+     *
+     * The result is capped at self::MAX_SECONDS, as the exact value overflows the
+     * integer range for very large numbers of tokens.
      */
     public function calculateTimeForTokens(int $tokens): int
     {
         $cyclesRequired = ceil($tokens / $this->refillAmount);
 
-        return TimeUtil::dateIntervalToSeconds($this->refillTime) * $cyclesRequired;
+        return (int) min(self::MAX_SECONDS, TimeUtil::dateIntervalToSeconds($this->refillTime) * $cyclesRequired);
     }
 
     /**

--- a/src/Symfony/Component/RateLimiter/Policy/TokenBucket.php
+++ b/src/Symfony/Component/RateLimiter/Policy/TokenBucket.php
@@ -20,6 +20,12 @@ use Symfony\Component\RateLimiter\LimiterStateInterface;
  */
 final class TokenBucket implements LimiterStateInterface
 {
+    /**
+     * __serialize() stores the burst size in a 32-bit field; 2^31-1 is the
+     * largest value that also survives the round trip on 32-bit platforms.
+     */
+    public const MAX_BURST_SIZE = 2147483647;
+
     private $id;
     private $rate;
 
@@ -40,7 +46,7 @@ final class TokenBucket implements LimiterStateInterface
 
     /**
      * @param string     $id            unique identifier for this bucket
-     * @param int        $initialTokens the initial number of tokens in the bucket (i.e. the max burst size)
+     * @param int        $initialTokens the initial number of tokens in the bucket (i.e. the max burst size), capped at self::MAX_BURST_SIZE
      * @param Rate       $rate          the fill rate and time of this bucket
      * @param float|null $timer         the current timer of the bucket, defaulting to microtime(true)
      */
@@ -51,7 +57,7 @@ final class TokenBucket implements LimiterStateInterface
         }
 
         $this->id = $id;
-        $this->tokens = $this->burstSize = $initialTokens;
+        $this->tokens = $this->burstSize = min($initialTokens, self::MAX_BURST_SIZE);
         $this->rate = $rate;
         $this->timer = $timer ?? microtime(true);
     }

--- a/src/Symfony/Component/RateLimiter/Policy/TokenBucketLimiter.php
+++ b/src/Symfony/Component/RateLimiter/Policy/TokenBucketLimiter.php
@@ -32,7 +32,7 @@ final class TokenBucketLimiter implements LimiterInterface
     public function __construct(string $id, int $maxBurst, Rate $rate, StorageInterface $storage, ?LockInterface $lock = null)
     {
         $this->id = $id;
-        $this->maxBurst = $maxBurst;
+        $this->maxBurst = min($maxBurst, TokenBucket::MAX_BURST_SIZE);
         $this->rate = $rate;
         $this->storage = $storage;
         $this->lock = $lock ?? new NoLock();

--- a/src/Symfony/Component/RateLimiter/Tests/Policy/RateTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/Policy/RateTest.php
@@ -47,7 +47,8 @@ class RateTest extends TestCase
     {
         yield 'product far above the int range' => [Rate::perHour(1), \PHP_INT_MAX];
         yield 'product rounding to exactly the int range bound' => [new Rate(new \DateInterval('PT10S'), 10), \PHP_INT_MAX];
-        yield 'product just above the cap' => [Rate::perSecond(1), 2147483648];
+        // the token count stays within the int range on 32-bit platforms, only the product exceeds the cap
+        yield 'product just above the cap' => [new Rate(new \DateInterval('PT2S'), 1), 1073741824];
     }
 
     public function testCalculateTimeForTokensBelowTheCapIsNotChanged()

--- a/src/Symfony/Component/RateLimiter/Tests/Policy/RateTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/Policy/RateTest.php
@@ -34,4 +34,25 @@ class RateTest extends TestCase
         yield [Rate::perMonth(10)];
         yield [Rate::perYear(10)];
     }
+
+    /**
+     * @dataProvider provideOverflowingRate
+     */
+    public function testCalculateTimeForTokensIsCappedOnOverflow(Rate $rate, int $tokens)
+    {
+        self::assertSame(2147483647, $rate->calculateTimeForTokens($tokens));
+    }
+
+    public static function provideOverflowingRate(): iterable
+    {
+        yield 'product far above the int range' => [Rate::perHour(1), \PHP_INT_MAX];
+        yield 'product rounding to exactly the int range bound' => [new Rate(new \DateInterval('PT10S'), 10), \PHP_INT_MAX];
+        yield 'product just above the cap' => [Rate::perSecond(1), 2147483648];
+    }
+
+    public function testCalculateTimeForTokensBelowTheCapIsNotChanged()
+    {
+        self::assertSame(2147483647, Rate::perSecond(1)->calculateTimeForTokens(2147483647));
+        self::assertSame(3600, Rate::perHour(1)->calculateTimeForTokens(1));
+    }
 }

--- a/src/Symfony/Component/RateLimiter/Tests/Policy/TokenBucketLimiterTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/Policy/TokenBucketLimiterTest.php
@@ -154,6 +154,27 @@ class TokenBucketLimiterTest extends TestCase
         }
     }
 
+    public function testEffectivelyInfiniteBurstSizeIsCapped()
+    {
+        $limiter = $this->createLimiter(\PHP_INT_MAX, new Rate(new \DateInterval('PT10S'), 10));
+
+        $rateLimit = $limiter->consume(1);
+
+        $this->assertTrue($rateLimit->isAccepted());
+        $this->assertSame(TokenBucket::MAX_BURST_SIZE, $rateLimit->getLimit());
+        $this->assertSame(TokenBucket::MAX_BURST_SIZE - 1, $rateLimit->getRemainingTokens());
+    }
+
+    public function testCappedBurstSizeSurvivesTheStorageRoundTrip()
+    {
+        $limiter = $this->createLimiter(\PHP_INT_MAX, new Rate(new \DateInterval('PT10S'), 10));
+
+        $limiter->consume(1);
+        $rateLimit = $limiter->consume(1);
+
+        $this->assertSame(TokenBucket::MAX_BURST_SIZE - 2, $rateLimit->getRemainingTokens());
+    }
+
     private function createLimiter($initialTokens = 10, ?Rate $rate = null)
     {
         return new TokenBucketLimiter('test', $initialTokens, $rate ?? Rate::perSecond(10), $this->storage);

--- a/src/Symfony/Component/RateLimiter/Tests/Policy/TokenBucketTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/Policy/TokenBucketTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\RateLimiter\Tests\Policy;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\RateLimiter\Policy\Rate;
+use Symfony\Component\RateLimiter\Policy\TokenBucket;
+
+class TokenBucketTest extends TestCase
+{
+    public function testBurstSizeIsCappedToWhatSerializationCanStore()
+    {
+        $bucket = new TokenBucket('test', \PHP_INT_MAX, Rate::perSecond(10));
+
+        $this->assertSame(TokenBucket::MAX_BURST_SIZE, $bucket->getAvailableTokens(microtime(true)));
+    }
+
+    public function testCappedBurstSizeRoundTripsThroughSerialization()
+    {
+        $bucket = new TokenBucket('test', \PHP_INT_MAX, Rate::perSecond(10));
+        $bucket->setTokens(TokenBucket::MAX_BURST_SIZE - 5);
+
+        $restored = unserialize(serialize($bucket));
+
+        $this->assertSame(TokenBucket::MAX_BURST_SIZE - 5, $restored->getAvailableTokens($restored->getTimer()));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Backport of #65193 (cherry-pick of 96c67ab3058) to 5.4.

Adapted for 5.4: ported by hand, 5.4 has no typed properties; `TokenBucketTest` is created with the two tests the original commit added to it.


Also cherry-picks c687a017715, the follow-up that keeps the token count within the int range on 32-bit platforms so the overflow test passes there.
