### PR TITLE
[PropertyInfo] Read only the doc block of a promoted property in getTypeFromConstructor()

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
@@ -132,21 +132,25 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
 
     public function getTypeFromConstructor(string $class, string $property): ?Type
     {
-        if (!$docBlock = $this->getDocBlockFromConstructor($class, $property)) {
-            return null;
-        }
-
         $types = [];
-        /** @var DocBlock\Tags\Var_|DocBlock\Tags\Return_|DocBlock\Tags\Param $tag */
-        foreach ($docBlock->getTagsByName('param') as $tag) {
-            if ($tag instanceof InvalidTag || !$tagType = $tag->getType()) {
-                continue;
-            }
 
-            $types[] = $this->phpDocTypeHelper->getType($tagType);
+        if ($docBlock = $this->getDocBlockFromConstructor($class, $property)) {
+            /** @var DocBlock\Tags\Var_|DocBlock\Tags\Return_|DocBlock\Tags\Param $tag */
+            foreach ($docBlock->getTagsByName('param') as $tag) {
+                if ($tag instanceof InvalidTag || !$tagType = $tag->getType()) {
+                    continue;
+                }
+
+                $types[] = $this->phpDocTypeHelper->getType($tagType);
+            }
         }
 
-        return $types[0] ?? null;
+        if (null !== $type = $types[0] ?? null) {
+            return $type;
+        }
+
+        // the doc block of a promoted property describes the constructor argument, the one of a plain property does not
+        return $this->isPromotedProperty($class, $property) ? $this->getType($class, $property) : null;
     }
 
     public function getDocBlock(string $class, string $property): ?DocBlock
@@ -453,5 +457,14 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
         }
 
         return null;
+    }
+
+    private function isPromotedProperty(string $class, string $property): bool
+    {
+        try {
+            return (new \ReflectionProperty($class, $property))->isPromoted();
+        } catch (\ReflectionException) {
+            return false;
+        }
     }
 }

--- a/src/Symfony/Component/PropertyInfo/Extractor/PhpStanExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/PhpStanExtractor.php
@@ -140,7 +140,8 @@ final class PhpStanExtractor implements PropertyDescriptionExtractorInterface, P
     {
         $declaringClass = $class;
         if (!$tagDocNode = $this->getDocBlockFromConstructor($declaringClass, $property)) {
-            return $this->getType($class, $property);
+            // the doc block of a promoted property describes the constructor argument, the one of a plain property does not
+            return $this->isPromotedProperty($class, $property) ? $this->getType($class, $property) : null;
         }
 
         $typeContext = $this->typeContextFactory->createFromClassName($class, $declaringClass);
@@ -480,5 +481,14 @@ final class PhpStanExtractor implements PropertyDescriptionExtractorInterface, P
     private function canAccessMemberBasedOnItsVisibility(\ReflectionProperty|\ReflectionMethod $member): bool
     {
         return $this->allowPrivateAccess || $member->isPublic();
+    }
+
+    private function isPromotedProperty(string $class, string $property): bool
+    {
+        try {
+            return (new \ReflectionProperty($class, $property))->isPromoted();
+        } catch (\ReflectionException) {
+            return false;
+        }
     }
 }

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
@@ -20,6 +20,8 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Clazz;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\ConstructorDummy;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\ConstructorDummyWithPropertyDocBlock;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\ConstructorDummyWithVarTagsDocBlock;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\DockBlockFallback;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\DummyCollection;
@@ -491,6 +493,40 @@ class PhpDocExtractorTest extends TestCase
         yield ['dateTime', null];
         yield ['ddd', null];
         yield ['mixed', Type::mixed()];
+    }
+
+    #[DataProvider('constructorTypesWithOnlyVarTagsProvider')]
+    public function testExtractConstructorTypesWithOnlyVarTags(string $property, ?Type $type)
+    {
+        $this->assertEquals($type, $this->extractor->getTypeFromConstructor(ConstructorDummyWithVarTagsDocBlock::class, $property));
+    }
+
+    /**
+     * @return iterable<array{0: string, 1: ?Type}>
+     */
+    public static function constructorTypesWithOnlyVarTagsProvider(): iterable
+    {
+        yield ['date', Type::int()];
+        yield ['dateObject', Type::object(\DateTimeInterface::class)];
+        yield ['objectsArray', Type::array(Type::object(ConstructorDummy::class))];
+        yield ['dateTime', null];
+        yield ['mixed', null];
+        yield ['timezone', null];
+    }
+
+    #[DataProvider('constructorTypesWithPropertyDocBlockProvider')]
+    public function testExtractConstructorTypesIgnoresTheDocBlockOfAPlainProperty(string $property)
+    {
+        $this->assertNull($this->extractor->getTypeFromConstructor(ConstructorDummyWithPropertyDocBlock::class, $property));
+    }
+
+    /**
+     * @return iterable<array{0: string}>
+     */
+    public static function constructorTypesWithPropertyDocBlockProvider(): iterable
+    {
+        yield ['date'];
+        yield ['objectsArray'];
     }
 
     #[DataProvider('pseudoTypeProvider')]

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpStanExtractorTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\PropertyInfo\Extractor\PhpStanExtractor;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Clazz;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\ConstructorDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\ConstructorDummyWithoutDocBlock;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\ConstructorDummyWithPropertyDocBlock;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\ConstructorDummyWithVarTagsDocBlock;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\DefaultValue;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\DockBlockFallback;
@@ -325,7 +326,7 @@ class PhpStanExtractorTest extends TestCase
         yield ['date', Type::int()];
         yield ['timezone', Type::object(\DateTimeZone::class)];
         yield ['dateObject', Type::object(\DateTimeInterface::class)];
-        yield ['dateTime', Type::int()];
+        yield ['dateTime', null];
         yield ['ddd', null];
     }
 
@@ -346,6 +347,21 @@ class PhpStanExtractorTest extends TestCase
         yield ['dateTime', null];
         yield ['mixed', null];
         yield ['timezone', null];
+    }
+
+    #[DataProvider('constructorTypesWithPropertyDocBlockProvider')]
+    public function testExtractConstructorTypesIgnoresTheDocBlockOfAPlainProperty(string $property)
+    {
+        $this->assertNull($this->extractor->getTypeFromConstructor(ConstructorDummyWithPropertyDocBlock::class, $property));
+    }
+
+    /**
+     * @return iterable<array{0: string}>
+     */
+    public static function constructorTypesWithPropertyDocBlockProvider(): iterable
+    {
+        yield ['date'];
+        yield ['objectsArray'];
     }
 
     #[DataProvider('constructorTypesOfParentClassProvider')]

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/ConstructorDummyWithPropertyDocBlock.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/ConstructorDummyWithPropertyDocBlock.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
+
+class ConstructorDummyWithPropertyDocBlock
+{
+    /** @var int */
+    public $date;
+
+    /** @var ConstructorDummy[] */
+    public array $objectsArray;
+
+    public function __construct(array $objectsArray, $date)
+    {
+        $this->objectsArray = $objectsArray;
+        $this->date = $date;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Related to #65661, #65291
| License       | MIT

`getTypeFromConstructor()` answers about a constructor argument. When the constructor declares no matching `@param`, only the doc block of a **promoted** property still describes that argument, because it sits on the parameter itself. The doc block of a plain property describes the property, not the argument.

The two doc block extractors got this wrong in opposite directions:

* `PhpStanExtractor` fell back to the doc block of **any** property, promoted or not
* `PhpDocExtractor` had no fallback at all, so it missed promoted properties

Both now fall back for a promoted property only.

### Why it matters

`ConstructorExtractor` collects these extractors, and FrameworkBundle puts it at the head of the type extractor chain. So the two defects reach the Serializer.

Take a class whose constructor converts its input:

```php
class Foo
{
    /** @var array<int> */
    public readonly array $values;

    public function __construct(array $values)
    {
        $this->values = array_map(intval(...), $values);
    }
}
```

The constructor argument is declared `array`, with no element type. Since 8.1.5 enforces the element type of scalar collections, denormalizing `['values' => ['1', '2']]` throws `The type of the "values" attribute for class "Foo" must be one of "int" ("string" given).`, because the doc block of the property is used to type the argument. Nobody declared `array<int>` for that argument.

The extracted type also depended on which doc block parser was installed, since the phpstan extractor outranks the reflection one inside `ConstructorExtractor`:

| installed extractors | before | after |
| --- | --- | --- |
| phpstan + phpdoc | `array<int>` | `array` |
| phpdoc only | `array` | `array` |
| phpstan only | `array<int>` | `array` |

### Before/after

Nothing changes when the constructor declares a `@param`, which is the common case, promoted properties included. What changes:

| shape | before | after |
| --- | --- | --- |
| promoted property with `/** @var int */` on the parameter | phpstan `int`, phpdoc `null` | `int` in both |
| plain property with `@var`, no `@param` | phpstan the property type, phpdoc `null` | `null` in both |

The fixture `ConstructorDummy` shows why the old answer was wrong: its `dateTime` parameter is a `\DateTimeImmutable`, the property it feeds is a `/** @var int */` holding `$dateTime->getTimestamp()`, and `getTypeFromConstructor()` reported `int` for the parameter. That expectation is updated in this PR.

### Trap

For the plain-property shape, the composite `PropertyInfoExtractor` now reports `array` instead of `array<int>` to every consumer, not only the Serializer, because `ConstructorExtractor` answers first. Validator auto mapping and Form type guessing lose the element type there. That is already what applications without the phpstan extractor get today, so this aligns the two setups rather than adding a new case.

### Tests

Five new cases, plus the `dateTime` expectation above, across both extractors. `ConstructorDummyWithPropertyDocBlock` is the new fixture for the plain shape; the promoted cases reuse `ConstructorDummyWithVarTagsDocBlock`, so both extractors now assert on the same values.

Ran locally: PropertyInfo 602, Serializer 1408, Validator 5166, Form 4958, all green. Each new test was checked against the unpatched source and fails there.
