### PR TITLE
[Serializer] Enforce the element type of nested scalar collections

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -581,7 +581,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                         $class = $collectionValueBaseType->getClassName().'[]';
                         $context['key_type'] = $collectionKeyType;
                         $context['value_type'] = $collectionValueType;
-                    } elseif (\is_array($data) && $collectionValueBaseType instanceof BuiltinType && \in_array($collectionValueBaseType->getTypeIdentifier(), [TypeIdentifier::BOOL, TypeIdentifier::FLOAT, TypeIdentifier::INT, TypeIdentifier::STRING], true)) {
+                    } elseif (\is_array($data) && self::hasScalarElements($collectionValueBaseType, $collectionValueType)) {
                         // elements of a scalar collection are converted and enforced with the very same rules as any other value
                         $result = [];
                         $childContext = null;
@@ -596,6 +596,8 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                                 TypeIdentifier::BOOL => \is_bool($value),
                                 TypeIdentifier::FLOAT => \is_float($value),
                                 TypeIdentifier::INT => \is_int($value),
+                                // a nested collection is an array already, its own elements still have to be checked
+                                TypeIdentifier::ARRAY => false,
                                 default => \is_string($value),
                             }) {
                                 $result[$key] = $value;
@@ -818,6 +820,22 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
         $parameterData = $this->applyCallbacks($parameterData, $class->getName(), $parameterName, $format, $context);
 
         return $this->applyFilterBool($parameter, $parameterData, $context);
+    }
+
+    /**
+     * Tells whether the elements of a collection are scalars, or nested collections of scalars.
+     */
+    private static function hasScalarElements(Type $collectionValueBaseType, Type $collectionValueType): bool
+    {
+        if ($collectionValueBaseType instanceof BuiltinType && TypeIdentifier::ARRAY === $collectionValueBaseType->getTypeIdentifier()) {
+            while ($collectionValueType instanceof NullableType || $collectionValueType instanceof CollectionType) {
+                $collectionValueType = $collectionValueType instanceof NullableType ? $collectionValueType->getWrappedType() : $collectionValueType->getCollectionValueType();
+            }
+
+            $collectionValueBaseType = $collectionValueType;
+        }
+
+        return $collectionValueBaseType instanceof BuiltinType && \in_array($collectionValueBaseType->getTypeIdentifier(), [TypeIdentifier::BOOL, TypeIdentifier::FLOAT, TypeIdentifier::INT, TypeIdentifier::STRING], true);
     }
 
     private function getType(string $currentClass, string $attribute): ?Type

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
@@ -1477,6 +1477,27 @@ class AbstractObjectNormalizerTest extends TestCase
         }
     }
 
+    public function testDenormalizeEnforcesNestedScalarCollectionElementType()
+    {
+        $normalizer = new AbstractObjectNormalizerWithMetadataAndPropertyTypeExtractors();
+
+        try {
+            $normalizer->denormalize(['intsByName' => ['a' => [1, 'nope']]], ScalarCollectionsDummy::class);
+            $this->fail(\sprintf('A "%s" should have been thrown.', NotNormalizableValueException::class));
+        } catch (NotNormalizableValueException $e) {
+            $this->assertSame('intsByName[a][1]', $e->getPath());
+        }
+    }
+
+    public function testDenormalizeConvertsNestedScalarCollectionElements()
+    {
+        $normalizer = new AbstractObjectNormalizerWithMetadataAndPropertyTypeExtractors();
+
+        $dummy = $normalizer->denormalize(['intsByName' => ['a' => ['1', '2']]], ScalarCollectionsDummy::class, null, [AbstractObjectNormalizer::ENABLE_TYPE_CONVERSION => true]);
+
+        $this->assertSame(['a' => [1, 2]], $dummy->intsByName);
+    }
+
     public function testDenormalizeCollectsScalarCollectionElementErrors()
     {
         $serializer = new Serializer([new AbstractObjectNormalizerWithMetadataAndPropertyTypeExtractors()]);
@@ -2312,6 +2333,9 @@ class ScalarCollectionsDummy
 
     /** @var int[]|string[] */
     public array $intsOrStrings = [];
+
+    /** @var array<string, list<int>> */
+    public array $intsByName = [];
 }
 
 class UnionCollectionDocBlockDummy


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Related to #65661, #65291
| License       | MIT

8.1.5 enforces the element type of a scalar collection, so `int[]` receiving `["1"]` throws instead of storing strings in a property declared to hold integers. The rule stops at the first level: `array<string, int[]>` and `int[][]` still keep whatever comes in. This applies it at every level.

```php
class Foo
{
    /** @var array<string, int[]> */
    public array $byName = [];
}
```

Denormalizing `['byName' => ['a' => ['1', 'x']]]`:

| | before | after |
| --- | --- | --- |
| default | kept as `['a' => ['1', 'x']]` | throws `must be one of "int" ("string" given)`, path `byName[a][0]` |
| `ENABLE_TYPE_CONVERSION` | kept as strings | `1` converts, `x` throws `must be int ("x" given)` |
| `DISABLE_TYPE_ENFORCEMENT` | kept as strings | kept as strings |

With `['a' => ['1', '2']]` and conversion enabled, the result is `['a' => [1, 2]]`.

A flat `int[]` already behaves exactly that way, down to the messages, so this removes a difference between two declarations that read the same to a user.

### How it works

`validateAndDenormalize()` already loops over the elements of a scalar collection. The loop now also runs when the element type is itself a collection of scalars, and recurses, so each level is checked by the same code. The fast path that keeps values already of the expected type returns false for an array, otherwise a nested collection would pass untouched because it is an array already.

Collections of objects and elements declared as a bare `array` are untouched.

### Edge cases checked

* conversion and enforcement at two and three levels
* `DISABLE_TYPE_ENFORCEMENT` still passes the values through
* nullable element types still accept `null`
* a non array where a nested collection is expected reports `must be one of "array"`
* `COLLECT_DENORMALIZATION_ERRORS` reports every offending element with its full path
* `array<string, array>` and `array<string, Foo[]>` keep their current behavior

### Trap

The first version of the helper that walks to the innermost element type recursed forever on `array<string, array>`, where the inner type is a bare `array` rather than a collection. The committed one is iterative.

Ran locally: Serializer 1410, HttpKernel 1694, PropertyInfo 592, all green. Both new tests were checked against the unpatched source and fail there.
