### PR TITLE
[HttpClient] Reject decompression bombs

### DIFF
--- a/src/Symfony/Component/HttpClient/Exception/HttpExceptionTrait.php
+++ b/src/Symfony/Component/HttpClient/Exception/HttpExceptionTrait.php
@@ -22,7 +22,10 @@ trait HttpExceptionTrait
 {
     private $response;
 
-    public function __construct(ResponseInterface $response)
+    /**
+     * @param (\Closure(): string)|null $getErrorBody Returns the part of the body the message is parsed from
+     */
+    public function __construct(ResponseInterface $response, ?\Closure $getErrorBody = null)
     {
         $this->response = $response;
         $code = $response->getInfo('http_code');
@@ -55,7 +58,7 @@ trait HttpExceptionTrait
         // Try to guess a better error message using common API error formats
         // The MIME type isn't explicitly checked because some formats inherit from others
         // Ex: JSON:API follows RFC 7807 semantics, Hydra can be used in any JSON-LD-compatible format
-        if ($isJson && $body = json_decode($response->getContent(false), true)) {
+        if ($isJson && $body = json_decode($getErrorBody ? $getErrorBody() : $response->getContent(false), true)) {
             if (isset($body['hydra:title']) || isset($body['hydra:description'])) {
                 // see http://www.hydra-cg.com/spec/latest/core/#description-of-http-status-codes-and-errors
                 $separator = isset($body['hydra:title'], $body['hydra:description']) ? "\n\n" : '';

--- a/src/Symfony/Component/HttpClient/Response/CommonResponseTrait.php
+++ b/src/Symfony/Component/HttpClient/Response/CommonResponseTrait.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpClient\Exception\JsonException;
 use Symfony\Component\HttpClient\Exception\RedirectionException;
 use Symfony\Component\HttpClient\Exception\ServerException;
 use Symfony\Component\HttpClient\Exception\TransportException;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 
 /**
  * Implements common logic for response classes.
@@ -170,16 +171,47 @@ trait CommonResponseTrait
     {
         $code = $this->getInfo('http_code');
 
+        if (300 > $code) {
+            return;
+        }
+
+        $getErrorBody = \Closure::fromCallable([$this, 'getErrorBody']);
+
         if (500 <= $code) {
-            throw new ServerException($this);
+            throw new ServerException($this, $getErrorBody);
         }
 
         if (400 <= $code) {
-            throw new ClientException($this);
+            throw new ClientException($this, $getErrorBody);
         }
 
-        if (300 <= $code) {
-            throw new RedirectionException($this);
+        throw new RedirectionException($this, $getErrorBody);
+    }
+
+    /**
+     * Returns the head of the body, where API error formats put the fields an error message is made of.
+     *
+     * The body can be arbitrarily large, and it is decompressed on the way in, so keeping it whole in
+     * memory is not an option. The rest of it is still streamed, so that the response is left in the
+     * state it would be in if this had not run. Read errors are ignored because this only makes the
+     * message nicer: they are reported again when the body itself is read.
+     */
+    private function getErrorBody(): string
+    {
+        $body = '';
+
+        try {
+            foreach (self::stream([$this]) as $chunk) {
+                if (!$chunk->isLast() && 32768 > \strlen($body)) {
+                    $body .= substr($chunk->getContent(), 0, 32768 - \strlen($body));
+                }
+
+                // Free the current chunk before the next one is inflated
+                $chunk = null;
+            }
+        } catch (TransportExceptionInterface $e) {
         }
+
+        return $body;
     }
 }

--- a/src/Symfony/Component/HttpClient/Response/TransportResponseTrait.php
+++ b/src/Symfony/Component/HttpClient/Response/TransportResponseTrait.php
@@ -41,6 +41,8 @@ trait TransportResponseTrait
     private $id;
     private $timeout = 0;
     private $inflate;
+    private $inflateIn = 0;
+    private $inflateOut = 0;
     private $finalInfo;
     private $logger;
 
@@ -199,9 +201,22 @@ trait TransportResponseTrait
                         $elapsedTimeout = 0;
 
                         if (\is_string($chunk = array_shift($multi->handlesActivity[$j]))) {
-                            if (null !== $response->inflate && false === $chunk = @inflate_add($response->inflate, $chunk)) {
-                                $multi->handlesActivity[$j] = [null, new TransportException(sprintf('Error while processing content unencoding for "%s".', $response->getInfo('url')))];
-                                continue;
+                            if (null !== $response->inflate) {
+                                $response->inflateIn += \strlen($chunk);
+
+                                if (false === $chunk = @inflate_add($response->inflate, $chunk)) {
+                                    $multi->handlesActivity[$j] = [null, new TransportException(sprintf('Error while processing content unencoding for "%s".', $response->getInfo('url')))];
+                                    continue;
+                                }
+
+                                $response->inflateOut += \strlen($chunk);
+
+                                // Reject decompression bombs. The ratio is meaningless on small bodies,
+                                // so it applies only past the 2 MB that php://temp keeps in memory.
+                                if (2097152 < $response->inflateOut && 100 * $response->inflateIn < $response->inflateOut) {
+                                    $multi->handlesActivity[$j] = [null, new TransportException(sprintf('Content of "%s" inflated to more than 100 times its compressed size.', $response->getInfo('url')))];
+                                    continue;
+                                }
                             }
 
                             if ('' !== $chunk && null !== $response->content && \strlen($chunk) !== fwrite($response->content, $chunk)) {

--- a/src/Symfony/Component/HttpClient/Tests/Exception/HttpExceptionTraitTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/Exception/HttpExceptionTraitTest.php
@@ -12,7 +12,11 @@
 namespace Symfony\Component\HttpClient\Tests\Exception;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\Exception\ClientException;
 use Symfony\Component\HttpClient\Exception\HttpExceptionTrait;
+use Symfony\Component\HttpClient\Exception\TransportException;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
 /**
@@ -57,6 +61,65 @@ ERROR;
         $e = new TestException($response);
         $this->assertSame(400, $e->getCode());
         $this->assertSame($expectedMessage, $e->getMessage());
+    }
+
+    public function testParseErrorOnAStreamedResponse()
+    {
+        $e = $this->requestError('{"title": "An error occurred", "detail": "Some details"}');
+
+        $this->assertSame("An error occurred\n\nSome details", $e->getMessage());
+    }
+
+    public function testParseErrorKeepsTheHeadOfTheBodyOnly()
+    {
+        $e = $this->requestError($this->longErrorBody());
+
+        $this->assertSame('HTTP/1.1 400 Bad Request returned for "http://example.com/".', $e->getMessage());
+    }
+
+    public function testBufferedResponseStaysReadable()
+    {
+        $e = $this->requestError($this->longErrorBody());
+
+        $this->assertSame($this->longErrorBody(), $e->getResponse()->getContent(false));
+    }
+
+    public function testUnbufferedResponseStaysUnreadable()
+    {
+        $e = $this->requestError($this->longErrorBody(), ['buffer' => false]);
+
+        $this->expectException(TransportException::class);
+        $this->expectExceptionMessage('Cannot get the content of the response twice: buffering is disabled.');
+
+        $e->getResponse()->getContent(false);
+    }
+
+    public function testNonJsonResponseIsNotRead()
+    {
+        $e = $this->requestError($this->longErrorBody(), ['buffer' => false], 'text/plain');
+
+        $this->assertSame($this->longErrorBody(), $e->getResponse()->getContent(false));
+    }
+
+    private function longErrorBody(): string
+    {
+        return json_encode(['title' => 'An error occurred', 'detail' => str_repeat('x', 64 * 1024)]);
+    }
+
+    private function requestError(string $body, array $options = [], string $contentType = 'application/problem+json'): ClientException
+    {
+        $client = new MockHttpClient(new MockResponse(str_split($body, 16384), [
+            'http_code' => 400,
+            'response_headers' => ['HTTP/1.1 400 Bad Request', 'Content-Type: '.$contentType],
+        ]));
+
+        try {
+            $client->request('GET', 'http://example.com/', $options)->getHeaders();
+        } catch (ClientException $e) {
+            return $e;
+        }
+
+        $this->fail(ClientException::class.' expected');
     }
 }
 

--- a/src/Symfony/Component/HttpClient/Tests/Fixtures/inflate/index.php
+++ b/src/Symfony/Component/HttpClient/Tests/Fixtures/inflate/index.php
@@ -1,0 +1,39 @@
+<?php
+
+if ('cli-server' !== \PHP_SAPI) {
+    // safe guard against unwanted execution
+    throw new \Exception("You cannot run this script directly, it's a fixture for TestHttpServer.");
+}
+
+switch (parse_url($_SERVER['REQUEST_URI'], \PHP_URL_PATH)) {
+    default:
+        exit;
+
+    case '/bomb':
+        // 8 MB of zeros, which gzip shrinks by about 1000 times
+        $body = str_repeat("\0", 8 * 1024 * 1024);
+        break;
+
+    case '/bomb-error':
+        http_response_code(500);
+        $body = str_repeat("\0", 8 * 1024 * 1024);
+        break;
+
+    case '/compressible':
+        // close to 4 MB of near identical records, which gzip shrinks by about 35 times
+        $rows = [];
+        for ($i = 0; $i < 40000; ++$i) {
+            $rows[] = ['id' => $i, 'status' => 'pending', 'message' => 'The operation is still running, please retry later.'];
+        }
+        $body = json_encode($rows);
+        break;
+
+    case '/padded':
+        // 64 KB of spaces, which gzip shrinks by about 675 times
+        $body = str_repeat(' ', 64 * 1024);
+        break;
+}
+
+header('Content-Type: application/json');
+header('Content-Encoding: gzip');
+echo gzencode($body);

--- a/src/Symfony/Component/HttpClient/Tests/Response/TransportResponseTraitTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/Response/TransportResponseTraitTest.php
@@ -1,0 +1,149 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\Tests\Response;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\AmpHttpClient;
+use Symfony\Component\HttpClient\CurlHttpClient;
+use Symfony\Component\HttpClient\Exception\ServerException;
+use Symfony\Component\HttpClient\Exception\TransportException;
+use Symfony\Component\HttpClient\NativeHttpClient;
+use Symfony\Component\Process\PhpExecutableFinder;
+use Symfony\Component\Process\Process;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * @requires extension zlib
+ */
+class TransportResponseTraitTest extends TestCase
+{
+    private const PORT = 8097;
+
+    private static $process;
+
+    public static function setUpBeforeClass(): void
+    {
+        $finder = new PhpExecutableFinder();
+        $process = new Process(array_merge([$finder->find(false)], $finder->findArguments(), ['-dopcache.enable=0', '-S', '127.0.0.1:'.self::PORT]));
+        $process->setWorkingDirectory(__DIR__.'/../Fixtures/inflate');
+        $process->start();
+        self::$process = $process;
+        register_shutdown_function([$process, 'stop']);
+
+        do {
+            usleep(50000);
+        } while ($process->isRunning() && !@fopen('http://127.0.0.1:'.self::PORT, 'r'));
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        self::$process->stop();
+    }
+
+    public static function provideClients(): iterable
+    {
+        yield 'native' => [NativeHttpClient::class];
+        yield 'curl' => [CurlHttpClient::class];
+        yield 'amp' => [AmpHttpClient::class];
+    }
+
+    /**
+     * @dataProvider provideClients
+     */
+    public function testDecompressionBombIsRejected(string $clientClass)
+    {
+        $response = $this->createClient($clientClass)->request('GET', $url = $this->url('/bomb'));
+
+        $this->expectException(TransportException::class);
+        $this->expectExceptionMessage(sprintf('Content of "%s" inflated to more than 100 times its compressed size.', $url));
+
+        $response->getContent();
+    }
+
+    /**
+     * @dataProvider provideClients
+     */
+    public function testDecompressionBombIsRejectedWhileStreaming(string $clientClass)
+    {
+        $client = $this->createClient($clientClass);
+        $response = $client->request('GET', $url = $this->url('/bomb'));
+        $read = 0;
+
+        try {
+            foreach ($client->stream($response) as $chunk) {
+                $read += \strlen($chunk->getContent());
+            }
+            $this->fail(TransportException::class.' expected');
+        } catch (TransportException $e) {
+            $this->assertSame(sprintf('Content of "%s" inflated to more than 100 times its compressed size.', $url), $e->getMessage());
+        }
+
+        $this->assertLessThan(8 * 1024 * 1024, $read);
+    }
+
+    /**
+     * @dataProvider provideClients
+     */
+    public function testDecompressionBombIsRejectedWhenTheResponseIsDiscarded(string $clientClass)
+    {
+        $client = $this->createClient($clientClass);
+        $url = $this->url('/bomb-error');
+
+        try {
+            $client->request('GET', $url);
+            $this->fail(ServerException::class.' expected');
+        } catch (ServerException $e) {
+            $this->assertSame(sprintf('HTTP/1.1 500 Internal Server Error returned for "%s".', $url), $e->getMessage());
+        }
+
+        $this->expectException(TransportException::class);
+        $this->expectExceptionMessage(sprintf('Content of "%s" inflated to more than 100 times its compressed size.', $url));
+
+        $e->getResponse()->getContent(false);
+    }
+
+    /**
+     * @dataProvider provideClients
+     */
+    public function testLargeBodyWithAnOrdinaryRatioIsAccepted(string $clientClass)
+    {
+        $response = $this->createClient($clientClass)->request('GET', $this->url('/compressible'));
+        $body = $response->getContent();
+
+        $this->assertGreaterThan(2 * 1024 * 1024, \strlen($body));
+        $this->assertCount(40000, json_decode($body, true));
+    }
+
+    /**
+     * @dataProvider provideClients
+     */
+    public function testSmallBodyWithAHighRatioIsAccepted(string $clientClass)
+    {
+        $response = $this->createClient($clientClass)->request('GET', $this->url('/padded'));
+
+        $this->assertSame(str_repeat(' ', 64 * 1024), $response->getContent());
+    }
+
+    private function createClient(string $clientClass): HttpClientInterface
+    {
+        if (CurlHttpClient::class === $clientClass && !\extension_loaded('curl')) {
+            $this->markTestSkipped('The "curl" extension is not available.');
+        }
+
+        return new $clientClass();
+    }
+
+    private function url(string $path): string
+    {
+        return 'http://127.0.0.1:'.self::PORT.$path;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

A response that is never read still gets fully inflated. `TransportResponseTrait::doDestruct()` calls `checkStatusCode()`, and for a status of 300 or more with a JSON content type `HttpExceptionTrait` runs `json_decode($response->getContent(false), true)` to build its message. A server answering 500 with `Content-Encoding: gzip` and 255 KB that expands to 256 MB therefore exhausts the memory limit of whoever sent the request:

```
PHP Fatal error: Allowed memory size of 134217728 bytes exhausted (tried to allocate 268443680 bytes)
  in Response/CommonResponseTrait.php on line 74
#2 Exception/HttpExceptionTrait.php(58): CurlResponse->getContent()
#4 TransportResponseTrait.php(132): CurlResponse->checkStatusCode()
#5 CurlResponse.php(244): CurlResponse->doDestruct()
```

Two costs sit on that path and only one of them is the exception message: the body is inflated into the `php://temp` buffer first, which spills to disk past 2 MB, and then read back into a single string. This patch bounds both.

Responses are inflated at one place, in `TransportResponseTrait::stream()`, which is shared by the curl, native, amphp and mock responses and runs before the buffer write. Counting the bytes on each side of `inflate_add()` there costs nothing and covers every consumer. A body that inflates to more than 100 times its compressed size is rejected with a `TransportException`, but only once it has grown past 2 MB, since the ratio is meaningless on small bodies: 64 KB of spaces legitimately compresses 675 times. 2 MB is also what `php://temp` keeps in memory, so below it there is nothing to protect. Ordinary payloads are far under the factor, measured at 4.5x for JSON, 34.7x for near-identical JSON records and 27.7x for log lines.

A factor of 100 is what Envoy's decompressor filter uses for `max_inflate_ratio`, added after its own zip-bomb advisory, and what Apache POI enforces through `ZipSecureFile::setMinInflateRatio()`, whose default of 0.01 is the same 100 to 1.

The exception message is now built from at most 32 KB of the body. It only looks for the `hydra:title`, `hydra:description`, `title` and `detail` fields of RFC 7807, JSON:API and Hydra envelopes, which are small and sit near the top; a truncated body simply fails to decode and the message falls back to the generic one. `CommonResponseTrait::checkStatusCode()` does that read, driving the response's own `stream()` event loop, and hands the result to the exception as a closure. Staying lazy matters: a non-JSON error response is never read today, and an eagerly computed string would change that. The loop still runs to the end, so the body lands where it would have landed anyway and the response behaves as before, buffered or not. `TraceableResponse` builds the same exceptions but passes nothing: it only reaches `checkStatusCode()` after `getContent()` or `toArray()` already read the whole body on purpose, and its destructor path goes through the response it decorates.

The guard is a bound, not a hard ceiling: `inflate_add()` has no output limit, so a chunk is inflated and then measured, and the overshoot is one chunk's expansion. In practice the reproduction above drops from 256 MiB to 16.2 MiB on curl, 16.0 MiB on native and 8.4 MiB on amphp, and at `memory_limit=128M` it now completes with a `ServerException` instead of a fatal.

The same code is on every maintained branch, so this targets the lowest one.

Note that `buffer => false` cannot be used to avoid this. `doDestruct()` sets `shouldBuffer` to true on purpose, so that a caught `HttpExceptionInterface` still has a readable response, which is what #35674 fixed.


