### PR TITLE
[HttpFoundation] Combine trusted host patterns into a single regexp

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -222,6 +222,11 @@ class Request
 
     private static $trustedHeaderSet = -1;
 
+    /**
+     * @var string|null
+     */
+    private static $trustedHostsRegexp;
+
     private const FORWARDED_PARAMS = [
         self::HEADER_X_FORWARDED_FOR => 'for',
         self::HEADER_X_FORWARDED_HOST => 'host',
@@ -669,8 +674,8 @@ class Request
         self::$trustedHostPatterns = array_map(function ($hostPattern) {
             return sprintf('{%s}i', $hostPattern);
         }, $hostPatterns);
-        // we need to reset trusted hosts on trusted host patterns change
-        self::$trustedHosts = [];
+        // the branch reset group keeps capturing groups, back references and inline modifiers local to each pattern
+        self::$trustedHostsRegexp = $hostPatterns ? sprintf('{(?|(?:%s))}i', implode(')|(?:', $hostPatterns)) : null;
     }
 
     /**
@@ -1244,19 +1249,11 @@ class Request
             throw new SuspiciousOperationException(sprintf('Invalid Host "%s".', $host));
         }
 
-        if (\count(self::$trustedHostPatterns) > 0) {
+        if (self::$trustedHostsRegexp) {
             // to avoid host header injection attacks, you should provide a list of trusted host patterns
 
-            if (\in_array($host, self::$trustedHosts)) {
+            if (preg_match(self::$trustedHostsRegexp, $host)) {
                 return $host;
-            }
-
-            foreach (self::$trustedHostPatterns as $pattern) {
-                if (preg_match($pattern, $host)) {
-                    self::$trustedHosts[] = $host;
-
-                    return $host;
-                }
             }
 
             if (!$this->isHostValid) {

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -2212,6 +2212,47 @@ class RequestTest extends TestCase
         $this->assertSame('localhost', $request->getHost());
     }
 
+    public function testSetTrustedHostsKeepsPatternsIndependent()
+    {
+        Request::setTrustedHosts(['^(a)\.example\.com$', '^(b)\.\1\.example\.com$']);
+
+        $request = Request::create('/');
+        $request->headers->set('host', 'b.b.example.com');
+        $this->assertSame('b.b.example.com', $request->getHost());
+    }
+
+    public function testTrustedHostsAreNotAccumulated()
+    {
+        Request::setTrustedHosts(['^[a-z]+\.example\.com$']);
+
+        $request = Request::create('/');
+        $request->headers->set('host', 'a.example.com');
+        $this->assertSame('a.example.com', $request->getHost());
+        $request->headers->set('host', 'b.example.com');
+        $this->assertSame('b.example.com', $request->getHost());
+
+        $trustedHosts = new \ReflectionProperty(Request::class, 'trustedHosts');
+        $trustedHosts->setAccessible(true);
+        $this->assertSame([], $trustedHosts->getValue());
+    }
+
+    public function testTrustedHostsAreNotMatchedLoosely()
+    {
+        Request::setTrustedHosts(['^123$']);
+
+        $request = Request::create('/');
+        $request->headers->set('host', '123');
+        $this->assertSame('123', $request->getHost());
+
+        $request = Request::create('/');
+        $request->headers->set('host', '0123');
+
+        $this->expectException(SuspiciousOperationException::class);
+        $this->expectExceptionMessage('Untrusted Host "0123".');
+
+        $request->getHost();
+    }
+
     public function testFactory()
     {
         Request::setFactory(function (array $query = [], array $request = [], array $attributes = [], array $cookies = [], array $files = [], array $server = [], $content = null) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Backport of #65252, which shipped on 6.4, 7.4, 8.1 and 8.2. 5.4 is the only maintained branch that still has the defect.

`Request::getHost()` memoizes in the static `Request::$trustedHosts` list every host that matched the trusted host patterns. Nothing ever evicts from that list. In a long-running runtime it grows by one entry per distinct host sent by clients, and the `in_array()` fast path in front of the pattern loop turns into a linear scan run on every request.

`setTrustedHosts()` now combines the patterns into a single regexp, and `getHost()` runs one `preg_match()` against it. The branch reset group keeps capturing groups, back references and inline modifiers local to each pattern. Matching that regexp is faster than the memoization it replaces, so the list is not needed anymore. The now unused `protected static $trustedHosts` property is kept, as on the other branches.

Measured on PHP 8.5, one pattern, distinct hosts, `memory_limit=8M`:

| | before | after |
| --- | --- | --- |
| per call at 50k distinct hosts | 149 us | 1.6 us |
| memory retained by 50k distinct hosts | 3371 KiB | 0 |
| distinct hosts before the limit is hit | 65536, in 12.8 s | 10M and still going, peak 2 MiB |

The cost per call grows with the number of hosts already seen: 13.9 us at 5k, 42.5 us at 20k, 149 us at 50k. After the change it stays flat.

Dropping the list also drops its non-strict `in_array()` comparison. With `^123$` as the only pattern, once the host `123` is cached, `0123`, `123.` and `1.23e2` pass the trusted check on 5.4 without matching any pattern. They are rejected after the change.

5.4 takes security fixes only, so it is for the maintainers to decide whether an availability fix of this shape is worth taking there.
