### PR TITLE
[PhpUnitBridge] Fix ClockMock::hrtime() when the clock is not mocked and when the nanoseconds have leading zeros

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/ClockMock.php
+++ b/src/Symfony/Bridge/PhpUnit/ClockMock.php
@@ -113,10 +113,14 @@ class ClockMock
      */
     public static function hrtime($asNumber = false)
     {
+        if (null === self::$now) {
+            return \hrtime($asNumber);
+        }
+
         $ns = (self::$now - (int) self::$now) * 1000000000;
 
         if ($asNumber) {
-            $number = sprintf('%d%d', (int) self::$now, $ns);
+            $number = sprintf('%d%09d', (int) self::$now, $ns);
 
             return \PHP_INT_SIZE === 8 ? (int) $number : (float) $number;
         }

--- a/src/Symfony/Bridge/PhpUnit/Tests/ClockMockTest.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/ClockMockTest.php
@@ -79,4 +79,20 @@ class ClockMockTest extends TestCase
     {
         $this->assertSame(1234567890125000000, hrtime(true));
     }
+
+    public function testHrTimeAsNumberWithLeadingZerosInTheNanoseconds()
+    {
+        ClockMock::withClockMock(1234567890.0625);
+
+        $this->assertSame([1234567890, 62500000], hrtime());
+        $this->assertSame(1234567890062500000, hrtime(true));
+    }
+
+    public function testHrTimeWithoutClockMock()
+    {
+        ClockMock::withClockMock(false);
+
+        $this->assertGreaterThan(0, hrtime()[0]);
+        $this->assertGreaterThan(0, hrtime(true));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`ClockMock::hrtime()` had two defects that the other mocked functions do not have:

- It did not fall back to the real `hrtime()` when the clock mock is disabled. `self::$now` is `null` in that state, so it returned `0` or `[0, 0]` instead of the monotonic clock. `time()`, `microtime()`, `sleep()` and `usleep()` all delegate to PHP in that state.
- The nanoseconds were appended to the seconds with `sprintf('%d%d')`, without zero-padding. Any fraction below 100 ms lost digits: at `1234567890.0625`, `hrtime(true)` returned `123456789062500000` instead of `1234567890062500000`.

The Doctrine bridge now measures query durations with `hrtime()` in `Debug\Query`, and its tests run in a `time-sensitive` namespace. That exposed both defects on CI: every duration is `0.0` when the mock is off (`MiddlewareTest`), and `DoctrineDataCollectorTest::testCollectTime` gets `1.0E-8` instead of `1` when it is on, because `usleep(1000000)` moves the mocked clock from `1500000000.0` to `1500000001.0`, which the unpadded format rendered as `15000000000` and `15000000010`.

Checks run, with the bridge of this branch taking precedence over the installed one:

- `ClockMockTest`: the two new tests fail on the base version with the values above and pass with the fix. The nine existing tests are unchanged.
- The bridge's own suite, run from its directory with its own dependencies as the deps jobs do: 130 tests, 2 skipped, no failure.
- `src/Symfony/Bridge/Doctrine/Tests/Middleware` and `Tests/DataCollector`: 8 failures with the base `ClockMock`, the same ones that are red on CI, and 14 plus 45 tests green with the fix.

Not covered: 32-bit PHP, where `hrtime(true)` returns a float. The padding does not depend on the integer size.

The unit-tests jobs install the bridge from the 7.4 and 8.2 branches of the split repository, so they turn green once this is merged up.
