### PR TITLE
[Form] Stop capturing Options in the upload_max_size_message closure

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -152,7 +152,14 @@ class FormType extends BaseType
         };
 
         // Wrap "post_max_size_message" in a closure to translate it lazily
-        $uploadMaxSizeMessage = static fn (Options $options) => static fn () => $options['post_max_size_message'];
+        $uploadMaxSizeMessage = static function (Options $options) {
+            // Read the message here rather than in the returned closure: an arrow
+            // function would capture $options and keep one Options instance alive
+            // for every resolved form.
+            $postMaxSizeMessage = $options['post_max_size_message'];
+
+            return static fn () => $postMaxSizeMessage;
+        };
 
         // For any form that is not represented by a single HTML control,
         // errors should bubble up by default

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
@@ -27,6 +27,7 @@ use Symfony\Component\Form\Forms;
 use Symfony\Component\Form\Tests\Fixtures\Author;
 use Symfony\Component\Form\Tests\Fixtures\FixedDataTransformer;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
+use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\PropertyAccess\PropertyPath;
 use Symfony\Component\Translation\TranslatableMessage;
 use Symfony\Component\Validator\Validation;
@@ -887,6 +888,20 @@ $ref2
             'child3',
         ];
         $this->assertSame($expected, array_keys($view->children));
+    }
+
+    public function testUploadMaxSizeMessageDoesNotCaptureOptions()
+    {
+        $form = $this->factory->create(self::TESTED_TYPE);
+        $uploadMaxSizeMessage = $form->getConfig()->getOption('upload_max_size_message');
+
+        $this->assertSame('The uploaded file was too large. Please try to upload a smaller file.', $uploadMaxSizeMessage());
+
+        // Capturing the Options instance keeps one OptionsResolver clone alive per
+        // resolved form, which is a significant amount of memory on large forms.
+        foreach ((new \ReflectionFunction($uploadMaxSizeMessage))->getStaticVariables() as $value) {
+            $this->assertNotInstanceOf(Options::class, $value);
+        }
     }
 }
 

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/UploadValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/UploadValidatorExtensionTest.php
@@ -34,19 +34,50 @@ class UploadValidatorExtensionTest extends TypeTestCase
 
         $resolver = new OptionsResolver();
         $resolver->setDefault('post_max_size_message', 'old max {{ max }}!');
-        $resolver->setDefault('upload_max_size_message', static fn (Options $options) => static fn () => $options['post_max_size_message']);
+        $resolver->setDefault('upload_max_size_message', static function (Options $options) {
+            $postMaxSizeMessage = $options['post_max_size_message'];
+
+            return static fn () => $postMaxSizeMessage;
+        });
 
         $extension->configureOptions($resolver);
         $options = $resolver->resolve();
 
         $this->assertEquals('translated max {{ max }}!', $options['upload_max_size_message']());
     }
+
+    public function testPostMaxSizeTranslationIsDeferred()
+    {
+        $translator = new DummyTranslator();
+        $extension = new UploadValidatorExtension($translator);
+
+        $resolver = new OptionsResolver();
+        $resolver->setDefault('post_max_size_message', 'old max {{ max }}!');
+        $resolver->setDefault('upload_max_size_message', static function (Options $options) {
+            $postMaxSizeMessage = $options['post_max_size_message'];
+
+            return static fn () => $postMaxSizeMessage;
+        });
+
+        $extension->configureOptions($resolver);
+        $options = $resolver->resolve();
+
+        $this->assertSame(0, $translator->transCalls, 'The message must not be translated while resolving options.');
+
+        $options['upload_max_size_message']();
+
+        $this->assertSame(1, $translator->transCalls);
+    }
 }
 
 class DummyTranslator implements TranslatorInterface, LocaleAwareInterface
 {
+    public int $transCalls = 0;
+
     public function trans($id, array $parameters = [], $domain = null, $locale = null): string
     {
+        ++$this->transCalls;
+
         return 'translated max {{ max }}!';
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`fn () => ...` automatically keeps hold of every variable its body uses. You never write `use (...)` yourself, so there is nothing in the code to spot when reading it.

The inner closure uses `$options`, so it kept the whole `Options` object alive. `OptionsResolver::resolve()` clones itself on every call, so each form field holds its own clone for the lifetime of the form.

```php
// before: the returned closure captures the Options instance
$uploadMaxSizeMessage = static fn (Options $options) => static fn () => $options['post_max_size_message'];

// after: it captures the resolved message
$uploadMaxSizeMessage = static function (Options $options) {
    $postMaxSizeMessage = $options['post_max_size_message'];

    return static fn () => $postMaxSizeMessage;
};
```

In the fixed version the lookup happens before the arrow function is created. The only variable it then uses is `$postMaxSizeMessage`, so a string is all it keeps.

### Impact

A form of 1 collection -> 20 sublocations -> 20 buildings -> 101 fields (40,400 fields), on 6.4 with PHP 8.4:

| | before | after |
| --- | --- | --- |
| Memory | 463.36 MB | 295.05 MB |
| Peak | 472.00 MB | 302.00 MB |
| Build time | 1,111 ms | 965 ms |