### PR TITLE
[Messenger] Support raw Redis stream messages

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Redis/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add support for consuming stream entries written with a raw `XADD`, using `body` and `headers` fields
+ * Report stream entries that cannot be decoded through the failure transport instead of dropping them silently
+
 8.1
 ---
 

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/RedisExtIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/RedisExtIntegrationTest.php
@@ -424,6 +424,20 @@ class RedisExtIntegrationTest extends TestCase
         $this->assertEquals('Hi2', $message->getMessage());
     }
 
+    public function testItConsumesEntriesAddedWithARawXadd()
+    {
+        $this->redis->xAdd('messages', '*', [
+            'body' => '{"message": "Hi"}',
+            'headers' => json_encode(['type' => DummyMessage::class]),
+        ]);
+
+        $receiver = new RedisReceiver($this->connection, new Serializer());
+        $envelopes = $receiver->get();
+
+        $this->assertCount(1, $envelopes);
+        $this->assertEquals(new DummyMessage('Hi'), $envelopes[0]->getMessage());
+    }
+
     public function testItCountMessages()
     {
         $this->assertSame(0, $this->connection->getMessageCount());

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/RedisReceiverTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/RedisReceiverTest.php
@@ -31,6 +31,8 @@ use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 
 class RedisReceiverTest extends TestCase
 {
+    private const RAW_MESSAGE_BODY = '{"message": "Hi"}';
+
     #[DataProvider('redisEnvelopeProvider')]
     public function testItReturnsTheDecodedMessageToTheHandler(array $redisEnvelope, $expectedMessage, SerializerInterface $serializer)
     {
@@ -304,6 +306,202 @@ class RedisReceiverTest extends TestCase
         $this->assertCount(1, $envelopes);
     }
 
+    public function testGetReturnsRawXaddMessagesToTheHandler()
+    {
+        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer->expects($this->once())
+            ->method('decode')
+            ->with([
+                'body' => self::RAW_MESSAGE_BODY,
+                'headers' => [],
+            ])
+            ->willReturn(new Envelope(new DummyMessage('Hi')));
+
+        $connection = $this->createStub(Connection::class);
+        $connection->method('get')->willReturn([
+            [
+                'id' => '1',
+                'data' => [
+                    'body' => self::RAW_MESSAGE_BODY,
+                ],
+            ],
+        ]);
+
+        $receiver = new RedisReceiver($connection, $serializer);
+
+        $envelopes = $receiver->get();
+
+        $this->assertCount(1, $envelopes);
+        $this->assertEquals(new DummyMessage('Hi'), $envelopes[0]->getMessage());
+        $this->assertNotNull($envelopes[0]->last(TransportMessageIdStamp::class));
+        $this->assertNotNull($envelopes[0]->last(RedisReceivedStamp::class));
+    }
+
+    public function testGetPassesTheRawXaddHeadersFieldToTheSerializer()
+    {
+        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer->expects($this->once())
+            ->method('decode')
+            ->with([
+                'body' => self::RAW_MESSAGE_BODY,
+                'headers' => ['type' => DummyMessage::class],
+            ])
+            ->willReturn(new Envelope(new DummyMessage('Hi')));
+
+        $connection = $this->createStub(Connection::class);
+        $connection->method('get')->willReturn([
+            [
+                'id' => '1',
+                'data' => [
+                    'body' => self::RAW_MESSAGE_BODY,
+                    'headers' => json_encode(['type' => DummyMessage::class]),
+                ],
+            ],
+        ]);
+
+        $receiver = new RedisReceiver($connection, $serializer);
+
+        $envelopes = $receiver->get();
+
+        $this->assertCount(1, $envelopes);
+        $this->assertEquals(new DummyMessage('Hi'), $envelopes[0]->getMessage());
+    }
+
+    public function testGetIgnoresARawXaddHeadersFieldThatIsNotAJsonObject()
+    {
+        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer->expects($this->once())
+            ->method('decode')
+            ->with([
+                'body' => self::RAW_MESSAGE_BODY,
+                'headers' => [],
+            ])
+            ->willReturn(new Envelope(new DummyMessage('Hi')));
+
+        $connection = $this->createStub(Connection::class);
+        $connection->method('get')->willReturn([
+            [
+                'id' => '1',
+                'data' => [
+                    'body' => self::RAW_MESSAGE_BODY,
+                    'headers' => '12345',
+                ],
+            ],
+        ]);
+
+        $receiver = new RedisReceiver($connection, $serializer);
+
+        $this->assertCount(1, $receiver->get());
+    }
+
+    public function testGetReportsARawXaddHeadersFieldThatIsNotJson()
+    {
+        $connection = $this->createStub(Connection::class);
+        $connection->method('get')->willReturn([
+            [
+                'id' => '1',
+                'data' => [
+                    'body' => self::RAW_MESSAGE_BODY,
+                    'headers' => 'not-json',
+                ],
+            ],
+        ]);
+
+        $receiver = new RedisReceiver($connection, new Serializer(
+            new SerializerComponent\Serializer([new ObjectNormalizer()], ['json' => new JsonEncoder()])
+        ));
+
+        $envelopes = $receiver->get();
+
+        $this->assertCount(1, $envelopes);
+        $this->assertInstanceOf(MessageDecodingFailedException::class, $envelopes[0]->getMessage());
+        $this->assertStringContainsString('Could not decode the Redis stream entry', $envelopes[0]->getMessage()->getMessage());
+        $this->assertNotNull($envelopes[0]->last(RedisReceivedStamp::class));
+    }
+
+    public function testGetReportsAMessageFieldThatIsNotJson()
+    {
+        $connection = $this->createStub(Connection::class);
+        $connection->method('get')->willReturn([
+            [
+                'id' => '1',
+                'data' => [
+                    'message' => 'invalid-json',
+                ],
+            ],
+        ]);
+
+        $receiver = new RedisReceiver($connection, new Serializer(
+            new SerializerComponent\Serializer([new ObjectNormalizer()], ['json' => new JsonEncoder()])
+        ));
+
+        $envelopes = $receiver->get();
+
+        $this->assertCount(1, $envelopes);
+        $this->assertInstanceOf(MessageDecodingFailedException::class, $envelopes[0]->getMessage());
+        $this->assertStringContainsString('Could not decode the Redis stream entry', $envelopes[0]->getMessage()->getMessage());
+        $this->assertNotNull($envelopes[0]->last(RedisReceivedStamp::class));
+    }
+
+    public function testGetKeepsIntegersLargerThanPhpIntMaxIntact()
+    {
+        $decoded = null;
+        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer->expects($this->once())
+            ->method('decode')
+            ->willReturnCallback(static function (array $encodedEnvelope) use (&$decoded) {
+                $decoded = $encodedEnvelope;
+
+                return new Envelope(new DummyMessage('Hi'));
+            });
+
+        $connection = $this->createStub(Connection::class);
+        $connection->method('get')->willReturn([
+            [
+                'id' => '1',
+                'data' => [
+                    'message' => '{"id":9223372036854775808}',
+                ],
+            ],
+        ]);
+
+        $receiver = new RedisReceiver($connection, $serializer);
+
+        $this->assertCount(1, $receiver->get());
+        $this->assertSame(['id' => '9223372036854775808'], $decoded);
+    }
+
+    public function testAllReturnsRawXaddMessages()
+    {
+        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer->expects($this->once())
+            ->method('decode')
+            ->with([
+                'body' => self::RAW_MESSAGE_BODY,
+                'headers' => [],
+            ])
+            ->willReturn(new Envelope(new DummyMessage('Hi')));
+
+        $connection = $this->createStub(Connection::class);
+        $connection->method('findAll')->willReturn([
+            [
+                'id' => '1',
+                'data' => [
+                    'body' => self::RAW_MESSAGE_BODY,
+                ],
+            ],
+        ]);
+
+        $receiver = new RedisReceiver($connection, $serializer);
+
+        $envelopes = iterator_to_array($receiver->all());
+
+        $this->assertCount(1, $envelopes);
+        $this->assertEquals(new DummyMessage('Hi'), $envelopes[0]->getMessage());
+        $this->assertNotNull($envelopes[0]->last(TransportMessageIdStamp::class));
+        $this->assertNotNull($envelopes[0]->last(RedisReceivedStamp::class));
+    }
+
     public function testAllSkipsInvalidMessages()
     {
         $messages = [
@@ -319,6 +517,12 @@ class RedisReceiverTest extends TestCase
             ],
             [
                 'id' => '3',
+                'data' => [
+                    'headers' => [],
+                ],
+            ],
+            [
+                'id' => '4',
                 'data' => [
                     'message' => json_encode([
                         'body' => '{"message": "Hi"}',
@@ -381,6 +585,60 @@ class RedisReceiverTest extends TestCase
 
         $envelope = $receiver->find('999');
         $this->assertNull($envelope);
+    }
+
+    public function testFindReturnsRawXaddMessageById()
+    {
+        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer->expects($this->once())
+            ->method('decode')
+            ->with([
+                'body' => self::RAW_MESSAGE_BODY,
+                'headers' => [],
+            ])
+            ->willReturn(new Envelope(new DummyMessage('Hi')));
+
+        $connection = $this->createStub(Connection::class);
+        $connection->method('find')->willReturn([
+            'id' => '123',
+            'data' => [
+                'body' => self::RAW_MESSAGE_BODY,
+            ],
+        ]);
+
+        $receiver = new RedisReceiver($connection, $serializer);
+
+        $envelope = $receiver->find('123');
+
+        $this->assertNotNull($envelope);
+        $this->assertEquals(new DummyMessage('Hi'), $envelope->getMessage());
+        $this->assertNotNull($envelope->last(TransportMessageIdStamp::class));
+        $this->assertNotNull($envelope->last(RedisReceivedStamp::class));
+    }
+
+    public function testFindPassesTheRawXaddHeadersFieldToTheSerializer()
+    {
+        $serializer = $this->createMock(SerializerInterface::class);
+        $serializer->expects($this->once())
+            ->method('decode')
+            ->with([
+                'body' => self::RAW_MESSAGE_BODY,
+                'headers' => ['type' => DummyMessage::class],
+            ])
+            ->willReturn(new Envelope(new DummyMessage('Hi')));
+
+        $connection = $this->createStub(Connection::class);
+        $connection->method('find')->willReturn([
+            'id' => '123',
+            'data' => [
+                'body' => self::RAW_MESSAGE_BODY,
+                'headers' => json_encode(['type' => DummyMessage::class]),
+            ],
+        ]);
+
+        $receiver = new RedisReceiver($connection, $serializer);
+
+        $this->assertNotNull($receiver->find('123'));
     }
 
     public function testFindReturnsNullForInvalidJson()

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Transport/RedisReceiver.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Transport/RedisReceiver.php
@@ -67,16 +67,16 @@ class RedisReceiver implements KeepaliveReceiverInterface, MessageCountAwareInte
                 continue;
             }
 
-            if (null === $redisEnvelope = json_decode($message['data']['message'] ?? '', true)) {
-                continue;
-            }
-
             $stamps = [
                 new RedisReceivedStamp($message['id']),
                 new TransportMessageIdStamp($message['id']),
             ];
 
             try {
+                if (null === $redisEnvelope = $this->decodeRedisEnvelope($message['data'])) {
+                    continue;
+                }
+
                 if (\array_key_exists('body', $redisEnvelope) && \array_key_exists('headers', $redisEnvelope)) {
                     $envelope = $this->serializer->decode($redisEnvelope = [
                         'body' => $redisEnvelope['body'],
@@ -85,6 +85,10 @@ class RedisReceiver implements KeepaliveReceiverInterface, MessageCountAwareInte
                 } else {
                     $envelope = $this->serializer->decode($redisEnvelope);
                 }
+            } catch (\JsonException $e) {
+                $envelopes[] = MessageDecodingFailedException::wrap($message['data'], 'Could not decode the Redis stream entry: '.$e->getMessage(), $e->getCode(), $e)->with(...$stamps);
+
+                continue;
             } catch (MessageDecodingFailedException $e) {
                 $envelopes[] = MessageDecodingFailedException::wrap($redisEnvelope, $e->getMessage(), $e->getCode(), $e)->with(...$stamps);
 
@@ -126,7 +130,7 @@ class RedisReceiver implements KeepaliveReceiverInterface, MessageCountAwareInte
         $messages = $this->connection->findAll($limit);
 
         foreach ($messages as $message) {
-            if (null !== $envelope = $this->createEnvelopeFromData($message['id'], $message['data']['message'] ?? null)) {
+            if (null !== $envelope = $this->createEnvelopeFromData($message['id'], $message['data'] ?? null)) {
                 yield $envelope;
             }
         }
@@ -138,20 +142,20 @@ class RedisReceiver implements KeepaliveReceiverInterface, MessageCountAwareInte
             return null;
         }
 
-        return $this->createEnvelopeFromData($message['id'], $message['data']['message'] ?? null);
+        return $this->createEnvelopeFromData($message['id'], $message['data'] ?? null);
     }
 
-    private function createEnvelopeFromData(string $id, ?string $json): ?Envelope
+    private function createEnvelopeFromData(string $id, ?array $data): ?Envelope
     {
-        if (null === $json) {
-            return null;
-        }
-
-        if (null === $redisEnvelope = json_decode($json, true)) {
+        if (null === $data) {
             return null;
         }
 
         try {
+            if (null === $redisEnvelope = $this->decodeRedisEnvelope($data)) {
+                return null;
+            }
+
             if (\array_key_exists('body', $redisEnvelope) && \array_key_exists('headers', $redisEnvelope)) {
                 $envelope = $this->serializer->decode([
                     'body' => $redisEnvelope['body'],
@@ -160,7 +164,7 @@ class RedisReceiver implements KeepaliveReceiverInterface, MessageCountAwareInte
             } else {
                 $envelope = $this->serializer->decode($redisEnvelope);
             }
-        } catch (MessageDecodingFailedException) {
+        } catch (\JsonException|MessageDecodingFailedException) {
             return null;
         }
 
@@ -170,6 +174,26 @@ class RedisReceiver implements KeepaliveReceiverInterface, MessageCountAwareInte
                 new RedisReceivedStamp($id),
                 new TransportMessageIdStamp($id)
             );
+    }
+
+    private function decodeRedisEnvelope(array $data): ?array
+    {
+        if (isset($data['message'])) {
+            $redisEnvelope = json_decode($data['message'], true, flags: \JSON_THROW_ON_ERROR | \JSON_BIGINT_AS_STRING);
+
+            return \is_array($redisEnvelope) ? $redisEnvelope : null;
+        }
+
+        if (!isset($data['body'])) {
+            return null;
+        }
+
+        $headers = isset($data['headers']) ? json_decode($data['headers'], true, flags: \JSON_THROW_ON_ERROR | \JSON_BIGINT_AS_STRING) : [];
+
+        return [
+            'body' => $data['body'],
+            'headers' => \is_array($headers) ? $headers : [],
+        ];
     }
 
     private function findRedisReceivedStampId(Envelope $envelope): string


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #65047
| License       | MIT

The Redis transport writes every message into a single stream field named `message`, holding a JSON object with a `body` and a `headers` key. A producer that is not Symfony has to reproduce that shape, which is undocumented, and an entry it does not match is dropped without a word.

This lets the receiver read entries added with a plain `XADD` instead:

```
redis-cli XADD messages '*' body '{"subject":"Hello"}' headers '{"type":"App\\Message\\Mail"}'
```

* `body` carries the serialized message, exactly as the `body` key of the `message` field does.
* `headers` is optional and holds a JSON object. It is passed to the serializer as an array. A missing field, or one that is not a JSON object, gives empty headers.
* The `message` field keeps precedence. An entry that has it is decoded as before, and the `body` and `headers` fields are ignored.

The stock `Serializer` needs a `type` header to know which class to build, so a producer using it must send the `headers` field. With empty headers it reports `Encoded envelope should have at least a "body" and some "headers"` and the message goes to the failure transport, instead of being dropped silently. A custom serializer receives `['body' => ..., 'headers' => [...]]` and can do without.

`get()`, `all()` and `find()` all go through the same decoding, so `messenger:failed:show` and the other listing commands see these entries too.

Both `json_decode()` calls use `JSON_THROW_ON_ERROR | JSON_BIGINT_AS_STRING`.

`ReceiverInterface::get()` asks a transport to return a `MessageDecodingFailedException` envelope for a message it cannot decode, so the worker can route it through the usual failure handling. The Redis receiver was skipping such an entry instead, which left it in the pending list of the consumer group for good, with nothing logged. It is now reported, so it reaches the failure transport and the pending list drains. An entry that carries neither a `message` nor a `body` field is still skipped, since the stream may be shared with a consumer that is not Messenger.

`JSON_BIGINT_AS_STRING` covers what the receiver decodes itself: the `headers` field, and the payload handed to a custom serializer when the `message` field holds something other than a `body` and `headers` pair. An integer above `PHP_INT_MAX` reached that serializer as a float before. It does not change what a serializer does inside `body`, which is that serializer's own decoding.

Points for the documentation:

* the stream layout the transport writes, so that a foreign producer can target it;
* the two accepted layouts, `message` and `body` plus `headers`, and which one wins;
* that the stock serializer requires the `type` header, and that skipping it means writing a custom serializer.
