### PR TITLE
[Runtime] Reject unparsable requests with a 400 response in FrankenPhpWorkerRunner

### DIFF
--- a/src/Symfony/Component/Runtime/CHANGELOG.md
+++ b/src/Symfony/Component/Runtime/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Reject requests PHP cannot parse with a 400 response in `FrankenPhpWorkerRunner` instead of letting them kill the worker
+
 8.1
 ---
 

--- a/src/Symfony/Component/Runtime/Runner/FrankenPhpWorkerRunner.php
+++ b/src/Symfony/Component/Runtime/Runner/FrankenPhpWorkerRunner.php
@@ -29,6 +29,9 @@ use Symfony\Component\Runtime\RunnerInterface;
  * "APP_RUNTIME_MODE" is set to "web=1&worker=1", or "web=1&worker=2" when FRANKENPHP_RESET_KERNEL
  * is active.
  *
+ * Requests PHP cannot fully parse (post_max_size, max_input_vars, ...) are rejected with
+ * a 400 response, without invoking the application.
+ *
  * @author Kévin Dunglas <kevin@dunglas.dev>
  */
 class FrankenPhpWorkerRunner implements RunnerInterface
@@ -48,7 +51,26 @@ class FrankenPhpWorkerRunner implements RunnerInterface
         $resetKernel = $this->application instanceof HttpKernelInterface && filter_var($server['FRANKENPHP_RESET_KERNEL'] ?? false, \FILTER_VALIDATE_BOOL);
         $server['APP_RUNTIME_MODE'] = $resetKernel ? 'web=1&worker=2' : 'web=1&worker=1';
 
-        $handler = function () use ($server, &$sfRequest, &$sfResponse): void {
+        // PHP reports a request it cannot fully parse (post_max_size, max_input_vars, ...) as an E_WARNING
+        // raised by frankenphp_handle_request() itself; an error handler that throws would then kill the
+        // worker script. Mask warnings while waiting for a request and reject the request with a 400
+        // response when one was recorded.
+        $errorReporting = error_reporting();
+
+        $handler = function () use ($server, $errorReporting, &$sfRequest, &$sfResponse): void {
+            error_reporting($errorReporting);
+
+            $lastError = error_get_last();
+            if ($lastError && ($lastError['type'] & (\E_WARNING | \E_USER_WARNING)) && str_starts_with($lastError['message'], 'frankenphp_handle_request(')) {
+                error_clear_last();
+                // don't terminate() the previous request again
+                $sfRequest = $sfResponse = null;
+
+                (new Response('Bad Request', 400, ['Content-Type' => 'text/plain; charset=UTF-8']))->send();
+
+                return;
+            }
+
             // Connect to the Xdebug client if it's available
             if (\extension_loaded('xdebug') && \function_exists('xdebug_connect_to_client')) {
                 xdebug_connect_to_client();
@@ -69,7 +91,12 @@ class FrankenPhpWorkerRunner implements RunnerInterface
 
         $loops = 0;
         do {
+            error_reporting($errorReporting & ~\E_WARNING);
+
             $ret = frankenphp_handle_request($handler);
+
+            error_reporting($errorReporting);
+            error_clear_last();
 
             if ($this->application instanceof TerminableInterface && $sfRequest && $sfResponse) {
                 $this->application->terminate($sfRequest, $sfResponse);

--- a/src/Symfony/Component/Runtime/Tests/FrankenPhpWorkerRunnerTest.php
+++ b/src/Symfony/Component/Runtime/Tests/FrankenPhpWorkerRunnerTest.php
@@ -29,6 +29,7 @@ class FrankenPhpWorkerRunnerTest extends TestCase
     protected function tearDown(): void
     {
         unset($_SERVER['FRANKENPHP_RESET_KERNEL'], $_SERVER['APP_RUNTIME_MODE']);
+        error_clear_last();
     }
 
     public function testRun()
@@ -124,5 +125,88 @@ class FrankenPhpWorkerRunnerTest extends TestCase
 
         $runner = new FrankenPhpWorkerRunner($application, -1);
         $this->assertSame(0, $runner->run());
+    }
+
+    public function testRunRejectsUnparsableRequests()
+    {
+        $application = $this->createMock(TestAppInterface::class);
+        $application->expects($this->never())->method('handle');
+        $application->expects($this->never())->method('terminate');
+
+        $this->recordError('frankenphp_handle_request(): Request body exceeds post_max_size');
+
+        $this->expectOutputString('Bad Request');
+
+        $runner = new FrankenPhpWorkerRunner($application, 500);
+        $this->assertSame(0, $runner->run());
+        $this->assertNull(error_get_last());
+    }
+
+    public function testRunWithResponseRejectsUnparsableRequests()
+    {
+        $response = $this->createMock(Response::class);
+        $response->expects($this->never())->method('send');
+
+        $this->recordError('frankenphp_handle_request(): Input variables exceeded 1000');
+
+        $this->expectOutputString('Bad Request');
+
+        $runner = new FrankenPhpWorkerRunner($response, 500);
+        $this->assertSame(0, $runner->run());
+    }
+
+    public function testRunKeepsUnrelatedLastErrors()
+    {
+        $application = $this->createMock(TestAppInterface::class);
+        $application
+            ->expects($this->once())
+            ->method('handle')
+            ->willReturnCallback(function (): Response {
+                $this->assertSame('Some unrelated warning', error_get_last()['message'] ?? null);
+
+                return new Response();
+            });
+        $application->expects($this->once())->method('terminate');
+
+        $this->recordError('Some unrelated warning');
+
+        $runner = new FrankenPhpWorkerRunner($application, 500);
+        $this->assertSame(0, $runner->run());
+    }
+
+    public function testRunIgnoresParsingNotices()
+    {
+        $application = $this->createMock(TestAppInterface::class);
+        $application->expects($this->once())->method('handle')->willReturn(new Response());
+
+        $this->recordError('frankenphp_handle_request(): some notice', \E_USER_NOTICE);
+
+        $runner = new FrankenPhpWorkerRunner($application, 500);
+        $this->assertSame(0, $runner->run());
+    }
+
+    public function testRunRestoresErrorReporting()
+    {
+        $errorReporting = error_reporting();
+        $application = $this->createMock(TestAppInterface::class);
+        $application
+            ->expects($this->once())
+            ->method('handle')
+            ->willReturnCallback(function () use ($errorReporting): Response {
+                $this->assertSame($errorReporting, error_reporting());
+
+                return new Response();
+            });
+
+        $runner = new FrankenPhpWorkerRunner($application, 500);
+        $this->assertSame(0, $runner->run());
+        $this->assertSame($errorReporting, error_reporting());
+    }
+
+    private function recordError(string $message, int $level = \E_USER_WARNING): void
+    {
+        $errorReporting = error_reporting(0);
+        trigger_error($message, $level);
+        error_reporting($errorReporting);
     }
 }


### PR DESCRIPTION
PHP reports a request it cannot fully parse (post_max_size, max_input_vars, ...) as an E_WARNING raised by frankenphp_handle_request() itself, between two requests. With a throwing error handler installed the warning becomes an uncaught ErrorException that kills the worker script. Mask E_WARNING while waiting for a request and reject the recorded one with a 400 response, without invoking the application.

| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

No upstream issue exists for this; the problem and a real-world occurrence are described below.

In FrankenPHP worker mode, a request PHP cannot fully parse (`post_max_size` exceeded, `max_input_vars` exceeded, ...) is reported as an `E_WARNING` raised by `frankenphp_handle_request()` itself — between two requests, outside the handler callback. With a throwing error handler installed (symfony/error-handler, i.e. every Symfony app), that warning becomes an uncaught `ErrorException` that kills the worker script:

```
PHP Fatal error: Uncaught ErrorException: Warning: frankenphp_handle_request():
Input variables exceeded 5000 ... in vendor/symfony/runtime/Runner/FrankenPhpWorkerRunner.php:72
```


The client gets a broken response (a raw fatal dump when `display_errors` is on, a dropped response otherwise) and FrankenPHP has to boot a replacement worker. We hit this in production after migrating from Apache to worker mode: a single oversized form post killed a worker thread every time it was submitted. Note that request parsing happens before authentication, so any unauthenticated client sending an oversized POST can restart workers at will.

This PR makes `FrankenPhpWorkerRunner` mask `E_WARNING` only while it is parked in `frankenphp_handle_request()` waiting for a request. The handler restores the reporting level as its first statement, so the application still runs at the caller's level. When PHP recorded a warning from `frankenphp_handle_request()` during parsing, the runner rejects the request with a plain `400 Bad Request` without invoking the application — `handle()` and `terminate()` never see it, and the worker keeps serving. Unrelated recorded errors, and notices/deprecations from the same frame, are left untouched.

Before/after, reproduced against a real FrankenPHP (1.12, PHP 8.5 ZTS) serving a Symfony app in worker mode with `post_max_size=1M` and `max_input_vars=10`:

```
# POST with 20 form fields (max_input_vars=10)

Before: HTTP/1.1 200 OK
        body: <b>Fatal error</b>: Uncaught ErrorException: Warning: frankenphp_handle_request(): Input variables exceeded 10. ...
        + the worker script dies and is restarted

After:  HTTP/1.1 400 Bad Request
        body: Bad Request
        + subsequent requests are served by the application as usual, no fatal logged, no worker restart

# POST with a 2 MB body (post_max_size=1M): same before/after
```
