### PR TITLE
[FrameworkBundle] Describe the webhook routing secret in the config reference

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -2285,6 +2285,7 @@ class Configuration implements ConfigurationInterface
                                 ->end()
                                 ->scalarNode('secret')
                                     ->defaultValue('')
+                                    ->info('The secret used to verify incoming request signatures. It must be set in production: with an empty value, requests from any sender are accepted.')
                                 ->end()
                             ->end()
                         ->end()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The `secret` node under `framework.webhook.routing` has no description, unlike its siblings, so `config:dump-reference framework` and IDE completion say nothing about it.

It defaults to an empty string, which is what makes local development work without credentials, and an empty value raises no error. But depending on the request parser, an empty secret either skips signature verification or runs it with an empty HMAC key, so the endpoint then accepts requests from any sender. This adds an `info()` saying so. No behavior change: the default stays `''` and an empty secret stays settable.

```
routing:

    # Prototype
    type:
        service:              ~ # Required

        # The secret used to verify incoming request signatures. It must be set in production: with an empty value, requests from any sender are accepted.
        secret:               ''
```

Checks: `./phpunit src/Symfony/Bundle/FrameworkBundle` gives 1388 tests, 4574 assertions, 5 skipped, no failures. `php-cs-fixer` on the patched file exits 0 with no diff. The dump above comes from `YamlReferenceDumper` on the patched tree.
