### PR TITLE
[Mailer][Notifier] Reject an empty secret in the AhaSend, Mailchimp and Sweego webhook parsers

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/AhaSend/Tests/Webhook/AhaSendRequestParserTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/AhaSend/Tests/Webhook/AhaSendRequestParserTest.php
@@ -17,6 +17,7 @@ use Symfony\Bridge\PhpUnit\ClockMock;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Mailer\Bridge\AhaSend\RemoteEvent\AhaSendPayloadConverter;
 use Symfony\Component\Mailer\Bridge\AhaSend\Webhook\AhaSendRequestParser;
+use Symfony\Component\Mailer\Exception\InvalidArgumentException;
 use Symfony\Component\Webhook\Client\RequestParserInterface;
 use Symfony\Component\Webhook\Exception\RejectWebhookException;
 use Symfony\Component\Webhook\Test\AbstractRequestParserTestCase;
@@ -57,6 +58,18 @@ class AhaSendRequestParserTest extends AbstractRequestParserTestCase
         ClockMock::withClockMock((int) $request->headers->get('webhook-timestamp') + $offset);
 
         $this->assertNotNull($this->createRequestParser()->parse($request, self::SECRET));
+    }
+
+    public function testRequestSignedWithAnEmptySecretIsRejected()
+    {
+        $request = $this->createRequest(file_get_contents(__DIR__.'/Fixtures/delivered.json'));
+        $signedPayload = $request->headers->get('webhook-id').'.'.$request->headers->get('webhook-timestamp').'.'.$request->getContent();
+        $request->headers->set('webhook-signature', 'v1,'.base64_encode(hash_hmac('sha256', $signedPayload, '', true)));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('A non-empty secret is required.');
+
+        $this->createRequestParser()->parse($request, '');
     }
 
     protected function createRequestParser(): RequestParserInterface

--- a/src/Symfony/Component/Mailer/Bridge/AhaSend/Webhook/AhaSendRequestParser.php
+++ b/src/Symfony/Component/Mailer/Bridge/AhaSend/Webhook/AhaSendRequestParser.php
@@ -17,6 +17,7 @@ use Symfony\Component\HttpFoundation\RequestMatcher\IsJsonRequestMatcher;
 use Symfony\Component\HttpFoundation\RequestMatcher\MethodRequestMatcher;
 use Symfony\Component\HttpFoundation\RequestMatcherInterface;
 use Symfony\Component\Mailer\Bridge\AhaSend\RemoteEvent\AhaSendPayloadConverter;
+use Symfony\Component\Mailer\Exception\InvalidArgumentException;
 use Symfony\Component\RemoteEvent\Event\Mailer\AbstractMailerEvent;
 use Symfony\Component\RemoteEvent\Exception\ParseException;
 use Symfony\Component\Webhook\Client\AbstractRequestParser;
@@ -41,6 +42,10 @@ final class AhaSendRequestParser extends AbstractRequestParser
 
     protected function doParse(Request $request, #[\SensitiveParameter] string $secret): ?AbstractMailerEvent
     {
+        if (!$secret) {
+            throw new InvalidArgumentException('A non-empty secret is required.');
+        }
+
         $payload = $request->toArray();
         $eventID = $request->headers->get('webhook-id');
         $signature = $request->headers->get('webhook-signature');

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Webhook/MailchimpSignatureRequestParserTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Webhook/MailchimpSignatureRequestParserTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Mailer\Bridge\Mailchimp\RemoteEvent\MailchimpPayloadConverter;
 use Symfony\Component\Mailer\Bridge\Mailchimp\Webhook\MailchimpRequestParser;
+use Symfony\Component\Mailer\Exception\InvalidArgumentException;
 use Symfony\Component\Webhook\Exception\RejectWebhookException;
 
 class MailchimpSignatureRequestParserTest extends TestCase
@@ -49,6 +50,28 @@ class MailchimpSignatureRequestParserTest extends TestCase
         $this->expectExceptionMessage('Signature is wrong.');
 
         $this->parse($request);
+    }
+
+    public function testEventsSignedWithAnEmptySecretAreRejected()
+    {
+        $request = $this->createRequest(['mandrill_events' => $this->events()]);
+        $request->headers->set('X-Mandrill-Signature', base64_encode(hash_hmac('sha1', 'http://localhost/mandrill_events'.$this->events(), '', true)));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('A non-empty secret is required.');
+
+        (new MailchimpRequestParser(new MailchimpPayloadConverter()))->parse($request, '');
+    }
+
+    public function testEmptyCheckIsRejectedWhenNoSecretIsConfigured()
+    {
+        $request = $this->createRequest(['mandrill_events' => '[]']);
+        $request->headers->set('X-Mandrill-Signature', base64_encode(hash_hmac('sha1', 'http://localhost/mandrill_events[]', 'test-webhook', true)));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('A non-empty secret is required.');
+
+        (new MailchimpRequestParser(new MailchimpPayloadConverter()))->parse($request, '');
     }
 
     public function testNonStringEventsParameterIsRejected()

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Webhook/MailchimpRequestParser.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Webhook/MailchimpRequestParser.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestMatcher\MethodRequestMatcher;
 use Symfony\Component\HttpFoundation\RequestMatcherInterface;
 use Symfony\Component\Mailer\Bridge\Mailchimp\RemoteEvent\MailchimpPayloadConverter;
+use Symfony\Component\Mailer\Exception\InvalidArgumentException;
 use Symfony\Component\RemoteEvent\Exception\ParseException;
 use Symfony\Component\RemoteEvent\RemoteEvent;
 use Symfony\Component\Webhook\Client\AbstractRequestParser;
@@ -37,6 +38,10 @@ final class MailchimpRequestParser extends AbstractRequestParser
 
     protected function doParse(Request $request, #[\SensitiveParameter] string $secret): RemoteEvent|array|null
     {
+        if (!$secret) {
+            throw new InvalidArgumentException('A non-empty secret is required.');
+        }
+
         $content = $request->request->all();
         if (!\is_string($content['mandrill_events'] ?? null)) {
             throw new RejectWebhookException(400, 'Payload malformed.');

--- a/src/Symfony/Component/Notifier/Bridge/Sweego/Tests/Webhook/SweegoRequestParserTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sweego/Tests/Webhook/SweegoRequestParserTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\Attributes\Group;
 use Symfony\Bridge\PhpUnit\ClockMock;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Notifier\Bridge\Sweego\Webhook\SweegoRequestParser;
+use Symfony\Component\Notifier\Exception\InvalidArgumentException;
 use Symfony\Component\Webhook\Client\RequestParserInterface;
 use Symfony\Component\Webhook\Exception\RejectWebhookException;
 use Symfony\Component\Webhook\Test\AbstractRequestParserTestCase;
@@ -23,6 +24,8 @@ use Symfony\Component\Webhook\Test\AbstractRequestParserTestCase;
 #[Group('time-sensitive')]
 class SweegoRequestParserTest extends AbstractRequestParserTestCase
 {
+    private const SECRET = 'GvLY88Uyj70jQm3fUwYyWmAaiz98wWim';
+
     public static function getStaleClockOffsets(): iterable
     {
         yield 'too old' => [301];
@@ -56,6 +59,17 @@ class SweegoRequestParserTest extends AbstractRequestParserTestCase
         $this->assertNotNull($this->createRequestParser()->parse($request, $this->getSecret()));
     }
 
+    public function testRequestSignedWithAnEmptySecretIsRejected()
+    {
+        $request = $this->createRequest(file_get_contents(__DIR__.'/Fixtures/sent.json'));
+        $request->headers->set('webhook-signature', 'k7SwzHXZqVKNvCpp6HwGS/5aDZ6NraYnKmVkBdx7MHE=');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('A non-empty secret is required.');
+
+        $this->createRequestParser()->parse($request, '');
+    }
+
     protected function createRequestParser(): RequestParserInterface
     {
         return new SweegoRequestParser();
@@ -69,7 +83,12 @@ class SweegoRequestParserTest extends AbstractRequestParserTestCase
             'Content-Type' => 'application/json',
             'HTTP_webhook-id' => 'a5ccc627-6e43-4012-bb29-f1bfe3a3d13e',
             'HTTP_webhook-timestamp' => '1725290740',
-            'HTTP_webhook-signature' => 'k7SwzHXZqVKNvCpp6HwGS/5aDZ6NraYnKmVkBdx7MHE=',
+            'HTTP_webhook-signature' => 'qL7CgyWXWDvo031SgV1IH0IdwgiL9mh3jVKNxjqsLkI=',
         ], $payload);
+    }
+
+    protected function getSecret(): string
+    {
+        return self::SECRET;
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Sweego/Tests/Webhook/SweegoWrongSignatureRequestParserTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sweego/Tests/Webhook/SweegoWrongSignatureRequestParserTest.php
@@ -36,4 +36,9 @@ class SweegoWrongSignatureRequestParserTest extends AbstractRequestParserTestCas
             'HTTP_webhook-signature' => 'wrong_signature',
         ], $payload);
     }
+
+    protected function getSecret(): string
+    {
+        return 'GvLY88Uyj70jQm3fUwYyWmAaiz98wWim';
+    }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Sweego/Webhook/SweegoRequestParser.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sweego/Webhook/SweegoRequestParser.php
@@ -17,6 +17,7 @@ use Symfony\Component\HttpFoundation\RequestMatcher\HeaderRequestMatcher;
 use Symfony\Component\HttpFoundation\RequestMatcher\IsJsonRequestMatcher;
 use Symfony\Component\HttpFoundation\RequestMatcher\MethodRequestMatcher;
 use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+use Symfony\Component\Notifier\Exception\InvalidArgumentException;
 use Symfony\Component\RemoteEvent\Event\Sms\SmsEvent;
 use Symfony\Component\Webhook\Client\AbstractRequestParser;
 use Symfony\Component\Webhook\Exception\RejectWebhookException;
@@ -41,6 +42,10 @@ final class SweegoRequestParser extends AbstractRequestParser
 
     protected function doParse(Request $request, #[\SensitiveParameter] string $secret): ?SmsEvent
     {
+        if (!$secret) {
+            throw new InvalidArgumentException('A non-empty secret is required.');
+        }
+
         $payload = $request->toArray();
 
         if (!isset($payload['event_type']) || !isset($payload['swg_uid']) || !isset($payload['phone_number'])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Eight webhook request parsers derive a signature from the configured secret. Five of them already refuse to run with an empty secret:

```php
if (!$secret) {
    throw new InvalidArgumentException('A non-empty secret is required.');
}
```

Three do not: `AhaSendRequestParser`, `MailchimpRequestParser` and the Notifier `SweegoRequestParser`. They compute the HMAC with an empty key and compare it to the header. Anyone who knows the scheme can produce that value, so a deployment that forgot to set the secret accepts forged webhooks while still looking like it verifies them. This adds the same guard to the three.

The nine parsers that skip verification outright when no secret is set (Brevo, Mailjet, Postmark, Mailtrap, MailerSend, Sendgrid, the Mailer Sweego bridge, Twilio and Lox24) are left alone: they never pretend to have checked anything.

One behavior change to know about. Mailchimp sends a `mandrill_events=[]` request to check the webhook URL is reachable, and signs it with the literal secret `test-webhook` rather than yours. `MailchimpRequestParser` mirrors that, so until now that check also passed when no secret was configured at all. With the guard it now fails in that case. It still passes as soon as a secret is configured, which is what the setup flow expects.

The Notifier Sweego test fixtures were signed with the empty secret, which is the same problem in test form. They are re-signed with a real secret here, and the old signature is reused in the new test as the forged one.

Checks run on this branch:

- `./phpunit src/Symfony/Component/Mailer`: 937 tests, 1866 assertions, 3 skipped, no failure.
- `./phpunit src/Symfony/Component/Notifier`: 2404 tests, 3691 assertions, 3 skipped, no failure.
- `php-cs-fixer` on the three bridges: clean.

With the fix reverted and the tests kept, each new test fails because no exception is raised at all, which is the forged request being accepted.
