### PR TITLE
[Mailer] Mark the Sendgrid webhook secret as sensitive

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Webhook/SendgridRequestParser.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Webhook/SendgridRequestParser.php
@@ -43,7 +43,7 @@ final class SendgridRequestParser extends AbstractRequestParser
         ]);
     }
 
-    protected function doParse(Request $request, string $secret): ?AbstractMailerEvent
+    protected function doParse(Request $request, #[\SensitiveParameter] string $secret): ?AbstractMailerEvent
     {
         $content = $request->toArray();
         if (


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`SendgridRequestParser::doParse()` takes the webhook secret without `#[\SensitiveParameter]`, so the value is exposed in stack traces. The pass that marked these parameters in 52ca69970 covered the bridge's private `validateSignature()` but missed `doParse()`, which is the method the base parser calls.

`./phpunit src/Symfony/Component/Mailer`: Tests: 610, Assertions: 1216, Skipped: 8.