### PR TITLE
[Mailer][Notifier] Mark webhook secrets as sensitive

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/AhaSend/Webhook/AhaSendRequestParser.php
+++ b/src/Symfony/Component/Mailer/Bridge/AhaSend/Webhook/AhaSendRequestParser.php
@@ -69,7 +69,7 @@ final class AhaSendRequestParser extends AbstractRequestParser
         }
     }
 
-    private function sign(string $eventID, string $timestamp, string $payload, $secret): string
+    private function sign(string $eventID, string $timestamp, string $payload, #[\SensitiveParameter] string $secret): string
     {
         $signaturePayload = "{$eventID}.{$timestamp}.{$payload}";
         $hash = hash_hmac('sha256', $signaturePayload, $secret);

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Webhook/MailchimpRequestParser.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Webhook/MailchimpRequestParser.php
@@ -78,7 +78,7 @@ final class MailchimpRequestParser extends AbstractRequestParser
     /**
      * @see https://mailchimp.com/developer/transactional/guides/track-respond-activity-webhooks/#authenticating-webhook-requests
      */
-    private function validateSignature(array $content, string $secret, string $webhookUrl, ?string $mandrillHeaderSignature): void
+    private function validateSignature(array $content, #[\SensitiveParameter] string $secret, string $webhookUrl, ?string $mandrillHeaderSignature): void
     {
         if (null === $mandrillHeaderSignature || !isset($content['mandrill_events'])) {
             throw new RejectWebhookException(400, 'Signature is wrong.');

--- a/src/Symfony/Component/Mailer/Bridge/Resend/Webhook/ResendRequestParser.php
+++ b/src/Symfony/Component/Mailer/Bridge/Resend/Webhook/ResendRequestParser.php
@@ -77,7 +77,7 @@ final class ResendRequestParser extends AbstractRequestParser
         }
     }
 
-    private function validateSignature(string $payload, HeaderBag $headers, string $secret): void
+    private function validateSignature(string $payload, HeaderBag $headers, #[\SensitiveParameter] string $secret): void
     {
         $secret = $this->decodeSecret($secret);
         $messageId = $headers->get('svix-id');
@@ -112,7 +112,7 @@ final class ResendRequestParser extends AbstractRequestParser
         }
     }
 
-    private function sign(string $secret, string $messageId, int $timestamp, string $payload): string
+    private function sign(#[\SensitiveParameter] string $secret, string $messageId, int $timestamp, string $payload): string
     {
         $toSign = \sprintf('%s.%s.%s', $messageId, $timestamp, $payload);
         $hash = hash_hmac('sha256', $toSign, $secret);
@@ -121,7 +121,7 @@ final class ResendRequestParser extends AbstractRequestParser
         return 'v1,'.$signature;
     }
 
-    private function decodeSecret(string $secret): string
+    private function decodeSecret(#[\SensitiveParameter] string $secret): string
     {
         $prefix = 'whsec_';
         if (str_starts_with($secret, $prefix)) {

--- a/src/Symfony/Component/Mailer/Bridge/Sweego/Webhook/SweegoRequestParser.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sweego/Webhook/SweegoRequestParser.php
@@ -73,7 +73,7 @@ final class SweegoRequestParser extends AbstractRequestParser
         }
     }
 
-    private function validateSignature(Request $request, string $secret): void
+    private function validateSignature(Request $request, #[\SensitiveParameter] string $secret): void
     {
         $timestamp = $request->headers->get('webhook-timestamp');
 

--- a/src/Symfony/Component/Notifier/Bridge/Sweego/Webhook/SweegoRequestParser.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sweego/Webhook/SweegoRequestParser.php
@@ -60,7 +60,7 @@ final class SweegoRequestParser extends AbstractRequestParser
         return $event;
     }
 
-    private function validateSignature(Request $request, string $secret): void
+    private function validateSignature(Request $request, #[\SensitiveParameter] string $secret): void
     {
         $timestamp = $request->headers->get('webhook-timestamp');
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Seven parameters holding a webhook secret are missing `#[\SensitiveParameter]`, so their values show up in stack traces: `AhaSend::sign()`, `Mailchimp::validateSignature()`, `Resend::validateSignature()`, `Resend::sign()`, `Resend::decodeSecret()`, and `validateSignature()` in both Sweego bridges. The bridges added since 52ca69970 never got the treatment that pass applied elsewhere.

Sendgrid has the same gap on `doParse()` and is fixed on 6.4 in #65765, so it arrives here on merge up.

`./phpunit src/Symfony/Component/Mailer`: Tests: 934, Assertions: 1860, Skipped: 3.
`./phpunit src/Symfony/Component/Notifier`: Tests: 2403, Assertions: 3689, Skipped: 3.