### PR TITLE
[Mailer] Reject an empty secret in the Azure webhook parser

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Azure/Tests/Webhook/AzureRequestParserTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Azure/Tests/Webhook/AzureRequestParserTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Mailer\Bridge\Azure\Tests\Webhook;
 
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Mailer\Bridge\Azure\RemoteEvent\AzurePayloadConverter;
 use Symfony\Component\Mailer\Bridge\Azure\Webhook\AzureRequestParser;
 use Symfony\Component\Webhook\Client\RequestParserInterface;
@@ -22,4 +23,18 @@ class AzureRequestParserTest extends AbstractRequestParserTestCase
     {
         return new AzureRequestParser(new AzurePayloadConverter());
     }
+
+    protected function createRequest(string $payload): Request
+    {
+        return Request::create('/?secret='.self::SECRET, 'POST', [], [], [], [
+            'CONTENT_TYPE' => 'application/json',
+        ], $payload);
+    }
+
+    protected function getSecret(): string
+    {
+        return self::SECRET;
+    }
+
+    private const SECRET = 'the-webhook-secret';
 }

--- a/src/Symfony/Component/Mailer/Bridge/Azure/Tests/Webhook/AzureSecretRequestParserTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Azure/Tests/Webhook/AzureSecretRequestParserTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Mailer\Bridge\Azure\RemoteEvent\AzurePayloadConverter;
 use Symfony\Component\Mailer\Bridge\Azure\Webhook\AzureRequestParser;
+use Symfony\Component\Mailer\Exception\InvalidArgumentException;
 use Symfony\Component\Webhook\Exception\RejectWebhookException;
 
 class AzureSecretRequestParserTest extends TestCase
@@ -25,6 +26,14 @@ class AzureSecretRequestParserTest extends TestCase
         $this->expectExceptionMessage('Invalid secret.');
 
         $this->parse(Request::create('/', 'POST', [], [], [], ['CONTENT_TYPE' => 'application/json'], '[]'), 'the-secret');
+    }
+
+    public function testAnEmptySecretIsRejected()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('A non-empty secret is required.');
+
+        $this->parse(Request::create('/', 'POST', [], [], [], ['CONTENT_TYPE' => 'application/json'], '[]'), '');
     }
 
     public function testRequestWithAWrongSecretIsRejected()

--- a/src/Symfony/Component/Mailer/Bridge/Azure/Webhook/AzureRequestParser.php
+++ b/src/Symfony/Component/Mailer/Bridge/Azure/Webhook/AzureRequestParser.php
@@ -17,6 +17,7 @@ use Symfony\Component\HttpFoundation\RequestMatcher\IsJsonRequestMatcher;
 use Symfony\Component\HttpFoundation\RequestMatcher\MethodRequestMatcher;
 use Symfony\Component\HttpFoundation\RequestMatcherInterface;
 use Symfony\Component\Mailer\Bridge\Azure\RemoteEvent\AzurePayloadConverter;
+use Symfony\Component\Mailer\Exception\InvalidArgumentException;
 use Symfony\Component\RemoteEvent\Event\Mailer\AbstractMailerEvent;
 use Symfony\Component\RemoteEvent\Exception\ParseException;
 use Symfony\Component\Webhook\Client\AbstractRequestParser;
@@ -59,6 +60,10 @@ final class AzureRequestParser extends AbstractRequestParser
      */
     protected function doParse(Request $request, #[\SensitiveParameter] string $secret): array
     {
+        if (!$secret) {
+            throw new InvalidArgumentException('A non-empty secret is required.');
+        }
+
         if (!hash_equals($secret, (string) $request->query->get('secret'))) {
             throw new RejectWebhookException(401, 'Invalid secret.');
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`AzureRequestParser` authenticates by comparing the configured secret with a `secret` query parameter. When the configured secret is empty, a request that carries no `secret` parameter compares `''` with `''`, so `hash_equals()` returns true and the request is accepted. The endpoint then rejects every caller that does send a secret and accepts every caller that sends none, under a check that reads like authentication.

This adds the guard the other bridges use, so an empty secret is a configuration error rather than an open door.

`AzureRequestParserTest` did not override `getSecret()`, so its seven fixture cases ran with the empty secret and passed through that same branch. It now uses a real secret and a matching query parameter, like `AzureMalformedPayloadRequestParserTest` next to it already did.

`./phpunit src/Symfony/Component/Mailer`: Tests: 1227, Assertions: 2521, Skipped: 3.