### PR TITLE
[Notifier] Reject an empty secret in the Twilio webhook parser

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Twilio/Tests/Webhook/TwilioRequestParserTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Twilio/Tests/Webhook/TwilioRequestParserTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Notifier\Bridge\Twilio\Tests\Webhook;
 
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Notifier\Bridge\Twilio\Webhook\TwilioRequestParser;
+use Symfony\Component\Notifier\Exception\InvalidArgumentException;
 use Symfony\Component\Webhook\Client\RequestParserInterface;
 use Symfony\Component\Webhook\Exception\RejectWebhookException;
 use Symfony\Component\Webhook\Test\AbstractRequestParserTestCase;
@@ -24,18 +25,39 @@ class TwilioRequestParserTest extends AbstractRequestParserTestCase
         return new TwilioRequestParser();
     }
 
+    /**
+     * The signature is the one Twilio computes for the "delivered.txt" fixture.
+     *
+     * @see https://www.twilio.com/docs/usage/webhooks/webhooks-security
+     */
     protected function createRequest(string $payload): Request
     {
         parse_str(trim($payload), $parameters);
 
         return Request::create('/', 'POST', $parameters, [], [], [
             'Content-Type' => 'application/x-www-form-urlencoded',
+            'HTTP_X-Twilio-Signature' => 'xllaS9aFah5h0erZk5LjbK8XC3M=',
         ]);
+    }
+
+    protected function getSecret(): string
+    {
+        return 's3cret-token';
     }
 
     protected static function getFixtureExtension(): string
     {
         return 'txt';
+    }
+
+    public function testEmptySecretIsRejected()
+    {
+        $request = $this->createRequest(file_get_contents(__DIR__.'/Fixtures/delivered.txt'));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('A non-empty secret is required.');
+
+        $this->createRequestParser()->parse($request, '');
     }
 
     public function testValidSignatureIsAccepted()

--- a/src/Symfony/Component/Notifier/Bridge/Twilio/Webhook/TwilioRequestParser.php
+++ b/src/Symfony/Component/Notifier/Bridge/Twilio/Webhook/TwilioRequestParser.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Notifier\Bridge\Twilio\Webhook;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestMatcher\MethodRequestMatcher;
 use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+use Symfony\Component\Notifier\Exception\InvalidArgumentException;
 use Symfony\Component\RemoteEvent\Event\Sms\SmsEvent;
 use Symfony\Component\Webhook\Client\AbstractRequestParser;
 use Symfony\Component\Webhook\Exception\RejectWebhookException;
@@ -27,6 +28,10 @@ final class TwilioRequestParser extends AbstractRequestParser
 
     protected function doParse(Request $request, #[\SensitiveParameter] string $secret): ?SmsEvent
     {
+        if (!$secret) {
+            throw new InvalidArgumentException('A non-empty secret is required.');
+        }
+
         // Statuses: https://www.twilio.com/docs/sms/api/message-resource#message-status-values
         // Payload examples: https://www.twilio.com/docs/sms/outbound-message-logging
         $payload = $request->request->all();
@@ -38,9 +43,7 @@ final class TwilioRequestParser extends AbstractRequestParser
             throw new RejectWebhookException(406, 'Payload is malformed.');
         }
 
-        if ('' !== $secret) {
-            $this->verifySignature($request, $payload, $secret);
-        }
+        $this->verifySignature($request, $payload, $secret);
 
         $name = match ($payload['MessageStatus']) {
             'delivered' => SmsEvent::DELIVERED,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`TwilioRequestParser` verified the `X-Twilio-Signature` header only when the configured secret was not empty. An empty secret silently turned verification off and every POST request matching the payload shape was accepted.

Twilio signs all its webhook requests with the account Auth Token. There is no per-webhook secret and no setting that stops the header from being sent. So an empty secret never means "this request was not signed", it only means a real signature arrived and was thrown away. That is a misconfiguration, and the parser now says so, with the same guard the other bridges already use:

```php
if (!$secret) {
    throw new InvalidArgumentException('A non-empty secret is required.');
}
```

`verifySignature()` is now called unconditionally.

The test case did not override `getSecret()`, so it inherited `''` from `AbstractRequestParserTestCase` and its fixtures ran down the skip path, never exercising verification. It now uses a real secret and sends the matching `X-Twilio-Signature` header, computed out of band and hardcoded, the way the Sendgrid and Vonage cases do.

Checks:
- `./phpunit src/Symfony/Component/Notifier`: Tests: 2037, Assertions: 2980, Skipped: 67, Incomplete: 1, no failures.
- Revert-verify of the new test against the unpatched parser: `Failed asserting that exception of type "Symfony\Component\Notifier\Exception\InvalidArgumentException" is thrown.`
- `php-cs-fixer fix --dry-run --path-mode=intersection` on both changed files: clean.
