### PR TITLE
[Mailer] Reject an empty secret in the Mailtrap, MailerSend and Sweego webhook parsers

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/MailerSend/Tests/Webhook/v1/MailerSendRequestParserTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/MailerSend/Tests/Webhook/v1/MailerSendRequestParserTest.php
@@ -14,16 +14,14 @@ namespace Symfony\Component\Mailer\Bridge\MailerSend\Tests\Webhook\v1;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Mailer\Bridge\MailerSend\RemoteEvent\MailerSendPayloadConverter;
 use Symfony\Component\Mailer\Bridge\MailerSend\Webhook\MailerSendRequestParser;
+use Symfony\Component\Mailer\Exception\InvalidArgumentException;
 use Symfony\Component\Webhook\Client\RequestParserInterface;
 use Symfony\Component\Webhook\Exception\RejectWebhookException;
 use Symfony\Component\Webhook\Test\AbstractRequestParserTestCase;
 
 class MailerSendRequestParserTest extends AbstractRequestParserTestCase
 {
-    protected function createRequestParser(): RequestParserInterface
-    {
-        return new MailerSendRequestParser(new MailerSendPayloadConverter());
-    }
+    private const SECRET = 'GvLY88Uyj70jQm3fUwYyWmAaiz98wWim';
 
     public function testWebhookTest()
     {
@@ -45,5 +43,58 @@ class MailerSendRequestParserTest extends AbstractRequestParserTestCase
         } catch (RejectWebhookException $e) {
             $this->assertSame(202, $e->getStatusCode());
         }
+    }
+
+    public function testWebhookTestIsAcceptedWithoutConfiguredSecret()
+    {
+        $payload = json_encode([
+            'type' => 'webhook.test',
+            'message' => 'This is a ping test message',
+            'created_at' => '2026-04-08T12:19:27.608339Z',
+        ]);
+
+        $request = Request::create('/', 'POST', [], [], [], [
+            'Content-Type' => 'application/json',
+            'HTTP_Signature' => '7fb29be5b1cdb588ee67fa43a0a9d1b394cbb9603a0ac0b87924649d715194c2',
+        ], $payload);
+
+        try {
+            $this->createRequestParser()->parse($request, '');
+            $this->fail('A RejectWebhookException with a 202 status code should have been thrown.');
+        } catch (RejectWebhookException $e) {
+            $this->assertSame(202, $e->getStatusCode());
+        }
+    }
+
+    public function testRequestSignedWithAnEmptySecretIsRejected()
+    {
+        $payload = file_get_contents(__DIR__.'/Fixtures/sent.json');
+        $request = Request::create('/', 'POST', [], [], [], [
+            'Content-Type' => 'application/json',
+            'HTTP_Signature' => 'f09863b0c747482e3ea5d3784bb51e71b60a4126d7ffd20397fa71f22f240de1',
+        ], $payload);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('A non-empty secret is required.');
+
+        $this->createRequestParser()->parse($request, '');
+    }
+
+    protected function createRequestParser(): RequestParserInterface
+    {
+        return new MailerSendRequestParser(new MailerSendPayloadConverter());
+    }
+
+    protected function getSecret(): string
+    {
+        return self::SECRET;
+    }
+
+    protected function createRequest(string $payload): Request
+    {
+        return Request::create('/', 'POST', [], [], [], [
+            'Content-Type' => 'application/json',
+            'HTTP_Signature' => hash_hmac('sha256', $payload, self::SECRET),
+        ], $payload);
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/MailerSend/Tests/Webhook/v2/MailerSendRequestParserTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/MailerSend/Tests/Webhook/v2/MailerSendRequestParserTest.php
@@ -14,16 +14,14 @@ namespace Symfony\Component\Mailer\Bridge\MailerSend\Tests\Webhook\v2;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Mailer\Bridge\MailerSend\RemoteEvent\MailerSendPayloadConverter;
 use Symfony\Component\Mailer\Bridge\MailerSend\Webhook\MailerSendRequestParser;
+use Symfony\Component\Mailer\Exception\InvalidArgumentException;
 use Symfony\Component\Webhook\Client\RequestParserInterface;
 use Symfony\Component\Webhook\Exception\RejectWebhookException;
 use Symfony\Component\Webhook\Test\AbstractRequestParserTestCase;
 
 class MailerSendRequestParserTest extends AbstractRequestParserTestCase
 {
-    protected function createRequestParser(): RequestParserInterface
-    {
-        return new MailerSendRequestParser(new MailerSendPayloadConverter());
-    }
+    private const SECRET = 'GvLY88Uyj70jQm3fUwYyWmAaiz98wWim';
 
     public function testWebhookTest()
     {
@@ -45,5 +43,58 @@ class MailerSendRequestParserTest extends AbstractRequestParserTestCase
         } catch (RejectWebhookException $e) {
             $this->assertSame(202, $e->getStatusCode());
         }
+    }
+
+    public function testWebhookTestIsAcceptedWithoutConfiguredSecret()
+    {
+        $payload = json_encode([
+            'type' => 'webhook.test',
+            'message' => 'This is a ping test message',
+            'created_at' => '2026-04-08T12:19:27.608339Z',
+        ]);
+
+        $request = Request::create('/', 'POST', [], [], [], [
+            'Content-Type' => 'application/json',
+            'HTTP_Signature' => '7fb29be5b1cdb588ee67fa43a0a9d1b394cbb9603a0ac0b87924649d715194c2',
+        ], $payload);
+
+        try {
+            $this->createRequestParser()->parse($request, '');
+            $this->fail('A RejectWebhookException with a 202 status code should have been thrown.');
+        } catch (RejectWebhookException $e) {
+            $this->assertSame(202, $e->getStatusCode());
+        }
+    }
+
+    public function testRequestSignedWithAnEmptySecretIsRejected()
+    {
+        $payload = file_get_contents(__DIR__.'/Fixtures/sent.json');
+        $request = Request::create('/', 'POST', [], [], [], [
+            'Content-Type' => 'application/json',
+            'HTTP_Signature' => '4da13a6cb012056c0f858fd06f8f02bd3568cc2c0e754bc01617dc0c28c0f380',
+        ], $payload);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('A non-empty secret is required.');
+
+        $this->createRequestParser()->parse($request, '');
+    }
+
+    protected function createRequestParser(): RequestParserInterface
+    {
+        return new MailerSendRequestParser(new MailerSendPayloadConverter());
+    }
+
+    protected function getSecret(): string
+    {
+        return self::SECRET;
+    }
+
+    protected function createRequest(string $payload): Request
+    {
+        return Request::create('/', 'POST', [], [], [], [
+            'Content-Type' => 'application/json',
+            'HTTP_Signature' => hash_hmac('sha256', $payload, self::SECRET),
+        ], $payload);
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/MailerSend/Webhook/MailerSendRequestParser.php
+++ b/src/Symfony/Component/Mailer/Bridge/MailerSend/Webhook/MailerSendRequestParser.php
@@ -17,6 +17,7 @@ use Symfony\Component\HttpFoundation\RequestMatcher\IsJsonRequestMatcher;
 use Symfony\Component\HttpFoundation\RequestMatcher\MethodRequestMatcher;
 use Symfony\Component\HttpFoundation\RequestMatcherInterface;
 use Symfony\Component\Mailer\Bridge\MailerSend\RemoteEvent\MailerSendPayloadConverter;
+use Symfony\Component\Mailer\Exception\InvalidArgumentException;
 use Symfony\Component\RemoteEvent\Event\Mailer\AbstractMailerEvent;
 use Symfony\Component\RemoteEvent\Exception\ParseException;
 use Symfony\Component\Webhook\Client\AbstractRequestParser;
@@ -58,20 +59,22 @@ final class MailerSendRequestParser extends AbstractRequestParser
             throw new RejectWebhookException(406, 'Payload is malformed.');
         }
 
-        if ($secret) {
-            if (!$request->headers->get('Signature')) {
-                throw new RejectWebhookException(406, 'Signature is required.');
-            }
+        if (!$secret) {
+            throw new InvalidArgumentException('A non-empty secret is required.');
+        }
 
-            $this->validateSignature(
-                $request->headers->get('Signature'),
-                $request->getContent(),
-                $secret,
-            );
+        if (!$request->headers->get('Signature')) {
+            throw new RejectWebhookException(406, 'Signature is required.');
+        }
 
-            if (self::TEST_SECRET === $secret) {
-                throw new RejectWebhookException(202);
-            }
+        $this->validateSignature(
+            $request->headers->get('Signature'),
+            $request->getContent(),
+            $secret,
+        );
+
+        if (self::TEST_SECRET === $secret) {
+            throw new RejectWebhookException(202);
         }
 
         try {

--- a/src/Symfony/Component/Mailer/Bridge/Mailtrap/Tests/Webhook/MailtrapRequestParserTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailtrap/Tests/Webhook/MailtrapRequestParserTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Mailer\Bridge\Mailtrap\Tests\Webhook;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Mailer\Bridge\Mailtrap\RemoteEvent\MailtrapPayloadConverter;
 use Symfony\Component\Mailer\Bridge\Mailtrap\Webhook\MailtrapRequestParser;
+use Symfony\Component\Mailer\Exception\InvalidArgumentException;
 use Symfony\Component\Webhook\Client\RequestParserInterface;
 use Symfony\Component\Webhook\Exception\RejectWebhookException;
 use Symfony\Component\Webhook\Test\AbstractRequestParserTestCase;
@@ -63,5 +64,20 @@ class MailtrapRequestParserTest extends AbstractRequestParserTestCase
         $this->expectException(RejectWebhookException::class);
         $this->expectExceptionMessage('Signature is wrong.');
         $parser->parse($request, 'top-secret');
+    }
+
+    public function testRequestSignedWithAnEmptySecretIsRejected()
+    {
+        $parser = new MailtrapRequestParser(new MailtrapPayloadConverter());
+        $payload = file_get_contents(__DIR__.'/Fixtures/delivery.json');
+        $request = Request::create('/', 'POST', [], [], [], [
+            'Content-Type' => 'application/json',
+            'HTTP_Mailtrap-Signature' => 'beb0cf17a6314aa51243ae6cfd66809bff36fa6764311d16bdd3d8c68601567c',
+        ], $payload);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('A non-empty secret is required.');
+
+        $parser->parse($request, '');
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Mailtrap/Webhook/MailtrapRequestParser.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailtrap/Webhook/MailtrapRequestParser.php
@@ -17,6 +17,7 @@ use Symfony\Component\HttpFoundation\RequestMatcher\IsJsonRequestMatcher;
 use Symfony\Component\HttpFoundation\RequestMatcher\MethodRequestMatcher;
 use Symfony\Component\HttpFoundation\RequestMatcherInterface;
 use Symfony\Component\Mailer\Bridge\Mailtrap\RemoteEvent\MailtrapPayloadConverter;
+use Symfony\Component\Mailer\Exception\InvalidArgumentException;
 use Symfony\Component\RemoteEvent\Exception\ParseException;
 use Symfony\Component\RemoteEvent\RemoteEvent;
 use Symfony\Component\Webhook\Client\AbstractRequestParser;
@@ -42,14 +43,16 @@ final class MailtrapRequestParser extends AbstractRequestParser
 
     protected function doParse(Request $request, #[\SensitiveParameter] string $secret): RemoteEvent|array|null
     {
-        if ($secret) {
-            if (!$signature = $request->headers->get('Mailtrap-Signature')) {
-                throw new RejectWebhookException(406, 'Signature is required.');
-            }
+        if (!$secret) {
+            throw new InvalidArgumentException('A non-empty secret is required.');
+        }
 
-            if (!hash_equals(hash_hmac('sha256', $request->getContent(), $secret), $signature)) {
-                throw new RejectWebhookException(406, 'Signature is wrong.');
-            }
+        if (!$signature = $request->headers->get('Mailtrap-Signature')) {
+            throw new RejectWebhookException(406, 'Signature is required.');
+        }
+
+        if (!hash_equals(hash_hmac('sha256', $request->getContent(), $secret), $signature)) {
+            throw new RejectWebhookException(406, 'Signature is wrong.');
         }
 
         $payload = $request->toArray();

--- a/src/Symfony/Component/Mailer/Bridge/Sweego/Tests/Webhook/SweegoRequestParserTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sweego/Tests/Webhook/SweegoRequestParserTest.php
@@ -14,23 +14,51 @@ namespace Symfony\Component\Mailer\Bridge\Sweego\Tests\Webhook;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Mailer\Bridge\Sweego\RemoteEvent\SweegoPayloadConverter;
 use Symfony\Component\Mailer\Bridge\Sweego\Webhook\SweegoRequestParser;
+use Symfony\Component\Mailer\Exception\InvalidArgumentException;
 use Symfony\Component\Webhook\Client\RequestParserInterface;
 use Symfony\Component\Webhook\Test\AbstractRequestParserTestCase;
 
 class SweegoRequestParserTest extends AbstractRequestParserTestCase
 {
+    private const SECRET = 'GvLY88Uyj70jQm3fUwYyWmAaiz98wWim';
+    private const WEBHOOK_ID = '9f26b9d0-13d7-410c-ba04-5019cd30e6d0';
+
+    public function testRequestSignedWithAnEmptySecretIsRejected()
+    {
+        $payload = file_get_contents(__DIR__.'/Fixtures/delivered.json');
+        $request = Request::create('/', 'POST', [], [], [], [
+            'Content-Type' => 'application/json',
+            'HTTP_webhook-id' => self::WEBHOOK_ID,
+            'HTTP_webhook-timestamp' => '1723737959',
+            'HTTP_webhook-signature' => 'uN8Pj2+RzSIzQh/FCnOLEmE40qcRFGuPuenm1t0DPk8=',
+        ], $payload);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('A non-empty secret is required.');
+
+        $this->createRequestParser()->parse($request, '');
+    }
+
     protected function createRequestParser(): RequestParserInterface
     {
         return new SweegoRequestParser(new SweegoPayloadConverter());
     }
 
+    protected function getSecret(): string
+    {
+        return self::SECRET;
+    }
+
     protected function createRequest(string $payload): Request
     {
+        $timestamp = (string) time();
+        $contentToSign = \sprintf('%s.%s.%s', self::WEBHOOK_ID, $timestamp, $payload);
+
         return Request::create('/', 'POST', [], [], [], [
             'Content-Type' => 'application/json',
-            'HTTP_webhook-id' => 'id',
-            'HTTP_webhook-timestamp' => 'timestamp',
-            'HTTP_webhook-signature' => 'signature',
+            'HTTP_webhook-id' => self::WEBHOOK_ID,
+            'HTTP_webhook-timestamp' => $timestamp,
+            'HTTP_webhook-signature' => base64_encode(hash_hmac('sha256', $contentToSign, base64_decode(self::SECRET), true)),
         ], $payload);
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Sweego/Webhook/SweegoRequestParser.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sweego/Webhook/SweegoRequestParser.php
@@ -18,6 +18,7 @@ use Symfony\Component\HttpFoundation\RequestMatcher\IsJsonRequestMatcher;
 use Symfony\Component\HttpFoundation\RequestMatcher\MethodRequestMatcher;
 use Symfony\Component\HttpFoundation\RequestMatcherInterface;
 use Symfony\Component\Mailer\Bridge\Sweego\RemoteEvent\SweegoPayloadConverter;
+use Symfony\Component\Mailer\Exception\InvalidArgumentException;
 use Symfony\Component\RemoteEvent\Event\Mailer\AbstractMailerEvent;
 use Symfony\Component\RemoteEvent\Exception\ParseException;
 use Symfony\Component\Webhook\Client\AbstractRequestParser;
@@ -43,6 +44,10 @@ final class SweegoRequestParser extends AbstractRequestParser
 
     protected function doParse(Request $request, #[\SensitiveParameter] string $secret): ?AbstractMailerEvent
     {
+        if (!$secret) {
+            throw new InvalidArgumentException('A non-empty secret is required.');
+        }
+
         $content = $request->toArray();
 
         if (
@@ -55,16 +60,14 @@ final class SweegoRequestParser extends AbstractRequestParser
             throw new RejectWebhookException(406, 'Payload is malformed.');
         }
 
-        if ($secret) {
-            if (!$request->headers->get('webhook-id')
-                && !$request->headers->get('webhook-timestamp')
-                && !$request->headers->get('webhook-signature')
-            ) {
-                throw new RejectWebhookException(406, 'Signature is required.');
-            }
-
-            $this->validateSignature($request, $secret);
+        if (!$request->headers->get('webhook-id')
+            && !$request->headers->get('webhook-timestamp')
+            && !$request->headers->get('webhook-signature')
+        ) {
+            throw new RejectWebhookException(406, 'Signature is required.');
         }
+
+        $this->validateSignature($request, $secret);
 
         try {
             return $this->converter->convert($content);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Three Mailer webhook request parsers skip signature verification when the configured secret is empty: `MailtrapRequestParser`, `MailerSendRequestParser` and the Mailer `SweegoRequestParser`. Each wraps the check in `if ($secret) { ... }`, so a deployment that forgot to set the secret accepts any payload posted to the webhook endpoint.

For these three providers an empty secret is not a supported mode, it is a misconfiguration:

- Mailtrap sends a `Mailtrap-Signature` header on every webhook request. The secret is generated when the webhook is created, and there is no API field or UI toggle to turn signing off.
- MailerSend signs real events with a per-webhook signing secret, with no documented opt-out.
- Sweego signs all webhooks with HMAC-SHA256. The create API has no signing flag and there is no sandbox mode.

So in all three cases a signature did arrive and was thrown away. This adds the guard the other parsers already use:

```php
if (!$secret) {
    throw new InvalidArgumentException('A non-empty secret is required.');
}
```

### The MailerSend `webhook.test` carve-out

MailerSend posts a `{"type":"webhook.test"}` ping when a webhook is created or updated, as a blocking reachability check. That ping is signed with a fixed, publicly documented secret, already present in the bridge as `MailerSendRequestParser::TEST_SECRET`. The real signing secret only becomes available after the webhook is saved, so the ping legitimately reaches an endpoint that cannot hold the real secret yet.

`MailerSendRequestParser` already overrides `$secret` with `TEST_SECRET` for that payload. The new guard is placed **after** that override rather than at the top of `doParse()`, so the ping keeps working with no secret configured, while real events are rejected. The existing `RejectWebhookException(202)` answer to the ping is unchanged. `testWebhookTestIsAcceptedWithoutConfiguredSecret` pins that behavior.

For Mailtrap and Sweego the guard sits at the top of `doParse()`, and the verification then runs unconditionally.

### Tests that were verifying nothing

`MailerSendRequestParserTest` (both `v1` and `v2`) and the Mailer `SweegoRequestParserTest` did not override `getSecret()`, so they inherited `''` from `AbstractRequestParserTestCase` and never exercised signature verification. They now use a real secret and send correctly computed signature headers.

`MailtrapRequestParserTest` already used a real secret and a real signature, so it needed no change.

### Checks run

- `./phpunit src/Symfony/Component/Mailer`: 943 tests, 1876 assertions, 3 skipped, 0 failures. The three skips are the pre-existing Windows-only `NativeTransportFactoryTest` cases.
- Revert-verify: with the tests in place and the three parsers back in their base state, `testRequestSignedWithAnEmptySecretIsRejected` fails in all four classes with `Failed asserting that exception of type "Symfony\Component\Mailer\Exception\InvalidArgumentException" is thrown.`, which is the proof the forged request was accepted before.
- `php-cs-fixer fix --dry-run --path-mode=intersection` over the seven touched files: clean.

Not covered: `SendgridRequestParser` and `TurboSmtpRequestParser` keep their current behavior on purpose. Sendgrid signing is opt-in and its API reports an empty public key when it is off, and TurboSmtp does not sign at all.
