### PR TITLE
[Mailer][Mime] Update the RFC references and document what Address validates

### DIFF
--- a/src/Symfony/Component/Mailer/Envelope.php
+++ b/src/Symfony/Component/Mailer/Envelope.php
@@ -52,7 +52,7 @@ class Envelope
     }
 
     /**
-     * @return Address Returns a "mailbox" as specified by RFC 2822
+     * @return Address Returns a "mailbox" as specified by RFC 5322
      *                 Must be converted to an "addr-spec" when used as a "MAIL FROM" value in SMTP (use getAddress())
      */
     public function getSender(): Address

--- a/src/Symfony/Component/Mime/Address.php
+++ b/src/Symfony/Component/Mime/Address.php
@@ -20,6 +20,12 @@ use Symfony\Component\Mime\Exception\LogicException;
 use Symfony\Component\Mime\Exception\RfcComplianceException;
 
 /**
+ * An addr-spec as defined by RFC 5322 (3.4.1), updated by RFC 6532 for the non-ASCII characters.
+ *
+ * The transport restrictions of RFC 5321 are deliberately not enforced here: the local part is
+ * not limited to 64 octets (4.5.3.1) and it is not restricted to a Dot-string or a Quoted-string
+ * (4.1.2). Deciding what an SMTP session accepts is up to the envelope and the transport.
+ *
  * @author Fabien Potencier <fabien@symfony.com>
  */
 final class Address
@@ -55,7 +61,7 @@ final class Address
         }
 
         if (!self::isValidAddrSpec($this->address)) {
-            throw new RfcComplianceException(\sprintf('Email "%s" does not comply with addr-spec of RFC 2822.', $address));
+            throw new RfcComplianceException(\sprintf('Email "%s" does not comply with addr-spec of RFC 5322.', $address));
         }
     }
 

--- a/src/Symfony/Component/Mime/Header/AbstractHeader.php
+++ b/src/Symfony/Component/Mime/Header/AbstractHeader.php
@@ -80,7 +80,7 @@ abstract class AbstractHeader implements HeaderInterface
     }
 
     /**
-     * Produces a compliant, formatted RFC 2822 'phrase' based on the string given.
+     * Produces a compliant, formatted RFC 5322 'phrase' based on the string given.
      *
      * @param string $string  as displayed
      * @param bool   $shorten the first line to make remove for header name
@@ -127,7 +127,7 @@ abstract class AbstractHeader implements HeaderInterface
         $value = '';
         $tokens = $this->getEncodableWordTokens($input);
         foreach ($tokens as $token) {
-            // See RFC 2822, Sect 2.2 (really 2.2 ??)
+            // See RFC 5322, Sect 2.2 (really 2.2 ??)
             if ($this->tokenNeedsEncoding($token)) {
                 // Don't encode starting WSP
                 $firstChar = substr($token, 0, 1);
@@ -262,7 +262,7 @@ abstract class AbstractHeader implements HeaderInterface
 
     /**
      * Takes an array of tokens which appear in the header and turns them into
-     * an RFC 2822 compliant string, adding FWSP where needed.
+     * an RFC 5322 compliant string, adding FWSP where needed.
      *
      * @param string[] $tokens
      */
@@ -289,7 +289,7 @@ abstract class AbstractHeader implements HeaderInterface
             }
         }
 
-        // Implode with FWS (RFC 2822, 2.2.3)
+        // Implode with FWS (RFC 5322, 2.2.3)
         return implode("\r\n", $headerLines);
     }
 }

--- a/src/Symfony/Component/Mime/Header/HeaderInterface.php
+++ b/src/Symfony/Component/Mime/Header/HeaderInterface.php
@@ -54,7 +54,7 @@ interface HeaderInterface
     /**
      * Gets the header's body, prepared for folding into a final header value.
      *
-     * This is not necessarily RFC 2822 compliant since folding white space is
+     * This is not necessarily RFC 5322 compliant since folding white space is
      * not added at this stage (see {@link toString()} for that).
      */
     public function getBodyAsString(): string;

--- a/src/Symfony/Component/Mime/Header/Headers.php
+++ b/src/Symfony/Component/Mime/Header/Headers.php
@@ -34,7 +34,7 @@ final class Headers
         'cc' => MailboxListHeader::class,
         'bcc' => MailboxListHeader::class,
         'message-id' => IdentificationHeader::class,
-        'in-reply-to' => [UnstructuredHeader::class, IdentificationHeader::class], // `In-Reply-To` and `References` are less strict than RFC 2822 (3.6.4) to allow users entering the original email's ...
+        'in-reply-to' => [UnstructuredHeader::class, IdentificationHeader::class], // `In-Reply-To` and `References` are less strict than RFC 5322 (3.6.4) to allow users entering the original email's ...
         'references' => [UnstructuredHeader::class, IdentificationHeader::class], // ... `Message-ID`, even if that is no valid `msg-id`
         'return-path' => PathHeader::class,
     ];

--- a/src/Symfony/Component/Mime/Header/MailboxHeader.php
+++ b/src/Symfony/Component/Mime/Header/MailboxHeader.php
@@ -76,7 +76,7 @@ final class MailboxHeader extends AbstractHeader
      *
      * All "specials" must be encoded as the full header value will not be quoted
      *
-     * @see RFC 2822 3.2.1
+     * @see RFC 5322 3.2.3
      */
     protected function tokenNeedsEncoding(string $token): bool
     {

--- a/src/Symfony/Component/Mime/Header/MailboxListHeader.php
+++ b/src/Symfony/Component/Mime/Header/MailboxListHeader.php
@@ -97,7 +97,7 @@ final class MailboxListHeader extends AbstractHeader
     }
 
     /**
-     * Gets the full mailbox list of this Header as an array of valid RFC 2822 strings.
+     * Gets the full mailbox list of this Header as an array of valid RFC 5322 strings.
      *
      * @return string[]
      *
@@ -127,7 +127,7 @@ final class MailboxListHeader extends AbstractHeader
      *
      * All "specials" must be encoded as the full header value will not be quoted
      *
-     * @see RFC 2822 3.2.1
+     * @see RFC 5322 3.2.3
      */
     protected function tokenNeedsEncoding(string $token): bool
     {

--- a/src/Symfony/Component/Mime/Tests/AddressTest.php
+++ b/src/Symfony/Component/Mime/Tests/AddressTest.php
@@ -42,7 +42,7 @@ class AddressTest extends TestCase
     public function testConstructorWithUnquotedAtSignInLocalPart()
     {
         $this->expectException(RfcComplianceException::class);
-        $this->expectExceptionMessage('Email "em@il@example.test" does not comply with addr-spec of RFC 2822.');
+        $this->expectExceptionMessage('Email "em@il@example.test" does not comply with addr-spec of RFC 5322.');
         new Address('em@il@example.test');
     }
 

--- a/src/Symfony/Component/Mime/Tests/Header/DateHeaderTest.php
+++ b/src/Symfony/Component/Mime/Tests/Header/DateHeaderTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\Mime\Header\DateHeader;
 class DateHeaderTest extends TestCase
 {
     /* --
-    The following tests refer to RFC 2822, section 3.6.1 and 3.3.
+    The following tests refer to RFC 5322, section 3.6.1 and 3.3.
     */
 
     public function testGetDateTime()

--- a/src/Symfony/Component/Mime/Tests/Header/IdentificationHeaderTest.php
+++ b/src/Symfony/Component/Mime/Tests/Header/IdentificationHeaderTest.php
@@ -18,7 +18,7 @@ class IdentificationHeaderTest extends TestCase
 {
     public function testValueMatchesMsgIdSpec()
     {
-        /* -- RFC 2822, 3.6.4.
+        /* -- RFC 5322, 3.6.4.
          message-id      =       "Message-ID:" msg-id CRLF
 
          in-reply-to     =       "In-Reply-To:" 1*msg-id CRLF
@@ -55,7 +55,7 @@ class IdentificationHeaderTest extends TestCase
 
     public function testSettingMultipleIdsProducesAListValue()
     {
-        /* -- RFC 2822, 3.6.4.
+        /* -- RFC 5322, 3.6.4.
         The "References:" and "In-Reply-To:" field each contain one or more
         unique message identifiers, optionally separated by CFWS.
 
@@ -72,7 +72,7 @@ class IdentificationHeaderTest extends TestCase
 
     public function testIdLeftCanBeQuoted()
     {
-        /* -- RFC 2822, 3.6.4.
+        /* -- RFC 5322, 3.6.4.
          id-left         =       dot-atom-text / no-fold-quote / obs-id-left
          */
 
@@ -83,7 +83,7 @@ class IdentificationHeaderTest extends TestCase
 
     public function testIdLeftCanContainAnglesAsQuotedPairs()
     {
-        /* -- RFC 2822, 3.6.4.
+        /* -- RFC 5322, 3.6.4.
          no-fold-quote   =       DQUOTE *(qtext / quoted-pair) DQUOTE
          */
 
@@ -102,13 +102,13 @@ class IdentificationHeaderTest extends TestCase
     public function testInvalidIdLeftThrowsException()
     {
         $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('Email "a b c@d" does not comply with addr-spec of RFC 2822.');
+        $this->expectExceptionMessage('Email "a b c@d" does not comply with addr-spec of RFC 5322.');
         new IdentificationHeader('References', 'a b c@d');
     }
 
     public function testIdRightCanBeDotAtom()
     {
-        /* -- RFC 2822, 3.6.4.
+        /* -- RFC 5322, 3.6.4.
          id-right        =       dot-atom-text / no-fold-literal / obs-id-right
          */
 
@@ -119,7 +119,7 @@ class IdentificationHeaderTest extends TestCase
 
     public function testIdRightCanBeLiteral()
     {
-        /* -- RFC 2822, 3.6.4.
+        /* -- RFC 5322, 3.6.4.
          no-fold-literal =       "[" *(dtext / quoted-pair) "]"
         */
 
@@ -138,15 +138,15 @@ class IdentificationHeaderTest extends TestCase
     public function testInvalidIdRightThrowsException()
     {
         $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('Email "a@b c d" does not comply with addr-spec of RFC 2822.');
+        $this->expectExceptionMessage('Email "a@b c d" does not comply with addr-spec of RFC 5322.');
         new IdentificationHeader('References', 'a@b c d');
     }
 
     public function testMissingAtSignThrowsException()
     {
         $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('Email "abc" does not comply with addr-spec of RFC 2822.');
-        /* -- RFC 2822, 3.6.4.
+        $this->expectExceptionMessage('Email "abc" does not comply with addr-spec of RFC 5322.');
+        /* -- RFC 5322, 3.6.4.
          msg-id          =       [CFWS] "<" id-left "@" id-right ">" [CFWS]
          */
         new IdentificationHeader('References', 'abc');

--- a/src/Symfony/Component/Mime/Tests/Header/MailboxListHeaderTest.php
+++ b/src/Symfony/Component/Mime/Tests/Header/MailboxListHeaderTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\Mime\Header\MailboxListHeader;
 
 class MailboxListHeaderTest extends TestCase
 {
-    // RFC 2822, 3.6.2 for all tests
+    // RFC 5322, 3.6.2 for all tests
 
     public function testMailboxIsSetForAddress()
     {

--- a/src/Symfony/Component/Mime/Tests/Header/PathHeaderTest.php
+++ b/src/Symfony/Component/Mime/Tests/Header/PathHeaderTest.php
@@ -31,7 +31,7 @@ class PathHeaderTest extends TestCase
 
     public function testValueIsAngleAddrWithValidAddress()
     {
-        /* -- RFC 2822, 3.6.7.
+        /* -- RFC 5322, 3.6.7.
 
             return          =       "Return-Path:" path CRLF
 

--- a/src/Symfony/Component/Mime/Tests/Header/UnstructuredHeaderTest.php
+++ b/src/Symfony/Component/Mime/Tests/Header/UnstructuredHeaderTest.php
@@ -30,7 +30,7 @@ class UnstructuredHeaderTest extends TestCase
 
     public function testBasicStructureIsKeyValuePair()
     {
-        /* -- RFC 2822, 2.2
+        /* -- RFC 5322, 2.2
         Header fields are lines composed of a field name, followed by a colon
         (":"), followed by a field body, and terminated by CRLF.
         */
@@ -40,7 +40,7 @@ class UnstructuredHeaderTest extends TestCase
 
     public function testLongHeadersAreFoldedAtWordBoundary()
     {
-        /* -- RFC 2822, 2.2.3
+        /* -- RFC 5322, 2.2.3
         Each header field is logically a single line of characters comprising
         the field name, the colon, and the field body.  For convenience
         however, and to deal with the 998/78 character limitations per line,
@@ -67,7 +67,7 @@ class UnstructuredHeaderTest extends TestCase
 
     public function testPrintableAsciiOnlyAppearsInHeaders()
     {
-        /* -- RFC 2822, 2.2.
+        /* -- RFC 5322, 2.2.
         A field name MUST be composed of printable US-ASCII characters (i.e.,
         characters that have values between 33 and 126, inclusive), except
         colon.  A field body may be composed of any US-ASCII characters,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Ref #65764
| License       | MIT

RFC 2822 was obsoleted by RFC 5322 in 2008, which was itself updated by RFC 6532 for non-ASCII characters. The component still references the obsolete one in ten places, including the message of the exception thrown by `Address::__construct()`. This is the one point of #65764 that stands; the rest of that report is answered on the issue itself.

Two of those references need more than a rename: the `@see RFC 2822 3.2.1` on `MailboxHeader::tokenNeedsEncoding()` and `MailboxListHeader::tokenNeedsEncoding()` point at `specials`, which moved to **3.2.3** in RFC 5322. The other sections quoted (2.2, 2.2.3, 3.3, 3.6.1, 3.6.2, 3.6.4, 3.6.7) are numbered the same in both documents. `\DateTimeInterface::RFC2822` is a PHP constant and is left alone.

The same commit states, on `Address` itself, which referential it validates against:

```php
/**
 * An addr-spec as defined by RFC 5322 (3.4.1), updated by RFC 6532 for the non-ASCII characters.
 *
 * The transport restrictions of RFC 5321 are deliberately not enforced here: the local part is
 * not limited to 64 octets (4.5.3.1) and it is not restricted to a Dot-string or a Quoted-string
 * (4.1.2). Deciding what an SMTP session accepts is up to the envelope and the transport.
 */
```

`Address` accepts a 65-octet local part, because egulias reports `LocalTooLong` as a warning and the class only looks at errors. That is a defensible choice, RFC 5321 being a transport concern rather than a message format one, but today it is only discoverable by probing the validator. Saying it out loud is the point of the second half of this PR.

After this, `grep -rn "RFC 2822" src/` returns nothing outside the PHP constant.
