### PR TITLE
[Mailer][Mime] Add RFC 6854 group support to mailbox list headers

### DIFF
--- a/src/Symfony/Component/Mailer/DelayedEnvelope.php
+++ b/src/Symfony/Component/Mailer/DelayedEnvelope.php
@@ -88,8 +88,8 @@ final class DelayedEnvelope extends Envelope
         if ($return = $headers->get('Return-Path')) {
             return $return->getAddress();
         }
-        if ($from = $headers->get('From')) {
-            return $from->getAddresses()[0];
+        if (($from = $headers->get('From')) && $addresses = $from->getAddresses()) {
+            return $addresses[0];
         }
 
         throw new LogicException('Unable to determine the sender of the message.');

--- a/src/Symfony/Component/Mailer/EventListener/MessageListener.php
+++ b/src/Symfony/Component/Mailer/EventListener/MessageListener.php
@@ -103,12 +103,11 @@ class MessageListener implements EventSubscriberInterface
                     }
 
                     $h = $headers->get($name);
-                    if (!$h instanceof MailboxListHeader) {
+                    if (!$h instanceof MailboxListHeader || !$header instanceof MailboxListHeader) {
                         throw new RuntimeException(\sprintf('Unable to set header "%s".', $name));
                     }
 
-                    Headers::checkHeaderClass($header);
-                    foreach ($header->getAddresses() as $address) {
+                    foreach ($header->getAddressList() as $address) {
                         $h->addAddress($address);
                     }
             }

--- a/src/Symfony/Component/Mailer/Tests/EnvelopeTest.php
+++ b/src/Symfony/Component/Mailer/Tests/EnvelopeTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Exception\InvalidArgumentException;
 use Symfony\Component\Mailer\Exception\LogicException;
 use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\Group;
 use Symfony\Component\Mime\Header\Headers;
 use Symfony\Component\Mime\Header\PathHeader;
 use Symfony\Component\Mime\Message;
@@ -79,6 +80,52 @@ class EnvelopeTest extends TestCase
         $headers->addMailboxListHeader('To', ['to@symfony.com']);
         $e = Envelope::create(new Message($headers));
         $this->assertEquals($from, $e->getSender());
+    }
+
+    public function testRecipientsFromHeadersExpandGroups()
+    {
+        if (!class_exists(Group::class)) {
+            $this->markTestSkipped('Groups require symfony/mime 8.2 or higher.');
+        }
+
+        $headers = new Headers();
+        $headers->addMailboxListHeader('From', ['from@symfony.com']);
+        $headers->addMailboxListHeader('To', [new Group('undisclosed-recipients')]);
+        $headers->addMailboxListHeader('Bcc', [new Group('Friends', [$helene = new Address('helene@symfony.com'), $thomas = new Address('thomas@symfony.com')]), $fabien = new Address('fabien@symfony.com')]);
+        $e = Envelope::create(new Message($headers));
+
+        $this->assertEquals([$helene, $thomas, $fabien], $e->getRecipients());
+    }
+
+    public function testSenderFromHeadersUsesTheFirstMailboxOfAGroup()
+    {
+        if (!class_exists(Group::class)) {
+            $this->markTestSkipped('Groups require symfony/mime 8.2 or higher.');
+        }
+
+        $headers = new Headers();
+        $headers->addMailboxListHeader('From', [new Group('Friends', [$from = new Address('from@symfony.com', 'from')])]);
+        $headers->addMailboxListHeader('To', ['to@symfony.com']);
+        $e = Envelope::create(new Message($headers));
+
+        $this->assertEquals($from, $e->getSender());
+    }
+
+    public function testSenderFromHeadersFailsWhenFromHasNoMailbox()
+    {
+        if (!class_exists(Group::class)) {
+            $this->markTestSkipped('Groups require symfony/mime 8.2 or higher.');
+        }
+
+        $headers = new Headers();
+        $headers->addMailboxListHeader('From', [new Group('Automated System')]);
+        $headers->addMailboxListHeader('To', ['to@symfony.com']);
+        $e = Envelope::create(new Message($headers));
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Unable to determine the sender of the message.');
+
+        $e->getSender();
     }
 
     public function testSenderFromHeadersFailsWithNonAsciiCharactersInLocalPart()

--- a/src/Symfony/Component/Mailer/Tests/EventListener/MessageListenerTest.php
+++ b/src/Symfony/Component/Mailer/Tests/EventListener/MessageListenerTest.php
@@ -17,6 +17,7 @@ use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Event\MessageEvent;
 use Symfony\Component\Mailer\EventListener\MessageListener;
 use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\Group;
 use Symfony\Component\Mime\Header\Headers;
 use Symfony\Component\Mime\Header\MailboxListHeader;
 use Symfony\Component\Mime\Header\UnstructuredHeader;
@@ -100,6 +101,17 @@ class MessageListenerTest extends TestCase
             ->add(new MailboxListHeader('bcc', [new Address('bcc-initial@example.com'), new Address('bcc-default@example.com'), new Address('bcc-default-1@example.com')]))
         ;
         yield 'bcc, add another bcc (unique header)' => [$initialHeaders, $defaultHeaders, $expectedHeaders];
+
+        $initialHeaders = (new Headers())
+            ->add(new MailboxListHeader('bcc', [new Address('bcc-initial@example.com')]))
+        ;
+        $defaultHeaders = (new Headers())
+            ->add(new MailboxListHeader('bcc', [new Group('Watchers', [new Address('bcc-default@example.com')])]))
+        ;
+        $expectedHeaders = (new Headers())
+            ->add(new MailboxListHeader('bcc', [new Address('bcc-initial@example.com'), new Group('Watchers', [new Address('bcc-default@example.com')])]))
+        ;
+        yield 'bcc, add a bcc holding a group (unique header)' => [$initialHeaders, $defaultHeaders, $expectedHeaders];
 
         $initialHeaders = (new Headers())
             ->add(new UnstructuredHeader('foo', 'initial'))

--- a/src/Symfony/Component/Mailer/composer.json
+++ b/src/Symfony/Component/Mailer/composer.json
@@ -22,7 +22,7 @@
         "psr/log": "^1|^2|^3",
         "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/event-dispatcher": "^7.4|^8.0",
-        "symfony/mime": "^7.4|^8.0",
+        "symfony/mime": "^8.2",
         "symfony/service-contracts": "^2.5|^3"
     },
     "require-dev": {

--- a/src/Symfony/Component/Mime/CHANGELOG.md
+++ b/src/Symfony/Component/Mime/CHANGELOG.md
@@ -7,6 +7,8 @@ CHANGELOG
  * Support `binary` as a `Content-Transfer-Encoding`
  * Add PGP/MIME signing and encryption support with the `PgpSigner` and `PgpEncrypter` classes
  * Add `AbstractPart::setContentTypeParameter()`
+ * Add the `Group` class to put a group of mailboxes in a mailbox list header (RFC 5322 and RFC 6854)
+ * Add `MailboxListHeader::getAddressList()` and `MailboxListHeader::createAddressList()`
 
 8.0
 ---

--- a/src/Symfony/Component/Mime/Group.php
+++ b/src/Symfony/Component/Mime/Group.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mime;
+
+use Symfony\Component\Mime\Exception\InvalidArgumentException;
+
+/**
+ * A named group of mailboxes, as defined by RFC 5322 (3.4).
+ *
+ * A group is an address just like a mailbox is, so it goes wherever an "address-list" is expected.
+ * To, Cc, Bcc and Reply-To have always accepted one, which is what makes
+ * "To: undisclosed-recipients:;" representable:
+ *
+ *     $email->getHeaders()->addMailboxListHeader('To', [new Group('undisclosed-recipients')]);
+ *
+ * RFC 6854 additionally allows a group in From and Resent-From, where RFC 5322 expected a
+ * "mailbox-list", and in Sender and Resent-Sender, where it expected a single "mailbox". It
+ * classifies that use as "Limited Use" and states that user agents SHOULD NOT permit groups in
+ * those fields in outgoing messages, so reach for it knowingly there. Symfony takes a group in
+ * From; Sender keeps taking a single mailbox.
+ *
+ * A group with no mailbox in From leaves the message without an author address, which is needed
+ * to generate the Message-ID and to address the SMTP envelope. Set a Sender next to it:
+ *
+ *     $email->getHeaders()->addMailboxListHeader('From', [new Group('Automated System')]);
+ *     $email->sender('robot@example.com');
+ *
+ * @author Florent Morselli <florent.morselli@spomky-labs.com>
+ */
+final class Group
+{
+    private string $name;
+    private array $addresses;
+
+    /**
+     * @param array<Address|string> $addresses
+     */
+    public function __construct(string $name, array $addresses = [])
+    {
+        $this->name = trim(preg_replace('/[\x00-\x08\x0A-\x1F\x7F]/', '', $name));
+
+        if ('' === $this->name) {
+            throw new InvalidArgumentException('A group must have a display name.');
+        }
+
+        $this->addresses = Address::createArray($addresses);
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return Address[]
+     */
+    public function getAddresses(): array
+    {
+        return $this->addresses;
+    }
+}

--- a/src/Symfony/Component/Mime/Header/Headers.php
+++ b/src/Symfony/Component/Mime/Header/Headers.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Mime\Header;
 
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Exception\LogicException;
+use Symfony\Component\Mime\Group;
 
 /**
  * A collection of headers.
@@ -75,13 +76,13 @@ final class Headers
     }
 
     /**
-     * @param array<Address|string> $addresses
+     * @param array<Address|Group|string> $addresses
      *
      * @return $this
      */
     public function addMailboxListHeader(string $name, array $addresses): static
     {
-        return $this->add(new MailboxListHeader($name, Address::createArray($addresses)));
+        return $this->add(new MailboxListHeader($name, MailboxListHeader::createAddressList($addresses)));
     }
 
     /**

--- a/src/Symfony/Component/Mime/Header/MailboxListHeader.php
+++ b/src/Symfony/Component/Mime/Header/MailboxListHeader.php
@@ -13,9 +13,12 @@ namespace Symfony\Component\Mime\Header;
 
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Exception\RfcComplianceException;
+use Symfony\Component\Mime\Group;
 
 /**
  * A Mailbox list MIME Header for something like From, To, Cc, and Bcc (one or more named addresses).
+ *
+ * An entry is either a mailbox or, since RFC 6854, a group of mailboxes (RFC 5322, 3.4).
  *
  * @author Chris Corbyn
  */
@@ -24,7 +27,7 @@ final class MailboxListHeader extends AbstractHeader
     private array $addresses = [];
 
     /**
-     * @param Address[] $addresses
+     * @param array<Address|Group> $addresses
      */
     public function __construct(string $name, array $addresses)
     {
@@ -34,7 +37,26 @@ final class MailboxListHeader extends AbstractHeader
     }
 
     /**
-     * @param Address[] $body
+     * Normalizes an address-list, where an entry is either a mailbox or a group.
+     *
+     * @param array<Address|Group|string> $addresses
+     *
+     * @return list<Address|Group>
+     *
+     * @throws RfcComplianceException
+     */
+    public static function createAddressList(array $addresses): array
+    {
+        $list = [];
+        foreach ($addresses as $address) {
+            $list[] = $address instanceof Group ? $address : Address::create($address);
+        }
+
+        return $list;
+    }
+
+    /**
+     * @param array<Address|Group> $body
      *
      * @throws RfcComplianceException
      */
@@ -44,7 +66,7 @@ final class MailboxListHeader extends AbstractHeader
     }
 
     /**
-     * @return Address[]
+     * @return list<Address>
      *
      * @throws RfcComplianceException
      */
@@ -56,7 +78,7 @@ final class MailboxListHeader extends AbstractHeader
     /**
      * Sets a list of addresses to be shown in this Header.
      *
-     * @param Address[] $addresses
+     * @param array<Address|Group> $addresses
      *
      * @throws RfcComplianceException
      */
@@ -69,7 +91,7 @@ final class MailboxListHeader extends AbstractHeader
     /**
      * Sets a list of addresses to be shown in this Header.
      *
-     * @param Address[] $addresses
+     * @param array<Address|Group> $addresses
      *
      * @throws RfcComplianceException
      */
@@ -83,15 +105,38 @@ final class MailboxListHeader extends AbstractHeader
     /**
      * @throws RfcComplianceException
      */
-    public function addAddress(Address $address): void
+    public function addAddress(Address|Group $address): void
     {
         $this->addresses[] = $address;
     }
 
     /**
-     * @return Address[]
+     * Gets every mailbox of this Header, the members of its groups included.
+     *
+     * @return list<Address>
      */
     public function getAddresses(): array
+    {
+        $mailboxes = [];
+        foreach ($this->addresses as $address) {
+            if ($address instanceof Group) {
+                foreach ($address->getAddresses() as $mailbox) {
+                    $mailboxes[] = $mailbox;
+                }
+            } else {
+                $mailboxes[] = $address;
+            }
+        }
+
+        return $mailboxes;
+    }
+
+    /**
+     * Gets the address-list of this Header, where an entry is either a mailbox or a group.
+     *
+     * @return list<Address|Group>
+     */
+    public function getAddressList(): array
     {
         return $this->addresses;
     }
@@ -107,11 +152,19 @@ final class MailboxListHeader extends AbstractHeader
     {
         $strings = [];
         foreach ($this->addresses as $address) {
-            $str = $address->getEncodedAddress();
-            if ($name = $address->getName()) {
-                $str = $this->createPhrase($this, $name, $this->getCharset(), !$strings).' <'.$str.'>';
+            if (!$address instanceof Group) {
+                $strings[] = $this->createMailboxString($address, !$strings);
+
+                continue;
             }
-            $strings[] = $str;
+
+            $name = $this->createPhrase($this, $address->getName(), $this->getCharset(), !$strings);
+            $mailboxes = [];
+            foreach ($address->getAddresses() as $mailbox) {
+                $mailboxes[] = $this->createMailboxString($mailbox, false);
+            }
+
+            $strings[] = $mailboxes ? $name.': '.implode(', ', $mailboxes).';' : $name.':;';
         }
 
         return $strings;
@@ -120,6 +173,19 @@ final class MailboxListHeader extends AbstractHeader
     public function getBodyAsString(): string
     {
         return implode(', ', $this->getAddressStrings());
+    }
+
+    /**
+     * @throws RfcComplianceException
+     */
+    private function createMailboxString(Address $address, bool $shorten): string
+    {
+        $str = $address->getEncodedAddress();
+        if ($name = $address->getName()) {
+            $str = $this->createPhrase($this, $name, $this->getCharset(), $shorten).' <'.$str.'>';
+        }
+
+        return $str;
     }
 
     /**

--- a/src/Symfony/Component/Mime/Tests/EmailTest.php
+++ b/src/Symfony/Component/Mime/Tests/EmailTest.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
 use Symfony\Component\Mime\Exception\LogicException;
+use Symfony\Component\Mime\Group;
 use Symfony\Component\Mime\Part\DataPart;
 use Symfony\Component\Mime\Part\File;
 use Symfony\Component\Mime\Part\Multipart\AlternativePart;
@@ -179,6 +180,27 @@ class EmailTest extends TestCase
         $e->replyTo('lucas@symfony.com');
         $e->replyTo($caramel);
         $this->assertSame([$caramel], $e->getReplyTo());
+    }
+
+    public function testToWithAnEmptyGroup()
+    {
+        $e = (new Email())->from('fabien@symfony.com')->bcc('helene@symfony.com')->text('content');
+        $e->getHeaders()->addMailboxListHeader('To', [$group = new Group('undisclosed-recipients')]);
+
+        $this->assertSame([], $e->getTo());
+        $this->assertSame([$group], $e->getHeaders()->get('To')->getAddressList());
+        $this->assertSame('To: undisclosed-recipients:;', $e->getHeaders()->get('To')->toString());
+
+        $e->ensureValidity();
+    }
+
+    public function testGetToFlattensTheGroups()
+    {
+        $e = (new Email())->from('fabien@symfony.com');
+        $e->getHeaders()->addMailboxListHeader('To', [new Group('Board', [$chair = new Address('chair@symfony.com')]), $observer = new Address('observer@symfony.com')]);
+
+        $this->assertSame([$chair, $observer], $e->getTo());
+        $this->assertSame('To: Board: chair@symfony.com;, observer@symfony.com', $e->getHeaders()->get('To')->toString());
     }
 
     public function testTo()

--- a/src/Symfony/Component/Mime/Tests/GroupTest.php
+++ b/src/Symfony/Component/Mime/Tests/GroupTest.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mime\Tests;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\Exception\InvalidArgumentException;
+use Symfony\Component\Mime\Exception\RfcComplianceException;
+use Symfony\Component\Mime\Group;
+
+class GroupTest extends TestCase
+{
+    public function testConstructor()
+    {
+        $g = new Group('Friends', [new Address('fabien@symfony.com'), 'helene@symfony.com']);
+        $this->assertSame('Friends', $g->getName());
+        $this->assertEquals([new Address('fabien@symfony.com'), new Address('helene@symfony.com')], $g->getAddresses());
+    }
+
+    public function testConstructorWithNoAddress()
+    {
+        $g = new Group('undisclosed-recipients');
+        $this->assertSame('undisclosed-recipients', $g->getName());
+        $this->assertSame([], $g->getAddresses());
+    }
+
+    public function testConstructorWithDisplayNameString()
+    {
+        $g = new Group('Friends', ['Fabien <fabien@symfony.com>']);
+        $this->assertSame('Fabien', $g->getAddresses()[0]->getName());
+    }
+
+    public function testConstructorWithInvalidAddress()
+    {
+        $this->expectException(RfcComplianceException::class);
+        new Group('Friends', ['fab   pot@symfony.com']);
+    }
+
+    #[DataProvider('provideEmptyNames')]
+    public function testConstructorWithEmptyName(string $name)
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('A group must have a display name.');
+        new Group($name);
+    }
+
+    public static function provideEmptyNames(): iterable
+    {
+        yield 'empty' => [''];
+        yield 'spaces' => ['   '];
+        yield 'control characters only' => ["\r\n\x00"];
+    }
+
+    public function testConstructorStripsControlCharactersFromName()
+    {
+        $g = new Group("a\x00b");
+        $this->assertSame('ab', $g->getName());
+    }
+}

--- a/src/Symfony/Component/Mime/Tests/Header/HeadersTest.php
+++ b/src/Symfony/Component/Mime/Tests/Header/HeadersTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Mime\Tests\Header;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\Group;
 use Symfony\Component\Mime\Header\DateHeader;
 use Symfony\Component\Mime\Header\Headers;
 use Symfony\Component\Mime\Header\IdentificationHeader;
@@ -27,6 +28,23 @@ class HeadersTest extends TestCase
         $headers = new Headers();
         $headers->addMailboxListHeader('From', ['person@domain']);
         $this->assertNotNull($headers->get('From'));
+    }
+
+    public function testAddMailboxListHeaderTakesGroupsAndStrings()
+    {
+        $headers = new Headers();
+        $headers->addMailboxListHeader('To', [$board = new Group('Board', ['chair@example.com']), 'observer@example.com']);
+
+        $this->assertEquals([$board, new Address('observer@example.com')], $headers->get('To')->getAddressList());
+        $this->assertSame('To: Board: chair@example.com;, observer@example.com', $headers->get('To')->toString());
+    }
+
+    public function testAddHeaderTakesAGroup()
+    {
+        $headers = new Headers();
+        $headers->addHeader('To', $group = new Group('undisclosed-recipients'));
+
+        $this->assertEquals([$group], $headers->get('To')->getAddressList());
     }
 
     public function testAddDateHeaderDelegatesToFactory()

--- a/src/Symfony/Component/Mime/Tests/Header/MailboxListHeaderTest.php
+++ b/src/Symfony/Component/Mime/Tests/Header/MailboxListHeaderTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Mime\Tests\Header;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\Group;
 use Symfony\Component\Mime\Header\MailboxListHeader;
 
 class MailboxListHeaderTest extends TestCase
@@ -137,5 +138,62 @@ class MailboxListHeaderTest extends TestCase
     {
         $header = new MailboxListHeader('To', [new Address('chris@example.org', "Chris\x00Corbyn")]);
         $this->assertEquals('To: ChrisCorbyn <chris@example.org>', $header->toString());
+    }
+
+    public function testToStringWithAGroup()
+    {
+        $header = new MailboxListHeader('To', [new Group('Friends', [new Address('chris@example.org'), new Address('mark@example.org', 'Mark Corbyn')])]);
+        $this->assertEquals('To: Friends: chris@example.org, Mark Corbyn <mark@example.org>;', $header->toString());
+    }
+
+    public function testToStringWithAnEmptyGroup()
+    {
+        $header = new MailboxListHeader('To', [new Group('undisclosed-recipients')]);
+        $this->assertEquals('To: undisclosed-recipients:;', $header->toString());
+    }
+
+    public function testToStringWithAGroupAndAMailbox()
+    {
+        $header = new MailboxListHeader('To', [new Address('chris@example.org'), new Group('Friends', [new Address('mark@example.org')])]);
+        $this->assertEquals('To: chris@example.org, Friends: mark@example.org;', $header->toString());
+    }
+
+    public function testGroupNameIsEncodedIfNonAscii()
+    {
+        $header = new MailboxListHeader('To', [new Group('Câlins', [new Address('chris@example.org')])]);
+        $this->assertEquals('To: =?utf-8?Q?C=C3=A2lins?=: chris@example.org;', $header->toString());
+    }
+
+    public function testGroupNameIsQuotedIfItHasSpecials()
+    {
+        $header = new MailboxListHeader('To', [new Group('a:b;c', [new Address('chris@example.org')])]);
+        $this->assertEquals('To: "a:b;c": chris@example.org;', $header->toString());
+    }
+
+    public function testGetAddressesFlattensGroups()
+    {
+        $chris = new Address('chris@example.org');
+        $mark = new Address('mark@example.org');
+        $header = new MailboxListHeader('To', [$chris, $friends = new Group('Friends', [$mark]), $undisclosed = new Group('undisclosed-recipients')]);
+
+        $this->assertSame([$chris, $mark], $header->getAddresses());
+        $this->assertSame([$chris, $mark], $header->getBody());
+        $this->assertSame([$chris, $friends, $undisclosed], $header->getAddressList());
+    }
+
+    public function testCreateAddressList()
+    {
+        $list = MailboxListHeader::createAddressList(['chris@example.org', $mark = new Address('mark@example.org'), $friends = new Group('Friends')]);
+
+        $this->assertEquals([new Address('chris@example.org'), $mark, $friends], $list);
+    }
+
+    public function testAddAddressAcceptsAGroup()
+    {
+        $header = new MailboxListHeader('To', []);
+        $header->addAddress($chris = new Address('chris@example.org'));
+        $header->addAddress($group = new Group('Friends', [new Address('mark@example.org')]));
+
+        $this->assertSame([$chris, $group], $header->getAddressList());
     }
 }

--- a/src/Symfony/Component/Mime/Tests/MessageTest.php
+++ b/src/Symfony/Component/Mime/Tests/MessageTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Exception\LogicException;
+use Symfony\Component\Mime\Group;
 use Symfony\Component\Mime\Header\Headers;
 use Symfony\Component\Mime\Header\MailboxListHeader;
 use Symfony\Component\Mime\Header\UnstructuredHeader;
@@ -125,6 +126,47 @@ class MessageTest extends TestCase
         $message->getHeaders()->addMailboxListHeader('From', ['fabien@symfony.com', 'lucas@symfony.com']);
         $message->getHeaders()->addMailboxHeader('Sender', 'thomas@symfony.com');
         $this->assertEquals('thomas@symfony.com', $message->getPreparedHeaders()->get('Sender')->getAddress()->getAddress());
+    }
+
+    public function testGetPreparedHeadersCountsTheMailboxesOfAGroupInFrom()
+    {
+        $message = new Message();
+        $message->getHeaders()->addMailboxListHeader('From', [new Group('Friends', ['fabien@symfony.com'])]);
+        $this->assertNull($message->getPreparedHeaders()->get('Sender'));
+
+        $message = new Message();
+        $message->getHeaders()->addMailboxListHeader('From', [new Group('Friends', ['fabien@symfony.com', 'lucas@symfony.com'])]);
+        $this->assertEquals('fabien@symfony.com', $message->getPreparedHeaders()->get('Sender')->getAddress()->getAddress());
+    }
+
+    public function testGetPreparedHeadersWithAnEmptyGroupInFromAndASender()
+    {
+        $message = new Message();
+        $message->getHeaders()->addMailboxListHeader('From', [new Group('Automated System')]);
+        $message->getHeaders()->addMailboxHeader('Sender', 'robot@symfony.com');
+        $headers = $message->getPreparedHeaders();
+
+        $this->assertSame('From: Automated System:;', $headers->get('From')->toString());
+        $this->assertSame('Sender: robot@symfony.com', $headers->get('Sender')->toString());
+        $this->assertStringEndsWith('@symfony.com>', $headers->get('Message-ID')->toString());
+    }
+
+    public function testGenerateMessageIdWithAGroupInFrom()
+    {
+        $message = new Message();
+        $message->getHeaders()->addMailboxListHeader('From', [new Group('Friends', ['fabien@symfony.com'])]);
+        $this->assertStringEndsWith('@symfony.com', $message->generateMessageId());
+    }
+
+    public function testGenerateMessageIdThrowsWhenFromOnlyHasAnEmptyGroup()
+    {
+        $message = new Message();
+        $message->getHeaders()->addMailboxListHeader('From', [new Group('undisclosed-recipients')]);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('A "From" header must have at least one email address.');
+
+        $message->generateMessageId();
     }
 
     public function testGenerateMessageIdThrowsWhenHasFromButNoAddresses()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

RFC 5322 defines `address = mailbox / group`, but there was no way to build a group, which made `To: undisclosed-recipients:;` unreachable. This adds `Symfony\Component\Mime\Group`.

### Sending to undisclosed recipients

```php
use Symfony\Component\Mime\Group;

$email = (new Email())
    ->from('newsletter@example.com')
    ->bcc('alice@example.com', 'bob@example.com')
    ->subject('Weekly digest')
    ->text('...');

$email->getHeaders()->addMailboxListHeader('To', [new Group('undisclosed-recipients')]);
```

```
From: newsletter@example.com
To: undisclosed-recipients:;
Subject: Weekly digest
```

while the envelope still carries the real recipients:

```
RCPT TO: alice@example.com
RCPT TO: bob@example.com
```

### Naming a group of recipients

A group takes strings or `Address` objects, and sits next to plain addresses in the same address-list:

```php
$email->getHeaders()->addMailboxListHeader('To', [
    new Group('Board', ['chair@example.com', new Address('cfo@example.com', 'Jane Roe')]),
    'observer@example.com',
]);
```

```
To: Board: chair@example.com, Jane Roe <cfo@example.com>;, observer@example.com
```

### Why the headers and not `Email::to()`

The first version of this PR widened `to()`, `cc()`, `bcc()`, `from()` and `replyTo()` to `Address|Group|string`. As @nicolas-grekas pointed out, `Email` is neither `final` nor `@internal`, so that breaks any child class overriding them with the current `Address|string` signature. Those signatures are back to what they were, and `Email.php` is no longer part of this PR at all. A group reaches an email through the headers, which both `Headers::addMailboxListHeader()` and `Headers::addHeader()` accept. The shortcuts can be widened in 9.0.

### Reading it back

`getTo()` and its siblings keep returning mailboxes, with the members of the groups included, so code that reads recipients needs no change:

```php
$email->getTo();
// [Address('chair@example.com'), Address('cfo@example.com'), Address('observer@example.com')]
```

The address-list itself, where an entry is either a mailbox or a group, is on the header:

```php
$email->getHeaders()->get('To')->getAddressList();
// [Group('Board'), Address('observer@example.com')]
```

`MailboxListHeader::createAddressList()` builds such a list from strings, `Address` and `Group` objects, the way `Address::createArray()` does for a mailbox-list. It is a new method rather than a widening of `Address::createArray()`, whose `Address[]` return type must not change.

### Groups in From

A group is accepted in `To`, `Cc`, `Bcc` and `Reply-To`, which have taken one since RFC 5322, and in `From`, which RFC 6854 opened in 2013. `Sender` still takes a single mailbox.

RFC 6854 requires a `Sender` as soon as `From` carries more than one mailbox, and it counts the mailboxes inside the groups. That is what `getPreparedHeaders()` does, so a group of two authors gets a `Sender` and a group of one does not.

An empty group in `From` leaves the message without an author address, which Symfony needs to generate the `Message-ID` and to address the SMTP envelope. Set a `Sender` next to it, and RFC 6854's own first example comes out as written:

```php
$email->getHeaders()->addMailboxListHeader('From', [new Group('Automated System')]);
$email->sender('robot@example.com');
```

```
From: Automated System:;
Sender: robot@example.com
```

Without that `Sender`, sending throws `A "From" header must have at least one email address.`

### Backward compatibility

Nothing is removed and no return type changes. The entire public surface diff of `symfony/mime` and `symfony/mailer` is:

- the new `final class Group`;
- the new `MailboxListHeader::getAddressList()` and `MailboxListHeader::createAddressList()`;
- `MailboxListHeader::addAddress()` widened from `Address` to `Address|Group`, on a `final` class, so no child class can be broken by it.

`MailboxListHeader::getAddresses()` and `getBody()` keep returning mailboxes only, so every existing consumer, from the envelope recipients to the API transports, behaves identically on any header that carries no group.

The one behaviour change is in `DelayedEnvelope`: a `From` header holding no mailbox at all, which an empty group now makes reachable, reports through the `LogicException` that method already throws instead of an undefined-index warning followed by a `TypeError`.

### For the documentation

- `Group` takes a display name, which is required, and an optional list of mailboxes.
- `To: undisclosed-recipients:;` is the reason most people will reach for it; the real recipients go in `Bcc`.
- A group is set on the header: `$email->getHeaders()->addMailboxListHeader('To', [new Group('undisclosed-recipients')])`. `Email::to()` and its siblings still take mailboxes only.
- `getTo()`, `getCc()`, `getBcc()`, `getFrom()` and `getReplyTo()` return mailboxes only, groups flattened. `getHeaders()->get('To')->getAddressList()` returns the address-list.
- API transports read `getTo()`, so a group is flattened to its members there and its name is not carried. `To: undisclosed-recipients:;` is an SMTP-shaped feature.
- A group in the originator fields is "Limited Use" per RFC 6854 section 3, and an empty one needs a `Sender`.
