### PR TITLE
[Webhook] Reject a malformed request body with a 406 instead of a 500

### DIFF
--- a/src/Symfony/Component/Webhook/Client/AbstractRequestParser.php
+++ b/src/Symfony/Component/Webhook/Client/AbstractRequestParser.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Webhook\Client;
 
+use Symfony\Component\HttpFoundation\Exception\RequestExceptionInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestMatcherInterface;
 use Symfony\Component\HttpFoundation\Response;
@@ -26,7 +27,11 @@ abstract class AbstractRequestParser implements RequestParserInterface
     {
         $this->validate($request);
 
-        return $this->doParse($request, $secret);
+        try {
+            return $this->doParse($request, $secret);
+        } catch (RequestExceptionInterface $e) {
+            throw new RejectWebhookException(406, 'Request body is malformed.', $e);
+        }
     }
 
     public function createSuccessfulResponse(): Response

--- a/src/Symfony/Component/Webhook/Tests/Client/RequestParserTest.php
+++ b/src/Symfony/Component/Webhook/Tests/Client/RequestParserTest.php
@@ -13,6 +13,10 @@ namespace Symfony\Component\Webhook\Tests\Client;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcher\IsJsonRequestMatcher;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
+use Symfony\Component\RemoteEvent\RemoteEvent;
+use Symfony\Component\Webhook\Client\AbstractRequestParser;
 use Symfony\Component\Webhook\Client\RequestParser;
 use Symfony\Component\Webhook\Exception\RejectWebhookException;
 
@@ -24,6 +28,28 @@ class RequestParserTest extends TestCase
 
         $request = new Request();
         $parser = new RequestParser();
+        $parser->parse($request, '$ecret');
+    }
+
+    public function testParseRejectsAJsonBodyThatIsNotAnArray()
+    {
+        $this->expectException(RejectWebhookException::class);
+        $this->expectExceptionMessage('Request body is malformed.');
+
+        $request = Request::create('/', 'POST', [], [], [], ['CONTENT_TYPE' => 'application/json'], '1');
+        $parser = new class extends AbstractRequestParser {
+            protected function getRequestMatcher(): RequestMatcherInterface
+            {
+                return new IsJsonRequestMatcher();
+            }
+
+            protected function doParse(Request $request, #[\SensitiveParameter] string $secret): ?RemoteEvent
+            {
+                $request->toArray();
+
+                return null;
+            }
+        };
         $parser->parse($request, '$ecret');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`IsJsonRequestMatcher` uses `json_validate()`, which accepts any valid JSON value, scalars included. `Request::toArray()` accepts only an array and throws `HttpFoundation\Exception\JsonException` otherwise. That exception does not implement `HttpExceptionInterface`, so it leaves `WebhookController::handle()` uncaught and the endpoint answers 500.

A body of `1` with `Content-Type: application/json` is therefore enough to turn any `/webhook/{type}` route into a 500 plus an exception log entry, before any signature is verified. Most parsers call `toArray()` first because the signature material lives in the body (Mailgun, Mailchimp, Twilio, MailerSend, Azure, Lox24, Scaleway), so they cannot avoid it by reordering.

`AbstractRequestParser::parse()` now catches `RequestExceptionInterface` around `doParse()` and rethrows it as `RejectWebhookException(406, 'Request body is malformed.')`, keeping the original exception as `$previous`. `RequestExceptionInterface` is the marker HttpFoundation puts on "the request itself is malformed" exceptions, which is exactly the 406 case here.

Tests: `RequestParserTest::testParseRejectsAJsonBodyThatIsNotAnArray()` posts `1` to a bare parser built on `IsJsonRequestMatcher`. It fails on 6.4 without the fix ("Failed asserting that exception of type JsonException matches expected exception RejectWebhookException").

Checks run:
- `./phpunit src/Symfony/Component/Webhook`: Tests: 2, Assertions: 3.
- The Mailgun, Mailchimp, Twilio, Mailjet, Postmark, Brevo and Sendgrid webhook suites are green.
