### PR TITLE
[Mailer][Sendgrid] Verify the webhook signature before parsing the payload

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Webhook/SendgridSignedRequestParserTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Webhook/SendgridSignedRequestParserTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Mailer\Bridge\Sendgrid\RemoteEvent\SendgridPayloadConverter;
 use Symfony\Component\Mailer\Bridge\Sendgrid\Webhook\SendgridRequestParser;
 use Symfony\Component\Webhook\Client\RequestParserInterface;
+use Symfony\Component\Webhook\Exception\RejectWebhookException;
 use Symfony\Component\Webhook\Test\AbstractRequestParserTestCase;
 
 /**
@@ -42,6 +43,27 @@ class SendgridSignedRequestParserTest extends AbstractRequestParserTestCase
         ClockMock::withClockMock((int) $request->headers->get('X-Twilio-Email-Event-Webhook-Timestamp') + $offset);
 
         $this->assertNotNull($this->createRequestParser()->parse($request, $this->getSecret()));
+    }
+
+    public function testRejectUnsignedRequestBeforeParsingThePayload()
+    {
+        $request = $this->createRequest('{"not":"an event"}');
+        $request->headers->remove('X-Twilio-Email-Event-Webhook-Signature');
+
+        $this->expectException(RejectWebhookException::class);
+        $this->expectExceptionMessage('Signature is required.');
+
+        $this->createRequestParser()->parse($request, $this->getSecret());
+    }
+
+    public function testRejectForgedSignatureBeforeParsingThePayload()
+    {
+        $request = $this->createRequest('{"not":"an event"}');
+
+        $this->expectException(RejectWebhookException::class);
+        $this->expectExceptionMessage('Signature is wrong.');
+
+        $this->createRequestParser()->parse($request, $this->getSecret());
     }
 
     protected function createRequestParser(): RequestParserInterface

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Webhook/SendgridRequestParser.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Webhook/SendgridRequestParser.php
@@ -45,16 +45,6 @@ final class SendgridRequestParser extends AbstractRequestParser
 
     protected function doParse(Request $request, #[\SensitiveParameter] string $secret): ?AbstractMailerEvent
     {
-        $content = $request->toArray();
-        if (
-            !isset($content[0]['email'])
-            || !isset($content[0]['timestamp'])
-            || !isset($content[0]['event'])
-            || !isset($content[0]['sg_event_id'])
-        ) {
-            throw new RejectWebhookException(406, 'Payload is malformed.');
-        }
-
         if ($secret) {
             if (!$request->headers->get('X-Twilio-Email-Event-Webhook-Signature')
                 || !$request->headers->get('X-Twilio-Email-Event-Webhook-Timestamp')
@@ -72,6 +62,16 @@ final class SendgridRequestParser extends AbstractRequestParser
                 $request->getContent(),
                 $secret,
             );
+        }
+
+        $content = $request->toArray();
+        if (
+            !isset($content[0]['email'])
+            || !isset($content[0]['timestamp'])
+            || !isset($content[0]['event'])
+            || !isset($content[0]['sg_event_id'])
+        ) {
+            throw new RejectWebhookException(406, 'Payload is malformed.');
         }
 
         try {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`SendgridRequestParser::doParse()` decodes the body and checks its shape before it looks at the signature. Two consequences for an unauthenticated caller:

- a body of `1` (valid JSON, not an array) makes `Request::toArray()` throw and the endpoint answers 500;
- the reject message tells the caller whether the payload shape was right, so the expected fields can be probed without ever holding a signature.

The Sendgrid signature is an ECDSA signature over `timestamp + rawBody`, so nothing in it depends on the decoded payload. Moving the `if ($secret)` block above `toArray()` makes the parser authenticate first and interpret second, which is what `Mailtrap` and `Vonage` already do.

Nothing else changes: the same checks run in the same way, and a request that passes the signature check produces the same events.

Tests: two cases send a payload that is valid JSON but not a Sendgrid event, once with no signature header and once with the fixture signature (wrong for that body). Both fail on 6.4 without the fix ("Failed asserting that exception message 'Payload is malformed.' contains 'Signature is required.'").

Checks run:
- `./phpunit src/Symfony/Component/Mailer/Bridge/Sendgrid`: Tests: 47, Assertions: 115.
- `php .github/sa-tools/check-hardening-tests.php`: convention satisfied.
