### PR TITLE
[Mailer][Notifier] Verify webhook signatures before parsing the payload

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/AhaSend/Tests/Webhook/AhaSendRequestParserTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/AhaSend/Tests/Webhook/AhaSendRequestParserTest.php
@@ -104,4 +104,15 @@ class AhaSendRequestParserTest extends AbstractRequestParserTestCase
     {
         return self::SECRET;
     }
+
+    public function testRejectForgedSignatureBeforeParsingThePayload()
+    {
+        $request = $this->createRequest(file_get_contents(__DIR__.'/Fixtures/delivered.json'));
+        $request = Request::create('/', 'POST', [], [], [], $request->server->all(), '1');
+
+        $this->expectException(RejectWebhookException::class);
+        $this->expectExceptionMessage('Invalid signature');
+
+        $this->createRequestParser()->parse($request, $this->getSecret());
+    }
 }

--- a/src/Symfony/Component/Mailer/Bridge/AhaSend/Webhook/AhaSendRequestParser.php
+++ b/src/Symfony/Component/Mailer/Bridge/AhaSend/Webhook/AhaSendRequestParser.php
@@ -46,7 +46,6 @@ final class AhaSendRequestParser extends AbstractRequestParser
             throw new InvalidArgumentException('A non-empty secret is required.');
         }
 
-        $payload = $request->toArray();
         $eventID = $request->headers->get('webhook-id');
         $signature = $request->headers->get('webhook-signature');
         $timestamp = $request->headers->get('webhook-timestamp');
@@ -63,6 +62,7 @@ final class AhaSendRequestParser extends AbstractRequestParser
         if (!hash_equals($expectedSignature, $signature)) {
             throw new RejectWebhookException(406, 'Invalid signature');
         }
+        $payload = $request->toArray();
         if (!isset($payload['type']) || !isset($payload['timestamp']) || !(isset($payload['data']))) {
             throw new RejectWebhookException(406, 'Payload is malformed.');
         }

--- a/src/Symfony/Component/Mailer/Bridge/Mailomat/Tests/Webhook/MailomatRequestParserTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailomat/Tests/Webhook/MailomatRequestParserTest.php
@@ -129,4 +129,15 @@ class MailomatRequestParserTest extends AbstractRequestParserTestCase
         yield 'sha1' => ['sha1'];
         yield 'sha512' => ['sha512'];
     }
+
+    public function testRejectForgedSignatureBeforeParsingThePayload()
+    {
+        $request = $this->createRequest('1');
+        $request->headers->set('X-MOM-Webhook-Signature', 'sha256='.hash_hmac('sha256', 'forged', 'another-secret'));
+
+        $this->expectException(RejectWebhookException::class);
+        $this->expectExceptionMessage('Signature is wrong.');
+
+        $this->createRequestParser()->parse($request, $this->getSecret());
+    }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Mailomat/Webhook/MailomatRequestParser.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailomat/Webhook/MailomatRequestParser.php
@@ -58,6 +58,12 @@ final class MailomatRequestParser extends AbstractRequestParser
             throw new InvalidArgumentException('A non-empty secret is required.');
         }
 
+        if (abs(time() - (int) $request->headers->get(self::HEADER_TIMESTAMP)) > self::TIMESTAMP_TOLERANCE) {
+            throw new RejectWebhookException(406, 'Timestamp is outside the allowed time window.');
+        }
+
+        $this->validateSignature($request->headers, $secret);
+
         $content = $request->toArray();
 
         if (
@@ -69,12 +75,6 @@ final class MailomatRequestParser extends AbstractRequestParser
         ) {
             throw new RejectWebhookException(406, 'Payload is malformed.');
         }
-
-        if (abs(time() - (int) $request->headers->get(self::HEADER_TIMESTAMP)) > self::TIMESTAMP_TOLERANCE) {
-            throw new RejectWebhookException(406, 'Timestamp is outside the allowed time window.');
-        }
-
-        $this->validateSignature($request->headers, $secret);
 
         try {
             return $this->converter->convert($content);

--- a/src/Symfony/Component/Mailer/Bridge/Resend/Tests/Webhook/ResendMalformedPayloadRequestParserTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Resend/Tests/Webhook/ResendMalformedPayloadRequestParserTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Mailer\Bridge\Resend\Tests\Webhook;
 
+use PHPUnit\Framework\Attributes\Group;
+use Symfony\Bridge\PhpUnit\ClockMock;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Mailer\Bridge\Resend\RemoteEvent\ResendPayloadConverter;
 use Symfony\Component\Mailer\Bridge\Resend\Webhook\ResendRequestParser;
@@ -18,6 +20,7 @@ use Symfony\Component\Webhook\Client\RequestParserInterface;
 use Symfony\Component\Webhook\Exception\RejectWebhookException;
 use Symfony\Component\Webhook\Test\AbstractRequestParserTestCase;
 
+#[Group('time-sensitive')]
 class ResendMalformedPayloadRequestParserTest extends AbstractRequestParserTestCase
 {
     protected function createRequestParser(): RequestParserInterface
@@ -40,11 +43,13 @@ class ResendMalformedPayloadRequestParserTest extends AbstractRequestParserTestC
 
     protected function createRequest(string $payload): Request
     {
+        ClockMock::withClockMock(1712569389);
+
         return Request::create('/', 'POST', [], [], [], [
             'Content-Type' => 'application/json',
             'HTTP_svix-id' => '172c41ce-ba6d-4281-8a7a-541faa725748',
             'HTTP_svix-timestamp' => '1712569389',
-            'HTTP_svix-signature' => 'v1,4wjuRp64yC/2itgCQwl2xPePVwSPTdPbXLIY6IxGLTA=',
+            'HTTP_svix-signature' => 'v1,3LK1qunqNcqstAUfpz7z6mR8MmnaY879b8972Avqv3E=',
         ], $payload);
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Resend/Tests/Webhook/ResendRequestParserTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Resend/Tests/Webhook/ResendRequestParserTest.php
@@ -108,4 +108,15 @@ class ResendRequestParserTest extends AbstractRequestParserTestCase
         $this->expectExceptionMessage('Request does not match.');
         $this->createRequestParser()->parse($request, $this->getSecret());
     }
+
+    public function testRejectForgedSignatureBeforeParsingThePayload()
+    {
+        $request = $this->createRequest('1');
+        $request->headers->set('svix-signature', 'v1,AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=');
+
+        $this->expectException(RejectWebhookException::class);
+        $this->expectExceptionMessage('No signatures found matching the expected signature.');
+
+        $this->createRequestParser()->parse($request, $this->getSecret());
+    }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Resend/Webhook/ResendRequestParser.php
+++ b/src/Symfony/Component/Mailer/Bridge/Resend/Webhook/ResendRequestParser.php
@@ -53,6 +53,8 @@ final class ResendRequestParser extends AbstractRequestParser
             throw new InvalidArgumentException('A non-empty secret is required.');
         }
 
+        $this->validateSignature($request->getContent(), $request->headers, $secret);
+
         $content = $request->toArray();
 
         if (
@@ -67,8 +69,6 @@ final class ResendRequestParser extends AbstractRequestParser
         ) {
             throw new RejectWebhookException(406, 'Payload is malformed.');
         }
-
-        $this->validateSignature($request->getContent(), $request->headers, $secret);
 
         try {
             return $this->converter->convert($content);

--- a/src/Symfony/Component/Mailer/Bridge/Sweego/Tests/Webhook/SweegoRequestParserTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sweego/Tests/Webhook/SweegoRequestParserTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\Mailer\Bridge\Sweego\RemoteEvent\SweegoPayloadConverter;
 use Symfony\Component\Mailer\Bridge\Sweego\Webhook\SweegoRequestParser;
 use Symfony\Component\Mailer\Exception\InvalidArgumentException;
 use Symfony\Component\Webhook\Client\RequestParserInterface;
+use Symfony\Component\Webhook\Exception\RejectWebhookException;
 use Symfony\Component\Webhook\Test\AbstractRequestParserTestCase;
 
 class SweegoRequestParserTest extends AbstractRequestParserTestCase
@@ -60,5 +61,16 @@ class SweegoRequestParserTest extends AbstractRequestParserTestCase
             'HTTP_webhook-timestamp' => $timestamp,
             'HTTP_webhook-signature' => base64_encode(hash_hmac('sha256', $contentToSign, base64_decode(self::SECRET), true)),
         ], $payload);
+    }
+
+    public function testRejectForgedSignatureBeforeParsingThePayload()
+    {
+        $request = $this->createRequest('1');
+        $request->headers->set('webhook-signature', 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=');
+
+        $this->expectException(RejectWebhookException::class);
+        $this->expectExceptionMessage('Invalid signature.');
+
+        $this->createRequestParser()->parse($request, $this->getSecret());
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Sweego/Webhook/SweegoRequestParser.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sweego/Webhook/SweegoRequestParser.php
@@ -48,6 +48,15 @@ final class SweegoRequestParser extends AbstractRequestParser
             throw new InvalidArgumentException('A non-empty secret is required.');
         }
 
+        if (!$request->headers->get('webhook-id')
+            || !$request->headers->get('webhook-timestamp')
+            || !$request->headers->get('webhook-signature')
+        ) {
+            throw new RejectWebhookException(406, 'Signature is required.');
+        }
+
+        $this->validateSignature($request, $secret);
+
         $content = $request->toArray();
 
         if (
@@ -59,15 +68,6 @@ final class SweegoRequestParser extends AbstractRequestParser
         ) {
             throw new RejectWebhookException(406, 'Payload is malformed.');
         }
-
-        if (!$request->headers->get('webhook-id')
-            && !$request->headers->get('webhook-timestamp')
-            && !$request->headers->get('webhook-signature')
-        ) {
-            throw new RejectWebhookException(406, 'Signature is required.');
-        }
-
-        $this->validateSignature($request, $secret);
 
         try {
             return $this->converter->convert($content);

--- a/src/Symfony/Component/Notifier/Bridge/Sweego/Tests/Webhook/SweegoRequestParserTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sweego/Tests/Webhook/SweegoRequestParserTest.php
@@ -91,4 +91,15 @@ class SweegoRequestParserTest extends AbstractRequestParserTestCase
     {
         return self::SECRET;
     }
+
+    public function testRejectForgedSignatureBeforeParsingThePayload()
+    {
+        $request = $this->createRequest('1');
+        $request->headers->set('webhook-signature', 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=');
+
+        $this->expectException(RejectWebhookException::class);
+        $this->expectExceptionMessage('Invalid signature.');
+
+        $this->createRequestParser()->parse($request, $this->getSecret());
+    }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Sweego/Webhook/SweegoRequestParser.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sweego/Webhook/SweegoRequestParser.php
@@ -46,13 +46,13 @@ final class SweegoRequestParser extends AbstractRequestParser
             throw new InvalidArgumentException('A non-empty secret is required.');
         }
 
+        $this->validateSignature($request, $secret);
+
         $payload = $request->toArray();
 
         if (!isset($payload['event_type']) || !isset($payload['swg_uid']) || !isset($payload['phone_number'])) {
             throw new RejectWebhookException(406, 'Payload is malformed.');
         }
-
-        $this->validateSignature($request, $secret);
 
         $name = match ($payload['event_type']) {
             'sms_sent' => SmsEvent::DELIVERED,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Five parsers decode and shape-check the request body before they verify the signature: `AhaSend`, `Mailomat`, `Resend`, `Mailer\Sweego` and `Notifier\Sweego`. In all five the signed material is either the raw body or the headers alone, so none of them needs the decoded payload to authenticate.

Two consequences for an unauthenticated caller:

- a body of `1` is valid JSON, so it passes `IsJsonRequestMatcher`, but `Request::toArray()` rejects it and the endpoint answers 500 before any signature is checked;
- the reject message says whether the payload shape was right, so the expected fields can be probed without holding a signature.

This moves the decoding below the signature check in each of them, which is what `Mailtrap` and `Vonage` already do.

`Mailer\Sweego` also required all three of `webhook-id`, `webhook-timestamp` and `webhook-signature` to be absent before reporting a missing signature (`&&`). Any one of them being empty is enough, so this is now `||`.

Nothing else changes: the same checks run in the same way, and a request that passes the signature check produces the same events.

Tests: each parser gets a case sending a body of `1` with a forged signature, asserting the parser's own signature message. All five fail without the fix ("Failed asserting that exception of type JsonException matches expected exception RejectWebhookException").

`ResendMalformedPayloadRequestParserTest` sent `{}` with the fixture's signature and no clock mock, so it only ever reached "Payload is malformed." because the shape check ran first. It now carries a signature computed over `{}` and mocks the clock, so it exercises the malformed-payload path behind a valid signature.

Checks run:
- AhaSend: Tests: 44, Assertions: 97. Mailomat: 33/64. Resend: 34/77. Mailer Sweego: 34/61. Notifier Sweego: 29/43.
- `php .github/sa-tools/check-hardening-tests.php`: convention satisfied.
