### PR TITLE
[HttpFoundation] Match paths with the DOTALL modifier

### DIFF
--- a/src/Symfony/Component/HttpFoundation/RequestMatcher.php
+++ b/src/Symfony/Component/HttpFoundation/RequestMatcher.php
@@ -173,7 +173,7 @@ class RequestMatcher implements RequestMatcherInterface
             }
         }
 
-        if (null !== $this->path && !preg_match('{'.$this->path.'}', rawurldecode($request->getPathInfo()))) {
+        if (null !== $this->path && !preg_match('{'.$this->path.'}s', rawurldecode($request->getPathInfo()))) {
             return false;
         }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestMatcherTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestMatcherTest.php
@@ -144,6 +144,33 @@ class RequestMatcherTest extends TestCase
         $this->assertTrue($matcher->matches($request));
     }
 
+    public function testPathWithEncodedControlCharacters()
+    {
+        $matcher = new RequestMatcher();
+        $request = Request::create('/admin/fo%0Ao');
+
+        $matcher->matchPath('^.*$');
+        $this->assertTrue($matcher->matches($request));
+
+        $matcher->matchPath('^/.*$');
+        $this->assertTrue($matcher->matches($request));
+
+        $matcher->matchPath('^/admin/.*$');
+        $this->assertTrue($matcher->matches($request));
+
+        $matcher->matchPath('^/blog/.*$');
+        $this->assertFalse($matcher->matches($request));
+    }
+
+    public function testPathStillMatchesBeforeATrailingNewLine()
+    {
+        $matcher = new RequestMatcher();
+
+        $matcher->matchPath('^/admin$');
+        $this->assertTrue($matcher->matches(Request::create('/admin')));
+        $this->assertTrue($matcher->matches(Request::create('/admin%0A')));
+    }
+
     public function testAttributes()
     {
         $matcher = new RequestMatcher();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`RequestMatcher` compiles the configured path pattern with no PCRE modifier, while `RouteCompiler` compiles route regexes with `sD`. Both sides match against the raw-url-decoded path info, so they can disagree about the very same string.

A path that decodes to a control character shows the disagreement. For the request `POST /connections/revoke/foo%0Abar` and the route `/connections/revoke/{clientId}`:

```
rawurldecode(path info)          "/connections/revoke/foo\nbar"
router                           matched, clientId === "foo\nbar"
firewall pattern  '^.*$'         false
access_control    '^/.*$'        false
prefix rule       '^/connections' true
```

Without `s`, `.` does not cross the decoded newline and `$` can never be reached past it, so end-anchored catch-all patterns fail while the router still dispatches the request. `RequestMatcher` is the matcher `SecurityExtension::createRequestMatcher()` registers for both the firewall `pattern` and every `access_control` `path`, so a firewall declared with `pattern: '^.*$'` is not selected at all, and its access listener never runs. With a pattern-less firewall the firewall still engages, but a `^/.*$` rule still fails to match and `AccessMap::getPatterns()` returns `[null, null]`. Prefix rules such as `^/admin` are unaffected.

The fix adds the `s` modifier to the path check. Host matching and attribute matching are left alone; the disagreement is about the path.

`s` only, not `sD` as in `RouteCompiler`. `D` can never add a match, it can only remove one, so it would turn `$`-anchored rules into no-ops and drop protection. With route `/admin/{section}` and rule `path: '^/admin/users$'`, request `/admin/users%0A` routes, and the rule matches with `s` but not with `sD`. When no catch-all rule follows, losing that match does not fall through to a weaker rule, it escapes `access_control` entirely. `testPathStillMatchesBeforeATrailingNewLine` guards this.

Note for the merge up: from 6.4 on, `SecurityExtension` wires `HttpFoundation\RequestMatcher\PathRequestMatcher` rather than the legacy `RequestMatcher`, and `PathRequestMatcher::matches()` has the same missing modifier. The same one-character change is needed there, otherwise this fix does not reach 6.4 and above.

Tests run on 5.4: HttpFoundation (1434 tests, 5 failures that also fail on the base commit, all PHP 8.5 cookie and session issues unrelated to this change), Security/Core (590), Security/Http (531), Security/Csrf (88), Security/Guard (37) and SecurityBundle (397) all pass. Reverting the modifier makes `testPathWithEncodedControlCharacters` fail; changing it to `sD` makes `testPathStillMatchesBeforeATrailingNewLine` fail.
