### PR TITLE
[Notifier][Vonage] Verify the payload_hash claim of signed webhooks

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Vonage/Tests/Webhook/VonageRequestParserTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Vonage/Tests/Webhook/VonageRequestParserTest.php
@@ -84,6 +84,32 @@ class VonageRequestParserTest extends AbstractRequestParserTestCase
         $parser->parse($request, $this->getSecret());
     }
 
+    public function testTamperedPayloadThrows()
+    {
+        $request = $this->createRequest('{"status":"delivered","message_uuid":"1","to":"447700900000","channel":"sms"}');
+        $token = substr($request->headers->get('Authorization'), \strlen('Bearer '));
+        $request = parent::createRequest('{"status":"rejected","message_uuid":"1","to":"447700900000","channel":"sms"}');
+        $request->headers->set('Authorization', 'Bearer '.$token);
+        $parser = $this->createRequestParser();
+
+        $this->expectException(RejectWebhookException::class);
+        $this->expectExceptionMessage('Payload hash is wrong');
+
+        $parser->parse($request, $this->getSecret());
+    }
+
+    public function testMissingPayloadHashThrows()
+    {
+        $request = $this->createRequest('{"status":"delivered","message_uuid":"1","to":"447700900000","channel":"sms"}');
+        $request->headers->set('Authorization', 'Bearer '.$this->createJwt([]));
+        $parser = $this->createRequestParser();
+
+        $this->expectException(RejectWebhookException::class);
+        $this->expectExceptionMessage('Payload hash is wrong');
+
+        $parser->parse($request, $this->getSecret());
+    }
+
     protected function createRequestParser(): RequestParserInterface
     {
         return new VonageRequestParser();
@@ -91,14 +117,19 @@ class VonageRequestParserTest extends AbstractRequestParserTestCase
 
     protected function createRequest(string $payload): Request
     {
-        // JWT Token signed with the secret key
-        $jwt = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.kK9JnTXZwzNo3BYNXJT57PGLnQk-Xyu7IBhRWFmc4C0';
-
         $request = parent::createRequest($payload);
-        $request->headers->set('Authorization', 'Bearer '.$jwt);
+        $request->headers->set('Authorization', 'Bearer '.$this->createJwt(['payload_hash' => hash('sha256', $payload)]));
         ClockMock::withClockMock(self::getIssuedAt($request));
 
         return $request;
+    }
+
+    private function createJwt(array $claims): string
+    {
+        $encode = static fn (string $data) => rtrim(strtr(base64_encode($data), '+/', '-_'), '=');
+        $jwt = $encode(json_encode(['alg' => 'HS256', 'typ' => 'JWT'])).'.'.$encode(json_encode($claims + ['iat' => 1516239022, 'jti' => 'jti', 'iss' => 'Vonage']));
+
+        return $jwt.'.'.$encode(hash_hmac('sha256', $jwt, $this->getSecret(), true));
     }
 
     protected function getSecret(): string

--- a/src/Symfony/Component/Notifier/Bridge/Vonage/Webhook/VonageRequestParser.php
+++ b/src/Symfony/Component/Notifier/Bridge/Vonage/Webhook/VonageRequestParser.php
@@ -43,7 +43,11 @@ final class VonageRequestParser extends AbstractRequestParser
         if (!$request->headers->has('Authorization')) {
             throw new RejectWebhookException(406, 'Missing "Authorization" header.');
         }
-        $this->validateSignature(substr($request->headers->get('Authorization'), \strlen('Bearer ')), $secret);
+        $claims = $this->validateSignature(substr($request->headers->get('Authorization'), \strlen('Bearer ')), $secret);
+
+        if (!\is_string($claims['payload_hash'] ?? null) || !hash_equals(hash('sha256', $request->getContent()), $claims['payload_hash'])) {
+            throw new RejectWebhookException(406, 'Payload hash is wrong.');
+        }
 
         // Statuses: https://developer.vonage.com/en/api/messages-olympus#message-status
         $payload = $request->toArray();
@@ -77,7 +81,7 @@ final class VonageRequestParser extends AbstractRequestParser
         return $event;
     }
 
-    private function validateSignature(string $jwt, #[\SensitiveParameter] string $secret): void
+    private function validateSignature(string $jwt, #[\SensitiveParameter] string $secret): array
     {
         $tokenParts = explode('.', $jwt);
         if (3 !== \count($tokenParts)) {
@@ -91,9 +95,15 @@ final class VonageRequestParser extends AbstractRequestParser
         }
 
         $claims = json_decode(base64_decode(strtr($payload, '-_', '+/')), true);
+        if (!\is_array($claims)) {
+            throw new RejectWebhookException(406, 'Signature is wrong.');
+        }
+
         if (abs(time() - (int) ($claims['iat'] ?? 0)) > self::TIMESTAMP_TOLERANCE) {
             throw new RejectWebhookException(406, 'Timestamp is outside the allowed time window.');
         }
+
+        return $claims;
     }
 
     private function base64EncodeUrl(string $string): string


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`VonageRequestParser` verifies the HS256 signature of the JWT in the `Authorization` header, but it never checks the JWT's `payload_hash` claim. Vonage sets that claim to the SHA-256 of the request body so that the body is bound to the token: https://developer.vonage.com/en/getting-started/concepts/webhooks#validating-signed-webhooks

Without the check, the signature only proves that the token was issued for the secret. It says nothing about the body, so a token can be re-sent with any body and the parser turns that body into an `SmsEvent`. #65700 bounded the window to the `iat` tolerance, but inside that window the body is still unauthenticated.

`validateSignature()` now returns the decoded claims, and the request is rejected with a 406 unless `payload_hash` is a string equal (`hash_equals`) to `hash('sha256', $request->getContent())`. A token whose claims do not decode to an array is rejected as a wrong signature.

Nothing else changes: the HMAC check, the `iat` tolerance, the accepted statuses and the produced events are the same. Requests sent by Vonage always carry `payload_hash`, so genuine deliveries keep working.

Tests: the fixture token is now built by the test itself with a correct `payload_hash`, and two cases cover a token replayed with a different body and a token with no `payload_hash` claim. Both fail on 6.4 without the fix ("Failed asserting that exception of type RejectWebhookException is thrown").

Checks run:
- `./phpunit src/Symfony/Component/Notifier/Bridge/Vonage`: Tests: 27, Assertions: 32, Skipped: 1.
- `php .github/sa-tools/check-hardening-tests.php`: convention satisfied.
