### PR TITLE
[Mime] Do not treat an "@" inside the domain as the addr-spec separator

### DIFF
--- a/src/Symfony/Component/Mime/Address.php
+++ b/src/Symfony/Component/Mime/Address.php
@@ -159,7 +159,9 @@ final class Address
             return false;
         }
 
-        if (substr_count($address, '@') < 2) {
+        // an address that already complies with the addr-spec needs no further check: the extra
+        // "@" then belongs to the domain, e.g. inside a domain-literal (RFC 5322, 3.4.1)
+        if (substr_count($address, '@') < 2 || self::$validator->isValid($address, new RFCValidation())) {
             return true;
         }
 

--- a/src/Symfony/Component/Mime/Tests/AddressTest.php
+++ b/src/Symfony/Component/Mime/Tests/AddressTest.php
@@ -51,6 +51,30 @@ class AddressTest extends TestCase
         $this->assertSame('"em@il"@example.test', $a->getAddress());
     }
 
+    public function testConstructorWithAtSignInDomainLiteral()
+    {
+        $a = new Address('user@[em@il]');
+        $this->assertSame('user@[em@il]', $a->getAddress());
+    }
+
+    public function testConstructorWithUnquotedAtSignInLocalPartAndDomainLiteral()
+    {
+        $this->expectException(RfcComplianceException::class);
+        new Address('em@il@[example]');
+    }
+
+    public function testConstructorWithQuotedAtSignInLocalPartAndDomainLiteral()
+    {
+        $a = new Address('"em@il"@[em@il]');
+        $this->assertSame('"em@il"@[em@il]', $a->getAddress());
+    }
+
+    public function testConstructorWithACommentAfterADomainLiteral()
+    {
+        $a = new Address('user@[em@il] (comment)');
+        $this->assertSame('user@[em@il] (comment)', $a->getAddress());
+    }
+
     /**
      * @dataProvider provideAddressesWithControlCharacters
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Ref #65764
| License       | MIT

`user@[em@il]` is a valid addr-spec, since `dtext` allows `@` (RFC 5322, 3.4.1). It has been rejected since #65744, which landed on 5.4.

That fix validates the local part a second time, on its own, to catch an unquoted `@` that `MessageIDValidation` lets through. To isolate the local part it splits the address on its last `@`. When the domain carries an `@` of its own, the split lands inside the domain and rebuilds a local part that no longer exists: `user@[em@il]` becomes `user@[em`, which is invalid, so the address is rejected.

A domain-literal is only one shape of that. The same split falls inside a comment, and inside any comment or folding white space that follows a domain-literal, so `user@(em@il)example.com` and `user@[em@il] (comment)` are rejected too.

An address that already complies with the addr-spec needs no second pass at all, which removes the question of where the separator is:

```php
if (substr_count($address, '@') < 2 || self::$validator->isValid($address, new RFCValidation())) {
    return true;
}
```

| Address | Before #65744 | After #65744 | With this PR |
| --- | --- | --- | --- |
| `user@[em@il]` | accepted | **rejected** | accepted |
| `user@[em@il] (comment)` | accepted | **rejected** | accepted |
| `user@(em@il)example.com` | accepted | **rejected** | accepted |
| `"em@il"@[em@il]` | accepted | **rejected** | accepted |
| `user@[IPv6:2001:db8::1]` | accepted | accepted | accepted |
| `em@il@example.test` | accepted | **rejected** | **rejected** |
| `em@il@[example]` | accepted | **rejected** | **rejected** |
| `test@example.com,test2@example.com` | accepted | **rejected** | **rejected** |

The last three lines are the point: the address only takes the early return when `RFCValidation` accepts it whole, so an unquoted `@` in the local part still falls through to the second pass and is still rejected, whether the domain is a dot-atom or a literal.
