### PR TITLE
[Mime] Never emit a raw control character in a header

### DIFF
--- a/src/Symfony/Component/Mime/Address.php
+++ b/src/Symfony/Component/Mime/Address.php
@@ -50,7 +50,7 @@ final class Address
         }
 
         $this->address = trim($address);
-        $this->name = trim(str_replace(["\n", "\r"], '', $name));
+        $this->name = trim(preg_replace('/[\x00-\x08\x0A-\x1F\x7F]/', '', $name));
 
         if (preg_match('/[\x00-\x1F\x7F]/', $this->address)) {
             throw new InvalidArgumentException('Email address contains control characters.');

--- a/src/Symfony/Component/Mime/Header/AbstractHeader.php
+++ b/src/Symfony/Component/Mime/Header/AbstractHeader.php
@@ -152,7 +152,7 @@ abstract class AbstractHeader implements HeaderInterface
 
     protected function tokenNeedsEncoding(string $token): bool
     {
-        return (bool) preg_match('~[\x00-\x08\x10-\x19\x7F-\xFF\r\n]~', $token);
+        return preg_match('~[\x00-\x08\x0A-\x1F\x7F-\xFF]~', $token);
     }
 
     /**

--- a/src/Symfony/Component/Mime/Header/ParameterizedHeader.php
+++ b/src/Symfony/Component/Mime/Header/ParameterizedHeader.php
@@ -117,7 +117,7 @@ final class ParameterizedHeader extends UnstructuredHeader
         if (!preg_match('/^'.self::TOKEN_REGEX.'$/D', $value)) {
             // TODO: text, or something else??
             // ... and it's not ascii
-            if (!preg_match('/^[\x00-\x08\x0B\x0C\x0E-\x7F]*$/D', $value)) {
+            if (!preg_match('/^[\x20-\x7E]*$/D', $value)) {
                 $encoded = true;
                 // Allow space for the indices, charset and language
                 $maxValueLength = $this->getMaxLineLength() - \strlen($name.'*N*="";') - 1;

--- a/src/Symfony/Component/Mime/Tests/AddressTest.php
+++ b/src/Symfony/Component/Mime/Tests/AddressTest.php
@@ -95,6 +95,33 @@ class AddressTest extends TestCase
         yield 'control char in domain' => ["foo@example\x01.com"];
     }
 
+    /**
+     * @dataProvider provideNamesWithControlCharacters
+     */
+    public function testConstructorStripsControlCharactersFromName(string $name)
+    {
+        $a = new Address('fabien@symfony.com', $name);
+        $this->assertSame('ab', $a->getName());
+        $this->assertSame('"ab" <fabien@symfony.com>', $a->toString());
+    }
+
+    public function testConstructorKeepsTheOnlyControlCharacterLegalInAPhrase()
+    {
+        $a = new Address('fabien@symfony.com', "Jean\tDupont");
+        $this->assertSame("Jean\tDupont", $a->getName());
+    }
+
+    public static function provideNamesWithControlCharacters(): iterable
+    {
+        yield 'NUL byte' => ["a\x00b"];
+        yield 'SOH (0x01)' => ["a\x01b"];
+        yield 'LF' => ["a\nb"];
+        yield 'CR' => ["a\rb"];
+        yield 'VT (0x0B)' => ["a\x0Bb"];
+        yield 'US (0x1F)' => ["a\x1Fb"];
+        yield 'DEL (0x7F)' => ["a\x7Fb"];
+    }
+
     public function testCreate()
     {
         $this->assertSame($a = new Address('fabien@symfony.com'), Address::create($a));

--- a/src/Symfony/Component/Mime/Tests/Header/MailboxListHeaderTest.php
+++ b/src/Symfony/Component/Mime/Tests/Header/MailboxListHeaderTest.php
@@ -132,4 +132,10 @@ class MailboxListHeaderTest extends TestCase
         $header = new MailboxListHeader('From', [new Address('chris@example.org', 'Chris Corbyn'), new Address('mark@example.org', 'Mark Corbyn')]);
         $this->assertEquals('From: Chris Corbyn <chris@example.org>, Mark Corbyn <mark@example.org>', $header->toString());
     }
+
+    public function testToStringNeverEmitsControlCharactersFromTheName()
+    {
+        $header = new MailboxListHeader('To', [new Address('chris@example.org', "Chris\x00Corbyn")]);
+        $this->assertEquals('To: ChrisCorbyn <chris@example.org>', $header->toString());
+    }
 }

--- a/src/Symfony/Component/Mime/Tests/Header/ParameterizedHeaderTest.php
+++ b/src/Symfony/Component/Mime/Tests/Header/ParameterizedHeaderTest.php
@@ -231,6 +231,24 @@ class ParameterizedHeaderTest extends TestCase
         $this->assertEquals('X-Foo: bar; says*='.$header->getCharset()."''fo%8Fbar", $header->toString());
     }
 
+    public function testParamsAreEncodedIfTheyHoldAControlCharacter()
+    {
+        $value = 'fo'.pack('C', 0x00).'bar';
+        $header = new ParameterizedHeader('X-Foo', 'bar');
+        $header->setCharset('iso-8859-1');
+        $header->setParameters(['says' => $value]);
+        $this->assertEquals('X-Foo: bar; says*='.$header->getCharset()."''fo%00bar", $header->toString());
+    }
+
+    public function testParamsAreEncodedIfTheyHoldAControlCharacterWithLegacyEncodingEnabled()
+    {
+        $value = 'fo'.pack('C', 0x00).'bar';
+        $header = new ParameterizedHeader('Content-Type', 'bar');
+        $header->setCharset('iso-8859-1');
+        $header->setParameters(['says' => $value]);
+        $this->assertEquals('Content-Type: bar; says="=?'.$header->getCharset().'?Q?fo=00bar?="', $header->toString());
+    }
+
     public function testParamsAreEncodedWithLegacyEncodingEnabled()
     {
         $value = 'fo'.pack('C', 0x8F).'bar';

--- a/src/Symfony/Component/Mime/Tests/Header/UnstructuredHeaderTest.php
+++ b/src/Symfony/Component/Mime/Tests/Header/UnstructuredHeaderTest.php
@@ -113,7 +113,7 @@ class UnstructuredHeaderTest extends TestCase
     public function testEncodedWordsAreUsedToEncodedNonPrintableAscii()
     {
         // SPACE and TAB permitted
-        $nonPrintableBytes = array_merge(range(0x00, 0x08), range(0x10, 0x19), [0x7F]);
+        $nonPrintableBytes = array_merge(range(0x00, 0x08), range(0x0A, 0x1F), [0x7F]);
         foreach ($nonPrintableBytes as $byte) {
             $char = pack('C', $byte);
             $encodedChar = sprintf('=%02X', $byte);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

A control character has no place in a header. RFC 5322 defines `qtext` as `%d33 / %d35-91 / %d93-126` and `atext` as a subset of the printable range, and a NUL inside a header field is a protocol violation whatever the next hop makes of it. Three places let one through.

### The display name of an `Address`

`Address::__construct()` removed only `\n` and `\r`, while it rejects the whole `[\x00-\x1F\x7F]` range in the address itself:

```php
$h = new Headers();
$h->addMailboxListHeader('To', [new Address('a@b.com', "a\x00b")]);
echo bin2hex($h->toString());
// 546f3a202261006222203c6140622e636f6d3e0d0a
//         ^^ To: "a<NUL>b" <a@b.com>
```

Same for `\x01`, `\x0B`, `\x1F` and `\x7F`.

```diff
-        $this->name = trim(str_replace(["\n", "\r"], '', $name));
+        $this->name = trim(preg_replace('/[\x00-\x08\x0A-\x1F\x7F]/', '', $name));
```

The fix belongs here rather than in the header. `AbstractHeader::createPhrase()` counts `[\x00-\x08\x0B\x0C\x0E-\x7F]` as "plain ascii, quote it", which includes NUL, and `PHRASE_PATTERN` matches `"a\x01b"` and `(a\x01b) x` as obsolete syntax and emits them verbatim without ever reaching that branch. `createPhrase()` is called from `MailboxHeader` and `MailboxListHeader` only, always with `$address->getName()`, so `Address` is the single entry point for a phrase.

### Any unstructured field, `Subject` first

`AbstractHeader::tokenNeedsEncoding()` tested for `[\x00-\x08\x10-\x19\x7F-\xFF\r\n]`. The `\x10-\x19` leg leaves out `\x0B`, `\x0C`, `\x0E`, `\x0F` and `\x1A` to `\x1F`, which were emitted as they came:

```php
$h = new Headers();
$h->addTextHeader('Subject', "a\x0Bb");
echo bin2hex($h->toString());   // 5375626a6563743a20610b62 -> Subject: a<VT>b
```

The range is now everything but HTAB, which also matches what the neighbouring test states in its own comment, `// SPACE and TAB permitted`, and which the test only half checked.

### Any header parameter, an attachment filename first

`ParameterizedHeader::createParameter()` counted a control character as plain ascii too, so it was quoted instead of encoded:

```php
$p = new DataPart('body', "f\x00n.txt");
echo $p->getPreparedHeaders()->toString();
// Content-Type: application/octet-stream; name="f<NUL>n.txt"
// Content-Disposition: attachment; name="f<NUL>n.txt"; filename="f<NUL>n.txt"
```

Every control character but HTAB, CR and LF went through, and it is now encoded:

```
Content-Type: application/octet-stream; name="=?utf-8?Q?f=00n=2Etxt?="
Content-Disposition: attachment; name*=utf-8''f%00n.txt; filename*=utf-8''f%00n.txt
```

### Why HTAB survives

HTAB is the one control character a producer may put in a phrase or an unstructured field, where it is folding white space. So `"Jean\tDupont"` keeps its tab and is emitted as `To: Jean\tDupont <a@b.com>`.

The rule is therefore narrower than the one two lines below in the constructor, which rejects the tab in the address as well: an addr-spec has no such allowance, as the existing `'HTAB' => ["foo\t@example.com"]` data set records.

### Why removing rather than throwing, for the name

`\r` and `\n` were already removed silently, so an application passing a user-supplied display name keeps working. Throwing would turn a name field into a source of exceptions.

### What is left alone

The `multipart/form-data` branch of `createParameter()`, which serves HTTP uploads rather than mail. The WHATWG living standard, 4.10.21.8, requires the value to carry every byte but the double quote, CR and LF, and says the user agent must not perform any other escapes.

### Not an injection

`\r` and `\n` were already removed from the name, the folding logic only emits `"\r\n"` tokens, `createPhrase()` escapes `"` and `\` before quoting, and both parameter paths already turned CR and LF into `%0D`/`%0A` or `=0D`/`=0A`. So the name could never break out of the quoted-string and no parameter could ever open a new header.
