### PR TITLE
[Messenger] Fix a crash when a Redis stream entry is not a JSON object

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/RedisReceiverTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/RedisReceiverTest.php
@@ -68,6 +68,30 @@ class RedisReceiverTest extends TestCase
         $receiver->get();
     }
 
+    public function testItIgnoresAMessageFieldThatDoesNotDecodeToAnArray()
+    {
+        $connection = $this->createStub(Connection::class);
+        $connection->method('get')->willReturn(['id' => '1', 'data' => ['message' => '12345']]);
+
+        $receiver = new RedisReceiver($connection, new PhpSerializer());
+
+        $this->assertSame([], $receiver->get());
+
+        $connection = $this->createStub(Connection::class);
+        $connection->method('get')->willReturn(['id' => '2', 'data' => ['message' => '"a string"']]);
+
+        $receiver = new RedisReceiver($connection, new PhpSerializer());
+
+        $this->assertSame([], $receiver->get());
+
+        $connection = $this->createStub(Connection::class);
+        $connection->method('get')->willReturn(['id' => '3', 'data' => ['message' => 'false']]);
+
+        $receiver = new RedisReceiver($connection, new PhpSerializer());
+
+        $this->assertSame([], $receiver->get());
+    }
+
     public static function redisEnvelopeProvider(): \Generator
     {
         yield [

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Transport/RedisReceiver.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Transport/RedisReceiver.php
@@ -58,7 +58,7 @@ class RedisReceiver implements ReceiverInterface, MessageCountAwareInterface
 
         $redisEnvelope = json_decode($message['data']['message'] ?? '', true);
 
-        if (null === $redisEnvelope) {
+        if (!\is_array($redisEnvelope)) {
             return [];
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`RedisReceiver::get()` guards its payload with `null === $redisEnvelope`, but `json_decode()` returns a scalar for a stream entry whose `message` field holds valid JSON that is not an object or an array. The guard lets it through and the next line raises an uncaught `TypeError`:

```
redis-cli XADD messages '*' message 12345
php bin/console messenger:consume async
```

```
TypeError: array_key_exists(): Argument #2 ($array) must be of type array, int given
```

`Worker::run()` does not catch it, so the worker process dies. The same happens for `"a string"`, `true` and `false`. Anything a foreign producer writes into the stream can trigger it.

The fix checks for an array instead, so such an entry is ignored like any other undecodable payload.

Merge-up note for 8.1 and up: `ListableReceiverInterface` added `createEnvelopeFromData()`, which carries the same guard and the same crash through `find()` and `all()`. It needs the same change there. On 8.2, #65760 routes both call sites through a single `decodeRedisEnvelope()` that already checks for an array, so once that lands the conflict resolves in favour of the 8.2 version.
