### PR TITLE
[Form] Accept UTC-equivalent timezones for date and time model data

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
@@ -49,6 +49,27 @@ class DateTimeType extends AbstractType
         \IntlDateFormatter::SHORT,
     ];
 
+    private const UTC_EQUIVALENT_TIMEZONES = [
+        '+00:00',
+        'Etc/GMT',
+        'Etc/GMT+0',
+        'Etc/GMT-0',
+        'Etc/GMT0',
+        'Etc/Greenwich',
+        'Etc/UCT',
+        'Etc/UTC',
+        'Etc/Universal',
+        'Etc/Zulu',
+        'GMT',
+        'GMT0',
+        'Greenwich',
+        'UCT',
+        'UTC',
+        'Universal',
+        'Z',
+        'Zulu',
+    ];
+
     /**
      * @return void
      */
@@ -205,9 +226,11 @@ class DateTimeType extends AbstractType
                     return;
                 }
 
-                if ($date->getTimezone()->getName() !== $options['model_timezone']) {
-                    trigger_deprecation('symfony/form', '6.4', \sprintf('Using a "%s" instance with a timezone ("%s") not matching the configured model timezone "%s" is deprecated.', $date::class, $date->getTimezone()->getName(), $options['model_timezone']));
-                    // throw new LogicException(sprintf('Using a "%s" instance with a timezone ("%s") not matching the configured model timezone "%s" is not supported.', $date::class, $date->getTimezone()->getName(), $options['model_timezone']));
+                $timezone = $date->getTimezone()->getName();
+
+                if ($timezone !== $options['model_timezone'] && !(\in_array($timezone, self::UTC_EQUIVALENT_TIMEZONES, true) && \in_array($options['model_timezone'], self::UTC_EQUIVALENT_TIMEZONES, true))) {
+                    trigger_deprecation('symfony/form', '6.4', \sprintf('Using a "%s" instance with a timezone ("%s") not matching the configured model timezone "%s" is deprecated.', $date::class, $timezone, $options['model_timezone']));
+                    // throw new LogicException(sprintf('Using a "%s" instance with a timezone ("%s") not matching the configured model timezone "%s" is not supported.', $date::class, $timezone, $options['model_timezone']));
                 }
             });
         }

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
@@ -45,6 +45,27 @@ class DateType extends AbstractType
         'choice' => ChoiceType::class,
     ];
 
+    private const UTC_EQUIVALENT_TIMEZONES = [
+        '+00:00',
+        'Etc/GMT',
+        'Etc/GMT+0',
+        'Etc/GMT-0',
+        'Etc/GMT0',
+        'Etc/Greenwich',
+        'Etc/UCT',
+        'Etc/UTC',
+        'Etc/Universal',
+        'Etc/Zulu',
+        'GMT',
+        'GMT0',
+        'Greenwich',
+        'UCT',
+        'UTC',
+        'Universal',
+        'Z',
+        'Zulu',
+    ];
+
     /**
      * @return void
      */
@@ -189,9 +210,11 @@ class DateType extends AbstractType
                     return;
                 }
 
-                if ($date->getTimezone()->getName() !== $options['model_timezone']) {
-                    trigger_deprecation('symfony/form', '6.4', \sprintf('Using a "%s" instance with a timezone ("%s") not matching the configured model timezone "%s" is deprecated.', $date::class, $date->getTimezone()->getName(), $options['model_timezone']));
-                    // throw new LogicException(sprintf('Using a "%s" instance with a timezone ("%s") not matching the configured model timezone "%s" is not supported.', $date::class, $date->getTimezone()->getName(), $options['model_timezone']));
+                $timezone = $date->getTimezone()->getName();
+
+                if ($timezone !== $options['model_timezone'] && !(\in_array($timezone, self::UTC_EQUIVALENT_TIMEZONES, true) && \in_array($options['model_timezone'], self::UTC_EQUIVALENT_TIMEZONES, true))) {
+                    trigger_deprecation('symfony/form', '6.4', \sprintf('Using a "%s" instance with a timezone ("%s") not matching the configured model timezone "%s" is deprecated.', $date::class, $timezone, $options['model_timezone']));
+                    // throw new LogicException(sprintf('Using a "%s" instance with a timezone ("%s") not matching the configured model timezone "%s" is not supported.', $date::class, $timezone, $options['model_timezone']));
                 }
             });
         }

--- a/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
@@ -35,6 +35,27 @@ class TimeType extends AbstractType
         'choice' => ChoiceType::class,
     ];
 
+    private const UTC_EQUIVALENT_TIMEZONES = [
+        '+00:00',
+        'Etc/GMT',
+        'Etc/GMT+0',
+        'Etc/GMT-0',
+        'Etc/GMT0',
+        'Etc/Greenwich',
+        'Etc/UCT',
+        'Etc/UTC',
+        'Etc/Universal',
+        'Etc/Zulu',
+        'GMT',
+        'GMT0',
+        'Greenwich',
+        'UCT',
+        'UTC',
+        'Universal',
+        'Z',
+        'Zulu',
+    ];
+
     /**
      * @return void
      */
@@ -219,9 +240,11 @@ class TimeType extends AbstractType
                     return;
                 }
 
-                if ($date->getTimezone()->getName() !== $options['model_timezone']) {
-                    trigger_deprecation('symfony/form', '6.4', \sprintf('Using a "%s" instance with a timezone ("%s") not matching the configured model timezone "%s" is deprecated.', $date::class, $date->getTimezone()->getName(), $options['model_timezone']));
-                    // throw new LogicException(sprintf('Using a "%s" instance with a timezone ("%s") not matching the configured model timezone "%s" is not supported.', $date::class, $date->getTimezone()->getName(), $options['model_timezone']));
+                $timezone = $date->getTimezone()->getName();
+
+                if ($timezone !== $options['model_timezone'] && !(\in_array($timezone, self::UTC_EQUIVALENT_TIMEZONES, true) && \in_array($options['model_timezone'], self::UTC_EQUIVALENT_TIMEZONES, true))) {
+                    trigger_deprecation('symfony/form', '6.4', \sprintf('Using a "%s" instance with a timezone ("%s") not matching the configured model timezone "%s" is deprecated.', $date::class, $timezone, $options['model_timezone']));
+                    // throw new LogicException(sprintf('Using a "%s" instance with a timezone ("%s") not matching the configured model timezone "%s" is not supported.', $date::class, $timezone, $options['model_timezone']));
                 }
             });
         }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
@@ -781,6 +781,54 @@ class DateTimeTypeTest extends BaseTypeTestCase
         ]);
     }
 
+    /**
+     * @dataProvider provideUtcEquivalentTimezones
+     */
+    public function testUtcEquivalentTimezoneIsAccepted(string $input, \DateTimeInterface $date, string $modelTimezone)
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, $date, [
+            'widget' => 'choice',
+            'input' => $input,
+            'model_timezone' => $modelTimezone,
+        ]);
+
+        $this->assertEquals($date, $form->getData());
+    }
+
+    public static function provideUtcEquivalentTimezones()
+    {
+        return [
+            'DateTime in +00:00 with UTC model timezone' => ['datetime', new \DateTime('2024-10-28 15:00:00', new \DateTimeZone('+00:00')), 'UTC'],
+            'DateTimeImmutable in +00:00 with UTC model timezone' => ['datetime_immutable', new \DateTimeImmutable('2024-10-28 15:00:00', new \DateTimeZone('+00:00')), 'UTC'],
+            'DateTime in Z with UTC model timezone' => ['datetime', new \DateTime('2024-10-28T15:00:00Z'), 'UTC'],
+            'DateTime in GMT with UTC model timezone' => ['datetime', new \DateTime('2024-10-28 15:00:00', new \DateTimeZone('GMT')), 'UTC'],
+            'DateTime in Etc/UTC with UTC model timezone' => ['datetime', new \DateTime('2024-10-28 15:00:00', new \DateTimeZone('Etc/UTC')), 'UTC'],
+            'DateTime in UTC with +00:00 model timezone' => ['datetime', new \DateTime('2024-10-28 15:00:00', new \DateTimeZone('UTC')), '+00:00'],
+        ];
+    }
+
+    /**
+     * @group legacy
+     *
+     * @dataProvider provideZeroOffsetRegionalTimezones
+     */
+    public function testZeroOffsetRegionalTimezoneIsDeprecated(string $timezone)
+    {
+        $this->expectDeprecation(\sprintf('Since symfony/form 6.4: Using a "DateTime" instance with a timezone ("%s") not matching the configured model timezone "UTC" is deprecated.', $timezone));
+
+        $this->factory->create(static::TESTED_TYPE, new \DateTime('2024-10-28 15:00:00', new \DateTimeZone($timezone)), [
+            'model_timezone' => 'UTC',
+        ]);
+    }
+
+    public static function provideZeroOffsetRegionalTimezones()
+    {
+        return [
+            'Europe/London on a winter date' => ['Europe/London'],
+            'Africa/Abidjan' => ['Africa/Abidjan'],
+        ];
+    }
+
     protected function getTestOptions(): array
     {
         return ['widget' => 'choice'];

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
@@ -1185,6 +1185,54 @@ class DateTypeTest extends BaseTypeTestCase
         ]);
     }
 
+    /**
+     * @dataProvider provideUtcEquivalentTimezones
+     */
+    public function testUtcEquivalentTimezoneIsAccepted(string $input, \DateTimeInterface $date, string $modelTimezone)
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, $date, [
+            'widget' => 'choice',
+            'input' => $input,
+            'model_timezone' => $modelTimezone,
+        ]);
+
+        $this->assertEquals($date, $form->getData());
+    }
+
+    public static function provideUtcEquivalentTimezones()
+    {
+        return [
+            'DateTime in +00:00 with UTC model timezone' => ['datetime', new \DateTime('2024-10-28 15:00:00', new \DateTimeZone('+00:00')), 'UTC'],
+            'DateTimeImmutable in +00:00 with UTC model timezone' => ['datetime_immutable', new \DateTimeImmutable('2024-10-28 15:00:00', new \DateTimeZone('+00:00')), 'UTC'],
+            'DateTime in Z with UTC model timezone' => ['datetime', new \DateTime('2024-10-28T15:00:00Z'), 'UTC'],
+            'DateTime in GMT with UTC model timezone' => ['datetime', new \DateTime('2024-10-28 15:00:00', new \DateTimeZone('GMT')), 'UTC'],
+            'DateTime in Etc/UTC with UTC model timezone' => ['datetime', new \DateTime('2024-10-28 15:00:00', new \DateTimeZone('Etc/UTC')), 'UTC'],
+            'DateTime in UTC with +00:00 model timezone' => ['datetime', new \DateTime('2024-10-28 15:00:00', new \DateTimeZone('UTC')), '+00:00'],
+        ];
+    }
+
+    /**
+     * @group legacy
+     *
+     * @dataProvider provideZeroOffsetRegionalTimezones
+     */
+    public function testZeroOffsetRegionalTimezoneIsDeprecated(string $timezone)
+    {
+        $this->expectDeprecation(\sprintf('Since symfony/form 6.4: Using a "DateTime" instance with a timezone ("%s") not matching the configured model timezone "UTC" is deprecated.', $timezone));
+
+        $this->factory->create(static::TESTED_TYPE, new \DateTime('2024-10-28 15:00:00', new \DateTimeZone($timezone)), [
+            'model_timezone' => 'UTC',
+        ]);
+    }
+
+    public static function provideZeroOffsetRegionalTimezones()
+    {
+        return [
+            'Europe/London on a winter date' => ['Europe/London'],
+            'Africa/Abidjan' => ['Africa/Abidjan'],
+        ];
+    }
+
     protected function getTestOptions(): array
     {
         return ['widget' => 'choice'];

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
@@ -1193,6 +1193,54 @@ class TimeTypeTest extends BaseTypeTestCase
         ]);
     }
 
+    /**
+     * @dataProvider provideUtcEquivalentTimezones
+     */
+    public function testUtcEquivalentTimezoneIsAccepted(string $input, \DateTimeInterface $date, string $modelTimezone)
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, $date, [
+            'widget' => 'choice',
+            'input' => $input,
+            'model_timezone' => $modelTimezone,
+        ]);
+
+        $this->assertEquals($date, $form->getData());
+    }
+
+    public static function provideUtcEquivalentTimezones()
+    {
+        return [
+            'DateTime in +00:00 with UTC model timezone' => ['datetime', new \DateTime('2024-10-28 15:00:00', new \DateTimeZone('+00:00')), 'UTC'],
+            'DateTimeImmutable in +00:00 with UTC model timezone' => ['datetime_immutable', new \DateTimeImmutable('2024-10-28 15:00:00', new \DateTimeZone('+00:00')), 'UTC'],
+            'DateTime in Z with UTC model timezone' => ['datetime', new \DateTime('2024-10-28T15:00:00Z'), 'UTC'],
+            'DateTime in GMT with UTC model timezone' => ['datetime', new \DateTime('2024-10-28 15:00:00', new \DateTimeZone('GMT')), 'UTC'],
+            'DateTime in Etc/UTC with UTC model timezone' => ['datetime', new \DateTime('2024-10-28 15:00:00', new \DateTimeZone('Etc/UTC')), 'UTC'],
+            'DateTime in UTC with +00:00 model timezone' => ['datetime', new \DateTime('2024-10-28 15:00:00', new \DateTimeZone('UTC')), '+00:00'],
+        ];
+    }
+
+    /**
+     * @group legacy
+     *
+     * @dataProvider provideZeroOffsetRegionalTimezones
+     */
+    public function testZeroOffsetRegionalTimezoneIsDeprecated(string $timezone)
+    {
+        $this->expectDeprecation(\sprintf('Since symfony/form 6.4: Using a "DateTime" instance with a timezone ("%s") not matching the configured model timezone "UTC" is deprecated.', $timezone));
+
+        $this->factory->create(static::TESTED_TYPE, new \DateTime('2024-10-28 15:00:00', new \DateTimeZone($timezone)), [
+            'model_timezone' => 'UTC',
+        ]);
+    }
+
+    public static function provideZeroOffsetRegionalTimezones()
+    {
+        return [
+            'Europe/London on a winter date' => ['Europe/London'],
+            'Africa/Abidjan' => ['Africa/Abidjan'],
+        ];
+    }
+
     protected function getTestOptions(): array
     {
         return ['widget' => 'choice'];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues       | Fix #58696
| License       | MIT

`DateTimeType`, `DateType` and `TimeType` reject model data whose timezone name differs from the `model_timezone` option (a deprecation on 6.4, a `LogicException` since 7.0). The comparison uses the timezone name only, so a `DateTime` in `+00:00`, `Z`, `GMT` or `Etc/UTC` is rejected when `model_timezone` is `UTC`, although all these describe the same time as UTC at every instant. Such values are common: parsing an RFC 3339 / ISO 8601 string yields `+00:00` or `Z`.

With this change, the three types accept a model value whose timezone is a UTC equivalent when the `model_timezone` option is also a UTC equivalent. The accepted names are the fixed zero-offset timezones: `+00:00` (PHP normalizes `+0000`, `+00`, `GMT+0` and `-00:00` to this name), `Z`, `GMT`, `UCT` and the tzdata aliases of UTC (`UTC`, `Etc/*`, `Zulu`, `Universal`, `Greenwich`, `GMT0`).

Regional timezones that happen to be at offset zero (`Europe/London` in winter, `Africa/Abidjan` all year) are still rejected: they carry their own rules, and accepting them would make the check depend on the value of the date.
