### PR TITLE
[Process] Use an absolute path for the cmd.exe fallback on Windows

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -1598,12 +1598,15 @@ class Process implements \IteratorAggregate
 
         static $comSpec;
 
-        if (!$comSpec && $comSpec = (new ExecutableFinder())->find('cmd.exe')) {
+        if (!$comSpec) {
+            // use an absolute path to prevent CreateProcess() from looking for "cmd" in the current directory
+            $comSpec = (new ExecutableFinder())->find('cmd.exe') ?: (getenv('SystemRoot') ?: 'C:\Windows').'\System32\cmd.exe';
+
             // Escape according to CommandLineToArgvW rules
-            $comSpec = '"'.preg_replace('{(\\\\*+)"}', '$1$1\"', $comSpec) .'"';
+            $comSpec = '"'.preg_replace('{(\\\\*+)"}', '$1$1\"', $comSpec).'"';
         }
 
-        $cmd = ($comSpec ?? 'cmd').' /V:ON /E:ON /D /C ('.str_replace("\n", ' ', $cmd).')';
+        $cmd = $comSpec.' /V:ON /E:ON /D /C ('.str_replace("\n", ' ', $cmd).')';
         foreach ($this->processPipes->getFiles() as $offset => $filename) {
             $cmd .= ' '.$offset.'>"'.$filename.'"';
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

When `ExecutableFinder` cannot resolve `cmd.exe` through `PATH`, `prepareWindowsCommandLine()` falls back to the bare `cmd` string. `CreateProcess()` resolves a bare name by searching the current working directory before the system directories, so a `cmd.exe` planted in the CWD would be picked up. The fallback is reachable in practice when `PATH` is unset or stripped of `System32`, or when `open_basedir` makes the `is_file()` checks fail while the binary itself remains perfectly runnable.

This hardening replaces the fallback with an absolute path derived from `%SystemRoot%`, so the shell is never resolved relative to the CWD, completing the intent of the fix for CVE-2024-51736. As a side effect, the `static` cache now also takes effect when the finder fails, instead of re-scanning `PATH` on every `start()`.
