### PR TITLE
fix(notifier): use HTTPS for KazInfoTeh requests

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/KazInfoTeh/KazInfoTehTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/KazInfoTeh/KazInfoTehTransport.php
@@ -60,7 +60,7 @@ class KazInfoTehTransport extends AbstractTransport
             throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
         }
 
-        $endpoint = \sprintf('http://%s/api', $this->getEndpoint());
+        $endpoint = \sprintf('https://%s/api', $this->getEndpoint());
         $response = $this->client->request('POST', $endpoint, [
             'query' => [
                 'action' => 'sendmessage',

--- a/src/Symfony/Component/Notifier/Bridge/KazInfoTeh/Tests/KazInfoTehTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/KazInfoTeh/Tests/KazInfoTehTransportTest.php
@@ -20,6 +20,7 @@ use Symfony\Component\Notifier\Test\TransportTestCase;
 use Symfony\Component\Notifier\Tests\Transport\DummyMessage;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
 
 /**
  * @author Egor Taranov <dev@taranovegor.com>
@@ -46,6 +47,19 @@ final class KazInfoTehTransportTest extends TransportTestCase
         yield [new SmsMessage('420000000000', 'KazInfoTeh!')];
 
         yield [new DummyMessage()];
+    }
+
+    public function testSendUsesHttpsEndpoint()
+    {
+        $client = new MockHttpClient(static function (string $method, string $url): ResponseInterface {
+            self::assertSame('POST', $method);
+            self::assertStringStartsWith('https://kazinfoteh.org:9507/api?', $url);
+
+            return new MockResponse('<?xml version="1.0" encoding="utf-8" ?><acceptreport><statuscode>0</statuscode></acceptreport>');
+        });
+        $transport = new KazInfoTehTransport('username', 'password', 'sender', $client);
+
+        $transport->send(new SmsMessage('77000000000', 'Hello!'));
     }
 
     public function createClient(int $statusCode, string $content): HttpClientInterface


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Related to #65781
| License       | MIT

`KazInfoTehTransport` hard-coded `http://` when constructing the sending endpoint, causing requests to use plaintext HTTP by default.

This changes the request URL to `https://` while preserving the existing host, port, path, and query parameters. A regression test inspects the URL received by `MockHttpClient` and verifies the HTTPS endpoint.

This PR intentionally implements only the maintainer-suggested HTTPS bugfix. It does not add the configurable setter/API feature also discussed in #65781.

Tests:

- `php ./phpunit src/Symfony/Component/Notifier/Bridge/KazInfoTeh`
- `php php-cs-fixer.phar fix --dry-run --diff --using-cache=no --path-mode=intersection --config=.php-cs-fixer.dist.php src/Symfony/Component/Notifier/Bridge/KazInfoTeh/KazInfoTehTransport.php src/Symfony/Component/Notifier/Bridge/KazInfoTeh/Tests/KazInfoTehTransportTest.php`

Related to #65781