### PR TITLE
Review Italian validator translations

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.it.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.it.xlf
@@ -572,11 +572,11 @@
             </trans-unit>
             <trans-unit id="147">
                 <source>The referenced entity does not exist.</source>
-                <target state="needs-review-translation">L'entità referenziata non esiste.</target>
+                <target>L'entità referenziata non esiste.</target>
             </trans-unit>
             <trans-unit id="148" resname="This is not a valid ULID.">
                 <source>This value is not a valid ULID.</source>
-                <target state="needs-review-translation">Questo valore non è un ULID valido.</target>
+                <target>Questo valore non è un ULID valido.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65557
| License       | MIT

The two Italian validator translations reported in #65557 were generated automatically and still carried the state="needs-review-translation" marker. They have now been reviewed by a native Italian speaker and confirmed to be correct.

This removes the review marker from the referenced entity and ULID messages. The translated text itself is unchanged.

Validation:

- git diff --check
- parsed the XLIFF file as XML
- validated the file against Symfony's bundled XLIFF 1.2 transitional schema
- verified that no needs-review-translation markers remain in the affected file