### PR TITLE
[Lock][Messenger][Notifier] Add the "ssl" DSN option to select the HTTP scheme

### DIFF
--- a/src/Symfony/Component/Lock/Bridge/DynamoDb/CHANGELOG.md
+++ b/src/Symfony/Component/Lock/Bridge/DynamoDb/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option, superseding `sslmode`
+
 7.4
 ---
 

--- a/src/Symfony/Component/Lock/Bridge/DynamoDb/Store/DynamoDbStore.php
+++ b/src/Symfony/Component/Lock/Bridge/DynamoDb/Store/DynamoDbStore.php
@@ -45,6 +45,7 @@ class DynamoDbStore implements PersistingStoreInterface
         'expiration_attr' => 'key_expiration',
         'read_capacity_units' => 10,
         'write_capacity_units' => 20,
+        'ssl' => null,
         'sslmode' => null,
         'debug' => null,
         'http_client' => null,
@@ -107,7 +108,7 @@ class DynamoDbStore implements PersistingStoreInterface
             unset($query['region']);
 
             if ('default' !== ($params['host'] ?? 'default')) {
-                $clientConfiguration['endpoint'] = \sprintf('%s://%s%s', ($options['sslmode'] ?? null) === 'disable' ? 'http' : 'https', $params['host'], ($params['port'] ?? null) ? ':'.$params['port'] : '');
+                $clientConfiguration['endpoint'] = \sprintf('%s://%s%s', self::isSslEnabled($options, $params['scheme'] ?? 'dynamodb') ? 'https' : 'http', $params['host'], ($params['port'] ?? null) ? ':'.$params['port'] : '');
                 if (preg_match(';^dynamodb\.([^\.]++)\.amazonaws\.com$;', $params['host'], $matches)) {
                     $clientConfiguration['region'] = $matches[1];
                 }
@@ -275,6 +276,16 @@ class DynamoDbStore implements PersistingStoreInterface
         ]));
 
         $this->client->tableExists(new DescribeTableInput(['TableName' => $this->tableName]))->wait();
+    }
+
+    private static function isSslEnabled(array $options, string $scheme): bool
+    {
+        if (null === $ssl = $options['ssl'] ?? null) {
+            // "sslmode=disable" is the legacy spelling of "ssl=false"
+            return 'disable' !== ($options['sslmode'] ?? null);
+        }
+
+        return filter_var($ssl, \FILTER_VALIDATE_BOOL, \FILTER_NULL_ON_FAILURE) ?? throw new InvalidArgumentException(\sprintf('Invalid value for the "ssl" option of the "%s" DSN, expected a boolean.', $scheme));
     }
 
     private function getHashedKey(Key $key): string

--- a/src/Symfony/Component/Lock/Bridge/DynamoDb/Tests/Store/DynamoDbStoreTest.php
+++ b/src/Symfony/Component/Lock/Bridge/DynamoDb/Tests/Store/DynamoDbStoreTest.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Lock\Bridge\DynamoDb\Store\DynamoDbStore;
+use Symfony\Component\Lock\Exception\InvalidArgumentException;
 use Symfony\Component\Lock\Key;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -106,6 +107,30 @@ class DynamoDbStoreTest extends TestCase
             new DynamoDbStore(new DynamoDbClient(['region' => null, 'accessKeyId' => null, 'accessKeySecret' => null], null, $this->httpClient), ['table_name' => 'table']),
             new DynamoDbStore('dynamodb://default/table?sslmode=disable', ['http_client' => $this->httpClient])
         );
+    }
+
+    public function testFromDsnWithSsl()
+    {
+        $this->assertEquals(
+            new DynamoDbStore(new DynamoDbClient(['region' => null, 'endpoint' => 'http://localhost', 'accessKeyId' => null, 'accessKeySecret' => null], null, $this->httpClient), ['table_name' => 'table']),
+            new DynamoDbStore('dynamodb://localhost/table?ssl=false', ['http_client' => $this->httpClient])
+        );
+    }
+
+    public function testFromDsnWithSslTakingPrecedenceOverSslMode()
+    {
+        $this->assertEquals(
+            new DynamoDbStore(new DynamoDbClient(['region' => null, 'endpoint' => 'https://localhost', 'accessKeyId' => null, 'accessKeySecret' => null], null, $this->httpClient), ['table_name' => 'table']),
+            new DynamoDbStore('dynamodb://localhost/table?ssl=true&sslmode=disable', ['http_client' => $this->httpClient])
+        );
+    }
+
+    public function testFromDsnWithInvalidSsl()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid value for the "ssl" option of the "dynamodb" DSN, expected a boolean.');
+
+        new DynamoDbStore('dynamodb://localhost/table?ssl=nope', ['http_client' => $this->httpClient]);
     }
 
     public function testFromDsnWithCustomEndpointAndPort()

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Stop deduplicating the messages sent to a FIFO queue on their content: the default `MessageDeduplicationId` is now unique per send
  * Allow auto-setup to create the queue when the DSN names the account the client already authenticates as
  * Add `AmazonSqsFairQueueStamp` to set a `MessageGroupId` on standard queues, enabling SQS fair queues
+ * Add the `ssl` DSN option, superseding `sslmode`
 
 7.4
 ---

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/ConnectionTest.php
@@ -186,6 +186,32 @@ class ConnectionTest extends TestCase
         );
     }
 
+    public function testFromDsnWithSsl()
+    {
+        $httpClient = new MockHttpClient();
+        $this->assertEquals(
+            new Connection(['queue_name' => 'queue'], new SqsClient(['region' => 'eu-west-1', 'endpoint' => 'http://localhost', 'accessKeyId' => null, 'accessKeySecret' => null], null, $httpClient)),
+            Connection::fromDsn('sqs://localhost/queue?ssl=false', [], $httpClient)
+        );
+    }
+
+    public function testFromDsnWithSslTakingPrecedenceOverSslMode()
+    {
+        $httpClient = new MockHttpClient();
+        $this->assertEquals(
+            new Connection(['queue_name' => 'queue'], new SqsClient(['region' => 'eu-west-1', 'endpoint' => 'https://localhost', 'accessKeyId' => null, 'accessKeySecret' => null], null, $httpClient)),
+            Connection::fromDsn('sqs://localhost/queue?ssl=true&sslmode=disable', [], $httpClient)
+        );
+    }
+
+    public function testFromDsnWithInvalidSsl()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid value for the "ssl" option of the "sqs" DSN, expected a boolean.');
+
+        Connection::fromDsn('sqs://localhost/queue?ssl=nope', [], new MockHttpClient());
+    }
+
     public function testFromDsnWithCustomEndpointAndPort()
     {
         $httpClient = new MockHttpClient();

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
@@ -52,6 +52,7 @@ class Connection
         'queue_attributes' => null,
         'queue_tags' => null,
         'account' => null,
+        'ssl' => null,
         'sslmode' => null,
         'debug' => null,
     ];
@@ -111,7 +112,7 @@ class Connection
      * * visibility_timeout: amount of seconds the message won't be visible
      * * delete_on_rejection: Whether to delete message on rejection or allow SQS to handle retries. (Default: true).
      * * retry_delay: amount of seconds the message won't be visible before retry. (Default: 0).
-     * * sslmode: Can be "disable" to use http for a custom endpoint
+     * * ssl: Whether to use https for a custom endpoint (Default: true)
      * * auto_setup: Whether the queue should be created automatically during send / get (Default: true)
      * * debug: Log all HTTP requests and responses as LoggerInterface::DEBUG (Default: false)
      */
@@ -167,7 +168,7 @@ class Connection
 
         $isAwsHost = false;
         if ('default' !== ($params['host'] ?? 'default')) {
-            $clientConfiguration['endpoint'] = \sprintf('%s://%s%s', ($options['sslmode'] ?? null) === 'disable' ? 'http' : 'https', $params['host'], ($params['port'] ?? null) ? ':'.$params['port'] : '');
+            $clientConfiguration['endpoint'] = \sprintf('%s://%s%s', self::isSslEnabled($options, $params['scheme'] ?? 'sqs') ? 'https' : 'http', $params['host'], ($params['port'] ?? null) ? ':'.$params['port'] : '');
             // Every AWS partition that serves SQS under amazonaws: aws, aws-cn and aws-eusc
             if (preg_match(';^sqs\.([^\.]++)\.amazonaws\.(?:com(?:\.cn)?|eu)$;', $params['host'], $matches)) {
                 $clientConfiguration['region'] = $matches[1];
@@ -453,6 +454,16 @@ class Connection
                 'VisibilityTimeout' => 0,
             ]);
         }
+    }
+
+    private static function isSslEnabled(array $options, string $scheme): bool
+    {
+        if (null === $ssl = $options['ssl'] ?? null) {
+            // "sslmode=disable" is the legacy spelling of "ssl=false"
+            return 'disable' !== ($options['sslmode'] ?? null);
+        }
+
+        return filter_var($ssl, \FILTER_VALIDATE_BOOL, \FILTER_NULL_ON_FAILURE) ?? throw new InvalidArgumentException(\sprintf('Invalid value for the "ssl" option of the "%s" DSN, expected a boolean.', $scheme));
     }
 
     private function getQueueUrl(): string

--- a/src/Symfony/Component/Notifier/Bridge/AllMySms/AllMySmsTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/AllMySms/AllMySmsTransport.php
@@ -62,7 +62,7 @@ final class AllMySmsTransport extends AbstractTransport
         $options['to'] = $message->getPhone();
         $options['text'] = $message->getSubject();
 
-        $endpoint = \sprintf('https://%s/sms/send/', $this->getEndpoint());
+        $endpoint = \sprintf('%s://%s/sms/send/', $this->getHttpScheme(), $this->getEndpoint());
         $response = $this->client->request('POST', $endpoint, [
             'auth_basic' => [$this->login, $this->apiKey],
             'json' => array_filter($options),

--- a/src/Symfony/Component/Notifier/Bridge/AllMySms/AllMySmsTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/AllMySms/AllMySmsTransportFactory.php
@@ -34,7 +34,7 @@ final class AllMySmsTransportFactory extends AbstractTransportFactory
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new AllMySmsTransport($login, $apiKey, $from, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new AllMySmsTransport($login, $apiKey, $from, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/AllMySms/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/AllMySms/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 7.3
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/AllMySms/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/AllMySms/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\AllMySms\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/AmazonSns/AmazonSnsTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/AmazonSns/AmazonSnsTransportFactory.php
@@ -31,7 +31,9 @@ final class AmazonSnsTransportFactory extends AbstractTransportFactory
 
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
-        $protocol = 'disable' === $dsn->getOption('sslmode') ? 'http' : 'https';
+        // "sslmode=disable" is the legacy spelling of the "ssl=false" option
+        $ssl = $this->getSsl($dsn) ?? ('disable' !== $dsn->getOption('sslmode'));
+        $protocol = $ssl ? 'https' : 'http';
 
         $options = null === $host ? [] : ['endpoint' => $protocol.'://'.$host.($port ? ':'.$port : '')];
 

--- a/src/Symfony/Component/Notifier/Bridge/AmazonSns/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/AmazonSns/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 6.2
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/AmazonSns/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/AmazonSns/README.md
@@ -7,7 +7,7 @@ DSN example
 -----------
 
 ```
-AMAZON_SNS_DSN=sns://ACCESS_ID:ACCESS_KEY@default?region=REGION&profile=PROFILE&sslmode=SSLMODE
+AMAZON_SNS_DSN=sns://ACCESS_ID:ACCESS_KEY@default?region=REGION&profile=PROFILE&ssl=SSL
 ```
 
 where:
@@ -15,7 +15,7 @@ where:
  - `ACCESS_KEY` is your AWS access key secret
  - `REGION` is the targeted AWS region (optional, default: `us-east-1`)
  - `PROFILE` is the name of your AWS configured profile (optional, default: `default`)
- - `SSLMODE` `https` is used by default. It can be changed by setting value to `disable`,
+ - `SSL` `https` is used by default. It can be changed by setting value to `false`,
    `http` will be used
 
 Adding Options to a Chat Message

--- a/src/Symfony/Component/Notifier/Bridge/AmazonSns/Tests/AmazonSnsTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/AmazonSns/Tests/AmazonSnsTransportFactoryTest.php
@@ -11,8 +11,10 @@
 
 namespace Symfony\Component\Notifier\Bridge\AmazonSns\Tests;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Component\Notifier\Bridge\AmazonSns\AmazonSnsTransportFactory;
 use Symfony\Component\Notifier\Test\AbstractTransportFactoryTestCase;
+use Symfony\Component\Notifier\Transport\Dsn;
 
 class AmazonSnsTransportFactoryTest extends AbstractTransportFactoryTestCase
 {
@@ -43,5 +45,23 @@ class AmazonSnsTransportFactoryTest extends AbstractTransportFactoryTestCase
     public static function unsupportedSchemeProvider(): iterable
     {
         yield ['somethingElse://default'];
+    }
+
+    #[DataProvider('endpointProvider')]
+    public function testEndpointUsesTheConfiguredScheme(string $dsn, string $expectedEndpoint)
+    {
+        $transport = $this->createFactory()->create(new Dsn($dsn));
+        $snsClient = (new \ReflectionProperty($transport, 'snsClient'))->getValue($transport);
+
+        $this->assertSame($expectedEndpoint, $snsClient->getConfiguration()->get('endpoint'));
+    }
+
+    public static function endpointProvider(): iterable
+    {
+        yield 'https by default' => ['sns://host.test', 'https://host.test'];
+        yield 'ssl disabled' => ['sns://host.test?ssl=false', 'http://host.test'];
+        yield 'ssl enabled' => ['sns://host.test?ssl=true', 'https://host.test'];
+        yield 'legacy sslmode' => ['sns://host.test?sslmode=disable', 'http://host.test'];
+        yield 'ssl wins over sslmode' => ['sns://host.test?ssl=true&sslmode=disable', 'https://host.test'];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/AmazonSns/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/AmazonSns/composer.json
@@ -19,7 +19,7 @@
         "php": ">=8.4.1",
         "async-aws/sns": "^1.0",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\AmazonSns\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Bandwidth/BandwidthTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Bandwidth/BandwidthTransport.php
@@ -75,7 +75,7 @@ final class BandwidthTransport extends AbstractTransport
         if (!preg_match('/^\+[1-9]\d{1,14}$/', $options['to'][0])) {
             throw new InvalidArgumentException(\sprintf('The "To" number "%s" is not a valid phone number. The number must be in E.164 format.', $options['to'][0]));
         }
-        $endpoint = \sprintf('https://%s/api/v2/users/%s/messages', $this->getEndpoint(), $options['accountId']);
+        $endpoint = \sprintf('%s://%s/api/v2/users/%s/messages', $this->getHttpScheme(), $this->getEndpoint(), $options['accountId']);
         unset($options['accountId']);
 
         $response = $this->client->request('POST', $endpoint, [

--- a/src/Symfony/Component/Notifier/Bridge/Bandwidth/BandwidthTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Bandwidth/BandwidthTransportFactory.php
@@ -39,7 +39,7 @@ final class BandwidthTransportFactory extends AbstractTransportFactory
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new BandwidthTransport($username, $password, $from, $accountId, $applicationId, $priority, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new BandwidthTransport($username, $password, $from, $accountId, $applicationId, $priority, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/Bandwidth/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Bandwidth/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 6.3
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Bandwidth/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Bandwidth/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "require-dev": {
         "symfony/event-dispatcher": "^7.4|^8.0"

--- a/src/Symfony/Component/Notifier/Bridge/Bluesky/BlueskyTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Bluesky/BlueskyTransport.php
@@ -112,7 +112,8 @@ final class BlueskyTransport extends AbstractTransport
             unset($options['external']);
         }
 
-        $response = $this->client->request('POST', \sprintf('https://%s/xrpc/com.atproto.repo.createRecord', $this->getEndpoint()), [
+        $endpoint = \sprintf('%s://%s/xrpc/com.atproto.repo.createRecord', $this->getHttpScheme(), $this->getEndpoint());
+        $response = $this->client->request('POST', $endpoint, [
             'auth_bearer' => $this->authSession['accessJwt'] ?? null,
             'json' => $options,
         ]);
@@ -146,7 +147,8 @@ final class BlueskyTransport extends AbstractTransport
 
     private function authenticate(): void
     {
-        $response = $this->client->request('POST', \sprintf('https://%s/xrpc/com.atproto.server.createSession', $this->getEndpoint()), [
+        $endpoint = \sprintf('%s://%s/xrpc/com.atproto.server.createSession', $this->getHttpScheme(), $this->getEndpoint());
+        $response = $this->client->request('POST', $endpoint, [
             'json' => [
                 'identifier' => $this->user,
                 'password' => $this->password,
@@ -177,7 +179,8 @@ final class BlueskyTransport extends AbstractTransport
         // regex based on: https://bluesky.com/specs/handle#handle-identifier-syntax
         $regex = '#[$|\W](@([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)#';
         foreach ($this->getMatchAndPosition($input, $regex) as $match) {
-            $response = $this->client->request('GET', \sprintf('https://%s/xrpc/com.atproto.identity.resolveHandle', $this->getEndpoint()), [
+            $endpoint = \sprintf('%s://%s/xrpc/com.atproto.identity.resolveHandle', $this->getHttpScheme(), $this->getEndpoint());
+            $response = $this->client->request('GET', $endpoint, [
                 'query' => [
                     'handle' => ltrim($match['match'], '@'),
                 ],
@@ -290,11 +293,12 @@ final class BlueskyTransport extends AbstractTransport
     private function uploadMedia(array $media): array
     {
         $pool = [];
+        $endpoint = \sprintf('%s://%s/xrpc/com.atproto.repo.uploadBlob', $this->getHttpScheme(), $this->getEndpoint());
 
         foreach ($media as ['file' => $file, 'description' => $description]) {
             $pool[] = [
                 'description' => $description,
-                'response' => $this->client->request('POST', \sprintf('https://%s/xrpc/com.atproto.repo.uploadBlob', $this->getEndpoint()), [
+                'response' => $this->client->request('POST', $endpoint, [
                     'auth_bearer' => $this->authSession['accessJwt'] ?? null,
                     'headers' => [
                         'Content-Type: '.$file->getContentType(),

--- a/src/Symfony/Component/Notifier/Bridge/Bluesky/BlueskyTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Bluesky/BlueskyTransportFactory.php
@@ -47,7 +47,8 @@ final class BlueskyTransportFactory extends AbstractTransportFactory
 
         return (new BlueskyTransport($user, $secret, $this->logger ?? new NullLogger(), $this->client, $this->dispatcher, $this->clock))
             ->setHost($dsn->getHost())
-            ->setPort($dsn->getPort());
+            ->setPort($dsn->getPort())
+            ->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/Bluesky/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Bluesky/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add support for hashtag facets
+ * Add the `ssl` DSN option to send requests over plain HTTP
 
 7.3
 ---

--- a/src/Symfony/Component/Notifier/Bridge/Bluesky/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Bluesky/composer.json
@@ -24,7 +24,7 @@
         "psr/log": "^1|^2|^3",
         "symfony/clock": "^7.4|^8.0",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "require-dev": {
         "symfony/mime": "^7.4|^8.0"

--- a/src/Symfony/Component/Notifier/Bridge/Brevo/BrevoTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Brevo/BrevoTransport.php
@@ -77,7 +77,8 @@ final class BrevoTransport extends AbstractTransport
             $body['tag'] = $options['tag'];
         }
 
-        $response = $this->client->request('POST', 'https://'.$this->getEndpoint().'/v3/transactionalSMS/sms', [
+        $endpoint = \sprintf('%s://%s/v3/transactionalSMS/sms', $this->getHttpScheme(), $this->getEndpoint());
+        $response = $this->client->request('POST', $endpoint, [
             'json' => $body,
             'headers' => [
                 'api-key' => $this->apiKey,

--- a/src/Symfony/Component/Notifier/Bridge/Brevo/BrevoTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Brevo/BrevoTransportFactory.php
@@ -33,7 +33,7 @@ final class BrevoTransportFactory extends AbstractTransportFactory
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new BrevoTransport($apiKey, $sender, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new BrevoTransport($apiKey, $sender, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/Brevo/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Brevo/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 7.3
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Brevo/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Brevo/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "require-dev": {
         "symfony/event-dispatcher": "^7.4|^8.0"

--- a/src/Symfony/Component/Notifier/Bridge/Chatwork/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Chatwork/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 6.2
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Chatwork/ChatworkTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Chatwork/ChatworkTransport.php
@@ -67,7 +67,7 @@ class ChatworkTransport extends AbstractTransport
             ->body($message->getSubject())
             ->getMessageBody();
 
-        $endpoint = \sprintf('https://%s/v2/rooms/%s/messages', $this->getEndpoint(), $this->roomId);
+        $endpoint = \sprintf('%s://%s/v2/rooms/%s/messages', $this->getHttpScheme(), $this->getEndpoint(), $this->roomId);
         $response = $this->client->request('POST', $endpoint, [
             'body' => $messageBody,
             'headers' => [

--- a/src/Symfony/Component/Notifier/Bridge/Chatwork/ChatworkTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Chatwork/ChatworkTransportFactory.php
@@ -39,6 +39,6 @@ class ChatworkTransportFactory extends AbstractTransportFactory
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new ChatworkTransport($token, $roomId, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new ChatworkTransport($token, $roomId, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSsl($this->getSsl($dsn));
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Chatwork/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Chatwork/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Chatwork\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/ClickSend/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/ClickSend/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 6.3
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/ClickSend/ClickSendTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/ClickSend/ClickSendTransport.php
@@ -68,7 +68,7 @@ final class ClickSendTransport extends AbstractTransport
             throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
         }
 
-        $endpoint = \sprintf('https://%s/v3/sms/send', $this->getEndpoint());
+        $endpoint = \sprintf('%s://%s/v3/sms/send', $this->getHttpScheme(), $this->getEndpoint());
 
         $options = $message->getOptions()?->toArray() ?? [];
         $options['body'] = $message->getSubject();

--- a/src/Symfony/Component/Notifier/Bridge/ClickSend/ClickSendTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/ClickSend/ClickSendTransportFactory.php
@@ -37,7 +37,7 @@ final class ClickSendTransportFactory extends AbstractTransportFactory
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new ClickSendTransport($apiUsername, $apiKey, $from, $source, $listId, $fromEmail, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new ClickSendTransport($apiUsername, $apiKey, $from, $source, $listId, $fromEmail, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/ClickSend/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/ClickSend/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "require-dev": {
         "symfony/event-dispatcher": "^7.4|^8.0"

--- a/src/Symfony/Component/Notifier/Bridge/Clickatell/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Clickatell/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 6.2
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Clickatell/ClickatellTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Clickatell/ClickatellTransport.php
@@ -57,7 +57,7 @@ final class ClickatellTransport extends AbstractTransport
             throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
         }
 
-        $endpoint = \sprintf('https://%s/rest/message', $this->getEndpoint());
+        $endpoint = \sprintf('%s://%s/rest/message', $this->getHttpScheme(), $this->getEndpoint());
 
         $options = [];
         $options['from'] = $message->getFrom() ?: $this->from;

--- a/src/Symfony/Component/Notifier/Bridge/Clickatell/ClickatellTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Clickatell/ClickatellTransportFactory.php
@@ -33,7 +33,7 @@ final class ClickatellTransportFactory extends AbstractTransportFactory
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new ClickatellTransport($authToken, $from, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new ClickatellTransport($authToken, $from, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/Clickatell/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Clickatell/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Clickatell\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/ContactEveryone/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/ContactEveryone/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 6.3
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/ContactEveryone/ContactEveryoneTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/ContactEveryone/ContactEveryoneTransport.php
@@ -77,7 +77,7 @@ final class ContactEveryoneTransport extends AbstractTransport
         $options['to'] = $message->getPhone();
         $options['msg'] = $message->getSubject();
 
-        $endpoint = \sprintf('https://%s/api/light/diffusions/sms', $this->getEndpoint());
+        $endpoint = \sprintf('%s://%s/api/light/diffusions/sms', $this->getHttpScheme(), $this->getEndpoint());
         $response = $this->client->request('POST', $endpoint, [
             'query' => array_filter($options),
         ]);

--- a/src/Symfony/Component/Notifier/Bridge/ContactEveryone/ContactEveryoneTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/ContactEveryone/ContactEveryoneTransportFactory.php
@@ -31,7 +31,7 @@ final class ContactEveryoneTransportFactory extends AbstractTransportFactory
         $diffusionName = $dsn->getOption('diffusionname');
         $category = $dsn->getOption('category');
 
-        return (new ContactEveryoneTransport($token, $diffusionName, $category, $this->client, $this->dispatcher))->setHost($host)->setPort($dsn->getPort());
+        return (new ContactEveryoneTransport($token, $diffusionName, $category, $this->client, $this->dispatcher))->setHost($host)->setPort($dsn->getPort())->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/ContactEveryone/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/ContactEveryone/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\ContactEveryone\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Discord/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 7.4
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Discord/DiscordBotTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/DiscordBotTransport.php
@@ -62,7 +62,7 @@ final class DiscordBotTransport extends AbstractTransport
         $options = $message->getOptions()?->toArray() ?? [];
         $options['content'] = $message->getSubject();
 
-        $endpoint = \sprintf('https://%s/api/channels/%s/messages', $this->getEndpoint(), $channelId);
+        $endpoint = \sprintf('%s://%s/api/channels/%s/messages', $this->getHttpScheme(), $this->getEndpoint(), $channelId);
         $response = $this->client->request('POST', $endpoint, [
             'headers' => [
                 'Authorization' => 'Bot '.$this->token,

--- a/src/Symfony/Component/Notifier/Bridge/Discord/DiscordTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/DiscordTransport.php
@@ -59,7 +59,7 @@ final class DiscordTransport extends AbstractTransport
         $options = $message->getOptions()?->toArray() ?? [];
         $options['content'] = $message->getSubject();
 
-        $endpoint = \sprintf('https://%s/api/webhooks/%s/%s', $this->getEndpoint(), $this->webhookId, $this->token);
+        $endpoint = \sprintf('%s://%s/api/webhooks/%s/%s', $this->getHttpScheme(), $this->getEndpoint(), $this->webhookId, $this->token);
         $response = $this->client->request('POST', $endpoint, [
             'json' => array_filter($options),
         ]);

--- a/src/Symfony/Component/Notifier/Bridge/Discord/DiscordTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/DiscordTransportFactory.php
@@ -32,7 +32,7 @@ final class DiscordTransportFactory extends AbstractTransportFactory
             $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
             $port = $dsn->getPort();
 
-            return (new DiscordTransport($token, $webhookId, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+            return (new DiscordTransport($token, $webhookId, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSsl($this->getSsl($dsn));
         }
 
         if ('discord+bot' === $scheme) {

--- a/src/Symfony/Component/Notifier/Bridge/Discord/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0",
+        "symfony/notifier": "^8.2",
         "symfony/polyfill-mbstring": "^1.0"
     },
     "autoload": {

--- a/src/Symfony/Component/Notifier/Bridge/Engagespot/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Engagespot/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 6.1
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Engagespot/EngagespotTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Engagespot/EngagespotTransport.php
@@ -54,7 +54,7 @@ final class EngagespotTransport extends AbstractTransport
             throw new UnsupportedMessageTypeException(__CLASS__, PushMessage::class, $message);
         }
 
-        $endpoint = \sprintf('https://%s', $this->getEndpoint());
+        $endpoint = \sprintf('%s://%s', $this->getHttpScheme(), $this->getEndpoint());
         $options = $message->getOptions()?->toArray() ?? [];
         $options['to'] ??= $message->getRecipientId();
 

--- a/src/Symfony/Component/Notifier/Bridge/Engagespot/EngagespotTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Engagespot/EngagespotTransportFactory.php
@@ -33,7 +33,7 @@ final class EngagespotTransportFactory extends AbstractTransportFactory
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new EngagespotTransport($apiKey, $campaignName, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new EngagespotTransport($apiKey, $campaignName, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/Engagespot/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Engagespot/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Engagespot\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Esendex/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Esendex/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 6.3
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Esendex/EsendexTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Esendex/EsendexTransport.php
@@ -63,7 +63,8 @@ final class EsendexTransport extends AbstractTransport
         ];
         $options['accountreference'] ??= $this->accountReference;
 
-        $response = $this->client->request('POST', 'https://'.$this->getEndpoint().'/v1.0/messagedispatcher', [
+        $endpoint = \sprintf('%s://%s/v1.0/messagedispatcher', $this->getHttpScheme(), $this->getEndpoint());
+        $response = $this->client->request('POST', $endpoint, [
             'auth_basic' => [$this->email, $this->password],
             'headers' => [
                 'Accept' => 'application/json',

--- a/src/Symfony/Component/Notifier/Bridge/Esendex/EsendexTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Esendex/EsendexTransportFactory.php
@@ -32,7 +32,7 @@ final class EsendexTransportFactory extends AbstractTransportFactory
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new EsendexTransport($email, $password, $accountReference, $from, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new EsendexTransport($email, $password, $accountReference, $from, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/Esendex/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Esendex/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Esendex\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Expo/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Expo/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 5.4
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Expo/ExpoTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Expo/ExpoTransport.php
@@ -56,7 +56,7 @@ final class ExpoTransport extends AbstractTransport
             throw new UnsupportedMessageTypeException(__CLASS__, PushMessage::class, $message);
         }
 
-        $endpoint = \sprintf('https://%s', $this->getEndpoint());
+        $endpoint = \sprintf('%s://%s', $this->getHttpScheme(), $this->getEndpoint());
         $options = $message->getOptions()?->toArray() ?? [];
         $options['to'] ??= $message->getRecipientId();
 

--- a/src/Symfony/Component/Notifier/Bridge/Expo/ExpoTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Expo/ExpoTransportFactory.php
@@ -32,7 +32,7 @@ final class ExpoTransportFactory extends AbstractTransportFactory
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new ExpoTransport($token, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new ExpoTransport($token, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/Expo/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Expo/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Expo\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/FacebookPage/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/FacebookPage/CHANGELOG.md
@@ -5,3 +5,4 @@ CHANGELOG
 ---
 
  * Add the bridge
+ * Add the `ssl` DSN option to send requests over plain HTTP

--- a/src/Symfony/Component/Notifier/Bridge/FacebookPage/FacebookPageTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/FacebookPage/FacebookPageTransport.php
@@ -65,7 +65,7 @@ final class FacebookPageTransport extends AbstractTransport
             throw new UnsupportedOptionsException(__CLASS__, FacebookPageOptions::class, $options);
         }
 
-        $endpoint = \sprintf('https://%s/%s/%s/feed', $this->getEndpoint(), $this->apiVersion, $this->pageId);
+        $endpoint = \sprintf('%s://%s/%s/%s/feed', $this->getHttpScheme(), $this->getEndpoint(), $this->apiVersion, $this->pageId);
 
         $body = ['message' => $message->getSubject()] + ($options?->toArray() ?? []);
 

--- a/src/Symfony/Component/Notifier/Bridge/FacebookPage/FacebookPageTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/FacebookPage/FacebookPageTransportFactory.php
@@ -36,7 +36,7 @@ final class FacebookPageTransportFactory extends AbstractTransportFactory
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new FacebookPageTransport($pageAccessToken, $pageId, $apiVersion, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new FacebookPageTransport($pageAccessToken, $pageId, $apiVersion, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/FacebookPage/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/FacebookPage/composer.json
@@ -25,7 +25,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Symfony/Component/Notifier/Bridge/Firebase/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Firebase/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Deprecate `AndroidNotification`, `IOSNotification` and `WebNotification`, use `FirebaseOptions` instead
  * Deprecate the `firebase://USERNAME:PASSWORD@default` DSN, use `firebase://PROJECT_ID?client_email=...&private_key_id=...&private_key=...` instead
  * Deprecate the `$token` argument of `FirebaseTransport::__construct()`
+ * Add the `ssl` DSN option to send requests over plain HTTP
 
 5.3
 ---

--- a/src/Symfony/Component/Notifier/Bridge/Firebase/FirebaseTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Firebase/FirebaseTransport.php
@@ -72,7 +72,7 @@ final class FirebaseTransport extends AbstractTransport
             throw new IncompleteDsnException(\sprintf('The "%s" transport requires project_id, private_key_id and private_key options to be specified in DSN.', self::class));
         }
 
-        $endpoint = \sprintf('https://%s/v1/projects/%s/messages:send', $this->getEndpoint(), $this->projectId);
+        $endpoint = \sprintf('%s://%s/v1/projects/%s/messages:send', $this->getHttpScheme(), $this->getEndpoint(), $this->projectId);
 
         $options = $message->getOptions()?->toArray() ?? [];
         $options['notification'] ??= [];

--- a/src/Symfony/Component/Notifier/Bridge/Firebase/FirebaseTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Firebase/FirebaseTransportFactory.php
@@ -41,13 +41,15 @@ final class FirebaseTransportFactory extends AbstractTransportFactory
 
             return (new FirebaseTransport('', $projectId, $user, $privateKeyId, $privateKey, $this->client, $this->dispatcher))
                 ->setHost($host)
-                ->setPort($port);
+                ->setPort($port)
+                ->setSsl($this->getSsl($dsn));
         } catch (MissingRequiredOptionException) {
             trigger_deprecation('symfony/firebase-notifier', '8.2', 'Using Firebase Notifier without project_id, private_key_id and private_key options is deprecated. Update your Firebase DSN.');
 
             return (new FirebaseTransport('', '', '', '', '', $this->client, $this->dispatcher))
                 ->setHost($host)
-                ->setPort($port);
+                ->setPort($port)
+                ->setSsl($this->getSsl($dsn));
         }
     }
 

--- a/src/Symfony/Component/Notifier/Bridge/Firebase/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Firebase/composer.json
@@ -20,7 +20,7 @@
         "ext-openssl": "*",
         "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Firebase\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/FortySixElks/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/FortySixElks/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 6.2
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/FortySixElks/FortySixElksTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/FortySixElks/FortySixElksTransport.php
@@ -59,7 +59,7 @@ final class FortySixElksTransport extends AbstractTransport
         $options['to'] = $message->getPhone();
         $options['message'] = $message->getSubject();
 
-        $endpoint = \sprintf('https://%s/a1/sms', $this->getEndpoint());
+        $endpoint = \sprintf('%s://%s/a1/sms', $this->getHttpScheme(), $this->getEndpoint());
         $response = $this->client->request('POST', $endpoint, [
             'auth_basic' => [$this->apiUsername, $this->apiPassword],
             'body' => array_filter($options),

--- a/src/Symfony/Component/Notifier/Bridge/FortySixElks/FortySixElksTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/FortySixElks/FortySixElksTransportFactory.php
@@ -29,7 +29,7 @@ final class FortySixElksTransportFactory extends AbstractTransportFactory
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $from = $dsn->getRequiredOption('from');
 
-        return (new FortySixElksTransport($this->getUser($dsn), $this->getPassword($dsn), $from, $this->client, $this->dispatcher))->setHost($host)->setPort($dsn->getPort());
+        return (new FortySixElksTransport($this->getUser($dsn), $this->getPassword($dsn), $from, $this->client, $this->dispatcher))->setHost($host)->setPort($dsn->getPort())->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/FortySixElks/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/FortySixElks/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\FortySixElks\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/FreeMobile/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/FreeMobile/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 6.2
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/FreeMobile/FreeMobileTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/FreeMobile/FreeMobileTransport.php
@@ -62,7 +62,7 @@ final class FreeMobileTransport extends AbstractTransport
             throw new InvalidArgumentException(\sprintf('The "%s" transport does not support "from" in "%s".', __CLASS__, SmsMessage::class));
         }
 
-        $endpoint = \sprintf('https://%s', $this->getEndpoint());
+        $endpoint = \sprintf('%s://%s', $this->getHttpScheme(), $this->getEndpoint());
 
         $response = $this->client->request('POST', $endpoint, [
             'query' => [

--- a/src/Symfony/Component/Notifier/Bridge/FreeMobile/FreeMobileTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/FreeMobile/FreeMobileTransportFactory.php
@@ -35,7 +35,7 @@ final class FreeMobileTransportFactory extends AbstractTransportFactory
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new FreeMobileTransport($login, $password, $phone, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new FreeMobileTransport($login, $password, $phone, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/FreeMobile/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/FreeMobile/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\FreeMobile\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/GatewayApi/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/GatewayApi/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 7.2
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/GatewayApi/GatewayApiTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/GatewayApi/GatewayApiTransport.php
@@ -58,7 +58,7 @@ final class GatewayApiTransport extends AbstractTransport
         $options['recipients'] = [['msisdn' => $message->getPhone()]];
         $options['message'] = $message->getSubject();
 
-        $endpoint = \sprintf('https://%s/rest/mtsms', $this->getEndpoint());
+        $endpoint = \sprintf('%s://%s/rest/mtsms', $this->getHttpScheme(), $this->getEndpoint());
 
         $response = $this->client->request('POST', $endpoint, [
             'auth_basic' => [$this->authToken, ''],

--- a/src/Symfony/Component/Notifier/Bridge/GatewayApi/GatewayApiTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/GatewayApi/GatewayApiTransportFactory.php
@@ -33,7 +33,7 @@ final class GatewayApiTransportFactory extends AbstractTransportFactory
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new GatewayApiTransport($authToken, $from, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new GatewayApiTransport($authToken, $from, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/GatewayApi/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/GatewayApi/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\GatewayApi\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/GoIp/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/GoIp/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 6.4
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/GoIp/GoIpTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/GoIp/GoIpTransport.php
@@ -71,7 +71,8 @@ final class GoIpTransport extends AbstractTransport
             throw new LogicException(\sprintf('The "%s" transport does not support the "From" option.', __CLASS__));
         }
 
-        $response = $this->client->request('GET', 'https://'.$this->getEndpoint(), [
+        $endpoint = \sprintf('%s://%s', $this->getHttpScheme(), $this->getEndpoint());
+        $response = $this->client->request('GET', $endpoint, [
             'query' => [
                 'u' => $this->username,
                 'p' => $this->password,

--- a/src/Symfony/Component/Notifier/Bridge/GoIp/GoIpTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/GoIp/GoIpTransportFactory.php
@@ -38,7 +38,8 @@ final class GoIpTransportFactory extends AbstractTransportFactory
 
         return (new GoIpTransport($username, $password, $simSlot, $this->client, $this->dispatcher))
             ->setHost($dsn->getHost())
-            ->setPort($dsn->getPort());
+            ->setPort($dsn->getPort())
+            ->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/GoIp/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/GoIp/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Symfony/Component/Notifier/Bridge/GoogleChat/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/GoogleChat/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 7.0
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/GoogleChat/GoogleChatTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/GoogleChat/GoogleChatTransport.php
@@ -87,7 +87,8 @@ final class GoogleChatTransport extends AbstractTransport
 
         $threadKey = $options->getThreadKey() ?: $this->threadKey;
 
-        $url = \sprintf('https://%s/v1/spaces/%s/messages?key=%s&token=%s%s',
+        $endpoint = \sprintf('%s://%s/v1/spaces/%s/messages?key=%s&token=%s%s',
+            $this->getHttpScheme(),
             $this->getEndpoint(),
             $this->space,
             urlencode($this->accessKey),
@@ -101,7 +102,7 @@ final class GoogleChatTransport extends AbstractTransport
             $body['thread']['threadKey'] = $threadKey;
         }
 
-        $response = $this->client->request('POST', $url, [
+        $response = $this->client->request('POST', $endpoint, [
             'json' => $body,
         ]);
 

--- a/src/Symfony/Component/Notifier/Bridge/GoogleChat/GoogleChatTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/GoogleChat/GoogleChatTransportFactory.php
@@ -38,7 +38,7 @@ final class GoogleChatTransportFactory extends AbstractTransportFactory
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new GoogleChatTransport($space, $accessKey, $accessToken, $threadKey, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new GoogleChatTransport($space, $accessKey, $accessToken, $threadKey, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/GoogleChat/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/GoogleChat/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\GoogleChat\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Infobip/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Infobip/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 6.2
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Infobip/InfobipTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Infobip/InfobipTransport.php
@@ -52,7 +52,7 @@ final class InfobipTransport extends AbstractTransport
             throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
         }
 
-        $endpoint = \sprintf('https://%s/sms/2/text/advanced', $this->getEndpoint());
+        $endpoint = \sprintf('%s://%s/sms/2/text/advanced', $this->getHttpScheme(), $this->getEndpoint());
 
         $response = $this->client->request('POST', $endpoint, [
             'headers' => [

--- a/src/Symfony/Component/Notifier/Bridge/Infobip/InfobipTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Infobip/InfobipTransportFactory.php
@@ -34,7 +34,7 @@ final class InfobipTransportFactory extends AbstractTransportFactory
         $host = $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new InfobipTransport($authToken, $from, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new InfobipTransport($authToken, $from, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/Infobip/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Infobip/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Infobip\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Instagram/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Instagram/CHANGELOG.md
@@ -5,3 +5,4 @@ CHANGELOG
 ---
 
  * Add the bridge
+ * Add the `ssl` DSN option to send requests over plain HTTP

--- a/src/Symfony/Component/Notifier/Bridge/Instagram/InstagramTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Instagram/InstagramTransport.php
@@ -185,7 +185,7 @@ final class InstagramTransport extends AbstractTransport
 
     private function graphUrl(string $path): string
     {
-        return \sprintf('https://%s/%s/%s', $this->getEndpoint(), $this->apiVersion, ltrim($path, '/'));
+        return \sprintf('%s://%s/%s/%s', $this->getHttpScheme(), $this->getEndpoint(), $this->apiVersion, ltrim($path, '/'));
     }
 
     /**

--- a/src/Symfony/Component/Notifier/Bridge/Instagram/InstagramTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Instagram/InstagramTransportFactory.php
@@ -38,7 +38,7 @@ final class InstagramTransportFactory extends AbstractTransportFactory
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new InstagramTransport($accessToken, $userId, $apiVersion, $this->client, $this->dispatcher, $pollAttempts, $pollDelay))->setHost($host)->setPort($port);
+        return (new InstagramTransport($accessToken, $userId, $apiVersion, $this->client, $this->dispatcher, $pollAttempts, $pollDelay))->setHost($host)->setPort($port)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/Instagram/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Instagram/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Symfony/Component/Notifier/Bridge/Iqsms/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Iqsms/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 6.2
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Iqsms/IqsmsTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Iqsms/IqsmsTransport.php
@@ -54,7 +54,8 @@ final class IqsmsTransport extends AbstractTransport
             throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
         }
 
-        $response = $this->client->request('POST', 'https://'.$this->getEndpoint().'/messages/v2/send.json', [
+        $endpoint = \sprintf('%s://%s/messages/v2/send.json', $this->getHttpScheme(), $this->getEndpoint());
+        $response = $this->client->request('POST', $endpoint, [
             'json' => [
                 'messages' => [
                     [

--- a/src/Symfony/Component/Notifier/Bridge/Iqsms/IqsmsTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Iqsms/IqsmsTransportFactory.php
@@ -34,7 +34,7 @@ final class IqsmsTransportFactory extends AbstractTransportFactory
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new IqsmsTransport($login, $password, $from, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new IqsmsTransport($login, $password, $from, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/Iqsms/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Iqsms/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Iqsms\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Isendpro/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Isendpro/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 6.3
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Isendpro/IsendproTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Isendpro/IsendproTransport.php
@@ -77,7 +77,8 @@ final class IsendproTransport extends AbstractTransport
             $messageData['emetteur'] = $this->from;
         }
 
-        $response = $this->client->request('POST', 'https://'.$this->getEndpoint().'/cgi-bin/sms', [
+        $endpoint = \sprintf('%s://%s/cgi-bin/sms', $this->getHttpScheme(), $this->getEndpoint());
+        $response = $this->client->request('POST', $endpoint, [
             'headers' => [
                 'Accept' => 'application/json',
                 'Cache-Control' => 'no-cache',

--- a/src/Symfony/Component/Notifier/Bridge/Isendpro/IsendproTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Isendpro/IsendproTransportFactory.php
@@ -30,7 +30,7 @@ final class IsendproTransportFactory extends AbstractTransportFactory
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new IsendproTransport($keyid, $from, $noStop, $sandbox, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new IsendproTransport($keyid, $from, $noStop, $sandbox, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/Isendpro/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Isendpro/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "require-dev": {
         "symfony/event-dispatcher": "^7.4|^8.0"

--- a/src/Symfony/Component/Notifier/Bridge/KazInfoTeh/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/KazInfoTeh/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over HTTPS
+
 6.2
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/KazInfoTeh/KazInfoTehTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/KazInfoTeh/KazInfoTehTransport.php
@@ -27,6 +27,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 class KazInfoTehTransport extends AbstractTransport
 {
     protected const HOST = 'kazinfoteh.org';
+    // the vendor endpoint is only served over plain HTTP
+    protected const SSL = false;
 
     public function __construct(
         private string $username,
@@ -57,7 +59,7 @@ class KazInfoTehTransport extends AbstractTransport
             throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
         }
 
-        $endpoint = \sprintf('http://%s/api', $this->getEndpoint());
+        $endpoint = \sprintf('%s://%s/api', $this->getHttpScheme(), $this->getEndpoint());
         $response = $this->client->request('POST', $endpoint, [
             'query' => [
                 'action' => 'sendmessage',

--- a/src/Symfony/Component/Notifier/Bridge/KazInfoTeh/KazInfoTehTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/KazInfoTeh/KazInfoTehTransportFactory.php
@@ -35,7 +35,7 @@ final class KazInfoTehTransportFactory extends AbstractTransportFactory
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new KazInfoTehTransport($username, $password, $sender, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new KazInfoTehTransport($username, $password, $sender, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/KazInfoTeh/Tests/KazInfoTehTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/KazInfoTeh/Tests/KazInfoTehTransportTest.php
@@ -69,6 +69,28 @@ final class KazInfoTehTransportTest extends TransportTestCase
         }
     }
 
+    public static function schemeProvider(): iterable
+    {
+        // the vendor endpoint is only served over plain HTTP, hence the default
+        yield 'plain http by default' => [null, 'http://test.host/api?'];
+        yield 'https when ssl is enabled' => [true, 'https://test.host/api?'];
+        yield 'plain http when ssl is disabled' => [false, 'http://test.host/api?'];
+    }
+
+    #[DataProvider('schemeProvider')]
+    public function testSendUsesTheConfiguredScheme(?bool $ssl, string $expectedEndpoint)
+    {
+        $client = new MockHttpClient(function (string $method, string $url) use ($expectedEndpoint): MockResponse {
+            $this->assertStringStartsWith($expectedEndpoint, $url);
+
+            return new MockResponse('<?xml version="1.0" encoding="utf-8" ?><acceptreport><statuscode>0</statuscode></acceptreport>');
+        });
+
+        $transport = (new KazInfoTehTransport('username', 'password', 'sender', $client))->setHost('test.host')->setSsl($ssl);
+
+        $transport->send(new SmsMessage('77000000000', 'Hello!'));
+    }
+
     #[DataProvider('responseProvider')]
     public function testThrowExceptionWhenMessageWasNotSent(int $statusCode, string $content, string $errorMessage)
     {

--- a/src/Symfony/Component/Notifier/Bridge/KazInfoTeh/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/KazInfoTeh/composer.json
@@ -20,7 +20,7 @@
         "php": ">=8.4.1",
         "ext-simplexml": "*",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\KazInfoTeh\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/LightSms/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/LightSms/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 6.2
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/LightSms/LightSmsTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/LightSms/LightSmsTransport.php
@@ -106,7 +106,7 @@ final class LightSmsTransport extends AbstractTransport
         ];
         $data['signature'] = $this->generateSignature($data);
 
-        $endpoint = \sprintf('https://%s/external/get/send.php', $this->getEndpoint());
+        $endpoint = \sprintf('%s://%s/external/get/send.php', $this->getHttpScheme(), $this->getEndpoint());
         $response = $this->client->request('GET', $endpoint, [
             'query' => $data,
         ]);

--- a/src/Symfony/Component/Notifier/Bridge/LightSms/LightSmsTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/LightSms/LightSmsTransportFactory.php
@@ -35,7 +35,7 @@ final class LightSmsTransportFactory extends AbstractTransportFactory
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new LightSmsTransport($login, $token, $from, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new LightSmsTransport($login, $token, $from, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/LightSms/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/LightSms/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\LightSms\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/LineBot/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/LineBot/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 7.2
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/LineBot/LineBotTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/LineBot/LineBotTransport.php
@@ -45,7 +45,7 @@ final class LineBotTransport extends AbstractTransport
 
         $response = $this->client->request(
             'POST',
-            \sprintf('https://%s/v2/bot/message/push', $this->getEndpoint()),
+            \sprintf('%s://%s/v2/bot/message/push', $this->getHttpScheme(), $this->getEndpoint()),
             [
                 'auth_bearer' => $this->accessToken,
                 'json' => [

--- a/src/Symfony/Component/Notifier/Bridge/LineBot/LineBotTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/LineBot/LineBotTransportFactory.php
@@ -43,6 +43,6 @@ final class LineBotTransportFactory extends AbstractTransportFactory
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new LineBotTransport($accessToken, $receiver, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new LineBotTransport($accessToken, $receiver, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSsl($this->getSsl($dsn));
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/LineBot/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/LineBot/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "require-dev": {
         "symfony/event-dispatcher": "^7.4|^8.0"

--- a/src/Symfony/Component/Notifier/Bridge/LineNotify/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/LineNotify/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 6.3
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/LineNotify/LineNotifyTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/LineNotify/LineNotifyTransport.php
@@ -41,7 +41,7 @@ final class LineNotifyTransport extends AbstractTransport
             throw new UnsupportedMessageTypeException(__CLASS__, ChatMessage::class, $message);
         }
 
-        $endpoint = \sprintf('https://%s/api/notify', $this->getEndpoint());
+        $endpoint = \sprintf('%s://%s/api/notify', $this->getHttpScheme(), $this->getEndpoint());
         $response = $this->client->request('POST', $endpoint, [
             'auth_bearer' => $this->token,
             'query' => [

--- a/src/Symfony/Component/Notifier/Bridge/LineNotify/LineNotifyTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/LineNotify/LineNotifyTransportFactory.php
@@ -37,6 +37,6 @@ final class LineNotifyTransportFactory extends AbstractTransportFactory
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new LineNotifyTransport($token, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new LineNotifyTransport($token, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSsl($this->getSsl($dsn));
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/LineNotify/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/LineNotify/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "require-dev": {
         "symfony/event-dispatcher": "^7.4|^8.0"

--- a/src/Symfony/Component/Notifier/Bridge/LinkedIn/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/LinkedIn/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add support for posting as a LinkedIn organization via the DSN `author` option
+ * Add the `ssl` DSN option to send requests over plain HTTP
 
 5.3
 ---

--- a/src/Symfony/Component/Notifier/Bridge/LinkedIn/LinkedInTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/LinkedIn/LinkedInTransport.php
@@ -75,7 +75,7 @@ final class LinkedInTransport extends AbstractTransport
             $options->author(new AuthorShare($this->accountId, $this->authorType->value));
         }
 
-        $endpoint = \sprintf('https://%s/v2/ugcPosts', $this->getEndpoint());
+        $endpoint = \sprintf('%s://%s/v2/ugcPosts', $this->getHttpScheme(), $this->getEndpoint());
 
         $response = $this->client->request('POST', $endpoint, [
             'auth_bearer' => $this->authToken,

--- a/src/Symfony/Component/Notifier/Bridge/LinkedIn/LinkedInTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/LinkedIn/LinkedInTransportFactory.php
@@ -35,7 +35,7 @@ final class LinkedInTransportFactory extends AbstractTransportFactory
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new LinkedInTransport($authToken, $accountId, $this->client, $this->dispatcher, $authorType))->setHost($host)->setPort($port);
+        return (new LinkedInTransport($authToken, $accountId, $this->client, $this->dispatcher, $authorType))->setHost($host)->setPort($port)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/LinkedIn/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/LinkedIn/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\LinkedIn\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Lox24/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Lox24/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 7.4
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Lox24/Lox24Transport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Lox24/Lox24Transport.php
@@ -94,7 +94,8 @@ final class Lox24Transport extends AbstractTransport
         $body = $this->setServiceCode($body, $options);
         $body = $this->setVoiceLang($body, $options);
 
-        $response = $this->client->request('POST', \sprintf('https://%s/sms', $this->getEndpoint()), [
+        $endpoint = \sprintf('%s://%s/sms', $this->getHttpScheme(), $this->getEndpoint());
+        $response = $this->client->request('POST', $endpoint, [
             'headers' => [
                 'X-LOX24-AUTH-TOKEN' => \sprintf('%s:%s', $this->user, $this->token),
                 'Accept' => 'application/json',

--- a/src/Symfony/Component/Notifier/Bridge/Lox24/Lox24TransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Lox24/Lox24TransportFactory.php
@@ -43,7 +43,7 @@ final class Lox24TransportFactory extends AbstractTransportFactory
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new Lox24Transport($user, $token, $from, $dsn->getOptions(), $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new Lox24Transport($user, $token, $from, $dsn->getOptions(), $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/Lox24/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Lox24/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "require-dev": {
         "symfony/webhook": "^7.4|^8.0"

--- a/src/Symfony/Component/Notifier/Bridge/Mailjet/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Mailjet/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 6.2
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Mailjet/MailjetTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mailjet/MailjetTransport.php
@@ -53,7 +53,7 @@ final class MailjetTransport extends AbstractTransport
             throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
         }
 
-        $endpoint = \sprintf('https://%s/v4/sms-send', $this->getEndpoint());
+        $endpoint = \sprintf('%s://%s/v4/sms-send', $this->getHttpScheme(), $this->getEndpoint());
 
         $response = $this->client->request('POST', $endpoint, [
             'auth_bearer' => $this->authToken,

--- a/src/Symfony/Component/Notifier/Bridge/Mailjet/MailjetTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mailjet/MailjetTransportFactory.php
@@ -33,7 +33,7 @@ final class MailjetTransportFactory extends AbstractTransportFactory
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new MailjetTransport($authToken, $from, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new MailjetTransport($authToken, $from, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/Mailjet/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Mailjet/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Mailjet\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Mastodon/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Mastodon/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 6.3
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Mastodon/MastodonTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mastodon/MastodonTransport.php
@@ -53,11 +53,11 @@ final class MastodonTransport extends AbstractTransport
 
     public function request(string $method, string $url, array $options): ResponseInterface
     {
-        $url = \sprintf('https://%s%s', $this->getEndpoint(), $url);
+        $endpoint = \sprintf('%s://%s%s', $this->getHttpScheme(), $this->getEndpoint(), $url);
 
         $options['auth_bearer'] = $this->accessToken;
 
-        return $this->client->request($method, $url, $options);
+        return $this->client->request($method, $endpoint, $options);
     }
 
     /**

--- a/src/Symfony/Component/Notifier/Bridge/Mastodon/MastodonTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mastodon/MastodonTransportFactory.php
@@ -32,7 +32,7 @@ final class MastodonTransportFactory extends AbstractTransportFactory
         $host = $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new MastodonTransport($token, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new MastodonTransport($token, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/Mastodon/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Mastodon/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "require-dev": {
         "symfony/mime": "^7.4|^8.0"

--- a/src/Symfony/Component/Notifier/Bridge/Matrix/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Matrix/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 7.3
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Matrix/MatrixTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Matrix/MatrixTransport.php
@@ -34,11 +34,13 @@ final class MatrixTransport extends AbstractTransport
 
     public function __construct(
         #[\SensitiveParameter] private string $accessToken,
-        private bool $ssl,
+        bool $ssl = true,
         ?HttpClientInterface $client = null,
         ?EventDispatcherInterface $dispatcher = null,
     ) {
         parent::__construct($client, $dispatcher);
+
+        $this->setSsl($ssl);
     }
 
     public function __toString(): string
@@ -97,7 +99,17 @@ final class MatrixTransport extends AbstractTransport
 
     protected function getEndpoint(bool $full = false): string
     {
-        return rtrim(($full ? $this->getScheme().'://' : '').$this->host.($this->port ? ':'.$this->port : ''), '/');
+        $endpoint = $this->host ?? '';
+
+        if ($this->port) {
+            $endpoint = \sprintf('%s:%d', $endpoint, $this->port);
+        }
+
+        if ($full) {
+            $endpoint = \sprintf('%s://%s', $this->getHttpScheme(), $endpoint);
+        }
+
+        return rtrim($endpoint, '/');
     }
 
     private function getRoomFromAlias(string $alias): string
@@ -149,11 +161,6 @@ final class MatrixTransport extends AbstractTransport
         $response = $this->request('GET', '/_matrix/client/v3/account/whoami');
 
         return $response->toArray();
-    }
-
-    private function getScheme(): string
-    {
-        return $this->ssl ? 'https' : 'http';
     }
 
     private function request(string $method, string $uri, ?array $options = []): ResponseInterface

--- a/src/Symfony/Component/Notifier/Bridge/Matrix/MatrixTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Matrix/MatrixTransportFactory.php
@@ -29,7 +29,7 @@ class MatrixTransportFactory extends AbstractTransportFactory
         $token = $dsn->getRequiredOption('accessToken');
         $host = $dsn->getHost();
         $port = $dsn->getPort();
-        $ssl = $dsn->getBooleanOption('ssl', true);
+        $ssl = $this->getSsl($dsn) ?? true;
 
         return (new MatrixTransport($token, $ssl, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
     }

--- a/src/Symfony/Component/Notifier/Bridge/Matrix/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Matrix/composer.json
@@ -18,7 +18,7 @@
   "require": {
     "php": ">=8.4.1",
     "symfony/http-client": "^7.4|^8.0",
-    "symfony/notifier": "^7.4|^8.0",
+    "symfony/notifier": "^8.2",
     "symfony/uid": "^7.4|^8.0"
   },
   "autoload": {

--- a/src/Symfony/Component/Notifier/Bridge/Mattermost/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Mattermost/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 5.3
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Mattermost/MattermostTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mattermost/MattermostTransport.php
@@ -59,7 +59,7 @@ final class MattermostTransport extends AbstractTransport
         $options['message'] = $message->getSubject();
         $options['channel_id'] ??= $message->getRecipientId() ?: $this->channel;
 
-        $endpoint = \sprintf('https://%s/api/v4/posts', $this->getEndpoint());
+        $endpoint = \sprintf('%s://%s/api/v4/posts', $this->getHttpScheme(), $this->getEndpoint());
 
         $response = $this->client->request('POST', $endpoint, [
             'auth_bearer' => $this->token,

--- a/src/Symfony/Component/Notifier/Bridge/Mattermost/MattermostTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mattermost/MattermostTransportFactory.php
@@ -34,7 +34,7 @@ final class MattermostTransportFactory extends AbstractTransportFactory
         $host = $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new MattermostTransport($token, $channel, $path, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new MattermostTransport($token, $channel, $path, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/Mattermost/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Mattermost/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Mattermost\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/MessageBird/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/MessageBird/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 6.3
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/MessageBird/MessageBirdTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/MessageBird/MessageBirdTransport.php
@@ -58,7 +58,7 @@ final class MessageBirdTransport extends AbstractTransport
         $options['recipients'] = [$message->getPhone()];
         $options['body'] = $message->getSubject();
 
-        $endpoint = \sprintf('https://%s/messages', $this->getEndpoint());
+        $endpoint = \sprintf('%s://%s/messages', $this->getHttpScheme(), $this->getEndpoint());
         $response = $this->client->request('POST', $endpoint, [
             'auth_basic' => ['AccessKey', $this->token],
             'body' => array_filter($options),

--- a/src/Symfony/Component/Notifier/Bridge/MessageBird/MessageBirdTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/MessageBird/MessageBirdTransportFactory.php
@@ -33,7 +33,7 @@ final class MessageBirdTransportFactory extends AbstractTransportFactory
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new MessageBirdTransport($token, $from, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new MessageBirdTransport($token, $from, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/MessageBird/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/MessageBird/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\MessageBird\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/MessageMedia/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/MessageMedia/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 6.3
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/MessageMedia/MessageMediaTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/MessageMedia/MessageMediaTransport.php
@@ -64,7 +64,7 @@ final class MessageMediaTransport extends AbstractTransport
         $options['destination_number'] = $message->getPhone();
         $options['content'] = $message->getSubject();
 
-        $endpoint = \sprintf('https://%s/v1/messages', $this->getEndpoint());
+        $endpoint = \sprintf('%s://%s/v1/messages', $this->getHttpScheme(), $this->getEndpoint());
         $response = $this->client->request('POST', $endpoint, [
             'auth_basic' => [$this->apiKey, $this->apiSecret],
             'json' => [

--- a/src/Symfony/Component/Notifier/Bridge/MessageMedia/MessageMediaTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/MessageMedia/MessageMediaTransportFactory.php
@@ -34,7 +34,7 @@ final class MessageMediaTransportFactory extends AbstractTransportFactory
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new MessageMediaTransport($apiKey, $apiSecret, $from, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new MessageMediaTransport($apiKey, $apiSecret, $from, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/MessageMedia/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/MessageMedia/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\MessageMedia\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/MicrosoftTeams/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/MicrosoftTeams/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 5.3
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/MicrosoftTeams/MicrosoftTeamsTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/MicrosoftTeams/MicrosoftTeamsTransport.php
@@ -60,7 +60,7 @@ final class MicrosoftTeamsTransport extends AbstractTransport
         $options['text'] ??= $message->getSubject();
 
         $path = $message->getRecipientId() ?? $this->path;
-        $endpoint = \sprintf('https://%s%s', $this->getEndpoint(), $path);
+        $endpoint = \sprintf('%s://%s%s', $this->getHttpScheme(), $this->getEndpoint(), $path);
         $response = $this->client->request('POST', $endpoint, [
             'json' => $options,
         ]);

--- a/src/Symfony/Component/Notifier/Bridge/MicrosoftTeams/MicrosoftTeamsTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/MicrosoftTeams/MicrosoftTeamsTransportFactory.php
@@ -42,7 +42,7 @@ final class MicrosoftTeamsTransportFactory extends AbstractTransportFactory
             $path .= '?'.http_build_query($query, '', '&');
         }
 
-        return (new MicrosoftTeamsTransport($path, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new MicrosoftTeamsTransport($path, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/MicrosoftTeams/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/MicrosoftTeams/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\MicrosoftTeams\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Mobyt/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Mobyt/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 6.2
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Mobyt/MobytTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mobyt/MobytTransport.php
@@ -68,7 +68,8 @@ final class MobytTransport extends AbstractTransport
         $options['recipient'] = [$message->getPhone()];
         $options['sender'] = $message->getFrom() ?: $this->from;
 
-        $response = $this->client->request('POST', 'https://'.$this->getEndpoint().'/API/v1.0/REST/sms', [
+        $endpoint = \sprintf('%s://%s/API/v1.0/REST/sms', $this->getHttpScheme(), $this->getEndpoint());
+        $response = $this->client->request('POST', $endpoint, [
             'headers' => [
                 'user_key' => $this->accountSid,
                 'Access_token' => $this->authToken,

--- a/src/Symfony/Component/Notifier/Bridge/Mobyt/MobytTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mobyt/MobytTransportFactory.php
@@ -35,7 +35,7 @@ final class MobytTransportFactory extends AbstractTransportFactory
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new MobytTransport($accountSid, $authToken, $from, $typeQuality, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new MobytTransport($accountSid, $authToken, $from, $typeQuality, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/Mobyt/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Mobyt/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Mobyt\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Novu/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Novu/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add `$context` parameter to `NovuOptions`
  * Deprecate `NovuSubscriberRecipient::getOverrides()` and its `$overrides` constructor parameter, pass overrides to `NovuOptions` instead
+ * Add the `ssl` DSN option to send requests over plain HTTP
 
 6.4
 ---

--- a/src/Symfony/Component/Notifier/Bridge/Novu/NovuTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Novu/NovuTransport.php
@@ -70,7 +70,7 @@ class NovuTransport extends AbstractTransport
             'context' => $options['context'] ?? [],
         ];
 
-        $endpoint = \sprintf('https://%s/v1/events/trigger', $this->getEndpoint());
+        $endpoint = \sprintf('%s://%s/v1/events/trigger', $this->getHttpScheme(), $this->getEndpoint());
         $response = $this->client->request('POST', $endpoint, [
             'body' => $body,
             'headers' => [

--- a/src/Symfony/Component/Notifier/Bridge/Novu/NovuTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Novu/NovuTransportFactory.php
@@ -38,6 +38,6 @@ class NovuTransportFactory extends AbstractTransportFactory
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new NovuTransport($key, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new NovuTransport($key, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSsl($this->getSsl($dsn));
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Novu/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Novu/composer.json
@@ -19,7 +19,7 @@
         "php": ">=8.4.1",
         "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Novu\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Ntfy/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Ntfy/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 6.4
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Ntfy/NtfyTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Ntfy/NtfyTransport.php
@@ -33,11 +33,13 @@ final class NtfyTransport extends AbstractTransport
 
     public function __construct(
         private string $topic,
-        private bool $secureHttp = true,
+        bool $ssl = true,
         ?HttpClientInterface $client = null,
         ?EventDispatcherInterface $dispatcher = null,
     ) {
         parent::__construct($client, $dispatcher);
+
+        $this->setSsl($ssl);
     }
 
     public function getTopic(): string
@@ -92,7 +94,8 @@ final class NtfyTransport extends AbstractTransport
             $headers['Authorization'] = 'Bearer '.$this->password;
         }
 
-        $response = $this->client->request('POST', ($this->secureHttp ? 'https' : 'http').'://'.$this->getEndpoint(), [
+        $endpoint = \sprintf('%s://%s', $this->getHttpScheme(), $this->getEndpoint());
+        $response = $this->client->request('POST', $endpoint, [
             'headers' => $headers,
             'json' => $options,
         ]);

--- a/src/Symfony/Component/Notifier/Bridge/Ntfy/NtfyTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Ntfy/NtfyTransportFactory.php
@@ -30,13 +30,10 @@ final class NtfyTransportFactory extends AbstractTransportFactory
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $topic = substr($dsn->getPath(), 1);
 
-        if (\in_array($dsn->getOption('secureHttp', true), [0, false, 'false', 'off', 'no'], true)) {
-            $secureHttp = false;
-        } else {
-            $secureHttp = true;
-        }
+        // "secureHttp" is the legacy spelling of the "ssl" option
+        $ssl = $this->getSsl($dsn) ?? !\in_array($dsn->getOption('secureHttp', true), [0, false, 'false', 'off', 'no'], true);
 
-        $transport = (new NtfyTransport($topic, $secureHttp))->setHost($host);
+        $transport = (new NtfyTransport($topic, $ssl))->setHost($host);
         if ($port = $dsn->getPort()) {
             $transport->setPort($port);
         }

--- a/src/Symfony/Component/Notifier/Bridge/Ntfy/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/Ntfy/README.md
@@ -7,7 +7,7 @@ DSN example
 -----------
 
 ```
-NTFY_DSN=ntfy://[USER:PASSWORD]@default[:PORT]/TOPIC?[secureHttp=[on]]
+NTFY_DSN=ntfy://[USER:PASSWORD]@default[:PORT]/TOPIC?[ssl=[true]]
 ```
 where:
 - `URL` is the ntfy server which you are using
@@ -16,7 +16,7 @@ where:
 - `PORT` is an optional specific port.
 - `USER`and `PASSWORD` are username and password in case of access control supported by the server
 
-In case of a non-secure server, you can disable https by setting `secureHttp=off`. For example if you use a local [Ntfy Docker image](https://hub.docker.com/r/binwiederhier/ntfy) during development or testing.
+In case of a non-secure server, you can disable https by setting `ssl=false`. For example if you use a local [Ntfy Docker image](https://hub.docker.com/r/binwiederhier/ntfy) during development or testing.
 
 Sponsor
 -------

--- a/src/Symfony/Component/Notifier/Bridge/Ntfy/Tests/NtfyTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Ntfy/Tests/NtfyTransportTest.php
@@ -78,6 +78,25 @@ final class NtfyTransportTest extends TransportTestCase
         $this->assertSame('2BYIwRmvBKcv', $sentMessage->getMessageId());
     }
 
+    public function testSendUsesPlainHttpWhenSslIsDisabled()
+    {
+        $client = new MockHttpClient(function (string $method, string $url, array $options = []): ResponseInterface {
+            $this->assertStringStartsWith('http://ntfy.sh', $url);
+
+            return new MockResponse(json_encode(['id' => '2BYIwRmvBKcv', 'event' => 'message']));
+        });
+
+        (new NtfyTransport('test', false, $client))->send(new PushMessage('Hello', 'World'));
+
+        $client = new MockHttpClient(function (string $method, string $url, array $options = []): ResponseInterface {
+            $this->assertStringStartsWith('http://ntfy.sh', $url);
+
+            return new MockResponse(json_encode(['id' => '2BYIwRmvBKcv', 'event' => 'message']));
+        });
+
+        $this->createTransport($client)->setSsl(false)->send(new PushMessage('Hello', 'World'));
+    }
+
     public function testSendWithPassword()
     {
         $client = new MockHttpClient(function (string $method, string $url, array $options = []): ResponseInterface {

--- a/src/Symfony/Component/Notifier/Bridge/Ntfy/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Ntfy/composer.json
@@ -19,7 +19,7 @@
         "php": ">=8.4.1",
         "symfony/clock": "^7.4|^8.0",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Ntfy\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Octopush/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Octopush/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 6.2
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Octopush/OctopushTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Octopush/OctopushTransport.php
@@ -57,7 +57,7 @@ final class OctopushTransport extends AbstractTransport
 
         $from = $message->getFrom() ?: $this->from;
 
-        $endpoint = \sprintf('https://%s/api/sms/json', $this->getEndpoint());
+        $endpoint = \sprintf('%s://%s/api/sms/json', $this->getHttpScheme(), $this->getEndpoint());
 
         $response = $this->client->request('POST', $endpoint, [
             'body' => [

--- a/src/Symfony/Component/Notifier/Bridge/Octopush/OctopushTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Octopush/OctopushTransportFactory.php
@@ -36,7 +36,7 @@ final class OctopushTransportFactory extends AbstractTransportFactory
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new OctopushTransport($userLogin, $apiKey, $from, $type, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new OctopushTransport($userLogin, $apiKey, $from, $type, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/Octopush/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Octopush/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Octopush\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/OneSignal/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/OneSignal/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 7.1
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/OneSignal/OneSignalTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/OneSignal/OneSignalTransport.php
@@ -86,7 +86,8 @@ final class OneSignalTransport extends AbstractTransport
         $options['headings'] ??= ['en' => $message->getSubject()];
         $options['contents'] ??= ['en' => $message->getContent()];
 
-        $response = $this->client->request('POST', 'https://'.$this->getEndpoint().'/api/v1/notifications', [
+        $endpoint = \sprintf('%s://%s/api/v1/notifications', $this->getHttpScheme(), $this->getEndpoint());
+        $response = $this->client->request('POST', $endpoint, [
             'headers' => [
                 'Accept' => 'application/json',
                 'Authorization' => 'Basic '.$this->apiKey,

--- a/src/Symfony/Component/Notifier/Bridge/OneSignal/OneSignalTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/OneSignal/OneSignalTransportFactory.php
@@ -32,7 +32,7 @@ final class OneSignalTransportFactory extends AbstractTransportFactory
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new OneSignalTransport($appId, $apiKey, $defaultRecipientId, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new OneSignalTransport($appId, $apiKey, $defaultRecipientId, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/OneSignal/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/OneSignal/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\OneSignal\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/OrangeSms/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/OrangeSms/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 6.2
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/OrangeSms/OrangeSmsTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/OrangeSms/OrangeSmsTransport.php
@@ -56,7 +56,7 @@ final class OrangeSmsTransport extends AbstractTransport
         }
 
         $from = $message->getFrom() ?: $this->from;
-        $url = 'https://'.$this->getEndpoint().'/smsmessaging/v1/outbound/'.urlencode('tel:'.$from).'/requests';
+        $endpoint = \sprintf('%s://%s/smsmessaging/v1/outbound/%s/requests', $this->getHttpScheme(), $this->getEndpoint(), urlencode('tel:'.$from));
         $payload = [
             'outboundSMSMessageRequest' => [
                 'address' => 'tel:'.$message->getPhone(),
@@ -71,7 +71,7 @@ final class OrangeSmsTransport extends AbstractTransport
             $payload['outboundSMSMessageRequest']['senderName'] = urlencode($this->senderName);
         }
 
-        $response = $this->client->request('POST', $url, [
+        $response = $this->client->request('POST', $endpoint, [
             'auth_bearer' => $this->getAccessToken(),
             'json' => $payload,
         ]);
@@ -89,14 +89,14 @@ final class OrangeSmsTransport extends AbstractTransport
 
     private function getAccessToken(): string
     {
-        $url = 'https://'.$this->getEndpoint().'/oauth/v3/token';
+        $endpoint = \sprintf('%s://%s/oauth/v3/token', $this->getHttpScheme(), $this->getEndpoint());
         $headers = [
             'Content-Type' => 'application/x-www-form-urlencoded',
             'Accept' => 'application/json',
         ];
         $args = ['grant_type' => 'client_credentials'];
 
-        $response = $this->client->request('POST', $url, [
+        $response = $this->client->request('POST', $endpoint, [
             'auth_basic' => [$this->clientID, $this->clientSecret],
             'headers' => $headers,
             'body' => $args,

--- a/src/Symfony/Component/Notifier/Bridge/OrangeSms/OrangeSmsTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/OrangeSms/OrangeSmsTransportFactory.php
@@ -32,7 +32,7 @@ final class OrangeSmsTransportFactory extends AbstractTransportFactory
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new OrangeSmsTransport($user, $password, $from, $senderName, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new OrangeSmsTransport($user, $password, $from, $senderName, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/OrangeSms/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/OrangeSms/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\OrangeSms\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/OvhCloud/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/OvhCloud/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 7.3
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/OvhCloud/OvhCloudTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/OvhCloud/OvhCloudTransport.php
@@ -81,7 +81,7 @@ final class OvhCloudTransport extends AbstractTransport
             throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
         }
 
-        $endpoint = \sprintf('https://%s/1.0/sms/%s/jobs', $this->getEndpoint(), $this->serviceName);
+        $endpoint = \sprintf('%s://%s/1.0/sms/%s/jobs', $this->getHttpScheme(), $this->getEndpoint(), $this->serviceName);
 
         $content = [
             'charset' => 'UTF-8',
@@ -149,7 +149,7 @@ final class OvhCloudTransport extends AbstractTransport
      */
     private function calculateTimeDelta(): int
     {
-        $endpoint = \sprintf('https://%s/1.0/auth/time', $this->getEndpoint());
+        $endpoint = \sprintf('%s://%s/1.0/auth/time', $this->getHttpScheme(), $this->getEndpoint());
         $response = $this->client->request('GET', $endpoint);
 
         return $response->getContent() - time();

--- a/src/Symfony/Component/Notifier/Bridge/OvhCloud/OvhCloudTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/OvhCloud/OvhCloudTransportFactory.php
@@ -37,7 +37,7 @@ final class OvhCloudTransportFactory extends AbstractTransportFactory
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new OvhCloudTransport($applicationKey, $applicationSecret, $consumerKey, $serviceName, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSender($sender)->setNoStopClause($noStopClause);
+        return (new OvhCloudTransport($applicationKey, $applicationSecret, $consumerKey, $serviceName, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSender($sender)->setNoStopClause($noStopClause)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/OvhCloud/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/OvhCloud/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\OvhCloud\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/PagerDuty/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/PagerDuty/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 6.3
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/PagerDuty/PagerDutyTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/PagerDuty/PagerDutyTransport.php
@@ -56,7 +56,8 @@ final class PagerDutyTransport extends AbstractTransport
         $options['payload']['summary'] = $message->getContent();
         $options['payload']['source'] = $message->getSubject();
 
-        $response = $this->client->request('POST', 'https://'.$this->getEndpoint().'/v2/enqueue', [
+        $endpoint = \sprintf('%s://%s/v2/enqueue', $this->getHttpScheme(), $this->getEndpoint());
+        $response = $this->client->request('POST', $endpoint, [
             'headers' => [
                 'Accept' => 'application/json',
                 'Authorization' => $this->token,

--- a/src/Symfony/Component/Notifier/Bridge/PagerDuty/PagerDutyTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/PagerDuty/PagerDutyTransportFactory.php
@@ -32,7 +32,7 @@ final class PagerDutyTransportFactory extends AbstractTransportFactory
         $apiToken = $this->getUser($dsn);
         $host = $this->getHost($dsn);
 
-        return (new PagerDutyTransport($apiToken, $this->client, $this->dispatcher))->setHost($host);
+        return (new PagerDutyTransport($apiToken, $this->client, $this->dispatcher))->setHost($host)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/PagerDuty/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/PagerDuty/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\PagerDuty\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Plivo/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Plivo/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 6.3
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Plivo/PlivoTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Plivo/PlivoTransport.php
@@ -65,7 +65,7 @@ final class PlivoTransport extends AbstractTransport
             throw new InvalidArgumentException(\sprintf('The "From" number "%s" is not a valid phone number, shortcode, or alphanumeric sender ID. Phone number must contain only numbers and optional + character.', $options['src']));
         }
 
-        $endpoint = \sprintf('https://%s/v1/Account/%s/Message/', $this->getEndpoint(), $this->authId);
+        $endpoint = \sprintf('%s://%s/v1/Account/%s/Message/', $this->getHttpScheme(), $this->getEndpoint(), $this->authId);
         $response = $this->client->request('POST', $endpoint, [
             'auth_basic' => [$this->authId, $this->authToken],
             'json' => array_filter($options),

--- a/src/Symfony/Component/Notifier/Bridge/Plivo/PlivoTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Plivo/PlivoTransportFactory.php
@@ -36,7 +36,7 @@ final class PlivoTransportFactory extends AbstractTransportFactory
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new PlivoTransport($authId, $authToken, $from, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new PlivoTransport($authId, $authToken, $from, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/Plivo/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Plivo/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "require-dev": {
         "symfony/event-dispatcher": "^7.4|^8.0"

--- a/src/Symfony/Component/Notifier/Bridge/Prelude/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Prelude/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 8.1
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Prelude/PreludeTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Prelude/PreludeTransport.php
@@ -75,7 +75,8 @@ final class PreludeTransport extends AbstractTransport
 
         $body = array_merge($body, $options);
 
-        $response = $this->client->request('POST', 'https://'.$this->getEndpoint().'/v2/notify', [
+        $endpoint = \sprintf('%s://%s/v2/notify', $this->getHttpScheme(), $this->getEndpoint());
+        $response = $this->client->request('POST', $endpoint, [
             'json' => $body,
             'headers' => [
                 'Authorization' => 'Bearer '.$this->apiKey,

--- a/src/Symfony/Component/Notifier/Bridge/Prelude/PreludeTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Prelude/PreludeTransportFactory.php
@@ -33,7 +33,7 @@ final class PreludeTransportFactory extends AbstractTransportFactory
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new PreludeTransport($apiKey, $sender ?? '', $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new PreludeTransport($apiKey, $sender ?? '', $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/Prelude/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Prelude/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Symfony/Component/Notifier/Bridge/Primotexto/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Primotexto/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 7.2
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Primotexto/PrimotextoTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Primotexto/PrimotextoTransport.php
@@ -49,7 +49,7 @@ final class PrimotextoTransport extends AbstractTransport
         $options['number'] = $message->getPhone();
         $options['message'] = $message->getSubject();
 
-        $endpoint = \sprintf('https://%s/v2/notification/messages/send', $this->getEndpoint());
+        $endpoint = \sprintf('%s://%s/v2/notification/messages/send', $this->getHttpScheme(), $this->getEndpoint());
         $response = $this->client->request('POST', $endpoint, [
             'headers' => [
                 'X-Primotexto-ApiKey' => $this->apiKey,

--- a/src/Symfony/Component/Notifier/Bridge/Primotexto/PrimotextoTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Primotexto/PrimotextoTransportFactory.php
@@ -33,7 +33,7 @@ final class PrimotextoTransportFactory extends AbstractTransportFactory
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new PrimotextoTransport($apiKey, $from, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new PrimotextoTransport($apiKey, $from, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/Primotexto/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Primotexto/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Primotexto\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Pushover/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Pushover/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 6.3
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Pushover/PushoverTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Pushover/PushoverTransport.php
@@ -59,7 +59,7 @@ final class PushoverTransport extends AbstractTransport
         $options['token'] = $this->appToken;
         $options['user'] = $this->userKey;
 
-        $endpoint = \sprintf('https://%s/1/messages.json', $this->getEndpoint());
+        $endpoint = \sprintf('%s://%s/1/messages.json', $this->getHttpScheme(), $this->getEndpoint());
         $response = $this->client->request('POST', $endpoint, [
             'body' => $options,
         ]);

--- a/src/Symfony/Component/Notifier/Bridge/Pushover/PushoverTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Pushover/PushoverTransportFactory.php
@@ -32,7 +32,7 @@ final class PushoverTransportFactory extends AbstractTransportFactory
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new PushoverTransport($userKey, $appToken, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new PushoverTransport($userKey, $appToken, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/Pushover/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Pushover/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "require-dev": {
         "symfony/event-dispatcher": "^7.4|^8.0"

--- a/src/Symfony/Component/Notifier/Bridge/Pushy/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Pushy/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 7.1
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Pushy/PushyTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Pushy/PushyTransport.php
@@ -62,7 +62,7 @@ final class PushyTransport extends AbstractTransport
             throw new InvalidArgumentException(\sprintf('The "%s" transport required the "to" option to be set.', __CLASS__));
         }
 
-        $endpoint = \sprintf('https://%s?api_key=%s', $this->getEndpoint(), $this->apiKey);
+        $endpoint = \sprintf('%s://%s?api_key=%s', $this->getHttpScheme(), $this->getEndpoint(), $this->apiKey);
         $response = $this->client->request('POST', $endpoint, [
             'headers' => [
                 'Accept' => 'application/json',

--- a/src/Symfony/Component/Notifier/Bridge/Pushy/PushyTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Pushy/PushyTransportFactory.php
@@ -31,7 +31,7 @@ final class PushyTransportFactory extends AbstractTransportFactory
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new PushyTransport($apiKey, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new PushyTransport($apiKey, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/Pushy/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Pushy/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "require-dev": {
         "symfony/event-dispatcher": "^7.4|^8.0"

--- a/src/Symfony/Component/Notifier/Bridge/Redlink/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Redlink/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 6.4
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Redlink/RedlinkTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Redlink/RedlinkTransport.php
@@ -64,7 +64,7 @@ final class RedlinkTransport extends AbstractTransport
 
         $from = $message->getFrom() ?: $this->from;
 
-        $endpoint = \sprintf('https://%s/%s/sms', $this->getEndpoint(), $this->version);
+        $endpoint = \sprintf('%s://%s/%s/sms', $this->getHttpScheme(), $this->getEndpoint(), $this->version);
 
         $response = $this->client->request('POST', $endpoint, [
             'headers' => [

--- a/src/Symfony/Component/Notifier/Bridge/Redlink/RedlinkTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Redlink/RedlinkTransportFactory.php
@@ -35,7 +35,7 @@ final class RedlinkTransportFactory extends AbstractTransportFactory
         $from = $dsn->getRequiredOption('from');
         $version = $dsn->getRequiredOption('version');
 
-        return (new RedlinkTransport($apiKey, $appToken, $from, $version, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new RedlinkTransport($apiKey, $appToken, $from, $version, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/Redlink/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Redlink/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Redlink\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/RingCentral/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/RingCentral/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 6.3
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/RingCentral/RingCentralTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/RingCentral/RingCentralTransport.php
@@ -63,7 +63,7 @@ final class RingCentralTransport extends AbstractTransport
             throw new InvalidArgumentException(\sprintf('The "From" number "%s" is not a valid phone number. Phone number must be in E.164 format.', $options['from']['phoneNumber'] ?? ''));
         }
 
-        $endpoint = \sprintf('https://%s/restapi/v1.0/account/~/extension/~/sms', $this->getEndpoint());
+        $endpoint = \sprintf('%s://%s/restapi/v1.0/account/~/extension/~/sms', $this->getHttpScheme(), $this->getEndpoint());
         $response = $this->client->request('POST', $endpoint, [
             'auth_bearer' => $this->apiToken,
             'json' => array_filter($options),

--- a/src/Symfony/Component/Notifier/Bridge/RingCentral/RingCentralTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/RingCentral/RingCentralTransportFactory.php
@@ -33,7 +33,7 @@ final class RingCentralTransportFactory extends AbstractTransportFactory
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new RingCentralTransport($apiKey, $from, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new RingCentralTransport($apiKey, $from, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/RingCentral/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/RingCentral/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "require-dev": {
         "symfony/event-dispatcher": "^7.4|^8.0"

--- a/src/Symfony/Component/Notifier/Bridge/RocketChat/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/RocketChat/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 6.2
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/RocketChat/RocketChatTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/RocketChat/RocketChatTransport.php
@@ -60,7 +60,7 @@ final class RocketChatTransport extends AbstractTransport
         $options['channel'] ??= $message->getRecipientId() ?: $this->chatChannel;
         $options['text'] = $message->getSubject();
 
-        $endpoint = \sprintf('https://%s/hooks/%s', $this->getEndpoint(), $this->accessToken);
+        $endpoint = \sprintf('%s://%s/hooks/%s', $this->getHttpScheme(), $this->getEndpoint(), $this->accessToken);
         $response = $this->client->request('POST', $endpoint, [
             'json' => array_filter($options),
         ]);

--- a/src/Symfony/Component/Notifier/Bridge/RocketChat/RocketChatTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/RocketChat/RocketChatTransportFactory.php
@@ -33,7 +33,7 @@ final class RocketChatTransportFactory extends AbstractTransportFactory
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new RocketChatTransport($accessToken, $channel, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new RocketChatTransport($accessToken, $channel, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/RocketChat/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/RocketChat/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\RocketChat\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Sendberry/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Sendberry/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 6.2
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Sendberry/SendberryTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sendberry/SendberryTransport.php
@@ -68,7 +68,7 @@ final class SendberryTransport extends AbstractTransport
             }
         }
 
-        $endpoint = \sprintf('https://%s/SMS/SEND', $this->getEndpoint());
+        $endpoint = \sprintf('%s://%s/SMS/SEND', $this->getHttpScheme(), $this->getEndpoint());
         $response = $this->client->request('POST', $endpoint, [
             'json' => [
                 'from' => $from,

--- a/src/Symfony/Component/Notifier/Bridge/Sendberry/SendberryTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sendberry/SendberryTransportFactory.php
@@ -31,7 +31,7 @@ final class SendberryTransportFactory extends AbstractTransportFactory
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new SendberryTransport($this->getUser($dsn), $this->getPassword($dsn), $dsn->getRequiredOption('auth_key'), $dsn->getRequiredOption('from'), $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new SendberryTransport($this->getUser($dsn), $this->getPassword($dsn), $dsn->getRequiredOption('auth_key'), $dsn->getRequiredOption('from'), $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/Sendberry/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Sendberry/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Sendberry\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Sevenio/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Sevenio/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 7.1
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Sevenio/SevenIoTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sevenio/SevenIoTransport.php
@@ -53,7 +53,8 @@ final class SevenIoTransport extends AbstractTransport
             throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
         }
 
-        $response = $this->client->request('POST', \sprintf('https://%s/api/sms', $this->getEndpoint()), [
+        $endpoint = \sprintf('%s://%s/api/sms', $this->getHttpScheme(), $this->getEndpoint());
+        $response = $this->client->request('POST', $endpoint, [
             'headers' => [
                 'Content-Type' => 'application/json',
                 'SentWith' => 'symfony/sevenio-notifier',

--- a/src/Symfony/Component/Notifier/Bridge/Sevenio/SevenIoTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sevenio/SevenIoTransportFactory.php
@@ -33,7 +33,7 @@ final class SevenIoTransportFactory extends AbstractTransportFactory
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new SevenIoTransport($apiKey, $from, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new SevenIoTransport($apiKey, $from, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/Sevenio/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Sevenio/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Sevenio\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/SimpleTextin/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/SimpleTextin/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 6.3
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/SimpleTextin/SimpleTextinTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/SimpleTextin/SimpleTextinTransport.php
@@ -56,7 +56,7 @@ final class SimpleTextinTransport extends AbstractTransport
         if (!$message instanceof SmsMessage) {
             throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
         }
-        $endpoint = \sprintf('https://%s/v2/api/messages', $this->getEndpoint());
+        $endpoint = \sprintf('%s://%s/v2/api/messages', $this->getHttpScheme(), $this->getEndpoint());
 
         $options = [];
         $options['text'] = $message->getSubject();

--- a/src/Symfony/Component/Notifier/Bridge/SimpleTextin/SimpleTextinTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/SimpleTextin/SimpleTextinTransportFactory.php
@@ -35,7 +35,7 @@ final class SimpleTextinTransportFactory extends AbstractTransportFactory
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new SimpleTextinTransport($apiKey, $from, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new SimpleTextinTransport($apiKey, $from, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/SimpleTextin/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/SimpleTextin/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "require-dev": {
         "symfony/event-dispatcher": "^7.4|^8.0"

--- a/src/Symfony/Component/Notifier/Bridge/Sinch/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Sinch/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 6.2
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Sinch/SinchTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sinch/SinchTransport.php
@@ -54,7 +54,7 @@ final class SinchTransport extends AbstractTransport
             throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
         }
 
-        $endpoint = \sprintf('https://%s/xms/v1/%s/batches', $this->getEndpoint(), $this->accountSid);
+        $endpoint = \sprintf('%s://%s/xms/v1/%s/batches', $this->getHttpScheme(), $this->getEndpoint(), $this->accountSid);
         $response = $this->client->request('POST', $endpoint, [
             'auth_bearer' => $this->authToken,
             'json' => [

--- a/src/Symfony/Component/Notifier/Bridge/Sinch/SinchTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sinch/SinchTransportFactory.php
@@ -34,7 +34,7 @@ final class SinchTransportFactory extends AbstractTransportFactory
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new SinchTransport($accountSid, $authToken, $from, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new SinchTransport($accountSid, $authToken, $from, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/Sinch/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Sinch/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Sinch\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Sipgate/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Sipgate/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 7.2
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Sipgate/SipgateTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sipgate/SipgateTransport.php
@@ -54,7 +54,7 @@ final class SipgateTransport extends AbstractTransport
             throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
         }
 
-        $endpoint = \sprintf('https://%s/v2/sessions/sms', $this->getEndpoint());
+        $endpoint = \sprintf('%s://%s/v2/sessions/sms', $this->getHttpScheme(), $this->getEndpoint());
 
         $options = [];
         $options['smsId'] = $this->senderId;

--- a/src/Symfony/Component/Notifier/Bridge/Sipgate/SipgateTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sipgate/SipgateTransportFactory.php
@@ -32,7 +32,7 @@ final class SipgateTransportFactory extends AbstractTransportFactory
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new SipgateTransport($tokenId, $token, $senderId, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new SipgateTransport($tokenId, $token, $senderId, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/Sipgate/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Sipgate/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Symfony/Component/Notifier/Bridge/Slack/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add `SlackPlainTextInputBlock` to add a plain-text input to a Slack message
+ * Add the `ssl` DSN option to send requests over plain HTTP
 
 7.4
 ---

--- a/src/Symfony/Component/Notifier/Bridge/Slack/SlackTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/SlackTransport.php
@@ -77,7 +77,8 @@ final class SlackTransport extends AbstractTransport
             $apiMethod = 'chat.scheduleMessage';
         }
 
-        $response = $this->client->request('POST', 'https://'.$this->getEndpoint().'/api/'.$apiMethod, [
+        $endpoint = \sprintf('%s://%s/api/%s', $this->getHttpScheme(), $this->getEndpoint(), $apiMethod);
+        $response = $this->client->request('POST', $endpoint, [
             'json' => array_filter($options, static fn ($value): bool => !\in_array($value, ['', [], null], true)),
             'auth_bearer' => $this->accessToken,
             'headers' => [

--- a/src/Symfony/Component/Notifier/Bridge/Slack/SlackTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/SlackTransportFactory.php
@@ -31,7 +31,7 @@ final class SlackTransportFactory extends AbstractTransportFactory
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new SlackTransport($accessToken, $channel, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new SlackTransport($accessToken, $channel, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/Slack/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Slack\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/SmsBiuras/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/SmsBiuras/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 6.2
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/SmsBiuras/SmsBiurasTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/SmsBiuras/SmsBiurasTransport.php
@@ -69,7 +69,7 @@ final class SmsBiurasTransport extends AbstractTransport
             throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
         }
 
-        $endpoint = \sprintf('https://%s/api?', $this->getEndpoint());
+        $endpoint = \sprintf('%s://%s/api?', $this->getHttpScheme(), $this->getEndpoint());
 
         $response = $this->client->request('GET', $endpoint, [
             'query' => [

--- a/src/Symfony/Component/Notifier/Bridge/SmsBiuras/SmsBiurasTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/SmsBiuras/SmsBiurasTransportFactory.php
@@ -35,7 +35,7 @@ final class SmsBiurasTransportFactory extends AbstractTransportFactory
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new SmsBiurasTransport($uid, $apiKey, $from, $testMode, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new SmsBiurasTransport($uid, $apiKey, $from, $testMode, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/SmsBiuras/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/SmsBiuras/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\SmsBiuras\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/SmsFactor/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/SmsFactor/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 6.2
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/SmsFactor/SmsFactorTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/SmsFactor/SmsFactorTransport.php
@@ -68,7 +68,8 @@ final class SmsFactorTransport extends AbstractTransport
             'pushtype' => $this->pushType?->value,
         ];
 
-        $response = $this->client->request('GET', 'https://'.$this->getEndpoint().'/send', [
+        $endpoint = \sprintf('%s://%s/send', $this->getHttpScheme(), $this->getEndpoint());
+        $response = $this->client->request('GET', $endpoint, [
             'query' => array_filter($query),
             'auth_bearer' => $this->tokenApi,
             'headers' => [

--- a/src/Symfony/Component/Notifier/Bridge/SmsFactor/SmsFactorTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/SmsFactor/SmsFactorTransportFactory.php
@@ -35,7 +35,7 @@ final class SmsFactorTransportFactory extends AbstractTransportFactory
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new SmsFactorTransport($tokenApi, $sender, $pushType, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new SmsFactorTransport($tokenApi, $sender, $pushType, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/SmsFactor/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/SmsFactor/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\SmsFactor\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/SmsProxima/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/SmsProxima/CHANGELOG.md
@@ -5,3 +5,4 @@ CHANGELOG
 ---
 
  * Add the bridge
+ * Add the `ssl` DSN option to send requests over plain HTTP

--- a/src/Symfony/Component/Notifier/Bridge/SmsProxima/SmsProximaTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/SmsProxima/SmsProximaTransport.php
@@ -85,7 +85,8 @@ final class SmsProximaTransport extends AbstractTransport
             }
         }
 
-        $response = $this->client->request('POST', 'https://'.$this->getEndpoint().'/api/sms/send', [
+        $endpoint = \sprintf('%s://%s/api/sms/send', $this->getHttpScheme(), $this->getEndpoint());
+        $response = $this->client->request('POST', $endpoint, [
             'headers' => $headers,
             'json' => $body,
         ]);

--- a/src/Symfony/Component/Notifier/Bridge/SmsProxima/SmsProximaTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/SmsProxima/SmsProximaTransportFactory.php
@@ -34,7 +34,8 @@ final class SmsProximaTransportFactory extends AbstractTransportFactory
 
         return (new SmsProximaTransport($token, $from, $this->client, $this->dispatcher))
             ->setHost($dsn->getHost())
-            ->setPort($dsn->getPort());
+            ->setPort($dsn->getPort())
+            ->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/SmsProxima/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/SmsProxima/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\SmsProxima\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/SmsSluzba/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/SmsSluzba/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 7.1
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/SmsSluzba/SmsSluzbaTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/SmsSluzba/SmsSluzbaTransport.php
@@ -55,7 +55,8 @@ final class SmsSluzbaTransport extends AbstractTransport
         }
 
         $endpoint = \sprintf(
-            'https://%s/apixml30/receiver?login=%s&password=%s',
+            '%s://%s/apixml30/receiver?login=%s&password=%s',
+            $this->getHttpScheme(),
             $this->getEndpoint(),
             $this->username,
             $this->password

--- a/src/Symfony/Component/Notifier/Bridge/SmsSluzba/SmsSluzbaTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/SmsSluzba/SmsSluzbaTransportFactory.php
@@ -33,7 +33,7 @@ final class SmsSluzbaTransportFactory extends AbstractTransportFactory
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new SmsSluzbaTransport($username, $password, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new SmsSluzbaTransport($username, $password, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/SmsSluzba/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/SmsSluzba/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0",
+        "symfony/notifier": "^8.2",
         "symfony/serializer": "^7.4|^8.0"
     },
     "autoload": {

--- a/src/Symfony/Component/Notifier/Bridge/Smsapi/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Smsapi/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 6.3
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Smsapi/SmsapiTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Smsapi/SmsapiTransport.php
@@ -97,7 +97,7 @@ final class SmsapiTransport extends AbstractTransport
             $body['from'] = $from;
         }
 
-        $endpoint = \sprintf('https://%s/sms.do', $this->getEndpoint());
+        $endpoint = \sprintf('%s://%s/sms.do', $this->getHttpScheme(), $this->getEndpoint());
         $response = $this->client->request('POST', $endpoint, [
             'auth_bearer' => $this->authToken,
             'body' => $body,

--- a/src/Symfony/Component/Notifier/Bridge/Smsapi/SmsapiTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Smsapi/SmsapiTransportFactory.php
@@ -35,7 +35,7 @@ final class SmsapiTransportFactory extends AbstractTransportFactory
         $test = $dsn->getBooleanOption('test');
         $port = $dsn->getPort();
 
-        return (new SmsapiTransport($authToken, $from, $this->client, $this->dispatcher))->setFast($fast)->setHost($host)->setPort($port)->setTest($test);
+        return (new SmsapiTransport($authToken, $from, $this->client, $this->dispatcher))->setFast($fast)->setHost($host)->setPort($port)->setTest($test)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/Smsapi/Tests/SmsapiTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Smsapi/Tests/SmsapiTransportTest.php
@@ -73,6 +73,25 @@ final class SmsapiTransportTest extends TransportTestCase
         }
     }
 
+    #[DataProvider('schemeProvider')]
+    public function testSendUsesTheConfiguredScheme(?bool $ssl, string $expectedEndpoint)
+    {
+        $client = new MockHttpClient(function (string $method, string $url) use ($expectedEndpoint): MockResponse {
+            $this->assertSame($expectedEndpoint, $url);
+
+            return new MockResponse('{"list":[{"id":"1"}]}');
+        });
+
+        self::createTransport($client)->setSsl($ssl)->send(new SmsMessage('0611223344', 'Hello!'));
+    }
+
+    public static function schemeProvider(): iterable
+    {
+        yield 'https by default' => [null, 'https://test.host/sms.do'];
+        yield 'plain http when ssl is disabled' => [false, 'http://test.host/sms.do'];
+        yield 'https when ssl is enabled' => [true, 'https://test.host/sms.do'];
+    }
+
     #[DataProvider('responseProvider')]
     public function testThrowExceptionWhenMessageWasNotSent(int $statusCode, string $content, string $errorMessage)
     {

--- a/src/Symfony/Component/Notifier/Bridge/Smsapi/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Smsapi/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Smsapi\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Smsbox/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Smsbox/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 7.1
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Smsbox/SmsboxTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Smsbox/SmsboxTransport.php
@@ -117,7 +117,8 @@ final class SmsboxTransport extends AbstractTransport
             unset($options['variable']);
         }
 
-        $response = $this->client->request('POST', \sprintf('https://%s/1.1/api.php', $this->getEndpoint()), [
+        $endpoint = \sprintf('%s://%s/1.1/api.php', $this->getHttpScheme(), $this->getEndpoint());
+        $response = $this->client->request('POST', $endpoint, [
             'headers' => [
                 'Content-Type' => 'application/x-www-form-urlencoded',
                 'Authorization' => 'App '.$this->apiKey,

--- a/src/Symfony/Component/Notifier/Bridge/Smsbox/SmsboxTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Smsbox/SmsboxTransportFactory.php
@@ -45,7 +45,8 @@ final class SmsboxTransportFactory extends AbstractTransportFactory
 
         return (new SmsboxTransport($apiKey, $mode, $strategy, $sender, $this->client, $this->dispatcher))
             ->setHost($host)
-            ->setPort($port);
+            ->setPort($port)
+            ->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/Smsbox/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Smsbox/composer.json
@@ -27,7 +27,7 @@
         "php": ">=8.4.1",
         "symfony/clock": "^7.4|^8.0",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "require-dev": {
         "symfony/webhook": "^7.4|^8.0"

--- a/src/Symfony/Component/Notifier/Bridge/Smsc/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Smsc/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 6.2
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Smsc/SmscTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Smsc/SmscTransport.php
@@ -67,7 +67,7 @@ final class SmscTransport extends AbstractTransport
             'time' => '0-24',
         ];
 
-        $endpoint = \sprintf('https://%s/sys/send.php', $this->getEndpoint());
+        $endpoint = \sprintf('%s://%s/sys/send.php', $this->getHttpScheme(), $this->getEndpoint());
         $response = $this->client->request('POST', $endpoint, ['body' => $body]);
 
         try {

--- a/src/Symfony/Component/Notifier/Bridge/Smsc/SmscTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Smsc/SmscTransportFactory.php
@@ -33,7 +33,7 @@ final class SmscTransportFactory extends AbstractTransportFactory
         $from = $dsn->getRequiredOption('from');
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
 
-        return (new SmscTransport($login, $password, $from, $this->client, $this->dispatcher))->setHost($host);
+        return (new SmscTransport($login, $password, $from, $this->client, $this->dispatcher))->setHost($host)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/Smsc/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Smsc/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Smsc\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Smsense/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Smsense/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 7.1
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Smsense/SmsenseTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Smsense/SmsenseTransport.php
@@ -55,7 +55,7 @@ final class SmsenseTransport extends AbstractTransport
 
         $from = $message->getFrom() ?: $this->from;
 
-        $endpoint = \sprintf('https://%s/rest/send_sms?from=%s&message=%s&to=%s', $this->getEndpoint(), $from, $message->getSubject(), $message->getPhone());
+        $endpoint = \sprintf('%s://%s/rest/send_sms?from=%s&message=%s&to=%s', $this->getHttpScheme(), $this->getEndpoint(), $from, $message->getSubject(), $message->getPhone());
         $response = $this->client->request('POST', $endpoint, [
             'auth_bearer' => $this->authToken,
             'headers' => [

--- a/src/Symfony/Component/Notifier/Bridge/Smsense/SmsenseTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Smsense/SmsenseTransportFactory.php
@@ -31,7 +31,7 @@ final class SmsenseTransportFactory extends AbstractTransportFactory
         $authToken = $this->getUser($dsn);
         $port = $dsn->getPort();
 
-        return (new SmsenseTransport($authToken, $from, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new SmsenseTransport($authToken, $from, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/Smsense/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Smsense/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Smsense\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Smsmode/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Smsmode/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 6.3
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Smsmode/SmsmodeTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Smsmode/SmsmodeTransport.php
@@ -57,7 +57,7 @@ final class SmsmodeTransport extends AbstractTransport
             throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
         }
 
-        $endpoint = \sprintf('https://%s/sms/v1/messages', $this->getEndpoint());
+        $endpoint = \sprintf('%s://%s/sms/v1/messages', $this->getHttpScheme(), $this->getEndpoint());
 
         $options = $message->getOptions()?->toArray() ?? [];
         $options['body']['text'] = $message->getSubject();

--- a/src/Symfony/Component/Notifier/Bridge/Smsmode/SmsmodeTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Smsmode/SmsmodeTransportFactory.php
@@ -35,7 +35,7 @@ final class SmsmodeTransportFactory extends AbstractTransportFactory
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new SmsmodeTransport($apiKey, $from, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new SmsmodeTransport($apiKey, $from, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/Smsmode/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Smsmode/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "require-dev": {
         "symfony/event-dispatcher": "^7.4|^8.0"

--- a/src/Symfony/Component/Notifier/Bridge/SpotHit/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/SpotHit/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 6.4
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/SpotHit/SpotHitTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/SpotHit/SpotHitTransport.php
@@ -89,7 +89,7 @@ final class SpotHitTransport extends AbstractTransport
             throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
         }
 
-        $endpoint = \sprintf('https://www.%s/api/envoyer/sms', $this->getEndpoint());
+        $endpoint = \sprintf('%s://www.%s/api/envoyer/sms', $this->getHttpScheme(), $this->getEndpoint());
         $response = $this->client->request('POST', $endpoint, [
             'body' => [
                 'key' => $this->token,

--- a/src/Symfony/Component/Notifier/Bridge/SpotHit/SpotHitTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/SpotHit/SpotHitTransportFactory.php
@@ -35,7 +35,7 @@ final class SpotHitTransportFactory extends AbstractTransportFactory
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new SpotHitTransport($token, $from, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSmsLong($smsLong)->setLongNBr($smsLongNBr);
+        return (new SpotHitTransport($token, $from, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSmsLong($smsLong)->setLongNBr($smsLongNBr)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/SpotHit/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/SpotHit/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\SpotHit\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Sweego/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Sweego/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add support for the `sms_clicked` and `sms_stop` webhook events
  * Allow updating region in SweegoOptions
+ * Add the `ssl` DSN option to send requests over plain HTTP
 
 7.2
 ---

--- a/src/Symfony/Component/Notifier/Bridge/Sweego/SweegoTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sweego/SweegoTransport.php
@@ -86,7 +86,7 @@ final class SweegoTransport extends AbstractTransport
         $body = $this->setShortenUrls($body, $options);
         $body = $this->setShortenWithProtocol($body, $options);
 
-        $endpoint = \sprintf('https://%s/send', $this->getEndpoint());
+        $endpoint = \sprintf('%s://%s/send', $this->getHttpScheme(), $this->getEndpoint());
         $response = $this->client->request('POST', $endpoint, [
             'headers' => [
                 'Api-Key' => $this->apiKey,

--- a/src/Symfony/Component/Notifier/Bridge/Sweego/SweegoTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sweego/SweegoTransportFactory.php
@@ -38,7 +38,7 @@ final class SweegoTransportFactory extends AbstractTransportFactory
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new SweegoTransport($apiKey, $region, $campaignType, $bat, $campaignId, $shortenUrls, $shortenWithProtocol, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new SweegoTransport($apiKey, $region, $campaignType, $bat, $campaignId, $shortenUrls, $shortenWithProtocol, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/Sweego/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Sweego/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "require-dev": {
         "symfony/webhook": "^7.4|^8.0"

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add support for editing media messages via the `editMessageMedia` and `editMessageCaption` API methods
+ * Add the `ssl` DSN option to send requests over plain HTTP
 
 8.1
 ---

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/README.md
@@ -7,13 +7,13 @@ DSN example
 -----------
 
 ```
-TELEGRAM_DSN=telegram://TOKEN@default?channel=CHAT_ID&sslmode=SSLMODE
+TELEGRAM_DSN=telegram://TOKEN@default?channel=CHAT_ID&ssl=SSL
 ```
 
 where:
  - `TOKEN` is your Telegram token
  - `CHAT_ID` is your Telegram chat id
- - `SSLMODE` https is used by default. It can be changed by setting value to `disable`, http will be used
+ - `SSL` https is used by default. It can be changed by setting value to `false`, http will be used
 
 Interacting with local API server instead of official Telegram API
 ------------------------------------------------------------------
@@ -25,7 +25,7 @@ can only accept `http` traffic.
 
 Example:
 ```
-TELEGRAM_DSN=telegram://TOKEN@localhost:5001?channel=CHAT_ID&sslmode=disable
+TELEGRAM_DSN=telegram://TOKEN@localhost:5001?channel=CHAT_ID&ssl=false
 ```
 
 Caution: Disabling the use of the `https` protocol can pose a security risk.

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramTransport.php
@@ -56,9 +56,11 @@ final class TelegramTransport extends AbstractTransport
         private ?string $chatChannel = null,
         ?HttpClientInterface $client = null,
         ?EventDispatcherInterface $dispatcher = null,
-        private readonly bool $disableHttps = false,
+        bool $disableHttps = false,
     ) {
         parent::__construct($client, $dispatcher);
+
+        $this->setSsl(!$disableHttps);
     }
 
     public function __toString(): string
@@ -67,7 +69,7 @@ final class TelegramTransport extends AbstractTransport
 
         $formattedOptions = http_build_query([
             'channel' => $this->chatChannel,
-            'sslmode' => $this->disableHttps ? 'disable' : null,
+            'ssl' => 'http' === $this->getHttpScheme() ? 'false' : null,
         ], '', '&');
 
         if ('' !== $formattedOptions) {
@@ -128,9 +130,7 @@ final class TelegramTransport extends AbstractTransport
         }
         unset($options['edit_caption']);
         $options = $this->expandOptions($options, 'contact', 'location', 'venue');
-        $protocolSchema = $this->disableHttps ? 'http' : 'https';
-
-        $endpoint = \sprintf('%s://%s/bot%s/%s', $protocolSchema, $this->getEndpoint(), $this->token, $method);
+        $endpoint = \sprintf('%s://%s/bot%s/%s', $this->getHttpScheme(), $this->getEndpoint(), $this->token, $method);
 
         $response = $this->client->request('POST', $endpoint, [
             $optionsContainer => array_filter($options),

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramTransportFactory.php
@@ -31,9 +31,10 @@ final class TelegramTransportFactory extends AbstractTransportFactory
         $channel = $dsn->getOption('channel');
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
-        $disableHttps = 'disable' === $dsn->getOption('sslmode');
+        // "sslmode=disable" is the legacy spelling of the "ssl=false" option
+        $ssl = $this->getSsl($dsn) ?? 'disable' !== $dsn->getOption('sslmode');
 
-        return (new TelegramTransport($token, $channel, $this->client, $this->dispatcher, $disableHttps))->setHost($host)->setPort($port);
+        return (new TelegramTransport($token, $channel, $this->client, $this->dispatcher, !$ssl))->setHost($host)->setPort($port);
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/Tests/TelegramTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/Tests/TelegramTransportFactoryTest.php
@@ -29,7 +29,11 @@ final class TelegramTransportFactoryTest extends AbstractTransportFactoryTestCas
         yield ['telegram://host.test?channel=testChannel', 'telegram://user:password@host.test?channel=testChannel'];
 
         // Tests for `sslmode` option
-        yield ['telegram://host.test?channel=testChannel&sslmode=disable', 'telegram://user:password@host.test?channel=testChannel&sslmode=disable'];
+        yield ['telegram://host.test?channel=testChannel&ssl=false', 'telegram://user:password@host.test?channel=testChannel&sslmode=disable'];
+
+        // the "ssl" option is the unified spelling of "sslmode"
+        yield ['telegram://host.test?channel=testChannel&ssl=false', 'telegram://user:password@host.test?channel=testChannel&ssl=false'];
+        yield ['telegram://host.test?channel=testChannel', 'telegram://user:password@host.test?channel=testChannel&ssl=true'];
     }
 
     public static function supportsProvider(): iterable

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/Tests/TelegramTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/Tests/TelegramTransportTest.php
@@ -43,8 +43,8 @@ final class TelegramTransportTest extends TransportTestCase
     {
         yield ['telegram://api.telegram.org', self::createTransport()];
         yield ['telegram://api.telegram.org?channel=testChannel', self::createTransport(null, 'testChannel')];
-        yield ['telegram://api.telegram.org?sslmode=disable', self::createTransport(null, null, true)];
-        yield ['telegram://api.telegram.org?channel=testChannel&sslmode=disable', self::createTransport(null, 'testChannel', true)];
+        yield ['telegram://api.telegram.org?ssl=false', self::createTransport(null, null, true)];
+        yield ['telegram://api.telegram.org?channel=testChannel&ssl=false', self::createTransport(null, 'testChannel', true)];
     }
 
     public static function supportedMessagesProvider(): iterable

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/composer.json
@@ -19,7 +19,7 @@
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
         "symfony/mime": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Telegram\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Telnyx/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Telnyx/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 6.2
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Telnyx/TelnyxTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telnyx/TelnyxTransport.php
@@ -73,7 +73,7 @@ final class TelnyxTransport extends AbstractTransport
             }
         }
 
-        $endpoint = \sprintf('https://%s/v2/messages', $this->getEndpoint());
+        $endpoint = \sprintf('%s://%s/v2/messages', $this->getHttpScheme(), $this->getEndpoint());
         $response = $this->client->request('POST', $endpoint, [
             'auth_bearer' => $this->apiKey,
             'json' => [

--- a/src/Symfony/Component/Notifier/Bridge/Telnyx/TelnyxTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telnyx/TelnyxTransportFactory.php
@@ -34,7 +34,7 @@ final class TelnyxTransportFactory extends AbstractTransportFactory
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new TelnyxTransport($apiKey, $from, $messagingProfileId, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new TelnyxTransport($apiKey, $from, $messagingProfileId, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/Telnyx/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Telnyx/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Telnyx\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Termii/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Termii/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 6.3
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Termii/TermiiTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Termii/TermiiTransport.php
@@ -68,7 +68,7 @@ final class TermiiTransport extends AbstractTransport
             throw new InvalidArgumentException(\sprintf('The "From" number "%s" is not a valid phone number, shortcode, or alphanumeric sender ID.', $options['from']));
         }
 
-        $endpoint = \sprintf('https://%s/api/sms/send', $this->getEndpoint());
+        $endpoint = \sprintf('%s://%s/api/sms/send', $this->getHttpScheme(), $this->getEndpoint());
         $response = $this->client->request('POST', $endpoint, [
             'json' => array_filter($options),
         ]);

--- a/src/Symfony/Component/Notifier/Bridge/Termii/TermiiTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Termii/TermiiTransportFactory.php
@@ -36,7 +36,7 @@ final class TermiiTransportFactory extends AbstractTransportFactory
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new TermiiTransport($apiKey, $from, $channel, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new TermiiTransport($apiKey, $from, $channel, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/Termii/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Termii/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "require-dev": {
         "symfony/event-dispatcher": "^7.4|^8.0"

--- a/src/Symfony/Component/Notifier/Bridge/Threads/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Threads/CHANGELOG.md
@@ -5,3 +5,4 @@ CHANGELOG
 ---
 
  * Add the bridge
+ * Add the `ssl` DSN option to send requests over plain HTTP

--- a/src/Symfony/Component/Notifier/Bridge/Threads/ThreadsTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Threads/ThreadsTransport.php
@@ -197,7 +197,7 @@ final class ThreadsTransport extends AbstractTransport
 
     private function graphUrl(string $path): string
     {
-        return \sprintf('https://%s/%s/%s', $this->getEndpoint(), $this->apiVersion, ltrim($path, '/'));
+        return \sprintf('%s://%s/%s/%s', $this->getHttpScheme(), $this->getEndpoint(), $this->apiVersion, ltrim($path, '/'));
     }
 
     /**

--- a/src/Symfony/Component/Notifier/Bridge/Threads/ThreadsTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Threads/ThreadsTransportFactory.php
@@ -38,7 +38,7 @@ final class ThreadsTransportFactory extends AbstractTransportFactory
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new ThreadsTransport($accessToken, $userId, $apiVersion, $this->client, $this->dispatcher, $pollAttempts, $pollDelay))->setHost($host)->setPort($port);
+        return (new ThreadsTransport($accessToken, $userId, $apiVersion, $this->client, $this->dispatcher, $pollAttempts, $pollDelay))->setHost($host)->setPort($port)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/Threads/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Threads/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Symfony/Component/Notifier/Bridge/TurboSms/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/TurboSms/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 6.2
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/TurboSms/TurboSmsTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/TurboSms/TurboSmsTransport.php
@@ -72,7 +72,7 @@ final class TurboSmsTransport extends AbstractTransport
             $from = $this->from;
         }
 
-        $endpoint = \sprintf('https://%s/message/send.json', $this->getEndpoint());
+        $endpoint = \sprintf('%s://%s/message/send.json', $this->getHttpScheme(), $this->getEndpoint());
         $response = $this->client->request('POST', $endpoint, [
             'auth_bearer' => $this->authToken,
             'json' => [

--- a/src/Symfony/Component/Notifier/Bridge/TurboSms/TurboSmsTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/TurboSms/TurboSmsTransportFactory.php
@@ -33,7 +33,7 @@ final class TurboSmsTransportFactory extends AbstractTransportFactory
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new TurboSmsTransport($authToken, $from, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new TurboSmsTransport($authToken, $from, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/TurboSms/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/TurboSms/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0",
+        "symfony/notifier": "^8.2",
         "symfony/polyfill-mbstring": "^1.0"
     },
     "autoload": {

--- a/src/Symfony/Component/Notifier/Bridge/Twilio/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Twilio/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 7.4
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Twilio/TwilioTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Twilio/TwilioTransport.php
@@ -61,7 +61,7 @@ final class TwilioTransport extends AbstractTransport
             throw new InvalidArgumentException(\sprintf('The "From" number "%s" is not a valid phone number, shortcode, or alphanumeric sender ID.', $from));
         }
 
-        $endpoint = \sprintf('https://%s/2010-04-01/Accounts/%s/Messages.json', $this->getEndpoint(), $this->accountSid);
+        $endpoint = \sprintf('%s://%s/2010-04-01/Accounts/%s/Messages.json', $this->getHttpScheme(), $this->getEndpoint(), $this->accountSid);
         $options = $message->getOptions()?->toArray() ?? [];
         $body = [
             'From' => $from,

--- a/src/Symfony/Component/Notifier/Bridge/Twilio/TwilioTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Twilio/TwilioTransportFactory.php
@@ -34,7 +34,7 @@ final class TwilioTransportFactory extends AbstractTransportFactory
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new TwilioTransport($accountSid, $authToken, $from, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new TwilioTransport($accountSid, $authToken, $from, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/Twilio/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Twilio/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "require-dev": {
         "symfony/webhook": "^7.4|^8.0"

--- a/src/Symfony/Component/Notifier/Bridge/Twitter/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Twitter/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 6.3
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Twitter/TwitterTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Twitter/TwitterTransport.php
@@ -59,7 +59,7 @@ final class TwitterTransport extends AbstractTransport
 
     public function request(string $method, string $url, array $options): ResponseInterface
     {
-        $url = 'https://'.str_replace('api.', str_starts_with($url, '/1.1/media/') ? 'upload.' : 'api.', $this->getEndpoint()).$url;
+        $endpoint = \sprintf('%s://%s%s', $this->getHttpScheme(), str_replace('api.', str_starts_with($url, '/1.1/media/') ? 'upload.' : 'api.', $this->getEndpoint()), $url);
 
         foreach (\is_array($options['body'] ?? null) ? $options['body'] : [] as $v) {
             if (!$v instanceof DataPart) {
@@ -93,7 +93,7 @@ final class TwitterTransport extends AbstractTransport
             'sha1',
             implode('&', array_map('rawurlencode', [
                 $method,
-                $url,
+                $endpoint,
                 implode('&', array_map(static fn ($k) => rawurlencode($k).'='.rawurlencode($sign[$k]), array_keys($sign))),
             ])),
             rawurlencode($this->apiSecret).'&'.rawurlencode($this->accessSecret),
@@ -102,7 +102,7 @@ final class TwitterTransport extends AbstractTransport
 
         $options['headers'][] = 'Authorization: OAuth '.implode(', ', array_map(static fn ($k) => $k.'="'.rawurlencode($oauth[$k]).'"', array_keys($oauth)));
 
-        return $this->client->request($method, $url, $options);
+        return $this->client->request($method, $endpoint, $options);
     }
 
     protected function doSend(MessageInterface $message): SentMessage

--- a/src/Symfony/Component/Notifier/Bridge/Twitter/TwitterTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Twitter/TwitterTransportFactory.php
@@ -40,7 +40,8 @@ final class TwitterTransportFactory extends AbstractTransportFactory
 
         return (new TwitterTransport($apiKey, $apiSecret, $accessToken, $accessSecret, $this->client, $this->dispatcher))
             ->setHost('default' === $dsn->getHost() ? null : $dsn->getHost())
-            ->setPort($dsn->getPort());
+            ->setPort($dsn->getPort())
+            ->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/Twitter/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Twitter/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "require-dev": {
         "symfony/mime": "^7.4|^8.0"

--- a/src/Symfony/Component/Notifier/Bridge/Unifonic/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Unifonic/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 7.1
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Unifonic/UnifonicTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Unifonic/UnifonicTransport.php
@@ -53,7 +53,7 @@ final class UnifonicTransport extends AbstractTransport
             throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
         }
 
-        $endpoint = \sprintf('https://%s/rest/SMS/messages', $this->getEndpoint());
+        $endpoint = \sprintf('%s://%s/rest/SMS/messages', $this->getHttpScheme(), $this->getEndpoint());
 
         $body = [
             'AppSid' => $this->appSid,

--- a/src/Symfony/Component/Notifier/Bridge/Unifonic/UnifonicTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Unifonic/UnifonicTransportFactory.php
@@ -33,7 +33,7 @@ final class UnifonicTransportFactory extends AbstractTransportFactory
             $dsn->getOption('from'),
             $this->client,
             $this->dispatcher,
-        ))->setHost($host)->setPort($dsn->getPort());
+        ))->setHost($host)->setPort($dsn->getPort())->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/Unifonic/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Unifonic/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Unifonic\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Vonage/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Vonage/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 6.4
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Vonage/VonageTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Vonage/VonageTransport.php
@@ -55,7 +55,8 @@ final class VonageTransport extends AbstractTransport
             throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
         }
 
-        $response = $this->client->request('POST', 'https://'.$this->getEndpoint().'/sms/json', [
+        $endpoint = \sprintf('%s://%s/sms/json', $this->getHttpScheme(), $this->getEndpoint());
+        $response = $this->client->request('POST', $endpoint, [
             'body' => [
                 'from' => $message->getFrom() ?: $this->from,
                 'to' => $message->getPhone(),

--- a/src/Symfony/Component/Notifier/Bridge/Vonage/VonageTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Vonage/VonageTransportFactory.php
@@ -34,7 +34,7 @@ final class VonageTransportFactory extends AbstractTransportFactory
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new VonageTransport($apiKey, $apiSecret, $from, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new VonageTransport($apiKey, $apiSecret, $from, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/Vonage/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Vonage/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "require-dev": {
         "symfony/webhook": "^7.4|^8.0"

--- a/src/Symfony/Component/Notifier/Bridge/WhatsApp/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/WhatsApp/CHANGELOG.md
@@ -5,3 +5,4 @@ CHANGELOG
 ---
 
  * Add the bridge
+ * Add the `ssl` DSN option to send requests over plain HTTP

--- a/src/Symfony/Component/Notifier/Bridge/WhatsApp/WhatsAppTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/WhatsApp/WhatsAppTransport.php
@@ -73,7 +73,7 @@ final class WhatsAppTransport extends AbstractTransport
             ...$this->messageBody($options, $message->getSubject()),
         ];
 
-        $endpoint = \sprintf('https://%s/%s/%s/messages', $this->getEndpoint(), $this->apiVersion, $this->phoneNumberId);
+        $endpoint = \sprintf('%s://%s/%s/%s/messages', $this->getHttpScheme(), $this->getEndpoint(), $this->apiVersion, $this->phoneNumberId);
 
         $response = $this->client->request('POST', $endpoint, [
             'auth_bearer' => $this->accessToken,

--- a/src/Symfony/Component/Notifier/Bridge/WhatsApp/WhatsAppTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/WhatsApp/WhatsAppTransportFactory.php
@@ -36,7 +36,7 @@ final class WhatsAppTransportFactory extends AbstractTransportFactory
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new WhatsAppTransport($accessToken, $phoneNumberId, $apiVersion, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new WhatsAppTransport($accessToken, $phoneNumberId, $apiVersion, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/WhatsApp/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/WhatsApp/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Symfony/Component/Notifier/Bridge/Yunpian/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Yunpian/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 6.2
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Yunpian/YunpianTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Yunpian/YunpianTransport.php
@@ -57,7 +57,7 @@ class YunpianTransport extends AbstractTransport
             throw new InvalidArgumentException(\sprintf('The "%s" transport does not support "from" in "%s".', __CLASS__, SmsMessage::class));
         }
 
-        $endpoint = \sprintf('https://%s/v2/sms/single_send.json', self::HOST);
+        $endpoint = \sprintf('%s://%s/v2/sms/single_send.json', $this->getHttpScheme(), self::HOST);
         $response = $this->client->request('POST', $endpoint, [
             'body' => [
                 'apikey' => $this->apiKey,

--- a/src/Symfony/Component/Notifier/Bridge/Yunpian/YunpianTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Yunpian/YunpianTransportFactory.php
@@ -29,7 +29,7 @@ class YunpianTransportFactory extends AbstractTransportFactory
         $apiKey = $this->getUser($dsn);
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
 
-        return (new YunpianTransport($apiKey, $this->client, $this->dispatcher))->setHost($host)->setPort($dsn->getPort());
+        return (new YunpianTransport($apiKey, $this->client, $this->dispatcher))->setHost($host)->setPort($dsn->getPort())->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/Yunpian/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Yunpian/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Yunpian\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Zendesk/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Zendesk/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 6.2
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Zendesk/ZendeskTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Zendesk/ZendeskTransport.php
@@ -51,7 +51,7 @@ final class ZendeskTransport extends AbstractTransport
             throw new UnsupportedMessageTypeException(__CLASS__, ChatMessage::class, $message);
         }
 
-        $endpoint = \sprintf('https://%s/api/v2/tickets.json', $this->getEndpoint());
+        $endpoint = \sprintf('%s://%s/api/v2/tickets.json', $this->getHttpScheme(), $this->getEndpoint());
 
         $body = [
             'ticket' => [

--- a/src/Symfony/Component/Notifier/Bridge/Zendesk/ZendeskTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Zendesk/ZendeskTransportFactory.php
@@ -33,7 +33,7 @@ final class ZendeskTransportFactory extends AbstractTransportFactory
         $apiToken = $this->getPassword($dsn);
         $host = $this->getHost($dsn);
 
-        return (new ZendeskTransport($emailAddress, $apiToken, $this->client, $this->dispatcher))->setHost($host);
+        return (new ZendeskTransport($emailAddress, $apiToken, $this->client, $this->dispatcher))->setHost($host)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/Zendesk/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Zendesk/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Zendesk\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Zulip/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Zulip/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option to send requests over plain HTTP
+
 5.3
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Zulip/ZulipTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Zulip/ZulipTransport.php
@@ -71,7 +71,7 @@ final class ZulipTransport extends AbstractTransport
             $options['to'] = $message->getRecipientId();
         }
 
-        $endpoint = \sprintf('https://%s/api/v1/messages', $this->getEndpoint());
+        $endpoint = \sprintf('%s://%s/api/v1/messages', $this->getHttpScheme(), $this->getEndpoint());
 
         $response = $this->client->request('POST', $endpoint, [
             'auth_basic' => [$this->email, $this->token],

--- a/src/Symfony/Component/Notifier/Bridge/Zulip/ZulipTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Zulip/ZulipTransportFactory.php
@@ -34,7 +34,7 @@ final class ZulipTransportFactory extends AbstractTransportFactory
         $host = $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new ZulipTransport($email, $token, $channel, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new ZulipTransport($email, $token, $channel, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSsl($this->getSsl($dsn));
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/Zulip/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Zulip/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.4.1",
         "symfony/http-client": "^7.4|^8.0",
-        "symfony/notifier": "^7.4|^8.0"
+        "symfony/notifier": "^8.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Zulip\\": "" },

--- a/src/Symfony/Component/Notifier/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/CHANGELOG.md
@@ -7,6 +7,8 @@ CHANGELOG
  * Add `AdminRecipientsProviderInterface`
  * Deprecate declaring `getAdminRecipients()` without implementing `AdminRecipientsProviderInterface`
  * Deprecate reading a value that is not a boolean with `Dsn::getBooleanOption()`; it will throw in 9.0
+ * Add the `ssl` DSN option to send requests over plain HTTP
+ * Add `AbstractTransport::setSsl()`, `AbstractTransport::getHttpScheme()`, the `AbstractTransport::SSL` constant and `AbstractTransportFactory::getSsl()`
 
 8.0
 ---

--- a/src/Symfony/Component/Notifier/Tests/Transport/AbstractTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Tests/Transport/AbstractTransportFactoryTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Tests\Transport;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Notifier\Transport\AbstractTransportFactory;
+use Symfony\Component\Notifier\Transport\Dsn;
+use Symfony\Component\Notifier\Transport\TransportInterface;
+
+class AbstractTransportFactoryTest extends TestCase
+{
+    #[DataProvider('sslProvider')]
+    public function testGetSsl(string $dsn, ?bool $expected)
+    {
+        $this->assertSame($expected, (new DummyTransportFactory())->exposedSsl(new Dsn($dsn)));
+    }
+
+    public static function sslProvider(): iterable
+    {
+        yield 'option not set' => ['dummy://host.test', null];
+        yield 'true' => ['dummy://host.test?ssl=true', true];
+        yield 'on' => ['dummy://host.test?ssl=on', true];
+        yield '1' => ['dummy://host.test?ssl=1', true];
+        yield 'false' => ['dummy://host.test?ssl=false', false];
+        yield 'off' => ['dummy://host.test?ssl=off', false];
+        yield '0' => ['dummy://host.test?ssl=0', false];
+        yield 'empty' => ['dummy://host.test?ssl=', false];
+    }
+}
+
+class DummyTransportFactory extends AbstractTransportFactory
+{
+    public function create(Dsn $dsn): TransportInterface
+    {
+        throw new \BadMethodCallException('Not implemented.');
+    }
+
+    public function exposedSsl(Dsn $dsn): ?bool
+    {
+        return $this->getSsl($dsn);
+    }
+
+    protected function getSupportedSchemes(): array
+    {
+        return ['dummy'];
+    }
+}

--- a/src/Symfony/Component/Notifier/Tests/Transport/AbstractTransportTest.php
+++ b/src/Symfony/Component/Notifier/Tests/Transport/AbstractTransportTest.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Tests\Transport;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\Notifier\Message\MessageInterface;
+use Symfony\Component\Notifier\Message\SentMessage;
+use Symfony\Component\Notifier\Transport\AbstractTransport;
+
+class AbstractTransportTest extends TestCase
+{
+    public function testSchemeIsHttpsByDefault()
+    {
+        $transport = new DummySchemeTransport(new MockHttpClient());
+
+        $this->assertSame('https', $transport->exposedScheme());
+    }
+
+    public function testSetSslSwitchesTheScheme()
+    {
+        $transport = new DummySchemeTransport(new MockHttpClient());
+
+        $this->assertSame('http', $transport->setSsl(false)->exposedScheme());
+        $this->assertSame('https', $transport->setSsl(true)->exposedScheme());
+    }
+
+    public function testSetSslNullRestoresTheTransportDefault()
+    {
+        $transport = (new DummySchemeTransport(new MockHttpClient()))->setSsl(false);
+
+        $this->assertSame('https', $transport->setSsl(null)->exposedScheme());
+    }
+
+    public function testTransportCanDefaultToHttp()
+    {
+        $transport = new DummyPlainHttpTransport(new MockHttpClient());
+
+        $this->assertSame('http', $transport->exposedScheme());
+        $this->assertSame('https', $transport->setSsl(true)->exposedScheme());
+        $this->assertSame('http', $transport->setSsl(null)->exposedScheme());
+    }
+}
+
+class DummySchemeTransport extends AbstractTransport
+{
+    public function __toString(): string
+    {
+        return \sprintf('dummy://%s', $this->getEndpoint());
+    }
+
+    public function supports(MessageInterface $message): bool
+    {
+        return true;
+    }
+
+    public function exposedScheme(): string
+    {
+        return $this->getHttpScheme();
+    }
+
+    protected function doSend(MessageInterface $message): SentMessage
+    {
+        throw new \BadMethodCallException('Not implemented.');
+    }
+}
+
+class DummyPlainHttpTransport extends DummySchemeTransport
+{
+    protected const SSL = false;
+}

--- a/src/Symfony/Component/Notifier/Transport/AbstractTransport.php
+++ b/src/Symfony/Component/Notifier/Transport/AbstractTransport.php
@@ -26,10 +26,14 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 abstract class AbstractTransport implements TransportInterface
 {
+    /** @var string */
     protected const HOST = 'localhost';
+    /** @var bool */
+    protected const SSL = true;
 
     protected ?string $host = null;
     protected ?int $port = null;
+    private ?bool $ssl = null;
 
     public function __construct(
         protected ?HttpClientInterface $client = null,
@@ -60,6 +64,16 @@ abstract class AbstractTransport implements TransportInterface
     public function setPort(?int $port): static
     {
         $this->port = $port;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setSsl(?bool $ssl): static
+    {
+        $this->ssl = $ssl;
 
         return $this;
     }
@@ -95,5 +109,10 @@ abstract class AbstractTransport implements TransportInterface
     protected function getDefaultHost(): string
     {
         return static::HOST;
+    }
+
+    protected function getHttpScheme(): string
+    {
+        return ($this->ssl ?? static::SSL) ? 'https' : 'http';
     }
 }

--- a/src/Symfony/Component/Notifier/Transport/AbstractTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Transport/AbstractTransportFactory.php
@@ -46,4 +46,9 @@ abstract class AbstractTransportFactory implements TransportFactoryInterface
     {
         return $dsn->getPassword() ?? throw new IncompleteDsnException('Password is not set.', $dsn->getOriginalDsn());
     }
+
+    protected function getSsl(Dsn $dsn): ?bool
+    {
+        return null === $dsn->getOption('ssl') ? null : $dsn->getBooleanOption('ssl');
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #65781
| License       | MIT

Almost every Notifier transport hard-codes `https://` when it builds its endpoint, which makes it impossible to point a transport at a server that only speaks plain HTTP: a self-hosted instance on an internal network, or a local capture gateway used during development.

`AbstractTransport` already owns the other two parts of the URL, so the scheme now sits next to `setHost()` and `setPort()`:

```php
protected const SSL = true;                     // per-transport default

public function setSsl(?bool $ssl): static;     // null restores that default
protected function getHttpScheme(): string;     // "https" or "http"
```

Transports build their endpoint with `$this->getHttpScheme()`, and every factory reads one unified DSN option through the new `AbstractTransportFactory::getSsl()`:

```
smsapi://token@localhost:9912?ssl=false
```

83 bridges are converted and now require `symfony/notifier: ^8.2`. `FakeChat`, `FakeSms`, `JoliNotif` and `Mercure` build no HTTP URL of their own and are left alone.

Four transports had already solved this on their own, each with a different spelling:

| Transport | Option             | Type              |
| --------- | ------------------ | ----------------- |
| Matrix    | `?ssl=`            | bool              |
| Ntfy      | `?secureHttp=`     | bool, hand-parsed |
| Telegram  | `?sslmode=disable` | string            |
| AmazonSns | `?sslmode=disable` | string            |

They keep accepting their own spelling, so no existing DSN has to change, but only `ssl` is documented from now on. When both are given, `ssl` wins.

The same option lands in the two other places that take an AWS-style DSN and still spell it `sslmode=disable`, the Amazon SQS Messenger bridge and the DynamoDB Lock bridge:

```
sqs://localhost:9324/queue?ssl=false
dynamodb://localhost:8000/lock_keys?ssl=false
```

There too `sslmode=disable` keeps working and `ssl` wins over it. Since `ssl` is new in those two, an unreadable value throws right away rather than silently selecting plain HTTP; on the Notifier side the value goes through `Dsn::getBooleanOption()`, which #65793 deprecates for non-boolean values and will make throw in 9.0.

Backward compatibility:

 * the default stays `https`, so the other bridges behave exactly as before;
 * `KazInfoTeh` declares `protected const SSL = false`, since as established in #65781 the vendor endpoint is only served over plain HTTP;
 * the constructor flags of `MatrixTransport` and `TelegramTransport` (`$disableHttps`) are kept and forwarded to `setSsl()`; `NtfyTransport`'s `$secureHttp` is renamed to `$ssl`.

`AmazonSns` still configures the async-aws client endpoint rather than an `AbstractTransport` URL; only the option spelling is unified there.

Tests cover the base class (default, per-transport default, setter, `null` reset), the option parsing in `AbstractTransportFactory`, the scheme actually used for an ordinary bridge (`Smsapi`), for the plain-HTTP one (`KazInfoTeh`), for the transports using a legacy spelling (`Ntfy`, `Telegram`, `AmazonSns`), and the endpoint built by the SQS and DynamoDB bridges.

The Notifier commit also cleans up the transports the sweep touched: the request URL is built into an `$endpoint` variable everywhere instead of inline, with `sprintf()` instead of concatenation.

Points the documentation has to carry:

 * `?ssl=false` is the way to send a request over plain HTTP, and it works for every notifier bridge as well as for the `sqs://` and `dynamodb://` DSNs;
 * it is meant for self-hosted or local servers; against a vendor API it only exposes the credentials;
 * `KazInfoTeh` is the one bridge that defaults to plain HTTP, and `?ssl=true` turns TLS on there;
 * the `secureHttp` and `sslmode` spellings still work but are superseded by `ssl`;
 * a transport that is not built from a DSN can call `setSsl()`, and a custom transport sets its own default with `protected const SSL`.
