### PR TITLE
[Clock] Fix flaky MockClockTest::testNow

### DIFF
--- a/src/Symfony/Component/Clock/Tests/MockClockTest.php
+++ b/src/Symfony/Component/Clock/Tests/MockClockTest.php
@@ -42,6 +42,7 @@ class MockClockTest extends TestCase
     public function testNow()
     {
         $before = new \DateTimeImmutable();
+        usleep(1);
         $clock = new MockClock();
         usleep(1);
         $after = new \DateTimeImmutable();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65789
| License       | MIT

`MockClockTest::testNow()` compares the time captured by `MockClock` with a `\DateTimeImmutable` read taken just before it, using a strict `assertGreaterThan()`. Both have microsecond resolution and nothing separates the two reads, so whenever they land in the same microsecond (which is not that rare on modern, fast hardware) the values are equal and the assertion fails:

```
Failed asserting that ...\DatePoint Object ('date' => '2026-09-01 14:13:22.002789', ...)
is greater than DateTimeImmutable Object ('date' => '2026-09-01 14:13:22.002789', ...).
```

Measured over 50,000 iterations on PHP 8.4/Linux running on a Ryzen 9 7900X3D, the two reads share a microsecond in about 11% of cases, which is roughly one CI run in nine. The upper bound never failed, because the `usleep(1)` sitting between the clock and `$after` already guarantees the counter has moved on.

The fix mirrors that existing `usleep(1)` on the other side of the clock construction, so both bounds are separated from it by at least one microsecond. Over 50,000 iterations this variant produced 0 failures.