### PR TITLE
[Mailer] Support tags in the MailerSend transports

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/MailerSend/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/Bridge/MailerSend/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add support for `TagHeader` in the API and SMTP transports
+
 7.1
 ---
 

--- a/src/Symfony/Component/Mailer/Bridge/MailerSend/Tests/Transport/MailerSendApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/MailerSend/Tests/Transport/MailerSendApiTransportTest.php
@@ -17,7 +17,10 @@ use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\JsonMockResponse;
 use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Mailer\Bridge\MailerSend\Transport\MailerSendApiTransport;
+use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Exception\HttpTransportException;
+use Symfony\Component\Mailer\Exception\TransportException;
+use Symfony\Component\Mailer\Header\TagHeader;
 use Symfony\Component\Mailer\Header\TrackingHeader;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
@@ -195,7 +198,7 @@ class MailerSendApiTransportTest extends TestCase
     {
         $transport = new MailerSendApiTransport('ACCESS_KEY');
         $method = new \ReflectionMethod(MailerSendApiTransport::class, 'getPayload');
-        $envelope = new \Symfony\Component\Mailer\Envelope(new Address('from@example.com'), [new Address('to@example.com')]);
+        $envelope = new Envelope(new Address('from@example.com'), [new Address('to@example.com')]);
 
         $enabledEmail = (new Email())->from('from@example.com')->to('to@example.com');
         $enabledEmail->getHeaders()->add(new TrackingHeader(opens: true, clicks: true));
@@ -214,7 +217,7 @@ class MailerSendApiTransportTest extends TestCase
     {
         $transport = new MailerSendApiTransport('ACCESS_KEY');
         $method = new \ReflectionMethod(MailerSendApiTransport::class, 'getPayload');
-        $envelope = new \Symfony\Component\Mailer\Envelope(new Address('from@example.com'), [new Address('to@example.com')]);
+        $envelope = new Envelope(new Address('from@example.com'), [new Address('to@example.com')]);
 
         $email = (new Email())->from('from@example.com')->to('to@example.com');
         $email->getHeaders()->add(new TrackingHeader(clicks: false));
@@ -222,5 +225,47 @@ class MailerSendApiTransportTest extends TestCase
 
         $this->assertArrayNotHasKey('track_opens', $payload['settings']);
         $this->assertFalse($payload['settings']['track_clicks']);
+    }
+
+    public function testTagHeaders()
+    {
+        $email = new Email();
+        $email->getHeaders()->add(new TagHeader('tag1'));
+        $email->getHeaders()->add(new TagHeader('tag2'));
+        $envelope = new Envelope(new Address('from@example.com'), [new Address('to@example.com')]);
+
+        $transport = new MailerSendApiTransport('ACCESS_KEY');
+        $method = new \ReflectionMethod(MailerSendApiTransport::class, 'getPayload');
+        $payload = $method->invoke($transport, $email, $envelope);
+
+        $this->assertSame(['tag1', 'tag2'], $payload['tags']);
+    }
+
+    public function testPayloadHasNoTagsWithoutTagHeader()
+    {
+        $email = new Email();
+        $envelope = new Envelope(new Address('from@example.com'), [new Address('to@example.com')]);
+
+        $transport = new MailerSendApiTransport('ACCESS_KEY');
+        $method = new \ReflectionMethod(MailerSendApiTransport::class, 'getPayload');
+        $payload = $method->invoke($transport, $email, $envelope);
+
+        $this->assertArrayNotHasKey('tags', $payload);
+    }
+
+    public function testTagHeadersThrowsForTooManyTags()
+    {
+        $email = new Email();
+        for ($i = 0; $i < 6; ++$i) {
+            $email->getHeaders()->add(new TagHeader('tag'.$i));
+        }
+        $envelope = new Envelope(new Address('from@example.com'), [new Address('to@example.com')]);
+
+        $transport = new MailerSendApiTransport('ACCESS_KEY');
+        $method = new \ReflectionMethod(MailerSendApiTransport::class, 'getPayload');
+
+        $this->expectException(TransportException::class);
+        $this->expectExceptionMessage('Too many "Symfony\Component\Mailer\Header\TagHeader" instances present in the email headers. MailerSend does not accept more than 5 tags on an email.');
+        $method->invoke($transport, $email, $envelope);
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/MailerSend/Tests/Transport/MailerSendSmtpTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/MailerSend/Tests/Transport/MailerSendSmtpTransportTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\MailerSend\Tests\Transport;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Mailer\Bridge\MailerSend\Transport\MailerSendSmtpTransport;
+use Symfony\Component\Mailer\Exception\TransportException;
+use Symfony\Component\Mailer\Header\TagHeader;
+use Symfony\Component\Mime\Email;
+
+class MailerSendSmtpTransportTest extends TestCase
+{
+    public function testTagHeaders()
+    {
+        $email = new Email();
+        $email->getHeaders()->add(new TagHeader('tag1'));
+        $email->getHeaders()->add(new TagHeader('tag2'));
+
+        $transport = new MailerSendSmtpTransport('USERNAME', 'PASSWORD');
+        $method = new \ReflectionMethod(MailerSendSmtpTransport::class, 'addMailerSendHeaders');
+        $method->invoke($transport, $email);
+
+        $this->assertSame('X-MailerSend-Tags: tag1,tag2', $email->getHeaders()->get('X-MailerSend-Tags')->toString());
+        $this->assertFalse($email->getHeaders()->has('X-Tag'));
+    }
+
+    public function testCustomHeaderIsKept()
+    {
+        $email = new Email();
+        $email->getHeaders()->addTextHeader('foo', 'bar');
+
+        $transport = new MailerSendSmtpTransport('USERNAME', 'PASSWORD');
+        $method = new \ReflectionMethod(MailerSendSmtpTransport::class, 'addMailerSendHeaders');
+        $method->invoke($transport, $email);
+
+        $this->assertCount(1, $email->getHeaders()->toArray());
+        $this->assertSame('foo: bar', $email->getHeaders()->get('FOO')->toString());
+    }
+
+    public function testTagHeadersThrowsForTooManyTags()
+    {
+        $email = new Email();
+        for ($i = 0; $i < 6; ++$i) {
+            $email->getHeaders()->add(new TagHeader('tag'.$i));
+        }
+
+        $transport = new MailerSendSmtpTransport('USERNAME', 'PASSWORD');
+        $method = new \ReflectionMethod(MailerSendSmtpTransport::class, 'addMailerSendHeaders');
+
+        $this->expectException(TransportException::class);
+        $this->expectExceptionMessage('Too many "Symfony\Component\Mailer\Header\TagHeader" instances present in the email headers. MailerSend does not accept more than 5 tags on an email.');
+        $method->invoke($transport, $email);
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/MailerSend/Transport/MailerSendApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/MailerSend/Transport/MailerSendApiTransport.php
@@ -16,6 +16,8 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpClient\Exception\JsonException;
 use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Exception\HttpTransportException;
+use Symfony\Component\Mailer\Exception\TransportException;
+use Symfony\Component\Mailer\Header\TagHeader;
 use Symfony\Component\Mailer\Header\TrackingHeader;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\AbstractApiTransport;
@@ -126,6 +128,21 @@ final class MailerSendApiTransport extends AbstractApiTransport
             if (null !== $tracking->getClicks()) {
                 $payload['settings']['track_clicks'] = $tracking->getClicks();
             }
+        }
+
+        $tags = [];
+        foreach ($email->getHeaders()->all() as $header) {
+            if ($header instanceof TagHeader) {
+                if (5 === \count($tags)) {
+                    throw new TransportException(\sprintf('Too many "%s" instances present in the email headers. MailerSend does not accept more than 5 tags on an email.', TagHeader::class));
+                }
+
+                $tags[] = $header->getValue();
+            }
+        }
+
+        if ($tags) {
+            $payload['tags'] = $tags;
         }
 
         return $payload;

--- a/src/Symfony/Component/Mailer/Bridge/MailerSend/Transport/MailerSendSmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/MailerSend/Transport/MailerSendSmtpTransport.php
@@ -13,7 +13,13 @@ namespace Symfony\Component\Mailer\Bridge\MailerSend\Transport;
 
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Mailer\Envelope;
+use Symfony\Component\Mailer\Exception\TransportException;
+use Symfony\Component\Mailer\Header\TagHeader;
+use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport;
+use Symfony\Component\Mime\Message;
+use Symfony\Component\Mime\RawMessage;
 
 /**
  * @author Yann LUCAS
@@ -26,5 +32,36 @@ final class MailerSendSmtpTransport extends EsmtpTransport
 
         $this->setUsername($username);
         $this->setPassword($password);
+    }
+
+    public function send(RawMessage $message, ?Envelope $envelope = null): ?SentMessage
+    {
+        if ($message instanceof Message) {
+            $message = clone $message;
+            $this->addMailerSendHeaders($message);
+        }
+
+        return parent::send($message, $envelope);
+    }
+
+    private function addMailerSendHeaders(Message $message): void
+    {
+        $headers = $message->getHeaders();
+        $tags = [];
+
+        foreach ($headers->all() as $name => $header) {
+            if ($header instanceof TagHeader) {
+                if (5 === \count($tags)) {
+                    throw new TransportException(\sprintf('Too many "%s" instances present in the email headers. MailerSend does not accept more than 5 tags on an email.', TagHeader::class));
+                }
+
+                $tags[] = $header->getValue();
+                $headers->remove($name);
+            }
+        }
+
+        if ($tags) {
+            $headers->addTextHeader('X-MailerSend-Tags', implode(',', $tags));
+        }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #65788
| License       | MIT

The MailerSend transports ignored `TagHeader`, so tags could not be attached to a message. Both transports now map it to MailerSend's own tagging mechanism.

```php
use Symfony\Component\Mailer\Header\TagHeader;
use Symfony\Component\Mime\Email;

$email = (new Email())
    ->from('noreply@example.com')
    ->to('user@example.com')
    ->subject('Password reset')
    ->text('Reset your password.');

$email->getHeaders()->add(new TagHeader('password-reset'));
$email->getHeaders()->add(new TagHeader('transactional'));

$mailer->send($email);
```

The API transport sends the tags as the `tags` parameter of `POST /v1/email`:

```json
{
    "from": {"email": "noreply@example.com"},
    "to": [{"email": "user@example.com"}],
    "subject": "Password reset",
    "text": "Reset your password.",
    "tags": ["password-reset", "transactional"]
}
```

The SMTP transport replaces the `X-Tag` headers with a single `X-MailerSend-Tags` header holding the comma-separated list:

```
X-MailerSend-Tags: password-reset,transactional
```

MailerSend accepts at most 5 tags per message. A 6th `TagHeader` throws a `TransportException` in both transports instead of letting the request fail remotely.

Documentation points:

 * `TagHeader` is supported by the `mailersend+api` and `mailersend+smtp` transports.
 * MailerSend allows up to 5 tags per message, and each tag is limited to 191 characters by the API. Longer tags are passed through and rejected by MailerSend.
 * Tags set on a template are overridden by the tags sent with the message.
