### PR TITLE
[Lock][Messenger] Add the "ssl" DSN option to the Amazon SQS and DynamoDB bridges

### DIFF
--- a/src/Symfony/Component/Lock/Bridge/DynamoDb/CHANGELOG.md
+++ b/src/Symfony/Component/Lock/Bridge/DynamoDb/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add the `ssl` DSN option, superseding `sslmode`
+
 7.4
 ---
 

--- a/src/Symfony/Component/Lock/Bridge/DynamoDb/Store/DynamoDbStore.php
+++ b/src/Symfony/Component/Lock/Bridge/DynamoDb/Store/DynamoDbStore.php
@@ -45,6 +45,7 @@ class DynamoDbStore implements PersistingStoreInterface
         'expiration_attr' => 'key_expiration',
         'read_capacity_units' => 10,
         'write_capacity_units' => 20,
+        'ssl' => null,
         'sslmode' => null,
         'debug' => null,
         'http_client' => null,
@@ -107,7 +108,7 @@ class DynamoDbStore implements PersistingStoreInterface
             unset($query['region']);
 
             if ('default' !== ($params['host'] ?? 'default')) {
-                $clientConfiguration['endpoint'] = \sprintf('%s://%s%s', ($options['sslmode'] ?? null) === 'disable' ? 'http' : 'https', $params['host'], ($params['port'] ?? null) ? ':'.$params['port'] : '');
+                $clientConfiguration['endpoint'] = \sprintf('%s://%s%s', self::isSslEnabled($options, $params['scheme'] ?? 'dynamodb') ? 'https' : 'http', $params['host'], ($params['port'] ?? null) ? ':'.$params['port'] : '');
                 if (preg_match(';^dynamodb\.([^\.]++)\.amazonaws\.com$;', $params['host'], $matches)) {
                     $clientConfiguration['region'] = $matches[1];
                 }
@@ -275,6 +276,16 @@ class DynamoDbStore implements PersistingStoreInterface
         ]));
 
         $this->client->tableExists(new DescribeTableInput(['TableName' => $this->tableName]))->wait();
+    }
+
+    private static function isSslEnabled(array $options, string $scheme): bool
+    {
+        if (null === $ssl = $options['ssl'] ?? null) {
+            // "sslmode=disable" is the legacy spelling of "ssl=false"
+            return 'disable' !== ($options['sslmode'] ?? null);
+        }
+
+        return filter_var($ssl, \FILTER_VALIDATE_BOOL, \FILTER_NULL_ON_FAILURE) ?? throw new InvalidArgumentException(\sprintf('Invalid value for the "ssl" option of the "%s" DSN, expected a boolean.', $scheme));
     }
 
     private function getHashedKey(Key $key): string

--- a/src/Symfony/Component/Lock/Bridge/DynamoDb/Tests/Store/DynamoDbStoreTest.php
+++ b/src/Symfony/Component/Lock/Bridge/DynamoDb/Tests/Store/DynamoDbStoreTest.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Lock\Bridge\DynamoDb\Store\DynamoDbStore;
+use Symfony\Component\Lock\Exception\InvalidArgumentException;
 use Symfony\Component\Lock\Key;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -106,6 +107,30 @@ class DynamoDbStoreTest extends TestCase
             new DynamoDbStore(new DynamoDbClient(['region' => null, 'accessKeyId' => null, 'accessKeySecret' => null], null, $this->httpClient), ['table_name' => 'table']),
             new DynamoDbStore('dynamodb://default/table?sslmode=disable', ['http_client' => $this->httpClient])
         );
+    }
+
+    public function testFromDsnWithSsl()
+    {
+        $this->assertEquals(
+            new DynamoDbStore(new DynamoDbClient(['region' => null, 'endpoint' => 'http://localhost', 'accessKeyId' => null, 'accessKeySecret' => null], null, $this->httpClient), ['table_name' => 'table']),
+            new DynamoDbStore('dynamodb://localhost/table?ssl=false', ['http_client' => $this->httpClient])
+        );
+    }
+
+    public function testFromDsnWithSslTakingPrecedenceOverSslMode()
+    {
+        $this->assertEquals(
+            new DynamoDbStore(new DynamoDbClient(['region' => null, 'endpoint' => 'https://localhost', 'accessKeyId' => null, 'accessKeySecret' => null], null, $this->httpClient), ['table_name' => 'table']),
+            new DynamoDbStore('dynamodb://localhost/table?ssl=true&sslmode=disable', ['http_client' => $this->httpClient])
+        );
+    }
+
+    public function testFromDsnWithInvalidSsl()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid value for the "ssl" option of the "dynamodb" DSN, expected a boolean.');
+
+        new DynamoDbStore('dynamodb://localhost/table?ssl=nope', ['http_client' => $this->httpClient]);
     }
 
     public function testFromDsnWithCustomEndpointAndPort()

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Stop deduplicating the messages sent to a FIFO queue on their content: the default `MessageDeduplicationId` is now unique per send
  * Allow auto-setup to create the queue when the DSN names the account the client already authenticates as
  * Add `AmazonSqsFairQueueStamp` to set a `MessageGroupId` on standard queues, enabling SQS fair queues
+ * Add the `ssl` DSN option, superseding `sslmode`
 
 7.4
 ---

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/ConnectionTest.php
@@ -186,6 +186,32 @@ class ConnectionTest extends TestCase
         );
     }
 
+    public function testFromDsnWithSsl()
+    {
+        $httpClient = new MockHttpClient();
+        $this->assertEquals(
+            new Connection(['queue_name' => 'queue'], new SqsClient(['region' => 'eu-west-1', 'endpoint' => 'http://localhost', 'accessKeyId' => null, 'accessKeySecret' => null], null, $httpClient)),
+            Connection::fromDsn('sqs://localhost/queue?ssl=false', [], $httpClient)
+        );
+    }
+
+    public function testFromDsnWithSslTakingPrecedenceOverSslMode()
+    {
+        $httpClient = new MockHttpClient();
+        $this->assertEquals(
+            new Connection(['queue_name' => 'queue'], new SqsClient(['region' => 'eu-west-1', 'endpoint' => 'https://localhost', 'accessKeyId' => null, 'accessKeySecret' => null], null, $httpClient)),
+            Connection::fromDsn('sqs://localhost/queue?ssl=true&sslmode=disable', [], $httpClient)
+        );
+    }
+
+    public function testFromDsnWithInvalidSsl()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid value for the "ssl" option of the "sqs" DSN, expected a boolean.');
+
+        Connection::fromDsn('sqs://localhost/queue?ssl=nope', [], new MockHttpClient());
+    }
+
     public function testFromDsnWithCustomEndpointAndPort()
     {
         $httpClient = new MockHttpClient();

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
@@ -52,6 +52,7 @@ class Connection
         'queue_attributes' => null,
         'queue_tags' => null,
         'account' => null,
+        'ssl' => null,
         'sslmode' => null,
         'debug' => null,
     ];
@@ -111,7 +112,7 @@ class Connection
      * * visibility_timeout: amount of seconds the message won't be visible
      * * delete_on_rejection: Whether to delete message on rejection or allow SQS to handle retries. (Default: true).
      * * retry_delay: amount of seconds the message won't be visible before retry. (Default: 0).
-     * * sslmode: Can be "disable" to use http for a custom endpoint
+     * * ssl: Whether to use https for a custom endpoint (Default: true)
      * * auto_setup: Whether the queue should be created automatically during send / get (Default: true)
      * * debug: Log all HTTP requests and responses as LoggerInterface::DEBUG (Default: false)
      */
@@ -167,7 +168,7 @@ class Connection
 
         $isAwsHost = false;
         if ('default' !== ($params['host'] ?? 'default')) {
-            $clientConfiguration['endpoint'] = \sprintf('%s://%s%s', ($options['sslmode'] ?? null) === 'disable' ? 'http' : 'https', $params['host'], ($params['port'] ?? null) ? ':'.$params['port'] : '');
+            $clientConfiguration['endpoint'] = \sprintf('%s://%s%s', self::isSslEnabled($options, $params['scheme'] ?? 'sqs') ? 'https' : 'http', $params['host'], ($params['port'] ?? null) ? ':'.$params['port'] : '');
             // Every AWS partition that serves SQS under amazonaws: aws, aws-cn and aws-eusc
             if (preg_match(';^sqs\.([^\.]++)\.amazonaws\.(?:com(?:\.cn)?|eu)$;', $params['host'], $matches)) {
                 $clientConfiguration['region'] = $matches[1];
@@ -453,6 +454,16 @@ class Connection
                 'VisibilityTimeout' => 0,
             ]);
         }
+    }
+
+    private static function isSslEnabled(array $options, string $scheme): bool
+    {
+        if (null === $ssl = $options['ssl'] ?? null) {
+            // "sslmode=disable" is the legacy spelling of "ssl=false"
+            return 'disable' !== ($options['sslmode'] ?? null);
+        }
+
+        return filter_var($ssl, \FILTER_VALIDATE_BOOL, \FILTER_NULL_ON_FAILURE) ?? throw new InvalidArgumentException(\sprintf('Invalid value for the "ssl" option of the "%s" DSN, expected a boolean.', $scheme));
     }
 
     private function getQueueUrl(): string


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Follow-up to #65787, which unifies the option that selects the HTTP scheme on `ssl` for every Notifier transport. Two more places take the same kind of DSN and still spell it `sslmode=disable`: the Amazon SQS Messenger bridge and the DynamoDB Lock bridge. Both now read `ssl` too:

```
sqs://localhost:9324/queue?ssl=false
dynamodb://localhost:8000/lock_keys?ssl=false
```

Like everywhere else, the option only applies to a custom endpoint, the default stays `https`, and `sslmode=disable` keeps working so no existing DSN has to change. When both are given, `ssl` wins. `sslmode` is no longer documented.

An unreadable value throws instead of silently falling back to plain HTTP, which would send the AWS credentials in clear text. The accepted spellings are the ones `FILTER_VALIDATE_BOOL` knows, plus an empty value for `false`, so `?ssl=%env(bool:AWS_SSL)%` works.
