### PR TITLE
[Mailer][Notifier] Deprecate reading a non-boolean value with `Dsn::getBooleanOption()`

### DIFF
--- a/UPGRADE-8.2.md
+++ b/UPGRADE-8.2.md
@@ -113,6 +113,9 @@ Mailer
    new `DkimSignedMessageListener::PRIORITY`, `SmimeSignedMessageListener::PRIORITY` and
    `SmimeEncryptedMessageListener::PRIORITY` constants if you register listeners that must run around them.
 
+ * Deprecate reading a value that is not a boolean with `Dsn::getBooleanOption()`; it will throw in 9.0. The
+   boolean values it accepts are `1`/`0`, `true`/`false`, `on`/`off`, `yes`/`no` and the empty string, which reads as `false`
+
 Messenger
 ---------
 
@@ -139,6 +142,8 @@ Notifier
 
  * Deprecate `NovuSubscriberRecipient::getOverrides()` and its `$overrides` constructor parameter, pass overrides to `NovuOptions` instead
  * Deprecate declaring `getAdminRecipients()` on a `NotifierInterface` implementation without implementing `AdminRecipientsProviderInterface`
+ * Deprecate reading a value that is not a boolean with `Dsn::getBooleanOption()`; it will throw in 9.0. The
+   boolean values it accepts are `1`/`0`, `true`/`false`, `on`/`off`, `yes`/`no` and the empty string, which reads as `false`
 
 Scheduler
 ---------

--- a/src/Symfony/Component/Mailer/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/CHANGELOG.md
@@ -16,6 +16,7 @@ CHANGELOG
  * Add `InMemoryPgpPublicKeyRepository` to provide recipient PGP public keys from a static map
  * Add a configurable behavior to `PgpMimeEncryptedMessageListener` when a recipient has no key (`fail`, `encrypt`, `skip`), overridable per message via the `X-Pgp-Encrypt` header
  * Add `TrackingHeader` for per-message open/click tracking and map it to provider-specific settings in the AhaSend, Azure, Brevo, Infobip, Mailchimp/Mandrill, MailerSend, Mailgun, Mailjet, Postmark and Sendgrid transports
+ * Deprecate reading a value that is not a boolean with `Dsn::getBooleanOption()`; it will throw in 9.0
 
 8.0
 ---

--- a/src/Symfony/Component/Mailer/Tests/Transport/DsnTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/DsnTest.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\Mailer\Tests\Transport;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Mailer\Exception\InvalidArgumentException;
 use Symfony\Component\Mailer\Transport\Dsn;
@@ -124,5 +126,26 @@ class DsnTest extends TestCase
 
         yield [false, 'scheme://localhost', 'not_existant', false];
         yield [true, 'scheme://localhost', 'not_existant', true];
+        yield [false, 'scheme://localhost?enabled=', 'enabled', true];
+    }
+
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
+    #[DataProvider('getNonBooleanOptionProvider')]
+    public function testGetBooleanOptionWithANonBooleanValue(string $dsnString, string $value)
+    {
+        $this->expectUserDeprecationMessage(\sprintf('Since symfony/mailer 8.2: Value "%s" of the "enabled" DSN option is not a boolean; reading it as false is deprecated and will throw in 9.0.', $value));
+
+        $dsn = Dsn::fromString($dsnString);
+
+        $this->assertFalse($dsn->getBooleanOption('enabled'));
+    }
+
+    public static function getNonBooleanOptionProvider(): iterable
+    {
+        yield ['scheme://localhost?enabled=ture', 'ture'];
+        yield ['scheme://localhost?enabled=enabled', 'enabled'];
+        yield ['scheme://localhost?enabled=2', '2'];
+        yield ['scheme://localhost?enabled[]=1', 'array'];
     }
 }

--- a/src/Symfony/Component/Mailer/Transport/Dsn.php
+++ b/src/Symfony/Component/Mailer/Transport/Dsn.php
@@ -82,6 +82,14 @@ final class Dsn
 
     public function getBooleanOption(string $key, bool $default = false): bool
     {
-        return filter_var($this->getOption($key, $default), \FILTER_VALIDATE_BOOLEAN);
+        $value = $this->getOption($key, $default);
+
+        if (null !== $boolean = filter_var($value, \FILTER_VALIDATE_BOOLEAN, \FILTER_NULL_ON_FAILURE)) {
+            return $boolean;
+        }
+
+        trigger_deprecation('symfony/mailer', '8.2', 'Value "%s" of the "%s" DSN option is not a boolean; reading it as false is deprecated and will throw in 9.0.', \is_string($value) ? $value : get_debug_type($value), $key);
+
+        return false;
     }
 }

--- a/src/Symfony/Component/Notifier/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add `AdminRecipientsProviderInterface`
  * Deprecate declaring `getAdminRecipients()` without implementing `AdminRecipientsProviderInterface`
+ * Deprecate reading a value that is not a boolean with `Dsn::getBooleanOption()`; it will throw in 9.0
 
 8.0
 ---

--- a/src/Symfony/Component/Notifier/Tests/Transport/DsnTest.php
+++ b/src/Symfony/Component/Notifier/Tests/Transport/DsnTest.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\Notifier\Tests\Transport;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Notifier\Exception\InvalidArgumentException;
 use Symfony\Component\Notifier\Exception\MissingRequiredOptionException;
@@ -272,5 +274,26 @@ final class DsnTest extends TestCase
 
         yield [false, 'scheme://localhost', 'not_existant', false];
         yield [true, 'scheme://localhost', 'not_existant', true];
+        yield [false, 'scheme://localhost?enabled=', 'enabled', true];
+    }
+
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
+    #[DataProvider('getNonBooleanOptionProvider')]
+    public function testGetBooleanOptionWithANonBooleanValue(string $dsnString, string $value)
+    {
+        $this->expectUserDeprecationMessage(\sprintf('Since symfony/notifier 8.2: Value "%s" of the "enabled" DSN option is not a boolean; reading it as false is deprecated and will throw in 9.0.', $value));
+
+        $dsn = new Dsn($dsnString);
+
+        $this->assertFalse($dsn->getBooleanOption('enabled'));
+    }
+
+    public static function getNonBooleanOptionProvider(): iterable
+    {
+        yield ['scheme://localhost?enabled=ture', 'ture'];
+        yield ['scheme://localhost?enabled=enabled', 'enabled'];
+        yield ['scheme://localhost?enabled=2', '2'];
+        yield ['scheme://localhost?enabled[]=1', 'array'];
     }
 }

--- a/src/Symfony/Component/Notifier/Transport/Dsn.php
+++ b/src/Symfony/Component/Notifier/Transport/Dsn.php
@@ -95,7 +95,15 @@ final class Dsn
 
     public function getBooleanOption(string $key, bool $default = false): bool
     {
-        return filter_var($this->getOption($key, $default), \FILTER_VALIDATE_BOOLEAN);
+        $value = $this->getOption($key, $default);
+
+        if (null !== $boolean = filter_var($value, \FILTER_VALIDATE_BOOLEAN, \FILTER_NULL_ON_FAILURE)) {
+            return $boolean;
+        }
+
+        trigger_deprecation('symfony/notifier', '8.2', 'Value "%s" of the "%s" DSN option is not a boolean; reading it as false is deprecated and will throw in 9.0.', \is_string($value) ? $value : get_debug_type($value), $key);
+
+        return false;
     }
 
     public function getOptions(): array


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Issues        | -
| License       | MIT

`Dsn::getBooleanOption()` exists in two components, `Mailer` and `Notifier`, with the same body:

```php
return filter_var($this->getOption($key, $default), \FILTER_VALIDATE_BOOLEAN);
```

`FILTER_VALIDATE_BOOLEAN` without `FILTER_NULL_ON_FAILURE` maps every value it does not recognise to `false`. So a DSN typo does not fail, it silently selects the `false` branch:

```
smtp://localhost?require_tls=ture   ->  require_tls disabled
smsapi://token@default?fast=maybe   ->  fast disabled
sns://host?ssl=enabled              ->  plain HTTP
```

That is the wrong default for options that gate TLS, and it is confusing for the others. This deprecates it so 9.0 can throw instead:

```
Since symfony/mailer 8.2: Value "ture" of the "require_tls" DSN option is not a boolean;
reading it as false is deprecated and will throw in 9.0.
```

The values that stay accepted are the ones `FILTER_VALIDATE_BOOLEAN` recognises: `1`/`0`, `true`/`false`, `on`/`off`, `yes`/`no`, and the empty string, which reads as `false`. The empty string matters because that is what `%env(bool:SOME_VAR)%` renders for `false`, so `?require_tls=%env(bool:REQUIRE_TLS)%` keeps working.

An absent option is unaffected: `getOption()` then returns the `$default`, which is already a real boolean.
