### PR TITLE
[Form] Use the POST_VALIDATE event in PasswordHasherExtension

### DIFF
--- a/UPGRADE-8.2.md
+++ b/UPGRADE-8.2.md
@@ -49,6 +49,11 @@ Form
    option is a string, wherever it sits in the form tree, and `form_<root id>` otherwise. Forms that do not
    use `form_attr` are unaffected: the `form_id` view variable stays `null` when nothing references it
  * Deprecate the `regions` option of `TimezoneType`, it has had no effect since 5.0 and will be removed in 9.0
+ * Deprecate the `FormTypePasswordHasherExtension` class and the `registerPassword()` and `hashPasswords()`
+   methods of `PasswordHasherListener`: the password of a field that uses the `hash_property_path` option
+   is now hashed during the `form.post_validate` event, which is dispatched only when the validator
+   extension is enabled. Wire `FormTypePasswordHasherExtension` yourself to keep hashing passwords in a
+   form system that does not use the validator extension
  * `TimezoneType` with the `intl` option enabled now offers the identifier PHP reports as canonical when ICU
    keys a zone and its legacy aliases under one display name, so `Asia/Kolkata` is offered where `Asia/Calcutta`
    used to be. The aliases stay submittable and are resolved to the offered identifier, so a stored value keeps

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -130,7 +130,6 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
 
         if (!class_exists(PasswordHasherExtension::class)) {
             $container->removeDefinition('form.listener.password_hasher');
-            $container->removeDefinition('form.type_extension.form.password_hasher');
             $container->removeDefinition('form.type_extension.password.password_hasher');
         }
 

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/password_hasher.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/password_hasher.php
@@ -11,10 +11,8 @@
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Extension\PasswordHasher\EventListener\PasswordHasherListener;
-use Symfony\Component\Form\Extension\PasswordHasher\Type\FormTypePasswordHasherExtension;
 use Symfony\Component\Form\Extension\PasswordHasher\Type\PasswordTypePasswordHasherExtension;
 use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactory;
 use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
@@ -37,12 +35,6 @@ return static function (ContainerConfigurator $container) {
                 service('security.password_hasher'),
                 service('property_accessor')->nullOnInvalid(),
             ])
-
-        ->set('form.type_extension.form.password_hasher', FormTypePasswordHasherExtension::class)
-            ->args([
-                service('form.listener.password_hasher'),
-            ])
-            ->tag('form.type_extension', ['extended-type' => FormType::class])
 
         ->set('form.type_extension.password.password_hasher', PasswordTypePasswordHasherExtension::class)
             ->args([

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -13,6 +13,7 @@ CHANGELOG
  * Add the `form_id` view variable, holding the id to render on the `<form>` element of a root form when a child uses `form_attr`
  * Allow the `group_by` option of `ChoiceType` to return `TranslatableInterface` instances
  * Add the `FormEvents::POST_VALIDATE` event, dispatched on each form of the tree after the validation of the root form
+ * Deprecate the `FormTypePasswordHasherExtension` class and the `registerPassword()` and `hashPasswords()` methods of `PasswordHasherListener`, passwords are now hashed during the `form.post_validate` event
 
 8.1
 ---

--- a/src/Symfony/Component/Form/Extension/PasswordHasher/EventListener/PasswordHasherListener.php
+++ b/src/Symfony/Component/Form/Extension/PasswordHasher/EventListener/PasswordHasherListener.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Form\Extension\PasswordHasher\EventListener;
 
+use Symfony\Component\Form\Event\PostValidateEvent;
 use Symfony\Component\Form\Exception\InvalidConfigurationException;
 use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
 use Symfony\Component\Form\FormEvent;
@@ -35,8 +36,36 @@ class PasswordHasherListener
         $this->propertyAccessor ??= PropertyAccess::createPropertyAccessor();
     }
 
+    public function hashPassword(PostValidateEvent $event): void
+    {
+        if (null === $event->getData() || '' === $event->getData()) {
+            return;
+        }
+
+        $form = $event->getForm();
+
+        $this->assertNotMapped($form);
+
+        if (!$form->getRoot()->isValid()) {
+            return;
+        }
+
+        $user = $this->getUser($form);
+
+        $this->propertyAccessor->setValue(
+            $user,
+            $form->getConfig()->getOption('hash_property_path'),
+            $this->passwordHasher->hashPassword($user, $event->getData())
+        );
+    }
+
+    /**
+     * @deprecated since Symfony 8.2, use hashPassword() instead
+     */
     public function registerPassword(FormEvent $event): void
     {
+        trigger_deprecation('symfony/form', '8.2', 'The "%s()" method is deprecated, use "hashPassword()" instead.', __METHOD__);
+
         if (null === $event->getData() || '' === $event->getData()) {
             return;
         }
@@ -50,6 +79,9 @@ class PasswordHasherListener
         ];
     }
 
+    /**
+     * @deprecated since Symfony 8.2, use hashPassword() instead
+     */
     public function hashPasswords(FormEvent $event): void
     {
         $form = $event->getForm();
@@ -57,6 +89,8 @@ class PasswordHasherListener
         if (!$form->isRoot()) {
             return;
         }
+
+        trigger_deprecation('symfony/form', '8.2', 'The "%s()" method is deprecated, use "hashPassword()" instead.', __METHOD__);
 
         if ($form->isValid()) {
             foreach ($this->passwords as $password) {

--- a/src/Symfony/Component/Form/Extension/PasswordHasher/PasswordHasherExtension.php
+++ b/src/Symfony/Component/Form/Extension/PasswordHasher/PasswordHasherExtension.php
@@ -29,7 +29,6 @@ class PasswordHasherExtension extends AbstractExtension
     protected function loadTypeExtensions(): array
     {
         return [
-            new Type\FormTypePasswordHasherExtension($this->passwordHasherListener),
             new Type\PasswordTypePasswordHasherExtension($this->passwordHasherListener),
         ];
     }

--- a/src/Symfony/Component/Form/Extension/PasswordHasher/Type/FormTypePasswordHasherExtension.php
+++ b/src/Symfony/Component/Form/Extension/PasswordHasher/Type/FormTypePasswordHasherExtension.php
@@ -19,16 +19,23 @@ use Symfony\Component\Form\FormEvents;
 
 /**
  * @author Sébastien Alfaiate <s.alfaiate@webarea.fr>
+ *
+ * @deprecated since Symfony 8.2, passwords are hashed during the "form.post_validate" event, which requires the validator extension
  */
 class FormTypePasswordHasherExtension extends AbstractTypeExtension
 {
     public function __construct(
         private PasswordHasherListener $passwordHasherListener,
     ) {
+        trigger_deprecation('symfony/form', '8.2', 'The "%s" class is deprecated, passwords are hashed during the "form.post_validate" event instead.', self::class);
     }
 
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
+        if ($options['hash_property_path'] ?? false) {
+            $builder->addEventListener(FormEvents::POST_SUBMIT, [$this->passwordHasherListener, 'registerPassword']);
+        }
+
         $builder->addEventListener(FormEvents::POST_SUBMIT, [$this->passwordHasherListener, 'hashPasswords']);
     }
 

--- a/src/Symfony/Component/Form/Extension/PasswordHasher/Type/PasswordTypePasswordHasherExtension.php
+++ b/src/Symfony/Component/Form/Extension/PasswordHasher/Type/PasswordTypePasswordHasherExtension.php
@@ -32,7 +32,7 @@ class PasswordTypePasswordHasherExtension extends AbstractTypeExtension
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         if ($options['hash_property_path']) {
-            $builder->addEventListener(FormEvents::POST_SUBMIT, [$this->passwordHasherListener, 'registerPassword']);
+            $builder->addEventListener(FormEvents::POST_VALIDATE, [$this->passwordHasherListener, 'hashPassword']);
         }
     }
 

--- a/src/Symfony/Component/Form/Tests/Extension/PasswordHasher/Type/PasswordTypePasswordHasherExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/PasswordHasher/Type/PasswordTypePasswordHasherExtensionTest.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\Form\Tests\Extension\PasswordHasher\Type;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Form\Exception\InvalidConfigurationException;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
@@ -19,7 +21,11 @@ use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
 use Symfony\Component\Form\Extension\PasswordHasher\EventListener\PasswordHasherListener;
 use Symfony\Component\Form\Extension\PasswordHasher\PasswordHasherExtension;
+use Symfony\Component\Form\Extension\PasswordHasher\Type\FormTypePasswordHasherExtension;
+use Symfony\Component\Form\Extension\PasswordHasher\Type\PasswordTypePasswordHasherExtension;
+use Symfony\Component\Form\Extension\Validator\ValidatorExtension;
 use Symfony\Component\Form\Extension\Validator\ViolationMapper\ViolationMapperInterface;
+use Symfony\Component\Form\Forms;
 use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\Form\Tests\Fixtures\RepeatedPasswordField;
 use Symfony\Component\Form\Tests\Fixtures\User;
@@ -28,6 +34,7 @@ use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactory;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasher;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
+use Symfony\Component\Validator\ValidatorBuilder;
 
 class PasswordTypePasswordHasherExtensionTest extends TypeTestCase
 {
@@ -50,6 +57,7 @@ class PasswordTypePasswordHasherExtensionTest extends TypeTestCase
     protected function getExtensions(?ViolationMapperInterface $violationMapper = null): array
     {
         return array_merge(parent::getExtensions(), [
+            new ValidatorExtension((new ValidatorBuilder())->getValidator(), $violationMapper),
             new PasswordHasherExtension(new PasswordHasherListener($this->passwordHasher)),
         ]);
     }
@@ -210,6 +218,38 @@ class PasswordTypePasswordHasherExtensionTest extends TypeTestCase
         ;
 
         $form->submit(['plainPassword' => 'PlainPassword']);
+    }
+
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
+    public function testLegacyPasswordHashWithoutValidator()
+    {
+        $this->expectUserDeprecationMessage('Since symfony/form 8.2: The "Symfony\Component\Form\Extension\PasswordHasher\Type\FormTypePasswordHasherExtension" class is deprecated, passwords are hashed during the "form.post_validate" event instead.');
+        $this->expectUserDeprecationMessage('Since symfony/form 8.2: The "Symfony\Component\Form\Extension\PasswordHasher\EventListener\PasswordHasherListener::registerPassword()" method is deprecated, use "hashPassword()" instead.');
+        $this->expectUserDeprecationMessage('Since symfony/form 8.2: The "Symfony\Component\Form\Extension\PasswordHasher\EventListener\PasswordHasherListener::hashPasswords()" method is deprecated, use "hashPassword()" instead.');
+
+        $listener = new PasswordHasherListener($this->passwordHasher);
+        $factory = Forms::createFormFactoryBuilder()
+            ->addTypeExtension(new FormTypePasswordHasherExtension($listener))
+            ->addTypeExtension(new PasswordTypePasswordHasherExtension($listener))
+            ->getFormFactory()
+        ;
+
+        $user = new User();
+
+        $form = $factory
+            ->createBuilder(FormType::class, $user)
+            ->add('plainPassword', PasswordType::class, [
+                'hash_property_path' => 'password',
+                'mapped' => false,
+            ])
+            ->getForm()
+        ;
+
+        $form->submit(['plainPassword' => 'PlainPassword']);
+
+        $this->assertTrue($form->isValid());
+        $this->assertSame('ec2d1846a8e988d344750b904739e19b', $user->getPassword());
     }
 
     public function testPasswordHashOnMappedFieldForbidden()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | yes
| Issues        | -
| License       | MIT

Since https://github.com/symfony/symfony/pull/47210#event-30394699034 is merged (cc @nicolas-grekas), we can now use the new `POST_VALIDATE` event with the Password Hasher form extension.

When that extension was implemented, we used a workaround to simulate the `POST_VALIDATE` event by implementing this feature in 2 steps:
1. `PasswordTypePasswordHasherExtension` to collect every `PasswordType`.
2. `FormTypePasswordHasherExtension` to add an event on the root form and hash the password if validation pass.

Since the `POST_VALIDATE` is now available, the 2nd step is no longer required, and we can use this event directly.

I kept the `PasswordHasherListener` class in this PR, but we can also totally remove it and inline the callable in the extension.
Initially, `PasswordHasherListener` was required to collect password fields.
