### PR TITLE
[JsonStreamer] Fix generator stream exhaustion on chunked file reading

### DIFF
--- a/src/Symfony/Component/JsonStreamer/Read/Lexer.php
+++ b/src/Symfony/Component/JsonStreamer/Read/Lexer.php
@@ -141,9 +141,13 @@ final class Lexer
 
         rewind($stream);
 
-        while (!feof($stream) && ($infiniteLength || $toReadLength > 0)) {
+        while (($infiniteLength && !feof($stream)) || $toReadLength > 0) {
             if (false === $chunk = stream_get_contents($stream, $infiniteLength ? $chunkLength : min($chunkLength, $toReadLength), $offset)) {
                 throw new RuntimeException('Failed to read JSON stream.');
+            }
+
+            if ('' === $chunk) {
+                break;
             }
 
             $toReadLength -= $l = \strlen($chunk);

--- a/src/Symfony/Component/JsonStreamer/Tests/Fixtures/Model/DummyWithIterable.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Fixtures/Model/DummyWithIterable.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\JsonStreamer\Tests\Fixtures\Model;
+
+class DummyWithIterable
+{
+    public string $customProperty;
+
+    /** @var iterable<int, ClassicDummy> */
+    public iterable $dummies;
+}

--- a/src/Symfony/Component/JsonStreamer/Tests/JsonStreamReaderTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/JsonStreamReaderTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\JsonStreamer\Tests\Fixtures\Mapping\SyntheticPropertyMetad
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\ClassicDummy;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithDateTimes;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithGenerics;
+use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithIterable;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNameAttributes;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithNullableProperties;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\DummyWithPhpDoc;
@@ -234,6 +235,33 @@ class JsonStreamReaderTest extends TestCase
         );
 
         $this->assertSame('CACHED', $reader->read('true', Type::bool()));
+    }
+
+    public function testReadNestedStream()
+    {
+        $longText = str_repeat('A', 8192);
+        $json = <<<JSON
+            {
+              "customProperty": "text",
+              "dummies": [
+                {
+                  "id": 1,
+                  "name": "{$longText}"
+                },
+                {
+                  "id": 2,
+                  "name": "{$longText}"
+                }
+              ],
+              "a": ["{$longText}", "{$longText}"]
+            }
+            JSON;
+
+        $reader = JsonStreamReader::create([], $this->streamReadersDir, $this->lazyGhostsDir);
+
+        $this->assertRead($reader, function (DummyWithIterable $read) {
+            $this->assertEquals(2, iterator_count($read->dummies));
+        }, $json, Type::object(DummyWithIterable::class));
     }
 
     private function assertRead(JsonStreamReader $reader, mixed $readOrAssert, string $json, Type $type, array $options = []): void

--- a/src/Symfony/Component/JsonStreamer/Tests/Read/LexerTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/Read/LexerTest.php
@@ -36,6 +36,33 @@ class LexerTest extends TestCase
         $this->assertTokens([['false', 7]], '[1, 2, false]', 7, 5);
     }
 
+    public function testTokensSubsetWhenStreamIsConsumedBetweenChunks()
+    {
+        $json = '['.str_repeat('1, ', 4000).'1]';
+        $resource = fopen('php://temp', 'w');
+        fwrite($resource, $json);
+
+        $lastToken = null;
+        foreach ((new Lexer())->getTokens($resource, 0, \strlen($json)) as $token) {
+            fseek($resource, 0, \SEEK_END);
+            fread($resource, 1);
+            $lastToken = $token[0];
+        }
+
+        $this->assertSame(']', $lastToken);
+    }
+
+    public function testRejectsLengthBeyondEndOfStream()
+    {
+        $resource = fopen('php://temp', 'w');
+        fwrite($resource, '[1, 2');
+
+        $this->expectException(InvalidStreamException::class);
+        $this->expectExceptionMessage('Unterminated JSON.');
+
+        iterator_to_array((new Lexer())->getTokens($resource, 0, 100));
+    }
+
     public function testTokenizeOverflowingBuffer()
     {
         $veryLongString = \sprintf('"%s"', str_repeat('.', 20000));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

### Description

Reading a bounded range of a stream (with an offset and a length) stopped at the first `feof()` check when a previous read of the shared stream had raised the EOF flag. Lazy nested structures in documents larger than one chunk (8192 bytes) were truncated, which surfaced as `InvalidStreamException` on valid JSON.

The chunk-reading loop now checks `feof()` only when no length is given (reading until the end of the stream). Bounded reads rely on the requested byte count instead, and stop on an empty chunk so that a length pointing beyond the end of the stream still terminates with `Unterminated JSON.` instead of looping.
