### PR TITLE
[RateLimiter] Stop consuming from the remaining limiters once one rejects the hit

### DIFF
--- a/UPGRADE-8.2.md
+++ b/UPGRADE-8.2.md
@@ -150,6 +150,12 @@ Notifier
  * Deprecate reading a value that is not a boolean with `Dsn::getBooleanOption()`; it will throw in 9.0. The
    boolean values it accepts are `1`/`0`, `true`/`false`, `on`/`off`, `yes`/`no` and the empty string, which reads as `false`
 
+RateLimiter
+-----------
+
+ * `CompoundLimiter::consume()` now stops consuming at the first limiter that rejects the request;
+   list limiters from the most specific to the most global to spare shared quotas from rejected hits
+
 Scheduler
 ---------
 

--- a/src/Symfony/Component/RateLimiter/CHANGELOG.md
+++ b/src/Symfony/Component/RateLimiter/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add `RateLimitExceededEvent`
+ * `CompoundLimiter::consume()` now stops consuming at the first limiter that rejects the request
  * Add `RateLimiterBuilder`
  * Allow `\DateInterval` for the `interval` and `rate.interval` options of `RateLimiterFactory`
 

--- a/src/Symfony/Component/RateLimiter/CompoundLimiter.php
+++ b/src/Symfony/Component/RateLimiter/CompoundLimiter.php
@@ -40,11 +40,11 @@ final class CompoundLimiter implements LimiterInterface
         foreach ($this->limiters as $limiter) {
             $rateLimit = $limiter->consume($tokens);
 
-            if (
-                null === $minimalRateLimit
-                || $rateLimit->getRemainingTokens() < $minimalRateLimit->getRemainingTokens()
-                || ($minimalRateLimit->isAccepted() && !$rateLimit->isAccepted())
-            ) {
+            if (!$rateLimit->isAccepted()) {
+                return $rateLimit;
+            }
+
+            if (null === $minimalRateLimit || $rateLimit->getRemainingTokens() < $minimalRateLimit->getRemainingTokens()) {
                 $minimalRateLimit = $rateLimit;
             }
         }

--- a/src/Symfony/Component/RateLimiter/Tests/CompoundLimiterTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/CompoundLimiterTest.php
@@ -48,37 +48,33 @@ class CompoundLimiterTest extends TestCase
 
         sleep(1); // reset limiter1's window
 
-        $rateLimit = $limiter->consume(3);
+        $rateLimit = $limiter->consume(4);
         $this->assertEquals(0, $rateLimit->getRemainingTokens(), 'Limiter 2 consumed exactly the remaining tokens');
         $this->assertTrue($rateLimit->isAccepted(), 'All accept the request (exact limit on limiter 2)');
 
+        sleep(1); // reset limiter1's window again, limiter2 is now the binding one
+
         $rateLimit = $limiter->consume(1);
-        $this->assertEquals(0, $rateLimit->getRemainingTokens(), 'Limiter 2 had remaining tokens left');
         $this->assertFalse($rateLimit->isAccepted(), 'Limiter 2 did not accept the request');
+        $this->assertEquals(3, $limiter1->consume(0)->getRemainingTokens(), 'Limiter 1 was consumed before limiter 2 rejected the request');
+        $this->assertEquals(8, $limiter3->consume(0)->getRemainingTokens(), 'Limiter 3 was not consumed once limiter 2 rejected the request');
 
-        sleep(1); // reset limiter1's window again,  to make sure that the limiter2 overrides limiter1
-
-        // make sure to consume all allowed by limiter1, limiter2 already had 0 remaining
-        $rateLimit = $limiter->consume(4);
-        $this->assertEquals(
-            0,
-            $rateLimit->getRemainingTokens(),
-            'Limiter 1 consumed the remaining tokens (accept), Limiter 2 did not have any remaining (not accept)'
-        );
-        $this->assertFalse($rateLimit->isAccepted(), 'Limiter 2 reached the limit already');
-
-        sleep(10); // reset limiter2's window (also limiter1)
-
-        $rateLimit = $limiter->consume(3);
-        $this->assertEquals(0, $rateLimit->getRemainingTokens(), 'Limiter 3 had exactly 3 tokens   (accept)');
-        $this->assertTrue($rateLimit->isAccepted());
-
-        $rateLimit = $limiter->consume(1);
-        $this->assertFalse($rateLimit->isAccepted(), 'Limiter 3 reached the limit previously');
-
-        sleep(30); // reset limiter3's window (also limiter1 and limiter2)
+        sleep(30); // reset all windows
 
         $this->assertTrue($limiter->consume()->isAccepted());
+    }
+
+    public function testConsumeStopsAtTheFirstRejection()
+    {
+        $limiter1 = $this->createLimiter(1, new \DateInterval('PT10S'));
+        $limiter2 = $this->createLimiter(10, new \DateInterval('PT10S'));
+        $limiter = new CompoundLimiter([$limiter1, $limiter2]);
+
+        $this->assertTrue($limiter->consume()->isAccepted());
+        $this->assertFalse($limiter->consume()->isAccepted(), 'Limiter 1 rejects the second hit');
+        $this->assertFalse($limiter->consume()->isAccepted());
+
+        $this->assertEquals(9, $limiter2->consume(0)->getRemainingTokens(), 'Rejected hits must not consume the next limiters');
     }
 
     public function testReserve()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no, behavior change
| Deprecations? | no
| License       | MIT

`CompoundLimiter::consume()` consumes from every sub-limiter, even after one of them has rejected the hit, and never refunds. This was a deliberate choice in #38353: it keeps the result independent from the order of the limiters.

That trade-off stops working once sub-limiters do not share the same key. #63389 adds first-class support for exactly that: a compound where one sub-limiter uses a fixed key, so a per-user limiter can sit beside a global quota. With the current behavior, a client that is already throttled by its own per-user limit keeps consuming the shared quota on every rejected hit:

```
per-user limit 1, global limit 10, the global limiter keyed 'global'
one client sends 20 requests
  1 accepted, 19 rejected by its own per-user limit
  the shared window still ends at 10/10
  the next honest user is refused
```

This PR makes `consume()` stop at the first limiter that rejects the hit. Limiters listed before the rejecting one keep their tokens consumed (there is no refund mechanism), so order becomes part of the policy: list limiters from the most specific to the most global, and rejected hits never reach the shared quotas.

Two visible consequences, pinned by the reworked `CompoundLimiterTest::testConsume()`:

- Limiters after the rejecting one are no longer consumed on rejected hits. Code that relied on rejected hits still counting against all windows must move those limiters before the strictest one.
- The returned `RateLimit` on rejection is the one of the first rejecting limiter. Before, it was the most restrictive one across all limiters, which could report a longer retry delay coming from a later limiter. A client honoring the shorter delay simply gets rejected again by the next limiter in line.

This lands before #63389, which builds a shared-quota compound in configuration and whose usefulness depends on this behavior.
