### PR TITLE
[Security] Verify the OIDC ID token signature against the provider JWKS

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -17,6 +17,7 @@ CHANGELOG
  * Add support for decorating custom authentication failure and success handlers
  * Add role hierarchy graph to the profiler security panel
  * Add `oidc_login` firewall authenticator for the OpenID Connect Authorization Code Flow, along with an `oidc` user provider for the users it builds from the OIDC claims
+ * Add the `id_token_signature` configuration (`required`, `algorithms`, `enforce_key_usage_verification`) to the `oidc_login` authenticator, which now verifies the ID token signature by default
  * Add the `token_endpoint_auth_method` option to the `oidc_login` authenticator: `client_secret_post`, `client_secret_basic`, or `none` to declare a public client, for which `client_secret` must not be set
 
 8.1

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/OidcLoginFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/OidcLoginFactory.php
@@ -85,12 +85,32 @@ class OidcLoginFactory extends AbstractFactory
             ->integerNode('discovery_cache_ttl')
                 ->defaultValue(3600)
                 ->min(0)
-                ->info('TTL in seconds for caching the OIDC discovery configuration.')
+                ->info('TTL in seconds for caching the OIDC discovery configuration, and for the provider JWKS when it advertises no cache lifetime itself.')
             ->end()
             ->integerNode('allowed_time_drift')
                 ->defaultValue(0)
                 ->min(0)
                 ->info('Allowed clock skew in seconds when validating ID token time claims.')
+            ->end()
+            ->arrayNode('id_token_signature')
+                ->addDefaultsIfNotSet()
+                ->children()
+                    ->booleanNode('required')
+                        ->defaultTrue()
+                        ->info('When true (default), the ID token signature is verified against the provider JWKS. Setting it to false decodes the ID token without verifying it, which OIDC Core 1.0, Section 3.1.3.7, item 6 only allows because the token comes from the token endpoint over TLS: it is then only as safe as the TLS verification of the HTTP client used for that request, so never turn it off with a client configured with "verify_peer: false" or "verify_host: false", nor behind a TLS-terminating proxy.')
+                    ->end()
+                    ->arrayNode('algorithms', 'algorithm')
+                        ->beforeNormalization()->castToArray()->end()
+                        ->scalarPrototype()->end()
+                        ->defaultValue(['RS256'])
+                        ->requiresAtLeastOneElement()
+                        ->info('The signature algorithms the ID token is accepted to be signed with, among "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384" and "PS512". Defaults to "RS256", the only algorithm OIDC Core 1.0 requires providers to support; list the one your provider announces in "id_token_signing_alg_values_supported" when it signs with another. No HMAC algorithm is accepted, so that a public key can never be used as a shared secret.')
+                    ->end()
+                    ->booleanNode('enforce_key_usage_verification')
+                        ->defaultTrue()
+                        ->info('When enabled (default), only keys explicitly designated for signature (via "use":"sig" or a "key_ops" entry containing "sign"/"verify") are accepted. When disabled, keys without any usage designation are also accepted; keys explicitly restricted to encryption are still rejected.')
+                    ->end()
+                ->end()
             ->end()
             ->enumNode('token_endpoint_auth_method')
                 ->values(['client_secret_post', 'client_secret_basic', 'none'])
@@ -177,6 +197,19 @@ class OidcLoginFactory extends AbstractFactory
             ;
         }
 
+        $signatureVerifier = null;
+        if ($config['id_token_signature']['required']) {
+            $signatureVerifierId = 'security.authenticator.oidc_login.signature_verifier.'.$firewallName;
+            $container
+                ->setDefinition($signatureVerifierId, new ChildDefinition('security.authenticator.oidc_login.signature_verifier'))
+                ->replaceArgument(0, new Reference($discoveryId))
+                ->replaceArgument(3, $config['id_token_signature']['algorithms'])
+                ->replaceArgument(4, $config['discovery_cache_ttl'])
+                ->replaceArgument(5, $config['id_token_signature']['enforce_key_usage_verification'])
+            ;
+            $signatureVerifier = new Reference($signatureVerifierId);
+        }
+
         $authenticatorId = 'security.authenticator.oidc_login.'.$firewallName;
         $options = array_intersect_key($config, $this->options);
         $options['firewall_name'] = $firewallName;
@@ -192,6 +225,7 @@ class OidcLoginFactory extends AbstractFactory
             ->replaceArgument(6, new Reference($this->createAuthenticationSuccessHandler($container, $firewallName, $config)))
             ->replaceArgument(7, new Reference($this->createAuthenticationFailureHandler($container, $firewallName, $config)))
             ->replaceArgument(8, $options)
+            ->replaceArgument(9, $signatureVerifier)
         ;
 
         $callbackUris = $container->hasParameter('security.oidc_login.callback_uris') ? (array) $container->getParameter('security.oidc_login.callback_uris') : [];

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator_oidc_login.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator_oidc_login.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 use Symfony\Component\Security\Http\Authenticator\Oidc\OidcConfidentialClient;
 use Symfony\Component\Security\Http\Authenticator\Oidc\OidcIdToken;
 use Symfony\Component\Security\Http\Authenticator\Oidc\OidcPublicClient;
+use Symfony\Component\Security\Http\Authenticator\Oidc\OidcSignatureVerifier;
 use Symfony\Component\Security\Http\Authenticator\OidcLoginAuthenticator;
 use Symfony\Component\Security\Http\Oidc\OidcDiscovery;
 
@@ -31,6 +32,20 @@ return static function (ContainerConfigurator $container) {
                 abstract_arg('authentication success handler'),
                 abstract_arg('authentication failure handler'),
                 abstract_arg('options'),
+                // replaced by the firewall verifier, unless the ID token signature is not verified
+                null,
+            ])
+
+        ->set('security.authenticator.oidc_login.signature_verifier', OidcSignatureVerifier::class)
+            ->abstract()
+            ->args([
+                abstract_arg('OIDC discovery'),
+                service('cache.app'),
+                service('http_client'),
+                abstract_arg('signature algorithms'),
+                abstract_arg('default JWKS cache TTL'),
+                abstract_arg('enforce key usage verification'),
+                service('clock'),
             ])
 
         ->set('security.authenticator.oidc_login.id_token', OidcIdToken::class)

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/OidcLoginFactoryTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/OidcLoginFactoryTest.php
@@ -58,49 +58,6 @@ class OidcLoginFactoryTest extends TestCase
         $this->assertSame(['kernel.reset' => [['method' => 'reset']]], $discoveryMain->getTags());
     }
 
-    public function testConfidentialClientIsWiredByDefault()
-    {
-        $container = new ContainerBuilder();
-
-        $config = [
-            'provider_uri' => 'https://provider.example.com',
-            'client_id' => 'my-client-id',
-            'client_secret' => 'my-client-secret',
-        ];
-
-        $factory = new OidcLoginFactory();
-        $factory->createAuthenticator($container, 'main', $this->processConfig($config, $factory), 'userprovider');
-
-        $client = $container->getDefinition('security.authenticator.oidc_login.client.main');
-        $this->assertInstanceOf(ChildDefinition::class, $client);
-        $this->assertSame('security.authenticator.oidc_login.client', $client->getParent());
-        $this->assertSame('my-client-secret', $client->getArgument(3));
-        $this->assertSame('client_secret_post', $client->getArgument(4));
-    }
-
-    public function testPublicClientIsWiredWhenTheTokenEndpointNeedsNoAuthentication()
-    {
-        $container = new ContainerBuilder();
-
-        $config = [
-            'provider_uri' => 'https://provider.example.com',
-            'client_id' => 'my-client-id',
-            'token_endpoint_auth_method' => 'none',
-        ];
-
-        $factory = new OidcLoginFactory();
-        $factory->createAuthenticator($container, 'main', $this->processConfig($config, $factory), 'userprovider');
-
-        $client = $container->getDefinition('security.authenticator.oidc_login.client.main');
-        $this->assertInstanceOf(ChildDefinition::class, $client);
-        $this->assertSame('security.authenticator.oidc_login.public_client', $client->getParent());
-        $this->assertEquals(new Reference('security.authenticator.oidc_login.discovery.main'), $client->getArgument(1));
-        $this->assertSame('my-client-id', $client->getArgument(2));
-        // a public client takes neither a secret nor an authentication method
-        $this->assertArrayNotHasKey('index_3', $client->getArguments());
-        $this->assertArrayNotHasKey('index_4', $client->getArguments());
-    }
-
     public function testFirewallUserProviderIsInjected()
     {
         // the user provider loads the user, so that the token stored in the session can be
@@ -389,6 +346,135 @@ class OidcLoginFactoryTest extends TestCase
         yield 'IPv6 loopback' => ['http://[::1]:8080'];
         yield 'localhost subdomain' => ['http://keycloak.localhost'];
         yield 'test TLD' => ['http://keycloak.test'];
+    }
+
+    public function testIdTokenSignatureIsVerifiedByDefault()
+    {
+        $container = new ContainerBuilder();
+        $factory = new OidcLoginFactory();
+
+        $config = $this->processConfig([
+            'provider_uri' => 'https://provider.example.com',
+            'client_id' => 'my-client-id',
+            'client_secret' => 'my-client-secret',
+        ], $factory);
+        $factory->createAuthenticator($container, 'main', $config, 'userprovider');
+
+        $this->assertTrue($config['id_token_signature']['required']);
+        // "RS256" is the only algorithm OIDC Core 1.0 requires providers to support
+        $this->assertSame(['RS256'], $config['id_token_signature']['algorithms']);
+        $this->assertTrue($config['id_token_signature']['enforce_key_usage_verification']);
+
+        $verifier = $container->getDefinition('security.authenticator.oidc_login.signature_verifier.main');
+        $this->assertSame('security.authenticator.oidc_login.signature_verifier', $verifier->getParent());
+        // the firewall discovery document is where the JWKS URI is announced
+        $this->assertEquals(new Reference('security.authenticator.oidc_login.discovery.main'), $verifier->getArgument(0));
+        $this->assertSame(['RS256'], $verifier->getArgument(3));
+        $this->assertSame(3600, $verifier->getArgument(4));
+        $this->assertTrue($verifier->getArgument(5));
+
+        $authenticator = $container->getDefinition('security.authenticator.oidc_login.main');
+        $this->assertEquals(new Reference('security.authenticator.oidc_login.signature_verifier.main'), $authenticator->getArgument(9));
+    }
+
+    public function testIdTokenSignatureVerificationCanBeTurnedOff()
+    {
+        $container = new ContainerBuilder();
+        $factory = new OidcLoginFactory();
+
+        $config = $this->processConfig([
+            'provider_uri' => 'https://provider.example.com',
+            'client_id' => 'my-client-id',
+            'client_secret' => 'my-client-secret',
+            'id_token_signature' => ['required' => false],
+        ], $factory);
+        $factory->createAuthenticator($container, 'main', $config, 'userprovider');
+
+        $this->assertFalse($container->hasDefinition('security.authenticator.oidc_login.signature_verifier.main'));
+
+        $authenticator = $container->getDefinition('security.authenticator.oidc_login.main');
+        $this->assertNull($authenticator->getArgument(9));
+    }
+
+    public function testIdTokenSignatureAlgorithmsAndKeyUsageAreConfigurable()
+    {
+        $container = new ContainerBuilder();
+        $factory = new OidcLoginFactory();
+
+        $config = $this->processConfig([
+            'provider_uri' => 'https://provider.example.com',
+            'client_id' => 'my-client-id',
+            'client_secret' => 'my-client-secret',
+            'discovery_cache_ttl' => 60,
+            'id_token_signature' => [
+                'algorithms' => ['ES256', 'PS256'],
+                'enforce_key_usage_verification' => false,
+            ],
+        ], $factory);
+        $factory->createAuthenticator($container, 'main', $config, 'userprovider');
+
+        $verifier = $container->getDefinition('security.authenticator.oidc_login.signature_verifier.main');
+        $this->assertSame(['ES256', 'PS256'], $verifier->getArgument(3));
+        // the JWKS falls back to the discovery TTL when the provider advertises none
+        $this->assertSame(60, $verifier->getArgument(4));
+        $this->assertFalse($verifier->getArgument(5));
+    }
+
+    public function testASingleIdTokenSignatureAlgorithmCanBeGivenAsAString()
+    {
+        $factory = new OidcLoginFactory();
+
+        $config = $this->processConfig([
+            'provider_uri' => 'https://provider.example.com',
+            'client_id' => 'my-client-id',
+            'client_secret' => 'my-client-secret',
+            'id_token_signature' => ['algorithms' => 'ES256'],
+        ], $factory);
+
+        $this->assertSame(['ES256'], $config['id_token_signature']['algorithms']);
+    }
+
+    public function testConfidentialClientIsWiredByDefault()
+    {
+        $container = new ContainerBuilder();
+
+        $config = [
+            'provider_uri' => 'https://provider.example.com',
+            'client_id' => 'my-client-id',
+            'client_secret' => 'my-client-secret',
+        ];
+
+        $factory = new OidcLoginFactory();
+        $factory->createAuthenticator($container, 'main', $this->processConfig($config, $factory), 'userprovider');
+
+        $client = $container->getDefinition('security.authenticator.oidc_login.client.main');
+        $this->assertInstanceOf(ChildDefinition::class, $client);
+        $this->assertSame('security.authenticator.oidc_login.client', $client->getParent());
+        $this->assertSame('my-client-secret', $client->getArgument(3));
+        $this->assertSame('client_secret_post', $client->getArgument(4));
+    }
+
+    public function testPublicClientIsWiredWhenTheTokenEndpointNeedsNoAuthentication()
+    {
+        $container = new ContainerBuilder();
+
+        $config = [
+            'provider_uri' => 'https://provider.example.com',
+            'client_id' => 'my-client-id',
+            'token_endpoint_auth_method' => 'none',
+        ];
+
+        $factory = new OidcLoginFactory();
+        $factory->createAuthenticator($container, 'main', $this->processConfig($config, $factory), 'userprovider');
+
+        $client = $container->getDefinition('security.authenticator.oidc_login.client.main');
+        $this->assertInstanceOf(ChildDefinition::class, $client);
+        $this->assertSame('security.authenticator.oidc_login.public_client', $client->getParent());
+        $this->assertEquals(new Reference('security.authenticator.oidc_login.discovery.main'), $client->getArgument(1));
+        $this->assertSame('my-client-id', $client->getArgument(2));
+        // a public client takes neither a secret nor an authentication method
+        $this->assertArrayNotHasKey('index_3', $client->getArguments());
+        $this->assertArrayNotHasKey('index_4', $client->getArguments());
     }
 
     #[DataProvider('provideSecretBasedAuthMethods')]

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
@@ -46,6 +46,7 @@ use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
 use Symfony\Component\Security\Http\Authenticator\HttpBasicAuthenticator;
 use Symfony\Component\Security\Http\Authenticator\Oidc\OidcPublicClient;
+use Symfony\Component\Security\Http\Authenticator\Oidc\OidcSignatureVerifier;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 
 class SecurityExtensionTest extends TestCase
@@ -1509,6 +1510,53 @@ class SecurityExtensionTest extends TestCase
 
         $authenticator = $container->getDefinition('security.authenticator.oidc_login.main');
         $this->assertSame('security.user.provider.concrete.oidc', (string) $authenticator->getArgument(1));
+    }
+
+    public function testOidcLoginVerifiesTheIdTokenSignature()
+    {
+        $container = $this->getRawContainer();
+        $container->loadFromExtension('security', [
+            'providers' => ['oidc' => ['oidc' => null]],
+            'firewalls' => [
+                'main' => [
+                    'oidc_login' => [
+                        'provider_uri' => 'https://provider.example.com',
+                        'client_id' => 'my-client-id',
+                        'client_secret' => 'my-client-secret',
+                    ],
+                ],
+            ],
+        ]);
+
+        $container->compile();
+
+        $verifier = $container->getDefinition('security.authenticator.oidc_login.signature_verifier.main');
+        $this->assertSame(OidcSignatureVerifier::class, $verifier->getClass());
+        $this->assertSame(['RS256'], $verifier->getArgument(3));
+        $this->assertSame('security.authenticator.oidc_login.signature_verifier.main', (string) $container->getDefinition('security.authenticator.oidc_login.main')->getArgument(9));
+    }
+
+    public function testOidcLoginCanSkipTheIdTokenSignatureVerification()
+    {
+        $container = $this->getRawContainer();
+        $container->loadFromExtension('security', [
+            'providers' => ['oidc' => ['oidc' => null]],
+            'firewalls' => [
+                'main' => [
+                    'oidc_login' => [
+                        'provider_uri' => 'https://provider.example.com',
+                        'client_id' => 'my-client-id',
+                        'client_secret' => 'my-client-secret',
+                        'id_token_signature' => ['required' => false],
+                    ],
+                ],
+            ],
+        ]);
+
+        $container->compile();
+
+        $this->assertFalse($container->hasDefinition('security.authenticator.oidc_login.signature_verifier.main'));
+        $this->assertNull($container->getDefinition('security.authenticator.oidc_login.main')->getArgument(9));
     }
 
     public function testOidcLoginSupportsAPublicClient()

--- a/src/Symfony/Component/Security/Http/Authenticator/Oidc/OidcIdToken.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Oidc/OidcIdToken.php
@@ -28,8 +28,9 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
  * Decodes and validates OIDC ID tokens using the web-token (JOSE) library,
  * reusing the same claim checkers as the OIDC access-token handlers.
  *
- * The signature is not verified: the ID token is received directly from the
- * token endpoint over TLS, where signature verification MAY be skipped
+ * The signature is not verified here: it is the job of {@see OidcSignatureVerifier},
+ * which the "oidc_login" authenticator uses by default, and which the ID token
+ * received directly from the token endpoint over TLS MAY do without
  * (OIDC Core 1.0, Section 3.1.3.7, item 6).
  *
  * @author Mathieu Santostefano <msantostefano@proton.me>

--- a/src/Symfony/Component/Security/Http/Authenticator/Oidc/OidcJwks.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Oidc/OidcJwks.php
@@ -1,0 +1,138 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Authenticator\Oidc;
+
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Contracts\Cache\ItemInterface;
+use Symfony\Contracts\HttpClient\Exception\ExceptionInterface as HttpClientExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * Fetches OpenID Connect signing keys (JWKS) and derives their cache lifetime
+ * from the provider's HTTP cache headers.
+ *
+ * The keys are filtered exactly as the "oidc" access token handler does, so that
+ * both OIDC entry points accept the same key material.
+ *
+ * @author Mathieu Santostefano <msantostefano@proton.me>
+ *
+ * @internal
+ */
+final class OidcJwks
+{
+    /**
+     * Cap the cache lifetime to 30 days to avoid keeping JWKS indefinitely.
+     */
+    private const MAX_TTL = 30 * 24 * 60 * 60;
+
+    /**
+     * JWKS documents are small. This limits untrusted data retained by the cache,
+     * as done for the discovery document.
+     */
+    private const MAX_JWKS_SIZE = 1024 * 1024;
+
+    /**
+     * Extracts the signing keys from a JWKS endpoint response, together with the TTL
+     * (in seconds) advertised by the provider via "Cache-Control: max-age" or
+     * "Expires", or null when none is advertised.
+     *
+     * @param bool $enforceKeyUsageVerification When true (default, strict), only JWKs whose `use` is "sig" or whose
+     *                                          `key_ops` contains "sign"/"verify" are kept. When false (lax), JWKs
+     *                                          missing both `use` and `key_ops` are kept too; JWKs explicitly scoped
+     *                                          to encryption are dropped either way.
+     *
+     * @return array{0: list<array<string, mixed>>, 1: int|null}
+     *
+     * @throws AuthenticationException If the JWKS cannot be fetched or decoded
+     */
+    public static function fromResponse(ResponseInterface $response, bool $enforceKeyUsageVerification = true): array
+    {
+        try {
+            $headers = $response->getHeaders();
+            $payload = $response->getContent();
+        } catch (HttpClientExceptionInterface $e) {
+            throw new AuthenticationException(\sprintf('The OIDC provider JWKS could not be fetched: "%s"', $e->getMessage()), previous: $e);
+        }
+
+        if (self::MAX_JWKS_SIZE < \strlen($payload)) {
+            throw new AuthenticationException('The OIDC provider JWKS exceeds the maximum size of 1 MiB.');
+        }
+
+        try {
+            $keys = json_decode($payload, true, 512, \JSON_THROW_ON_ERROR);
+        } catch (\JsonException $e) {
+            throw new AuthenticationException('The OIDC provider JWKS could not be fetched: invalid JSON: '.$e->getMessage(), previous: $e);
+        }
+
+        // a "keys" member that is not a list of JWK objects yields no usable key
+        $keys = \is_array($keys['keys'] ?? null) ? array_values(array_filter($keys['keys'], is_array(...))) : [];
+
+        $ttl = null;
+        if (preg_match('/max-age=(\d+)/', $headers['cache-control'][0] ?? '', $m)) {
+            $ttl = (int) $m[1];
+        } elseif (0 < $expires = strtotime($headers['expires'][0] ?? '@0') - time()) {
+            $ttl = $expires;
+        }
+
+        return [self::filterSignatureKeys($keys, $enforceKeyUsageVerification), $ttl];
+    }
+
+    /**
+     * Fetches the provider signing keys from the given JWKS URI and adjusts the
+     * cache item lifetime from the response headers (capped at 30 days).
+     *
+     * @return list<array<string, mixed>>
+     */
+    public static function fetchKeys(HttpClientInterface $httpClient, string $jwksUri, ItemInterface $item, int $defaultTtl = 3600, bool $enforceKeyUsageVerification = true): array
+    {
+        [$keys, $ttl] = self::fromResponse($httpClient->request('GET', $jwksUri), $enforceKeyUsageVerification);
+
+        $item->expiresAfter(null === $ttl ? $defaultTtl : min($ttl, self::MAX_TTL));
+
+        return $keys;
+    }
+
+    /**
+     * @param list<array<string, mixed>> $keys
+     *
+     * @return list<array<string, mixed>>
+     */
+    private static function filterSignatureKeys(array $keys, bool $enforceKeyUsageVerification): array
+    {
+        return array_values(array_filter($keys, static function (array $jwk) use ($enforceKeyUsageVerification): bool {
+            if ($enforceKeyUsageVerification) {
+                if (isset($jwk['use']) && 'sig' === $jwk['use']) {
+                    return true;
+                }
+                if (isset($jwk['key_ops']) && \is_array($jwk['key_ops'])) {
+                    return (bool) array_intersect($jwk['key_ops'], ['sign', 'verify']);
+                }
+
+                return false;
+            }
+
+            if (isset($jwk['use']) && 'enc' === $jwk['use']) {
+                return false;
+            }
+            if (isset($jwk['key_ops']) && \is_array($jwk['key_ops'])) {
+                $hasEnc = (bool) array_intersect($jwk['key_ops'], ['encrypt', 'decrypt', 'wrapKey', 'unwrapKey', 'deriveKey', 'deriveBits']);
+                $hasSig = (bool) array_intersect($jwk['key_ops'], ['sign', 'verify']);
+                if ($hasEnc && !$hasSig) {
+                    return false;
+                }
+            }
+
+            return true;
+        }));
+    }
+}

--- a/src/Symfony/Component/Security/Http/Authenticator/Oidc/OidcSignatureVerifier.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Oidc/OidcSignatureVerifier.php
@@ -1,0 +1,229 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Authenticator\Oidc;
+
+use Jose\Component\Checker;
+use Jose\Component\Core\Algorithm;
+use Jose\Component\Core\AlgorithmManager;
+use Jose\Component\Core\JWKSet;
+use Jose\Component\Signature\Algorithm\ES256;
+use Jose\Component\Signature\Algorithm\ES384;
+use Jose\Component\Signature\Algorithm\ES512;
+use Jose\Component\Signature\Algorithm\PS256;
+use Jose\Component\Signature\Algorithm\PS384;
+use Jose\Component\Signature\Algorithm\PS512;
+use Jose\Component\Signature\Algorithm\RS256;
+use Jose\Component\Signature\Algorithm\RS384;
+use Jose\Component\Signature\Algorithm\RS512;
+use Jose\Component\Signature\JWSTokenSupport;
+use Jose\Component\Signature\JWSVerifier;
+use Jose\Component\Signature\Serializer\CompactSerializer;
+use Jose\Component\Signature\Serializer\JWSSerializerManager;
+use Psr\Clock\ClockInterface;
+use Symfony\Component\Clock\Clock;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Http\Oidc\OidcDiscovery;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * Verifies the signature of an OIDC ID token against the provider's JWKS.
+ *
+ * The signing keys are discovered from the "jwks_uri" of the discovery document
+ * and cached, as the "oidc" access token handler does. Verifying the signature is
+ * what OIDC Core 1.0, Section 3.1.3.7, item 6 allows to replace by the transport
+ * security of the token endpoint request: doing it anyway keeps the guarantee
+ * independent of the TLS configuration of the HTTP client in use.
+ *
+ * @author Mathieu Santostefano <msantostefano@proton.me>
+ */
+final class OidcSignatureVerifier
+{
+    /**
+     * The asymmetric algorithms the "oidc" access token handler supports too. No HMAC
+     * algorithm is part of them, so a public key published by the provider can never be
+     * turned into the shared secret of an "HS256" token (key confusion).
+     */
+    private const SIGNATURE_ALGORITHMS = [
+        'RS256' => RS256::class,
+        'RS384' => RS384::class,
+        'RS512' => RS512::class,
+        'ES256' => ES256::class,
+        'ES384' => ES384::class,
+        'ES512' => ES512::class,
+        'PS256' => PS256::class,
+        'PS384' => PS384::class,
+        'PS512' => PS512::class,
+    ];
+
+    /**
+     * How long a JWKS refetched for an unknown "kid" is kept before another one is allowed.
+     */
+    private const ROTATION_COOLDOWN = 60;
+
+    /**
+     * @param list<string> $algorithms                  The signature algorithms accepted to verify the ID token (e.g. ["RS256"])
+     * @param int          $jwksCacheTtl                The JWKS cache lifetime used when the provider advertises none
+     * @param bool         $enforceKeyUsageVerification Whether to only accept keys explicitly designated for signature,
+     *                                                  see {@see OidcJwks::fromResponse()}
+     */
+    public function __construct(
+        private readonly OidcDiscovery $discovery,
+        private readonly CacheInterface $jwksCache,
+        private readonly HttpClientInterface $httpClient,
+        private readonly array $algorithms = ['RS256'],
+        private readonly int $jwksCacheTtl = 3600,
+        private readonly bool $enforceKeyUsageVerification = true,
+        private readonly ClockInterface $clock = new Clock(),
+    ) {
+    }
+
+    /**
+     * Verifies the signature of the given ID token and returns its claims.
+     *
+     * The claims are only structurally valid at this point: they still have to be
+     * validated by {@see OidcIdToken::validateClaims()}.
+     *
+     * @return array<string, mixed> The claims of the verified ID token
+     *
+     * @throws AuthenticationException If the signature cannot be verified
+     */
+    public function verify(string $idToken): array
+    {
+        if (!class_exists(JWSVerifier::class) || !class_exists(Checker\HeaderCheckerManager::class)) {
+            throw new \LogicException('You cannot verify OIDC ID token signatures since the "web-token/jwt-library" package is not installed. Try running "composer require web-token/jwt-library".');
+        }
+
+        $algorithms = $this->createAlgorithmManager();
+
+        try {
+            $jws = (new JWSSerializerManager([new CompactSerializer()]))->unserialize($idToken);
+        } catch (\InvalidArgumentException $e) {
+            throw new AuthenticationException('Invalid ID token format.', previous: $e);
+        }
+
+        // The "alg" header is checked first, and required: JWSVerifier throws on an
+        // algorithm it does not know, "none" among them, instead of reporting a failed
+        // verification. Checking it here also rejects a token announcing an algorithm
+        // the provider is not configured for before any request is sent to its JWKS.
+        try {
+            (new Checker\HeaderCheckerManager([new Checker\AlgorithmChecker($algorithms->list())], [new JWSTokenSupport()]))->check($jws, 0, ['alg']);
+        } catch (Checker\InvalidHeaderException|Checker\MissingMandatoryHeaderParameterException $e) {
+            throw new AuthenticationException(\sprintf('The ID token is not signed with any of the expected algorithms ("%s").', implode('", "', $algorithms->list())), previous: $e);
+        }
+
+        $keys = $this->getKeys($jws->getSignature(0)->hasProtectedHeaderParameter('kid') ? $jws->getSignature(0)->getProtectedHeaderParameter('kid') : null);
+        if (!$keys) {
+            throw new AuthenticationException('The OIDC provider published no signing key usable to verify the ID token signature.');
+        }
+
+        $jwsVerifier = new JWSVerifier($algorithms);
+        $jwkSet = JWKSet::createFromKeyData(['keys' => $keys]);
+
+        try {
+            // the component supports web-token/jwt-library 3.x too, where verify() does not
+            // exist and verifyWithKeySet() is not deprecated yet; static analysis only ever
+            // sees the newest version, hence the two ignores
+            if (method_exists($jwsVerifier, 'verify')) { // @phpstan-ignore function.alreadyNarrowedType
+                $verified = $jwsVerifier->verify($jws, $jwkSet, 0)->isVerified();
+            } else {
+                $verified = $jwsVerifier->verifyWithKeySet($jws, $jwkSet, 0); // @phpstan-ignore method.deprecated
+            }
+        } catch (\InvalidArgumentException $e) {
+            throw new AuthenticationException('The ID token signature could not be verified.', previous: $e);
+        }
+
+        if (!$verified) {
+            throw new AuthenticationException('The ID token signature is invalid.');
+        }
+
+        try {
+            $claims = json_decode($jws->getPayload() ?? '', true, 512, \JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            throw new AuthenticationException('Invalid ID token payload.');
+        }
+
+        if (!\is_array($claims)) {
+            throw new AuthenticationException('Invalid ID token payload.');
+        }
+
+        return $claims;
+    }
+
+    private function createAlgorithmManager(): AlgorithmManager
+    {
+        return new AlgorithmManager(array_map(static function (string $name): Algorithm {
+            if (!isset(self::SIGNATURE_ALGORITHMS[$name])) {
+                throw new \LogicException(\sprintf('Unsupported OIDC ID token signature algorithm "%s". Supported algorithms are: "%s".', $name, implode('", "', array_keys(self::SIGNATURE_ALGORITHMS))));
+            }
+
+            return new (self::SIGNATURE_ALGORITHMS[$name])();
+        }, $this->algorithms));
+    }
+
+    /**
+     * Returns the cached signing keys of the provider, refetching them when the ID token
+     * announces a "kid" none of them holds.
+     *
+     * A provider that rotated its keys signs with one the cached JWKS does not know yet.
+     * The refetch is throttled, so that tokens carrying an unknown "kid" cannot drive
+     * one outbound request each.
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function getKeys(?string $kid): array
+    {
+        $jwksUri = $this->discovery->getConfiguration()['jwks_uri'] ?? null;
+        if (!\is_string($jwksUri) || '' === $jwksUri) {
+            throw new AuthenticationException('The OIDC provider announces no "jwks_uri", which is required to verify the ID token signature.');
+        }
+
+        // the JWKS carries the very keys the verification relies on, so a discovery
+        // document downgrading its transport to plain HTTP must not be honored
+        $jwksUri = $this->discovery->getSecureEndpoint('jwks_uri');
+
+        $cacheKey = 'oidc_jwks.'.hash('xxh128', $jwksUri);
+        $compute = fn (ItemInterface $item): array => [
+            'keys' => OidcJwks::fetchKeys($this->httpClient, $jwksUri, $item, $this->jwksCacheTtl, $this->enforceKeyUsageVerification),
+            // the JWKS is stored with the time it was fetched, so that the rotation
+            // refetch below can be throttled without a second cache entry
+            'fetched_at' => $this->clock->now()->getTimestamp(),
+        ];
+
+        /** @var array{keys: list<array<string, mixed>>, fetched_at: int} $jwks */
+        $jwks = $this->jwksCache->get($cacheKey, $compute);
+
+        if (null !== $kid
+            && !$this->hasKey($jwks['keys'], $kid)
+            && ($jwks['fetched_at'] ?? 0) <= $this->clock->now()->getTimestamp() - self::ROTATION_COOLDOWN
+        ) {
+            $jwks = $this->jwksCache->get($cacheKey, $compute, \INF);
+        }
+
+        return $jwks['keys'];
+    }
+
+    /**
+     * @param list<array<string, mixed>> $keys
+     */
+    private function hasKey(array $keys, string $kid): bool
+    {
+        foreach ($keys as $key) {
+            if (isset($key['kid']) && hash_equals($kid, (string) $key['kid'])) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Symfony/Component/Security/Http/Authenticator/OidcLoginAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/OidcLoginAuthenticator.php
@@ -22,6 +22,7 @@ use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerI
 use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface;
 use Symfony\Component\Security\Http\Authenticator\Oidc\OidcClient;
 use Symfony\Component\Security\Http\Authenticator\Oidc\OidcIdToken;
+use Symfony\Component\Security\Http\Authenticator\Oidc\OidcSignatureVerifier;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
@@ -43,6 +44,12 @@ final class OidcLoginAuthenticator extends AbstractAuthenticator implements Auth
 
     private array $options;
 
+    /**
+     * @param OidcSignatureVerifier|null $signatureVerifier Verifies the ID token signature against the provider JWKS, or null
+     *                                                      to decode the token without verifying it, which OIDC Core 1.0,
+     *                                                      Section 3.1.3.7, item 6 only allows as long as the token endpoint
+     *                                                      request verifies TLS
+     */
     public function __construct(
         private readonly HttpUtils $httpUtils,
         private readonly UserProviderInterface $userProvider,
@@ -53,6 +60,7 @@ final class OidcLoginAuthenticator extends AbstractAuthenticator implements Auth
         private readonly AuthenticationSuccessHandlerInterface $successHandler,
         private readonly AuthenticationFailureHandlerInterface $failureHandler,
         array $options,
+        private readonly ?OidcSignatureVerifier $signatureVerifier = null,
     ) {
         $this->options = array_merge([
             'check_path' => '/oidc/callback',
@@ -186,7 +194,14 @@ final class OidcLoginAuthenticator extends AbstractAuthenticator implements Auth
 
         $tokenData = $this->exchangeAuthorizationCode($redirectUri, $code, $codeVerifier);
 
-        $idTokenClaims = $this->idToken->decode($tokenData['id_token']);
+        // the signature is verified before the claims are read, so that a token the
+        // provider did not issue never reaches the claim validation at all
+        if (null !== $this->signatureVerifier) {
+            $idTokenClaims = $this->signatureVerifier->verify($tokenData['id_token']);
+        } else {
+            $idTokenClaims = $this->idToken->decode($tokenData['id_token']);
+        }
+
         $this->idToken->validateClaims(
             $idTokenClaims,
             $this->discovery->getConfiguration()['issuer'] ?? '',

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -19,6 +19,7 @@ CHANGELOG
  * Add `OidcLoginAuthenticator` for the OpenID Connect Authorization Code Flow (interactive login via OIDC provider)
  * Add `OidcClient` and `OidcDiscovery` protocol classes
  * Cache the discovery document of the `oidc` access token handler for one hour, where it was fetched again on every refresh of the JWKS
+ * Add `OidcSignatureVerifier` to verify the ID token signature of the OIDC login authenticator against the provider JWKS, which it now does by default
  * Add `OidcPublicClient` to run the OIDC login flow as a public client, which holds no client secret and relies on PKCE, and support `client_secret_basic` in `OidcConfidentialClient`
 
 8.1

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/Oidc/OidcConfidentialClientTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/Oidc/OidcConfidentialClientTest.php
@@ -205,8 +205,8 @@ class OidcConfidentialClientTest extends TestCase
 
     public function testExchangeCodeRejectsAnInsecureTokenEndpoint()
     {
-        // the ID token signature is not verified because the token endpoint is reached over
-        // TLS: a discovery document announcing a plain HTTP endpoint takes that away
+        // the client secret and the tokens travel through the token endpoint: a discovery
+        // document announcing a plain HTTP endpoint takes their confidentiality away
         $discovery = $this->createDiscovery(['token_endpoint' => 'http://provider.example.com/token']);
 
         $this->httpClient->expects($this->never())->method('request');

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/Oidc/OidcJwksTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/Oidc/OidcJwksTest.php
@@ -1,0 +1,150 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Tests\Authenticator\Oidc;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\JsonMockResponse;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Http\Authenticator\Oidc\OidcJwks;
+use Symfony\Contracts\Cache\ItemInterface;
+
+class OidcJwksTest extends TestCase
+{
+    #[DataProvider('getKeyUsages')]
+    public function testFromResponseKeepsTheKeysUsableForSignature(array $jwk, bool $strict, bool $lax)
+    {
+        $response = (new MockHttpClient(new JsonMockResponse(['keys' => [['kid' => 'other', 'use' => 'sig'], $jwk]])))
+            ->request('GET', 'https://provider.example.com/jwks');
+
+        [$keys] = OidcJwks::fromResponse($response, true);
+        $this->assertSame($strict, \in_array($jwk, $keys, true), 'strict mode');
+
+        $response = (new MockHttpClient(new JsonMockResponse(['keys' => [['kid' => 'other', 'use' => 'sig'], $jwk]])))
+            ->request('GET', 'https://provider.example.com/jwks');
+
+        [$keys] = OidcJwks::fromResponse($response, false);
+        $this->assertSame($lax, \in_array($jwk, $keys, true), 'lax mode');
+    }
+
+    /**
+     * The very filtering the "oidc" access token handler applies, so that both OIDC
+     * entry points accept the same key material.
+     */
+    public static function getKeyUsages(): iterable
+    {
+        yield 'use=sig' => [['kid' => 'k', 'use' => 'sig'], true, true];
+        yield 'use=enc' => [['kid' => 'k', 'use' => 'enc'], false, false];
+        yield 'no usage at all' => [['kid' => 'k'], false, true];
+        yield 'key_ops=verify' => [['kid' => 'k', 'key_ops' => ['verify']], true, true];
+        yield 'key_ops=sign' => [['kid' => 'k', 'key_ops' => ['sign']], true, true];
+        yield 'key_ops=encrypt' => [['kid' => 'k', 'key_ops' => ['encrypt']], false, false];
+        yield 'key_ops=encrypt+verify' => [['kid' => 'k', 'key_ops' => ['encrypt', 'verify']], true, true];
+    }
+
+    public function testFromResponseRejectsAnOversizedJwks()
+    {
+        $response = (new MockHttpClient(new MockResponse('{"keys": ["'.str_repeat('a', 1024 * 1024).'"]}')))
+            ->request('GET', 'https://provider.example.com/jwks');
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('The OIDC provider JWKS exceeds the maximum size of 1 MiB.');
+
+        OidcJwks::fromResponse($response);
+    }
+
+    public function testFromResponseIgnoresKeysThatAreNotObjects()
+    {
+        $response = (new MockHttpClient(new JsonMockResponse(['keys' => ['garbage', ['kid' => 'k', 'use' => 'sig']]])))
+            ->request('GET', 'https://provider.example.com/jwks');
+
+        [$keys] = OidcJwks::fromResponse($response);
+
+        $this->assertSame([['kid' => 'k', 'use' => 'sig']], $keys);
+    }
+
+    public function testFromResponseReadsTheProviderMaxAge()
+    {
+        $response = (new MockHttpClient(new JsonMockResponse(
+            ['keys' => [['kid' => 'sig-key', 'use' => 'sig']]],
+            ['response_headers' => ['cache-control' => 'public, max-age=600']],
+        )))->request('GET', 'https://provider.example.com/jwks');
+
+        [$keys, $ttl] = OidcJwks::fromResponse($response);
+
+        $this->assertSame([['kid' => 'sig-key', 'use' => 'sig']], $keys);
+        $this->assertSame(600, $ttl);
+    }
+
+    public function testFromResponseReturnsNullTtlWithoutCacheHeaders()
+    {
+        $response = (new MockHttpClient(new JsonMockResponse(['keys' => []])))
+            ->request('GET', 'https://provider.example.com/jwks');
+
+        [$keys, $ttl] = OidcJwks::fromResponse($response);
+
+        $this->assertSame([], $keys);
+        $this->assertNull($ttl);
+    }
+
+    public function testFetchKeysAppliesProviderTtlToCacheItem()
+    {
+        $httpClient = new MockHttpClient(new JsonMockResponse(
+            ['keys' => [['kid' => 'sig-key', 'use' => 'sig']]],
+            ['response_headers' => ['cache-control' => 'max-age=120']],
+        ));
+
+        $item = $this->createMock(ItemInterface::class);
+        $item->expects($this->once())->method('expiresAfter')->with(120);
+
+        $keys = OidcJwks::fetchKeys($httpClient, 'https://provider.example.com/jwks', $item);
+
+        $this->assertSame([['kid' => 'sig-key', 'use' => 'sig']], $keys);
+    }
+
+    public function testFetchKeysCapsTheProviderTtl()
+    {
+        $httpClient = new MockHttpClient(new JsonMockResponse(
+            ['keys' => []],
+            ['response_headers' => ['cache-control' => 'max-age=31536000']],
+        ));
+
+        $item = $this->createMock(ItemInterface::class);
+        // 30 days, and not the year the provider advertises
+        $item->expects($this->once())->method('expiresAfter')->with(30 * 24 * 60 * 60);
+
+        OidcJwks::fetchKeys($httpClient, 'https://provider.example.com/jwks', $item);
+    }
+
+    public function testFetchKeysFallsBackToDefaultTtl()
+    {
+        $httpClient = new MockHttpClient(new JsonMockResponse(['keys' => []]));
+
+        $item = $this->createMock(ItemInterface::class);
+        $item->expects($this->once())->method('expiresAfter')->with(3600);
+
+        OidcJwks::fetchKeys($httpClient, 'https://provider.example.com/jwks', $item);
+    }
+
+    public function testFetchKeysIsUsableAsACacheCallback()
+    {
+        $httpClient = new MockHttpClient(new JsonMockResponse(['keys' => [['kid' => 'sig-key', 'use' => 'sig']]]));
+        $cache = new ArrayAdapter();
+
+        $keys = $cache->get('jwks', static fn (ItemInterface $item) => OidcJwks::fetchKeys($httpClient, 'https://provider.example.com/jwks', $item));
+
+        $this->assertSame([['kid' => 'sig-key', 'use' => 'sig']], $keys);
+    }
+}

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/Oidc/OidcSignatureVerifierTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/Oidc/OidcSignatureVerifierTest.php
@@ -1,0 +1,335 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Tests\Authenticator\Oidc;
+
+use Jose\Component\Core\AlgorithmManager;
+use Jose\Component\Core\JWK;
+use Jose\Component\Signature\Algorithm\ES256;
+use Jose\Component\Signature\JWSBuilder;
+use Jose\Component\Signature\Serializer\CompactSerializer;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Clock\MockClock;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\JsonMockResponse;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Http\Authenticator\Oidc\OidcSignatureVerifier;
+use Symfony\Component\Security\Http\Oidc\OidcDiscovery;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+#[RequiresPhpExtension('openssl')]
+class OidcSignatureVerifierTest extends TestCase
+{
+    private const PUBLIC_JWK = [
+        'kid' => 'signing-key',
+        'kty' => 'EC',
+        'crv' => 'P-256',
+        'x' => '0QEAsI1wGI-dmYatdUZoWSRWggLEpyzopuhwk-YUnA4',
+        'y' => 'KYl-qyZ26HobuYwlQh-r0iHX61thfP82qqEku7i0woo',
+        'use' => 'sig',
+        'alg' => 'ES256',
+    ];
+
+    /**
+     * Another key pair entirely: a signature made with the key above cannot be verified with it.
+     */
+    private const FOREIGN_JWK = [
+        'kid' => 'foreign-key',
+        'kty' => 'EC',
+        'crv' => 'P-256',
+        'x' => 'N1aUu8Pd2WdClkpCQ4QCPnGjYe_bTmDgEaSoxy5LhTw',
+        'y' => 'Yr1v-tCNxE8QgAGlartrJAi343bI8VlAaNvgCOp8Azs',
+        'use' => 'sig',
+        'alg' => 'ES256',
+    ];
+
+    public function testVerifyReturnsTheClaimsOfAValidlySignedToken()
+    {
+        $claims = ['iss' => 'https://provider.example.com', 'sub' => 'user-42', 'email' => 'test@example.com'];
+
+        $this->assertSame($claims, $this->createVerifier()->verify($this->buildJws(json_encode($claims))));
+    }
+
+    public function testVerifyRejectsATamperedSignature()
+    {
+        // a valid JWS structure, whose signature comes from another payload
+        [$header, $payload] = explode('.', $this->buildJws(json_encode(['sub' => 'user-42'])));
+        [, , $foreignSignature] = explode('.', $this->buildJws(json_encode(['sub' => 'someone-else'])));
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('The ID token signature is invalid.');
+
+        $this->createVerifier()->verify($header.'.'.$payload.'.'.$foreignSignature);
+    }
+
+    public function testVerifyRejectsAnEmptySignature()
+    {
+        [$header, $payload] = explode('.', $this->buildJws(json_encode(['sub' => 'user-42'])));
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('The ID token signature is invalid.');
+
+        $this->createVerifier()->verify($header.'.'.$payload.'.');
+    }
+
+    public function testVerifyRejectsAnUnsignedToken()
+    {
+        $httpClient = $this->createMock(HttpClientInterface::class);
+        // the "alg" header is rejected before the provider keys are even requested
+        $httpClient->expects($this->never())->method('request');
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('The ID token is not signed with any of the expected algorithms ("ES256").');
+
+        $this->createVerifier(httpClient: $httpClient)->verify($this->buildUnsecuredJws(['sub' => 'admin', 'roles' => ['ROLE_ADMIN']]));
+    }
+
+    public function testVerifyRejectsATokenWithoutAnyAlgorithm()
+    {
+        $token = $this->base64Url('{"typ":"JWT"}').'.'.$this->base64Url('{"sub":"user-42"}').'.'.$this->base64Url('signature');
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('The ID token is not signed with any of the expected algorithms ("ES256").');
+
+        $this->createVerifier()->verify($token);
+    }
+
+    public function testVerifyRejectsAnAlgorithmOutsideTheAllowlist()
+    {
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('The ID token is not signed with any of the expected algorithms ("RS256", "PS256").');
+
+        // the token is properly signed, but with an algorithm the provider is not configured for
+        $this->createVerifier(algorithms: ['RS256', 'PS256'])->verify($this->buildJws(json_encode(['sub' => 'user-42'])));
+    }
+
+    public function testVerifyRejectsAnHmacAlgorithm()
+    {
+        // an HMAC algorithm is never supported, so the public keys of the provider can
+        // never be turned into the shared secret of an "HS256" token (key confusion)
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Unsupported OIDC ID token signature algorithm "HS256".');
+
+        $this->createVerifier(algorithms: ['HS256'])->verify($this->buildJws(json_encode(['sub' => 'user-42'])));
+    }
+
+    public function testVerifyRejectsATokenThatIsNotAJws()
+    {
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Invalid ID token format.');
+
+        $this->createVerifier()->verify('not-a-jwt');
+    }
+
+    public function testVerifyRejectsAnUnknownSigningKey()
+    {
+        // the provider publishes a valid key, under the "kid" the token announces, but
+        // not the one it was signed with
+        $verifier = $this->createVerifier(jwks: [['keys' => [['kid' => 'signing-key'] + self::FOREIGN_JWK]]]);
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('The ID token signature is invalid.');
+
+        $verifier->verify($this->buildJws(json_encode(['sub' => 'user-42'])));
+    }
+
+    public function testVerifyFailsWhenTheProviderPublishesNoUsableKey()
+    {
+        // the only key the provider publishes is scoped to encryption
+        $verifier = $this->createVerifier(jwks: [['keys' => [['kid' => 'k', 'kty' => 'EC', 'use' => 'enc']]]]);
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('published no signing key');
+
+        $verifier->verify($this->buildJws(json_encode(['sub' => 'user-42'])));
+    }
+
+    public function testVerifyRejectsAPlainHttpJwksUri()
+    {
+        $httpClient = $this->createMock(HttpClientInterface::class);
+        // the JWKS carries the keys the whole verification relies on: it must never
+        // be requested over a transport a MITM can rewrite
+        $httpClient->expects($this->never())->method('request');
+
+        $verifier = $this->createVerifier(configuration: [
+            'issuer' => 'https://provider.example.com',
+            'jwks_uri' => 'http://provider.example.com/jwks',
+        ], httpClient: $httpClient);
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('The "jwks_uri" announced by the OIDC provider must use HTTPS');
+
+        $verifier->verify($this->buildJws(json_encode(['sub' => 'user-42'])));
+    }
+
+    public function testVerifyFailsWhenTheJwksCannotBeFetched()
+    {
+        $verifier = $this->createVerifier(httpClient: new MockHttpClient(new JsonMockResponse(['error' => 'server_error'], ['http_code' => 500])));
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('The OIDC provider JWKS could not be fetched');
+
+        $verifier->verify($this->buildJws(json_encode(['sub' => 'user-42'])));
+    }
+
+    public function testVerifyFailsWhenTheJwksIsNotValidJson()
+    {
+        $verifier = $this->createVerifier(httpClient: new MockHttpClient(new MockResponse('not-json', ['response_headers' => ['content-type' => 'application/json']])));
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('The OIDC provider JWKS could not be fetched');
+
+        $verifier->verify($this->buildJws(json_encode(['sub' => 'user-42'])));
+    }
+
+    public function testVerifyFailsWhenTheProviderAnnouncesNoJwksUri()
+    {
+        $verifier = $this->createVerifier(configuration: ['issuer' => 'https://provider.example.com']);
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('announces no "jwks_uri"');
+
+        $verifier->verify($this->buildJws(json_encode(['sub' => 'user-42'])));
+    }
+
+    public function testVerifyRejectsAnInvalidPayload()
+    {
+        [$header, , $signature] = explode('.', $this->buildJws('not-json'));
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Invalid ID token payload.');
+
+        $this->createVerifier()->verify($header.'.'.$this->base64Url('not-json').'.'.$signature);
+    }
+
+    public function testVerifyFetchesTheProviderKeysOnce()
+    {
+        $requests = 0;
+        $httpClient = new MockHttpClient(static function () use (&$requests): JsonMockResponse {
+            ++$requests;
+
+            return new JsonMockResponse(['keys' => [self::PUBLIC_JWK]]);
+        });
+        $verifier = $this->createVerifier(httpClient: $httpClient);
+        $token = $this->buildJws(json_encode(['sub' => 'user-42']));
+
+        $verifier->verify($token);
+        $verifier->verify($token);
+
+        $this->assertSame(1, $requests);
+    }
+
+    public function testVerifyRefetchesTheKeysWhenTheTokenAnnouncesAnUnknownKid()
+    {
+        // the JWKS is cached before the provider rotated its keys, the next one holds the new key
+        $verifier = $this->createVerifier(jwks: [
+            ['keys' => [self::FOREIGN_JWK]],
+            ['keys' => [['kid' => 'rotated-key'] + self::PUBLIC_JWK]],
+        ], clock: $clock = new MockClock());
+        $this->warmTheJwksCache($verifier);
+
+        $clock->sleep(120);
+        $claims = $verifier->verify($this->buildJws(json_encode(['sub' => 'user-42']), 'rotated-key'));
+
+        $this->assertSame(['sub' => 'user-42'], $claims);
+    }
+
+    public function testVerifyThrottlesTheRefetchOfTheProviderKeys()
+    {
+        $verifier = $this->createVerifier(jwks: [
+            ['keys' => [self::FOREIGN_JWK]],
+            ['keys' => [['kid' => 'rotated-key'] + self::PUBLIC_JWK]],
+        ], clock: new MockClock());
+        $this->warmTheJwksCache($verifier);
+
+        // the JWKS was just fetched, so a token carrying an unknown "kid" does not get to
+        // trigger another request: forged tokens cannot drive the outbound traffic
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('The ID token signature is invalid.');
+
+        $verifier->verify($this->buildJws(json_encode(['sub' => 'user-42']), 'rotated-key'));
+    }
+
+    /**
+     * Verifies a token announcing a "kid" the provider does publish, so that the JWKS ends
+     * up cached without any rotation refetch being attempted.
+     */
+    private function warmTheJwksCache(OidcSignatureVerifier $verifier): void
+    {
+        try {
+            $verifier->verify($this->buildJws(json_encode(['sub' => 'user-42']), self::FOREIGN_JWK['kid']));
+            $this->fail('The foreign key should not have verified the signature.');
+        } catch (AuthenticationException) {
+        }
+    }
+
+    /**
+     * @param list<array<string, mixed>> $jwks
+     * @param list<string>               $algorithms
+     */
+    private function createVerifier(?array $jwks = null, array $algorithms = ['ES256'], ?array $configuration = null, ?HttpClientInterface $httpClient = null, ?MockClock $clock = null): OidcSignatureVerifier
+    {
+        $configuration ??= [
+            'issuer' => 'https://provider.example.com',
+            'jwks_uri' => 'https://provider.example.com/jwks',
+        ];
+        $jwks ??= [['keys' => [self::PUBLIC_JWK]]];
+
+        $discovery = new OidcDiscovery(
+            new MockHttpClient(new JsonMockResponse($configuration)),
+            new ArrayAdapter(),
+            'https://provider.example.com/.well-known/openid-configuration',
+        );
+
+        return new OidcSignatureVerifier(
+            $discovery,
+            new ArrayAdapter(),
+            $httpClient ?? new MockHttpClient(array_map(static fn (array $jwkSet): JsonMockResponse => new JsonMockResponse($jwkSet), $jwks)),
+            $algorithms,
+            clock: $clock ?? new MockClock(),
+        );
+    }
+
+    private function buildJws(string $payload, string $kid = 'signing-key'): string
+    {
+        // tip: use https://mkjwk.org/ to generate a JWK
+        $jwk = new JWK([
+            'kty' => 'EC',
+            'crv' => 'P-256',
+            'x' => '0QEAsI1wGI-dmYatdUZoWSRWggLEpyzopuhwk-YUnA4',
+            'y' => 'KYl-qyZ26HobuYwlQh-r0iHX61thfP82qqEku7i0woo',
+            'd' => 'iA_TV2zvftni_9aFAQwFO_9aypfJFCSpcCyevDvz220',
+        ]);
+
+        return (new CompactSerializer())->serialize(
+            (new JWSBuilder(new AlgorithmManager([new ES256()])))
+                ->withPayload($payload)
+                ->addSignature($jwk, ['alg' => 'ES256', 'kid' => $kid])
+                ->build()
+        );
+    }
+
+    /**
+     * Builds the "alg": "none" token of RFC 7519, Section 6: a JWS with no signature at all.
+     */
+    private function buildUnsecuredJws(array $claims): string
+    {
+        return $this->base64Url('{"alg":"none"}').'.'.$this->base64Url(json_encode($claims)).'.';
+    }
+
+    private function base64Url(string $value): string
+    {
+        return rtrim(strtr(base64_encode($value), '+/', '-_'), '=');
+    }
+}

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/OidcLoginAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/OidcLoginAuthenticatorTest.php
@@ -11,6 +11,11 @@
 
 namespace Symfony\Component\Security\Http\Tests\Authenticator;
 
+use Jose\Component\Core\AlgorithmManager;
+use Jose\Component\Core\JWK;
+use Jose\Component\Signature\Algorithm\ES256;
+use Jose\Component\Signature\JWSBuilder;
+use Jose\Component\Signature\Serializer\CompactSerializer;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -34,6 +39,7 @@ use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerI
 use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface;
 use Symfony\Component\Security\Http\Authenticator\Oidc\OidcClient;
 use Symfony\Component\Security\Http\Authenticator\Oidc\OidcIdToken;
+use Symfony\Component\Security\Http\Authenticator\Oidc\OidcSignatureVerifier;
 use Symfony\Component\Security\Http\Authenticator\OidcLoginAuthenticator;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\RememberMeBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
@@ -56,6 +62,7 @@ class OidcLoginAuthenticatorTest extends TestCase
             'token_endpoint' => 'https://provider.example.com/token',
             'issuer' => 'https://provider.example.com',
             'userinfo_endpoint' => 'https://provider.example.com/userinfo',
+            'jwks_uri' => 'https://provider.example.com/jwks',
         ]);
 
         $this->oidcClient = $this->createMock(OidcClient::class);
@@ -171,6 +178,72 @@ class OidcLoginAuthenticatorTest extends TestCase
         // and the OIDC user provider cannot reload a user by its identifier alone
         $this->assertFalse($passport->hasBadge(RememberMeBadge::class));
         $this->assertSame('access-123', $passport->getAttribute('oidc_token_data')['access_token']);
+    }
+
+    public function testAuthenticateVerifiesTheIdTokenSignature()
+    {
+        $nonce = bin2hex(random_bytes(16));
+        $state = bin2hex(random_bytes(16));
+
+        $this->oidcClient->method('exchangeCode')->willReturn([
+            'access_token' => 'access-123',
+            'id_token' => $this->buildSignedIdToken(['nonce' => $nonce]),
+        ]);
+        $this->oidcClient->method('fetchUserInfo')->willReturn(['sub' => 'user-42']);
+
+        $authenticator = $this->createAuthenticator(signatureVerifier: $this->createSignatureVerifier());
+        $passport = $authenticator->authenticate($this->createCallbackRequest($state, $nonce));
+
+        $this->assertSame('user-42', $passport->getBadge(UserBadge::class)->getUserIdentifier());
+    }
+
+    #[DataProvider('getUnverifiableIdTokens')]
+    public function testAuthenticateRejectsAnIdTokenTheProviderDidNotSign(string $idTokenBuilder, string $expectedMessage)
+    {
+        $nonce = bin2hex(random_bytes(16));
+        $state = bin2hex(random_bytes(16));
+
+        $this->oidcClient->method('exchangeCode')->willReturn([
+            'access_token' => 'access-123',
+            // the attacker owns the claims: the identity and the roles they carry
+            'id_token' => $this->$idTokenBuilder(['nonce' => $nonce, 'sub' => 'admin', 'roles' => ['ROLE_ADMIN']]),
+        ]);
+        $this->oidcClient->expects($this->never())->method('fetchUserInfo');
+
+        $authenticator = $this->createAuthenticator(signatureVerifier: $this->createSignatureVerifier());
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage($expectedMessage);
+
+        $authenticator->authenticate($this->createCallbackRequest($state, $nonce));
+    }
+
+    public static function getUnverifiableIdTokens(): iterable
+    {
+        yield 'forged signature' => ['buildForgedIdToken', 'The ID token signature is invalid.'];
+        yield 'no signature at all' => ['buildUnsecuredIdToken', 'The ID token is not signed with any of the expected algorithms ("ES256").'];
+        yield 'signature of another provider' => ['buildIdToken', 'The ID token is not signed with any of the expected algorithms ("ES256").'];
+    }
+
+    #[DataProvider('getUnverifiableIdTokens')]
+    public function testAuthenticateAcceptsAnyIdTokenWhenTheSignatureIsNotVerified(string $idTokenBuilder, string $expectedMessage)
+    {
+        // without a verifier, the transport security of the token endpoint request is the
+        // only thing standing between the provider and a forged token: this is the very
+        // behavior the "id_token_signature.required" option opts out of
+        $nonce = bin2hex(random_bytes(16));
+        $state = bin2hex(random_bytes(16));
+
+        $this->oidcClient->method('exchangeCode')->willReturn([
+            'access_token' => 'access-123',
+            'id_token' => $this->$idTokenBuilder(['nonce' => $nonce, 'sub' => 'admin', 'roles' => ['ROLE_ADMIN']]),
+        ]);
+        $this->oidcClient->method('fetchUserInfo')->willReturn(['sub' => 'admin']);
+
+        $authenticator = $this->createAuthenticator();
+        $passport = $authenticator->authenticate($this->createCallbackRequest($state, $nonce));
+
+        $this->assertSame('admin', $passport->getBadge(UserBadge::class)->getUserIdentifier());
     }
 
     public function testAuthenticateDoesNotGrantRolesFromClaims()
@@ -997,20 +1070,82 @@ class OidcLoginAuthenticatorTest extends TestCase
     private function buildIdToken(array $extraClaims = []): string
     {
         $header = rtrim(strtr(base64_encode(json_encode(['alg' => 'RS256', 'typ' => 'JWT'])), '+/', '-_'), '=');
-        $claims = array_merge([
+        $payload = rtrim(strtr(base64_encode(json_encode($this->buildIdTokenClaims($extraClaims))), '+/', '-_'), '=');
+        $signature = rtrim(strtr(base64_encode('fake-signature'), '+/', '-_'), '=');
+
+        return $header.'.'.$payload.'.'.$signature;
+    }
+
+    private function buildIdTokenClaims(array $extraClaims = []): array
+    {
+        return array_merge([
             'iss' => 'https://provider.example.com',
             'aud' => 'test-client-id',
             'sub' => 'user-42',
             'exp' => time() + 3600,
             'iat' => time(),
         ], $extraClaims);
-        $payload = rtrim(strtr(base64_encode(json_encode($claims)), '+/', '-_'), '=');
-        $signature = rtrim(strtr(base64_encode('fake-signature'), '+/', '-_'), '=');
-
-        return $header.'.'.$payload.'.'.$signature;
     }
 
-    private function createAuthenticator(array $options = [], ?UserProviderInterface $userProvider = null): OidcLoginAuthenticator
+    /**
+     * An ID token really signed with the key the provider publishes below.
+     */
+    private function buildSignedIdToken(array $extraClaims = []): string
+    {
+        return (new CompactSerializer())->serialize(
+            (new JWSBuilder(new AlgorithmManager([new ES256()])))
+                ->withPayload(json_encode($this->buildIdTokenClaims($extraClaims)))
+                // tip: use https://mkjwk.org/ to generate a JWK
+                ->addSignature(new JWK([
+                    'kty' => 'EC',
+                    'crv' => 'P-256',
+                    'x' => '0QEAsI1wGI-dmYatdUZoWSRWggLEpyzopuhwk-YUnA4',
+                    'y' => 'KYl-qyZ26HobuYwlQh-r0iHX61thfP82qqEku7i0woo',
+                    'd' => 'iA_TV2zvftni_9aFAQwFO_9aypfJFCSpcCyevDvz220',
+                ]), ['alg' => 'ES256', 'kid' => 'signing-key'])
+                ->build()
+        );
+    }
+
+    /**
+     * The very same claims, signed with nothing at all.
+     */
+    private function buildForgedIdToken(array $extraClaims = []): string
+    {
+        [$header, $payload] = explode('.', $this->buildSignedIdToken($extraClaims));
+
+        return $header.'.'.$payload.'.'.rtrim(strtr(base64_encode('forged-signature'), '+/', '-_'), '=');
+    }
+
+    /**
+     * The "alg": "none" token of RFC 7519, Section 6: a JWS with no signature at all.
+     */
+    private function buildUnsecuredIdToken(array $extraClaims = []): string
+    {
+        $encode = static fn (array $value): string => rtrim(strtr(base64_encode(json_encode($value)), '+/', '-_'), '=');
+
+        return $encode(['alg' => 'none', 'typ' => 'JWT']).'.'.$encode($this->buildIdTokenClaims($extraClaims)).'.';
+    }
+
+    private function createSignatureVerifier(): OidcSignatureVerifier
+    {
+        return new OidcSignatureVerifier(
+            $this->discovery,
+            new ArrayAdapter(),
+            new MockHttpClient(new JsonMockResponse(['keys' => [[
+                'kid' => 'signing-key',
+                'kty' => 'EC',
+                'crv' => 'P-256',
+                'x' => '0QEAsI1wGI-dmYatdUZoWSRWggLEpyzopuhwk-YUnA4',
+                'y' => 'KYl-qyZ26HobuYwlQh-r0iHX61thfP82qqEku7i0woo',
+                'use' => 'sig',
+                'alg' => 'ES256',
+            ]]])),
+            ['ES256'],
+        );
+    }
+
+    private function createAuthenticator(array $options = [], ?UserProviderInterface $userProvider = null, ?OidcSignatureVerifier $signatureVerifier = null): OidcLoginAuthenticator
     {
         return new OidcLoginAuthenticator(
             new HttpUtils(),
@@ -1022,6 +1157,7 @@ class OidcLoginAuthenticatorTest extends TestCase
             $this->successHandler,
             $this->failureHandler,
             $options,
+            $signatureVerifier,
         );
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Follow-up of #64954. That PR left one open question: the `oidc_login` authenticator accepted the ID token on the strength of the token endpoint TLS alone (which OIDC Core 1.0 §3.1.3.7 item 6 allows), while `OidcTokenHandler` verifies signatures. This aligns the two.

The ID token signature is now verified against the provider JWKS, on by default:

```yaml
security:
    firewalls:
        main:
            oidc_login:
                # ...
                id_token_signature:
                    required:   true      # default
                    algorithms: ['RS256'] # default
                    enforce_key_usage_verification: true # default
```

- `OidcJwks` fetches the JWKS announced in the discovery document and caches it, deriving the lifetime from the provider's own `Cache-Control`/`Expires` headers (capped at 30 days, `discovery_cache_ttl` as the fallback).
- `OidcSignatureVerifier` verifies the token with that key set.
- The `algorithms` allowlist is applied to the JWS header before verification, so `alg: none` and algorithm substitution are rejected whatever the token claims to be signed with. No HMAC algorithm is accepted, so a public key can never be used as a shared secret.
- `enforce_key_usage_verification: false` also accepts JWKs that declare no `use`/`key_ops`, mirroring the option the `oidc` token handler already has.
- `required: false` keeps the previous behaviour, for a provider whose keys cannot be fetched.

Verification runs before the claims are read, so a token the provider did not issue never reaches claim validation.
