### PR TITLE
[Security] Add OIDC token-endpoint client authentication methods

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -17,6 +17,7 @@ CHANGELOG
  * Add support for decorating custom authentication failure and success handlers
  * Add role hierarchy graph to the profiler security panel
  * Add `oidc_login` firewall authenticator for the OpenID Connect Authorization Code Flow, along with an `oidc` user provider for the users it builds from the OIDC claims
+ * Add the `token_endpoint_auth_method` option to the `oidc_login` authenticator: `client_secret_post`, `client_secret_basic`, or `none` to declare a public client, for which `client_secret` must not be set
 
 8.1
 ---

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/OidcLoginFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/OidcLoginFactory.php
@@ -68,9 +68,8 @@ class OidcLoginFactory extends AbstractFactory
                 ->info('The OIDC client identifier.')
             ->end()
             ->scalarNode('client_secret')
-                ->isRequired()
-                ->cannotBeEmpty()
-                ->info('The OIDC client secret.')
+                ->defaultNull()
+                ->info('The OIDC client secret. Required by every "token_endpoint_auth_method" but "none", which declares a public client.')
             ->end()
             ->arrayNode('scope')
                 ->beforeNormalization()->castToArray()->end()
@@ -92,6 +91,27 @@ class OidcLoginFactory extends AbstractFactory
                 ->defaultValue(0)
                 ->min(0)
                 ->info('Allowed clock skew in seconds when validating ID token time claims.')
+            ->end()
+            ->enumNode('token_endpoint_auth_method')
+                ->values(['client_secret_post', 'client_secret_basic', 'none'])
+                ->defaultValue('client_secret_post')
+                ->info('Authentication method for the token endpoint. "none" declares a public client (a SPA, a mobile or a native application), which holds no secret and relies on PKCE to protect the code exchange.')
+            ->end()
+        ;
+
+        // the client type is what "token_endpoint_auth_method" really selects, so the
+        // options it makes mandatory or meaningless can only be checked here, once the
+        // whole authenticator configuration is known; an empty "client_secret" is also
+        // caught here and not on the scalar node, whose validators would reject the empty
+        // string an environment variable resolves to while the container compiles
+        $node
+            ->validate()
+                ->ifTrue(static fn ($v): bool => 'none' !== $v['token_endpoint_auth_method'] && (null === $v['client_secret'] || '' === $v['client_secret']))
+                ->thenInvalid('The OIDC "client_secret" is required by the "token_endpoint_auth_method" in use, which defaults to "client_secret_post". Set a secret, or set "token_endpoint_auth_method" to "none" to declare a public client, which authenticates with its "client_id" and PKCE only.')
+            ->end()
+            ->validate()
+                ->ifTrue(static fn ($v): bool => 'none' === $v['token_endpoint_auth_method'] && null !== $v['client_secret'])
+                ->thenInvalid('The OIDC "client_secret" must not be set when "token_endpoint_auth_method" is "none", as a public client never sends it. Remove the secret, or authenticate with it by using "client_secret_post" or "client_secret_basic".')
             ->end()
         ;
     }
@@ -139,12 +159,23 @@ class OidcLoginFactory extends AbstractFactory
         ;
 
         $oidcClientId = 'security.authenticator.oidc_login.client.'.$firewallName;
-        $container
-            ->setDefinition($oidcClientId, new ChildDefinition('security.authenticator.oidc_login.client'))
-            ->replaceArgument(1, new Reference($discoveryId))
-            ->replaceArgument(2, $config['client_id'])
-            ->replaceArgument(3, $config['client_secret'])
-        ;
+        if ('none' === $config['token_endpoint_auth_method']) {
+            // a public client holds no secret, so it only tells the token endpoint which
+            // client_id the authorization code was issued to, and proves it with PKCE
+            $container
+                ->setDefinition($oidcClientId, new ChildDefinition('security.authenticator.oidc_login.public_client'))
+                ->replaceArgument(1, new Reference($discoveryId))
+                ->replaceArgument(2, $config['client_id'])
+            ;
+        } else {
+            $container
+                ->setDefinition($oidcClientId, new ChildDefinition('security.authenticator.oidc_login.client'))
+                ->replaceArgument(1, new Reference($discoveryId))
+                ->replaceArgument(2, $config['client_id'])
+                ->replaceArgument(3, $config['client_secret'])
+                ->replaceArgument(4, $config['token_endpoint_auth_method'])
+            ;
+        }
 
         $authenticatorId = 'security.authenticator.oidc_login.'.$firewallName;
         $options = array_intersect_key($config, $this->options);

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator_oidc_login.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator_oidc_login.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 use Symfony\Bundle\SecurityBundle\Routing\OidcLoginRouteLoader;
 use Symfony\Component\Security\Http\Authenticator\Oidc\OidcConfidentialClient;
 use Symfony\Component\Security\Http\Authenticator\Oidc\OidcIdToken;
+use Symfony\Component\Security\Http\Authenticator\Oidc\OidcPublicClient;
 use Symfony\Component\Security\Http\Authenticator\OidcLoginAuthenticator;
 use Symfony\Component\Security\Http\Oidc\OidcDiscovery;
 
@@ -62,6 +63,15 @@ return static function (ContainerConfigurator $container) {
                 abstract_arg('OIDC discovery'),
                 abstract_arg('client ID'),
                 abstract_arg('client secret'),
+                abstract_arg('token endpoint auth method'),
+            ])
+
+        ->set('security.authenticator.oidc_login.public_client', OidcPublicClient::class)
+            ->abstract()
+            ->args([
+                service('http_client'),
+                abstract_arg('OIDC discovery'),
+                abstract_arg('client ID'),
             ])
 
         ->set('security.authenticator.oidc_login.route_loader', OidcLoginRouteLoader::class)

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/OidcLoginFactoryTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/OidcLoginFactoryTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\OidcLoginFactory;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
@@ -55,6 +56,49 @@ class OidcLoginFactoryTest extends TestCase
         // the per-firewall discovery definition carries the kernel.reset tag with method reset
         $discoveryMain = $container->getDefinition('security.authenticator.oidc_login.discovery.main');
         $this->assertSame(['kernel.reset' => [['method' => 'reset']]], $discoveryMain->getTags());
+    }
+
+    public function testConfidentialClientIsWiredByDefault()
+    {
+        $container = new ContainerBuilder();
+
+        $config = [
+            'provider_uri' => 'https://provider.example.com',
+            'client_id' => 'my-client-id',
+            'client_secret' => 'my-client-secret',
+        ];
+
+        $factory = new OidcLoginFactory();
+        $factory->createAuthenticator($container, 'main', $this->processConfig($config, $factory), 'userprovider');
+
+        $client = $container->getDefinition('security.authenticator.oidc_login.client.main');
+        $this->assertInstanceOf(ChildDefinition::class, $client);
+        $this->assertSame('security.authenticator.oidc_login.client', $client->getParent());
+        $this->assertSame('my-client-secret', $client->getArgument(3));
+        $this->assertSame('client_secret_post', $client->getArgument(4));
+    }
+
+    public function testPublicClientIsWiredWhenTheTokenEndpointNeedsNoAuthentication()
+    {
+        $container = new ContainerBuilder();
+
+        $config = [
+            'provider_uri' => 'https://provider.example.com',
+            'client_id' => 'my-client-id',
+            'token_endpoint_auth_method' => 'none',
+        ];
+
+        $factory = new OidcLoginFactory();
+        $factory->createAuthenticator($container, 'main', $this->processConfig($config, $factory), 'userprovider');
+
+        $client = $container->getDefinition('security.authenticator.oidc_login.client.main');
+        $this->assertInstanceOf(ChildDefinition::class, $client);
+        $this->assertSame('security.authenticator.oidc_login.public_client', $client->getParent());
+        $this->assertEquals(new Reference('security.authenticator.oidc_login.discovery.main'), $client->getArgument(1));
+        $this->assertSame('my-client-id', $client->getArgument(2));
+        // a public client takes neither a secret nor an authentication method
+        $this->assertArrayNotHasKey('index_3', $client->getArguments());
+        $this->assertArrayNotHasKey('index_4', $client->getArguments());
     }
 
     public function testFirewallUserProviderIsInjected()
@@ -347,6 +391,101 @@ class OidcLoginFactoryTest extends TestCase
         yield 'IPv6 loopback' => ['http://[::1]:8080'];
         yield 'localhost subdomain' => ['http://keycloak.localhost'];
         yield 'test TLD' => ['http://keycloak.test'];
+    }
+
+    #[DataProvider('provideSecretBasedAuthMethods')]
+    public function testRejectsAMissingClientSecretForSecretBasedAuthentication(?string $tokenEndpointAuthMethod)
+    {
+        $factory = new OidcLoginFactory();
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('The OIDC "client_secret" is required by the "token_endpoint_auth_method" in use');
+
+        $config = [
+            'provider_uri' => 'https://provider.example.com',
+            'client_id' => 'my-client-id',
+        ];
+        if (null !== $tokenEndpointAuthMethod) {
+            $config['token_endpoint_auth_method'] = $tokenEndpointAuthMethod;
+        }
+
+        $this->processConfig($config, $factory);
+    }
+
+    public static function provideSecretBasedAuthMethods(): iterable
+    {
+        yield 'implicit default' => [null];
+        yield 'client_secret_post' => ['client_secret_post'];
+        yield 'client_secret_basic' => ['client_secret_basic'];
+    }
+
+    public function testRejectsAClientSecretForAPublicClient()
+    {
+        $factory = new OidcLoginFactory();
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('The OIDC "client_secret" must not be set when "token_endpoint_auth_method" is "none"');
+
+        $this->processConfig([
+            'provider_uri' => 'https://provider.example.com',
+            'client_id' => 'my-client-id',
+            'client_secret' => 'my-client-secret',
+            'token_endpoint_auth_method' => 'none',
+        ], $factory);
+    }
+
+    public function testAllowsAnExplicitNullClientSecretForAPublicClient()
+    {
+        $factory = new OidcLoginFactory();
+
+        $finalizedConfig = $this->processConfig([
+            'provider_uri' => 'https://provider.example.com',
+            'client_id' => 'my-client-id',
+            'client_secret' => null,
+            'token_endpoint_auth_method' => 'none',
+        ], $factory);
+
+        $this->assertNull($finalizedConfig['client_secret']);
+    }
+
+    public function testRejectsAnEmptyClientSecret()
+    {
+        $factory = new OidcLoginFactory();
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('The OIDC "client_secret" is required by the "token_endpoint_auth_method" in use');
+
+        $this->processConfig([
+            'provider_uri' => 'https://provider.example.com',
+            'client_id' => 'my-client-id',
+            'client_secret' => '',
+        ], $factory);
+    }
+
+    public function testPublicClientDefaults()
+    {
+        $factory = new OidcLoginFactory();
+
+        $finalizedConfig = $this->processConfig([
+            'provider_uri' => 'https://provider.example.com',
+            'client_id' => 'my-client-id',
+            'token_endpoint_auth_method' => 'none',
+        ], $factory);
+
+        $this->assertNull($finalizedConfig['client_secret']);
+    }
+
+    public function testTokenEndpointAuthMethodDefaultsToClientSecretPost()
+    {
+        $factory = new OidcLoginFactory();
+
+        $finalizedConfig = $this->processConfig([
+            'provider_uri' => 'https://provider.example.com',
+            'client_id' => 'my-client-id',
+            'client_secret' => 'my-client-secret',
+        ], $factory);
+
+        $this->assertSame('client_secret_post', $finalizedConfig['token_endpoint_auth_method']);
     }
 
     private function processConfig(array $config, OidcLoginFactory $factory): array

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
@@ -44,6 +44,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
 use Symfony\Component\Security\Http\Authenticator\HttpBasicAuthenticator;
+use Symfony\Component\Security\Http\Authenticator\Oidc\OidcPublicClient;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 
 class SecurityExtensionTest extends TestCase
@@ -1507,6 +1508,29 @@ class SecurityExtensionTest extends TestCase
 
         $authenticator = $container->getDefinition('security.authenticator.oidc_login.main');
         $this->assertSame('security.user.provider.concrete.oidc', (string) $authenticator->getArgument(1));
+    }
+
+    public function testOidcLoginSupportsAPublicClient()
+    {
+        $container = $this->getRawContainer();
+        $container->loadFromExtension('security', [
+            'providers' => ['oidc' => ['oidc' => null]],
+            'firewalls' => [
+                'main' => [
+                    'oidc_login' => [
+                        'provider_uri' => 'https://provider.example.com',
+                        'client_id' => 'my-client-id',
+                        'token_endpoint_auth_method' => 'none',
+                    ],
+                ],
+            ],
+        ]);
+
+        $container->compile();
+
+        $client = $container->getDefinition('security.authenticator.oidc_login.client.main');
+        $this->assertSame(OidcPublicClient::class, $client->getClass());
+        $this->assertCount(3, $client->getArguments());
     }
 
     protected function getRawContainer()

--- a/src/Symfony/Component/Security/Http/Authenticator/Oidc/OidcConfidentialClient.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Oidc/OidcConfidentialClient.php
@@ -17,8 +17,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * OIDC client for confidential clients (holding a client secret).
  *
- * Authenticates at the token endpoint using `client_secret_post` (secret in the
- * request body), per RFC 6749 §2.3.1.
+ * Authenticates at the token endpoint using either `client_secret_post` (secret
+ * in the request body) or `client_secret_basic` (HTTP Basic Auth), per RFC 6749 §2.3.1.
  *
  * @author Mathieu Santostefano <msantostefano@proton.me>
  */
@@ -29,12 +29,27 @@ class OidcConfidentialClient extends OidcClient
         OidcDiscovery $discovery,
         string $clientId,
         #[\SensitiveParameter] private readonly string $clientSecret,
+        private readonly string $tokenEndpointAuthMethod = 'client_secret_post',
     ) {
+        if (!\in_array($tokenEndpointAuthMethod, ['client_secret_post', 'client_secret_basic'], true)) {
+            throw new \InvalidArgumentException(\sprintf('A confidential OIDC client authenticates with "client_secret_post" or "client_secret_basic", "%s" given.', $tokenEndpointAuthMethod));
+        }
+
         parent::__construct($httpClient, $discovery, $clientId);
     }
 
     protected function applyClientAuthentication(array $body, array $options): array
     {
+        if ('client_secret_basic' === $this->tokenEndpointAuthMethod) {
+            // RFC 6749 Section 2.3.1: the client id and the secret are each form-urlencoded
+            // before being combined into the HTTP Basic credentials, so that a colon, a
+            // percent sign or a non-ASCII byte in either of them survives the round trip
+            $options['auth_basic'] = urlencode($this->clientId).':'.urlencode($this->clientSecret);
+            $options['body'] = $body;
+
+            return $options;
+        }
+
         $body['client_secret'] = $this->clientSecret;
         $options['body'] = $body;
 

--- a/src/Symfony/Component/Security/Http/Authenticator/Oidc/OidcPublicClient.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Oidc/OidcPublicClient.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Authenticator\Oidc;
+
+/**
+ * OIDC client for public clients (holding no client secret).
+ *
+ * A public client cannot keep a secret confidential (RFC 6749 §2.1), so it sends
+ * no credentials at the token endpoint: it is identified by the `client_id` the
+ * authorization code was issued to, which the token request always carries. This
+ * is the `token_endpoint_auth_method` value `none` of RFC 7591 §2.
+ *
+ * Nothing else then binds the authorization code to this client, so PKCE
+ * (RFC 7636) is what protects the exchange: a code intercepted on the redirect
+ * cannot be redeemed without the code verifier. This client therefore refuses to
+ * exchange a code that is not protected by PKCE.
+ *
+ * @see https://datatracker.ietf.org/doc/html/rfc6749#section-2.1 OAuth 2.0 client types
+ * @see https://datatracker.ietf.org/doc/html/rfc7636             PKCE (RFC 7636)
+ *
+ * @author Mathieu Santostefano <msantostefano@proton.me>
+ */
+class OidcPublicClient extends OidcClient
+{
+    protected function applyClientAuthentication(array $body, array $options): array
+    {
+        if ('' === ($body['code_verifier'] ?? '')) {
+            throw new \LogicException('A public OIDC client must exchange the authorization code with PKCE, as it sends no client secret. Pass the code verifier to "exchangeCode()", or use a confidential client.');
+        }
+
+        $options['body'] = $body;
+
+        return $options;
+    }
+}

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -19,6 +19,7 @@ CHANGELOG
  * Add `OidcLoginAuthenticator` for the OpenID Connect Authorization Code Flow (interactive login via OIDC provider)
  * Add `OidcClient` and `OidcDiscovery` protocol classes
  * Cache the discovery document of the `oidc` access token handler for one hour, where it was fetched again on every refresh of the JWKS
+ * Add `OidcPublicClient` to run the OIDC login flow as a public client, which holds no client secret and relies on PKCE, and support `client_secret_basic` in `OidcConfidentialClient`
 
 8.1
 ---

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/Oidc/OidcConfidentialClientTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/Oidc/OidcConfidentialClientTest.php
@@ -82,6 +82,56 @@ class OidcConfidentialClientTest extends TestCase
         $this->assertSame('id-token-abc', $tokens['id_token']);
     }
 
+    public function testExchangeCodeWithClientSecretBasic()
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('toArray')->willReturn([
+            'access_token' => 'access-123',
+            'id_token' => 'id-token-abc',
+        ]);
+
+        $this->httpClient->expects($this->once())
+            ->method('request')
+            ->with('POST', 'https://provider.example.com/token', $this->callback(function (array $options) {
+                $this->assertSame('test-client-id:test-client-secret', $options['auth_basic']);
+                $this->assertArrayNotHasKey('client_secret', $options['body']);
+
+                return true;
+            }))
+            ->willReturn($response);
+
+        $client = $this->createClient(tokenEndpointAuthMethod: 'client_secret_basic');
+        $client->exchangeCode('auth-code', 'https://app.example.com/callback');
+    }
+
+    public function testClientSecretBasicCredentialsAreFormUrlEncoded()
+    {
+        // RFC 6749 Section 2.3.1: the client id and the secret are each form-urlencoded
+        // before being combined into the HTTP Basic credentials
+        $mockResponse = new JsonMockResponse(['access_token' => 'access-123', 'id_token' => 'id-token-abc']);
+
+        $client = new OidcConfidentialClient(
+            httpClient: new MockHttpClient($mockResponse),
+            discovery: $this->discovery,
+            clientId: 'client:id',
+            clientSecret: 'sec:ret% +é',
+            tokenEndpointAuthMethod: 'client_secret_basic',
+        );
+        $client->exchangeCode('auth-code', 'https://app.example.com/callback');
+
+        $requestOptions = $mockResponse->getRequestOptions();
+        $this->assertSame(['Authorization: Basic '.base64_encode('client%3Aid:sec%3Aret%25+%2B%C3%A9')], $requestOptions['normalized_headers']['authorization']);
+        $this->assertStringNotContainsString('client_secret', $requestOptions['body']);
+    }
+
+    public function testRejectsAnUnknownTokenEndpointAuthMethod()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('A confidential OIDC client authenticates with "client_secret_post" or "client_secret_basic", "none" given.');
+
+        $this->createClient(tokenEndpointAuthMethod: 'none');
+    }
+
     public function testExchangeCodeWithCodeVerifier()
     {
         $response = $this->createMock(ResponseInterface::class);
@@ -209,13 +259,14 @@ class OidcConfidentialClientTest extends TestCase
         $this->createClient()->fetchUserInfo('access-token');
     }
 
-    private function createClient(): OidcConfidentialClient
+    private function createClient(string $tokenEndpointAuthMethod = 'client_secret_post'): OidcConfidentialClient
     {
         return new OidcConfidentialClient(
             httpClient: $this->httpClient,
             discovery: $this->discovery,
             clientId: 'test-client-id',
             clientSecret: 'test-client-secret',
+            tokenEndpointAuthMethod: $tokenEndpointAuthMethod,
         );
     }
 }

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/Oidc/OidcPublicClientTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/Oidc/OidcPublicClientTest.php
@@ -1,0 +1,140 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Tests\Authenticator\Oidc;
+
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\JsonMockResponse;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\Security\Http\Authenticator\Oidc\OidcPublicClient;
+use Symfony\Component\Security\Http\Oidc\OidcDiscovery;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+#[AllowMockObjectsWithoutExpectations]
+class OidcPublicClientTest extends TestCase
+{
+    private OidcDiscovery $discovery;
+    private HttpClientInterface $httpClient;
+
+    protected function setUp(): void
+    {
+        $this->discovery = $this->createDiscovery([
+            'token_endpoint' => 'https://provider.example.com/token',
+            'userinfo_endpoint' => 'https://provider.example.com/userinfo',
+            'issuer' => 'https://provider.example.com',
+        ]);
+
+        $this->httpClient = $this->createMock(HttpClientInterface::class);
+    }
+
+    /**
+     * @param array<string, mixed> $configuration
+     */
+    private function createDiscovery(array $configuration): OidcDiscovery
+    {
+        return new OidcDiscovery(
+            new MockHttpClient(static fn (): MockResponse => new JsonMockResponse($configuration)),
+            new ArrayAdapter(),
+            'https://provider.example.com/.well-known/openid-configuration',
+        );
+    }
+
+    public function testExchangeCodeSendsNoClientCredentials()
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('toArray')->willReturn([
+            'access_token' => 'access-123',
+            'id_token' => 'id-token-abc',
+        ]);
+
+        $this->httpClient->expects($this->once())
+            ->method('request')
+            ->with('POST', 'https://provider.example.com/token', $this->callback(function (array $options) {
+                $this->assertSame('authorization_code', $options['body']['grant_type']);
+                $this->assertSame('auth-code', $options['body']['code']);
+                $this->assertSame('https://app.example.com/callback', $options['body']['redirect_uri']);
+                // the client_id and the code verifier are all a public client sends
+                $this->assertSame('test-client-id', $options['body']['client_id']);
+                $this->assertSame('my-code-verifier', $options['body']['code_verifier']);
+                $this->assertArrayNotHasKey('client_secret', $options['body']);
+                $this->assertArrayNotHasKey('auth_basic', $options);
+
+                return true;
+            }))
+            ->willReturn($response);
+
+        $client = $this->createClient();
+        $tokens = $client->exchangeCode('auth-code', 'https://app.example.com/callback', 'my-code-verifier');
+
+        $this->assertSame('access-123', $tokens['access_token']);
+        $this->assertSame('id-token-abc', $tokens['id_token']);
+    }
+
+    public function testExchangeCodeRequiresPkce()
+    {
+        // without a secret and without PKCE, nothing binds the authorization code to
+        // this client: an intercepted code could be redeemed by anyone
+        $this->httpClient->expects($this->never())->method('request');
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('must exchange the authorization code with PKCE');
+
+        $this->createClient()->exchangeCode('auth-code', 'https://app.example.com/callback');
+    }
+
+    public function testExchangeCodeRejectsAnEmptyCodeVerifier()
+    {
+        // an empty verifier would make the exchange look protected while it is not
+        $this->httpClient->expects($this->never())->method('request');
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('must exchange the authorization code with PKCE');
+
+        $this->createClient()->exchangeCode('auth-code', 'https://app.example.com/callback', '');
+    }
+
+    public function testFetchUserInfoUsesTheAccessToken()
+    {
+        // the UserInfo endpoint is a protected resource: it takes the access token as a
+        // bearer credential, so it needs no client authentication at all
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('toArray')->willReturn([
+            'sub' => '123',
+            'email' => 'test@example.com',
+        ]);
+
+        $this->httpClient->expects($this->once())
+            ->method('request')
+            ->with('GET', 'https://provider.example.com/userinfo', [
+                'auth_bearer' => 'access-token',
+            ])
+            ->willReturn($response);
+
+        $client = $this->createClient();
+        $claims = $client->fetchUserInfo('access-token');
+
+        $this->assertSame('123', $claims['sub']);
+        $this->assertSame('test@example.com', $claims['email']);
+    }
+
+    private function createClient(): OidcPublicClient
+    {
+        return new OidcPublicClient(
+            httpClient: $this->httpClient,
+            discovery: $this->discovery,
+            clientId: 'test-client-id',
+        );
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Follow-up of #64954, which only supported `client_secret_post` at the token endpoint. Some providers only accept `client_secret_basic`, and public clients (SPAs, mobile and native applications) hold no secret at all.

```yaml
security:
    firewalls:
        main:
            oidc_login:
                # ...
                token_endpoint_auth_method: client_secret_basic # or client_secret_post (default), or none
```

- `client_secret_post` (default) and `client_secret_basic` are handled by `OidcConfidentialClient`, which now applies the credentials according to the option.
- `none` declares a public client (RFC 7591 §2): the new `OidcPublicClient` sends only the `client_id`, and refuses to exchange a code that carries no PKCE verifier, since PKCE is then the only thing binding the authorization code to the client. `client_secret` becomes forbidden for it, and required for the two others; both are enforced by configuration validation.

One note for the reviewer: `OidcDiscovery::getSecureEndpoint()` refuses a plain HTTP `token_endpoint` even on a loopback host, and its comment justifies that by the client secret travelling through it. That reasoning no longer covers a public client, but the rule still holds: the authorization code and the tokens it is exchanged for travel there too. I can reword that comment here if you prefer.
