### PR TITLE
[SecurityBundle] Always register the OIDC login callback route loader

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -172,6 +172,7 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
             $this->createLogoutUrisParameter($config['firewalls'] ?? [], $container);
         } else {
             $container->removeDefinition('security.route_loader.logout');
+            $container->removeDefinition('security.authenticator.oidc_login.route_loader');
         }
 
         $this->createAuthorization($config, $container);

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 use Symfony\Bundle\SecurityBundle\CacheWarmer\ExpressionCacheWarmer;
 use Symfony\Bundle\SecurityBundle\EventListener\FirewallListener;
 use Symfony\Bundle\SecurityBundle\Routing\LogoutRouteLoader;
+use Symfony\Bundle\SecurityBundle\Routing\OidcLoginRouteLoader;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Bundle\SecurityBundle\Security\FirewallConfig;
 use Symfony\Bundle\SecurityBundle\Security\FirewallContext;
@@ -62,6 +63,9 @@ use Symfony\Component\Security\Http\Session\SessionAuthenticationStrategyInterfa
 return static function (ContainerConfigurator $container) {
     $container->parameters()
         ->set('security.role_hierarchy.roles', [])
+        // the OIDC login callback route loader is wired on this parameter, which the
+        // "oidc_login" firewall factory fills in; it stays empty when no firewall uses one
+        ->set('security.oidc_login.callback_uris', [])
     ;
 
     $container->services()
@@ -262,6 +266,13 @@ return static function (ContainerConfigurator $container) {
             ->args([
                 '%security.logout_uris%',
                 'security.logout_uris',
+            ])
+            ->tag('routing.route_loader')
+
+        ->set('security.authenticator.oidc_login.route_loader', OidcLoginRouteLoader::class)
+            ->args([
+                '%security.oidc_login.callback_uris%',
+                'security.oidc_login.callback_uris',
             ])
             ->tag('routing.route_loader')
 

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator_oidc_login.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator_oidc_login.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-use Symfony\Bundle\SecurityBundle\Routing\OidcLoginRouteLoader;
 use Symfony\Component\Security\Http\Authenticator\Oidc\OidcConfidentialClient;
 use Symfony\Component\Security\Http\Authenticator\Oidc\OidcIdToken;
 use Symfony\Component\Security\Http\Authenticator\Oidc\OidcPublicClient;
@@ -73,12 +72,5 @@ return static function (ContainerConfigurator $container) {
                 abstract_arg('OIDC discovery'),
                 abstract_arg('client ID'),
             ])
-
-        ->set('security.authenticator.oidc_login.route_loader', OidcLoginRouteLoader::class)
-            ->args([
-                '%security.oidc_login.callback_uris%',
-                'security.oidc_login.callback_uris',
-            ])
-            ->tag('routing.route_loader')
     ;
 };

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/OidcLoginFactoryTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/OidcLoginFactoryTest.php
@@ -312,7 +312,6 @@ class OidcLoginFactoryTest extends TestCase
         $finalizedConfig = $this->processConfig($config, $factory);
         $factory->createAuthenticator($container, 'main', $finalizedConfig, 'userprovider');
 
-        $this->assertTrue($container->hasDefinition('security.authenticator.oidc_login.route_loader'));
         $this->assertSame(['main' => '/oidc/callback'], $container->getParameter('security.oidc_login.callback_uris'));
     }
 
@@ -332,7 +331,6 @@ class OidcLoginFactoryTest extends TestCase
         $finalizedConfig = $this->processConfig($config, $factory);
         $factory->createAuthenticator($container, 'main', $finalizedConfig, 'userprovider');
 
-        $this->assertTrue($container->hasDefinition('security.authenticator.oidc_login.route_loader'));
         $this->assertSame('oidc_callback_route', $finalizedConfig['check_path']);
         // no route is declared for a route name, but the parameter the route loader
         // is wired on must exist

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\AuthenticatorFactoryInterface;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\FirewallListenerFactoryInterface;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\SecurityExtension;
+use Symfony\Bundle\SecurityBundle\Routing\OidcLoginRouteLoader;
 use Symfony\Bundle\SecurityBundle\SecurityBundle;
 use Symfony\Bundle\SecurityBundle\Tests\DependencyInjection\Fixtures\UserProviderFactory\CustomProviderFactory;
 use Symfony\Bundle\SecurityBundle\Tests\DependencyInjection\Fixtures\UserProviderFactory\DummyProviderFactory;
@@ -1531,6 +1532,28 @@ class SecurityExtensionTest extends TestCase
         $client = $container->getDefinition('security.authenticator.oidc_login.client.main');
         $this->assertSame(OidcPublicClient::class, $client->getClass());
         $this->assertCount(3, $client->getArguments());
+    }
+
+    public function testOidcLoginCallbackRouteLoaderIsAlwaysRegistered()
+    {
+        // the "security.yaml" routing recipe imports this loader unconditionally, so it
+        // must exist even in an application no firewall of which uses the OIDC authenticator
+        $container = $this->getRawContainer();
+        $container->loadFromExtension('security', [
+            'providers' => ['default' => ['memory' => null]],
+            'firewalls' => ['main' => ['form_login' => null]],
+        ]);
+
+        $container->compile();
+
+        $this->assertTrue($container->hasDefinition('security.authenticator.oidc_login.route_loader'));
+        $this->assertSame([], $container->getParameter('security.oidc_login.callback_uris'));
+
+        $loader = $container->getDefinition('security.authenticator.oidc_login.route_loader');
+        $this->assertSame(OidcLoginRouteLoader::class, $loader->getClass());
+        $this->assertArrayHasKey('routing.route_loader', $loader->getTags());
+        // it declares no route as long as no firewall configures an OIDC callback path
+        $this->assertCount(0, (new OidcLoginRouteLoader($container->getParameter('security.oidc_login.callback_uris'), 'security.oidc_login.callback_uris'))());
     }
 
     protected function getRawContainer()

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/OidcLoginRouteLoaderTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/OidcLoginRouteLoaderTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
+
+class OidcLoginRouteLoaderTest extends AbstractWebTestCase
+{
+    public function testRouteLoaderCanBeImportedWithoutOidcLoginFirewall()
+    {
+        $this->createClient(['test_case' => 'OidcLoginRouteLoader', 'root_config' => 'config.yml']);
+
+        $routes = static::getContainer()->get('router')->getRouteCollection();
+
+        $this->assertSame([], array_filter(array_keys($routes->all()), static fn (string $name) => str_starts_with($name, '_oidc_login_callback_')));
+        $this->assertNotNull($routes->get('_logout_main'));
+    }
+
+    public function testRouteLoaderDeclaresTheCallbackRoute()
+    {
+        $this->createClient(['test_case' => 'OidcLoginRouteLoader', 'root_config' => 'config_oidc.yml']);
+
+        $routes = static::getContainer()->get('router')->getRouteCollection();
+
+        $this->assertSame('/oidc/callback', $routes->get('_oidc_login_callback_oidc')?->getPath());
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/OidcLoginRouteLoader/bundles.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/OidcLoginRouteLoader/bundles.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\SecurityBundle\SecurityBundle;
+
+return [
+    new FrameworkBundle(),
+    new SecurityBundle(),
+];

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/OidcLoginRouteLoader/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/OidcLoginRouteLoader/config.yml
@@ -1,0 +1,13 @@
+imports:
+    - { resource: ./../config/framework.yml }
+
+security:
+    providers:
+        in_memory:
+            memory: ~
+
+    firewalls:
+        main:
+            http_basic: ~
+            logout: ~
+            stateless: true

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/OidcLoginRouteLoader/config_oidc.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/OidcLoginRouteLoader/config_oidc.yml
@@ -1,0 +1,22 @@
+imports:
+    - { resource: ./../config/framework.yml }
+
+framework:
+    http_client: ~
+
+security:
+    providers:
+        in_memory:
+            memory: ~
+
+    firewalls:
+        oidc:
+            pattern: ^/oidc
+            provider: in_memory
+            oidc_login:
+                provider_uri: 'https://accounts.example.com'
+                client_id: client_id
+                client_secret: client_secret
+        main:
+            http_basic: ~
+            stateless: true

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/OidcLoginRouteLoader/routing.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/OidcLoginRouteLoader/routing.yml
@@ -1,0 +1,8 @@
+# mirrors what the routing recipe ships for every application
+_security_oidc_login:
+    resource: security.authenticator.oidc_login.route_loader
+    type: service
+
+_security_logout:
+    resource: security.route_loader.logout
+    type: service


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Follow-up of #64954. The `oidc_login` callback path needs a route, otherwise the router answers the provider's redirect with a 404 before the firewall sees it. #64954 declares it through `security.authenticator.oidc_login.route_loader`, which the application imports, exactly as it does for the logout routes:

```yaml
# config/routes/security.yaml
_oidc_login_callbacks:
    resource: security.authenticator.oidc_login.route_loader
    type: service
```

That import belongs in the `symfony/security-bundle` recipe, next to the existing `_security_logout` one. But the service is registered by `OidcLoginFactory::createAuthenticator()`, so it only exists when a firewall declares an `oidc_login` authenticator: shipping the import in the recipe would throw a `ServiceNotFoundException` in every application that does not use OIDC.

This PR registers it in `security.php` next to `security.route_loader.logout`, with `security.oidc_login.callback_uris` defaulting to an empty array, so the loader always exists and simply declares no route until a firewall configures a callback path. It is removed, like the logout one, when `symfony/routing` is not installed.

The companion recipe pull request follows once this is merged.
