### PR TITLE
[Finder] Fix prune filters not applied to nested directories and with path excludes

### DIFF
--- a/src/Symfony/Component/Finder/Iterator/ExcludeDirectoryFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/ExcludeDirectoryFilterIterator.php
@@ -80,7 +80,9 @@ class ExcludeDirectoryFilterIterator extends \FilterIterator implements \Recursi
             $path = $this->isDir() ? $this->current()->getRelativePathname() : $this->current()->getRelativePath();
             $path = str_replace('\\', '/', $path);
 
-            return !preg_match($this->excludedPattern, $path);
+            if (preg_match($this->excludedPattern, $path)) {
+                return false;
+            }
         }
 
         if ($this->pruneFilters && $this->hasChildren()) {
@@ -104,6 +106,7 @@ class ExcludeDirectoryFilterIterator extends \FilterIterator implements \Recursi
         $children = new self($this->iterator->getChildren(), []);
         $children->excludedDirs = $this->excludedDirs;
         $children->excludedPattern = $this->excludedPattern;
+        $children->pruneFilters = $this->pruneFilters;
 
         return $children;
     }

--- a/src/Symfony/Component/Finder/Tests/FinderTest.php
+++ b/src/Symfony/Component/Finder/Tests/FinderTest.php
@@ -1051,11 +1051,68 @@ class FinderTest extends Iterator\RealIteratorTestCase
             ['x/x', 'exclude_filter', true], // from CustomFilterIterator::accept() (regular filter)
             ['x/x', 'list_dir_open', ['d']],
             ['x/x/d', 'is_dir', true],
-            ['x/x/d', 'exclude_filter', true],
+            ['x/x/d', 'exclude_filter', true], // from ExcludeDirectoryFilterIterator::accept() (prune directory filter)
+            ['x/x/d', 'exclude_filter', true], // from CustomFilterIterator::accept() (regular filter)
             ['x/x/d', 'list_dir_open', ['u2.php']],
             ['x/x/d/u2.php', 'is_dir', false],
             ['x/x/d/u2.php', 'exclude_filter', true],
         ], $this->vfsLog);
+    }
+
+    public function testFilterPruneNestedDirectory()
+    {
+        $this->setupVfsProvider([
+            'x' => [
+                'a.php' => '',
+                'n' => [
+                    'd' => [
+                        'u.php' => '',
+                    ],
+                    'z.php' => '',
+                ],
+            ],
+        ]);
+
+        $finder = $this->buildFinder();
+        $finder
+            ->in($this->vfsScheme.'://x')
+            ->filter(static fn (\SplFileInfo $file): bool => 'd' !== $file->getFilename(), true);
+
+        $this->assertSameVfsIterator([
+            'x/a.php',
+            'x/n',
+            'x/n/z.php',
+        ], $finder->getIterator());
+    }
+
+    public function testFilterPruneWithExcludedPath()
+    {
+        $this->setupVfsProvider([
+            'x' => [
+                'a.php' => '',
+                'd' => [
+                    'u.php' => '',
+                ],
+                'g' => [
+                    'h' => [
+                        'v.php' => '',
+                    ],
+                    'w.php' => '',
+                ],
+            ],
+        ]);
+
+        $finder = $this->buildFinder();
+        $finder
+            ->in($this->vfsScheme.'://x')
+            ->exclude('g/h')
+            ->filter(static fn (\SplFileInfo $file): bool => 'd' !== $file->getFilename(), true);
+
+        $this->assertSameVfsIterator([
+            'x/a.php',
+            'x/g',
+            'x/g/w.php',
+        ], $finder->getIterator());
     }
 
     public function testFollowLinks()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues       | -
| License       | MIT

Since 6.4.0, prune filters registered with `Finder::filter($closure, prune: true)` are only applied to the directories at the root of the search tree: `getChildren()` does not pass them down to child iterators. Because every prune filter is also a regular result filter, the rejected directory itself disappears from the results, which hides the defect, but its subtree is still traversed: the scan is not avoided and the children of the rejected directory leak into the results.

```php
// $dir contains n/d/u.php
$finder = (new Finder())
    ->in($dir)
    ->filter(fn (\SplFileInfo $f) => 'd' !== $f->getFilename(), true);

// before: "n/d" is hidden from the results, but "n/d" is still scanned and "n/d/u.php" is listed
// after: the whole "n/d" subtree is pruned
```

On top of that, when `exclude()` is given a value that contains a slash, it compiles to a regex and `accept()` then returns early, so prune filters are skipped entirely, even at the root:

```php
$finder = (new Finder())
    ->in($dir)
    ->exclude('g/h')
    ->filter(fn (\SplFileInfo $f) => 'd' !== $f->getFilename(), true); // was ignored during traversal
```

Both fixed by letting `accept()` fall through to the prune filters and by copying the filters to child iterators. The extra entry in the `testFilterPrune` expectation is the prune filter now being consulted for the nested `x/x/d` directory (it accepts it, as before).

Merge-up note for 8.2: #54752 restructures `accept()` in the same place; keep its structure and keep the `$children->pruneFilters` line from this PR.
