### PR TITLE
[Translation] Add translation:update-xliff-sources command

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1623,6 +1623,7 @@ class FrameworkExtension extends Extension
             $container->removeDefinition('console.command.translation_pull');
             $container->removeDefinition('console.command.translation_push');
             $container->removeDefinition('console.command.translation_lint');
+            $container->removeDefinition('console.command.translation_xliff_update_sources');
 
             return;
         }
@@ -1698,6 +1699,10 @@ class FrameworkExtension extends Extension
 
         if ($container->hasDefinition('console.command.translation_extract')) {
             $container->getDefinition('console.command.translation_extract')->replaceArgument(6, $transPaths);
+        }
+
+        if ($container->hasDefinition('console.command.translation_xliff_update_sources')) {
+            $container->getDefinition('console.command.translation_xliff_update_sources')->replaceArgument(3, array_merge($config['paths'], [$config['default_path']]));
         }
 
         if (null === $defaultDir) {

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.php
@@ -60,6 +60,7 @@ use Symfony\Component\Translation\Command\TranslationLintCommand;
 use Symfony\Component\Translation\Command\TranslationPullCommand;
 use Symfony\Component\Translation\Command\TranslationPushCommand;
 use Symfony\Component\Translation\Command\XliffLintCommand;
+use Symfony\Component\Translation\Command\XliffUpdateSourcesCommand;
 use Symfony\Component\Validator\Command\DebugCommand as ValidatorDebugCommand;
 use Symfony\Component\Workflow\Command\WorkflowDumpCommand;
 use Symfony\Component\Yaml\Schema\FileHeaderSchemaResolver;
@@ -324,6 +325,16 @@ return static function (ContainerConfigurator $container) {
             ->tag('console.command')
 
         ->set('console.command.xliff_lint', XliffLintCommand::class)
+            ->tag('console.command')
+
+        ->set('console.command.translation_xliff_update_sources', XliffUpdateSourcesCommand::class)
+            ->args([
+                service('translation.writer'),
+                service('translation.reader'),
+                param('kernel.default_locale'),
+                [], // Translator paths
+                param('kernel.enabled_locales'),
+            ])
             ->tag('console.command')
 
         ->set('console.command.yaml_lint', YamlLintCommand::class)

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -1719,6 +1719,12 @@ abstract class FrameworkExtensionTestCase extends TestCase
         $this->assertNotEmpty($nonExistingDirectories, 'FrameworkBundle should pass non existing directories to Translator');
 
         $this->assertSame('Fixtures/translations', $options['cache_vary']['scanned_directories'][3]);
+
+        $this->assertSame(
+            [__DIR__.'/Fixtures/translations', __DIR__.'/translations'],
+            $container->getParameterBag()->resolveValue($container->getDefinition('console.command.translation_xliff_update_sources')->getArgument(3)),
+            '->registerTranslatorConfiguration() passes only app-owned paths to the XLIFF source updater'
+        );
     }
 
     public function testTranslatorProvidersMergedEnabledLocales()

--- a/src/Symfony/Component/Translation/CHANGELOG.md
+++ b/src/Symfony/Component/Translation/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Preserve the XLIFF `<source>` element when loading and dumping a file, instead of overwriting it with the message key
  * Add a locale-aware `Plural-Forms` header to the output of `PoFileDumper`
  * Re-add `PoEditorProvider`
+ * Add `translation:update-xliff-sources` command to fill the `<source>` tags of XLIFF files with the default locale's translations
 
 8.1
 ---

--- a/src/Symfony/Component/Translation/Command/XliffUpdateSourcesCommand.php
+++ b/src/Symfony/Component/Translation/Command/XliffUpdateSourcesCommand.php
@@ -1,0 +1,202 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Command;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Completion\CompletionInput;
+use Symfony\Component\Console\Completion\CompletionSuggestions;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Translation\MessageCatalogue;
+use Symfony\Component\Translation\MetadataAwareInterface;
+use Symfony\Component\Translation\Reader\TranslationReaderInterface;
+use Symfony\Component\Translation\Writer\TranslationWriterInterface;
+
+/**
+ * @author Nicolas Rigaud <squrious@protonmail.com>
+ */
+#[AsCommand(name: 'translation:update-xliff-sources', description: 'Update source tags with default locale targets in XLIFF files')]
+class XliffUpdateSourcesCommand extends Command
+{
+    use TranslationTrait;
+
+    private const array FORMATS = [
+        'xlf12' => ['xlf', '1.2'],
+        'xlf20' => ['xlf', '2.0'],
+    ];
+
+    public function __construct(
+        private readonly TranslationWriterInterface $writer,
+        private readonly TranslationReaderInterface $reader,
+        private readonly string $defaultLocale,
+        private readonly array $transPaths = [],
+        private readonly array $enabledLocales = [],
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setDefinition([
+                new InputArgument('paths', InputArgument::OPTIONAL | InputArgument::IS_ARRAY, 'Paths to look for translations.'),
+                new InputOption('format', null, InputOption::VALUE_REQUIRED, 'Override the default output format.', 'xlf12'),
+                new InputOption('domains', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Specify the domain to update.'),
+                new InputOption('locales', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Specify the locale to update.', $this->enabledLocales),
+            ])
+            ->setHelp(<<<EOF
+                The <info>%command.name%</info> command updates the source tags in XLIFF files with the default locale translation if available.
+
+                You can specify directories to update in the command arguments:
+
+                  <info>php %command.full_name% path/to/dir path/to/another/dir</info>
+
+                To restrict the updates to one or more locales, including the default locale itself, use the <comment>--locales</comment> option:
+
+                  <info>php %command.full_name% --locales en --locales fr</info>
+
+                You can specify one or more domains to target with the <comment>--domains</comment> option. By default, all available domains for the targeted locales are used.
+
+                  <info>php %command.full_name% --domains messages</info>
+
+                EOF,
+            )
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $format = $input->getOption('format');
+
+        if (!\array_key_exists($format, self::FORMATS)) {
+            $io->error(\sprintf('Unknown format "%s". Available formats are: %s.', $format, implode(', ', array_map(static fn ($f) => '"'.$f.'"', array_keys(self::FORMATS)))));
+
+            return self::INVALID;
+        }
+
+        [$format, $xliffVersion] = self::FORMATS[$format];
+
+        $locales = $input->getOption('locales');
+
+        if (!$locales) {
+            $io->error('No locales provided in --locales options and no defaults provided to the command.');
+
+            return self::INVALID;
+        }
+
+        $transPaths = $input->getArgument('paths') ?: $this->transPaths;
+
+        if (!$transPaths) {
+            $io->error('No paths specified in arguments, and no default paths provided to the command.');
+
+            return self::INVALID;
+        }
+
+        $domains = $input->getOption('domains');
+
+        $io->title('XLIFF Source Tag Updater');
+
+        foreach ($transPaths as $transPath) {
+            $io->comment(\sprintf('Updating XLIFF files in <info>%s</info>...', $transPath));
+
+            $translatorBag = $this->readLocalTranslations(array_unique(array_merge($locales, [$this->defaultLocale])), $domains, [$transPath]);
+
+            $defaultLocaleCatalogue = $translatorBag->getCatalogue($this->defaultLocale);
+
+            if (!$defaultLocaleCatalogue instanceof MetadataAwareInterface) {
+                $io->error(\sprintf('The default locale catalogue must implement "%s" to be used in this tool.', MetadataAwareInterface::class));
+
+                return self::FAILURE;
+            }
+
+            foreach ($locales as $locale) {
+                $currentCatalogue = $translatorBag->getCatalogue($locale);
+
+                if (!$currentCatalogue instanceof MessageCatalogue) {
+                    $io->warning(\sprintf('The catalogue for locale "%s" must be an instance of "%s" to be used in this tool.', $locale, MessageCatalogue::class));
+
+                    continue;
+                }
+
+                if (!\count($currentCatalogue->getDomains())) {
+                    $io->warning(\sprintf('No messages found for locale "%s".', $locale));
+
+                    continue;
+                }
+
+                $updateSourceCount = 0;
+
+                foreach ($currentCatalogue->getDomains() as $domain) {
+                    foreach ($currentCatalogue->all($domain) as $key => $value) {
+                        if (!$defaultLocaleCatalogue->has($key, $domain)) {
+                            continue;
+                        }
+
+                        $resultMetadata = $currentCatalogue->getMetadata($key, $domain);
+                        $defaultTranslation = $defaultLocaleCatalogue->get($key, $domain);
+                        if (!isset($resultMetadata['source']) || $resultMetadata['source'] !== $defaultTranslation) {
+                            ++$updateSourceCount;
+                            $resultMetadata['source'] = $defaultTranslation;
+                            $currentCatalogue->setMetadata($key, $resultMetadata, $domain);
+                        }
+                    }
+                }
+
+                if (0 === $updateSourceCount) {
+                    $io->info(\sprintf('All source tags are already up-to-date for locale "%s".', $locale));
+
+                    continue;
+                }
+
+                $this->writer->write($currentCatalogue, $format, ['path' => $transPath, 'default_locale' => $this->defaultLocale, 'xliff_version' => $xliffVersion]);
+
+                $io->info(\sprintf('Updated %d source tag%s for locale "%s".', $updateSourceCount, $updateSourceCount > 1 ? 's' : '', $locale));
+            }
+        }
+
+        $io->success('Operation succeeded.');
+
+        return self::SUCCESS;
+    }
+
+    public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void
+    {
+        if ($input->mustSuggestOptionValuesFor('locales')) {
+            $suggestions->suggestValues($this->enabledLocales);
+
+            return;
+        }
+
+        if ($input->mustSuggestOptionValuesFor('format')) {
+            $suggestions->suggestValues(array_keys(self::FORMATS));
+
+            return;
+        }
+
+        if ($input->mustSuggestOptionValuesFor('domains') && $locales = $input->getOption('locales')) {
+            $suggestedDomains = [];
+            $translatorBag = $this->readLocalTranslations($locales, [], $input->getArgument('paths') ?: $this->transPaths);
+            foreach ($translatorBag->getCatalogues() as $catalogue) {
+                array_push($suggestedDomains, ...$catalogue->getDomains());
+            }
+            if ($suggestedDomains) {
+                $suggestions->suggestValues(array_unique($suggestedDomains));
+            }
+        }
+    }
+}

--- a/src/Symfony/Component/Translation/Tests/Command/XliffUpdateSourcesCommandTest.php
+++ b/src/Symfony/Component/Translation/Tests/Command/XliffUpdateSourcesCommandTest.php
@@ -1,0 +1,379 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Tests\Command;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandCompletionTester;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Translation\Command\XliffUpdateSourcesCommand;
+use Symfony\Component\Translation\Dumper\XliffFileDumper;
+use Symfony\Component\Translation\Loader\XliffFileLoader;
+use Symfony\Component\Translation\Reader\TranslationReader;
+use Symfony\Component\Translation\Reader\TranslationReaderInterface;
+use Symfony\Component\Translation\Writer\TranslationWriter;
+use Symfony\Component\Translation\Writer\TranslationWriterInterface;
+
+class XliffUpdateSourcesCommandTest extends TestCase
+{
+    private string $translationAppDir;
+    private string $defaultTranslationPath;
+
+    private Filesystem $fs;
+
+    private string|false $colSize;
+
+    protected function setUp(): void
+    {
+        $this->colSize = getenv('COLUMNS');
+        putenv('COLUMNS='.(119 + \strlen(\PHP_EOL)));
+        $this->fs = new Filesystem();
+        $this->translationAppDir = \sprintf('%s/translation-xliff-update-source-test', sys_get_temp_dir());
+        $this->defaultTranslationPath = \sprintf('%s/translations', $this->translationAppDir);
+        $this->fs->mkdir($this->defaultTranslationPath);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->fs->remove($this->translationAppDir);
+        putenv($this->colSize ? 'COLUMNS='.$this->colSize : 'COLUMNS');
+    }
+
+    public function testCommandUpdatesXliff1Files()
+    {
+        $originalEnContent = $this->createXliff1('en', 'hello', 'hello', 'Hello there');
+        $enFile = $this->createFile($originalEnContent, 'messages.en.xlf');
+
+        $originalFrContent = $this->createXliff1('fr', 'hello', 'hello', 'Bonjour !');
+        $frFile = $this->createFile($originalFrContent, 'messages.fr.xlf');
+
+        $tester = new CommandTester($this->createCommand(enabledLocales: ['en', 'fr']));
+        $tester->execute([]);
+
+        $tester->assertCommandIsSuccessful();
+
+        // All locales should be updated
+        $this->assertFileContainsSource('Hello there', $enFile);
+        $this->assertFileContainsSource('Hello there', $frFile);
+    }
+
+    public function testCommandUpdatesXliff2Files()
+    {
+        $originalEnContent = $this->createXliff2('en', 'hello', 'hello', 'Hello there');
+        $enFile = $this->createFile($originalEnContent, 'messages.en.xlf');
+
+        $originalFrContent = $this->createXliff2('fr', 'hello', 'hello', 'Bonjour !');
+        $frFile = $this->createFile($originalFrContent, 'messages.fr.xlf');
+
+        $tester = new CommandTester($this->createCommand(enabledLocales: ['en', 'fr']));
+        $tester->execute(['--format' => 'xlf20']);
+
+        $tester->assertCommandIsSuccessful();
+
+        // All locales should be updated
+        $this->assertFileContainsSource('Hello there', $enFile);
+        $this->assertFileContainsSource('Hello there', $frFile);
+    }
+
+    public function testCommandUpdatesOnlyProvidedLocales()
+    {
+        $originalEnContent = $this->createXliff1('en', 'hello', 'hello', 'Hello there');
+        $enFile = $this->createFile($originalEnContent, 'messages.en.xlf');
+
+        $originalFrContent = $this->createXliff1('fr', 'hello', 'hello', 'Bonjour !');
+        $frFile = $this->createFile($originalFrContent, 'messages.fr.xlf');
+
+        $tester = new CommandTester($this->createCommand(enabledLocales: ['en', 'fr']));
+        $tester->execute(['--locales' => ['fr']]);
+
+        $tester->assertCommandIsSuccessful();
+
+        // Default locale shouldn't be updated
+        $this->assertFileContainsSource('hello', $enFile);
+
+        // Locale fr should be updated
+        $this->assertFileContainsSource('Hello there', $frFile);
+    }
+
+    public function testCommandDoesNotRewriteFilesWhenSourcesAreUpToDate()
+    {
+        $originalContent = $this->createXliff1('en', 'hello', 'Hello there', 'Hello there');
+        $enFile = $this->createFile($originalContent, 'messages.en.xlf');
+
+        $tester = new CommandTester($this->createCommand(enabledLocales: ['en']));
+        $tester->execute([]);
+
+        $tester->assertCommandIsSuccessful();
+
+        $this->assertStringContainsString('already up-to-date', $tester->getDisplay());
+        $this->assertStringEqualsFile($enFile, $originalContent);
+    }
+
+    public function testCommandUpdatesAllAvailablePathsByDefault()
+    {
+        $otherPath = \sprintf('%s/other', $this->translationAppDir);
+        $this->fs->mkdir($otherPath);
+
+        $originalContent = $this->createXliff1('en', 'hello', 'hello', 'Hello there');
+        $enFileInDefaultDir = $this->createFile($originalContent, 'messages.en.xlf');
+        $enFileInOtherDir = $this->createFile($originalContent, 'messages.en.xlf', 'other');
+
+        $tester = new CommandTester($this->createCommand(additionalTransPaths: [$otherPath], enabledLocales: ['en']));
+        $tester->execute([]);
+
+        $tester->assertCommandIsSuccessful();
+
+        // translations/messages.en.xlf should be updated
+        $this->assertStringContainsString(
+            \sprintf('Updating XLIFF files in %s...', $this->defaultTranslationPath),
+            $tester->getDisplay(),
+        );
+        $this->assertFileContainsSource('Hello there', $enFileInDefaultDir);
+
+        // other/messages.en.xlf should be updated
+        $this->assertStringContainsString(
+            \sprintf('Updating XLIFF files in %s...', $otherPath),
+            $tester->getDisplay()
+        );
+        $this->assertFileContainsSource('Hello there', $enFileInOtherDir);
+    }
+
+    public function testCommandUpdatesOnlyProvidedPaths()
+    {
+        $fooDir = \sprintf('%s/foo', $this->translationAppDir);
+
+        $this->fs->mkdir($fooDir);
+
+        $originalContent = $this->createXliff1('en', 'hello', 'hello', 'Hello there');
+        $fileInFooDir = $this->createFile($originalContent, 'messages.en.xlf', 'foo');
+        $fileInDefaultDir = $this->createFile($originalContent, 'messages.en.xlf');
+
+        $tester = new CommandTester($this->createCommand(enabledLocales: ['en']));
+        $tester->execute(['paths' => [$fooDir]]);
+
+        $tester->assertCommandIsSuccessful();
+
+        // foo/messages.en.xlf should be updated
+        $this->assertStringContainsString(
+            \sprintf('Updating XLIFF files in %s...', $fooDir),
+            $tester->getDisplay(),
+        );
+        $this->assertFileContainsSource('Hello there', $fileInFooDir);
+
+        // translations/messages.en.xlf shouldn't be updated
+        $this->assertStringNotContainsString(
+            \sprintf('Updating XLIFF files in %s...', $this->defaultTranslationPath),
+            $tester->getDisplay(),
+        );
+        $this->assertFileContainsSource('hello', $fileInDefaultDir);
+    }
+
+    public function testCommandUpdatesAllDomainsByDefault()
+    {
+        $originalContent = $this->createXliff1('en', 'hello', 'hello', 'Hello there');
+        $messagesEnFile = $this->createFile($originalContent, 'messages.en.xlf');
+        $othersEnFile = $this->createFile($originalContent, 'others.en.xlf');
+
+        $tester = new CommandTester($this->createCommand());
+        $tester->execute(['--locales' => ['en']]);
+
+        $tester->assertCommandIsSuccessful();
+
+        // All files should be updated
+        $this->assertFileContainsSource('Hello there', $messagesEnFile);
+        $this->assertFileContainsSource('Hello there', $othersEnFile);
+    }
+
+    public function testCommandOnlyUpdatesProvidedDomains()
+    {
+        $originalContent = $this->createXliff1('en', 'hello', 'hello', 'Hello there');
+        $messagesEnFile = $this->createFile($originalContent, 'messages.en.xlf');
+        $othersEnFile = $this->createFile($originalContent, 'others.en.xlf');
+
+        $tester = new CommandTester($this->createCommand());
+        $tester->execute(['--locales' => ['en'], '--domains' => ['others']]);
+
+        $tester->assertCommandIsSuccessful();
+
+        // messages.en.xlf shouldn't be updated
+        $this->assertFileContainsSource('hello', $messagesEnFile);
+
+        // others.en.xlf should be updated
+        $this->assertFileContainsSource('Hello there', $othersEnFile);
+    }
+
+    public function testCommandFailsIfFormatIsNotSupported()
+    {
+        $command = new XliffUpdateSourcesCommand(
+            $this->createStub(TranslationWriterInterface::class),
+            $this->createStub(TranslationReaderInterface::class),
+            defaultLocale: 'en',
+            transPaths: []
+        );
+
+        $tester = new CommandTester($command);
+        $tester->execute(['--format' => 'unknown']);
+
+        $this->assertEquals(Command::INVALID, $tester->getStatusCode());
+        $this->assertStringContainsString(
+            'Unknown format "unknown".',
+            $tester->getDisplay(),
+        );
+    }
+
+    public function testCommandFailsIfNoTranslationPathIsAvailable()
+    {
+        $command = new XliffUpdateSourcesCommand(
+            $this->createStub(TranslationWriterInterface::class),
+            $this->createStub(TranslationReaderInterface::class),
+            defaultLocale: 'en',
+            transPaths: []
+        );
+
+        $tester = new CommandTester($command);
+
+        $tester->execute(['--locales' => ['en']]);
+
+        $this->assertEquals(Command::INVALID, $tester->getStatusCode());
+        $this->assertStringContainsString(
+            'No paths specified in arguments, and no default paths provided to the command.',
+            $tester->getDisplay(),
+        );
+    }
+
+    public function testCommandFailsIfNoLocaleProvidedAndNoEnabledLocalesAreAvailable()
+    {
+        $command = new XliffUpdateSourcesCommand(
+            $this->createStub(TranslationWriterInterface::class),
+            $this->createStub(TranslationReaderInterface::class),
+            defaultLocale: 'en',
+            transPaths: ['some/path'],
+            enabledLocales: []
+        );
+
+        $tester = new CommandTester($command);
+        $tester->execute([]);
+
+        $this->assertStringContainsString(
+            'No locales provided in --locales options and no defaults provided to the command.',
+            $tester->getDisplay(),
+        );
+        $this->assertEquals(Command::INVALID, $tester->getStatusCode());
+    }
+
+    #[DataProvider('provideCompletionSuggestions')]
+    public function testComplete(array $input, array $expectedSuggestions)
+    {
+        $domainsByLocale = [
+            'en' => ['messages', 'others'],
+            'fr' => ['messages'],
+            'it' => ['validators'],
+        ];
+
+        foreach ($domainsByLocale as $locale => $domains) {
+            foreach ($domains as $domain) {
+                $this->createFile($this->createXliff1($locale, 'foo', 'foo', 'bar'), \sprintf('%s.%s.xlf', $domain, $locale));
+            }
+        }
+
+        $application = new Application();
+        $application->addCommand($this->createCommand(enabledLocales: array_keys($domainsByLocale)));
+
+        $tester = new CommandCompletionTester($application->get('translation:update-xliff-sources'));
+        $suggestions = $tester->complete($input);
+        $this->assertSame($expectedSuggestions, $suggestions);
+    }
+
+    public static function provideCompletionSuggestions(): iterable
+    {
+        yield '--locales' => [
+            ['--locales'],
+            ['en', 'fr', 'it'],
+        ];
+
+        yield '--domains' => [
+            ['--locales', 'fr', '--locales', 'it', '--domains'],
+            ['messages', 'validators'],
+        ];
+    }
+
+    private function createCommand(array $additionalTransPaths = [], array $enabledLocales = []): Command
+    {
+        $application = new Application();
+
+        $reader = new TranslationReader();
+        $reader->addLoader('xlf', new XliffFileLoader());
+        $writer = new TranslationWriter();
+        $writer->addDumper('xlf', new XliffFileDumper());
+        $additionalTransPaths[] = $this->defaultTranslationPath;
+
+        $command = new XliffUpdateSourcesCommand($writer, $reader, 'en', $additionalTransPaths, $enabledLocales);
+        $application->addCommand($command);
+
+        return $command;
+    }
+
+    private function createXliff1(string $locale, string $resname, string $source, string $target): string
+    {
+        return <<<XLIFF
+            <?xml version="1.0" encoding="utf-8"?>
+            <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+              <file source-language="en" target-language="{$locale}" datatype="plaintext" original="file.ext">
+                <header>
+                  <tool tool-id="symfony" tool-name="Symfony"/>
+                </header>
+                <body>
+                  <trans-unit id="some-id" resname="{$resname}">
+                    <source>{$source}</source>
+                    <target>{$target}</target>
+                  </trans-unit>
+                </body>
+              </file>
+            </xliff>
+
+            XLIFF;
+    }
+
+    private function createXliff2(string $locale, string $name, string $source, string $target, string $domain = 'messages'): string
+    {
+        return <<<XLIFF
+            <?xml version="1.0" encoding="utf-8"?>
+            <xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="{$locale}">
+              <file id="{$domain}.{$locale}">
+                <unit id="some-id" name="{$name}">
+                  <segment>
+                    <source>{$source}</source>
+                    <target>{$target}</target>
+                  </segment>
+                </unit>
+              </file>
+            </xliff>
+
+            XLIFF;
+    }
+
+    private function createFile(string $content, string $filename, string $directory = 'translations'): string
+    {
+        $filename = \sprintf('%s/%s/%s', $this->translationAppDir, $directory, $filename);
+        file_put_contents($filename, $content);
+
+        return $filename;
+    }
+
+    private function assertFileContainsSource(string $expectedSource, string $file): void
+    {
+        $this->assertStringContainsString("<source>{$expectedSource}</source>", file_get_contents($file));
+    }
+}


### PR DESCRIPTION
| Q             | A          |
|---------------|------------|
| Branch?       | 8.2        |
| Bug fix?      | no         |
| New feature?  | yes        |
| Deprecations? | no         |
| Issues        | no |
| License       | MIT        |

## Context

This is a revival of https://github.com/symfony/symfony/pull/53630, that has been partially implemented in https://github.com/symfony/symfony/pull/62023.

Currently, XLIFF files generated with the `translation:extract` command use the translation key in the `<source>` tag:

```xml
<trans-unit id="hVNhFLX" resname="navbar.home">
  <source>navbar.home</source>
  <target>__navbar.home</target>
</trans-unit>
```

But this `<source>` tag usually contains the default locale text to be translated ([XLIFF 1.2](http://docs.oasis-open.org/xliff/v1.2/os/xliff-core.html#source), [XLIFF 2.0](http://docs.oasis-open.org/xliff/xliff-core/v2.0/xliff-core-v2.0.html#source)).

## Proposed solution

Add a `translation:update-xliff-sources` command to update the `source` tag in XLIFF files:
- Load message catalogues
- For each message, replace `source` metadata value with the message translated in the default locale when available
- Write back the catalogues whose sources changed

A dedicated command was preferred over updating the `translation:extract` command, as it serves a different purpose and may be used to update existing keys as well (see https://github.com/symfony/symfony/pull/53630#issuecomment-1908617337).

## Result

Given the following entries in XLIFF files:

```xml
<!-- translations/messages.en.xlf -->

<trans-unit id="hVNhFLX" resname="navbar.home">
  <source>navbar.home</source>
  <target>Home</target>
</trans-unit>
```

```xml
<!-- translations/messages.fr.xlf -->

<trans-unit id="hVNhFLX" resname="navbar.home">
  <source>navbar.home</source>
  <target>__navbar.home</target>
</trans-unit>
```

Running

```bash
bin/console translation:update-xliff-sources
```

Will update the files with:

```xml
<!-- translations/messages.en.xlf -->

<trans-unit id="hVNhFLX" resname="navbar.home">
  <source>Home</source>
  <target>Home</target>
</trans-unit>
```

```xml
<!-- translations/messages.fr.xlf -->

<trans-unit id="hVNhFLX" resname="navbar.home">
  <source>Home</source>
  <target>__navbar.home</target>
</trans-unit>
```

The command has options to specify locales, domains, and paths:

```text
Description:
  Update source tags with default locale targets in XLIFF files

Usage:
  translation:update-xliff-sources [options] [--] [<paths>...]

Arguments:
  paths                    Paths to look for translations.

Options:
      --format=FORMAT      Override the default output format. [default: "xlf12"]
      --domains=DOMAINS    Specify the domain to update. (multiple values allowed)
      --locales=LOCALES    Specify the locale to update. (multiple values allowed)
```

## Behavior notes (for the documentation)

- Without path arguments, the command updates the directories configured in `framework.translator.paths` plus the default `translations/` directory. Vendor and bundle translation directories are never touched.
- `--locales` defaults to `framework.enabled_locales`. The default locale's own files are only updated when it is part of the targeted locales.
- The default locale's texts are resolved per directory: the sources of the files in a given directory are filled from the default locale files of that same directory.
- A file is only rewritten when at least one of its `source` tags changes. A rewritten file is normalized by the XLIFF dumper: it is written in the format selected by `--format` (XLIFF 1.2 by default) and `trans-unit` ids are regenerated, like `translation:extract` does.
