### PR TITLE
[Console] Declare docblock types for parameters of addArgument() and addOption()

### DIFF
--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -413,8 +413,8 @@ class Command implements SignalableCommandInterface
     /**
      * Adds an argument.
      *
-     * @param                                                                               $mode            The argument mode: InputArgument::REQUIRED or InputArgument::OPTIONAL
-     * @param                                                                               $default         The default value (for InputArgument::OPTIONAL mode only)
+     * @param int-mask-of<InputArgument::*>|null                                            $mode            The argument mode: InputArgument::REQUIRED or InputArgument::OPTIONAL
+     * @param mixed                                                                         $default         The default value (for InputArgument::OPTIONAL mode only)
      * @param array|\Closure(CompletionInput,CompletionSuggestions):list<string|Suggestion> $suggestedValues The values used for input completion
      *
      * @return $this
@@ -432,9 +432,9 @@ class Command implements SignalableCommandInterface
     /**
      * Adds an option.
      *
-     * @param                                                                               $shortcut        The shortcuts, can be null, a string of shortcuts delimited by | or an array of shortcuts
-     * @param                                                                               $mode            The option mode: One of the InputOption::VALUE_* constants
-     * @param                                                                               $default         The default value (must be null for InputOption::VALUE_NONE)
+     * @param string|string[]|null                                                          $shortcut        The shortcuts, can be null, a string of shortcuts delimited by | or an array of shortcuts
+     * @param int-mask-of<InputOption::*>|null                                              $mode            The option mode: One of the InputOption::VALUE_* constants
+     * @param mixed                                                                         $default         The default value (must be null for InputOption::VALUE_NONE)
      * @param array|\Closure(CompletionInput,CompletionSuggestions):list<string|Suggestion> $suggestedValues The values used for input completion
      *
      * @return $this

--- a/src/Symfony/Component/Console/Input/InputOption.php
+++ b/src/Symfony/Component/Console/Input/InputOption.php
@@ -66,7 +66,7 @@ class InputOption
     private mixed $default;
 
     /**
-     * @param string|array|null                                                             $shortcut        The shortcuts, can be null, a string of shortcuts delimited by | or an array of shortcuts
+     * @param string|string[]|null                                                          $shortcut        The shortcuts, can be null, a string of shortcuts delimited by | or an array of shortcuts
      * @param int-mask-of<InputOption::*>|null                                              $mode            The option mode: One of the VALUE_* constants
      * @param mixed                                                                         $default         The default value (must be null for self::VALUE_NONE)
      * @param array|\Closure(CompletionInput,CompletionSuggestions):list<string|Suggestion> $suggestedValues The values used for input completion


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | N/A <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

Fixes an issue with phpstorm where docblock params without a type are not parsed correctly.
<img width="1348" height="148" alt="image" src="https://github.com/user-attachments/assets/67057232-2297-4ed5-9076-c5ddd115772e" />

Contributor guidelines:
- ✅ Add tests and ensure they pass
- 🐞 Bug fixes must target the **lowest maintained** branch where they apply
  https://symfony.com/releases#maintained-symfony-branches
- ✨ New features and deprecations must target the **feature** branch
  and must add an entry to the changelog file of the patched component:
  https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
- 🔒 Do not break backward compatibility:
  https://symfony.com/bc
-->
