### PR TITLE
[Notifier] Fix typo in Bluesky transport exception message

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Bluesky/BlueskyTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Bluesky/BlueskyTransport.php
@@ -290,7 +290,7 @@ final class BlueskyTransport extends AbstractTransport
                 $result = $response->toArray(false);
 
                 if (300 <= $response->getStatusCode()) {
-                    throw new TransportException('Unable to embed medias.', $response);
+                    throw new TransportException('Unable to embed media.', $response);
                 }
 
                 $embeds[] = [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        |
| License       | MIT

Noticed this while reading through the Bluesky bridge: the exception message says "Unable to embed medias." but "media" is already plural, so "medias" reads as a typo. Fixed it to "Unable to embed media."

Targeting 8.2 since that's the only branch this file exists on (the Bluesky bridge hasn't been released yet).