### PR TITLE
[FrameworkBundle] Remove dev requirement on symfony/amp-sql-messenger

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -42,7 +42,6 @@
         "phpdocumentor/reflection-docblock": "^5.2|^6.0",
         "phpstan/phpdoc-parser": "^1.0|^2.0",
         "seld/jsonlint": "^1.10",
-        "symfony/amp-sql-messenger": "^8.2",
         "symfony/asset": "^7.4|^8.0",
         "symfony/asset-mapper": "^7.4|^8.0",
         "symfony/browser-kit": "^7.4|^8.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Follow up to #64892.

No other Messenger bridge is listed in the dev requirements of FrameworkBundle: `symfony/amqp-messenger`, `symfony/redis-messenger`, `symfony/amazon-sqs-messenger` and `symfony/beanstalkd-messenger` are all absent. The transport factory is registered behind `ContainerBuilder::willBeAvailable()`, and the test that checks it is guarded by `class_exists()`, so nothing needs the package to be installed.

The package is also not published yet, so the split `symfony/framework-bundle` is currently uninstallable on 8.2.
