### PR TITLE
[Config][FrameworkBundle][Yaml] Fix schema violation lines and the list form of keyed maps

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/JsonSchemaConfigDumpPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/JsonSchemaConfigDumpPassTest.php
@@ -11,9 +11,11 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler;
 
+use Opis\JsonSchema\Validator;
 use PHPUnit\Framework\Attributes\RequiresMethod;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\JsonSchemaConfigDumpPass;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\Definition\Dumper\JsonSchemaDumper;
@@ -23,6 +25,7 @@ use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Symfony\Component\Yaml\Schema\SchemaValidator;
 use Symfony\Component\Yaml\Yaml;
 
 #[RequiresMethod(JsonSchemaDumper::class, 'dump')]
@@ -136,6 +139,47 @@ class JsonSchemaConfigDumpPassTest extends TestCase
         // when@test must not contain when@dev
         $this->assertArrayNotHasKey('when@dev', $schema['properties']['when@test']['properties']);
         $this->assertArrayNotHasKey('when@test', $schema['properties']['when@dev']['properties']);
+    }
+
+    #[RequiresMethod(Validator::class, 'validate')]
+    public function testGeneratedSchemaKeepsTheListFormOfNormalizedKeyedMaps()
+    {
+        $schemaFile = $this->tempDir.'/framework_schema.json';
+        $container = new ContainerBuilder();
+        $container->setParameter('kernel.debug', true);
+
+        (new JsonSchemaConfigDumpPass($schemaFile, [FrameworkBundle::class => ['all' => true]]))->process($container);
+
+        // The asset-mapper recipe configures "paths" as a list, which a
+        // normalization closure turns into a map keyed by path.
+        $config = Yaml::parse(<<<YAML
+            framework:
+                asset_mapper:
+                    paths:
+                        - assets/
+            YAML);
+
+        $this->assertSame([], (new SchemaValidator())->validate($config, $schemaFile));
+    }
+
+    #[RequiresMethod(Validator::class, 'validate')]
+    public function testGeneratedSchemaRejectsTheListFormOfPlainKeyedMaps()
+    {
+        $schemaFile = $this->tempDir.'/framework_schema.json';
+        $container = new ContainerBuilder();
+        $container->setParameter('kernel.debug', true);
+
+        (new JsonSchemaConfigDumpPass($schemaFile, [FrameworkBundle::class => ['all' => true]]))->process($container);
+
+        // A list here would configure a context entry named "0" instead of "enable_max_depth".
+        $config = Yaml::parse(<<<YAML
+            framework:
+                serializer:
+                    default_context:
+                        - enable_max_depth
+            YAML);
+
+        $this->assertNotSame([], (new SchemaValidator())->validate($config, $schemaFile));
     }
 
     public function testProcessIgnoresFileWriteErrors()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/config/schema.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/config/schema.json
@@ -325,20 +325,10 @@
                                                         "default": "_token"
                                                     },
                                                     "field_attr": {
-                                                        "anyOf": [
-                                                            {
-                                                                "$ref": "#/$defs/types/object_null",
-                                                                "additionalProperties": {
-                                                                    "$ref": "#/$defs/types/scalar"
-                                                                }
-                                                            },
-                                                            {
-                                                                "$ref": "#/$defs/types/array_null",
-                                                                "items": {
-                                                                    "$ref": "#/$defs/types/scalar"
-                                                                }
-                                                            }
-                                                        ],
+                                                        "$ref": "#/$defs/types/object_null",
+                                                        "additionalProperties": {
+                                                            "$ref": "#/$defs/types/scalar"
+                                                        },
                                                         "default": {
                                                             "data-controller": "csrf-protection"
                                                         }
@@ -828,20 +818,10 @@
                                                                         "$ref": "#/$defs/types/scalar"
                                                                     },
                                                                     "metadata": {
-                                                                        "anyOf": [
-                                                                            {
-                                                                                "$ref": "#/$defs/types/object_null",
-                                                                                "additionalProperties": {
-                                                                                    "$ref": "#/$defs/types/variable"
-                                                                                }
-                                                                            },
-                                                                            {
-                                                                                "$ref": "#/$defs/types/array_null",
-                                                                                "items": {
-                                                                                    "$ref": "#/$defs/types/variable"
-                                                                                }
-                                                                            }
-                                                                        ],
+                                                                        "$ref": "#/$defs/types/object_null",
+                                                                        "additionalProperties": {
+                                                                            "$ref": "#/$defs/types/variable"
+                                                                        },
                                                                         "examples": [
                                                                             {
                                                                                 "color": "blue",
@@ -943,20 +923,10 @@
                                                                 "default": 1
                                                             },
                                                             "metadata": {
-                                                                "anyOf": [
-                                                                    {
-                                                                        "$ref": "#/$defs/types/object_null",
-                                                                        "additionalProperties": {
-                                                                            "$ref": "#/$defs/types/variable"
-                                                                        }
-                                                                    },
-                                                                    {
-                                                                        "$ref": "#/$defs/types/array_null",
-                                                                        "items": {
-                                                                            "$ref": "#/$defs/types/variable"
-                                                                        }
-                                                                    }
-                                                                ],
+                                                                "$ref": "#/$defs/types/object_null",
+                                                                "additionalProperties": {
+                                                                    "$ref": "#/$defs/types/variable"
+                                                                },
                                                                 "examples": [
                                                                     {
                                                                         "color": "blue",
@@ -973,20 +943,10 @@
                                                     "minItems": 1
                                                 },
                                                 "metadata": {
-                                                    "anyOf": [
-                                                        {
-                                                            "$ref": "#/$defs/types/object_null",
-                                                            "additionalProperties": {
-                                                                "$ref": "#/$defs/types/variable"
-                                                            }
-                                                        },
-                                                        {
-                                                            "$ref": "#/$defs/types/array_null",
-                                                            "items": {
-                                                                "$ref": "#/$defs/types/variable"
-                                                            }
-                                                        }
-                                                    ],
+                                                    "$ref": "#/$defs/types/object_null",
+                                                    "additionalProperties": {
+                                                        "$ref": "#/$defs/types/variable"
+                                                    },
                                                     "examples": [
                                                         {
                                                             "color": "blue",
@@ -1422,20 +1382,10 @@
                                         "description": "Behavior if an asset cannot be found when imported from JavaScript or CSS files - e.g. \"import './non-existent.js'\". \"strict\" means an exception is thrown, \"warn\" means a warning is logged, \"ignore\" means the import is left as-is."
                                     },
                                     "extensions": {
-                                        "anyOf": [
-                                            {
-                                                "$ref": "#/$defs/types/object_null",
-                                                "additionalProperties": {
-                                                    "$ref": "#/$defs/types/scalar"
-                                                }
-                                            },
-                                            {
-                                                "$ref": "#/$defs/types/array_null",
-                                                "items": {
-                                                    "$ref": "#/$defs/types/scalar"
-                                                }
-                                            }
-                                        ],
+                                        "$ref": "#/$defs/types/object_null",
+                                        "additionalProperties": {
+                                            "$ref": "#/$defs/types/scalar"
+                                        },
                                         "description": "Key-value pair of file extensions set to their mime type.",
                                         "examples": [
                                             {
@@ -1469,20 +1419,10 @@
                                         "description": "Which entries end up in the rendered importmap: \"all\" of them, or only the ones \"reachable\" from the rendered entrypoints (their eager and lazy import chains) plus the polyfill."
                                     },
                                     "importmap_script_attributes": {
-                                        "anyOf": [
-                                            {
-                                                "$ref": "#/$defs/types/object_null",
-                                                "additionalProperties": {
-                                                    "$ref": "#/$defs/types/scalar"
-                                                }
-                                            },
-                                            {
-                                                "$ref": "#/$defs/types/array_null",
-                                                "items": {
-                                                    "$ref": "#/$defs/types/scalar"
-                                                }
-                                            }
-                                        ],
+                                        "$ref": "#/$defs/types/object_null",
+                                        "additionalProperties": {
+                                            "$ref": "#/$defs/types/scalar"
+                                        },
                                         "description": "Key-value pair of attributes to add to script tags output for the importmap.",
                                         "examples": [
                                             {
@@ -1756,20 +1696,10 @@
                                                     "$ref": "#/$defs/types/scalar"
                                                 },
                                                 "domains": {
-                                                    "anyOf": [
-                                                        {
-                                                            "$ref": "#/$defs/types/object_null",
-                                                            "additionalProperties": {
-                                                                "$ref": "#/$defs/types/scalar"
-                                                            }
-                                                        },
-                                                        {
-                                                            "$ref": "#/$defs/types/array_null",
-                                                            "items": {
-                                                                "$ref": "#/$defs/types/scalar"
-                                                            }
-                                                        }
-                                                    ]
+                                                    "$ref": "#/$defs/types/object_null",
+                                                    "additionalProperties": {
+                                                        "$ref": "#/$defs/types/scalar"
+                                                    }
                                                 },
                                                 "locales": {
                                                     "$ref": "#/$defs/types/array_null",
@@ -1797,20 +1727,10 @@
                                                             "$ref": "#/$defs/types/string_null"
                                                         },
                                                         "parameters": {
-                                                            "anyOf": [
-                                                                {
-                                                                    "$ref": "#/$defs/types/object_null",
-                                                                    "additionalProperties": {
-                                                                        "$ref": "#/$defs/types/scalar"
-                                                                    }
-                                                                },
-                                                                {
-                                                                    "$ref": "#/$defs/types/array_null",
-                                                                    "items": {
-                                                                        "$ref": "#/$defs/types/scalar"
-                                                                    }
-                                                                }
-                                                            ]
+                                                            "$ref": "#/$defs/types/object_null",
+                                                            "additionalProperties": {
+                                                                "$ref": "#/$defs/types/scalar"
+                                                            }
                                                         },
                                                         "domain": {
                                                             "$ref": "#/$defs/types/string_null"
@@ -2057,20 +1977,10 @@
                                         }
                                     },
                                     "default_context": {
-                                        "anyOf": [
-                                            {
-                                                "$ref": "#/$defs/types/object_null",
-                                                "additionalProperties": {
-                                                    "$ref": "#/$defs/types/variable"
-                                                }
-                                            },
-                                            {
-                                                "$ref": "#/$defs/types/array_null",
-                                                "items": {
-                                                    "$ref": "#/$defs/types/variable"
-                                                }
-                                            }
-                                        ]
+                                        "$ref": "#/$defs/types/object_null",
+                                        "additionalProperties": {
+                                            "$ref": "#/$defs/types/variable"
+                                        }
                                     },
                                     "named_serializers": {
                                         "$ref": "#/$defs/types/object_null",
@@ -2081,20 +1991,10 @@
                                                     "$ref": "#/$defs/types/scalar"
                                                 },
                                                 "default_context": {
-                                                    "anyOf": [
-                                                        {
-                                                            "$ref": "#/$defs/types/object_null",
-                                                            "additionalProperties": {
-                                                                "$ref": "#/$defs/types/variable"
-                                                            }
-                                                        },
-                                                        {
-                                                            "$ref": "#/$defs/types/array_null",
-                                                            "items": {
-                                                                "$ref": "#/$defs/types/variable"
-                                                            }
-                                                        }
-                                                    ]
+                                                    "$ref": "#/$defs/types/object_null",
+                                                    "additionalProperties": {
+                                                        "$ref": "#/$defs/types/variable"
+                                                    }
                                                 },
                                                 "include_built_in_normalizers": {
                                                     "$ref": "#/$defs/types/boolean",
@@ -2188,20 +2088,10 @@
                                         "default": false
                                     },
                                     "aliases": {
-                                        "anyOf": [
-                                            {
-                                                "$ref": "#/$defs/types/object_null",
-                                                "additionalProperties": {
-                                                    "$ref": "#/$defs/types/scalar"
-                                                }
-                                            },
-                                            {
-                                                "$ref": "#/$defs/types/array_null",
-                                                "items": {
-                                                    "$ref": "#/$defs/types/scalar"
-                                                }
-                                            }
-                                        ],
+                                        "$ref": "#/$defs/types/object_null",
+                                        "additionalProperties": {
+                                            "$ref": "#/$defs/types/scalar"
+                                        },
                                         "description": "Additional type aliases to be used during type context creation."
                                     }
                                 },
@@ -2603,20 +2493,10 @@
                                                         "description": "Serialization format for the messenger.transport.symfony_serializer service (which is not the serializer used by default)."
                                                     },
                                                     "context": {
-                                                        "anyOf": [
-                                                            {
-                                                                "$ref": "#/$defs/types/object_null",
-                                                                "additionalProperties": {
-                                                                    "$ref": "#/$defs/types/variable"
-                                                                }
-                                                            },
-                                                            {
-                                                                "$ref": "#/$defs/types/array_null",
-                                                                "items": {
-                                                                    "$ref": "#/$defs/types/variable"
-                                                                }
-                                                            }
-                                                        ],
+                                                        "$ref": "#/$defs/types/object_null",
+                                                        "additionalProperties": {
+                                                            "$ref": "#/$defs/types/variable"
+                                                        },
                                                         "description": "Context array for the messenger.transport.symfony_serializer service (which is not the serializer used by default)."
                                                     }
                                                 },
@@ -2671,20 +2551,10 @@
                                                             "additionalProperties": false
                                                         },
                                                         "options": {
-                                                            "anyOf": [
-                                                                {
-                                                                    "$ref": "#/$defs/types/object_null",
-                                                                    "additionalProperties": {
-                                                                        "$ref": "#/$defs/types/variable"
-                                                                    }
-                                                                },
-                                                                {
-                                                                    "$ref": "#/$defs/types/array_null",
-                                                                    "items": {
-                                                                        "$ref": "#/$defs/types/variable"
-                                                                    }
-                                                                }
-                                                            ]
+                                                            "$ref": "#/$defs/types/object_null",
+                                                            "additionalProperties": {
+                                                                "$ref": "#/$defs/types/variable"
+                                                            }
                                                         },
                                                         "failure_transport": {
                                                             "$ref": "#/$defs/types/scalar",
@@ -2982,37 +2852,17 @@
                                         "$ref": "#/$defs/types/object_null",
                                         "properties": {
                                             "vars": {
-                                                "anyOf": [
-                                                    {
-                                                        "$ref": "#/$defs/types/object_null",
-                                                        "additionalProperties": {
-                                                            "$ref": "#/$defs/types/variable"
-                                                        }
-                                                    },
-                                                    {
-                                                        "$ref": "#/$defs/types/array_null",
-                                                        "items": {
-                                                            "$ref": "#/$defs/types/variable"
-                                                        }
-                                                    }
-                                                ],
+                                                "$ref": "#/$defs/types/object_null",
+                                                "additionalProperties": {
+                                                    "$ref": "#/$defs/types/variable"
+                                                },
                                                 "description": "Associative array: the default vars used to expand the templated URI."
                                             },
                                             "headers": {
-                                                "anyOf": [
-                                                    {
-                                                        "$ref": "#/$defs/types/object_null",
-                                                        "additionalProperties": {
-                                                            "$ref": "#/$defs/types/variable"
-                                                        }
-                                                    },
-                                                    {
-                                                        "$ref": "#/$defs/types/array_null",
-                                                        "items": {
-                                                            "$ref": "#/$defs/types/variable"
-                                                        }
-                                                    }
-                                                ],
+                                                "$ref": "#/$defs/types/object_null",
+                                                "additionalProperties": {
+                                                    "$ref": "#/$defs/types/variable"
+                                                },
                                                 "description": "Associative array: header => value(s)."
                                             },
                                             "max_redirects": {
@@ -3117,20 +2967,10 @@
                                                 "description": "The minimum version of TLS to accept; must be one of STREAM_CRYPTO_METHOD_TLSv*_CLIENT constants."
                                             },
                                             "extra": {
-                                                "anyOf": [
-                                                    {
-                                                        "$ref": "#/$defs/types/object_null",
-                                                        "additionalProperties": {
-                                                            "$ref": "#/$defs/types/variable"
-                                                        }
-                                                    },
-                                                    {
-                                                        "$ref": "#/$defs/types/array_null",
-                                                        "items": {
-                                                            "$ref": "#/$defs/types/variable"
-                                                        }
-                                                    }
-                                                ],
+                                                "$ref": "#/$defs/types/object_null",
+                                                "additionalProperties": {
+                                                    "$ref": "#/$defs/types/variable"
+                                                },
                                                 "description": "Extra options for specific HTTP client."
                                             },
                                             "rate_limiter": {
@@ -3356,20 +3196,10 @@
                                                             "description": "`true` to always return empty 200 responses, `false` to disable mocking, or the id of the service to use to generate mock responses (invokable or iterable)."
                                                         },
                                                         "headers": {
-                                                            "anyOf": [
-                                                                {
-                                                                    "$ref": "#/$defs/types/object_null",
-                                                                    "additionalProperties": {
-                                                                        "$ref": "#/$defs/types/variable"
-                                                                    }
-                                                                },
-                                                                {
-                                                                    "$ref": "#/$defs/types/array_null",
-                                                                    "items": {
-                                                                        "$ref": "#/$defs/types/variable"
-                                                                    }
-                                                                }
-                                                            ],
+                                                            "$ref": "#/$defs/types/object_null",
+                                                            "additionalProperties": {
+                                                                "$ref": "#/$defs/types/variable"
+                                                            },
                                                             "description": "Associative array: header => value(s)."
                                                         },
                                                         "max_redirects": {
@@ -3474,20 +3304,10 @@
                                                             "description": "The minimum version of TLS to accept; must be one of STREAM_CRYPTO_METHOD_TLSv*_CLIENT constants."
                                                         },
                                                         "extra": {
-                                                            "anyOf": [
-                                                                {
-                                                                    "$ref": "#/$defs/types/object_null",
-                                                                    "additionalProperties": {
-                                                                        "$ref": "#/$defs/types/variable"
-                                                                    }
-                                                                },
-                                                                {
-                                                                    "$ref": "#/$defs/types/array_null",
-                                                                    "items": {
-                                                                        "$ref": "#/$defs/types/variable"
-                                                                    }
-                                                                }
-                                                            ],
+                                                            "$ref": "#/$defs/types/object_null",
+                                                            "additionalProperties": {
+                                                                "$ref": "#/$defs/types/variable"
+                                                            },
                                                             "description": "Extra options for specific HTTP client."
                                                         },
                                                         "rate_limiter": {
@@ -3863,20 +3683,10 @@
                                                         "description": "The private key passphrase"
                                                     },
                                                     "options": {
-                                                        "anyOf": [
-                                                            {
-                                                                "$ref": "#/$defs/types/object_null",
-                                                                "additionalProperties": {
-                                                                    "$ref": "#/$defs/types/variable"
-                                                                }
-                                                            },
-                                                            {
-                                                                "$ref": "#/$defs/types/array_null",
-                                                                "items": {
-                                                                    "$ref": "#/$defs/types/variable"
-                                                                }
-                                                            }
-                                                        ]
+                                                        "$ref": "#/$defs/types/object_null",
+                                                        "additionalProperties": {
+                                                            "$ref": "#/$defs/types/variable"
+                                                        }
                                                     }
                                                 },
                                                 "additionalProperties": false
@@ -3963,20 +3773,10 @@
                                                         "description": "S/MIME certificate repository service. This service shall implement the `Symfony\\Component\\Mailer\\EventListener\\SmimeCertificateRepositoryInterface`."
                                                     },
                                                     "certificates": {
-                                                        "anyOf": [
-                                                            {
-                                                                "$ref": "#/$defs/types/object_null",
-                                                                "additionalProperties": {
-                                                                    "$ref": "#/$defs/types/scalar"
-                                                                }
-                                                            },
-                                                            {
-                                                                "$ref": "#/$defs/types/array_null",
-                                                                "items": {
-                                                                    "$ref": "#/$defs/types/scalar"
-                                                                }
-                                                            }
-                                                        ],
+                                                        "$ref": "#/$defs/types/object_null",
+                                                        "additionalProperties": {
+                                                            "$ref": "#/$defs/types/scalar"
+                                                        },
                                                         "description": "Recipient S/MIME certificates, as a map of email address to certificate file path. Cannot be used together with \"repository\"."
                                                     },
                                                     "on_missing_certificate": {
@@ -4105,20 +3905,10 @@
                                                         "description": "Service or class implementing `Symfony\\Component\\Mailer\\EventListener\\PgpPublicKeyRepositoryInterface` to provide recipient PGP public keys."
                                                     },
                                                     "keys": {
-                                                        "anyOf": [
-                                                            {
-                                                                "$ref": "#/$defs/types/object_null",
-                                                                "additionalProperties": {
-                                                                    "$ref": "#/$defs/types/scalar"
-                                                                }
-                                                            },
-                                                            {
-                                                                "$ref": "#/$defs/types/array_null",
-                                                                "items": {
-                                                                    "$ref": "#/$defs/types/scalar"
-                                                                }
-                                                            }
-                                                        ],
+                                                        "$ref": "#/$defs/types/object_null",
+                                                        "additionalProperties": {
+                                                            "$ref": "#/$defs/types/scalar"
+                                                        },
                                                         "description": "Recipient PGP public keys, as a map of email address to public key file path. Cannot be used together with \"repository\"."
                                                     },
                                                     "binary": {
@@ -4316,36 +4106,16 @@
                                         "description": "The message bus to use. Defaults to the default bus if the Messenger component is installed."
                                     },
                                     "chatter_transports": {
-                                        "anyOf": [
-                                            {
-                                                "$ref": "#/$defs/types/object_null",
-                                                "additionalProperties": {
-                                                    "$ref": "#/$defs/types/scalar"
-                                                }
-                                            },
-                                            {
-                                                "$ref": "#/$defs/types/array_null",
-                                                "items": {
-                                                    "$ref": "#/$defs/types/scalar"
-                                                }
-                                            }
-                                        ]
+                                        "$ref": "#/$defs/types/object_null",
+                                        "additionalProperties": {
+                                            "$ref": "#/$defs/types/scalar"
+                                        }
                                     },
                                     "texter_transports": {
-                                        "anyOf": [
-                                            {
-                                                "$ref": "#/$defs/types/object_null",
-                                                "additionalProperties": {
-                                                    "$ref": "#/$defs/types/scalar"
-                                                }
-                                            },
-                                            {
-                                                "$ref": "#/$defs/types/array_null",
-                                                "items": {
-                                                    "$ref": "#/$defs/types/scalar"
-                                                }
-                                            }
-                                        ]
+                                        "$ref": "#/$defs/types/object_null",
+                                        "additionalProperties": {
+                                            "$ref": "#/$defs/types/scalar"
+                                        }
                                     },
                                     "notification_on_failed_messages": {
                                         "$ref": "#/$defs/types/boolean",
@@ -4673,20 +4443,10 @@
                                                     "description": "Allows all static elements and attributes from the W3C Sanitizer API standard."
                                                 },
                                                 "allow_elements": {
-                                                    "anyOf": [
-                                                        {
-                                                            "$ref": "#/$defs/types/object_null",
-                                                            "additionalProperties": {
-                                                                "$ref": "#/$defs/types/variable"
-                                                            }
-                                                        },
-                                                        {
-                                                            "$ref": "#/$defs/types/array_null",
-                                                            "items": {
-                                                                "$ref": "#/$defs/types/variable"
-                                                            }
-                                                        }
-                                                    ],
+                                                    "$ref": "#/$defs/types/object_null",
+                                                    "additionalProperties": {
+                                                        "$ref": "#/$defs/types/variable"
+                                                    },
                                                     "description": "Configures the elements that the sanitizer should retain from the input. The element name is the key, the value is either a list of allowed attributes for this element or \"*\" to allow the default set of attributes (https://wicg.github.io/sanitizer-api/#default-configuration).",
                                                     "examples": [
                                                         {
@@ -4731,56 +4491,26 @@
                                                     "description": "Configures elements as dropped. Dropped elements are elements the sanitizer should remove from the input, including their children."
                                                 },
                                                 "allow_attributes": {
-                                                    "anyOf": [
-                                                        {
-                                                            "$ref": "#/$defs/types/object_null",
-                                                            "additionalProperties": {
-                                                                "$ref": "#/$defs/types/variable"
-                                                            }
-                                                        },
-                                                        {
-                                                            "$ref": "#/$defs/types/array_null",
-                                                            "items": {
-                                                                "$ref": "#/$defs/types/variable"
-                                                            }
-                                                        }
-                                                    ],
+                                                    "$ref": "#/$defs/types/object_null",
+                                                    "additionalProperties": {
+                                                        "$ref": "#/$defs/types/variable"
+                                                    },
                                                     "description": "Configures attributes as allowed. Allowed attributes are attributes the sanitizer should retain from the input."
                                                 },
                                                 "drop_attributes": {
-                                                    "anyOf": [
-                                                        {
-                                                            "$ref": "#/$defs/types/object_null",
-                                                            "additionalProperties": {
-                                                                "$ref": "#/$defs/types/variable"
-                                                            }
-                                                        },
-                                                        {
-                                                            "$ref": "#/$defs/types/array_null",
-                                                            "items": {
-                                                                "$ref": "#/$defs/types/variable"
-                                                            }
-                                                        }
-                                                    ],
+                                                    "$ref": "#/$defs/types/object_null",
+                                                    "additionalProperties": {
+                                                        "$ref": "#/$defs/types/variable"
+                                                    },
                                                     "description": "Configures attributes as dropped. Dropped attributes are attributes the sanitizer should remove from the input."
                                                 },
                                                 "force_attributes": {
                                                     "$ref": "#/$defs/types/object_null",
                                                     "additionalProperties": {
-                                                        "anyOf": [
-                                                            {
-                                                                "$ref": "#/$defs/types/object_null",
-                                                                "additionalProperties": {
-                                                                    "$ref": "#/$defs/types/string_null"
-                                                                }
-                                                            },
-                                                            {
-                                                                "$ref": "#/$defs/types/array_null",
-                                                                "items": {
-                                                                    "$ref": "#/$defs/types/string_null"
-                                                                }
-                                                            }
-                                                        ]
+                                                        "$ref": "#/$defs/types/object_null",
+                                                        "additionalProperties": {
+                                                            "$ref": "#/$defs/types/string_null"
+                                                        }
                                                     },
                                                     "description": "Forcefully set the values of certain attributes on certain elements."
                                                 },

--- a/src/Symfony/Component/Config/CHANGELOG.md
+++ b/src/Symfony/Component/Config/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add `JsonSchemaDumper` to dump JSON Schema from configuration node definitions
  * Add `BaseNode::isNullable()` to check if a node accepts null as input
+ * Add `BaseNode::hasNormalizationClosures()` to check if closures are used to normalize the value
  * Add `NodeBuilder::appendFromCallback()` to reuse child node definitions
 
 8.0

--- a/src/Symfony/Component/Config/Definition/BaseNode.php
+++ b/src/Symfony/Component/Config/Definition/BaseNode.php
@@ -236,6 +236,14 @@ abstract class BaseNode implements NodeInterface
     }
 
     /**
+     * Tells whether closures are used to normalize the value.
+     */
+    public function hasNormalizationClosures(): bool
+    {
+        return (bool) $this->normalizationClosures;
+    }
+
+    /**
      * Sets the list of types supported by normalization.
      *
      * @param list<ExprBuilder::TYPE_*> $types

--- a/src/Symfony/Component/Config/Definition/Dumper/JsonSchemaDumper.php
+++ b/src/Symfony/Component/Config/Definition/Dumper/JsonSchemaDumper.php
@@ -103,10 +103,9 @@ final class JsonSchemaDumper
                     $schema['minProperties'] = $node->getMinNumberOfElements();
                 }
 
-                // A key-attribute map also accepts the equivalent list form, which the Config
-                // layer normalizes back into a map. Only scalar prototypes are exposed as a
-                // list, where each item is the attribute value.
-                if (!$node->getPrototype() instanceof ArrayNode) {
+                // A normalization closure rewrites the input before the key-attribute
+                // rules apply, so such a map also accepts the equivalent list form.
+                if ($node->hasNormalizationClosures() && !$node->getPrototype() instanceof ArrayNode) {
                     $listSchema = [
                         '$ref' => $node->isNullable() ? '#/$defs/types/array_null' : '#/$defs/types/array',
                         'items' => $prototypeSchema,

--- a/src/Symfony/Component/Config/Tests/Definition/Dumper/JsonSchemaDumperTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Dumper/JsonSchemaDumperTest.php
@@ -121,15 +121,25 @@ class JsonSchemaDumperTest extends TestCase
         $prototype->setKeyAttribute('name');
         $root = new ArrayNode('root');
         $root->addChild($prototype);
-        yield 'key-attribute map with scalar prototype also accepts a list' => [$prototype, [
+        yield 'key-attribute map with scalar prototype' => [$prototype, [
+            '$ref' => '#/$defs/types/object',
+            'additionalProperties' => ['$ref' => '#/$defs/types/string'],
+        ]];
+
+        $mapWithNormalization = (new ArrayNodeDefinition('proto'))
+            ->useAttributeAsKey('name')
+            ->stringPrototype()->end()
+            ->beforeNormalization()->ifArray()->then(static fn ($v) => $v)->end()
+            ->getNode();
+        yield 'key-attribute map with a normalization closure also accepts a list' => [$mapWithNormalization, [
             'anyOf' => [
                 [
-                    '$ref' => '#/$defs/types/object',
-                    'additionalProperties' => ['$ref' => '#/$defs/types/string'],
+                    '$ref' => '#/$defs/types/object_null',
+                    'additionalProperties' => ['$ref' => '#/$defs/types/string_null'],
                 ],
                 [
-                    '$ref' => '#/$defs/types/array',
-                    'items' => ['$ref' => '#/$defs/types/string'],
+                    '$ref' => '#/$defs/types/array_null',
+                    'items' => ['$ref' => '#/$defs/types/string_null'],
                 ],
             ],
         ]];
@@ -145,16 +155,8 @@ class JsonSchemaDumperTest extends TestCase
         // A prototyped map with a null default is nullable, so it uses the object_null ref.
         $mapWithNullDefault = (new ArrayNodeDefinition('proto'))->defaultNull()->useAttributeAsKey('name')->stringPrototype()->end()->getNode();
         yield 'array map with null default uses the nullable ref' => [$mapWithNullDefault, [
-            'anyOf' => [
-                [
-                    '$ref' => '#/$defs/types/object_null',
-                    'additionalProperties' => ['$ref' => '#/$defs/types/string_null'],
-                ],
-                [
-                    '$ref' => '#/$defs/types/array_null',
-                    'items' => ['$ref' => '#/$defs/types/string_null'],
-                ],
-            ],
+            '$ref' => '#/$defs/types/object_null',
+            'additionalProperties' => ['$ref' => '#/$defs/types/string_null'],
             'default' => null,
         ]];
 

--- a/src/Symfony/Component/Config/Tests/Fixtures/Configuration/ExampleConfiguration.schema.json
+++ b/src/Symfony/Component/Config/Tests/Fixtures/Configuration/ExampleConfiguration.schema.json
@@ -206,22 +206,11 @@
                     ]
                 },
                 "parameters": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/$defs/types/object_null",
-                            "additionalProperties": {
-                                "$ref": "#/$defs/types/scalar",
-                                "description": "Parameter name"
-                            }
-                        },
-                        {
-                            "$ref": "#/$defs/types/array_null",
-                            "items": {
-                                "$ref": "#/$defs/types/scalar",
-                                "description": "Parameter name"
-                            }
-                        }
-                    ]
+                    "$ref": "#/$defs/types/object_null",
+                    "additionalProperties": {
+                        "$ref": "#/$defs/types/scalar",
+                        "description": "Parameter name"
+                    }
                 },
                 "connections": {
                     "$ref": "#/$defs/types/array_null",

--- a/src/Symfony/Component/Yaml/Schema/SchemaValidator.php
+++ b/src/Symfony/Component/Yaml/Schema/SchemaValidator.php
@@ -120,34 +120,140 @@ final class SchemaValidator implements SchemaValidatorInterface
     /**
      * Best-effort resolution of the YAML line for a JSON Schema error path.
      *
-     * The path is a JSON Pointer (for example "/when@prod/framework") or a dotted
-     * property path. The line of the deepest matching key is returned, or 0 when
-     * it cannot be located.
+     * The path is a JSON Pointer (for example "/when@prod/framework" or "/paths/0/name").
+     * Keys are matched at the indentation level of the block they belong to, and numeric
+     * segments follow block sequence items, so a key nested in another block is never
+     * mistaken for the target. The line of the deepest located segment is returned, or 0
+     * when none is located. A value in flow notation resolves to the line where it starts.
      */
     private static function locateLine(string $content, string $path): int
     {
-        $path = str_replace(['~1', '~0'], ['/', '~'], $path);
-        $segments = preg_split('#[/.]#', trim($path, '/.'), -1, \PREG_SPLIT_NO_EMPTY) ?: [];
+        $segments = [];
+        foreach (explode('/', $path) as $segment) {
+            if ('' !== $segment) {
+                $segments[] = str_replace(['~1', '~0'], ['/', '~'], $segment);
+            }
+        }
 
         $lines = explode("\n", $content);
         $line = 0;
-        $offset = 0;
+        $start = 0;
+        $end = \count($lines);
+        $compactItem = false;
 
         foreach ($segments as $segment) {
-            // Array indices in the path do not map to a key in the document.
-            if (ctype_digit($segment)) {
-                continue;
-            }
+            $found = false;
 
-            for ($i = $offset; $i < \count($lines); ++$i) {
-                if (preg_match('/^\s*'.preg_quote($segment, '/').'\s*:/', $lines[$i])) {
+            // A digit can be a sequence index or a mapping key: peek at the block to know.
+            if (ctype_digit($segment) && self::startsWithSequenceItem($lines, $start, $end)) {
+                $remaining = (int) $segment;
+                $itemIndent = null;
+
+                for ($i = $start; $i < $end; ++$i) {
+                    $text = rtrim(ltrim($lines[$i], ' '));
+                    if ('' === $text || '#' === $text[0]) {
+                        continue;
+                    }
+                    $indent = \strlen(rtrim($lines[$i])) - \strlen($text);
+                    $isItem = '-' === $text || str_starts_with($text, '- ');
+
+                    if (null === $itemIndent) {
+                        $itemIndent = $indent;
+                    } elseif ($indent > $itemIndent) {
+                        continue;
+                    } elseif ($indent < $itemIndent || !$isItem) {
+                        break;
+                    }
+
+                    if ($remaining-- > 0) {
+                        continue;
+                    }
+
                     $line = $i + 1;
-                    $offset = $i + 1;
+                    $start = $i;
+                    $end = self::findBlockEnd($lines, $i + 1, $end, $itemIndent, true);
+                    $compactItem = true;
+                    $found = true;
                     break;
                 }
+            } else {
+                $childIndent = null;
+                $pattern = '/^(["\']?)'.preg_quote($segment, '/').'\1\s*:(.*)$/';
+
+                for ($i = $start; $i < $end; ++$i) {
+                    $text = rtrim(ltrim($lines[$i], ' '));
+                    if ($compactItem && $i === $start && ('-' === $text || str_starts_with($text, '- '))) {
+                        // The first key of a sequence item can sit on the "-" line itself.
+                        $text = ltrim(substr($text, 1), ' ');
+                    }
+                    if ('' === $text || '#' === $text[0]) {
+                        continue;
+                    }
+                    $indent = \strlen(rtrim($lines[$i])) - \strlen($text);
+                    $childIndent ??= $indent;
+
+                    if ($indent !== $childIndent || !preg_match($pattern, $text, $matches)) {
+                        continue;
+                    }
+
+                    $line = $i + 1;
+                    $rest = trim($matches[2]);
+                    if ('' !== $rest && '#' !== $rest[0]) {
+                        // The value is inline, a scalar or a flow collection: deeper
+                        // segments cannot be resolved to a more precise line.
+                        return $line;
+                    }
+
+                    $start = $i + 1;
+                    $end = self::findBlockEnd($lines, $i + 1, $end, $childIndent, false);
+                    $compactItem = false;
+                    $found = true;
+                    break;
+                }
+            }
+
+            if (!$found) {
+                break;
             }
         }
 
         return $line;
+    }
+
+    /**
+     * Tells whether the first content line of the range is a block sequence item.
+     */
+    private static function startsWithSequenceItem(array $lines, int $start, int $end): bool
+    {
+        for ($i = $start; $i < $end; ++$i) {
+            $text = rtrim(ltrim($lines[$i], ' '));
+            if ('' !== $text && '#' !== $text[0]) {
+                return '-' === $text || str_starts_with($text, '- ');
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns the exclusive end of the block made of the lines more indented than $indent.
+     *
+     * Sequence items indented exactly at $indent are part of the block when $stopAtItems
+     * is false, which matches the value of a mapping key whose items are not indented.
+     */
+    private static function findBlockEnd(array $lines, int $start, int $end, int $indent, bool $stopAtItems): int
+    {
+        for ($i = $start; $i < $end; ++$i) {
+            $text = rtrim(ltrim($lines[$i], ' '));
+            if ('' === $text || '#' === $text[0]) {
+                continue;
+            }
+            $lineIndent = \strlen(rtrim($lines[$i])) - \strlen($text);
+            if ($lineIndent < $indent || ($lineIndent === $indent && ($stopAtItems || ('-' !== $text && !str_starts_with($text, '- '))))) {
+                return $i;
+            }
+        }
+
+        return $end;
     }
 }

--- a/src/Symfony/Component/Yaml/Tests/Schema/SchemaValidatorTest.php
+++ b/src/Symfony/Component/Yaml/Tests/Schema/SchemaValidatorTest.php
@@ -86,6 +86,113 @@ class SchemaValidatorTest extends TestCase
         $this->assertSame(2, $errors[0]['line']);
     }
 
+    public function testErrorLineSkipsSameKeyNestedDeeper()
+    {
+        $schema = $this->createFile(json_encode([
+            'type' => 'object',
+            'properties' => [
+                'second' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'other' => ['type' => 'object', 'properties' => ['target' => ['type' => 'integer']]],
+                        'target' => ['type' => 'integer'],
+                    ],
+                ],
+            ],
+        ]));
+
+        $content = "second:\n    other:\n        target: 1\n    target: not-an-integer";
+        $validator = new SchemaValidator();
+
+        $errors = $validator->validate(Yaml::parse($content), $schema, $content);
+
+        $this->assertCount(1, $errors);
+        $this->assertSame(4, $errors[0]['line']);
+    }
+
+    public function testErrorLineDoesNotLeaveTheParentBlock()
+    {
+        $schema = $this->createFile(json_encode([
+            'type' => 'object',
+            'properties' => [
+                'first' => ['type' => 'object', 'properties' => ['target' => ['type' => 'string']]],
+                'second' => ['type' => 'object', 'properties' => ['target' => ['type' => 'string']]],
+            ],
+        ]));
+
+        // The invalid value sits in a flow mapping; the same key exists later in another block.
+        $content = "first: { target: 1 }\nsecond:\n    target: not-an-integer";
+        $validator = new SchemaValidator();
+
+        $errors = $validator->validate(Yaml::parse($content), $schema, $content);
+
+        $this->assertCount(1, $errors);
+        $this->assertSame(1, $errors[0]['line']);
+    }
+
+    public function testErrorLineFollowsSequenceIndices()
+    {
+        $schema = $this->createFile(json_encode([
+            'type' => 'object',
+            'properties' => [
+                'items' => [
+                    'type' => 'array',
+                    'items' => ['type' => 'object', 'properties' => ['name' => ['type' => 'integer']]],
+                ],
+            ],
+        ]));
+
+        $content = "items:\n    - name: 1\n    - name: not-an-integer\n    - name: 3";
+        $validator = new SchemaValidator();
+
+        $errors = $validator->validate(Yaml::parse($content), $schema, $content);
+
+        $this->assertCount(1, $errors);
+        $this->assertSame(3, $errors[0]['line']);
+    }
+
+    public function testErrorLineWithSequenceItemsAtTheKeyIndentation()
+    {
+        $schema = $this->createFile(json_encode([
+            'type' => 'object',
+            'properties' => [
+                'list' => [
+                    'type' => 'array',
+                    'items' => ['type' => 'object', 'properties' => ['name' => ['type' => 'integer']]],
+                ],
+            ],
+        ]));
+
+        $content = "list:\n- name: 1\n- name: not-an-integer";
+        $validator = new SchemaValidator();
+
+        $errors = $validator->validate(Yaml::parse($content), $schema, $content);
+
+        $this->assertCount(1, $errors);
+        $this->assertSame(3, $errors[0]['line']);
+    }
+
+    public function testErrorLineWithSequenceItemOnItsOwnLine()
+    {
+        $schema = $this->createFile(json_encode([
+            'type' => 'object',
+            'properties' => [
+                'list' => [
+                    'type' => 'array',
+                    'items' => ['type' => 'object', 'properties' => ['name' => ['type' => 'integer']]],
+                ],
+            ],
+        ]));
+
+        $content = "list:\n    -\n        name: not-an-integer";
+        $validator = new SchemaValidator();
+
+        $errors = $validator->validate(Yaml::parse($content), $schema, $content);
+
+        $this->assertCount(1, $errors);
+        $this->assertSame(3, $errors[0]['line']);
+    }
+
     public function testInvalidUtf8ThrowsRuntimeException()
     {
         // Encoding such a value to JSON fails, and the data must not be silently validated as null.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        |
| License       | MIT

Follow-up to #65394, addressing @stof's review comments posted after the merge.

**Yaml: structure-aware violation lines.** `SchemaValidator::locateLine()` matched a key anywhere below the previous match, so a key nested in an earlier sibling block (or the same key in a later block) won the search, and numeric pointer segments were skipped, so a violation in the n-th sequence item reported the first item's line. The method now resolves JSON Pointers against the document structure: keys only match at the indentation level of the block being descended, numeric segments follow block sequence items (a digit that is a mapping key, as in `404:`, still matches as a key), and a value in flow notation resolves to the line where the flow collection starts, which is the exact line in the common single-line case. Pointer segments are decoded per segment, so keys containing dots (`example.com:`) or escaped slashes are located too.

**Config: no more generic list form for keyed maps.** The dumper documented an equivalent list form for every key-attribute map with a scalar prototype. As stof noted, that form is XML legacy: the Config layer only builds map keys from list items that carry the key attribute, and a plain list keeps integer keys, which is a config mistake a linter should report. The blanket `anyOf` is gone.

It cannot go away entirely, though: some nodes rewrite list input into a map through `beforeNormalization()` closures, and the shipped asset-mapper recipe relies on that (`paths: [assets/]`). Dropping the list form there would make `lint:yaml` flag the default config of every AssetMapper app. So the list alternative is now dumped only when the node registers normalization closures, exposed through the new `BaseNode::hasNormalizationClosures()`. In the framework schema exactly five nodes keep it: `asset_mapper.paths`, `semaphore.resources`, and the http_client `resolve`/`query` options; the other 27 keyed maps (for example `notifier.chatter_transports`, `serializer.default_context`) become strict, so a list there is reported instead of silently configuring entries named `0`, `1`, ... `JsonSchemaConfigDumpPassTest` pins both directions against the real FrameworkBundle configuration.

Checks run: full Yaml (985 tests), Config (627) and FrameworkBundle suites; the only FrameworkBundle failures are the five pre-existing local ones (SchedulerTest x2, ConfigurationTest x3), which reproduce on the merge commit. Revert-verified: with the source changes reverted, the new locateLine tests fail with the wrong line numbers and the "rejects the list form" test fails because the old schema accepted it.

Not covered here: `Tests/Functional/app/config/schema.json` is rewritten by whichever debug functional app compiled last, and the apps register different extension sets, so the committed file depends on test order (this predates #65394; the fixture in this PR matches the committed state, regenerated through the Notifier app). Worth its own cleanup.
