### PR TITLE
[Config][Yaml] Drop the schema list form and fix the error line lookup

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/config/schema.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/config/schema.json
@@ -325,20 +325,10 @@
                                                         "default": "_token"
                                                     },
                                                     "field_attr": {
-                                                        "anyOf": [
-                                                            {
-                                                                "$ref": "#/$defs/types/object_null",
-                                                                "additionalProperties": {
-                                                                    "$ref": "#/$defs/types/scalar"
-                                                                }
-                                                            },
-                                                            {
-                                                                "$ref": "#/$defs/types/array_null",
-                                                                "items": {
-                                                                    "$ref": "#/$defs/types/scalar"
-                                                                }
-                                                            }
-                                                        ],
+                                                        "$ref": "#/$defs/types/object_null",
+                                                        "additionalProperties": {
+                                                            "$ref": "#/$defs/types/scalar"
+                                                        },
                                                         "default": {
                                                             "data-controller": "csrf-protection"
                                                         }
@@ -828,20 +818,10 @@
                                                                         "$ref": "#/$defs/types/scalar"
                                                                     },
                                                                     "metadata": {
-                                                                        "anyOf": [
-                                                                            {
-                                                                                "$ref": "#/$defs/types/object_null",
-                                                                                "additionalProperties": {
-                                                                                    "$ref": "#/$defs/types/variable"
-                                                                                }
-                                                                            },
-                                                                            {
-                                                                                "$ref": "#/$defs/types/array_null",
-                                                                                "items": {
-                                                                                    "$ref": "#/$defs/types/variable"
-                                                                                }
-                                                                            }
-                                                                        ],
+                                                                        "$ref": "#/$defs/types/object_null",
+                                                                        "additionalProperties": {
+                                                                            "$ref": "#/$defs/types/variable"
+                                                                        },
                                                                         "examples": [
                                                                             {
                                                                                 "color": "blue",
@@ -943,20 +923,10 @@
                                                                 "default": 1
                                                             },
                                                             "metadata": {
-                                                                "anyOf": [
-                                                                    {
-                                                                        "$ref": "#/$defs/types/object_null",
-                                                                        "additionalProperties": {
-                                                                            "$ref": "#/$defs/types/variable"
-                                                                        }
-                                                                    },
-                                                                    {
-                                                                        "$ref": "#/$defs/types/array_null",
-                                                                        "items": {
-                                                                            "$ref": "#/$defs/types/variable"
-                                                                        }
-                                                                    }
-                                                                ],
+                                                                "$ref": "#/$defs/types/object_null",
+                                                                "additionalProperties": {
+                                                                    "$ref": "#/$defs/types/variable"
+                                                                },
                                                                 "examples": [
                                                                     {
                                                                         "color": "blue",
@@ -973,20 +943,10 @@
                                                     "minItems": 1
                                                 },
                                                 "metadata": {
-                                                    "anyOf": [
-                                                        {
-                                                            "$ref": "#/$defs/types/object_null",
-                                                            "additionalProperties": {
-                                                                "$ref": "#/$defs/types/variable"
-                                                            }
-                                                        },
-                                                        {
-                                                            "$ref": "#/$defs/types/array_null",
-                                                            "items": {
-                                                                "$ref": "#/$defs/types/variable"
-                                                            }
-                                                        }
-                                                    ],
+                                                    "$ref": "#/$defs/types/object_null",
+                                                    "additionalProperties": {
+                                                        "$ref": "#/$defs/types/variable"
+                                                    },
                                                     "examples": [
                                                         {
                                                             "color": "blue",
@@ -1359,12 +1319,6 @@
                                                 }
                                             },
                                             {
-                                                "$ref": "#/$defs/types/array_null",
-                                                "items": {
-                                                    "$ref": "#/$defs/types/scalar"
-                                                }
-                                            },
-                                            {
                                                 "type": [
                                                     "string"
                                                 ]
@@ -1422,20 +1376,10 @@
                                         "description": "Behavior if an asset cannot be found when imported from JavaScript or CSS files - e.g. \"import './non-existent.js'\". \"strict\" means an exception is thrown, \"warn\" means a warning is logged, \"ignore\" means the import is left as-is."
                                     },
                                     "extensions": {
-                                        "anyOf": [
-                                            {
-                                                "$ref": "#/$defs/types/object_null",
-                                                "additionalProperties": {
-                                                    "$ref": "#/$defs/types/scalar"
-                                                }
-                                            },
-                                            {
-                                                "$ref": "#/$defs/types/array_null",
-                                                "items": {
-                                                    "$ref": "#/$defs/types/scalar"
-                                                }
-                                            }
-                                        ],
+                                        "$ref": "#/$defs/types/object_null",
+                                        "additionalProperties": {
+                                            "$ref": "#/$defs/types/scalar"
+                                        },
                                         "description": "Key-value pair of file extensions set to their mime type.",
                                         "examples": [
                                             {
@@ -1469,20 +1413,10 @@
                                         "description": "Which entries end up in the rendered importmap: \"all\" of them, or only the ones \"reachable\" from the rendered entrypoints (their eager and lazy import chains) plus the polyfill."
                                     },
                                     "importmap_script_attributes": {
-                                        "anyOf": [
-                                            {
-                                                "$ref": "#/$defs/types/object_null",
-                                                "additionalProperties": {
-                                                    "$ref": "#/$defs/types/scalar"
-                                                }
-                                            },
-                                            {
-                                                "$ref": "#/$defs/types/array_null",
-                                                "items": {
-                                                    "$ref": "#/$defs/types/scalar"
-                                                }
-                                            }
-                                        ],
+                                        "$ref": "#/$defs/types/object_null",
+                                        "additionalProperties": {
+                                            "$ref": "#/$defs/types/scalar"
+                                        },
                                         "description": "Key-value pair of attributes to add to script tags output for the importmap.",
                                         "examples": [
                                             {
@@ -1756,20 +1690,10 @@
                                                     "$ref": "#/$defs/types/scalar"
                                                 },
                                                 "domains": {
-                                                    "anyOf": [
-                                                        {
-                                                            "$ref": "#/$defs/types/object_null",
-                                                            "additionalProperties": {
-                                                                "$ref": "#/$defs/types/scalar"
-                                                            }
-                                                        },
-                                                        {
-                                                            "$ref": "#/$defs/types/array_null",
-                                                            "items": {
-                                                                "$ref": "#/$defs/types/scalar"
-                                                            }
-                                                        }
-                                                    ]
+                                                    "$ref": "#/$defs/types/object_null",
+                                                    "additionalProperties": {
+                                                        "$ref": "#/$defs/types/scalar"
+                                                    }
                                                 },
                                                 "locales": {
                                                     "$ref": "#/$defs/types/array_null",
@@ -1797,20 +1721,10 @@
                                                             "$ref": "#/$defs/types/string_null"
                                                         },
                                                         "parameters": {
-                                                            "anyOf": [
-                                                                {
-                                                                    "$ref": "#/$defs/types/object_null",
-                                                                    "additionalProperties": {
-                                                                        "$ref": "#/$defs/types/scalar"
-                                                                    }
-                                                                },
-                                                                {
-                                                                    "$ref": "#/$defs/types/array_null",
-                                                                    "items": {
-                                                                        "$ref": "#/$defs/types/scalar"
-                                                                    }
-                                                                }
-                                                            ]
+                                                            "$ref": "#/$defs/types/object_null",
+                                                            "additionalProperties": {
+                                                                "$ref": "#/$defs/types/scalar"
+                                                            }
                                                         },
                                                         "domain": {
                                                             "$ref": "#/$defs/types/string_null"
@@ -2057,20 +1971,10 @@
                                         }
                                     },
                                     "default_context": {
-                                        "anyOf": [
-                                            {
-                                                "$ref": "#/$defs/types/object_null",
-                                                "additionalProperties": {
-                                                    "$ref": "#/$defs/types/variable"
-                                                }
-                                            },
-                                            {
-                                                "$ref": "#/$defs/types/array_null",
-                                                "items": {
-                                                    "$ref": "#/$defs/types/variable"
-                                                }
-                                            }
-                                        ]
+                                        "$ref": "#/$defs/types/object_null",
+                                        "additionalProperties": {
+                                            "$ref": "#/$defs/types/variable"
+                                        }
                                     },
                                     "named_serializers": {
                                         "$ref": "#/$defs/types/object_null",
@@ -2081,20 +1985,10 @@
                                                     "$ref": "#/$defs/types/scalar"
                                                 },
                                                 "default_context": {
-                                                    "anyOf": [
-                                                        {
-                                                            "$ref": "#/$defs/types/object_null",
-                                                            "additionalProperties": {
-                                                                "$ref": "#/$defs/types/variable"
-                                                            }
-                                                        },
-                                                        {
-                                                            "$ref": "#/$defs/types/array_null",
-                                                            "items": {
-                                                                "$ref": "#/$defs/types/variable"
-                                                            }
-                                                        }
-                                                    ]
+                                                    "$ref": "#/$defs/types/object_null",
+                                                    "additionalProperties": {
+                                                        "$ref": "#/$defs/types/variable"
+                                                    }
                                                 },
                                                 "include_built_in_normalizers": {
                                                     "$ref": "#/$defs/types/boolean",
@@ -2188,20 +2082,10 @@
                                         "default": false
                                     },
                                     "aliases": {
-                                        "anyOf": [
-                                            {
-                                                "$ref": "#/$defs/types/object_null",
-                                                "additionalProperties": {
-                                                    "$ref": "#/$defs/types/scalar"
-                                                }
-                                            },
-                                            {
-                                                "$ref": "#/$defs/types/array_null",
-                                                "items": {
-                                                    "$ref": "#/$defs/types/scalar"
-                                                }
-                                            }
-                                        ],
+                                        "$ref": "#/$defs/types/object_null",
+                                        "additionalProperties": {
+                                            "$ref": "#/$defs/types/scalar"
+                                        },
                                         "description": "Additional type aliases to be used during type context creation."
                                     }
                                 },
@@ -2529,13 +2413,6 @@
                                                 "minProperties": 1
                                             },
                                             {
-                                                "$ref": "#/$defs/types/array_null",
-                                                "items": {
-                                                    "$ref": "#/$defs/types/scalar"
-                                                },
-                                                "minItems": 1
-                                            },
-                                            {
                                                 "type": [
                                                     "string"
                                                 ]
@@ -2603,20 +2480,10 @@
                                                         "description": "Serialization format for the messenger.transport.symfony_serializer service (which is not the serializer used by default)."
                                                     },
                                                     "context": {
-                                                        "anyOf": [
-                                                            {
-                                                                "$ref": "#/$defs/types/object_null",
-                                                                "additionalProperties": {
-                                                                    "$ref": "#/$defs/types/variable"
-                                                                }
-                                                            },
-                                                            {
-                                                                "$ref": "#/$defs/types/array_null",
-                                                                "items": {
-                                                                    "$ref": "#/$defs/types/variable"
-                                                                }
-                                                            }
-                                                        ],
+                                                        "$ref": "#/$defs/types/object_null",
+                                                        "additionalProperties": {
+                                                            "$ref": "#/$defs/types/variable"
+                                                        },
                                                         "description": "Context array for the messenger.transport.symfony_serializer service (which is not the serializer used by default)."
                                                     }
                                                 },
@@ -2671,20 +2538,10 @@
                                                             "additionalProperties": false
                                                         },
                                                         "options": {
-                                                            "anyOf": [
-                                                                {
-                                                                    "$ref": "#/$defs/types/object_null",
-                                                                    "additionalProperties": {
-                                                                        "$ref": "#/$defs/types/variable"
-                                                                    }
-                                                                },
-                                                                {
-                                                                    "$ref": "#/$defs/types/array_null",
-                                                                    "items": {
-                                                                        "$ref": "#/$defs/types/variable"
-                                                                    }
-                                                                }
-                                                            ]
+                                                            "$ref": "#/$defs/types/object_null",
+                                                            "additionalProperties": {
+                                                                "$ref": "#/$defs/types/variable"
+                                                            }
                                                         },
                                                         "failure_transport": {
                                                             "$ref": "#/$defs/types/scalar",
@@ -2982,37 +2839,17 @@
                                         "$ref": "#/$defs/types/object_null",
                                         "properties": {
                                             "vars": {
-                                                "anyOf": [
-                                                    {
-                                                        "$ref": "#/$defs/types/object_null",
-                                                        "additionalProperties": {
-                                                            "$ref": "#/$defs/types/variable"
-                                                        }
-                                                    },
-                                                    {
-                                                        "$ref": "#/$defs/types/array_null",
-                                                        "items": {
-                                                            "$ref": "#/$defs/types/variable"
-                                                        }
-                                                    }
-                                                ],
+                                                "$ref": "#/$defs/types/object_null",
+                                                "additionalProperties": {
+                                                    "$ref": "#/$defs/types/variable"
+                                                },
                                                 "description": "Associative array: the default vars used to expand the templated URI."
                                             },
                                             "headers": {
-                                                "anyOf": [
-                                                    {
-                                                        "$ref": "#/$defs/types/object_null",
-                                                        "additionalProperties": {
-                                                            "$ref": "#/$defs/types/variable"
-                                                        }
-                                                    },
-                                                    {
-                                                        "$ref": "#/$defs/types/array_null",
-                                                        "items": {
-                                                            "$ref": "#/$defs/types/variable"
-                                                        }
-                                                    }
-                                                ],
+                                                "$ref": "#/$defs/types/object_null",
+                                                "additionalProperties": {
+                                                    "$ref": "#/$defs/types/variable"
+                                                },
                                                 "description": "Associative array: header => value(s)."
                                             },
                                             "max_redirects": {
@@ -3024,20 +2861,10 @@
                                                 "description": "The default HTTP version, typically 1.1 or 2.0, leave to null for the best version."
                                             },
                                             "resolve": {
-                                                "anyOf": [
-                                                    {
-                                                        "$ref": "#/$defs/types/object_null",
-                                                        "additionalProperties": {
-                                                            "$ref": "#/$defs/types/scalar"
-                                                        }
-                                                    },
-                                                    {
-                                                        "$ref": "#/$defs/types/array_null",
-                                                        "items": {
-                                                            "$ref": "#/$defs/types/scalar"
-                                                        }
-                                                    }
-                                                ],
+                                                "$ref": "#/$defs/types/object_null",
+                                                "additionalProperties": {
+                                                    "$ref": "#/$defs/types/scalar"
+                                                },
                                                 "description": "Associative array: domain => IP."
                                             },
                                             "proxy": {
@@ -3117,20 +2944,10 @@
                                                 "description": "The minimum version of TLS to accept; must be one of STREAM_CRYPTO_METHOD_TLSv*_CLIENT constants."
                                             },
                                             "extra": {
-                                                "anyOf": [
-                                                    {
-                                                        "$ref": "#/$defs/types/object_null",
-                                                        "additionalProperties": {
-                                                            "$ref": "#/$defs/types/variable"
-                                                        }
-                                                    },
-                                                    {
-                                                        "$ref": "#/$defs/types/array_null",
-                                                        "items": {
-                                                            "$ref": "#/$defs/types/variable"
-                                                        }
-                                                    }
-                                                ],
+                                                "$ref": "#/$defs/types/object_null",
+                                                "additionalProperties": {
+                                                    "$ref": "#/$defs/types/variable"
+                                                },
                                                 "description": "Extra options for specific HTTP client."
                                             },
                                             "rate_limiter": {
@@ -3335,20 +3152,10 @@
                                                             "description": "A \"username:password\" pair to use Microsoft NTLM authentication (requires the cURL extension)."
                                                         },
                                                         "query": {
-                                                            "anyOf": [
-                                                                {
-                                                                    "$ref": "#/$defs/types/object_null",
-                                                                    "additionalProperties": {
-                                                                        "$ref": "#/$defs/types/scalar"
-                                                                    }
-                                                                },
-                                                                {
-                                                                    "$ref": "#/$defs/types/array_null",
-                                                                    "items": {
-                                                                        "$ref": "#/$defs/types/scalar"
-                                                                    }
-                                                                }
-                                                            ],
+                                                            "$ref": "#/$defs/types/object_null",
+                                                            "additionalProperties": {
+                                                                "$ref": "#/$defs/types/scalar"
+                                                            },
                                                             "description": "Associative array of query string values merged with the base URI."
                                                         },
                                                         "mock_response_factory": {
@@ -3356,20 +3163,10 @@
                                                             "description": "`true` to always return empty 200 responses, `false` to disable mocking, or the id of the service to use to generate mock responses (invokable or iterable)."
                                                         },
                                                         "headers": {
-                                                            "anyOf": [
-                                                                {
-                                                                    "$ref": "#/$defs/types/object_null",
-                                                                    "additionalProperties": {
-                                                                        "$ref": "#/$defs/types/variable"
-                                                                    }
-                                                                },
-                                                                {
-                                                                    "$ref": "#/$defs/types/array_null",
-                                                                    "items": {
-                                                                        "$ref": "#/$defs/types/variable"
-                                                                    }
-                                                                }
-                                                            ],
+                                                            "$ref": "#/$defs/types/object_null",
+                                                            "additionalProperties": {
+                                                                "$ref": "#/$defs/types/variable"
+                                                            },
                                                             "description": "Associative array: header => value(s)."
                                                         },
                                                         "max_redirects": {
@@ -3381,20 +3178,10 @@
                                                             "description": "The default HTTP version, typically 1.1 or 2.0, leave to null for the best version."
                                                         },
                                                         "resolve": {
-                                                            "anyOf": [
-                                                                {
-                                                                    "$ref": "#/$defs/types/object_null",
-                                                                    "additionalProperties": {
-                                                                        "$ref": "#/$defs/types/scalar"
-                                                                    }
-                                                                },
-                                                                {
-                                                                    "$ref": "#/$defs/types/array_null",
-                                                                    "items": {
-                                                                        "$ref": "#/$defs/types/scalar"
-                                                                    }
-                                                                }
-                                                            ],
+                                                            "$ref": "#/$defs/types/object_null",
+                                                            "additionalProperties": {
+                                                                "$ref": "#/$defs/types/scalar"
+                                                            },
                                                             "description": "Associative array: domain => IP."
                                                         },
                                                         "proxy": {
@@ -3474,20 +3261,10 @@
                                                             "description": "The minimum version of TLS to accept; must be one of STREAM_CRYPTO_METHOD_TLSv*_CLIENT constants."
                                                         },
                                                         "extra": {
-                                                            "anyOf": [
-                                                                {
-                                                                    "$ref": "#/$defs/types/object_null",
-                                                                    "additionalProperties": {
-                                                                        "$ref": "#/$defs/types/variable"
-                                                                    }
-                                                                },
-                                                                {
-                                                                    "$ref": "#/$defs/types/array_null",
-                                                                    "items": {
-                                                                        "$ref": "#/$defs/types/variable"
-                                                                    }
-                                                                }
-                                                            ],
+                                                            "$ref": "#/$defs/types/object_null",
+                                                            "additionalProperties": {
+                                                                "$ref": "#/$defs/types/variable"
+                                                            },
                                                             "description": "Extra options for specific HTTP client."
                                                         },
                                                         "rate_limiter": {
@@ -3863,20 +3640,10 @@
                                                         "description": "The private key passphrase"
                                                     },
                                                     "options": {
-                                                        "anyOf": [
-                                                            {
-                                                                "$ref": "#/$defs/types/object_null",
-                                                                "additionalProperties": {
-                                                                    "$ref": "#/$defs/types/variable"
-                                                                }
-                                                            },
-                                                            {
-                                                                "$ref": "#/$defs/types/array_null",
-                                                                "items": {
-                                                                    "$ref": "#/$defs/types/variable"
-                                                                }
-                                                            }
-                                                        ]
+                                                        "$ref": "#/$defs/types/object_null",
+                                                        "additionalProperties": {
+                                                            "$ref": "#/$defs/types/variable"
+                                                        }
                                                     }
                                                 },
                                                 "additionalProperties": false
@@ -3963,20 +3730,10 @@
                                                         "description": "S/MIME certificate repository service. This service shall implement the `Symfony\\Component\\Mailer\\EventListener\\SmimeCertificateRepositoryInterface`."
                                                     },
                                                     "certificates": {
-                                                        "anyOf": [
-                                                            {
-                                                                "$ref": "#/$defs/types/object_null",
-                                                                "additionalProperties": {
-                                                                    "$ref": "#/$defs/types/scalar"
-                                                                }
-                                                            },
-                                                            {
-                                                                "$ref": "#/$defs/types/array_null",
-                                                                "items": {
-                                                                    "$ref": "#/$defs/types/scalar"
-                                                                }
-                                                            }
-                                                        ],
+                                                        "$ref": "#/$defs/types/object_null",
+                                                        "additionalProperties": {
+                                                            "$ref": "#/$defs/types/scalar"
+                                                        },
                                                         "description": "Recipient S/MIME certificates, as a map of email address to certificate file path. Cannot be used together with \"repository\"."
                                                     },
                                                     "on_missing_certificate": {
@@ -4105,20 +3862,10 @@
                                                         "description": "Service or class implementing `Symfony\\Component\\Mailer\\EventListener\\PgpPublicKeyRepositoryInterface` to provide recipient PGP public keys."
                                                     },
                                                     "keys": {
-                                                        "anyOf": [
-                                                            {
-                                                                "$ref": "#/$defs/types/object_null",
-                                                                "additionalProperties": {
-                                                                    "$ref": "#/$defs/types/scalar"
-                                                                }
-                                                            },
-                                                            {
-                                                                "$ref": "#/$defs/types/array_null",
-                                                                "items": {
-                                                                    "$ref": "#/$defs/types/scalar"
-                                                                }
-                                                            }
-                                                        ],
+                                                        "$ref": "#/$defs/types/object_null",
+                                                        "additionalProperties": {
+                                                            "$ref": "#/$defs/types/scalar"
+                                                        },
                                                         "description": "Recipient PGP public keys, as a map of email address to public key file path. Cannot be used together with \"repository\"."
                                                     },
                                                     "binary": {
@@ -4316,36 +4063,16 @@
                                         "description": "The message bus to use. Defaults to the default bus if the Messenger component is installed."
                                     },
                                     "chatter_transports": {
-                                        "anyOf": [
-                                            {
-                                                "$ref": "#/$defs/types/object_null",
-                                                "additionalProperties": {
-                                                    "$ref": "#/$defs/types/scalar"
-                                                }
-                                            },
-                                            {
-                                                "$ref": "#/$defs/types/array_null",
-                                                "items": {
-                                                    "$ref": "#/$defs/types/scalar"
-                                                }
-                                            }
-                                        ]
+                                        "$ref": "#/$defs/types/object_null",
+                                        "additionalProperties": {
+                                            "$ref": "#/$defs/types/scalar"
+                                        }
                                     },
                                     "texter_transports": {
-                                        "anyOf": [
-                                            {
-                                                "$ref": "#/$defs/types/object_null",
-                                                "additionalProperties": {
-                                                    "$ref": "#/$defs/types/scalar"
-                                                }
-                                            },
-                                            {
-                                                "$ref": "#/$defs/types/array_null",
-                                                "items": {
-                                                    "$ref": "#/$defs/types/scalar"
-                                                }
-                                            }
-                                        ]
+                                        "$ref": "#/$defs/types/object_null",
+                                        "additionalProperties": {
+                                            "$ref": "#/$defs/types/scalar"
+                                        }
                                     },
                                     "notification_on_failed_messages": {
                                         "$ref": "#/$defs/types/boolean",
@@ -4673,20 +4400,10 @@
                                                     "description": "Allows all static elements and attributes from the W3C Sanitizer API standard."
                                                 },
                                                 "allow_elements": {
-                                                    "anyOf": [
-                                                        {
-                                                            "$ref": "#/$defs/types/object_null",
-                                                            "additionalProperties": {
-                                                                "$ref": "#/$defs/types/variable"
-                                                            }
-                                                        },
-                                                        {
-                                                            "$ref": "#/$defs/types/array_null",
-                                                            "items": {
-                                                                "$ref": "#/$defs/types/variable"
-                                                            }
-                                                        }
-                                                    ],
+                                                    "$ref": "#/$defs/types/object_null",
+                                                    "additionalProperties": {
+                                                        "$ref": "#/$defs/types/variable"
+                                                    },
                                                     "description": "Configures the elements that the sanitizer should retain from the input. The element name is the key, the value is either a list of allowed attributes for this element or \"*\" to allow the default set of attributes (https://wicg.github.io/sanitizer-api/#default-configuration).",
                                                     "examples": [
                                                         {
@@ -4731,56 +4448,26 @@
                                                     "description": "Configures elements as dropped. Dropped elements are elements the sanitizer should remove from the input, including their children."
                                                 },
                                                 "allow_attributes": {
-                                                    "anyOf": [
-                                                        {
-                                                            "$ref": "#/$defs/types/object_null",
-                                                            "additionalProperties": {
-                                                                "$ref": "#/$defs/types/variable"
-                                                            }
-                                                        },
-                                                        {
-                                                            "$ref": "#/$defs/types/array_null",
-                                                            "items": {
-                                                                "$ref": "#/$defs/types/variable"
-                                                            }
-                                                        }
-                                                    ],
+                                                    "$ref": "#/$defs/types/object_null",
+                                                    "additionalProperties": {
+                                                        "$ref": "#/$defs/types/variable"
+                                                    },
                                                     "description": "Configures attributes as allowed. Allowed attributes are attributes the sanitizer should retain from the input."
                                                 },
                                                 "drop_attributes": {
-                                                    "anyOf": [
-                                                        {
-                                                            "$ref": "#/$defs/types/object_null",
-                                                            "additionalProperties": {
-                                                                "$ref": "#/$defs/types/variable"
-                                                            }
-                                                        },
-                                                        {
-                                                            "$ref": "#/$defs/types/array_null",
-                                                            "items": {
-                                                                "$ref": "#/$defs/types/variable"
-                                                            }
-                                                        }
-                                                    ],
+                                                    "$ref": "#/$defs/types/object_null",
+                                                    "additionalProperties": {
+                                                        "$ref": "#/$defs/types/variable"
+                                                    },
                                                     "description": "Configures attributes as dropped. Dropped attributes are attributes the sanitizer should remove from the input."
                                                 },
                                                 "force_attributes": {
                                                     "$ref": "#/$defs/types/object_null",
                                                     "additionalProperties": {
-                                                        "anyOf": [
-                                                            {
-                                                                "$ref": "#/$defs/types/object_null",
-                                                                "additionalProperties": {
-                                                                    "$ref": "#/$defs/types/string_null"
-                                                                }
-                                                            },
-                                                            {
-                                                                "$ref": "#/$defs/types/array_null",
-                                                                "items": {
-                                                                    "$ref": "#/$defs/types/string_null"
-                                                                }
-                                                            }
-                                                        ]
+                                                        "$ref": "#/$defs/types/object_null",
+                                                        "additionalProperties": {
+                                                            "$ref": "#/$defs/types/string_null"
+                                                        }
                                                     },
                                                     "description": "Forcefully set the values of certain attributes on certain elements."
                                                 },

--- a/src/Symfony/Component/Config/Definition/Dumper/JsonSchemaDumper.php
+++ b/src/Symfony/Component/Config/Definition/Dumper/JsonSchemaDumper.php
@@ -102,22 +102,6 @@ final class JsonSchemaDumper
                 if ($node->getMinNumberOfElements()) {
                     $schema['minProperties'] = $node->getMinNumberOfElements();
                 }
-
-                // A key-attribute map also accepts the equivalent list form, which the Config
-                // layer normalizes back into a map. Only scalar prototypes are exposed as a
-                // list, where each item is the attribute value.
-                if (!$node->getPrototype() instanceof ArrayNode) {
-                    $listSchema = [
-                        '$ref' => $node->isNullable() ? '#/$defs/types/array_null' : '#/$defs/types/array',
-                        'items' => $prototypeSchema,
-                    ];
-
-                    if ($node->getMinNumberOfElements()) {
-                        $listSchema['minItems'] = $node->getMinNumberOfElements();
-                    }
-
-                    $schema = ['anyOf' => [$schema, $listSchema]];
-                }
             } else {
                 $schema = [
                     '$ref' => $node->isNullable() ? '#/$defs/types/array_null' : '#/$defs/types/array',

--- a/src/Symfony/Component/Config/Tests/Definition/Dumper/JsonSchemaDumperTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Dumper/JsonSchemaDumperTest.php
@@ -121,17 +121,9 @@ class JsonSchemaDumperTest extends TestCase
         $prototype->setKeyAttribute('name');
         $root = new ArrayNode('root');
         $root->addChild($prototype);
-        yield 'key-attribute map with scalar prototype also accepts a list' => [$prototype, [
-            'anyOf' => [
-                [
-                    '$ref' => '#/$defs/types/object',
-                    'additionalProperties' => ['$ref' => '#/$defs/types/string'],
-                ],
-                [
-                    '$ref' => '#/$defs/types/array',
-                    'items' => ['$ref' => '#/$defs/types/string'],
-                ],
-            ],
+        yield 'key-attribute map with scalar prototype' => [$prototype, [
+            '$ref' => '#/$defs/types/object',
+            'additionalProperties' => ['$ref' => '#/$defs/types/string'],
         ]];
 
         // A prototyped list with a null default is nullable, so it uses the array_null ref.
@@ -145,16 +137,8 @@ class JsonSchemaDumperTest extends TestCase
         // A prototyped map with a null default is nullable, so it uses the object_null ref.
         $mapWithNullDefault = (new ArrayNodeDefinition('proto'))->defaultNull()->useAttributeAsKey('name')->stringPrototype()->end()->getNode();
         yield 'array map with null default uses the nullable ref' => [$mapWithNullDefault, [
-            'anyOf' => [
-                [
-                    '$ref' => '#/$defs/types/object_null',
-                    'additionalProperties' => ['$ref' => '#/$defs/types/string_null'],
-                ],
-                [
-                    '$ref' => '#/$defs/types/array_null',
-                    'items' => ['$ref' => '#/$defs/types/string_null'],
-                ],
-            ],
+            '$ref' => '#/$defs/types/object_null',
+            'additionalProperties' => ['$ref' => '#/$defs/types/string_null'],
             'default' => null,
         ]];
 

--- a/src/Symfony/Component/Config/Tests/Fixtures/Configuration/ExampleConfiguration.schema.json
+++ b/src/Symfony/Component/Config/Tests/Fixtures/Configuration/ExampleConfiguration.schema.json
@@ -206,22 +206,11 @@
                     ]
                 },
                 "parameters": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/$defs/types/object_null",
-                            "additionalProperties": {
-                                "$ref": "#/$defs/types/scalar",
-                                "description": "Parameter name"
-                            }
-                        },
-                        {
-                            "$ref": "#/$defs/types/array_null",
-                            "items": {
-                                "$ref": "#/$defs/types/scalar",
-                                "description": "Parameter name"
-                            }
-                        }
-                    ]
+                    "$ref": "#/$defs/types/object_null",
+                    "additionalProperties": {
+                        "$ref": "#/$defs/types/scalar",
+                        "description": "Parameter name"
+                    }
                 },
                 "connections": {
                     "$ref": "#/$defs/types/array_null",

--- a/src/Symfony/Component/Yaml/Schema/SchemaValidator.php
+++ b/src/Symfony/Component/Yaml/Schema/SchemaValidator.php
@@ -120,34 +120,161 @@ final class SchemaValidator implements SchemaValidatorInterface
     /**
      * Best-effort resolution of the YAML line for a JSON Schema error path.
      *
-     * The path is a JSON Pointer (for example "/when@prod/framework") or a dotted
-     * property path. The line of the deepest matching key is returned, or 0 when
-     * it cannot be located.
+     * The path is a JSON Pointer, for example "/when@prod/framework" or
+     * "/monolog/handlers/0/type". Each segment is looked up among the direct
+     * children of the previous one, so a key nested deeper in the document is
+     * never mistaken for the one being looked for. The line of the deepest
+     * segment that could be located is returned, or 0 when even the first one
+     * could not be.
+     *
+     * A node written in flow notation ("{foo: bar}") holds its children on its
+     * own line, so the line of the flow container is returned for them.
      */
-    private static function locateLine(string $content, string $path): int
+    private static function locateLine(string $content, string $pointer): int
     {
-        $path = str_replace(['~1', '~0'], ['/', '~'], $path);
-        $segments = preg_split('#[/.]#', trim($path, '/.'), -1, \PREG_SPLIT_NO_EMPTY) ?: [];
-
-        $lines = explode("\n", $content);
-        $line = 0;
-        $offset = 0;
-
-        foreach ($segments as $segment) {
-            // Array indices in the path do not map to a key in the document.
-            if (ctype_digit($segment)) {
-                continue;
-            }
-
-            for ($i = $offset; $i < \count($lines); ++$i) {
-                if (preg_match('/^\s*'.preg_quote($segment, '/').'\s*:/', $lines[$i])) {
-                    $line = $i + 1;
-                    $offset = $i + 1;
-                    break;
-                }
+        $segments = [];
+        foreach (explode('/', trim($pointer, '/')) as $segment) {
+            if ('' !== $segment) {
+                $segments[] = str_replace(['~1', '~0'], ['/', '~'], $segment);
             }
         }
 
+        $lines = explode("\n", $content);
+        $line = 0;
+        // Lines the children of the current node span, and the indentation of the node itself.
+        $start = 0;
+        $end = \count($lines);
+        $indent = -1;
+
+        foreach ($segments as $segment) {
+            $located = ctype_digit($segment)
+                ? self::locateItem($lines, (int) $segment, $start, $end, $indent)
+                : self::locateKey($lines, $segment, $start, $end, $indent);
+
+            if (null === $located) {
+                // The deepest ancestor located is a better answer than a key looked up further down.
+                break;
+            }
+
+            [$line, $start, $end, $indent] = $located;
+        }
+
         return $line;
+    }
+
+    /**
+     * Locates a mapping key among the direct children of a node.
+     *
+     * @param list<string> $lines
+     *
+     * @return array{int, int, int, int}|null The 1-based line of the key, then the lines its own children span and its indentation
+     */
+    private static function locateKey(array $lines, string $key, int $start, int $end, int $indent): ?array
+    {
+        $quoted = preg_quote($key, '/');
+        $pattern = '/^\s*(?:"'.$quoted.'"|\''.$quoted.'\'|'.$quoted.')\s*:(?:\s|$)/';
+        $childIndent = null;
+
+        foreach (self::significantLines($lines, $start, $end) as $i => $lineIndent) {
+            if ($lineIndent <= $indent) {
+                // A line at the indentation of the node itself ends it.
+                break;
+            }
+
+            // Only the shallowest level in the range holds the direct children.
+            $childIndent ??= $lineIndent;
+
+            if ($lineIndent === $childIndent && preg_match($pattern, $lines[$i])) {
+                return [$i + 1, $i + 1, self::endOfNode($lines, $i + 1, $end, $lineIndent, true), $lineIndent];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Locates the nth item of a sequence among the direct children of a node.
+     *
+     * @param list<string> $lines
+     *
+     * @return array{int, int, int, int}|null The 1-based line of the item, then the lines its own children span and its indentation
+     */
+    private static function locateItem(array &$lines, int $index, int $start, int $end, int $indent): ?array
+    {
+        $itemIndent = null;
+        $found = 0;
+
+        foreach (self::significantLines($lines, $start, $end) as $i => $lineIndent) {
+            $isItem = self::isSequenceItem($lines[$i]);
+
+            // A sequence may be indented at the level of its parent key, so only a
+            // line that is not an item ends the node at that level.
+            if ($lineIndent < $indent || ($lineIndent === $indent && !$isItem)) {
+                break;
+            }
+
+            $itemIndent ??= $lineIndent;
+
+            if ($lineIndent !== $itemIndent || !$isItem || $found++ !== $index) {
+                continue;
+            }
+
+            $childrenEnd = self::endOfNode($lines, $i + 1, $end, $lineIndent, false);
+
+            // Blank out the dash so a key written on the item line ("- name: a") is
+            // seen as a child of the item, indented past it.
+            $lines[$i] = substr_replace($lines[$i], ' ', strpos($lines[$i], '-'), 1);
+
+            return [$i + 1, $i, $childrenEnd, $lineIndent];
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns the line the node starting at $start and indented at $indent ends on, exclusive.
+     *
+     * @param list<string> $lines
+     */
+    private static function endOfNode(array $lines, int $start, int $end, int $indent, bool $flushSequenceContinues): int
+    {
+        foreach (self::significantLines($lines, $start, $end) as $i => $lineIndent) {
+            if ($lineIndent > $indent) {
+                continue;
+            }
+
+            if ($lineIndent === $indent && $flushSequenceContinues && self::isSequenceItem($lines[$i])) {
+                continue;
+            }
+
+            return $i;
+        }
+
+        return $end;
+    }
+
+    /**
+     * Yields the indentation of each line in the range that carries content, keyed by line index.
+     *
+     * @param list<string> $lines
+     *
+     * @return iterable<int, int>
+     */
+    private static function significantLines(array $lines, int $start, int $end): iterable
+    {
+        for ($i = $start; $i < $end; ++$i) {
+            $trimmed = ltrim($lines[$i], " \t");
+
+            if ('' === $trimmed || '#' === $trimmed[0]) {
+                continue;
+            }
+
+            yield $i => \strlen($lines[$i]) - \strlen($trimmed);
+        }
+    }
+
+    private static function isSequenceItem(string $line): bool
+    {
+        return (bool) preg_match('/^\s*-(?:\s|$)/', $line);
     }
 }

--- a/src/Symfony/Component/Yaml/Tests/Schema/SchemaValidatorTest.php
+++ b/src/Symfony/Component/Yaml/Tests/Schema/SchemaValidatorTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Yaml\Tests\Schema;
 
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Yaml\Exception\RuntimeException;
 use Symfony\Component\Yaml\Schema\SchemaValidator;
@@ -78,6 +79,77 @@ class SchemaValidatorTest extends TestCase
         ]));
 
         $content = "parent:\n    child: not-an-integer";
+        $validator = new SchemaValidator();
+
+        $errors = $validator->validate(Yaml::parse($content), $schema, $content);
+
+        $this->assertNotEmpty($errors);
+        $this->assertSame(2, $errors[0]['line']);
+    }
+
+    public function testErrorLineIgnoresTheSameKeyNestedInAnotherBlock()
+    {
+        $schema = $this->createFile(json_encode([
+            'type' => 'object',
+            'properties' => [
+                'router' => [
+                    'type' => 'object',
+                    'required' => ['resource'],
+                ],
+                'session' => ['type' => 'object'],
+            ],
+        ]));
+
+        // "resource" is missing from "router" but present in "session": the line of the
+        // node the violation belongs to must be reported, not the one of the other block.
+        $content = "router:\n    utf8: true\nsession:\n    resource: bar";
+        $validator = new SchemaValidator();
+
+        $errors = $validator->validate(Yaml::parse($content), $schema, $content);
+
+        $this->assertNotEmpty($errors);
+        $this->assertSame(1, $errors[0]['line']);
+    }
+
+    #[TestWith(["handlers:\n    - type: a\n    - type: 8", 3])]
+    #[TestWith(["handlers:\n- type: a\n- type: 8", 3])]
+    public function testErrorLineIsResolvedFromSequenceIndex(string $content, int $line)
+    {
+        $schema = $this->createFile(json_encode([
+            'type' => 'object',
+            'properties' => [
+                'handlers' => [
+                    'type' => 'array',
+                    'items' => [
+                        'type' => 'object',
+                        'properties' => ['type' => ['type' => 'string']],
+                    ],
+                ],
+            ],
+        ]));
+
+        $validator = new SchemaValidator();
+
+        $errors = $validator->validate(Yaml::parse($content), $schema, $content);
+
+        $this->assertNotEmpty($errors);
+        $this->assertSame($line, $errors[0]['line']);
+    }
+
+    public function testErrorLineFallsBackToTheFlowContainer()
+    {
+        $schema = $this->createFile(json_encode([
+            'type' => 'object',
+            'properties' => [
+                'parent' => [
+                    'type' => 'object',
+                    'properties' => ['child' => ['type' => 'integer']],
+                ],
+            ],
+        ]));
+
+        // A node written in flow notation holds its children on its own line.
+        $content = "name: Symfony\nparent: {child: not-an-integer}";
         $validator = new SchemaValidator();
 
         $errors = $validator->validate(Yaml::parse($content), $schema, $content);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Follow-up of #65394
| License       | MIT

Follow-up on the review comments @stof left on #65394 shortly after it was merged. Both points were valid and are addressed here.

## The list form of key-attribute maps

The dumper no longer describes the list form as an accepted alternative to the map form for a `useAttributeAsKey()` node.

The guard that was in place only exposed the list form for scalar prototypes, so the two first comments (the item needs an extra attribute holding the key, and `null` cannot be a value then) did not apply. The third one does, and the runtime confirms it. In `PrototypedArrayNode::normalizeValue()` the key extraction is conditioned on `\is_array($v)`, so a list given to a scalar prototype keeps its positional keys:

```php
$tb = new TreeBuilder('root');
$tb->getRootNode()->children()
    ->arrayNode('params')->useAttributeAsKey('name')->scalarPrototype()
->end()->end()->end();

$processor->process($tb->buildTree(), [['params' => ['a', 'b']]]);
// ['params' => [0 => 'a', 1 => 'b']]

$processor->process($tb->buildTree(), [['params' => ['a' => 1, 'b' => 2]]]);
// ['params' => ['a' => 1, 'b' => 2]]
```

Nothing throws, but the configuration built from a document the schema declared valid is not the one the author meant. As @stof points out, this form is a consequence of the XML support, where a map key has to be carried by an attribute. YAML and PHP have native maps, so only the map form is described.

The `isNullable()` changes from #65394 are untouched.

## The error line lookup

`SchemaValidator::locateLine()` used to scan the file for each pointer segment with a line-anchored regex and a forward-only offset, without any notion of indentation or of where a node ends. Three consequences:

* a key nested deeper in the document, or belonging to another block, could be matched instead of the one being looked for;
* sequence indices were skipped, so the next subkey was typically found in the first item of the sequence;
* a segment that could not be found left the previous line in place with nothing signalling the degradation.

It now walks the document. Each segment is looked up among the direct children of the previous one: `locateKey()` only considers the shallowest indentation level of the current range and stops when a line returns to the indentation of the node itself, and `locateItem()` counts sequence items to reach the requested index. A sequence indented at the level of its parent key is handled, and the dash is blanked out so a key written on the item line (`- name: a`) is seen as a child of the item.

When a segment cannot be located the walk stops and the line of the deepest ancestor found is reported, which is more useful than a line picked further down the file. Children of a node written in flow notation report the line of the container, which the PHPDoc now states.

Splitting the pointer also changed from `preg_split('#[/.]#')` to `explode('/')` with per-segment `~1`/`~0` decoding. The old split also cut on dots, which broke keys such as `App\Foo.bar`.

## Note on the scope

A linter cannot match a language server on position accuracy, since `Yaml\Parser` does not expose per-node offsets. The lookup stays best-effort by design, and that is now documented rather than implied. The generated `config/schema.json` and the `# yaml-language-server: $schema=` header convention remain the way editors get exact positions.

## Fixtures

`ExampleConfiguration.schema.json` and the `Tests/Functional/app/config/schema.json` fixture are updated for the dumper change. The latter was cross-checked against a real regeneration by `JsonSchemaConfigDumpPass`, which matches except for the `mercure` section, absent locally because `symfony/mercure-bundle` is not installed in the working copy, and kept as committed.
