### PR TITLE
[FrameworkBundle] Skip yaml_lint wiring tests when symfony/yaml has no schema support

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -136,6 +136,7 @@ use Symfony\Component\Workflow\DependencyInjection\WorkflowValidatorPass;
 use Symfony\Component\Workflow\Exception\InvalidDefinitionException;
 use Symfony\Component\Workflow\Metadata\InMemoryMetadataStore;
 use Symfony\Component\Workflow\WorkflowEvents;
+use Symfony\Component\Yaml\Schema\SchemaResolverInterface;
 use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Cache\TagAwareCacheInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -3986,6 +3987,10 @@ abstract class FrameworkExtensionTestCase extends TestCase
 
     public function testYamlLintCommandUsesTheKernelConfigDir()
     {
+        if (!interface_exists(SchemaResolverInterface::class)) {
+            $this->markTestSkipped('The installed symfony/yaml has no JSON schema support.');
+        }
+
         $container = $this->createContainerFromFile('default_config', ['.kernel.config_dir' => '/project/config']);
 
         $resolver = $container->getDefinition('console.command.yaml_lint')->getArgument(0);
@@ -3995,6 +4000,10 @@ abstract class FrameworkExtensionTestCase extends TestCase
 
     public function testYamlLintCommandWithoutKernelConfigDir()
     {
+        if (!interface_exists(SchemaResolverInterface::class)) {
+            $this->markTestSkipped('The installed symfony/yaml has no JSON schema support.');
+        }
+
         $container = $this->createContainerFromFile('default_config');
 
         $resolver = $container->getDefinition('console.command.yaml_lint')->getArgument(0);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The low-deps job installs symfony/yaml 7.4, which has no `SchemaResolverInterface`, so `FrameworkExtension` empties the arguments of `console.command.yaml_lint` and the two wiring tests error out on `getArgument(0)` in each config-format variant. The failure was hidden until now because the same job aborted earlier on the missing `symfony/amp-sql-messenger` package.

The tests now feature-detect the interface, mirroring the extension's own check.