### PR TITLE
[Security] Share the JWKS parsing of the oidc token handler and the oidc_login authenticator

### DIFF
--- a/src/Symfony/Component/Security/Http/AccessToken/Oidc/OidcTokenHandler.php
+++ b/src/Symfony/Component/Security/Http/AccessToken/Oidc/OidcTokenHandler.php
@@ -31,6 +31,7 @@ use Symfony\Component\Security\Http\AccessToken\AccessTokenHandlerInterface;
 use Symfony\Component\Security\Http\AccessToken\Oidc\Exception\InvalidSignatureException;
 use Symfony\Component\Security\Http\AccessToken\Oidc\Exception\MissingClaimException;
 use Symfony\Component\Security\Http\Authenticator\FallbackUserLoader;
+use Symfony\Component\Security\Http\Authenticator\Oidc\OidcJwks;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Oidc\OidcDiscovery;
 use Symfony\Contracts\Cache\CacheInterface;
@@ -184,27 +185,20 @@ final class OidcTokenHandler implements AccessTokenHandlerInterface, ResetInterf
             }
 
             foreach ($jwkSetResponses as $response) {
-                $headers = $response->getHeaders();
-                if (preg_match('/max-age=(\d+)/', $headers['cache-control'][0] ?? '', $m)) {
-                    $currentTtl = (int) $m[1];
-                } elseif (0 >= $currentTtl = strtotime($headers['expires'][0] ?? '@0') - time()) {
-                    $currentTtl = null;
-                }
+                [$keys, $currentTtl] = OidcJwks::fromResponse($response, $this->enforceKeyUsageVerification);
 
                 // Apply the lowest TTL found to ensure all keys in the set are still valid
                 if (null !== $currentTtl && (null === $minTtl || $currentTtl < $minTtl)) {
                     $minTtl = $currentTtl;
                 }
 
-                $keys = $response->toArray()['keys'];
-                foreach ($this->filterSignatureKeys($keys) as $key) {
+                foreach ($keys as $key) {
                     $discoveredKeys[] = $key;
                 }
             }
 
             if (0 < ($minTtl ?? -1)) {
-                // Cap the TTL to 30 days to avoid keeping JWKS indefinitely
-                $item->expiresAfter(min($minTtl, 30 * 24 * 60 * 60));
+                $item->expiresAfter(min($minTtl, OidcJwks::MAX_TTL));
             }
 
             return $discoveredKeys;
@@ -216,37 +210,6 @@ final class OidcTokenHandler implements AccessTokenHandlerInterface, ResetInterf
 
             throw new BadCredentialsException('Invalid credentials.', $e->getCode(), $e);
         }
-    }
-
-    private function filterSignatureKeys(array $keys): array
-    {
-        return array_values(array_filter($keys, function (array $jwk): bool {
-            if ($this->enforceKeyUsageVerification) {
-                if (isset($jwk['use']) && 'sig' === $jwk['use']) {
-                    return true;
-                }
-                if (isset($jwk['key_ops']) && \is_array($jwk['key_ops'])) {
-                    return !empty(array_intersect($jwk['key_ops'], ['sign', 'verify']));
-                }
-
-                return false;
-            }
-
-            if (isset($jwk['use']) && 'enc' === $jwk['use']) {
-                return false;
-            }
-            if (isset($jwk['key_ops']) && \is_array($jwk['key_ops'])) {
-                $encOps = ['encrypt', 'decrypt', 'wrapKey', 'unwrapKey', 'deriveKey', 'deriveBits'];
-                $sigOps = ['sign', 'verify'];
-                $hasEnc = !empty(array_intersect($jwk['key_ops'], $encOps));
-                $hasSig = !empty(array_intersect($jwk['key_ops'], $sigOps));
-                if ($hasEnc && !$hasSig) {
-                    return false;
-                }
-            }
-
-            return true;
-        }));
     }
 
     private function loadAndVerifyJws(string $accessToken, JWKSet $jwkset): array

--- a/src/Symfony/Component/Security/Http/Authenticator/Oidc/OidcJwks.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Oidc/OidcJwks.php
@@ -21,8 +21,9 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  * Fetches OpenID Connect signing keys (JWKS) and derives their cache lifetime
  * from the provider's HTTP cache headers.
  *
- * The keys are filtered exactly as the "oidc" access token handler does, so that
- * both OIDC entry points accept the same key material.
+ * The "oidc" access token handler and the "oidc_login" authenticator both parse
+ * and filter JWKS responses through this class, so the two OIDC entry points
+ * accept the same key material.
  *
  * @author Mathieu Santostefano <msantostefano@proton.me>
  *
@@ -33,7 +34,7 @@ final class OidcJwks
     /**
      * Cap the cache lifetime to 30 days to avoid keeping JWKS indefinitely.
      */
-    private const MAX_TTL = 30 * 24 * 60 * 60;
+    public const MAX_TTL = 30 * 24 * 60 * 60;
 
     /**
      * JWKS documents are small. This limits untrusted data retained by the cache,

--- a/src/Symfony/Component/Security/Http/Tests/AccessToken/Oidc/OidcTokenHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/AccessToken/Oidc/OidcTokenHandlerTest.php
@@ -273,6 +273,53 @@ class OidcTokenHandlerTest extends TestCase
         $this->assertSame('e21bf182-1538-406e-8ccb-e25a17aba39f', $userBadge->getUserIdentifier());
     }
 
+    public function testDiscoveryRejectsAnOversizedJwks()
+    {
+        $token = $this->buildJWS(json_encode(['sub' => 'e21bf182-1538-406e-8ccb-e25a17aba39f']));
+
+        $oversized = json_encode(['keys' => [['kty' => 'oct', 'use' => 'sig', 'k' => str_repeat('A', 1024 * 1024)]]]);
+        $httpClient = new MockHttpClient([
+            new JsonMockResponse(['jwks_uri' => 'https://www.example.com/.well-known/jwks.json']),
+            new MockResponse($oversized, ['response_headers' => ['content-type' => 'application/json']]),
+        ]);
+
+        $handler = new OidcTokenHandler(
+            new AlgorithmManager([new ES256()]),
+            null,
+            self::AUDIENCE,
+            ['https://www.example.com']
+        );
+        $handler->enableDiscovery(new ArrayAdapter(), $httpClient, 'oidc_config');
+
+        $this->expectException(BadCredentialsException::class);
+        $this->expectExceptionMessage('Invalid credentials.');
+
+        $handler->getUserBadgeFrom($token);
+    }
+
+    public function testDiscoveryRejectsAJwksWithoutKeys()
+    {
+        $token = $this->buildJWS(json_encode(['sub' => 'e21bf182-1538-406e-8ccb-e25a17aba39f']));
+
+        $httpClient = new MockHttpClient([
+            new JsonMockResponse(['jwks_uri' => 'https://www.example.com/.well-known/jwks.json']),
+            new JsonMockResponse(['error' => 'temporarily_unavailable']),
+        ]);
+
+        $handler = new OidcTokenHandler(
+            new AlgorithmManager([new ES256()]),
+            null,
+            self::AUDIENCE,
+            ['https://www.example.com']
+        );
+        $handler->enableDiscovery(new ArrayAdapter(), $httpClient, 'oidc_config');
+
+        $this->expectException(BadCredentialsException::class);
+        $this->expectExceptionMessage('Invalid credentials.');
+
+        $handler->getUserBadgeFrom($token);
+    }
+
     public function testGetsUserIdentifierWithMultipleDiscoveryEndpoints()
     {
         $time = time();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Follow-up of #65798, which introduced `OidcJwks` for the `oidc_login` authenticator and left `OidcTokenHandler` with its own copy of the JWKS parsing (`max-age`/`Expires` handling and signature-key filtering). The new copy is the hardened one, so the handler was the lagging duplicate.

`OidcTokenHandler::computeDiscoveryKeys()` now parses each JWKS response through `OidcJwks::fromResponse()`. The multi-provider aggregation and the cache TTL policy stay in the handler, unchanged: lowest TTL across providers, and no advertised lifetime (or `max-age=0`) still falls back to the cache pool's default expiry, unlike the authenticator's per-entry default. What the handler gains:

- the 1 MiB response cap the discovery document fetch already has;
- a JWKS response without a `keys` list now fails as `BadCredentialsException`; it previously exploded with a `TypeError`, which `catch (\Exception)` does not intercept;
- malformed entries inside `keys` are skipped instead of breaking the filter.

Both entry points now accept exactly the same key material by construction.