### PR TITLE
[SecurityBundle] Require the OIDC ID token signature verification for public clients

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/OidcLoginFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/OidcLoginFactory.php
@@ -97,7 +97,7 @@ class OidcLoginFactory extends AbstractFactory
                 ->children()
                     ->booleanNode('required')
                         ->defaultTrue()
-                        ->info('When true (default), the ID token signature is verified against the provider JWKS. Setting it to false decodes the ID token without verifying it, which OIDC Core 1.0, Section 3.1.3.7, item 6 only allows because the token comes from the token endpoint over TLS: it is then only as safe as the TLS verification of the HTTP client used for that request, so never turn it off with a client configured with "verify_peer: false" or "verify_host: false", nor behind a TLS-terminating proxy.')
+                        ->info('When true (default), the ID token signature is verified against the provider JWKS. Setting it to false decodes the ID token without verifying it, which OIDC Core 1.0, Section 3.1.3.7, item 6 only allows because the token comes from the token endpoint over TLS: it is then only as safe as the TLS verification of the HTTP client used for that request, so never turn it off with a client configured with "verify_peer: false" or "verify_host: false", nor behind a TLS-terminating proxy. A public client ("token_endpoint_auth_method: none") cannot turn it off at all.')
                     ->end()
                     ->arrayNode('algorithms', 'algorithm')
                         ->beforeNormalization()->castToArray()->end()
@@ -132,6 +132,10 @@ class OidcLoginFactory extends AbstractFactory
             ->validate()
                 ->ifTrue(static fn ($v): bool => 'none' === $v['token_endpoint_auth_method'] && null !== $v['client_secret'])
                 ->thenInvalid('The OIDC "client_secret" must not be set when "token_endpoint_auth_method" is "none", as a public client never sends it. Remove the secret, or authenticate with it by using "client_secret_post" or "client_secret_basic".')
+            ->end()
+            ->validate()
+                ->ifTrue(static fn ($v): bool => 'none' === $v['token_endpoint_auth_method'] && !$v['id_token_signature']['required'])
+                ->thenInvalid('The OIDC "id_token_signature.required" option cannot be false when "token_endpoint_auth_method" is "none": without the signature check, only the TLS verification of the token request ties the ID token to the provider, which is too little for a public client that has nothing but PKCE protecting its code exchange. Keep the check enabled, or authenticate with "client_secret_post" or "client_secret_basic".')
             ->end()
         ;
     }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/OidcLoginFactoryTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/OidcLoginFactoryTest.php
@@ -572,6 +572,48 @@ class OidcLoginFactoryTest extends TestCase
         $this->assertSame('client_secret_post', $finalizedConfig['token_endpoint_auth_method']);
     }
 
+    public function testRejectsTurningTheIdTokenSignatureVerificationOffForAPublicClient()
+    {
+        $factory = new OidcLoginFactory();
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('The OIDC "id_token_signature.required" option cannot be false when "token_endpoint_auth_method" is "none"');
+
+        $this->processConfig([
+            'provider_uri' => 'https://provider.example.com',
+            'client_id' => 'my-client-id',
+            'token_endpoint_auth_method' => 'none',
+            'id_token_signature' => ['required' => false],
+        ], $factory);
+    }
+
+    public function testAConfidentialClientMayTurnTheIdTokenSignatureVerificationOff()
+    {
+        $factory = new OidcLoginFactory();
+
+        $finalizedConfig = $this->processConfig([
+            'provider_uri' => 'https://provider.example.com',
+            'client_id' => 'my-client-id',
+            'client_secret' => 'my-client-secret',
+            'id_token_signature' => ['required' => false],
+        ], $factory);
+
+        $this->assertFalse($finalizedConfig['id_token_signature']['required']);
+    }
+
+    public function testAPublicClientVerifiesTheIdTokenSignatureByDefault()
+    {
+        $factory = new OidcLoginFactory();
+
+        $finalizedConfig = $this->processConfig([
+            'provider_uri' => 'https://provider.example.com',
+            'client_id' => 'my-client-id',
+            'token_endpoint_auth_method' => 'none',
+        ], $factory);
+
+        $this->assertTrue($finalizedConfig['id_token_signature']['required']);
+    }
+
     private function processConfig(array $config, OidcLoginFactory $factory): array
     {
         $nodeDefinition = new ArrayNodeDefinition('oidc-login');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Follow-up of #65799 and #65798, which each landed one half of a pair that only makes sense together.

A public client (`token_endpoint_auth_method: none`) sends no secret at the token endpoint: PKCE is what ties the authorization code to it, and the ID token signature is what ties the identity to the provider. Turning the signature verification off leaves such a client with nothing proving the provider issued the token it opens a session from.

The two options can be set independently today, so this rejects the combination at compile time:

```yaml
security:
    firewalls:
        main:
            oidc_login:
                # ...
                token_endpoint_auth_method: none
                id_token_signature:
                    required: false # now rejected
```

A confidential client keeps the option, as its secret already authenticates the exchange.
