### PR TITLE
[Security][SecurityBundle] Add OIDC PKCE, max_age, authorization-request and start-route options

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -19,6 +19,8 @@ CHANGELOG
  * Add `oidc_login` firewall authenticator for the OpenID Connect Authorization Code Flow, along with an `oidc` user provider for the users it builds from the OIDC claims
  * Add the `id_token_signature` configuration (`required`, `algorithms`, `enforce_key_usage_verification`) to the `oidc_login` authenticator, which now verifies the ID token signature by default
  * Add the `token_endpoint_auth_method` option to the `oidc_login` authenticator: `client_secret_post`, `client_secret_basic`, or `none` to declare a public client, for which `client_secret` must not be set
+ * Add the `pkce` (`enabled`, `method`), `max_age` and `authorization_params` options to the `oidc_login` authenticator
+ * Add a `start_path` option to the `oidc_login` authenticator and declare a route there that starts the flow by redirecting to the provider, for login pages linking to it
 
 8.1
 ---

--- a/src/Symfony/Bundle/SecurityBundle/Controller/OidcLoginStartController.php
+++ b/src/Symfony/Bundle/SecurityBundle/Controller/OidcLoginStartController.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Controller;
+
+use Psr\Container\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * Starts the OIDC Authorization Code Flow of an oidc_login firewall by redirecting
+ * to the provider, so that a page can link to it, e.g. the login page of a firewall
+ * offering several ways to log in. The route loader declares a route for it at each
+ * firewall's "start_path".
+ *
+ * @author Mathieu Santostefano <msantostefano@proton.me>
+ */
+final class OidcLoginStartController
+{
+    /**
+     * @param ContainerInterface $authenticators oidc_login authenticators, indexed by firewall name
+     */
+    public function __construct(
+        private readonly ContainerInterface $authenticators,
+    ) {
+    }
+
+    public function __invoke(Request $request, string $firewallName): Response
+    {
+        if (!$this->authenticators->has($firewallName)) {
+            throw new NotFoundHttpException(\sprintf('No "oidc_login" authenticator is registered for the "%s" firewall.', $firewallName));
+        }
+
+        return $this->authenticators->get($firewallName)->start($request);
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/OidcLoginFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/OidcLoginFactory.php
@@ -82,6 +82,11 @@ class OidcLoginFactory extends AbstractFactory
                 ->defaultValue('/oidc/callback')
                 ->info('The firewall path where the OIDC provider redirects after authentication. Must match a redirect URI registered with the provider. A route is declared for this path by the "security.authenticator.oidc_login.route_loader" service, which the application must import (see the OIDC login documentation), as it does for the logout routes. A route name is accepted too, in which case no route is declared for it.')
             ->end()
+            ->scalarNode('start_path')
+                ->cannotBeEmpty()
+                ->defaultValue('/oidc/start')
+                ->info('The path where the route loader declares a route that starts the flow by redirecting to the provider; link to it e.g. from the login page of a firewall offering several ways to log in. A route name is accepted too, in which case no route is declared for it.')
+            ->end()
             ->integerNode('discovery_cache_ttl')
                 ->defaultValue(3600)
                 ->min(0)
@@ -117,6 +122,34 @@ class OidcLoginFactory extends AbstractFactory
                 ->defaultValue('client_secret_post')
                 ->info('Authentication method for the token endpoint. "none" declares a public client (a SPA, a mobile or a native application), which holds no secret and relies on PKCE to protect the code exchange.')
             ->end()
+            ->arrayNode('pkce')
+                ->addDefaultsIfNotSet()
+                ->children()
+                    ->booleanNode('enabled')
+                        ->defaultTrue()
+                        ->info('Whether to use PKCE (Proof Key for Code Exchange, RFC 7636), which any current provider should support; only disable it for one that rejects the "code_challenge" parameter.')
+                    ->end()
+                    ->enumNode('method')
+                        ->values(['S256', 'plain'])
+                        ->defaultValue('S256')
+                        ->info('The PKCE code challenge method. RFC 7636, Section 4.2 mandates "S256" for every client able to compute it, so only ever pick "plain" for a provider that supports nothing else.')
+                    ->end()
+                ->end()
+            ->end()
+            ->integerNode('max_age')
+                ->min(0)
+                ->info('Maximum elapsed seconds since the end-user authentication, sent as the "max_age" authorization parameter; the ID token must then carry an "auth_time" claim, which is checked against this value, "allowed_time_drift" included.')
+            ->end()
+            ->arrayNode('authorization_params')
+                ->useAttributeAsKey('name')
+                ->scalarPrototype()->end()
+                ->defaultValue([])
+                ->info('Additional parameters of the authorization request (e.g. "prompt", "display", "ui_locales", "acr_values", "login_hint").')
+                ->validate()
+                    ->ifTrue(static fn ($v): bool => (bool) array_intersect_key($v, array_flip(['response_type', 'client_id', 'redirect_uri', 'scope', 'state', 'nonce', 'code_challenge', 'code_challenge_method', 'max_age'])))
+                    ->thenInvalid('The OIDC "authorization_params" option cannot set "response_type", "client_id", "redirect_uri", "scope", "state", "nonce", "code_challenge", "code_challenge_method" nor "max_age": the authenticator manages these; use the dedicated "scope" and "max_age" options.')
+                ->end()
+            ->end()
         ;
 
         // the client type is what "token_endpoint_auth_method" really selects, so the
@@ -132,6 +165,10 @@ class OidcLoginFactory extends AbstractFactory
             ->validate()
                 ->ifTrue(static fn ($v): bool => 'none' === $v['token_endpoint_auth_method'] && null !== $v['client_secret'])
                 ->thenInvalid('The OIDC "client_secret" must not be set when "token_endpoint_auth_method" is "none", as a public client never sends it. Remove the secret, or authenticate with it by using "client_secret_post" or "client_secret_basic".')
+            ->end()
+            ->validate()
+                ->ifTrue(static fn ($v): bool => 'none' === $v['token_endpoint_auth_method'] && !$v['pkce']['enabled'])
+                ->thenInvalid('The OIDC "pkce.enabled" option cannot be false when "token_endpoint_auth_method" is "none": a public client sends no secret, so PKCE is the only thing binding the authorization code to it.')
             ->end()
             ->validate()
                 ->ifTrue(static fn ($v): bool => 'none' === $v['token_endpoint_auth_method'] && !$v['id_token_signature']['required'])
@@ -218,6 +255,11 @@ class OidcLoginFactory extends AbstractFactory
         $options = array_intersect_key($config, $this->options);
         $options['firewall_name'] = $firewallName;
         $options['scope'] = $config['scope'];
+        $options['pkce_enabled'] = $config['pkce']['enabled'];
+        $options['pkce_method'] = $config['pkce']['method'];
+        if (isset($config['max_age'])) {
+            $options['max_age'] = $config['max_age'];
+        }
 
         $container
             ->setDefinition($authenticatorId, new ChildDefinition('security.authenticator.oidc_login'))
@@ -229,7 +271,8 @@ class OidcLoginFactory extends AbstractFactory
             ->replaceArgument(6, new Reference($this->createAuthenticationSuccessHandler($container, $firewallName, $config)))
             ->replaceArgument(7, new Reference($this->createAuthenticationFailureHandler($container, $firewallName, $config)))
             ->replaceArgument(8, $options)
-            ->replaceArgument(9, $signatureVerifier)
+            ->replaceArgument(9, $config['authorization_params'])
+            ->replaceArgument(10, $signatureVerifier)
         ;
 
         $callbackUris = $container->hasParameter('security.oidc_login.callback_uris') ? (array) $container->getParameter('security.oidc_login.callback_uris') : [];
@@ -239,6 +282,15 @@ class OidcLoginFactory extends AbstractFactory
             $callbackUris[$firewallName] = $config['check_path'];
         }
         $container->setParameter('security.oidc_login.callback_uris', $callbackUris);
+
+        $startPaths = $container->hasParameter('security.oidc_login.start_paths') ? (array) $container->getParameter('security.oidc_login.start_paths') : [];
+        if ('/' === $config['start_path'][0]) {
+            $startPaths[$firewallName] = $config['start_path'];
+        }
+        $container->setParameter('security.oidc_login.start_paths', $startPaths);
+
+        $startControllerLocator = $container->getDefinition('security.authenticator.oidc_login.start_controller')->getArgument(0);
+        $startControllerLocator->setValues([$firewallName => new Reference($authenticatorId)] + $startControllerLocator->getValues());
 
         return $authenticatorId;
     }

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
@@ -63,9 +63,10 @@ use Symfony\Component\Security\Http\Session\SessionAuthenticationStrategyInterfa
 return static function (ContainerConfigurator $container) {
     $container->parameters()
         ->set('security.role_hierarchy.roles', [])
-        // the OIDC login callback route loader is wired on this parameter, which the
-        // "oidc_login" firewall factory fills in; it stays empty when no firewall uses one
+        // the OIDC login route loader is wired on these parameters, which the
+        // "oidc_login" firewall factory fills in; they stay empty when no firewall uses one
         ->set('security.oidc_login.callback_uris', [])
+        ->set('security.oidc_login.start_paths', [])
     ;
 
     $container->services()
@@ -273,6 +274,8 @@ return static function (ContainerConfigurator $container) {
             ->args([
                 '%security.oidc_login.callback_uris%',
                 'security.oidc_login.callback_uris',
+                '%security.oidc_login.start_paths%',
+                'security.oidc_login.start_paths',
             ])
             ->tag('routing.route_loader')
 

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator_oidc_login.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator_oidc_login.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
+use Symfony\Bundle\SecurityBundle\Controller\OidcLoginStartController;
 use Symfony\Component\Security\Http\Authenticator\Oidc\OidcConfidentialClient;
 use Symfony\Component\Security\Http\Authenticator\Oidc\OidcIdToken;
 use Symfony\Component\Security\Http\Authenticator\Oidc\OidcPublicClient;
@@ -32,6 +33,7 @@ return static function (ContainerConfigurator $container) {
                 abstract_arg('authentication success handler'),
                 abstract_arg('authentication failure handler'),
                 abstract_arg('options'),
+                abstract_arg('authorization params'),
                 // replaced by the firewall verifier, unless the ID token signature is not verified
                 null,
             ])
@@ -86,6 +88,14 @@ return static function (ContainerConfigurator $container) {
                 service('http_client'),
                 abstract_arg('OIDC discovery'),
                 abstract_arg('client ID'),
+            ])
+
+        // the target of the routes declared for the "start_path" of each oidc_login
+        // firewall; public, as the routes reference it by id as their controller
+        ->set('security.authenticator.oidc_login.start_controller', OidcLoginStartController::class)
+            ->public()
+            ->args([
+                service_locator([]),
             ])
     ;
 };

--- a/src/Symfony/Bundle/SecurityBundle/Routing/OidcLoginRouteLoader.php
+++ b/src/Symfony/Bundle/SecurityBundle/Routing/OidcLoginRouteLoader.php
@@ -18,26 +18,34 @@ use Symfony\Component\Routing\RouteCollection;
 /**
  * Registers a route for each oidc_login firewall callback path, so the provider's
  * redirect lands on a matched route and is handled by the firewall instead of
- * returning a 404 from the router.
+ * returning a 404 from the router, and a route for each start path, which redirects
+ * to the provider so that e.g. a login page can link to it.
  *
  * @author Mathieu Santostefano <msantostefano@proton.me>
  */
 final class OidcLoginRouteLoader
 {
     /**
-     * @param array<string, string> $callbackUris  Callback URIs indexed by the corresponding firewall name
-     * @param string                $parameterName Name of the container parameter containing {@see $callbackUris} value
+     * @param array<string, string> $callbackUris              Callback URIs indexed by the corresponding firewall name
+     * @param string                $callbackUrisParameterName Name of the container parameter containing {@see $callbackUris} value
+     * @param array<string, string> $startPaths                Start paths indexed by the corresponding firewall name
+     * @param string                $startPathsParameterName   Name of the container parameter containing {@see $startPaths} value
      */
     public function __construct(
         private readonly array $callbackUris,
-        private readonly string $parameterName,
+        private readonly string $callbackUrisParameterName,
+        private readonly array $startPaths,
+        private readonly string $startPathsParameterName,
     ) {
     }
 
     public function __invoke(): RouteCollection
     {
         $collection = new RouteCollection();
-        $collection->addResource(new ContainerParametersResource([$this->parameterName => $this->callbackUris]));
+        $collection->addResource(new ContainerParametersResource([
+            $this->callbackUrisParameterName => $this->callbackUris,
+            $this->startPathsParameterName => $this->startPaths,
+        ]));
 
         $routeNames = [];
         foreach ($this->callbackUris as $firewallName => $callbackPath) {
@@ -49,6 +57,18 @@ final class OidcLoginRouteLoader
                 $routeNames[$callbackPath] = $routeName;
                 $collection->add($routeName, new Route($callbackPath));
             }
+        }
+
+        $startFirewalls = [];
+        foreach ($this->startPaths as $firewallName => $startPath) {
+            // the route carries the firewall name, so unlike a callback path, a start
+            // path cannot be shared: the route of one firewall would start the other's flow
+            if (isset($startFirewalls[$startPath])) {
+                throw new \LogicException(\sprintf('The "%s" and "%s" firewalls both use "%s" as their oidc_login "start_path"; give each firewall its own.', $startFirewalls[$startPath], $firewallName, $startPath));
+            }
+
+            $startFirewalls[$startPath] = $firewallName;
+            $collection->add('_oidc_login_start_'.$firewallName, new Route($startPath, ['_controller' => 'security.authenticator.oidc_login.start_controller', 'firewallName' => $firewallName]));
         }
 
         return $collection;

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Controller/OidcLoginStartControllerTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Controller/OidcLoginStartControllerTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\Controller;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\SecurityBundle\Controller\OidcLoginStartController;
+use Symfony\Component\DependencyInjection\ServiceLocator;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
+
+class OidcLoginStartControllerTest extends TestCase
+{
+    public function testDelegatesToTheFirewallAuthenticator()
+    {
+        $redirect = new RedirectResponse('https://provider.example.com/authorize');
+        $authenticator = new class($redirect) implements AuthenticationEntryPointInterface {
+            public ?Request $request = null;
+
+            public function __construct(private readonly Response $response)
+            {
+            }
+
+            public function start(Request $request, ?AuthenticationException $authException = null): Response
+            {
+                $this->request = $request;
+
+                return $this->response;
+            }
+        };
+
+        $controller = new OidcLoginStartController(new ServiceLocator(['main' => static fn () => $authenticator]));
+        $request = new Request();
+
+        $this->assertSame($redirect, $controller($request, 'main'));
+        $this->assertSame($request, $authenticator->request);
+    }
+
+    public function testThrowsNotFoundForAnUnknownFirewall()
+    {
+        $controller = new OidcLoginStartController(new ServiceLocator([]));
+
+        $this->expectException(NotFoundHttpException::class);
+        $this->expectExceptionMessage('No "oidc_login" authenticator is registered for the "main" firewall.');
+
+        $controller(new Request(), 'main');
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/OidcLoginFactoryTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/OidcLoginFactoryTest.php
@@ -123,6 +123,79 @@ class OidcLoginFactoryTest extends TestCase
         $this->assertSame(-25, $factory->getPriority());
     }
 
+    public function testDefaultConfiguration()
+    {
+        $config = [
+            'provider_uri' => 'https://provider.example.com',
+            'client_id' => 'my-client-id',
+            'client_secret' => 'my-client-secret',
+            'check_path' => '/oidc/callback',
+        ];
+
+        $factory = new OidcLoginFactory();
+        $finalizedConfig = $this->processConfig($config, $factory);
+
+        $this->assertSame('/oidc/callback', $finalizedConfig['check_path']);
+        $this->assertSame(['openid'], $finalizedConfig['scope']);
+        $this->assertTrue($finalizedConfig['pkce']['enabled']);
+        $this->assertSame('S256', $finalizedConfig['pkce']['method']);
+        $this->assertSame(3600, $finalizedConfig['discovery_cache_ttl']);
+        $this->assertSame([], $finalizedConfig['authorization_params']);
+        $this->assertArrayNotHasKey('max_age', $finalizedConfig);
+    }
+
+    public function testMaxAgeAndAuthorizationParamsArePassedToTheAuthenticator()
+    {
+        $container = new ContainerBuilder();
+
+        $config = [
+            'provider_uri' => 'https://provider.example.com',
+            'client_id' => 'my-client-id',
+            'client_secret' => 'my-client-secret',
+            'check_path' => '/oidc/callback',
+            'max_age' => 3600,
+            'authorization_params' => ['prompt' => 'consent', 'ui_locales' => 'fr'],
+        ];
+
+        $factory = new OidcLoginFactory();
+        $finalizedConfig = $this->processConfig($config, $factory);
+        $factory->createAuthenticator($container, 'main', $finalizedConfig, 'userprovider');
+
+        $authenticator = $container->getDefinition('security.authenticator.oidc_login.main');
+
+        $this->assertSame(3600, $authenticator->getArgument(8)['max_age']);
+        $this->assertSame(['prompt' => 'consent', 'ui_locales' => 'fr'], $authenticator->getArgument(9));
+    }
+
+    public function testAuthorizationParamsCannotSetTheManagedParameters()
+    {
+        $factory = new OidcLoginFactory();
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('The OIDC "authorization_params" option cannot set');
+
+        $this->processConfig([
+            'provider_uri' => 'https://provider.example.com',
+            'client_id' => 'my-client-id',
+            'client_secret' => 'my-client-secret',
+            'authorization_params' => ['code_challenge' => ''],
+        ], $factory);
+    }
+
+    public function testPkceMethodRejectsUnknownValue()
+    {
+        $factory = new OidcLoginFactory();
+
+        $this->expectException(InvalidConfigurationException::class);
+
+        $this->processConfig([
+            'provider_uri' => 'https://provider.example.com',
+            'client_id' => 'my-client-id',
+            'client_secret' => 'my-client-secret',
+            'pkce' => ['method' => 'S512'],
+        ], $factory);
+    }
+
     public function testRequiredOptions()
     {
         $factory = new OidcLoginFactory();
@@ -294,6 +367,47 @@ class OidcLoginFactoryTest extends TestCase
         $this->assertSame([], $container->getParameter('security.oidc_login.callback_uris'));
     }
 
+    public function testStartRouteIsRegistered()
+    {
+        $container = new ContainerBuilder();
+
+        $config = [
+            'provider_uri' => 'https://provider.example.com',
+            'client_id' => 'my-client-id',
+            'client_secret' => 'my-client-secret',
+        ];
+
+        $factory = new OidcLoginFactory();
+        $finalizedConfig = $this->processConfig($config, $factory);
+        $factory->createAuthenticator($container, 'main', $finalizedConfig, 'userprovider');
+
+        $this->assertSame(['main' => '/oidc/start'], $container->getParameter('security.oidc_login.start_paths'));
+
+        $locator = $container->getDefinition('security.authenticator.oidc_login.start_controller')->getArgument(0);
+        $this->assertEquals(['main' => new Reference('security.authenticator.oidc_login.main')], $locator->getValues());
+    }
+
+    public function testStartRouteNameIsNotRegistered()
+    {
+        $container = new ContainerBuilder();
+
+        $config = [
+            'provider_uri' => 'https://provider.example.com',
+            'client_id' => 'my-client-id',
+            'client_secret' => 'my-client-secret',
+            'start_path' => 'oidc_start_route',
+        ];
+
+        $factory = new OidcLoginFactory();
+        $finalizedConfig = $this->processConfig($config, $factory);
+        $factory->createAuthenticator($container, 'main', $finalizedConfig, 'userprovider');
+
+        $this->assertSame([], $container->getParameter('security.oidc_login.start_paths'));
+        // the controller still serves the firewall, as the named route may point to it
+        $locator = $container->getDefinition('security.authenticator.oidc_login.start_controller')->getArgument(0);
+        $this->assertEquals(['main' => new Reference('security.authenticator.oidc_login.main')], $locator->getValues());
+    }
+
     public function testRejectsNonHttpsProviderUri()
     {
         $factory = new OidcLoginFactory();
@@ -348,6 +462,27 @@ class OidcLoginFactoryTest extends TestCase
         yield 'test TLD' => ['http://keycloak.test'];
     }
 
+    public function testPkceCanBeDisabled()
+    {
+        // e.g. for a provider that does not support PKCE yet
+        $container = new ContainerBuilder();
+        $factory = new OidcLoginFactory();
+
+        $config = $this->processConfig([
+            'provider_uri' => 'https://provider.example.com',
+            'client_id' => 'my-client-id',
+            'client_secret' => 'my-client-secret',
+            'pkce' => ['enabled' => false, 'method' => 'plain'],
+        ], $factory);
+        $factory->createAuthenticator($container, 'main', $config, 'userprovider');
+
+        $this->assertFalse($config['pkce']['enabled']);
+
+        $options = $container->getDefinition('security.authenticator.oidc_login.main')->getArgument(8);
+        $this->assertFalse($options['pkce_enabled']);
+        $this->assertSame('plain', $options['pkce_method']);
+    }
+
     public function testIdTokenSignatureIsVerifiedByDefault()
     {
         $container = new ContainerBuilder();
@@ -374,7 +509,7 @@ class OidcLoginFactoryTest extends TestCase
         $this->assertTrue($verifier->getArgument(5));
 
         $authenticator = $container->getDefinition('security.authenticator.oidc_login.main');
-        $this->assertEquals(new Reference('security.authenticator.oidc_login.signature_verifier.main'), $authenticator->getArgument(9));
+        $this->assertEquals(new Reference('security.authenticator.oidc_login.signature_verifier.main'), $authenticator->getArgument(10));
     }
 
     public function testIdTokenSignatureVerificationCanBeTurnedOff()
@@ -393,7 +528,7 @@ class OidcLoginFactoryTest extends TestCase
         $this->assertFalse($container->hasDefinition('security.authenticator.oidc_login.signature_verifier.main'));
 
         $authenticator = $container->getDefinition('security.authenticator.oidc_login.main');
-        $this->assertNull($authenticator->getArgument(9));
+        $this->assertNull($authenticator->getArgument(10));
     }
 
     public function testIdTokenSignatureAlgorithmsAndKeyUsageAreConfigurable()
@@ -570,6 +705,34 @@ class OidcLoginFactoryTest extends TestCase
         ], $factory);
 
         $this->assertSame('client_secret_post', $finalizedConfig['token_endpoint_auth_method']);
+    }
+
+    public function testRejectsAPublicClientWithoutPkce()
+    {
+        $factory = new OidcLoginFactory();
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('The OIDC "pkce.enabled" option cannot be false when "token_endpoint_auth_method" is "none"');
+
+        $this->processConfig([
+            'provider_uri' => 'https://provider.example.com',
+            'client_id' => 'my-client-id',
+            'token_endpoint_auth_method' => 'none',
+            'pkce' => ['enabled' => false],
+        ], $factory);
+    }
+
+    public function testAPublicClientKeepsPkceEnabledByDefault()
+    {
+        $factory = new OidcLoginFactory();
+
+        $finalizedConfig = $this->processConfig([
+            'provider_uri' => 'https://provider.example.com',
+            'client_id' => 'my-client-id',
+            'token_endpoint_auth_method' => 'none',
+        ], $factory);
+
+        $this->assertTrue($finalizedConfig['pkce']['enabled']);
     }
 
     public function testRejectsTurningTheIdTokenSignatureVerificationOffForAPublicClient()

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
@@ -1533,7 +1533,7 @@ class SecurityExtensionTest extends TestCase
         $verifier = $container->getDefinition('security.authenticator.oidc_login.signature_verifier.main');
         $this->assertSame(OidcSignatureVerifier::class, $verifier->getClass());
         $this->assertSame(['RS256'], $verifier->getArgument(3));
-        $this->assertSame('security.authenticator.oidc_login.signature_verifier.main', (string) $container->getDefinition('security.authenticator.oidc_login.main')->getArgument(9));
+        $this->assertSame('security.authenticator.oidc_login.signature_verifier.main', (string) $container->getDefinition('security.authenticator.oidc_login.main')->getArgument(10));
     }
 
     public function testOidcLoginCanSkipTheIdTokenSignatureVerification()
@@ -1556,7 +1556,7 @@ class SecurityExtensionTest extends TestCase
         $container->compile();
 
         $this->assertFalse($container->hasDefinition('security.authenticator.oidc_login.signature_verifier.main'));
-        $this->assertNull($container->getDefinition('security.authenticator.oidc_login.main')->getArgument(9));
+        $this->assertNull($container->getDefinition('security.authenticator.oidc_login.main')->getArgument(10));
     }
 
     public function testOidcLoginSupportsAPublicClient()
@@ -1596,12 +1596,13 @@ class SecurityExtensionTest extends TestCase
 
         $this->assertTrue($container->hasDefinition('security.authenticator.oidc_login.route_loader'));
         $this->assertSame([], $container->getParameter('security.oidc_login.callback_uris'));
+        $this->assertSame([], $container->getParameter('security.oidc_login.start_paths'));
 
         $loader = $container->getDefinition('security.authenticator.oidc_login.route_loader');
         $this->assertSame(OidcLoginRouteLoader::class, $loader->getClass());
         $this->assertArrayHasKey('routing.route_loader', $loader->getTags());
-        // it declares no route as long as no firewall configures an OIDC callback path
-        $this->assertCount(0, (new OidcLoginRouteLoader($container->getParameter('security.oidc_login.callback_uris'), 'security.oidc_login.callback_uris'))());
+        // it declares no route as long as no firewall configures the OIDC authenticator
+        $this->assertCount(0, (new OidcLoginRouteLoader($container->getParameter('security.oidc_login.callback_uris'), 'security.oidc_login.callback_uris', $container->getParameter('security.oidc_login.start_paths'), 'security.oidc_login.start_paths'))());
     }
 
     protected function getRawContainer()

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/OidcLoginRouteLoaderTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/OidcLoginRouteLoaderTest.php
@@ -11,6 +11,9 @@
 
 namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
 
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
 class OidcLoginRouteLoaderTest extends AbstractWebTestCase
 {
     public function testRouteLoaderCanBeImportedWithoutOidcLoginFirewall()
@@ -19,16 +22,55 @@ class OidcLoginRouteLoaderTest extends AbstractWebTestCase
 
         $routes = static::getContainer()->get('router')->getRouteCollection();
 
-        $this->assertSame([], array_filter(array_keys($routes->all()), static fn (string $name) => str_starts_with($name, '_oidc_login_callback_')));
+        $this->assertSame([], array_filter(array_keys($routes->all()), static fn (string $name) => str_starts_with($name, '_oidc_login_')));
         $this->assertNotNull($routes->get('_logout_main'));
     }
 
-    public function testRouteLoaderDeclaresTheCallbackRoute()
+    public function testRouteLoaderDeclaresTheCallbackAndStartRoutes()
     {
         $this->createClient(['test_case' => 'OidcLoginRouteLoader', 'root_config' => 'config_oidc.yml']);
 
         $routes = static::getContainer()->get('router')->getRouteCollection();
 
         $this->assertSame('/oidc/callback', $routes->get('_oidc_login_callback_oidc')?->getPath());
+
+        $startRoute = $routes->get('_oidc_login_start_oidc');
+        $this->assertSame('/oidc/start', $startRoute?->getPath());
+        $this->assertSame('security.authenticator.oidc_login.start_controller', $startRoute->getDefault('_controller'));
+        $this->assertSame('oidc', $startRoute->getDefault('firewallName'));
+    }
+
+    public function testStartRouteRedirectsToTheProvider()
+    {
+        $discoveryResponse = new MockResponse(json_encode([
+            'issuer' => 'https://accounts.example.com',
+            'authorization_endpoint' => 'https://accounts.example.com/authorize',
+            'token_endpoint' => 'https://accounts.example.com/token',
+            'userinfo_endpoint' => 'https://accounts.example.com/userinfo',
+            'jwks_uri' => 'https://accounts.example.com/jwks',
+        ]), ['response_headers' => ['content-type' => 'application/json']]);
+
+        $client = $this->createClient(['test_case' => 'OidcLoginRouteLoader', 'root_config' => 'config_oidc.yml']);
+        $client->getContainer()->set('Symfony\Contracts\HttpClient\HttpClientInterface', new MockHttpClient($discoveryResponse));
+
+        $client->request('GET', '/oidc/start');
+        $response = $client->getResponse();
+
+        $this->assertSame(302, $response->getStatusCode());
+
+        $location = parse_url($response->headers->get('Location'));
+        parse_str($location['query'], $query);
+
+        $this->assertSame('https', $location['scheme']);
+        $this->assertSame('accounts.example.com', $location['host']);
+        $this->assertSame('/authorize', $location['path']);
+        $this->assertSame('code', $query['response_type']);
+        $this->assertSame('client_id', $query['client_id']);
+        $this->assertSame('http://localhost/oidc/callback', $query['redirect_uri']);
+        $this->assertSame('openid', $query['scope']);
+        $this->assertSame('S256', $query['code_challenge_method']);
+        $this->assertNotEmpty($query['state']);
+        $this->assertNotEmpty($query['nonce']);
+        $this->assertNotEmpty($query['code_challenge']);
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Routing/OidcLoginRouteLoaderTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Routing/OidcLoginRouteLoaderTest.php
@@ -21,25 +21,41 @@ class OidcLoginRouteLoaderTest extends TestCase
 {
     public function testLoad()
     {
-        $paths = [
+        $callbackUris = [
             'main' => '/callback',
             'admin' => '/callback',
         ];
+        $startPaths = [
+            'main' => '/start',
+            'admin' => '/admin/start',
+        ];
 
-        $loader = new OidcLoginRouteLoader($paths, 'parameterName');
+        $loader = new OidcLoginRouteLoader($callbackUris, 'callbackParameterName', $startPaths, 'startParameterName');
         $collection = $loader();
 
         self::assertInstanceOf(RouteCollection::class, $collection);
-        self::assertCount(1, $collection);
+        self::assertCount(3, $collection);
         self::assertEquals(new Route('/callback'), $collection->get('_oidc_login_callback_main'));
         self::assertCount(1, $collection->getAliases());
         self::assertEquals('_oidc_login_callback_main', $collection->getAlias('_oidc_login_callback_admin')->getId());
+        self::assertEquals(new Route('/start', ['_controller' => 'security.authenticator.oidc_login.start_controller', 'firewallName' => 'main']), $collection->get('_oidc_login_start_main'));
+        self::assertEquals(new Route('/admin/start', ['_controller' => 'security.authenticator.oidc_login.start_controller', 'firewallName' => 'admin']), $collection->get('_oidc_login_start_admin'));
 
         $resources = $collection->getResources();
         self::assertCount(1, $resources);
 
         $resource = reset($resources);
         self::assertInstanceOf(ContainerParametersResource::class, $resource);
-        self::assertSame(['parameterName' => $paths], $resource->getParameters());
+        self::assertSame(['callbackParameterName' => $callbackUris, 'startParameterName' => $startPaths], $resource->getParameters());
+    }
+
+    public function testRejectsAStartPathSharedBetweenFirewalls()
+    {
+        $loader = new OidcLoginRouteLoader([], 'callbackParameterName', ['main' => '/start', 'admin' => '/start'], 'startParameterName');
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('The "main" and "admin" firewalls both use "/start" as their oidc_login "start_path"; give each firewall its own.');
+
+        $loader();
     }
 }

--- a/src/Symfony/Component/Security/Http/Authenticator/Oidc/OidcIdToken.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Oidc/OidcIdToken.php
@@ -85,7 +85,7 @@ final class OidcIdToken
      *
      * @throws AuthenticationException If any claim validation fails
      */
-    public function validateClaims(array $claims, string $expectedIssuer, string $expectedAudience, ?string $expectedNonce = null): void
+    public function validateClaims(array $claims, string $expectedIssuer, string $expectedAudience, ?string $expectedNonce = null, ?int $maxAge = null): void
     {
         if (!class_exists(ClaimCheckerManager::class)) {
             throw new \LogicException('You cannot validate OIDC ID tokens since the "web-token/jwt-library" package is not installed. Try running "composer require web-token/jwt-library".');
@@ -112,6 +112,18 @@ final class OidcIdToken
 
         if (null !== $expectedNonce && (!isset($claims['nonce']) || !hash_equals($expectedNonce, (string) $claims['nonce']))) {
             throw new AuthenticationException('ID token nonce does not match.');
+        }
+
+        if (null === $maxAge) {
+            return;
+        }
+
+        if (!isset($claims['auth_time']) || !is_numeric($claims['auth_time'])) {
+            throw new AuthenticationException('ID token is missing the "auth_time" claim required when "max_age" is requested.');
+        }
+
+        if ($this->clock->now()->getTimestamp() - (int) $claims['auth_time'] > $maxAge + $this->allowedTimeDrift) {
+            throw new AuthenticationException('ID token "auth_time" exceeds the requested "max_age"; re-authentication is required.');
         }
     }
 }

--- a/src/Symfony/Component/Security/Http/Authenticator/OidcLoginAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/OidcLoginAuthenticator.php
@@ -42,13 +42,21 @@ final class OidcLoginAuthenticator extends AbstractAuthenticator implements Auth
 {
     private const MAX_CONCURRENT_ATTEMPTS = 5;
 
+    // parameters of the authorization request the authenticator computes itself, so
+    // that no configuration can weaken them; "max_age" is owned too, as sending it
+    // obliges this client to check the "auth_time" claim of the resulting ID token
+    private const MANAGED_PARAMS = ['response_type', 'client_id', 'redirect_uri', 'scope', 'state', 'nonce', 'code_challenge', 'code_challenge_method', 'max_age'];
+
     private array $options;
 
     /**
-     * @param OidcSignatureVerifier|null $signatureVerifier Verifies the ID token signature against the provider JWKS, or null
-     *                                                      to decode the token without verifying it, which OIDC Core 1.0,
-     *                                                      Section 3.1.3.7, item 6 only allows as long as the token endpoint
-     *                                                      request verifies TLS
+     * @param array<string, string>      $authorizationParams Additional parameters of the authorization request, e.g.
+     *                                                        "prompt" or "ui_locales"; the protocol parameters the
+     *                                                        authenticator manages itself are rejected
+     * @param OidcSignatureVerifier|null $signatureVerifier   Verifies the ID token signature against the provider JWKS,
+     *                                                        or null to decode the token without verifying it, which
+     *                                                        OIDC Core 1.0, Section 3.1.3.7, item 6 only allows as long
+     *                                                        as the token endpoint request verifies TLS
      */
     public function __construct(
         private readonly HttpUtils $httpUtils,
@@ -60,13 +68,24 @@ final class OidcLoginAuthenticator extends AbstractAuthenticator implements Auth
         private readonly AuthenticationSuccessHandlerInterface $successHandler,
         private readonly AuthenticationFailureHandlerInterface $failureHandler,
         array $options,
+        private readonly array $authorizationParams = [],
         private readonly ?OidcSignatureVerifier $signatureVerifier = null,
     ) {
         $this->options = array_merge([
             'check_path' => '/oidc/callback',
             'firewall_name' => 'main',
             'scope' => ['openid'],
+            'pkce_enabled' => true,
+            'pkce_method' => 'S256',
         ], $options);
+
+        if (!\in_array($this->options['pkce_method'], ['S256', 'plain'], true)) {
+            throw new \InvalidArgumentException(\sprintf('Invalid PKCE method "%s": RFC 7636 defines "S256" and "plain" only.', $this->options['pkce_method']));
+        }
+
+        if ($managed = array_intersect_key($authorizationParams, array_flip(self::MANAGED_PARAMS))) {
+            throw new \InvalidArgumentException(\sprintf('The authorization request parameter(s) "%s" are managed by the authenticator and cannot be set through $authorizationParams.', implode('", "', array_keys($managed))));
+        }
     }
 
     public function supports(Request $request): bool
@@ -90,7 +109,29 @@ final class OidcLoginAuthenticator extends AbstractAuthenticator implements Auth
 
         $state = bin2hex(random_bytes(32));
         $nonce = bin2hex(random_bytes(32));
-        $codeVerifier = $this->generateCodeVerifier();
+
+        $params = [
+            'response_type' => 'code',
+            'client_id' => $this->clientId,
+            'redirect_uri' => $redirectUri,
+            'scope' => implode(' ', $this->getScopes()),
+            'state' => $state,
+            'nonce' => $nonce,
+        ];
+
+        $codeVerifier = null;
+        if ($this->options['pkce_enabled']) {
+            $codeVerifier = $this->generateCodeVerifier();
+
+            $params['code_challenge'] = $this->deriveCodeChallenge($codeVerifier);
+            $params['code_challenge_method'] = $this->options['pkce_method'];
+        }
+
+        if (null !== ($this->options['max_age'] ?? null)) {
+            $params['max_age'] = (string) $this->options['max_age'];
+        }
+
+        $params = array_merge($params, $this->authorizationParams);
 
         // each pending attempt lives under its own session key, carrying the state, so
         // that concurrent logins started from several tabs write distinct entries instead
@@ -107,17 +148,6 @@ final class OidcLoginAuthenticator extends AbstractAuthenticator implements Auth
             'code_verifier' => $codeVerifier,
             'redirect_uri' => $redirectUri,
         ]);
-
-        $params = [
-            'response_type' => 'code',
-            'client_id' => $this->clientId,
-            'redirect_uri' => $redirectUri,
-            'scope' => implode(' ', $this->getScopes()),
-            'state' => $state,
-            'nonce' => $nonce,
-            'code_challenge' => rtrim(strtr(base64_encode(hash('sha256', $codeVerifier, true)), '+/', '-_'), '='),
-            'code_challenge_method' => 'S256',
-        ];
 
         $authorizationUrl = $authorizationEndpoint
             .(str_contains($authorizationEndpoint, '?') ? '&' : '?')
@@ -179,8 +209,9 @@ final class OidcLoginAuthenticator extends AbstractAuthenticator implements Auth
             throw new AuthenticationException('Missing OIDC nonce in session.');
         }
 
-        // same for the PKCE verifier: exchanging the code without it would downgrade PKCE
-        if (!\is_string($codeVerifier) || '' === $codeVerifier) {
+        // same for the PKCE verifier when PKCE is enabled: exchanging the code
+        // without it would downgrade PKCE
+        if ($this->options['pkce_enabled'] && (!\is_string($codeVerifier) || '' === $codeVerifier)) {
             throw new AuthenticationException('Missing PKCE code verifier in session.');
         }
 
@@ -207,6 +238,7 @@ final class OidcLoginAuthenticator extends AbstractAuthenticator implements Auth
             $this->discovery->getConfiguration()['issuer'] ?? '',
             $this->clientId,
             $nonce,
+            $this->options['max_age'] ?? null,
         );
 
         $claims = $this->fetchUserClaims($tokenData['access_token'], $idTokenClaims);
@@ -278,7 +310,7 @@ final class OidcLoginAuthenticator extends AbstractAuthenticator implements Auth
      *
      * @return array<string, mixed>
      */
-    private function exchangeAuthorizationCode(string $redirectUri, string $code, string $codeVerifier): array
+    private function exchangeAuthorizationCode(string $redirectUri, string $code, ?string $codeVerifier): array
     {
         $tokenData = $this->oidcClient->exchangeCode($code, $redirectUri, $codeVerifier);
 
@@ -338,8 +370,17 @@ final class OidcLoginAuthenticator extends AbstractAuthenticator implements Auth
     private function generateCodeVerifier(): string
     {
         // A 32-byte (256-bit) verifier, hex-encoded to 64 characters, as recommended
-        // by RFC 7636 Appendix B. The S256 challenge below is the only base64url step.
+        // by RFC 7636 Appendix B
         return bin2hex(random_bytes(32));
+    }
+
+    private function deriveCodeChallenge(string $codeVerifier): string
+    {
+        return match ($this->options['pkce_method']) {
+            // BASE64URL(SHA256(verifier)) without padding, per RFC 7636, Section 4.2
+            'S256' => rtrim(strtr(base64_encode(hash('sha256', $codeVerifier, true)), '+/', '-_'), '='),
+            'plain' => $codeVerifier,
+        };
     }
 
     private function getSession(Request $request): SessionInterface

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -21,6 +21,7 @@ CHANGELOG
  * Cache the discovery document of the `oidc` access token handler for one hour, where it was fetched again on every refresh of the JWKS
  * Add `OidcSignatureVerifier` to verify the ID token signature of the OIDC login authenticator against the provider JWKS, which it now does by default
  * Add `OidcPublicClient` to run the OIDC login flow as a public client, which holds no client secret and relies on PKCE, and support `client_secret_basic` in `OidcConfidentialClient`
+ * Add the `pkce_enabled`, `pkce_method` and `max_age` options and the `$authorizationParams` argument to `OidcLoginAuthenticator`, which checks the ID token `auth_time` claim when `max_age` is used
 
 8.1
 ---

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/Oidc/OidcIdTokenTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/Oidc/OidcIdTokenTest.php
@@ -320,6 +320,73 @@ class OidcIdTokenTest extends TestCase
         return new OidcIdToken(new MockClock());
     }
 
+    public function testValidateClaimsChecksMaxAgeWithTheInjectedClock()
+    {
+        $claims = [
+            'iss' => 'https://provider.example.com',
+            'aud' => 'my-client-id',
+            'exp' => 1750003600,
+            'iat' => 1750000000,
+            'auth_time' => 1749999700,
+        ];
+
+        // the user authenticated exactly max_age seconds before the injected clock's now...
+        (new OidcIdToken(new MockClock('@1750000000')))->validateClaims($claims, 'https://provider.example.com', 'my-client-id', null, 300);
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('max_age');
+
+        // ...and one second too early for a clock one second later
+        (new OidcIdToken(new MockClock('@1750000001')))->validateClaims($claims, 'https://provider.example.com', 'my-client-id', null, 300);
+    }
+
+    public function testValidateClaimsMaxAgeAllowsTimeDrift()
+    {
+        $claims = [
+            'iss' => 'https://provider.example.com',
+            'aud' => 'my-client-id',
+            'exp' => 1750003600,
+            'iat' => 1750000000,
+            'auth_time' => 1749999698,
+        ];
+
+        // 302 seconds elapsed, accepted with max_age 300 and a 2-second drift allowance
+        (new OidcIdToken(new MockClock('@1750000000'), 2))->validateClaims($claims, 'https://provider.example.com', 'my-client-id', null, 300);
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testValidateClaimsMissingAuthTimeWhenMaxAgeRequested()
+    {
+        $claims = [
+            'iss' => 'https://provider.example.com',
+            'aud' => 'my-client-id',
+            'exp' => 1750003600,
+            'iat' => 1750000000,
+        ];
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('auth_time');
+
+        (new OidcIdToken(new MockClock('@1750000000')))->validateClaims($claims, 'https://provider.example.com', 'my-client-id', null, 300);
+    }
+
+    public function testValidateClaimsRejectsANonNumericAuthTime()
+    {
+        $claims = [
+            'iss' => 'https://provider.example.com',
+            'aud' => 'my-client-id',
+            'exp' => 1750003600,
+            'iat' => 1750000000,
+            'auth_time' => 'yesterday',
+        ];
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('auth_time');
+
+        (new OidcIdToken(new MockClock('@1750000000')))->validateClaims($claims, 'https://provider.example.com', 'my-client-id', null, 300);
+    }
+
     private function buildJwt(array $claims = []): string
     {
         return (new CompactSerializer())->serialize(

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/OidcLoginAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/OidcLoginAuthenticatorTest.php
@@ -657,8 +657,131 @@ class OidcLoginAuthenticatorTest extends TestCase
         $this->assertIsArray($attempt);
         $this->assertSame($params['nonce'], $attempt['nonce']);
         $this->assertNotNull($attempt['code_verifier']);
+        // the challenge is BASE64URL(SHA256(verifier)) without padding, per RFC 7636, Section 4.2
+        $this->assertSame(rtrim(strtr(base64_encode(hash('sha256', $attempt['code_verifier'], true)), '+/', '-_'), '='), $params['code_challenge']);
         // the very redirect URI sent to the provider is the one kept for the token request
         $this->assertSame($params['redirect_uri'], $attempt['redirect_uri']);
+    }
+
+    public function testStartWithoutPkce()
+    {
+        $authenticator = $this->createAuthenticator(['pkce_enabled' => false]);
+        $request = Request::create('/protected');
+        $request->setSession(new Session(new MockArraySessionStorage()));
+
+        $location = $authenticator->start($request)->getTargetUrl();
+        $params = [];
+        parse_str(parse_url($location, \PHP_URL_QUERY), $params);
+
+        $this->assertArrayNotHasKey('code_challenge', $params);
+        $this->assertArrayNotHasKey('code_challenge_method', $params);
+    }
+
+    public function testStartWithPlainPkce()
+    {
+        $authenticator = $this->createAuthenticator(['pkce_method' => 'plain']);
+        $request = Request::create('/protected');
+        $session = new Session(new MockArraySessionStorage());
+        $request->setSession($session);
+
+        $location = $authenticator->start($request)->getTargetUrl();
+        $params = [];
+        parse_str(parse_url($location, \PHP_URL_QUERY), $params);
+
+        $this->assertSame('plain', $params['code_challenge_method']);
+        // with "plain", RFC 7636, Section 4.2 sends the verifier itself as the challenge
+        $attempt = $session->get('_security.oidc_login.main.attempt.'.$params['state']);
+        $this->assertSame($attempt['code_verifier'], $params['code_challenge']);
+    }
+
+    public function testAnUnknownPkceMethodIsRejected()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid PKCE method "unknown"');
+
+        $this->createAuthenticator(['pkce_method' => 'unknown']);
+    }
+
+    public function testStartForwardsAuthorizationParams()
+    {
+        $authenticator = $this->createAuthenticator(authorizationParams: ['prompt' => 'consent', 'ui_locales' => 'fr-FR']);
+        $request = Request::create('/protected');
+        $request->setSession(new Session(new MockArraySessionStorage()));
+
+        $location = $authenticator->start($request)->getTargetUrl();
+        $params = [];
+        parse_str(parse_url($location, \PHP_URL_QUERY), $params);
+
+        $this->assertSame('consent', $params['prompt']);
+        $this->assertSame('fr-FR', $params['ui_locales']);
+    }
+
+    public function testManagedAuthorizationParamsAreRejected()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The authorization request parameter(s) "state", "code_challenge" are managed by the authenticator');
+
+        $this->createAuthenticator(authorizationParams: ['state' => 'fixed', 'code_challenge' => '', 'prompt' => 'consent']);
+    }
+
+    public function testStartSendsTheConfiguredMaxAge()
+    {
+        $authenticator = $this->createAuthenticator(['max_age' => 3600]);
+        $request = Request::create('/protected');
+        $request->setSession(new Session(new MockArraySessionStorage()));
+
+        $location = $authenticator->start($request)->getTargetUrl();
+        $params = [];
+        parse_str(parse_url($location, \PHP_URL_QUERY), $params);
+
+        $this->assertSame('3600', $params['max_age']);
+    }
+
+    public function testAuthenticateEnforcesMaxAgeAgainstTheAuthTimeClaim()
+    {
+        $nonce = bin2hex(random_bytes(16));
+        $state = bin2hex(random_bytes(16));
+        $idToken = $this->buildIdToken(['nonce' => $nonce, 'auth_time' => time() - 600]);
+
+        $this->oidcClient->expects($this->once())
+            ->method('exchangeCode')
+            ->willReturn([
+                'access_token' => 'access-123',
+                'id_token' => $idToken,
+            ]);
+
+        $authenticator = $this->createAuthenticator(['max_age' => 300]);
+        $request = $this->createCallbackRequest($state, $nonce);
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('max_age');
+
+        $authenticator->authenticate($request);
+    }
+
+    public function testAuthenticateAcceptsARecentAuthTimeWithinMaxAge()
+    {
+        $nonce = bin2hex(random_bytes(16));
+        $state = bin2hex(random_bytes(16));
+        $idToken = $this->buildIdToken(['nonce' => $nonce, 'auth_time' => time() - 30]);
+
+        $this->oidcClient->expects($this->once())
+            ->method('exchangeCode')
+            ->willReturn([
+                'access_token' => 'access-123',
+                'id_token' => $idToken,
+            ]);
+
+        $this->oidcClient->expects($this->once())
+            ->method('fetchUserInfo')
+            ->willReturn(['sub' => 'user-42']);
+
+        $authenticator = $this->createAuthenticator(['max_age' => 300]);
+        $request = $this->createCallbackRequest($state, $nonce);
+
+        $passport = $authenticator->authenticate($request);
+
+        $this->assertSame('user-42', $passport->getBadge(UserBadge::class)->getUserIdentifier());
     }
 
     public function testAuthenticatePassesCodeVerifierToExchangeCode()
@@ -1145,7 +1268,7 @@ class OidcLoginAuthenticatorTest extends TestCase
         );
     }
 
-    private function createAuthenticator(array $options = [], ?UserProviderInterface $userProvider = null, ?OidcSignatureVerifier $signatureVerifier = null): OidcLoginAuthenticator
+    private function createAuthenticator(array $options = [], ?UserProviderInterface $userProvider = null, array $authorizationParams = [], ?OidcSignatureVerifier $signatureVerifier = null): OidcLoginAuthenticator
     {
         return new OidcLoginAuthenticator(
             new HttpUtils(),
@@ -1157,6 +1280,7 @@ class OidcLoginAuthenticatorTest extends TestCase
             $this->successHandler,
             $this->failureHandler,
             $options,
+            $authorizationParams,
             $signatureVerifier,
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Follow-up of #64954. The `oidc_login` authenticator sends a fixed authorization request: PKCE with `S256`, and no way to add a parameter. This makes that request configurable.

```yaml
security:
    firewalls:
        main:
            oidc_login:
                # ...
                max_age: 3600
                authorization_params:
                    prompt: consent
                    ui_locales: 'fr-FR'
                pkce:
                    enabled: true               # default
                    method: S256                # default
```

- **`pkce`** becomes configurable: `method` is `S256` (default) or `plain`, the two methods RFC 7636 defines. A confidential client may disable PKCE; a public client (`token_endpoint_auth_method: none`) may not, since PKCE is then the only thing binding the authorization code to the client, and that combination is rejected at compile time.
- **`start_path`** (default `/oidc/start`): the route loader now also declares a route there (`_oidc_login_start_<firewall>`), served by a small controller that starts the flow by redirecting to the provider. A login page offering several ways to log in links to it (`path('_oidc_login_start_main')`) while the firewall `entry_point` key points at the login form. Like `check_path`, a route name is accepted, in which case no route is declared.
- **`max_age`** is a first-class option because it carries an obligation, not just a parameter: when it is sent, the provider must return an `auth_time` claim, and the authenticator now enforces `now - auth_time <= max_age + allowed_time_drift` (OIDC Core 1.0, Section 3.1.2.1). A missing or malformed `auth_time` fails the login.
- **`authorization_params`** is a free-form bag for any other parameter (`prompt`, `display`, `ui_locales`, `acr_values`, `login_hint`...). Parameters the protocol relies on (`response_type`, `client_id`, `redirect_uri`, `scope`, `state`, `nonce`, `code_challenge`, `code_challenge_method`, `max_age`) are refused there at config time, so the bag can never weaken CSRF, replay or PKCE protection; use the dedicated options instead.

Points for the documentation:
- the options above, with `S256` as the default and the public-client PKCE rule;
- small `max_age` values need a matching `allowed_time_drift`, since even a just-issued token has nonzero elapsed time (`max_age: 0` rejects logins whose redirect takes longer than the drift);
- a firewall offering several ways to log in: set the firewall `entry_point` key (for example to `form_login`) and add a link to the start route on the login page, e.g. `<a href="{{ path('_oidc_login_start_main') }}">`; the start path must stay anonymously accessible (mind `access_control`).
