### PR TITLE
[Console] Fix the bash completion of "--option=value" and of an aliased command

### DIFF
--- a/src/Symfony/Component/Console/Resources/completion.bash
+++ b/src/Symfony/Component/Console/Resources/completion.bash
@@ -17,16 +17,24 @@ _sf_{{ COMMAND_NAME }}() {
     done
 
     local sf_cmd="${COMP_WORDS[0]}"
+    local sf_cmd_parts
 
-    # for an alias, get the real script behind it
+    # for an alias, get the real command behind it, which may carry arguments
     sf_cmd_type=$(type -t $sf_cmd)
     if [[ $sf_cmd_type == "alias" ]]; then
         sf_cmd=$(alias $sf_cmd | sed -E "s/alias $sf_cmd='(.*)'/\1/")
+        read -ra sf_cmd_parts <<< "$sf_cmd"
     elif [[ $sf_cmd_type == "file" ]]; then
-        sf_cmd=$(type -p $sf_cmd)
+        sf_cmd_parts=("$(type -p $sf_cmd)")
+    else
+        sf_cmd_parts=("$sf_cmd")
     fi
 
-    if [[ $sf_cmd_type != "function" && ! -x $sf_cmd ]]; then
+    # the command must be a function, an executable of the PATH or an executable file
+    if [[ $sf_cmd_type != "function" ]] \
+        && ! type -P "${sf_cmd_parts[0]}" > /dev/null \
+        && [[ ! -x ${sf_cmd_parts[0]} ]] \
+    ; then
         return 1
     fi
 
@@ -45,7 +53,7 @@ _sf_{{ COMMAND_NAME }}() {
     # Use newline as only separator to allow space in completion values
     local IFS=$'\n'
 
-    local completecmd=("$sf_cmd" "_complete" "--no-interaction" "-sbash" "-c$cword" "-a{{ VERSION }}")
+    local completecmd=("${sf_cmd_parts[@]}" "_complete" "--no-interaction" "-sbash" "-c$cword" "-a{{ VERSION }}")
     for w in "${words[@]}"; do
         w="${w//\\\\/\\}"
         # remove quotes from typed values
@@ -64,13 +72,12 @@ _sf_{{ COMMAND_NAME }}() {
     done
 
     local sfcomplete
-    if sfcomplete=$(SHELL_VERBOSITY=0 ${completecmd[@]} 2>&1); then
-        local quote suggestions flagPrefix=''
+    if sfcomplete=$(SHELL_VERBOSITY=0 "${completecmd[@]}" 2>&1); then
+        local quote suggestions
 
-        # "=" is not a word break, so the whole "--option=value" word is completed:
-        # filter on the value and prepend the option to the suggestions
+        # for the "--option=value" form, the suggestions are the values: readline
+        # keeps the "--option=" part, which is a word of its own for it
         if [[ "$cur" == -*=* ]]; then
-            flagPrefix="${cur%%=*}="
             cur="${cur#*=}"
         fi
 
@@ -100,8 +107,8 @@ _sf_{{ COMMAND_NAME }}() {
             # no quotes: double escaping
             suggestions=$(for s in $sfcomplete; do printf $'%q\n' $(printf '%q' "$s"); done)
         fi
-        COMPREPLY=($(IFS=$'\n' compgen -P "$flagPrefix" -W "$suggestions" -- $(printf -- "%q" "$cur")))
-        __ltrim_colon_completions "$flagPrefix$cur"
+        COMPREPLY=($(IFS=$'\n' compgen -W "$suggestions" -- $(printf -- "%q" "$cur")))
+        __ltrim_colon_completions "$cur"
     else
         if [[ "$sfcomplete" != *"Command \"_complete\" is not defined."* ]]; then
             >&2 echo

--- a/src/Symfony/Component/Console/Tests/shell-completion/cases.txt
+++ b/src/Symfony/Component/Console/Tests/shell-completion/cases.txt
@@ -6,23 +6,20 @@
 # Suggestions are compared as sorted logical values: descriptions are stripped and
 # shell escaping is undone by the drivers.
 #
-# In bash, ":" is part of COMP_WORDBREAKS, so the completion script trims what is
-# before the last colon of the word being completed (__ltrim_colon_completions).
-# Readline puts it back, which is why the expectations differ for bash.
+# The expectations are what the user ends up with. In bash, ":" and "=" are part
+# of COMP_WORDBREAKS, so readline only replaces what follows them: the driver
+# prepends the part it keeps in place, as readline does.
 
 # command names
-zsh,fish|app demo:|demo:hello;demo:other;demo:special
-bash|app demo:|hello;other;special
-zsh,fish|app demo:h|demo:hello
-bash|app demo:h|hello
+all|app demo:|demo:hello;demo:other;demo:special
+all|app demo:h|demo:hello
 
 # global option names
 all|app --|--ansi;--help;--no-ansi;--no-interaction;--quiet;--verbose;--version
 
 # the application called through a path instead of a name (%app% is replaced by
 # the absolute path of the fixture)
-zsh,fish|%app% demo:|demo:hello;demo:other;demo:special
-bash|%app% demo:|hello;other;special
+all|%app% demo:|demo:hello;demo:other;demo:special
 
 # option names
 all|app demo:hello --d|--dry-run
@@ -67,8 +64,7 @@ all|app demo:hello b|bob;bob smith
 
 # values containing a colon
 all|app demo:hello ns|ns:member
-zsh,fish|app demo:hello ns:|ns:member
-bash|app demo:hello ns:|member
+all|app demo:hello ns:|ns:member
 
 # values containing a backslash (FQCN)
 all|app demo:hello App|App\Entity\User

--- a/src/Symfony/Component/Console/Tests/shell-completion/drivers/bash-completion.sh
+++ b/src/Symfony/Component/Console/Tests/shell-completion/drivers/bash-completion.sh
@@ -1,0 +1,33 @@
+# This file is part of the Symfony package.
+#
+# (c) Fabien Potencier <fabien@symfony.com>
+#
+# For the full copyright and license information, please view
+# https://symfony.com/doc/current/contributing/code/license.html
+
+# Loads the bash-completion package, which provides the parsing of the command
+# line used by the completion script. Meant to be sourced.
+
+# the profile.d files only load the package for an interactive shell
+PS1='$ '
+
+# the Linux locations, then Homebrew's bash-completion@2 and 1.x
+for bash_completion in \
+    /usr/share/bash-completion/bash_completion \
+    /etc/bash_completion \
+    /opt/homebrew/etc/profile.d/bash_completion.sh \
+    /opt/homebrew/etc/bash_completion \
+    /usr/local/etc/profile.d/bash_completion.sh \
+    /usr/local/etc/bash_completion \
+; do
+    if [ -f "$bash_completion" ]; then
+        # shellcheck disable=SC1090
+        source "$bash_completion"
+        break
+    fi
+done
+
+if ! declare -F _get_comp_words_by_ref > /dev/null; then
+    echo "bash-completion is not installed" >&2
+    exit 1
+fi

--- a/src/Symfony/Component/Console/Tests/shell-completion/drivers/bash.sh
+++ b/src/Symfony/Component/Console/Tests/shell-completion/drivers/bash.sh
@@ -7,7 +7,8 @@
 # For the full copyright and license information, please view
 # https://symfony.com/doc/current/contributing/code/license.html
 
-# Runs the bash completion of a command line and prints one logical suggestion per line.
+# Runs the bash completion of a command line and prints, one per line, the value
+# readline would insert for each suggestion.
 #
 # Usage: bash.sh <completion script> <command line>
 #
@@ -17,62 +18,62 @@
 completion_script="$1"
 command_line="$2"
 
-# the Linux locations, then Homebrew's bash-completion@2 and 1.x
-for bash_completion in \
-    /usr/share/bash-completion/bash_completion \
-    /etc/bash_completion \
-    /opt/homebrew/etc/profile.d/bash_completion.sh \
-    /opt/homebrew/etc/bash_completion \
-    /usr/local/etc/profile.d/bash_completion.sh \
-    /usr/local/etc/bash_completion \
-; do
-    if [ -f "$bash_completion" ]; then
-        # shellcheck disable=SC1090
-        source "$bash_completion"
-        break
-    fi
-done
-
-if ! declare -F _get_comp_words_by_ref > /dev/null; then
-    echo "bash-completion is not installed" >&2
-    exit 1
-fi
+# shellcheck disable=SC1091
+source "$(dirname "$0")/bash-completion.sh"
 
 # shellcheck disable=SC1090
 source "$completion_script"
 
-# Split the command line the way readline does: on unquoted whitespace, keeping the quotes.
+# Splits the command line the way readline does: on the characters of
+# COMP_WORDBREAKS, which are words of their own, and on unquoted whitespace.
+# Quotes are kept, and open quotes protect the characters they contain.
+#
+# Sets: words, cword, cur and prefix, the part of the current shell token that
+# readline keeps in place, before the word being completed.
 tokenize() {
-    local line="$1" token='' char quote='' i
-    tokens=()
+    local line="$1" word='' token='' quote='' char i
+    words=()
+
     for ((i = 0; i < ${#line}; i++)); do
         char="${line:i:1}"
+
         if [ -n "$quote" ]; then
-            token+="$char"
+            word+="$char" token+="$char"
             [ "$char" = "$quote" ] && quote=''
             continue
         fi
+
         case "$char" in
             \'|\")
                 quote="$char"
-                token+="$char"
+                word+="$char" token+="$char"
                 ;;
-            ' ')
-                tokens+=("$token")
-                token=''
+            ' '|$'\t')
+                [ -n "$word" ] && words+=("$word")
+                word='' token=''
                 ;;
             *)
-                token+="$char"
+                if [[ "$COMP_WORDBREAKS" == *"$char"* ]]; then
+                    [ -n "$word" ] && words+=("$word")
+                    words+=("$char")
+                    word='' token+="$char"
+                else
+                    word+="$char" token+="$char"
+                fi
                 ;;
         esac
     done
-    tokens+=("$token")
+
+    words+=("$word")
+    cword=$((${#words[@]} - 1))
+    cur="$word"
+    prefix="${token%"$word"}"
 }
 
 tokenize "$command_line"
 
-COMP_WORDS=("${tokens[@]}")
-COMP_CWORD=$((${#COMP_WORDS[@]} - 1))
+COMP_WORDS=("${words[@]}")
+COMP_CWORD=$cword
 COMP_LINE="$command_line"
 COMP_POINT=${#COMP_LINE}
 COMPREPLY=()
@@ -82,7 +83,9 @@ compopt() { :; }
 
 "_sf_${COMP_WORDS[0]##*/}" || exit $?
 
-# Undo the shell escaping added by the completion script to compare logical values
+# Undo the shell escaping and prepend what readline keeps, to print the value the
+# user ends up with
 for suggestion in "${COMPREPLY[@]}"; do
-    eval "printf '%s\n' $suggestion" 2> /dev/null || printf '%s\n' "$suggestion"
+    suggestion="$(eval "printf '%s' $suggestion" 2> /dev/null || printf '%s' "$suggestion")"
+    printf '%s%s\n' "$prefix" "$suggestion"
 done

--- a/src/Symfony/Component/Console/Tests/shell-completion/run.sh
+++ b/src/Symfony/Component/Console/Tests/shell-completion/run.sh
@@ -123,6 +123,31 @@ test_missing_bash_completion() {
     esac
 }
 
+# The command may be reached through an alias, which can carry arguments. The
+# driver cannot be used here, aliases need a shell of their own.
+test_alias() {
+    local name="$1" definition="$2" expected="$3" actual
+
+    actual="$(bash --noprofile --norc -c '
+        shopt -s expand_aliases
+        source "$1/drivers/bash-completion.sh"
+        source "$2"
+        alias "$3"
+        compopt() { :; }
+        COMP_WORDS=("${3%%=*}" demo : "") COMP_CWORD=3 COMP_LINE="${3%%=*} demo:" COMP_POINT=9 COMPREPLY=()
+        _sf_app
+        printf "%s\n" "${COMPREPLY[@]}"
+    ' _ "$dir" "$tmp/completion.bash" "$definition" 2> "$tmp/case.err" | normalize)"
+
+    expected="$(printf '%s' "$expected" | tr ';' '\n' | normalize)"
+
+    if [ "$actual" = "$expected" ]; then
+        pass "[bash] completion through $name"
+    else
+        fail "[bash] completion through $name" "expected:" "$expected" "actual:" "${actual:-<none>}" "$(cat "$tmp/case.err")"
+    fi
+}
+
 for shell in $shells; do
     if ! command -v "$shell" > /dev/null; then
         skipped=$((skipped + 1))
@@ -150,6 +175,8 @@ for shell in $shells; do
     if [ "$shell" = "bash" ]; then
         test_api_version
         test_missing_bash_completion
+        test_alias 'an alias' 'sfa=app' 'hello;other;special'
+        test_alias 'an alias with arguments' "sfb=app --no-ansi" 'hello;other;special'
     fi
 done
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Two defects of the bash completion script, the first one being a regression of #65811.

**The `--option=value` form inserts the option twice.** `=` is part of `COMP_WORDBREAKS`, so readline only replaces what follows it and keeps the `--option=` part in place. Prepending the option to the suggestions, as #65811 does, duplicates it: completing `app demo:hello --greeting=` inserts `--greeting=--greeting=hi`. Only the values are suggested again, the current word being filtered on its value part:

```bash
# for the "--option=value" form, the suggestions are the values: readline
# keeps the "--option=" part, which is a word of its own for it
if [[ "$cur" == -*=* ]]; then
    cur="${cur#*=}"
fi
```

Sorry for the noise, this one is on me: the harness validated a behaviour that does not exist in a real shell, see below.

**The completion never runs when the command is reached through an alias**, which the script explicitly tries to support:

* `alias sf=app` resolves to `app`, which was then validated with `-x app`. That tests a file of the current directory, not the `PATH`, so the function returned without any suggestion;
* `alias sf='php bin/console'`, a common shape, resolves to a string that is never an executable file, so it was rejected too.

The alias value is now split into a command and its arguments, and the command is looked up in the `PATH`:

```bash
if [[ $sf_cmd_type == "alias" ]]; then
    sf_cmd=$(alias $sf_cmd | sed -E "s/alias $sf_cmd='(.*)'/\1/")
    read -ra sf_cmd_parts <<< "$sf_cmd"
...
local completecmd=("${sf_cmd_parts[@]}" "_complete" ...)
```

The expansion of the request is quoted as well, so a typed word is no longer subject to globbing.

### Harness

The first defect was hidden by the harness: its bash driver split the command line on whitespace only. It now splits it the way readline does, on the characters of `COMP_WORDBREAKS`, and prints the value the user ends up with rather than the raw `COMPREPLY`. As a result the expectations for the words containing a colon no longer differ from zsh and fish, and four duplicated cases are gone.

Two cases cover the aliases, and the loading of bash-completion moved to `drivers/bash-completion.sh`, shared by the driver and those cases. It also carries a fix of its own: the `profile.d` file of the Homebrew package returns immediately unless `$PS1` is set, so the paths added by #65811 made the whole suite fail on macOS.

115 cases pass on bash 5.2, zsh 5.9 and fish 3.6 in Docker, and 41 on macOS with bash 3.2 and bash-completion 1.3. Both fixes were checked by reverting them and confirming that only the related cases fail.
