### PR TITLE
[Console] Test the completion of an aliased command in zsh and fish

### DIFF
--- a/src/Symfony/Component/Console/Tests/shell-completion/drivers/bash.sh
+++ b/src/Symfony/Component/Console/Tests/shell-completion/drivers/bash.sh
@@ -10,19 +10,28 @@
 # Runs the bash completion of a command line and prints, one per line, the value
 # readline would insert for each suggestion.
 #
-# Usage: bash.sh <completion script> <command line>
+# Usage: bash.sh <completion script> <command line> [<alias definition>]
 #
 # No "set -u" here: an interactive shell does not use it, and bash-completion 1.x
 # relies on unset variables.
 
 completion_script="$1"
 command_line="$2"
+alias_definition="$3"
 
 # shellcheck disable=SC1091
 source "$(dirname "$0")/bash-completion.sh"
 
 # shellcheck disable=SC1090
 source "$completion_script"
+
+# the function is named after the command the script was dumped for
+completion_function="$(grep -o '^_sf_[A-Za-z0-9_]*' "$completion_script" | head -n1)"
+
+if [ -n "$alias_definition" ]; then
+    shopt -s expand_aliases
+    alias "$alias_definition"
+fi
 
 # Splits the command line the way readline does: on the characters of
 # COMP_WORDBREAKS, which are words of their own, and on unquoted whitespace.
@@ -81,7 +90,7 @@ COMPREPLY=()
 # compopt is only available while a completion is running
 compopt() { :; }
 
-"_sf_${COMP_WORDS[0]##*/}" || exit $?
+"$completion_function" || exit $?
 
 # Undo the shell escaping and prepend what readline keeps, to print the value the
 # user ends up with

--- a/src/Symfony/Component/Console/Tests/shell-completion/drivers/fish.fish
+++ b/src/Symfony/Component/Console/Tests/shell-completion/drivers/fish.fish
@@ -9,9 +9,14 @@
 
 # Runs the fish completion of a command line and prints one logical suggestion per line.
 #
-# Usage: fish.fish <completion script> <command line>
+# Usage: fish.fish <completion script> <command line> [<alias definition>]
 
 source $argv[1]
+
+# an alias is a function wrapping the command, fish reuses its completions
+if set -q argv[3]
+    alias (string split -m1 '=' -- $argv[3])
+end
 
 # fish returns "value<TAB>description", keep the value only
 for suggestion in (complete --do-complete=$argv[2])

--- a/src/Symfony/Component/Console/Tests/shell-completion/drivers/zsh.zsh
+++ b/src/Symfony/Component/Console/Tests/shell-completion/drivers/zsh.zsh
@@ -13,13 +13,14 @@
 # candidates instead of displaying them. This keeps the test deterministic while
 # still running the real completion script.
 #
-# Usage: zsh.zsh <completion script> <command line>
+# Usage: zsh.zsh <completion script> <command line> [<alias definition>]
 
 emulate -L zsh
 setopt no_nomatch
 
 local completion_script="$1"
 local command_line="$2"
+local alias_definition="$3"
 local separator=$'\1'
 
 local -a words
@@ -61,4 +62,11 @@ compdef() { :; }
 
 source "$completion_script"
 
-"_sf_${${words[1]}:t}"
+# the function is named after the command the script was dumped for
+local completion_function="$(grep -o '^_sf_[A-Za-z0-9_]*' $completion_script | head -n1)"
+
+if [ -n "$alias_definition" ]; then
+    alias "$alias_definition"
+fi
+
+"$completion_function"

--- a/src/Symfony/Component/Console/Tests/shell-completion/run.sh
+++ b/src/Symfony/Component/Console/Tests/shell-completion/run.sh
@@ -124,27 +124,24 @@ test_missing_bash_completion() {
 }
 
 # The command may be reached through an alias, which can carry arguments. The
-# driver cannot be used here, aliases need a shell of their own.
+# completion is requested on "--ans" so that the expectation does not depend on
+# the word breaks of the shell.
 test_alias() {
-    local name="$1" definition="$2" expected="$3" actual
+    local shell="$1" name="$2" definition="$3" actual
+    local driver
 
-    actual="$(bash --noprofile --norc -c '
-        shopt -s expand_aliases
-        source "$1/drivers/bash-completion.sh"
-        source "$2"
-        alias "$3"
-        compopt() { :; }
-        COMP_WORDS=("${3%%=*}" demo : "") COMP_CWORD=3 COMP_LINE="${3%%=*} demo:" COMP_POINT=9 COMPREPLY=()
-        _sf_app
-        printf "%s\n" "${COMPREPLY[@]}"
-    ' _ "$dir" "$tmp/completion.bash" "$definition" 2> "$tmp/case.err" | normalize)"
+    case "$shell" in
+        bash) driver=(bash "$dir/drivers/bash.sh") ;;
+        zsh) driver=(zsh "$dir/drivers/zsh.zsh") ;;
+        fish) driver=(fish "$dir/drivers/fish.fish") ;;
+    esac
 
-    expected="$(printf '%s' "$expected" | tr ';' '\n' | normalize)"
+    actual="$("${driver[@]}" "$tmp/completion.$shell" "${definition%%=*} --ans" "$definition" 2> "$tmp/case.err" | normalize)"
 
-    if [ "$actual" = "$expected" ]; then
-        pass "[bash] completion through $name"
+    if [ "$actual" = '--ansi' ]; then
+        pass "[$shell] completion through $name"
     else
-        fail "[bash] completion through $name" "expected:" "$expected" "actual:" "${actual:-<none>}" "$(cat "$tmp/case.err")"
+        fail "[$shell] completion through $name" "expected:" "--ansi" "actual:" "${actual:-<none>}" "$(cat "$tmp/case.err")"
     fi
 }
 
@@ -172,11 +169,12 @@ for shell in $shells; do
         run_case "$shell" "${command_line//%app%/$dir/app}" "$expected"
     done < "$dir/cases.txt"
 
+    test_alias "$shell" 'an alias' 'sfa=app'
+    test_alias "$shell" 'an alias with arguments' 'sfb=app --no-ansi'
+
     if [ "$shell" = "bash" ]; then
         test_api_version
         test_missing_bash_completion
-        test_alias 'an alias' 'sfa=app' 'hello;other;special'
-        test_alias 'an alias with arguments' "sfb=app --no-ansi" 'hello;other;special'
     fi
 done
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Follow-up of #65815, which fixed the completion of an aliased command in bash but only covered bash in the harness. zsh and fish support the aliases as well, each for a reason of its own:

* zsh, because `requestComp` is passed to `eval`, which expands the alias when it reads the code, so `alias sf='php bin/console'` ends up calling the right command;
* fish, because `alias` defines a function wrapping the command (`function sf --wraps=app`), whose completions fish reuses.

Both are worth locking. The zsh one holds by a side effect of the `eval`, so removing that `eval` would silently drop the support of the aliases. Checked by replacing it with a plain expansion: the two zsh alias cases fail and the 37 others pass.

Two cases per shell, `alias sfa=app` and `alias sfb='app --no-ansi'`:

```
OK [bash] completion through an alias
OK [bash] completion through an alias with arguments
OK [zsh] completion through an alias
OK [zsh] completion through an alias with arguments
OK [fish] completion through an alias
OK [fish] completion through an alias with arguments
```

The drivers now take an optional alias definition, and read the name of the completion function from the dumped script instead of deriving it from the first word of the command line, which an alias changes. The completion is requested on `--ans` so that the expectation, `--ansi`, does not depend on the word breaks of the shell.

119 cases pass on bash 5.2, zsh 5.9 and fish 3.6 in Docker, and 41 on macOS with bash 3.2 and bash-completion 1.3.
