### PR TITLE
[Security][SecurityBundle] Add OIDC claims source, user-identifier mapping and RP-Initiated Logout

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -21,6 +21,7 @@ CHANGELOG
  * Add the `token_endpoint_auth_method` option to the `oidc_login` authenticator: `client_secret_post`, `client_secret_basic`, or `none` to declare a public client, for which `client_secret` must not be set
  * Add the `pkce` (`enabled`, `method`), `max_age` and `authorization_params` options to the `oidc_login` authenticator
  * Add a `start_path` option to the `oidc_login` authenticator and declare a route there that starts the flow by redirecting to the provider, for login pages linking to it
+ * Add `user_data_source` and `user_identifier_claim` options to the `oidc_login` authenticator
 
 8.1
 ---

--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -22,6 +22,7 @@ CHANGELOG
  * Add the `pkce` (`enabled`, `method`), `max_age` and `authorization_params` options to the `oidc_login` authenticator
  * Add a `start_path` option to the `oidc_login` authenticator and declare a route there that starts the flow by redirecting to the provider, for login pages linking to it
  * Add `user_data_source` and `user_identifier_claim` options to the `oidc_login` authenticator
+ * Add `enable_end_session` and `post_logout_redirect_path` options to the `oidc_login` authenticator for RP-Initiated Logout
 
 8.1
 ---

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/OidcLoginFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/OidcLoginFactory.php
@@ -159,6 +159,14 @@ class OidcLoginFactory extends AbstractFactory
                     ->thenInvalid('The OIDC "authorization_params" option cannot set "response_type", "client_id", "redirect_uri", "scope", "state", "nonce", "code_challenge", "code_challenge_method" nor "max_age": the authenticator manages these; use the dedicated "scope" and "max_age" options.')
                 ->end()
             ->end()
+            ->booleanNode('enable_end_session')
+                ->defaultFalse()
+                ->info('Enable RP-Initiated Logout via the OIDC end_session_endpoint.')
+            ->end()
+            ->scalarNode('post_logout_redirect_path')
+                ->defaultValue('/')
+                ->info('Path or route to redirect to after OIDC logout.')
+            ->end()
         ;
 
         // the client type is what "token_endpoint_auth_method" really selects, so the
@@ -295,6 +303,16 @@ class OidcLoginFactory extends AbstractFactory
             ->replaceArgument(9, $config['authorization_params'])
             ->replaceArgument(10, $signatureVerifier)
         ;
+
+        if ($config['enable_end_session']) {
+            $endSessionListenerId = 'security.authenticator.oidc_login.end_session_listener.'.$firewallName;
+            $container
+                ->setDefinition($endSessionListenerId, new ChildDefinition('security.authenticator.oidc_login.end_session_listener'))
+                ->replaceArgument(0, new Reference($discoveryId))
+                ->replaceArgument(2, $config['post_logout_redirect_path'])
+                ->addTag('kernel.event_subscriber', ['dispatcher' => 'security.event_dispatcher.'.$firewallName])
+            ;
+        }
 
         $callbackUris = $container->hasParameter('security.oidc_login.callback_uris') ? (array) $container->getParameter('security.oidc_login.callback_uris') : [];
         // a "check_path" holding a route name instead of a path gets no route declared

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/OidcLoginFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/OidcLoginFactory.php
@@ -97,6 +97,15 @@ class OidcLoginFactory extends AbstractFactory
                 ->min(0)
                 ->info('Allowed clock skew in seconds when validating ID token time claims.')
             ->end()
+            ->enumNode('user_data_source')
+                ->values(['userinfo', 'id_token'])
+                ->defaultValue('userinfo')
+                ->info('Where the user claims are read from: "userinfo" (default) fetches them from the UserInfo endpoint; "id_token" reads them from the validated ID token instead, for providers that put the requested claims there, some of which expose no UserInfo endpoint at all, which is then not required to be announced.')
+            ->end()
+            ->scalarNode('user_identifier_claim')
+                ->defaultValue('sub')
+                ->info('The claim the user identifier is read from. "sub" (default) is the only claim OIDC guarantees stable and unique for the user. Only pick another claim, e.g. "email", when the provider guarantees its value unique, verified and stable too: whoever controls the value of that claim at the provider owns the matching account here.')
+            ->end()
             ->arrayNode('id_token_signature')
                 ->addDefaultsIfNotSet()
                 ->children()
@@ -202,6 +211,15 @@ class OidcLoginFactory extends AbstractFactory
             $loader->load('security_authenticator_oidc_login.php');
         }
 
+        // these endpoints must be announced and must not downgrade to plain HTTP the
+        // transport of the discovery document; the UserInfo endpoint is only required
+        // when it is the source of the user claims, as a provider putting them in the
+        // ID token does not necessarily expose one
+        $checkedEndpoints = ['authorization_endpoint', 'token_endpoint'];
+        if ('userinfo' === $config['user_data_source']) {
+            $checkedEndpoints[] = 'userinfo_endpoint';
+        }
+
         $discoveryId = 'security.authenticator.oidc_login.discovery.'.$firewallName;
         $container
             ->setDefinition($discoveryId, new ChildDefinition('security.authenticator.oidc_login.discovery'))
@@ -209,6 +227,7 @@ class OidcLoginFactory extends AbstractFactory
             // place a "provider_uri" coming from an environment variable can be normalized
             ->replaceArgument(3, $config['provider_uri'])
             ->replaceArgument(4, $config['discovery_cache_ttl'])
+            ->replaceArgument(6, $checkedEndpoints)
             ->addTag('kernel.reset', ['method' => 'reset'])
         ;
 
@@ -255,6 +274,8 @@ class OidcLoginFactory extends AbstractFactory
         $options = array_intersect_key($config, $this->options);
         $options['firewall_name'] = $firewallName;
         $options['scope'] = $config['scope'];
+        $options['user_data_source'] = $config['user_data_source'];
+        $options['user_identifier_claim'] = $config['user_identifier_claim'];
         $options['pkce_enabled'] = $config['pkce']['enabled'];
         $options['pkce_method'] = $config['pkce']['method'];
         if (isset($config['max_age'])) {

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator_oidc_login.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator_oidc_login.php
@@ -66,10 +66,9 @@ return static function (ContainerConfigurator $container) {
                 '.well-known/openid-configuration',
                 abstract_arg('issuer'),
                 abstract_arg('cache TTL'),
-                // the cache key is derived from the configuration URL; these endpoints must be
-                // announced and must not downgrade to plain HTTP the transport of the discovery document
+                // the cache key is derived from the configuration URL
                 null,
-                ['authorization_endpoint', 'token_endpoint', 'userinfo_endpoint'],
+                abstract_arg('endpoints that must be announced and must not downgrade to plain HTTP the transport of the discovery document'),
             ])
 
         ->set('security.authenticator.oidc_login.client', OidcConfidentialClient::class)

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator_oidc_login.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator_oidc_login.php
@@ -17,6 +17,7 @@ use Symfony\Component\Security\Http\Authenticator\Oidc\OidcIdToken;
 use Symfony\Component\Security\Http\Authenticator\Oidc\OidcPublicClient;
 use Symfony\Component\Security\Http\Authenticator\Oidc\OidcSignatureVerifier;
 use Symfony\Component\Security\Http\Authenticator\OidcLoginAuthenticator;
+use Symfony\Component\Security\Http\EventListener\OidcEndSessionListener;
 use Symfony\Component\Security\Http\Oidc\OidcDiscovery;
 
 return static function (ContainerConfigurator $container) {
@@ -95,6 +96,15 @@ return static function (ContainerConfigurator $container) {
             ->public()
             ->args([
                 service_locator([]),
+            ])
+
+        ->set('security.authenticator.oidc_login.end_session_listener', OidcEndSessionListener::class)
+            ->abstract()
+            ->args([
+                abstract_arg('OIDC discovery'),
+                service('security.http_utils'),
+                abstract_arg('post-logout redirect path'),
+                service('logger')->nullOnInvalid(),
             ])
     ;
 };

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/OidcLoginFactoryTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/OidcLoginFactoryTest.php
@@ -47,14 +47,12 @@ class OidcLoginFactoryTest extends TestCase
         $this->assertEquals(new Reference('security.authenticator.oidc_login.discovery.main'), $authenticator->getArgument(3));
         $this->assertSame('my-client-id', $authenticator->getArgument(5));
 
-        // the endpoints checked against the transport of the discovery document stay wired: the
-        // per-firewall child definition only replaces the issuer and the cache TTL, so it
-        // inherits this argument from the abstract definition
-        $discovery = $container->getDefinition('security.authenticator.oidc_login.discovery');
-        $this->assertSame(['authorization_endpoint', 'token_endpoint', 'userinfo_endpoint'], $discovery->getArgument(6));
+        // the endpoints checked against the transport of the discovery document stay wired
+        // on the per-firewall child definition, which computes them from the claims source
+        $discoveryMain = $container->getDefinition('security.authenticator.oidc_login.discovery.main');
+        $this->assertSame(['authorization_endpoint', 'token_endpoint', 'userinfo_endpoint'], $discoveryMain->getArgument(6));
 
         // the per-firewall discovery definition carries the kernel.reset tag with method reset
-        $discoveryMain = $container->getDefinition('security.authenticator.oidc_login.discovery.main');
         $this->assertSame(['kernel.reset' => [['method' => 'reset']]], $discoveryMain->getTags());
     }
 
@@ -775,6 +773,72 @@ class OidcLoginFactoryTest extends TestCase
         ], $factory);
 
         $this->assertTrue($finalizedConfig['id_token_signature']['required']);
+    }
+
+    public function testClaimsSourceAndUserIdentifierDefaults()
+    {
+        $factory = new OidcLoginFactory();
+
+        $finalizedConfig = $this->processConfig([
+            'provider_uri' => 'https://provider.example.com',
+            'client_id' => 'my-client-id',
+            'client_secret' => 'my-client-secret',
+        ], $factory);
+
+        $this->assertSame('userinfo', $finalizedConfig['user_data_source']);
+        $this->assertSame('sub', $finalizedConfig['user_identifier_claim']);
+    }
+
+    public function testClaimsMayBeSourcedFromTheIdToken()
+    {
+        $container = new ContainerBuilder();
+        $factory = new OidcLoginFactory();
+
+        $config = $this->processConfig([
+            'provider_uri' => 'https://provider.example.com',
+            'client_id' => 'my-client-id',
+            'client_secret' => 'my-client-secret',
+            'user_data_source' => 'id_token',
+            'user_identifier_claim' => 'email',
+        ], $factory);
+        $factory->createAuthenticator($container, 'main', $config, 'userprovider');
+
+        $options = $container->getDefinition('security.authenticator.oidc_login.main')->getArgument(8);
+        $this->assertSame('id_token', $options['user_data_source']);
+        $this->assertSame('email', $options['user_identifier_claim']);
+    }
+
+    public function testUserinfoEndpointRequiredWithTheUserinfoClaimsSource()
+    {
+        $container = new ContainerBuilder();
+        $factory = new OidcLoginFactory();
+
+        $config = $this->processConfig([
+            'provider_uri' => 'https://provider.example.com',
+            'client_id' => 'my-client-id',
+            'client_secret' => 'my-client-secret',
+        ], $factory);
+        $factory->createAuthenticator($container, 'main', $config, 'userprovider');
+
+        $this->assertSame(['authorization_endpoint', 'token_endpoint', 'userinfo_endpoint'], $container->getDefinition('security.authenticator.oidc_login.discovery.main')->getArgument(6));
+    }
+
+    public function testUserinfoEndpointNotRequiredWithTheIdTokenClaimsSource()
+    {
+        // a provider putting the claims in the ID token does not necessarily announce
+        // any UserInfo endpoint, so the discovery must not require one then
+        $container = new ContainerBuilder();
+        $factory = new OidcLoginFactory();
+
+        $config = $this->processConfig([
+            'provider_uri' => 'https://provider.example.com',
+            'client_id' => 'my-client-id',
+            'client_secret' => 'my-client-secret',
+            'user_data_source' => 'id_token',
+        ], $factory);
+        $factory->createAuthenticator($container, 'main', $config, 'userprovider');
+
+        $this->assertSame(['authorization_endpoint', 'token_endpoint'], $container->getDefinition('security.authenticator.oidc_login.discovery.main')->getArgument(6));
     }
 
     private function processConfig(array $config, OidcLoginFactory $factory): array

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/OidcLoginFactoryTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/OidcLoginFactoryTest.php
@@ -107,6 +107,44 @@ class OidcLoginFactoryTest extends TestCase
         $this->assertSame(['openid profile email'], $options['scope']);
     }
 
+    public function testEndSessionListenerRegistration()
+    {
+        $container = new ContainerBuilder();
+
+        $config = [
+            'provider_uri' => 'https://provider.example.com',
+            'client_id' => 'my-client-id',
+            'client_secret' => 'my-client-secret',
+            'check_path' => '/oidc/callback',
+            'enable_end_session' => true,
+            'post_logout_redirect_path' => '/logged-out',
+        ];
+
+        $factory = new OidcLoginFactory();
+        $finalizedConfig = $this->processConfig($config, $factory);
+        $factory->createAuthenticator($container, 'main', $finalizedConfig, 'userprovider');
+
+        $this->assertTrue($container->hasDefinition('security.authenticator.oidc_login.end_session_listener.main'));
+    }
+
+    public function testEndSessionListenerNotRegisteredByDefault()
+    {
+        $container = new ContainerBuilder();
+
+        $config = [
+            'provider_uri' => 'https://provider.example.com',
+            'client_id' => 'my-client-id',
+            'client_secret' => 'my-client-secret',
+            'check_path' => '/oidc/callback',
+        ];
+
+        $factory = new OidcLoginFactory();
+        $finalizedConfig = $this->processConfig($config, $factory);
+        $factory->createAuthenticator($container, 'main', $finalizedConfig, 'userprovider');
+
+        $this->assertFalse($container->hasDefinition('security.authenticator.oidc_login.end_session_listener.main'));
+    }
+
     public function testGetKey()
     {
         $factory = new OidcLoginFactory();

--- a/src/Symfony/Component/Security/Core/User/OidcUserProvider.php
+++ b/src/Symfony/Component/Security/Core/User/OidcUserProvider.php
@@ -47,7 +47,9 @@ final class OidcUserProvider implements AttributesBasedUserProviderInterface
             throw $exception;
         }
 
-        return OidcUser::fromClaims($this->filterPrivilegedClaims($attributes));
+        // the identifier is the one the caller validated, which the OIDC authenticator reads
+        // from the claim its firewall configures, and not a claim picked from the attributes
+        return OidcUser::fromClaims(['user_identifier' => $identifier] + $this->filterPrivilegedClaims($attributes));
     }
 
     public function refreshUser(UserInterface $user): OidcUser

--- a/src/Symfony/Component/Security/Http/Authenticator/OidcLoginAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/OidcLoginAuthenticator.php
@@ -77,6 +77,8 @@ final class OidcLoginAuthenticator extends AbstractAuthenticator implements Auth
             'scope' => ['openid'],
             'pkce_enabled' => true,
             'pkce_method' => 'S256',
+            'user_data_source' => 'userinfo',
+            'user_identifier_claim' => 'sub',
         ], $options);
 
         if (!\in_array($this->options['pkce_method'], ['S256', 'plain'], true)) {
@@ -243,13 +245,13 @@ final class OidcLoginAuthenticator extends AbstractAuthenticator implements Auth
 
         $claims = $this->fetchUserClaims($tokenData['access_token'], $idTokenClaims);
 
-        // The user is loaded by the firewall's user provider, from the verified "sub"
+        // The user is loaded by the firewall's user provider, from the configured identifier
         // claim and with every claim passed as badge attributes: a provider implementing
         // AttributesBasedUserProviderInterface receives them, which is where mapping
         // claims onto roles belongs. The built-in "oidc" provider builds a self-contained
         // OidcUser, without letting a claim define the identity or grant any role.
         $passport = new SelfValidatingPassport(
-            new UserBadge($claims['sub'], $this->userProvider->loadUserByIdentifier(...), $claims),
+            new UserBadge($claims[$this->options['user_identifier_claim']], $this->userProvider->loadUserByIdentifier(...), $claims),
         );
         $passport->setAttribute('oidc_token_data', $tokenData);
 
@@ -325,8 +327,10 @@ final class OidcLoginAuthenticator extends AbstractAuthenticator implements Auth
     }
 
     /**
-     * Fetches user claims from the UserInfo endpoint and enforces the OIDC Core
-     * 1.0, Section 5.3.2 rule that its "sub" matches the ID token "sub".
+     * Returns the user claims from the configured source, the UserInfo endpoint or
+     * the validated ID token, and checks the claim the user identifier is read from.
+     * Claims fetched from UserInfo are tied to the authenticated user by the OIDC
+     * Core 1.0, Section 5.3.2 rule that its "sub" matches the ID token "sub".
      *
      * @param array<string, mixed> $idTokenClaims
      *
@@ -334,13 +338,23 @@ final class OidcLoginAuthenticator extends AbstractAuthenticator implements Auth
      */
     private function fetchUserClaims(string $accessToken, array $idTokenClaims): array
     {
-        $claims = $this->oidcClient->fetchUserInfo($accessToken);
-
-        if (!\is_string($claims['sub'] ?? null) || '' === $claims['sub']) {
-            throw new AuthenticationException('The "sub" claim is missing or invalid in the OIDC response.');
+        if ('userinfo' === $this->options['user_data_source']) {
+            $claims = $this->oidcClient->fetchUserInfo($accessToken);
+        } else {
+            $claims = $idTokenClaims;
         }
 
-        if (!\is_string($idTokenClaims['sub'] ?? null) || !hash_equals($idTokenClaims['sub'], $claims['sub'])) {
+        $userIdentifierClaim = $this->options['user_identifier_claim'];
+        if (!\is_string($claims[$userIdentifierClaim] ?? null) || '' === $claims[$userIdentifierClaim]) {
+            throw new AuthenticationException(\sprintf('The "%s" claim is missing or invalid in the OIDC response.', $userIdentifierClaim));
+        }
+
+        if (!\is_string($idTokenClaims['sub'] ?? null) || '' === $idTokenClaims['sub']) {
+            throw new AuthenticationException('The "sub" claim is missing or invalid in the ID token.');
+        }
+        if ('userinfo' === $this->options['user_data_source']
+            && (!\is_string($claims['sub'] ?? null) || !hash_equals($idTokenClaims['sub'], $claims['sub']))
+        ) {
             throw new AuthenticationException('The "sub" claim from the UserInfo endpoint does not match the ID token.');
         }
 

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -22,6 +22,7 @@ CHANGELOG
  * Add `OidcSignatureVerifier` to verify the ID token signature of the OIDC login authenticator against the provider JWKS, which it now does by default
  * Add `OidcPublicClient` to run the OIDC login flow as a public client, which holds no client secret and relies on PKCE, and support `client_secret_basic` in `OidcConfidentialClient`
  * Add the `pkce_enabled`, `pkce_method` and `max_age` options and the `$authorizationParams` argument to `OidcLoginAuthenticator`, which checks the ID token `auth_time` claim when `max_age` is used
+ * Add the `user_data_source` and `user_identifier_claim` options to `OidcLoginAuthenticator` to pick where the user claims are read from and the claim the user identifier is read from
 
 8.1
 ---

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -23,6 +23,7 @@ CHANGELOG
  * Add `OidcPublicClient` to run the OIDC login flow as a public client, which holds no client secret and relies on PKCE, and support `client_secret_basic` in `OidcConfidentialClient`
  * Add the `pkce_enabled`, `pkce_method` and `max_age` options and the `$authorizationParams` argument to `OidcLoginAuthenticator`, which checks the ID token `auth_time` claim when `max_age` is used
  * Add the `user_data_source` and `user_identifier_claim` options to `OidcLoginAuthenticator` to pick where the user claims are read from and the claim the user identifier is read from
+ * Add `OidcEndSessionListener` for RP-Initiated Logout via the OIDC `end_session_endpoint`
 
 8.1
 ---

--- a/src/Symfony/Component/Security/Http/EventListener/OidcEndSessionListener.php
+++ b/src/Symfony/Component/Security/Http/EventListener/OidcEndSessionListener.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\EventListener;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Http\Event\LogoutEvent;
+use Symfony\Component\Security\Http\HttpUtils;
+use Symfony\Component\Security\Http\Oidc\OidcDiscovery;
+
+/**
+ * Handles RP-Initiated Logout by redirecting to the OIDC provider's
+ * end_session_endpoint on logout.
+ *
+ * @see https://openid.net/specs/openid-connect-rpinitiated-1_0.html
+ *
+ * @author Mathieu Santostefano <msantostefano@proton.me>
+ */
+final class OidcEndSessionListener implements EventSubscriberInterface
+{
+    public function __construct(
+        private readonly OidcDiscovery $discovery,
+        private readonly HttpUtils $httpUtils,
+        private readonly ?string $postLogoutRedirectPath = null,
+        private readonly ?LoggerInterface $logger = null,
+    ) {
+    }
+
+    public function onLogout(LogoutEvent $event): void
+    {
+        // a listener registered earlier already decided the logout response, and
+        // whoever sets it first wins, as for the default logout response
+        if (null !== $event->getResponse()) {
+            return;
+        }
+
+        $token = $event->getToken();
+        if (null === $token || !$token->hasAttribute('oidc_id_token')) {
+            return;
+        }
+
+        $idToken = $token->getAttribute('oidc_id_token');
+        if (!\is_string($idToken)) {
+            return;
+        }
+
+        try {
+            $endSessionEndpoint = $this->discovery->getSecureEndpoint('end_session_endpoint');
+        } catch (AuthenticationException $e) {
+            // logging out of the application must not depend on the provider being
+            // reachable and correctly configured, so the logout stays a local one
+            $this->logger?->warning('The OIDC provider does not announce a usable "end_session_endpoint"; falling back to a local logout.', ['exception' => $e]);
+
+            return;
+        }
+
+        $params = ['id_token_hint' => $idToken];
+
+        if (null !== $this->postLogoutRedirectPath) {
+            $params['post_logout_redirect_uri'] = $this->httpUtils->generateUri($event->getRequest(), $this->postLogoutRedirectPath);
+        }
+
+        $endSessionUrl = $endSessionEndpoint
+            .(str_contains($endSessionEndpoint, '?') ? '&' : '?')
+            .http_build_query($params, '', '&', \PHP_QUERY_RFC3986);
+
+        $event->setResponse(new RedirectResponse($endSessionUrl));
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            // before the default logout listener at priority 64, whose response this
+            // one replaces when RP-Initiated Logout is enabled
+            LogoutEvent::class => ['onLogout', 65],
+        ];
+    }
+}

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/OidcLoginAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/OidcLoginAuthenticatorTest.php
@@ -274,7 +274,7 @@ class OidcLoginAuthenticatorTest extends TestCase
     public function testAuthenticateIgnoresProviderSuppliedIdentifierClaim()
     {
         // a provider "userIdentifier" claim must not override the identity derived
-        // from the verified "sub"
+        // from the configured identifier claim
         $nonce = bin2hex(random_bytes(16));
         $state = bin2hex(random_bytes(16));
         $idToken = $this->buildIdToken(['nonce' => $nonce]);
@@ -295,6 +295,112 @@ class OidcLoginAuthenticatorTest extends TestCase
 
         $this->assertSame('user-42', $passport->getUser()->getUserIdentifier());
         $this->assertSame('user-42', $passport->getBadge(UserBadge::class)->getUserIdentifier());
+    }
+
+    public function testAuthenticateWithIdTokenDataSource()
+    {
+        $nonce = bin2hex(random_bytes(16));
+        $state = bin2hex(random_bytes(16));
+        $idToken = $this->buildIdToken([
+            'nonce' => $nonce,
+            'sub' => 'user-42',
+            'email' => 'test@example.com',
+        ]);
+
+        $this->oidcClient->expects($this->once())
+            ->method('exchangeCode')
+            ->willReturn([
+                'access_token' => 'access-123',
+                'id_token' => $idToken,
+            ]);
+
+        $this->oidcClient->expects($this->never())
+            ->method('fetchUserInfo');
+
+        $authenticator = $this->createAuthenticator(['user_data_source' => 'id_token']);
+        $request = $this->createCallbackRequest($state, $nonce);
+
+        $passport = $authenticator->authenticate($request);
+
+        $this->assertSame('user-42', $passport->getBadge(UserBadge::class)->getUserIdentifier());
+    }
+
+    public function testAuthenticateWithCustomUserIdentifierClaim()
+    {
+        $nonce = bin2hex(random_bytes(16));
+        $state = bin2hex(random_bytes(16));
+        $idToken = $this->buildIdToken(['nonce' => $nonce]);
+
+        $this->oidcClient->method('exchangeCode')->willReturn([
+            'access_token' => 'access-123',
+            'id_token' => $idToken,
+        ]);
+        $this->oidcClient->method('fetchUserInfo')->willReturn([
+            'sub' => 'user-42',
+            'email' => 'test@example.com',
+        ]);
+
+        $authenticator = $this->createAuthenticator(['user_identifier_claim' => 'email']);
+        $request = $this->createCallbackRequest($state, $nonce);
+
+        $passport = $authenticator->authenticate($request);
+
+        $this->assertSame('test@example.com', $passport->getBadge(UserBadge::class)->getUserIdentifier());
+        // the user provider receives that identifier, and the built-in one keeps it
+        $this->assertSame('test@example.com', $passport->getUser()->getUserIdentifier());
+    }
+
+    public function testAuthenticateRejectsANonStringUserIdentifierClaim()
+    {
+        // providers do send numeric values in custom claims; a non-string identifier
+        // must fail authentication cleanly instead of escaping as a TypeError
+        $nonce = bin2hex(random_bytes(16));
+        $state = bin2hex(random_bytes(16));
+        $idToken = $this->buildIdToken(['nonce' => $nonce]);
+
+        $this->oidcClient->method('exchangeCode')->willReturn([
+            'access_token' => 'access-123',
+            'id_token' => $idToken,
+        ]);
+        $this->oidcClient->method('fetchUserInfo')->willReturn([
+            'sub' => 'user-42',
+            'uid' => 12345,
+        ]);
+
+        $authenticator = $this->createAuthenticator(['user_identifier_claim' => 'uid']);
+        $request = $this->createCallbackRequest($state, $nonce);
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('The "uid" claim is missing or invalid in the OIDC response.');
+
+        $authenticator->authenticate($request);
+    }
+
+    public function testAuthenticateRejectsUserInfoSubMismatchWithACustomUserIdentifierClaim()
+    {
+        // the "sub" binding of OIDC Core 1.0, Section 5.3.2 is what ties the UserInfo
+        // document to the authenticated user: it holds whatever claim the identifier
+        // is read from, so a swapped document cannot define the identity
+        $nonce = bin2hex(random_bytes(16));
+        $state = bin2hex(random_bytes(16));
+        $idToken = $this->buildIdToken(['nonce' => $nonce]);
+
+        $this->oidcClient->method('exchangeCode')->willReturn([
+            'access_token' => 'access-123',
+            'id_token' => $idToken,
+        ]);
+        $this->oidcClient->method('fetchUserInfo')->willReturn([
+            'sub' => 'other-user',
+            'email' => 'victim@example.com',
+        ]);
+
+        $authenticator = $this->createAuthenticator(['user_identifier_claim' => 'email']);
+        $request = $this->createCallbackRequest($state, $nonce);
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('The "sub" claim from the UserInfo endpoint does not match the ID token.');
+
+        $authenticator->authenticate($request);
     }
 
     public function testAuthenticateLoadsTheUserFromTheFirewallUserProvider()

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/OidcEndSessionListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/OidcEndSessionListenerTest.php
@@ -1,0 +1,243 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Tests\EventListener;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\JsonMockResponse;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Http\Event\LogoutEvent;
+use Symfony\Component\Security\Http\EventListener\ClearSiteDataLogoutListener;
+use Symfony\Component\Security\Http\EventListener\DefaultLogoutListener;
+use Symfony\Component\Security\Http\EventListener\OidcEndSessionListener;
+use Symfony\Component\Security\Http\HttpUtils;
+use Symfony\Component\Security\Http\Oidc\OidcDiscovery;
+
+class OidcEndSessionListenerTest extends TestCase
+{
+    public function testOnLogoutRedirectsToEndSessionEndpoint()
+    {
+        $discovery = $this->createDiscovery([
+            'end_session_endpoint' => 'https://provider.example.com/logout',
+        ]);
+
+        $listener = new OidcEndSessionListener($discovery, new HttpUtils(), '/');
+
+        $token = $this->createStub(TokenInterface::class);
+        $token->method('hasAttribute')->willReturn(true);
+        $token->method('getAttribute')->willReturn('my-id-token');
+
+        $event = new LogoutEvent(Request::create('/logout'), $token);
+        $listener->onLogout($event);
+
+        $response = $event->getResponse();
+        $this->assertInstanceOf(RedirectResponse::class, $response);
+        $this->assertStringStartsWith('https://provider.example.com/logout?', $response->getTargetUrl());
+        $this->assertStringContainsString('id_token_hint=my-id-token', $response->getTargetUrl());
+    }
+
+    public function testOnLogoutIncludesPostLogoutRedirectUri()
+    {
+        $discovery = $this->createDiscovery([
+            'end_session_endpoint' => 'https://provider.example.com/logout',
+        ]);
+
+        $listener = new OidcEndSessionListener($discovery, new HttpUtils(), '/logged-out');
+
+        $token = $this->createStub(TokenInterface::class);
+        $token->method('hasAttribute')->willReturn(true);
+        $token->method('getAttribute')->willReturn('my-id-token');
+
+        $event = new LogoutEvent(Request::create('/logout'), $token);
+        $listener->onLogout($event);
+
+        $url = $event->getResponse()->getTargetUrl();
+        $this->assertStringContainsString('post_logout_redirect_uri=', $url);
+        $this->assertStringContainsString('logged-out', $url);
+    }
+
+    public function testOnLogoutWithoutPostLogoutRedirectPath()
+    {
+        $discovery = $this->createDiscovery([
+            'end_session_endpoint' => 'https://provider.example.com/logout',
+        ]);
+
+        $listener = new OidcEndSessionListener($discovery, new HttpUtils());
+
+        $token = $this->createStub(TokenInterface::class);
+        $token->method('hasAttribute')->willReturn(true);
+        $token->method('getAttribute')->willReturn('my-id-token');
+
+        $event = new LogoutEvent(Request::create('/logout'), $token);
+        $listener->onLogout($event);
+
+        $url = $event->getResponse()->getTargetUrl();
+        $this->assertStringContainsString('id_token_hint=my-id-token', $url);
+        $this->assertStringNotContainsString('post_logout_redirect_uri', $url);
+    }
+
+    public function testOnLogoutFallsBackToLocalLogoutWhenEndSessionEndpointMissing()
+    {
+        $discovery = $this->createDiscovery([
+            'issuer' => 'https://provider.example.com',
+        ]);
+
+        $listener = new OidcEndSessionListener($discovery, new HttpUtils(), '/');
+
+        $token = $this->createStub(TokenInterface::class);
+        $token->method('hasAttribute')->willReturn(true);
+        $token->method('getAttribute')->willReturn('my-id-token');
+
+        $event = new LogoutEvent(Request::create('/logout'), $token);
+
+        $listener->onLogout($event);
+
+        $this->assertNull($event->getResponse());
+    }
+
+    public function testOnLogoutDoesNothingWithoutOidcIdToken()
+    {
+        $discovery = $this->createNeverQueriedDiscovery();
+
+        $listener = new OidcEndSessionListener($discovery, new HttpUtils(), '/');
+
+        $token = $this->createStub(TokenInterface::class);
+        $token->method('hasAttribute')->willReturn(false);
+
+        $event = new LogoutEvent(Request::create('/logout'), $token);
+        $listener->onLogout($event);
+
+        $this->assertNull($event->getResponse());
+    }
+
+    public function testOnLogoutDoesNothingWithoutToken()
+    {
+        $discovery = $this->createNeverQueriedDiscovery();
+
+        $listener = new OidcEndSessionListener($discovery, new HttpUtils(), '/');
+
+        $event = new LogoutEvent(Request::create('/logout'), null);
+        $listener->onLogout($event);
+
+        $this->assertNull($event->getResponse());
+    }
+
+    public function testOnLogoutRespectsAResponseSetByAnEarlierListener()
+    {
+        // whoever sets the logout response first wins, as for the default logout
+        // response, so a listener customizing it keeps working with RP logout enabled
+        $listener = new OidcEndSessionListener($this->createNeverQueriedDiscovery(), new HttpUtils(), '/');
+
+        $token = $this->createStub(TokenInterface::class);
+        $token->method('hasAttribute')->willReturn(true);
+        $token->method('getAttribute')->willReturn('my-id-token');
+
+        $event = new LogoutEvent(Request::create('/logout'), $token);
+        $custom = new Response('custom goodbye page');
+        $event->setResponse($custom);
+        $listener->onLogout($event);
+
+        $this->assertSame($custom, $event->getResponse());
+    }
+
+    public function testOnLogoutReplacesTheDefaultLogoutResponse()
+    {
+        $discovery = $this->createDiscovery([
+            'end_session_endpoint' => 'https://provider.example.com/logout',
+        ]);
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addSubscriber(new DefaultLogoutListener(new HttpUtils(), '/after-logout'));
+        $dispatcher->addSubscriber(new ClearSiteDataLogoutListener(['cookies']));
+        $dispatcher->addSubscriber(new OidcEndSessionListener($discovery, new HttpUtils(), '/'));
+
+        $token = $this->createStub(TokenInterface::class);
+        $token->method('hasAttribute')->willReturn(true);
+        $token->method('getAttribute')->willReturn('my-id-token');
+
+        $event = new LogoutEvent(Request::create('/logout'), $token);
+        $dispatcher->dispatch($event);
+
+        $response = $event->getResponse();
+        $this->assertInstanceOf(RedirectResponse::class, $response);
+        $this->assertStringStartsWith('https://provider.example.com/logout?', $response->getTargetUrl());
+        // the listeners decorating the response, like Clear-Site-Data, act on the final one
+        $this->assertTrue($response->headers->has('Clear-Site-Data'));
+    }
+
+    public function testOnLogoutKeepsTheQueryStringOfTheEndSessionEndpoint()
+    {
+        $discovery = $this->createDiscovery([
+            'end_session_endpoint' => 'https://provider.example.com/logout?tenant=acme',
+        ]);
+
+        $listener = new OidcEndSessionListener($discovery, new HttpUtils(), '/');
+
+        $token = $this->createStub(TokenInterface::class);
+        $token->method('hasAttribute')->willReturn(true);
+        $token->method('getAttribute')->willReturn('my-id-token');
+
+        $event = new LogoutEvent(Request::create('/logout'), $token);
+        $listener->onLogout($event);
+
+        $url = $event->getResponse()->getTargetUrl();
+        $this->assertStringStartsWith('https://provider.example.com/logout?tenant=acme&id_token_hint=', $url);
+    }
+
+    public function testOnLogoutFallsBackToLocalLogoutWhenEndSessionEndpointIsNotHttps()
+    {
+        $discovery = $this->createDiscovery([
+            'end_session_endpoint' => 'http://provider.example.com/logout',
+        ]);
+
+        $listener = new OidcEndSessionListener($discovery, new HttpUtils(), '/');
+
+        $token = $this->createStub(TokenInterface::class);
+        $token->method('hasAttribute')->willReturn(true);
+        $token->method('getAttribute')->willReturn('my-id-token');
+
+        $event = new LogoutEvent(Request::create('/logout'), $token);
+        $listener->onLogout($event);
+
+        $this->assertNull($event->getResponse());
+    }
+
+    /**
+     * @param array<string, mixed> $configuration
+     */
+    private function createDiscovery(array $configuration): OidcDiscovery
+    {
+        return new OidcDiscovery(
+            new MockHttpClient(static fn (): MockResponse => new JsonMockResponse($configuration)),
+            new ArrayAdapter(),
+            'https://provider.example.com/.well-known/openid-configuration',
+        );
+    }
+
+    /**
+     * A discovery whose HTTP client fails the test if the document is ever fetched.
+     */
+    private function createNeverQueriedDiscovery(): OidcDiscovery
+    {
+        return new OidcDiscovery(
+            new MockHttpClient(static fn (): MockResponse => throw new \LogicException('The discovery document must not be fetched.')),
+            new ArrayAdapter(),
+            'https://provider.example.com/.well-known/openid-configuration',
+        );
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Two follow-ups to the `oidc_login` authenticator, kept as two commits.

**Claims source and user-identifier mapping** (`user_data_source`, `user_identifier_claim`)

The authenticator always fetched the user claims from the UserInfo endpoint and always took `sub` as the identity. Some providers put everything in the ID token and expose no useful UserInfo endpoint, and some deployments key their users on another claim.

- `user_data_source`: `userinfo` (default, unchanged) or `id_token` to read the claims from the ID token instead. With `id_token`, the provider no longer has to announce a `userinfo_endpoint` in its discovery document at all.
- `user_identifier_claim`: the claim the `UserBadge` identifier is read from, `sub` by default. A missing, empty or non-string claim fails the authentication; it never produces an empty identifier. `sub` is the only claim OIDC guarantees stable and unique, so any other choice must be a claim that is unique, verified and stable at the provider.

The `sub` of the ID token is still required and still validated in both modes; the UserInfo/ID token `sub` match of OIDC Core 1.0, Section 5.3.2 is checked whenever the claims come from UserInfo. `OidcUserProvider` now builds the `OidcUser` on the identifier the authenticator validated, rather than on a claim picked out of the attributes, so configuring another identifier claim cannot be turned into an identity swap.

**RP-Initiated Logout** (`enable_end_session`, `post_logout_redirect_path`)

Logging out currently ends the session in the application only: the user stays logged in at the provider and is logged straight back in on the next protected page. `OidcEndSessionListener` redirects to the `end_session_endpoint` the provider announces, with the ID token as `id_token_hint` and `post_logout_redirect_uri` built from `post_logout_redirect_path` (`null` disables the parameter; the option is ignored while `enable_end_session` is false).

- Disabled by default (`enable_end_session: false`), as not every provider announces an `end_session_endpoint`; the listener is only registered when it is turned on.
- The listener runs at priority 65 and only sets a response when no earlier listener did: a custom logout listener keeps precedence, and decorating listeners such as Clear-Site-Data act on the final response.
- When the provider is unreachable or announces no usable (HTTPS) `end_session_endpoint`, the logout completes locally and a warning is logged, so a broken single-logout never blocks logging out of the application.
- The optional end-session `state` round-trip and the `client_id` parameter are not implemented: `id_token_hint` is always sent, and the post-logout target is a page of the application itself.

**Known caveat: apps using symfony/ux-turbo**

RP-Initiated Logout may break on Symfony apps with ux-turbo installed and enabled. Turbo intercepts network calls, and the logout is a chain of redirections: the clicked link leads to the Symfony app, which logs the user out, then redirects to the IdP, which logs the user out there, then redirects back to the now unauthenticated app. Turbo does not handle that chain by default, so the redirection to the IdP is not effective. The logout link or form needs to opt out of Turbo (e.g. `data-turbo="false"`) so the chain runs as full page navigations. This belongs in the documentation next to the option.

Documentation: symfony/symfony-docs#22881 covers the whole authenticator and will be extended with both options once this lands.
