### PR TITLE
[Console] Do not evaluate the command line in the zsh completion

### DIFF
--- a/src/Symfony/Component/Console/Resources/completion.zsh
+++ b/src/Symfony/Component/Console/Resources/completion.zsh
@@ -15,8 +15,8 @@
 #   - https://github.com/symfony/symfony/blob/5.4/src/Symfony/Component/Console/Resources/completion.bash
 #
 _sf_{{ COMMAND_NAME }}() {
-    local lastParam flagPrefix requestComp out comp
-    local -a completions
+    local lastParam out comp sf_cmd
+    local -a completions flagPrefix requestComp inputs
 
     # The user could have moved the cursor backwards on the command-line.
     # We need to trigger completion from the $CURRENT location, so we need
@@ -29,11 +29,20 @@ _sf_{{ COMMAND_NAME }}() {
     setopt local_options BASH_REMATCH
     if [[ "${lastParam}" =~ '-.*=' ]]; then
         # We are dealing with a flag with an =
-        flagPrefix="-P ${BASH_REMATCH}"
+        flagPrefix=(-P "${BASH_REMATCH}")
     fi
 
-    # Prepare the command to obtain completions
-    requestComp="${words[0]} ${words[1]} _complete --no-interaction -szsh -a{{ VERSION }} -c$((CURRENT-1))" i=""
+    # Prepare the command to obtain completions. An alias is resolved here,
+    # because the request is no longer read again by the shell.
+    sf_cmd="${words[1]}"
+    if [[ -n "${aliases[$sf_cmd]}" ]]; then
+        requestComp=(${(z)aliases[$sf_cmd]})
+    else
+        requestComp=("$sf_cmd")
+    fi
+
+    requestComp+=(_complete --no-interaction -szsh -a{{ VERSION }} "-c$((CURRENT-1))")
+
     for w in ${words[@]}; do
         w=$(printf -- '%b' "$w")
         # remove quotes from typed values
@@ -47,19 +56,18 @@ _sf_{{ COMMAND_NAME }}() {
         fi
         # empty values are ignored
         if [ ! -z "$w" ]; then
-            i="${i}-i${w} "
+            inputs+=("-i$w")
         fi
     done
 
     # Ensure at least 1 input
-    if [ "${i}" = "" ]; then
-        requestComp="${requestComp} -i\" \""
-    else
-        requestComp="${requestComp} ${i}"
+    if (( ! $#inputs )); then
+        inputs=(-i' ')
     fi
 
-    # Use eval to handle any environment variables and such
-    out=$(eval SHELL_VERBOSITY=0 ${requestComp} 2>/dev/null)
+    # The request is run without being read again by the shell, so that a
+    # "$(...)" or a backtick typed on the command line is not executed
+    out=$(SHELL_VERBOSITY=0 "${requestComp[@]}" "${inputs[@]}" 2>/dev/null)
 
     while IFS='\n' read -r comp; do
         if [ -n "$comp" ]; then
@@ -75,7 +83,7 @@ _sf_{{ COMMAND_NAME }}() {
     done < <(printf "%s\n" "${out[@]}")
 
     # Let inbuilt _describe handle completions
-    eval _describe "completions" completions $flagPrefix
+    _describe "completions" completions "${flagPrefix[@]}"
     return $?
 }
 

--- a/src/Symfony/Component/Console/Resources/completion.zsh
+++ b/src/Symfony/Component/Console/Resources/completion.zsh
@@ -38,7 +38,7 @@ _sf_{{ COMMAND_NAME }}() {
     if [[ -n "${aliases[$sf_cmd]}" ]]; then
         requestComp=(${(z)aliases[$sf_cmd]})
     else
-        requestComp=("$sf_cmd")
+        requestComp=(${~sf_cmd})
     fi
 
     requestComp+=(_complete --no-interaction -szsh -a{{ VERSION }} "-c$((CURRENT-1))")

--- a/src/Symfony/Component/Console/Tests/shell-completion/run.sh
+++ b/src/Symfony/Component/Console/Tests/shell-completion/run.sh
@@ -145,6 +145,54 @@ test_alias() {
     fi
 }
 
+# The command may be reached through a path starting with a tilde. Only zsh expands
+# it: the bash script looks the command up without expanding the tilde.
+test_tilde_path() {
+    local home="$tmp/home" actual
+
+    mkdir -p "$home/bin"
+    ln -sf "$dir/app" "$home/bin/app"
+
+    actual="$(HOME="$home" zsh "$dir/drivers/zsh.zsh" "$tmp/completion.zsh" '~/bin/app --ans' 2> "$tmp/case.err" | normalize)"
+
+    if [ "$actual" = '--ansi' ]; then
+        pass "[zsh] completion through a tilde path"
+    else
+        fail "[zsh] completion through a tilde path" "expected:" "--ansi" "actual:" "${actual:-<none>}" "$(cat "$tmp/case.err")"
+    fi
+}
+
+# The completion must not run the code the user is typing. The payload is put in a
+# word the cursor is not on: zsh expands the word being completed on its own, for
+# every command, so that one says nothing about the completion script.
+test_no_command_execution() {
+    local shell="$1" driver payload name
+    local marker="$tmp/pwned"
+
+    case "$shell" in
+        bash) driver=(bash "$dir/drivers/bash.sh") ;;
+        zsh) driver=(zsh "$dir/drivers/zsh.zsh") ;;
+        fish) driver=(fish "$dir/drivers/fish.fish") ;;
+    esac
+
+    # a payload must not contain a space: the zsh script re-splits the words, which
+    # breaks it apart and neutralises it by accident, turning the case into a no-op
+    for payload in "\$(>$marker)" "\`>$marker\`"; do
+        name="[$shell] a command substitution on the line is not executed: $payload"
+        rm -f "$marker"
+
+        "${driver[@]}" "$tmp/completion.$shell" "app demo:hello $payload --format=" > /dev/null 2>&1
+
+        if [ -e "$marker" ]; then
+            fail "$name" "the completion executed the command substitution"
+        else
+            pass "$name"
+        fi
+    done
+
+    rm -f "$marker"
+}
+
 for shell in $shells; do
     if ! command -v "$shell" > /dev/null; then
         skipped=$((skipped + 1))
@@ -171,10 +219,15 @@ for shell in $shells; do
 
     test_alias "$shell" 'an alias' 'sfa=app'
     test_alias "$shell" 'an alias with arguments' 'sfb=app --no-ansi'
+    test_no_command_execution "$shell"
 
     if [ "$shell" = "bash" ]; then
         test_api_version
         test_missing_bash_completion
+    fi
+
+    if [ "$shell" = "zsh" ]; then
+        test_tilde_path
     fi
 done
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The zsh completion script assembles the request from the raw words of the command line and passes it to `eval`, so a command substitution present in a word is executed when the user presses TAB:

```zsh
requestComp="${words[0]} ${words[1]} _complete --no-interaction -szsh -a1 -c$((CURRENT-1))" i=""
for w in ${words[@]}; do
    ...
    i="${i}-i${w} "
done
...
out=$(eval SHELL_VERBOSITY=0 ${requestComp} 2>/dev/null)
```

A second `eval`, the one passing `flagPrefix` to `_describe`, does the same for the `--option=value` form. Unchanged since the script was added in v6.2.0. bash and fish are not concerned, both build the request as an array.

### What this actually changes

zsh expands the word under the cursor by itself, for every command. With no completion system loaded at all, `ls $(>/tmp/pwned)<TAB>` creates the file, and so does a command whose completion function is `return 1`. That is the shell, not us, and no completion script can prevent it.

What the `eval` adds is expansion of the **other** words of the line, which zsh does not do. Measured by pressing TAB in a real zsh:

| Line, TAB at the end | stock zsh (`ls`, `git`) | 6.4 | this PR |
| --- | --- | --- | --- |
| payload under the cursor, `… --foo=$(>/tmp/pwned)` | executed | executed | executed |
| payload in an earlier word, `… $(>/tmp/pwned) --foo=` | not executed | **executed** | not executed |

So this is a hardening, not a vulnerability: it brings the script in line with what the shell does anyway, and with what bash and fish already do. It does not make a pasted command safe to complete, since the word under the cursor is expanded regardless of the completion.

For the record, the same `eval` is in [cobra's zsh template](https://github.com/spf13/cobra/blob/main/zsh_completions.go), which this script is derived from.

### The fix

The request is run as an array of arguments, and `_describe` is called directly:

```zsh
out=$(SHELL_VERBOSITY=0 "${requestComp[@]}" "${inputs[@]}" 2>/dev/null)
...
_describe "completions" completions "${flagPrefix[@]}"
```

Two things the `eval` was providing as a side effect had to be restored explicitly, since the shell no longer re-reads the request:

* **aliases**, resolved through the `aliases` associative array of `zsh/parameter`, which zsh loads by default. This is what the bash script already does with `type`/`alias`;
* **tilde paths**, kept with `requestComp=(${~sf_cmd})`. Without it `~/bin/app <TAB>` silently stops completing, because the array quotes the tilde away.

Environment variables typed on the line are no longer expanded before the words are sent to the application, `--env=$SOME_VAR` now arrives literally. That expansion is the defect itself, so it goes.

### Tests

Three cases are added to `Tests/shell-completion`, on top of the existing suite:

* two assert that a command substitution on the line is not run. The payload sits in a word the cursor is not on, since the word being completed says nothing about the script. It must also contain no space, or the word re-splitting breaks it apart and the case quietly becomes a no-op;
* one keeps a tilde path completing. It passes on 6.4, and fails on the fix without `${~sf_cmd}`.

Suite is green: 42 zsh, 43 bash. The alias cases added by #65816 cover the `$aliases` resolution.
