### PR TITLE
[Mailer] Add RemoteTemplateEmail support to the remaining bridges with provider-hosted templates

### DIFF
--- a/UPGRADE-8.2.md
+++ b/UPGRADE-8.2.md
@@ -102,6 +102,9 @@ Mailer
 ------
 
  * [AhaSend] Deprecate sending through the legacy v1 API, use a v2 API key and add your account id to the DSN
+ * [Brevo] Deprecate the "templateid" and "params" email headers, use a `RemoteTemplateEmail` instead
+ * [Mailgun] Deprecate the "template" email header, use a `RemoteTemplateEmail` instead
+ * [Mailjet] Deprecate the "X-MJ-TemplateID" email header, use a `RemoteTemplateEmail` instead
  * Deprecate sending an S/MIME message unencrypted when a recipient has no certificate (the default
    `SmimeEncryptedMessageListener::ON_MISSING_CERTIFICATE_SEND_UNENCRYPTED` behavior); it will throw in 9.0.
    Set the `on_missing_certificate` option (or the `X-SMime-Encrypt` header) to `fail`, `encrypt` or `skip`:
@@ -197,11 +200,6 @@ SecurityBundle
    `setFirewallName()` for success handlers, to the service it decorates whenever that service relies on them,
    as `DefaultAuthenticationSuccessHandler` and `DefaultAuthenticationFailureHandler` do. Without forwarding,
    the authenticator options and the session target path are lost, and a successful login redirects to `/`
-
-Mailer
-------
-
- * Deprecate the "templateid" and "params" email headers in the Brevo bridge, use a `RemoteTemplateEmail` instead
 
 Serializer
 ----------

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add support for `RemoteTemplateEmail` to `SesApiAsyncAwsTransport`
+
 8.1
 ---
 

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesApiAsyncAwsTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesApiAsyncAwsTransportTest.php
@@ -21,7 +21,9 @@ use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Mailer\Bridge\Amazon\Transport\SesApiAsyncAwsTransport;
 use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Exception\HttpTransportException;
+use Symfony\Component\Mailer\Exception\InvalidArgumentException;
 use Symfony\Component\Mailer\Header\MetadataHeader;
+use Symfony\Component\Mailer\RemoteTemplateEmail;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
 use Symfony\Component\Mime\RawMessage;
@@ -191,6 +193,71 @@ class SesApiAsyncAwsTransportTest extends TestCase
         $message = $transport->send($mail);
 
         $this->assertSame('foobar', $message->getMessageId());
+    }
+
+    public function testSendRemoteTemplate()
+    {
+        $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
+            $this->assertSame('POST', $method);
+            $this->assertSame('https://email.us-east-1.amazonaws.com/v2/email/outbound-emails', $url);
+
+            $content = json_decode($options['body'], true);
+
+            $this->assertSame('welcome', $content['Content']['Template']['TemplateName']);
+            $this->assertSame('{"firstName":"Fabien"}', $content['Content']['Template']['TemplateData']);
+            $this->assertSame([['Name' => 'X-Custom-Header', 'Value' => 'foobar']], $content['Content']['Template']['Headers']);
+            $this->assertArrayNotHasKey('Simple', $content['Content']);
+
+            $json = '{"MessageId": "foobar"}';
+
+            return new MockResponse($json, [
+                'http_code' => 200,
+            ]);
+        });
+
+        $transport = new SesApiAsyncAwsTransport(new SesClient(Configuration::create(['sharedConfigFile' => false]), new NullProvider(), $client));
+
+        $mail = (new RemoteTemplateEmail())
+            ->to(new Address('saif.gmati@symfony.com', 'Saif Eddin'))
+            ->from(new Address('fabpot@symfony.com', 'Fabien'))
+            ->template('welcome', ['firstName' => 'Fabien']);
+        $mail->getHeaders()->addTextHeader('X-Custom-Header', 'foobar');
+
+        $message = $transport->send($mail);
+
+        $this->assertSame('foobar', $message->getMessageId());
+    }
+
+    public function testRemoteTemplateRejectsSubject()
+    {
+        $transport = new SesApiAsyncAwsTransport(new SesClient(Configuration::create(['sharedConfigFile' => false]), new NullProvider(), new MockHttpClient()));
+
+        $mail = (new RemoteTemplateEmail())
+            ->to(new Address('saif.gmati@symfony.com', 'Saif Eddin'))
+            ->from(new Address('fabpot@symfony.com', 'Fabien'))
+            ->subject('Hello!')
+            ->template('welcome');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Amazon SES does not support overriding the subject of a template; define the subject in the template itself.');
+
+        $transport->send($mail);
+    }
+
+    public function testRemoteTemplateRejectsAttachments()
+    {
+        $transport = new SesApiAsyncAwsTransport(new SesClient(Configuration::create(['sharedConfigFile' => false]), new NullProvider(), new MockHttpClient()));
+
+        $mail = (new RemoteTemplateEmail())
+            ->to(new Address('saif.gmati@symfony.com', 'Saif Eddin'))
+            ->from(new Address('fabpot@symfony.com', 'Fabien'))
+            ->template('welcome')
+            ->attach('some attachment', 'attachment.txt');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The Amazon SES API does not support attachments when using a remote template.');
+
+        $transport->send($mail);
     }
 
     public function testSendThrowsForErrorResponse()

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesApiAsyncAwsTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesApiAsyncAwsTransport.php
@@ -14,10 +14,13 @@ namespace Symfony\Component\Mailer\Bridge\Amazon\Transport;
 use AsyncAws\Ses\Input\SendEmailRequest;
 use AsyncAws\Ses\ValueObject\Content;
 use Symfony\Component\Mailer\Envelope;
+use Symfony\Component\Mailer\Exception\InvalidArgumentException;
 use Symfony\Component\Mailer\Exception\LogicException;
 use Symfony\Component\Mailer\Exception\RuntimeException;
 use Symfony\Component\Mailer\Header\MetadataHeader;
+use Symfony\Component\Mailer\RemoteTemplateEmail;
 use Symfony\Component\Mailer\SentMessage;
+use Symfony\Component\Mailer\Transport\RemoteTemplateTransportInterface;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
 use Symfony\Component\Mime\Header\Headers;
@@ -27,7 +30,7 @@ use Symfony\Component\Mime\MessageConverter;
 /**
  * @author Jérémy Derussé <jeremy@derusse.com>
  */
-class SesApiAsyncAwsTransport extends SesHttpAsyncAwsTransport
+class SesApiAsyncAwsTransport extends SesHttpAsyncAwsTransport implements RemoteTemplateTransportInterface
 {
     public function __toString(): string
     {
@@ -57,7 +60,13 @@ class SesApiAsyncAwsTransport extends SesHttpAsyncAwsTransport
             throw new RuntimeException(\sprintf('Unable to send message with the "%s" transport: ', __CLASS__).$e->getMessage(), 0, $e);
         }
 
+        $template = $email instanceof RemoteTemplateEmail ? $email->getRemoteTemplate() : null;
+
         if ($email->getAttachments()) {
+            if (null !== $template) {
+                throw new InvalidArgumentException('The Amazon SES API does not support attachments when using a remote template.');
+            }
+
             return parent::getRequest($message);
         }
 
@@ -68,7 +77,19 @@ class SesApiAsyncAwsTransport extends SesHttpAsyncAwsTransport
             'Destination' => [
                 'ToAddresses' => $this->stringifyAddresses($this->getRecipients($email, $envelope)),
             ],
-            'Content' => [
+        ];
+        if (null !== $template) {
+            if (null !== $email->getSubject()) {
+                throw new InvalidArgumentException('Amazon SES does not support overriding the subject of a template; define the subject in the template itself.');
+            }
+            $request['Content'] = [
+                'Template' => [
+                    'TemplateName' => $template->getReference(),
+                    'TemplateData' => json_encode($template->getVariables() ?: new \stdClass(), \JSON_THROW_ON_ERROR),
+                ],
+            ];
+        } else {
+            $request['Content'] = [
                 'Simple' => [
                     'Subject' => [
                         'Data' => $email->getSubject(),
@@ -76,8 +97,8 @@ class SesApiAsyncAwsTransport extends SesHttpAsyncAwsTransport
                     ],
                     'Body' => [],
                 ],
-            ],
-        ];
+            ];
+        }
 
         if ($emails = $email->getCc()) {
             $request['Destination']['CcAddresses'] = $this->stringifyAddresses($emails);
@@ -116,7 +137,11 @@ class SesApiAsyncAwsTransport extends SesHttpAsyncAwsTransport
         }
 
         if ($customHeaders = $this->getCustomHeaders($email->getHeaders())) {
-            $request['Content']['Simple']['Headers'] = $customHeaders;
+            if (null !== $template) {
+                $request['Content']['Template']['Headers'] = $customHeaders;
+            } else {
+                $request['Content']['Simple']['Headers'] = $customHeaders;
+            }
         }
 
         foreach ($email->getHeaders()->all() as $header) {

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.4.1",
         "async-aws/ses": "^1.8",
-        "symfony/mailer": "^7.4|^8.0"
+        "symfony/mailer": "^8.2"
     },
     "require-dev": {
         "symfony/http-client": "^7.4|^8.0"

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.2
 ---
 
+ * Add support for `RemoteTemplateEmail` to `MandrillApiTransport`
  * Add support for specifying the return path domain using the `X-MC-ReturnPathDomain` header
 
 7.4

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Transport/MandrillApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Transport/MandrillApiTransportTest.php
@@ -21,6 +21,7 @@ use Symfony\Component\Mailer\Exception\HttpTransportException;
 use Symfony\Component\Mailer\Header\MetadataHeader;
 use Symfony\Component\Mailer\Header\TagHeader;
 use Symfony\Component\Mailer\Header\TrackingHeader;
+use Symfony\Component\Mailer\RemoteTemplateEmail;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
 use Symfony\Component\Mime\Part\DataPart;
@@ -130,6 +131,53 @@ class MandrillApiTransportTest extends TestCase
         $message = $transport->send($mail);
 
         $this->assertSame('foobar', $message->getMessageId());
+    }
+
+    public function testSendRemoteTemplate()
+    {
+        $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
+            $this->assertSame('POST', $method);
+            $this->assertSame('https://mandrillapp.com/api/1.0/messages/send-template.json', $url);
+
+            $body = json_decode($options['body'], true);
+            $this->assertSame('welcome', $body['template_name']);
+            $this->assertSame([], $body['template_content']);
+            $this->assertSame([['name' => 'firstName', 'content' => 'Fabien']], $body['message']['global_merge_vars']);
+            $this->assertArrayNotHasKey('subject', $body['message']);
+            $this->assertNull($body['message']['html']);
+            $this->assertNull($body['message']['text']);
+
+            return new JsonMockResponse([['_id' => 'foobar']], [
+                'http_code' => 200,
+            ]);
+        });
+
+        $transport = new MandrillApiTransport('KEY', $client);
+
+        $mail = (new RemoteTemplateEmail())
+            ->to(new Address('saif.gmati@symfony.com', 'Saif Eddin'))
+            ->from(new Address('fabpot@symfony.com', 'Fabien'))
+            ->template('welcome', ['firstName' => 'Fabien']);
+
+        $message = $transport->send($mail);
+
+        $this->assertSame('foobar', $message->getMessageId());
+    }
+
+    public function testRemoteTemplateWithSubject()
+    {
+        $email = (new RemoteTemplateEmail())
+            ->subject('Hello!')
+            ->template('welcome');
+        $envelope = new Envelope(new Address('fabpot@symfony.com', 'Fabien'), [new Address('saif.gmati@symfony.com', 'Saif Eddin')]);
+
+        $transport = new MandrillApiTransport('KEY');
+        $method = new \ReflectionMethod(MandrillApiTransport::class, 'getPayload');
+        $payload = $method->invoke($transport, $email, $envelope);
+
+        $this->assertSame('welcome', $payload['template_name']);
+        $this->assertSame('Hello!', $payload['message']['subject']);
+        $this->assertArrayNotHasKey('global_merge_vars', $payload['message']);
     }
 
     public function testSendThrowsForErrorResponse()

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Transport/MandrillApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Transport/MandrillApiTransport.php
@@ -18,8 +18,10 @@ use Symfony\Component\Mailer\Exception\HttpTransportException;
 use Symfony\Component\Mailer\Header\MetadataHeader;
 use Symfony\Component\Mailer\Header\TagHeader;
 use Symfony\Component\Mailer\Header\TrackingHeader;
+use Symfony\Component\Mailer\RemoteTemplateEmail;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\AbstractApiTransport;
+use Symfony\Component\Mailer\Transport\RemoteTemplateTransportInterface;
 use Symfony\Component\Mime\Email;
 use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
@@ -29,7 +31,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 /**
  * @author Kevin Verschaeve
  */
-class MandrillApiTransport extends AbstractApiTransport
+class MandrillApiTransport extends AbstractApiTransport implements RemoteTemplateTransportInterface
 {
     private const HOST = 'mandrillapp.com';
 
@@ -49,7 +51,8 @@ class MandrillApiTransport extends AbstractApiTransport
 
     protected function doSendApi(SentMessage $sentMessage, Email $email, Envelope $envelope): ResponseInterface
     {
-        $response = $this->client->request('POST', 'https://'.$this->getEndpoint().'/api/1.0/messages/send.json', [
+        $endpoint = $email instanceof RemoteTemplateEmail && null !== $email->getRemoteTemplate() ? 'send-template' : 'send';
+        $response = $this->client->request('POST', 'https://'.$this->getEndpoint().'/api/1.0/messages/'.$endpoint.'.json', [
             'json' => $this->getPayload($email, $envelope),
         ]);
 
@@ -83,16 +86,28 @@ class MandrillApiTransport extends AbstractApiTransport
 
     private function getPayload(Email $email, Envelope $envelope): array
     {
+        $template = $email instanceof RemoteTemplateEmail ? $email->getRemoteTemplate() : null;
+
         $payload = [
             'key' => $this->key,
             'message' => [
                 'html' => $email->getHtmlBody(),
                 'text' => $email->getTextBody(),
-                'subject' => $email->getSubject(),
-                'from_email' => $envelope->getSender()->getAddress(),
-                'to' => $this->getRecipientsPayload($email, $envelope),
             ],
         ];
+        if (null === $template || null !== $email->getSubject()) {
+            $payload['message']['subject'] = $email->getSubject();
+        }
+        $payload['message']['from_email'] = $envelope->getSender()->getAddress();
+        $payload['message']['to'] = $this->getRecipientsPayload($email, $envelope);
+
+        if (null !== $template) {
+            $payload['template_name'] = $template->getReference();
+            $payload['template_content'] = [];
+            foreach ($template->getVariables() as $name => $content) {
+                $payload['message']['global_merge_vars'][] = ['name' => $name, 'content' => $content];
+            }
+        }
 
         if ($email->getHeaders()->get('X-MC-Subaccount')) {
             $payload['message']['subaccount'] = $email->getHeaders()->get('X-MC-Subaccount')->getBodyAsString();

--- a/src/Symfony/Component/Mailer/Bridge/MailerSend/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/Bridge/MailerSend/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.2
 ---
 
+ * Add support for `RemoteTemplateEmail` to `MailerSendApiTransport`
  * Add support for `TagHeader` in the API and SMTP transports
 
 7.1

--- a/src/Symfony/Component/Mailer/Bridge/MailerSend/Tests/Transport/MailerSendApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/MailerSend/Tests/Transport/MailerSendApiTransportTest.php
@@ -22,6 +22,7 @@ use Symfony\Component\Mailer\Exception\HttpTransportException;
 use Symfony\Component\Mailer\Exception\TransportException;
 use Symfony\Component\Mailer\Header\TagHeader;
 use Symfony\Component\Mailer\Header\TrackingHeader;
+use Symfony\Component\Mailer\RemoteTemplateEmail;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
 use Symfony\Component\Mime\Part\DataPart;
@@ -128,6 +129,39 @@ class MailerSendApiTransportTest extends TestCase
         $message = $transport->send($mail);
 
         $this->assertSame('test_message_id', $message->getMessageId());
+    }
+
+    public function testRemoteTemplate()
+    {
+        $email = (new RemoteTemplateEmail())
+            ->template('tpl_123', ['firstName' => 'Fabien']);
+        $envelope = new Envelope(new Address('alice@system.com', 'Alice'), [new Address('bob@system.com', 'Bob')]);
+
+        $transport = new MailerSendApiTransport('ACCESS_KEY');
+        $method = new \ReflectionMethod(MailerSendApiTransport::class, 'getPayload');
+        $payload = $method->invoke($transport, $email, $envelope);
+
+        $this->assertSame('tpl_123', $payload['template_id']);
+        $this->assertSame([['email' => 'bob@system.com', 'data' => ['firstName' => 'Fabien']]], $payload['personalization']);
+        $this->assertArrayNotHasKey('subject', $payload);
+        $this->assertArrayNotHasKey('text', $payload);
+        $this->assertArrayNotHasKey('html', $payload);
+    }
+
+    public function testRemoteTemplateWithSubject()
+    {
+        $email = (new RemoteTemplateEmail())
+            ->subject('Hello!')
+            ->template('tpl_123');
+        $envelope = new Envelope(new Address('alice@system.com', 'Alice'), [new Address('bob@system.com', 'Bob')]);
+
+        $transport = new MailerSendApiTransport('ACCESS_KEY');
+        $method = new \ReflectionMethod(MailerSendApiTransport::class, 'getPayload');
+        $payload = $method->invoke($transport, $email, $envelope);
+
+        $this->assertSame('Hello!', $payload['subject']);
+        $this->assertSame('tpl_123', $payload['template_id']);
+        $this->assertArrayNotHasKey('personalization', $payload);
     }
 
     public function testSendThrowsForErrorResponse()

--- a/src/Symfony/Component/Mailer/Bridge/MailerSend/Transport/MailerSendApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/MailerSend/Transport/MailerSendApiTransport.php
@@ -19,8 +19,10 @@ use Symfony\Component\Mailer\Exception\HttpTransportException;
 use Symfony\Component\Mailer\Exception\TransportException;
 use Symfony\Component\Mailer\Header\TagHeader;
 use Symfony\Component\Mailer\Header\TrackingHeader;
+use Symfony\Component\Mailer\RemoteTemplateEmail;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\AbstractApiTransport;
+use Symfony\Component\Mailer\Transport\RemoteTemplateTransportInterface;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
@@ -30,7 +32,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 /**
  * @see https://developers.mailersend.com/api/v1/email.html
  */
-final class MailerSendApiTransport extends AbstractApiTransport
+final class MailerSendApiTransport extends AbstractApiTransport implements RemoteTemplateTransportInterface
 {
     public function __construct(
         #[\SensitiveParameter] private string $key,
@@ -87,15 +89,25 @@ final class MailerSendApiTransport extends AbstractApiTransport
     private function getPayload(Email $email, Envelope $envelope): array
     {
         $sender = $envelope->getSender();
+        $template = $email instanceof RemoteTemplateEmail ? $email->getRemoteTemplate() : null;
+        $recipients = $this->getRecipients($email, $envelope);
 
         $payload = [
             'from' => array_filter([
                 'email' => $sender->getAddress(),
                 'name' => $sender->getName(),
             ]),
-            'to' => $this->prepareAddresses($this->getRecipients($email, $envelope)),
-            'subject' => $email->getSubject(),
+            'to' => $this->prepareAddresses($recipients),
         ];
+        if (null === $template || null !== $email->getSubject()) {
+            $payload['subject'] = $email->getSubject();
+        }
+        if (null !== $template) {
+            $payload['template_id'] = $template->getReference();
+            if ($variables = $template->getVariables()) {
+                $payload['personalization'] = array_map(static fn ($recipient) => ['email' => $recipient->getAddress(), 'data' => $variables], $recipients);
+            }
+        }
 
         if ($attachments = $this->prepareAttachments($email)) {
             $payload['attachments'] = $attachments;

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add support for `RemoteTemplateEmail` to `MailgunApiTransport`
+ * Deprecate the "template" email header, use a `RemoteTemplateEmail` instead
+
 6.1
 ---
 

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Transport/MailgunApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Transport/MailgunApiTransportTest.php
@@ -12,7 +12,10 @@
 namespace Symfony\Component\Mailer\Bridge\Mailgun\Tests\Transport;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectUserDeprecationMessageTrait;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\JsonMockResponse;
 use Symfony\Component\HttpClient\Response\MockResponse;
@@ -22,6 +25,7 @@ use Symfony\Component\Mailer\Exception\HttpTransportException;
 use Symfony\Component\Mailer\Header\MetadataHeader;
 use Symfony\Component\Mailer\Header\TagHeader;
 use Symfony\Component\Mailer\Header\TrackingHeader;
+use Symfony\Component\Mailer\RemoteTemplateEmail;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
 use Symfony\Component\Mime\Part\DataPart;
@@ -29,6 +33,8 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class MailgunApiTransportTest extends TestCase
 {
+    use ExpectUserDeprecationMessageTrait;
+
     #[DataProvider('getTransportData')]
     public function testToString(MailgunApiTransport $transport, string $expected)
     {
@@ -57,6 +63,56 @@ class MailgunApiTransportTest extends TestCase
         ];
     }
 
+    public function testRemoteTemplate()
+    {
+        $email = (new RemoteTemplateEmail())
+            ->template('order-confirmation', ['firstName' => 'Fabien']);
+        $envelope = new Envelope(new Address('alice@system.com', 'Alice'), [new Address('bob@system.com', 'Bob')]);
+
+        $transport = new MailgunApiTransport('ACCESS_KEY', 'symfony');
+        $method = new \ReflectionMethod(MailgunApiTransport::class, 'getPayload');
+        $payload = $method->invoke($transport, $email, $envelope);
+
+        $this->assertSame('order-confirmation', $payload['template']);
+        $this->assertSame('{"firstName":"Fabien"}', $payload['t:variables']);
+        $this->assertArrayNotHasKey('subject', $payload);
+        $this->assertArrayNotHasKey('text', $payload);
+        $this->assertArrayNotHasKey('html', $payload);
+    }
+
+    public function testRemoteTemplateWithSubject()
+    {
+        $email = (new RemoteTemplateEmail())
+            ->subject('Hello!')
+            ->template('order-confirmation');
+        $envelope = new Envelope(new Address('alice@system.com', 'Alice'), [new Address('bob@system.com', 'Bob')]);
+
+        $transport = new MailgunApiTransport('ACCESS_KEY', 'symfony');
+        $method = new \ReflectionMethod(MailgunApiTransport::class, 'getPayload');
+        $payload = $method->invoke($transport, $email, $envelope);
+
+        $this->assertSame('Hello!', $payload['subject']);
+        $this->assertSame('order-confirmation', $payload['template']);
+        $this->assertArrayNotHasKey('t:variables', $payload);
+    }
+
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
+    public function testDeprecatedTemplateHeader()
+    {
+        $this->expectUserDeprecationMessage(\sprintf('Since symfony/mailgun-mailer 8.2: Using the "template" email header to select a Mailgun template is deprecated, use a "%s" instead.', RemoteTemplateEmail::class));
+
+        $email = (new Email())->subject('Hello!');
+        $email->getHeaders()->addTextHeader('template', 'order-confirmation');
+        $envelope = new Envelope(new Address('alice@system.com', 'Alice'), [new Address('bob@system.com', 'Bob')]);
+
+        $transport = new MailgunApiTransport('ACCESS_KEY', 'symfony');
+        $method = new \ReflectionMethod(MailgunApiTransport::class, 'getPayload');
+        $payload = $method->invoke($transport, $email, $envelope);
+
+        $this->assertSame('order-confirmation', $payload['template']);
+    }
+
     public function testCustomHeader()
     {
         $json = json_encode(['foo' => 'bar']);
@@ -70,7 +126,6 @@ class MailgunApiTransportTest extends TestCase
         $email->getHeaders()->addTextHeader('t:text', 'text-value');
         $email->getHeaders()->addTextHeader('o:deliverytime', $deliveryTime);
         $email->getHeaders()->addTextHeader('v:version', 'version-value');
-        $email->getHeaders()->addTextHeader('template', 'template-value');
         $email->getHeaders()->addTextHeader('recipient-variables', 'recipient-variables-value');
         $email->getHeaders()->addTextHeader('amp-html', 'amp-html-value');
 
@@ -91,8 +146,6 @@ class MailgunApiTransportTest extends TestCase
         $this->assertEquals($deliveryTime, $payload['o:deliverytime']);
         $this->assertArrayHasKey('v:version', $payload);
         $this->assertEquals('version-value', $payload['v:version']);
-        $this->assertArrayHasKey('template', $payload);
-        $this->assertEquals('template-value', $payload['template']);
         $this->assertArrayHasKey('recipient-variables', $payload);
         $this->assertEquals('recipient-variables-value', $payload['recipient-variables']);
         $this->assertArrayHasKey('amp-html', $payload);

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunApiTransport.php
@@ -18,8 +18,10 @@ use Symfony\Component\Mailer\Exception\HttpTransportException;
 use Symfony\Component\Mailer\Header\MetadataHeader;
 use Symfony\Component\Mailer\Header\TagHeader;
 use Symfony\Component\Mailer\Header\TrackingHeader;
+use Symfony\Component\Mailer\RemoteTemplateEmail;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\AbstractApiTransport;
+use Symfony\Component\Mailer\Transport\RemoteTemplateTransportInterface;
 use Symfony\Component\Mime\Email;
 use Symfony\Component\Mime\Part\Multipart\FormDataPart;
 use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
@@ -30,7 +32,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 /**
  * @author Kevin Verschaeve
  */
-class MailgunApiTransport extends AbstractApiTransport
+class MailgunApiTransport extends AbstractApiTransport implements RemoteTemplateTransportInterface
 {
     private const HOST = 'api.%region_dot%mailgun.net';
 
@@ -96,14 +98,17 @@ class MailgunApiTransport extends AbstractApiTransport
             $html = stream_get_contents($html);
         }
         [$attachments, $inlines, $html] = $this->prepareAttachments($email, $html);
+        $template = $email instanceof RemoteTemplateEmail ? $email->getRemoteTemplate() : null;
 
         $payload = [
             'from' => $envelope->getSender()->toString(),
             'to' => implode(',', $this->stringifyAddresses($this->getRecipients($email, $envelope))),
-            'subject' => $email->getSubject(),
-            'attachment' => $attachments,
-            'inline' => $inlines,
         ];
+        if (null === $template || null !== $email->getSubject()) {
+            $payload['subject'] = $email->getSubject();
+        }
+        $payload['attachment'] = $attachments;
+        $payload['inline'] = $inlines;
         if ($emails = $email->getCc()) {
             $payload['cc'] = implode(',', $this->stringifyAddresses($emails));
         }
@@ -147,12 +152,22 @@ class MailgunApiTransport extends AbstractApiTransport
             // Check if it is a valid prefix or header name according to Mailgun API
             $prefix = substr($name, 0, 2);
             if (\in_array($prefix, ['h:', 't:', 'o:', 'v:']) || \in_array($name, ['recipient-variables', 'template', 'amp-html'], true)) {
+                if ('template' === $name) {
+                    trigger_deprecation('symfony/mailgun-mailer', '8.2', 'Using the "template" email header to select a Mailgun template is deprecated, use a "%s" instead.', RemoteTemplateEmail::class);
+                }
                 $headerName = $header->getName();
             } else {
                 $headerName = 'h:'.$header->getName();
             }
 
             $payload[$headerName] = $header->getBodyAsString();
+        }
+
+        if (null !== $template) {
+            $payload['template'] = $template->getReference();
+            if ($template->getVariables()) {
+                $payload['t:variables'] = json_encode($template->getVariables(), \JSON_THROW_ON_ERROR);
+            }
         }
 
         return $payload;

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=8.4.1",
+        "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/mailer": "^8.2"
     },
     "require-dev": {

--- a/src/Symfony/Component/Mailer/Bridge/Mailjet/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/Bridge/Mailjet/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add support for `RemoteTemplateEmail` to `MailjetApiTransport`
+ * Deprecate the "X-MJ-TemplateID" email header, use a `RemoteTemplateEmail` instead
+
 6.4
 ---
 

--- a/src/Symfony/Component/Mailer/Bridge/Mailjet/Tests/Transport/MailjetApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailjet/Tests/Transport/MailjetApiTransportTest.php
@@ -12,13 +12,18 @@
 namespace Symfony\Component\Mailer\Bridge\Mailjet\Tests\Transport;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectUserDeprecationMessageTrait;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Mailer\Bridge\Mailjet\Transport\MailjetApiTransport;
 use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Exception\HttpTransportException;
+use Symfony\Component\Mailer\Exception\InvalidArgumentException;
 use Symfony\Component\Mailer\Header\TrackingHeader;
+use Symfony\Component\Mailer\RemoteTemplateEmail;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
@@ -26,6 +31,8 @@ use Symfony\Component\Mime\Part\DataPart;
 
 class MailjetApiTransportTest extends TestCase
 {
+    use ExpectUserDeprecationMessageTrait;
+
     protected const USER = 'u$er';
     protected const PASSWORD = 'pa$s';
 
@@ -302,6 +309,73 @@ class MailjetApiTransportTest extends TestCase
         $method->invoke($transport, $email, $envelope);
     }
 
+    public function testRemoteTemplate()
+    {
+        $email = (new RemoteTemplateEmail())
+            ->template('12345', ['firstName' => 'Fabien']);
+        $envelope = new Envelope(new Address('foo@example.com', 'Foo'), [new Address('bar@example.com', 'Bar')]);
+
+        $transport = new MailjetApiTransport(self::USER, self::PASSWORD);
+        $method = new \ReflectionMethod(MailjetApiTransport::class, 'getPayload');
+        $message = $method->invoke($transport, $email, $envelope)['Messages'][0];
+
+        $this->assertSame(12345, $message['TemplateID']);
+        $this->assertTrue($message['TemplateLanguage']);
+        $this->assertSame(['firstName' => 'Fabien'], $message['Variables']);
+        $this->assertArrayNotHasKey('Subject', $message);
+        $this->assertArrayNotHasKey('TextPart', $message);
+        $this->assertArrayNotHasKey('HTMLPart', $message);
+    }
+
+    public function testRemoteTemplateWithSubject()
+    {
+        $email = (new RemoteTemplateEmail())
+            ->subject('Hello!')
+            ->template('12345');
+        $envelope = new Envelope(new Address('foo@example.com', 'Foo'), [new Address('bar@example.com', 'Bar')]);
+
+        $transport = new MailjetApiTransport(self::USER, self::PASSWORD);
+        $method = new \ReflectionMethod(MailjetApiTransport::class, 'getPayload');
+        $message = $method->invoke($transport, $email, $envelope)['Messages'][0];
+
+        $this->assertSame('Hello!', $message['Subject']);
+        $this->assertSame(12345, $message['TemplateID']);
+    }
+
+    public function testRemoteTemplateWithNonNumericReference()
+    {
+        $email = (new RemoteTemplateEmail())
+            ->template('welcome');
+        $envelope = new Envelope(new Address('foo@example.com', 'Foo'), [new Address('bar@example.com', 'Bar')]);
+
+        $transport = new MailjetApiTransport(self::USER, self::PASSWORD);
+        $method = new \ReflectionMethod(MailjetApiTransport::class, 'getPayload');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The Mailjet API expects a numeric template id, "welcome" given.');
+
+        $method->invoke($transport, $email, $envelope);
+    }
+
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
+    public function testDeprecatedTemplateIdHeader()
+    {
+        $this->expectUserDeprecationMessage(\sprintf('Since symfony/mailjet-mailer 8.2: Using the "X-MJ-TemplateID" email header to select a Mailjet template is deprecated, use a "%s" instead.', RemoteTemplateEmail::class));
+
+        $email = (new Email())->subject('Hello!');
+        $email->getHeaders()->addTextHeader('X-MJ-TemplateID', '12345');
+        $envelope = new Envelope(new Address('foo@example.com', 'Foo'), [new Address('bar@example.com', 'Bar')]);
+
+        $transport = new MailjetApiTransport(self::USER, self::PASSWORD);
+        $method = new \ReflectionMethod(MailjetApiTransport::class, 'getPayload');
+        $message = $method->invoke($transport, $email, $envelope)['Messages'][0];
+
+        $this->assertSame(12345, $message['TemplateID']);
+    }
+
+    #[IgnoreDeprecations]
+    #[Group('legacy')]
     public function testHeaderToMessage()
     {
         $email = (new Email())

--- a/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetApiTransport.php
@@ -15,10 +15,13 @@ use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Exception\HttpTransportException;
+use Symfony\Component\Mailer\Exception\InvalidArgumentException;
 use Symfony\Component\Mailer\Exception\TransportException;
 use Symfony\Component\Mailer\Header\TrackingHeader;
+use Symfony\Component\Mailer\RemoteTemplateEmail;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\AbstractApiTransport;
+use Symfony\Component\Mailer\Transport\RemoteTemplateTransportInterface;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
 use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
@@ -26,7 +29,7 @@ use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
-class MailjetApiTransport extends AbstractApiTransport
+class MailjetApiTransport extends AbstractApiTransport implements RemoteTemplateTransportInterface
 {
     private const HOST = 'api.mailjet.com';
     private const API_VERSION = '3.1';
@@ -113,14 +116,17 @@ class MailjetApiTransport extends AbstractApiTransport
             $html = stream_get_contents($html);
         }
         [$attachments, $inlines, $html] = $this->prepareAttachments($email, $html);
+        $template = $email instanceof RemoteTemplateEmail ? $email->getRemoteTemplate() : null;
 
         $message = [
             'From' => $this->formatAddress($envelope->getSender()),
             'To' => $this->formatAddresses($this->getRecipients($email, $envelope)),
-            'Subject' => $email->getSubject(),
-            'Attachments' => $attachments,
-            'InlinedAttachments' => $inlines,
         ];
+        if (null === $template || null !== $email->getSubject()) {
+            $message['Subject'] = $email->getSubject();
+        }
+        $message['Attachments'] = $attachments;
+        $message['InlinedAttachments'] = $inlines;
         if ($emails = $email->getCc()) {
             $message['Cc'] = $this->formatAddresses($emails);
         }
@@ -152,6 +158,9 @@ class MailjetApiTransport extends AbstractApiTransport
 
         foreach ($email->getHeaders()->all() as $headerName => $header) {
             if ($convertConf = self::HEADER_TO_MESSAGE[$headerName] ?? false) {
+                if ('x-mj-templateid' === $headerName) {
+                    trigger_deprecation('symfony/mailjet-mailer', '8.2', 'Using the "X-MJ-TemplateID" email header to select a Mailjet template is deprecated, use a "%s" instead.', RemoteTemplateEmail::class);
+                }
                 $message[$convertConf[0]] = $this->castCustomHeader($header->getBodyAsString(), $convertConf[1]);
                 continue;
             }
@@ -165,6 +174,17 @@ class MailjetApiTransport extends AbstractApiTransport
             }
 
             $message['Headers'][$header->getName()] = $header->getBodyAsString();
+        }
+
+        if (null !== $template) {
+            if (!ctype_digit($template->getReference())) {
+                throw new InvalidArgumentException(\sprintf('The Mailjet API expects a numeric template id, "%s" given.', $template->getReference()));
+            }
+            $message['TemplateID'] = (int) $template->getReference();
+            $message['TemplateLanguage'] = true;
+            if ($template->getVariables()) {
+                $message['Variables'] = $template->getVariables();
+            }
         }
 
         return [

--- a/src/Symfony/Component/Mailer/Bridge/Mailjet/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Mailjet/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=8.4.1",
+        "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/mailer": "^8.2"
     },
     "require-dev": {

--- a/src/Symfony/Component/Mailer/Bridge/Mailtrap/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/Bridge/Mailtrap/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add support for `RemoteTemplateEmail` to `MailtrapApiTransport`
+
 7.4
 ---
 

--- a/src/Symfony/Component/Mailer/Bridge/Mailtrap/Tests/Transport/MailtrapApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailtrap/Tests/Transport/MailtrapApiTransportTest.php
@@ -18,9 +18,11 @@ use Symfony\Component\HttpClient\Response\JsonMockResponse;
 use Symfony\Component\Mailer\Bridge\Mailtrap\Transport\MailtrapApiTransport;
 use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Exception\HttpTransportException;
+use Symfony\Component\Mailer\Exception\InvalidArgumentException;
 use Symfony\Component\Mailer\Exception\TransportException;
 use Symfony\Component\Mailer\Header\MetadataHeader;
 use Symfony\Component\Mailer\Header\TagHeader;
+use Symfony\Component\Mailer\RemoteTemplateEmail;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
 use Symfony\Contracts\HttpClient\ResponseInterface;
@@ -135,6 +137,55 @@ class MailtrapApiTransportTest extends TestCase
             ->text('Hello There!');
 
         $transport->send($mail);
+    }
+
+    public function testRemoteTemplate()
+    {
+        $email = (new RemoteTemplateEmail())
+            ->template('813e39e9-49b6-4560-a5d9-b7ffb0a5486f', ['firstName' => 'Fabien']);
+        $envelope = new Envelope(new Address('alice@system.com', 'Alice'), [new Address('bob@system.com', 'Bob')]);
+
+        $transport = new MailtrapApiTransport('ACCESS_KEY');
+        $method = new \ReflectionMethod(MailtrapApiTransport::class, 'getPayload');
+        $payload = $method->invoke($transport, $email, $envelope);
+
+        $this->assertSame('813e39e9-49b6-4560-a5d9-b7ffb0a5486f', $payload['template_uuid']);
+        $this->assertSame(['firstName' => 'Fabien'], $payload['template_variables']);
+        $this->assertArrayNotHasKey('subject', $payload);
+        $this->assertArrayNotHasKey('text', $payload);
+        $this->assertArrayNotHasKey('html', $payload);
+    }
+
+    public function testRemoteTemplateRejectsSubject()
+    {
+        $email = (new RemoteTemplateEmail())
+            ->subject('Hello!')
+            ->template('813e39e9-49b6-4560-a5d9-b7ffb0a5486f');
+        $envelope = new Envelope(new Address('alice@system.com', 'Alice'), [new Address('bob@system.com', 'Bob')]);
+
+        $transport = new MailtrapApiTransport('ACCESS_KEY');
+        $method = new \ReflectionMethod(MailtrapApiTransport::class, 'getPayload');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Mailtrap does not support overriding the subject of a template; define the subject in the template itself.');
+
+        $method->invoke($transport, $email, $envelope);
+    }
+
+    public function testRemoteTemplateRejectsCategory()
+    {
+        $email = (new RemoteTemplateEmail())
+            ->template('813e39e9-49b6-4560-a5d9-b7ffb0a5486f');
+        $email->getHeaders()->add(new TagHeader('some-category'));
+        $envelope = new Envelope(new Address('alice@system.com', 'Alice'), [new Address('bob@system.com', 'Bob')]);
+
+        $transport = new MailtrapApiTransport('ACCESS_KEY');
+        $method = new \ReflectionMethod(MailtrapApiTransport::class, 'getPayload');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Mailtrap does not allow a category when using a template; define the category in the template itself.');
+
+        $method->invoke($transport, $email, $envelope);
     }
 
     public function testSendThrowsForErrorResponse()

--- a/src/Symfony/Component/Mailer/Bridge/Mailtrap/Transport/MailtrapApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailtrap/Transport/MailtrapApiTransport.php
@@ -15,11 +15,14 @@ use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Exception\HttpTransportException;
+use Symfony\Component\Mailer\Exception\InvalidArgumentException;
 use Symfony\Component\Mailer\Exception\TransportException;
 use Symfony\Component\Mailer\Header\MetadataHeader;
 use Symfony\Component\Mailer\Header\TagHeader;
+use Symfony\Component\Mailer\RemoteTemplateEmail;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\AbstractApiTransport;
+use Symfony\Component\Mailer\Transport\RemoteTemplateTransportInterface;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
 use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
@@ -30,7 +33,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
-final class MailtrapApiTransport extends AbstractApiTransport
+final class MailtrapApiTransport extends AbstractApiTransport implements RemoteTemplateTransportInterface
 {
     private const LIVE_API_HOST = 'send.api.mailtrap.io';
     private const SANDBOX_API_HOST = 'sandbox.api.mailtrap.io';
@@ -80,16 +83,28 @@ final class MailtrapApiTransport extends AbstractApiTransport
 
     private function getPayload(Email $email, Envelope $envelope): array
     {
+        $template = $email instanceof RemoteTemplateEmail ? $email->getRemoteTemplate() : null;
+
         $payload = [
             'from' => self::encodeEmail($envelope->getSender()),
             'to' => array_map(self::encodeEmail(...), $email->getTo()),
             'cc' => array_map(self::encodeEmail(...), $email->getCc()),
             'bcc' => array_map(self::encodeEmail(...), $email->getBcc()),
-            'subject' => $email->getSubject(),
-            'text' => $email->getTextBody(),
-            'html' => $email->getHtmlBody(),
-            'attachments' => $this->getAttachments($email),
         ];
+        if (null === $template) {
+            $payload['subject'] = $email->getSubject();
+            $payload['text'] = $email->getTextBody();
+            $payload['html'] = $email->getHtmlBody();
+        } else {
+            if (null !== $email->getSubject()) {
+                throw new InvalidArgumentException('Mailtrap does not support overriding the subject of a template; define the subject in the template itself.');
+            }
+            $payload['template_uuid'] = $template->getReference();
+            if ($template->getVariables()) {
+                $payload['template_variables'] = $template->getVariables();
+            }
+        }
+        $payload['attachments'] = $this->getAttachments($email);
 
         foreach ($email->getHeaders()->all() as $name => $header) {
             if (\in_array($name, self::HEADERS_TO_BYPASS, true)) {
@@ -97,6 +112,9 @@ final class MailtrapApiTransport extends AbstractApiTransport
             }
 
             if ($header instanceof TagHeader) {
+                if (null !== $template) {
+                    throw new InvalidArgumentException('Mailtrap does not allow a category when using a template; define the category in the template itself.');
+                }
                 if (isset($payload['category'])) {
                     throw new TransportException('Mailtrap only allows a single category per email.');
                 }

--- a/src/Symfony/Component/Mailer/Bridge/Mailtrap/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Mailtrap/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=8.4.1",
         "psr/event-dispatcher": "^1",
-        "symfony/mailer": "^7.4|^8.0"
+        "symfony/mailer": "^8.2"
     },
     "require-dev": {
         "symfony/http-client": "^7.4|^8.0",

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add support for `RemoteTemplateEmail` to `PostmarkApiTransport`
+
 6.3
 ---
 

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/Tests/Transport/PostmarkApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/Tests/Transport/PostmarkApiTransportTest.php
@@ -21,10 +21,12 @@ use Symfony\Component\Mailer\Bridge\Postmark\Transport\MessageStreamHeader;
 use Symfony\Component\Mailer\Bridge\Postmark\Transport\PostmarkApiTransport;
 use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Exception\HttpTransportException;
+use Symfony\Component\Mailer\Exception\InvalidArgumentException;
 use Symfony\Component\Mailer\Exception\TransportException;
 use Symfony\Component\Mailer\Header\MetadataHeader;
 use Symfony\Component\Mailer\Header\TagHeader;
 use Symfony\Component\Mailer\Header\TrackingHeader;
+use Symfony\Component\Mailer\RemoteTemplateEmail;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
 use Symfony\Contracts\HttpClient\ResponseInterface;
@@ -112,6 +114,68 @@ class PostmarkApiTransportTest extends TestCase
         $message = $transport->send($mail);
 
         $this->assertSame('foobar', $message->getMessageId());
+    }
+
+    public function testSendRemoteTemplate()
+    {
+        $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
+            $this->assertSame('POST', $method);
+            $this->assertSame('https://api.postmarkapp.com/email/withTemplate', $url);
+
+            $body = json_decode($options['body'], true);
+            $this->assertSame(12345, $body['TemplateId']);
+            $this->assertSame(['name' => 'Fabien'], $body['TemplateModel']);
+            $this->assertArrayNotHasKey('TemplateAlias', $body);
+            $this->assertArrayNotHasKey('Subject', $body);
+            $this->assertArrayNotHasKey('TextBody', $body);
+            $this->assertArrayNotHasKey('HtmlBody', $body);
+
+            return new JsonMockResponse(['MessageID' => 'foobar'], [
+                'http_code' => 200,
+            ]);
+        });
+
+        $transport = new PostmarkApiTransport('KEY', $client);
+
+        $mail = (new RemoteTemplateEmail())
+            ->to(new Address('saif.gmati@symfony.com', 'Saif Eddin'))
+            ->from(new Address('fabpot@symfony.com', 'Fabien'))
+            ->template('12345', ['name' => 'Fabien']);
+
+        $message = $transport->send($mail);
+
+        $this->assertSame('foobar', $message->getMessageId());
+    }
+
+    public function testRemoteTemplateWithAlias()
+    {
+        $email = (new RemoteTemplateEmail())
+            ->template('welcome');
+        $envelope = new Envelope(new Address('fabpot@symfony.com', 'Fabien'), [new Address('saif.gmati@symfony.com', 'Saif Eddin')]);
+
+        $transport = new PostmarkApiTransport('KEY');
+        $method = new \ReflectionMethod(PostmarkApiTransport::class, 'getPayload');
+        $payload = $method->invoke($transport, $email, $envelope);
+
+        $this->assertSame('welcome', $payload['TemplateAlias']);
+        $this->assertArrayNotHasKey('TemplateId', $payload);
+        $this->assertEquals(new \stdClass(), $payload['TemplateModel']);
+    }
+
+    public function testRemoteTemplateRejectsSubject()
+    {
+        $email = (new RemoteTemplateEmail())
+            ->subject('Hello!')
+            ->template('welcome');
+        $envelope = new Envelope(new Address('fabpot@symfony.com', 'Fabien'), [new Address('saif.gmati@symfony.com', 'Saif Eddin')]);
+
+        $transport = new PostmarkApiTransport('KEY');
+        $method = new \ReflectionMethod(PostmarkApiTransport::class, 'getPayload');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Postmark does not support overriding the subject of a template; define the subject in the template itself.');
+
+        $method->invoke($transport, $email, $envelope);
     }
 
     public function testSendThrowsForErrorResponse()

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/Transport/PostmarkApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/Transport/PostmarkApiTransport.php
@@ -16,12 +16,15 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\Mailer\Bridge\Postmark\Event\PostmarkDeliveryEvent;
 use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Exception\HttpTransportException;
+use Symfony\Component\Mailer\Exception\InvalidArgumentException;
 use Symfony\Component\Mailer\Exception\TransportException;
 use Symfony\Component\Mailer\Header\MetadataHeader;
 use Symfony\Component\Mailer\Header\TagHeader;
 use Symfony\Component\Mailer\Header\TrackingHeader;
+use Symfony\Component\Mailer\RemoteTemplateEmail;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\AbstractApiTransport;
+use Symfony\Component\Mailer\Transport\RemoteTemplateTransportInterface;
 use Symfony\Component\Mime\Email;
 use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
@@ -31,7 +34,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 /**
  * @author Kevin Verschaeve
  */
-class PostmarkApiTransport extends AbstractApiTransport
+class PostmarkApiTransport extends AbstractApiTransport implements RemoteTemplateTransportInterface
 {
     private const HOST = 'api.postmarkapp.com';
     private const CODE_INACTIVE_RECIPIENT = 406;
@@ -64,7 +67,8 @@ class PostmarkApiTransport extends AbstractApiTransport
 
     protected function doSendApi(SentMessage $sentMessage, Email $email, Envelope $envelope): ResponseInterface
     {
-        $response = $this->client->request('POST', 'https://'.$this->getEndpoint().'/email', [
+        $endpoint = $email instanceof RemoteTemplateEmail && null !== $email->getRemoteTemplate() ? '/email/withTemplate' : '/email';
+        $response = $this->client->request('POST', 'https://'.$this->getEndpoint().$endpoint, [
             'headers' => [
                 'Accept' => 'application/json',
                 'X-Postmark-Server-Token' => $this->key,
@@ -102,17 +106,33 @@ class PostmarkApiTransport extends AbstractApiTransport
 
     private function getPayload(Email $email, Envelope $envelope): array
     {
+        $template = $email instanceof RemoteTemplateEmail ? $email->getRemoteTemplate() : null;
+
         $payload = [
             'From' => $envelope->getSender()->toString(),
             'To' => implode(',', $this->stringifyAddresses($this->getRecipients($email, $envelope))),
             'Cc' => implode(',', $this->stringifyAddresses($email->getCc())),
             'Bcc' => implode(',', $this->stringifyAddresses($email->getBcc())),
             'ReplyTo' => implode(',', $this->stringifyAddresses($email->getReplyTo())),
-            'Subject' => $email->getSubject(),
-            'TextBody' => $email->getTextBody(),
-            'HtmlBody' => $email->getHtmlBody(),
-            'Attachments' => $this->getAttachments($email),
         ];
+
+        if (null === $template) {
+            $payload['Subject'] = $email->getSubject();
+            $payload['TextBody'] = $email->getTextBody();
+            $payload['HtmlBody'] = $email->getHtmlBody();
+        } else {
+            if (null !== $email->getSubject()) {
+                throw new InvalidArgumentException('Postmark does not support overriding the subject of a template; define the subject in the template itself.');
+            }
+            if (ctype_digit($template->getReference())) {
+                $payload['TemplateId'] = (int) $template->getReference();
+            } else {
+                $payload['TemplateAlias'] = $template->getReference();
+            }
+            $payload['TemplateModel'] = $template->getVariables() ?: new \stdClass();
+        }
+
+        $payload['Attachments'] = $this->getAttachments($email);
 
         if ($tracking = TrackingHeader::fromHeaders($email->getHeaders())) {
             if (null !== $tracking->getOpens()) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Issues        | -
| License       | MIT

Follow-up to #64782, which introduced `RemoteTemplateEmail` and implemented it in the Brevo, Resend and SendGrid bridges. This PR implements `RemoteTemplateTransportInterface` in the seven remaining bridges whose provider exposes the same `{template reference, variables}` pair:

| Bridge | Reference | Variables |
|---|---|---|
| Mailjet | `TemplateID` (numeric only, `TemplateLanguage` enabled) | `Variables` |
| Mailgun | `template` | `t:variables` |
| Postmark | `TemplateId` / `TemplateAlias` (numeric reference means id), sent to `/email/withTemplate` | `TemplateModel` |
| Mailchimp (Mandrill) | `template_name`, sent to `messages/send-template.json` | `global_merge_vars` |
| MailerSend | `template_id` | `personalization[].data` (same data for every recipient) |
| Mailtrap | `template_uuid` | `template_variables` |
| Amazon SES | `Content.Template.TemplateName` | `TemplateData` |

As agreed on #64782, the ad hoc template mechanisms that the abstraction supersedes are deprecated in the same go:
- the `X-MJ-TemplateID` header mapping of the Mailjet bridge (the `X-MJ-TemplateLanguage` / `X-MJ-Vars` headers stay, they also interpolate variables into inline content without a stored template);
- the bare `template` header pass-through of the Mailgun bridge (the namespaced `h:`/`t:`/`o:`/`v:` pass-through stays).

Provider constraints are enforced with explicit exceptions instead of silently dropped fields:
- Postmark, Mailtrap and Amazon SES cannot override the subject of a template: a set subject throws, define it in the template;
- Mailjet only accepts numeric template ids, like Brevo;
- Mailtrap forbids a category (`TagHeader`) with a template;
- the Amazon SES API cannot combine attachments with a template (async-aws/ses models template attachments only since 1.12, above the `^1.8` constraint).

Not covered, on purpose: Sweego and Infobip require a subject even with a stored template and their template documentation is too thin to commit to a mapping; AhaSend only substitutes variables into inline content; Cloudflare, MailKite, TurboSmtp, MailPace, Azure, Microsoft Graph, Mailomat, Postal and Scaleway have no hosted-template feature in their send APIs.

## For the documentation

- The subject-override table above: Mailjet, Mailgun, Mandrill and MailerSend accept a local subject with a template, Postmark, Mailtrap and Amazon SES throw.
- With MailerSend, the same variables are applied to every recipient; per-recipient variables stay out of scope of the abstraction.
