### PR TITLE
[WebProfilerBundle] Fix a TypeError when the ajax toolbar panel is missing from the page

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
@@ -142,6 +142,10 @@
                     }
 
                     var ajaxToolbarPanel = document.querySelector('.sf-toolbar-block-ajax');
+                    if (!ajaxToolbarPanel) {
+                        return;
+                    }
+
                     if (requestStack.length) {
                         ajaxToolbarPanel.style.display = 'block';
                     } else {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65820
| License       | MIT

`renderAjaxRequests()` checks the request counter and the info span before touching them, but not `.sf-toolbar-block-ajax`. The toolbar wraps `window.fetch`, and a Turbo Drive navigation is a fetch, so after Turbo swaps the `<body>` the previous page's still-live handler runs the function against a DOM where the counter is already there but the ajax block is not yet, and reading `.style` off null throws.

This adds the same early return the counter above it already uses.

No test covers this: `toolbar_js.html.twig` has no JavaScript tests, and `WebDebugToolbarListenerTest` mocks the Twig environment to return a literal string, so the template is never rendered there. The full bundle suite passes (140 tests, 402 assertions).
