### PR TITLE
[Cache] Add MongoDB cache adapters

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -280,6 +280,7 @@ jobs:
           MESSENGER_AMQP_DSN: amqp://localhost/%2f/messages
           MESSENGER_SQS_DSN: "sqs://localhost:4566/messages?sslmode=disable&poll_timeout=0.01"
           MESSENGER_SQS_FIFO_QUEUE_DSN: "sqs://localhost:4566/messages.fifo?sslmode=disable&poll_timeout=0.01"
+          MONGODB_URI: 'mongodb://localhost:27017'
           AWS_ENDPOINT_URL: "http://localhost:4566"
           KAFKA_BROKER: 127.0.0.1:9092
           POSTGRES_HOST: localhost

--- a/composer.json
+++ b/composer.json
@@ -137,7 +137,7 @@
         "async-aws/ses": "^1.0",
         "async-aws/sqs": "^1.0|^2.0",
         "async-aws/sns": "^1.0",
-        "cache/integration-tests": "^1.0.3",
+        "cache/integration-tests": "^1.0.5",
         "doctrine/collections": "^1.8|^2.0",
         "doctrine/data-fixtures": "^1.1|^2",
         "doctrine/dbal": "^4.3",

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Auto-configure the `form.data_class` resource tag for classes with the `#[AsFormType]` attribute
+ * Add the `cache.adapter.mongodb` and `cache.adapter.mongodb_tag_aware` cache adapters, and the `framework.cache.default_mongodb_provider` option
  * Add the `framework.webhook.no_private_network` and `framework.webhook.http_client` options
  * Add the `claim_check` option to Messenger transports
  * Add the `framework.asset_mapper.importmap_entries` option to limit the rendered import map to the entries reachable from the rendered entrypoints

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -1558,6 +1558,7 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('default_memcached_provider')->defaultValue('memcached://localhost')->end()
                         ->scalarNode('default_doctrine_dbal_provider')->defaultValue('database_connection')->end()
                         ->scalarNode('default_pdo_provider')->defaultValue($willBeAvailable('doctrine/dbal', Connection::class) && class_exists(DoctrineAdapter::class) ? 'database_connection' : null)->end()
+			->scalarNode('default_mongodb_provider')->defaultValue('mongodb://localhost/app')->end()
                         ->arrayNode('pools', 'pool')
                             ->useAttributeAsKey('name')
                             ->prototype('array')

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -2811,7 +2811,7 @@ class FrameworkExtension extends Extension
             // Inline any env vars referenced in the parameter
             $container->setParameter('cache.prefix.seed', $container->resolveEnvPlaceholders($container->getParameter('cache.prefix.seed'), true));
         }
-        foreach (['psr6', 'redis', 'valkey', 'memcached', 'doctrine_dbal', 'pdo'] as $name) {
+        foreach (['psr6', 'redis', 'valkey', 'memcached', 'doctrine_dbal', 'pdo', 'mongodb'] as $name) {
             if (isset($config[$name = 'default_'.$name.'_provider'])) {
                 $container->setAlias('cache.'.$name, new Alias(CachePoolPass::getServiceProvider($container, $config[$name]), false));
             }
@@ -2825,7 +2825,7 @@ class FrameworkExtension extends Extension
                 'tags' => false,
             ];
         }
-        $nativeTagAwareAdapters = [['cache.adapter.redis_tag_aware'], ['cache.adapter.valkey_tag_aware'], ['cache.adapter.pdo_tag_aware']];
+        $nativeTagAwareAdapters = [['cache.adapter.redis_tag_aware'], ['cache.adapter.valkey_tag_aware'], ['cache.adapter.pdo_tag_aware'], ['cache.adapter.mongodb_tag_aware']];
         foreach ($config['pools'] as $name => $pool) {
             if (null === ($pool['provider'] ??= null)) {
                 unset($pool['provider']);

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/cache.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/cache.php
@@ -19,6 +19,8 @@ use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\DoctrineDbalAdapter;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Cache\Adapter\MemcachedAdapter;
+use Symfony\Component\Cache\Adapter\MongoDbAdapter;
+use Symfony\Component\Cache\Adapter\MongoDbTagAwareAdapter;
 use Symfony\Component\Cache\Adapter\PdoAdapter;
 use Symfony\Component\Cache\Adapter\PdoTagAwareAdapter;
 use Symfony\Component\Cache\Adapter\ProxyAdapter;
@@ -242,6 +244,40 @@ return static function (ContainerConfigurator $container) {
             ->call('setLogger', [service('logger')->ignoreOnInvalid()])
             ->tag('cache.pool', [
                 'provider' => 'cache.default_pdo_provider',
+                'clearer' => 'cache.default_clearer',
+                'reset' => 'reset',
+            ])
+            ->tag('monolog.logger', ['channel' => 'cache'])
+
+        ->set('cache.adapter.mongodb', MongoDbAdapter::class)
+            ->abstract()
+            ->args([
+                abstract_arg('MongoDB connection service'),
+                '', // namespace
+                0, // default lifetime
+                [], // options
+                service('cache.default_marshaller')->ignoreOnInvalid(),
+            ])
+            ->call('setLogger', [service('logger')->ignoreOnInvalid()])
+            ->tag('cache.pool', [
+                'provider' => 'cache.default_mongodb_provider',
+                'clearer' => 'cache.default_clearer',
+                'reset' => 'reset',
+            ])
+            ->tag('monolog.logger', ['channel' => 'cache'])
+
+        ->set('cache.adapter.mongodb_tag_aware', MongoDbTagAwareAdapter::class)
+            ->abstract()
+            ->args([
+                abstract_arg('MongoDB connection service'),
+                '', // namespace
+                0, // default lifetime
+                [], // options
+                service('cache.default_marshaller')->ignoreOnInvalid(),
+            ])
+            ->call('setLogger', [service('logger')->ignoreOnInvalid()])
+            ->tag('cache.pool', [
+                'provider' => 'cache.default_mongodb_provider',
                 'clearer' => 'cache.default_clearer',
                 'reset' => 'reset',
             ])

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -1291,6 +1291,7 @@ class ConfigurationTest extends TestCase
                 'default_memcached_provider' => 'memcached://localhost',
                 'default_doctrine_dbal_provider' => 'database_connection',
                 'default_pdo_provider' => ContainerBuilder::willBeAvailable('doctrine/dbal', Connection::class, ['symfony/framework-bundle']) && class_exists(DoctrineAdapter::class) ? 'database_connection' : null,
+                'default_mongodb_provider' => 'mongodb://localhost/app',
                 'prefix_seed' => '_%kernel.project_dir%.%kernel.container_class%',
             ],
             'workflows' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/cache_mongodb.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/cache_mongodb.php
@@ -1,0 +1,18 @@
+<?php
+
+$container->loadFromExtension('framework', [
+    'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
+    'cache' => [
+        'default_mongodb_provider' => 'mongodb://localhost:27017/db?collection_name=cache',
+        'pools' => [
+            'cache.mongodb_tag_aware' => [
+                'adapter' => 'cache.adapter.mongodb_tag_aware',
+            ],
+            'my_mongodb_pool' => [
+                'provider' => 'mongodb://localhost:27017/db?collection_name=pool',
+            ],
+        ],
+    ],
+]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/cache_mongodb.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/cache_mongodb.yml
@@ -1,0 +1,12 @@
+framework:
+    http_method_override: false
+    handle_all_throwables: true
+    php_errors:
+        log: true
+    cache:
+        default_mongodb_provider: 'mongodb://localhost:27017/db?collection_name=cache'
+        pools:
+            cache.mongodb_tag_aware:
+                adapter: cache.adapter.mongodb_tag_aware
+            my_mongodb_pool:
+                provider: 'mongodb://localhost:27017/db?collection_name=pool'

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -2392,6 +2392,36 @@ abstract class FrameworkExtensionTestCase extends TestCase
         $this->assertSame('memcached://localhost', $connection->getArgument(0));
     }
 
+    public function testCacheDefaultMongodbProvider()
+    {
+        $container = $this->createContainerFromFile('cache_mongodb');
+
+        foreach (['cache.adapter.mongodb', 'cache.adapter.mongodb_tag_aware'] as $id) {
+            $this->assertTrue($container->hasDefinition($id), \sprintf('"%s" should be a service, not an alias.', $id));
+            $this->assertSame('cache.default_mongodb_provider', $container->getDefinition($id)->getTag('cache.pool')[0]['provider']);
+        }
+
+        $dsn = 'mongodb://localhost:27017/db?collection_name=cache';
+        $providerId = '.cache_connection.'.ContainerBuilder::hash($dsn);
+
+        $this->assertTrue($container->hasDefinition($providerId));
+
+        $connection = $container->getDefinition($providerId);
+        $this->assertSame([AbstractAdapter::class, 'createConnection'], $connection->getFactory());
+        $this->assertSame($dsn, $connection->getArgument(0));
+    }
+
+    public function testCacheMongodbPoolDeducesTheAdapterFromTheDsn()
+    {
+        $container = $this->createContainerFromFile('cache_mongodb');
+
+        $pool = $container->getDefinition('my_mongodb_pool');
+        $this->assertSame([AbstractAdapter::class, 'createAdapter'], $pool->getFactory());
+
+        $connection = $container->getDefinition((string) $pool->getArgument(0));
+        $this->assertSame('mongodb://localhost:27017/db?collection_name=pool', $connection->getArgument(0));
+    }
+
     public function testCacheDefaultValkeyProvider()
     {
         $container = $this->createContainerFromFile('cache');

--- a/src/Symfony/Component/Cache/Adapter/AbstractAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/AbstractAdapter.php
@@ -137,8 +137,11 @@ abstract class AbstractAdapter implements AdapterInterface, CacheInterface, Name
         if (preg_match('/^(mysql|oci|pgsql|sqlsrv|sqlite):/', $dsn)) {
             return PdoAdapter::createConnection($dsn, $options);
         }
+        if (str_starts_with($dsn, 'mongodb:') || str_starts_with($dsn, 'mongodb+srv:')) {
+            return MongoDbAdapter::createConnection($dsn, $options);
+        }
 
-        throw new InvalidArgumentException('Unsupported DSN: it does not start with "redis[s]:", "valkey[s]:", "memcached:", "couchbase:", "mysql:", "oci:", "pgsql:", "sqlsrv:" nor "sqlite:".');
+        throw new InvalidArgumentException('Unsupported DSN: it does not start with "redis[s]:", "valkey[s]:", "memcached:", "couchbase:", "mysql:", "oci:", "pgsql:", "sqlsrv:", "sqlite:" nor "mongodb[+srv]:".');
     }
 
     /**
@@ -154,6 +157,7 @@ abstract class AbstractAdapter implements AdapterInterface, CacheInterface, Name
             $connection instanceof \Predis\ClientInterface,
             $connection instanceof \Relay\Relay, $connection instanceof \Relay\Cluster => new RedisAdapter($connection, $namespace, $defaultLifetime, $marshaller),
             $connection instanceof \Couchbase\Collection => new CouchbaseCollectionAdapter($connection, $namespace, $defaultLifetime, $marshaller),
+            $connection instanceof \MongoDB\Collection => new MongoDbAdapter($connection, $namespace, $defaultLifetime, [], $marshaller),
             default => throw new InvalidArgumentException(\sprintf('Unsupported connection: "%s".', get_debug_type($connection))),
         };
     }

--- a/src/Symfony/Component/Cache/Adapter/MongoDbAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/MongoDbAdapter.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Adapter;
+
+use Symfony\Component\Cache\Marshaller\DefaultMarshaller;
+use Symfony\Component\Cache\Marshaller\MarshallerInterface;
+use Symfony\Component\Cache\PruneableInterface;
+use Symfony\Component\Cache\Traits\MongoDbTrait;
+
+/**
+ * A cache adapter storing items as documents in a MongoDB collection.
+ *
+ * Each item is a document {_id, data, expires_at}. When a TTL index is created
+ * on "expires_at" (see setup()), the server removes expired items by itself.
+ *
+ * @author Jérôme Tamarelle <jerome@tamarelle.net>
+ */
+class MongoDbAdapter extends AbstractAdapter implements PruneableInterface
+{
+    use MongoDbTrait;
+
+    private function createMarshaller(?MarshallerInterface $marshaller): MarshallerInterface
+    {
+        return $marshaller ?? new DefaultMarshaller();
+    }
+
+    protected function doSave(array $values, int $lifetime): array|bool
+    {
+        if (!$values = $this->marshaller->marshall($values, $failed)) {
+            return $failed ?? [];
+        }
+
+        $expiresAt = $this->expiry($lifetime);
+
+        $operations = [];
+        foreach ($values as $id => $value) {
+            $document = ['_id' => $id, 'data' => self::createBinary($value)];
+            if (null !== $expiresAt) {
+                $document['expires_at'] = $expiresAt;
+            }
+
+            $operations[] = ['replaceOne' => [
+                ['_id' => ['$eq' => $id]],
+                $document,
+                ['upsert' => true],
+            ]];
+        }
+
+        $this->collection->bulkWrite($operations);
+
+        return $failed ?? [];
+    }
+}

--- a/src/Symfony/Component/Cache/Adapter/MongoDbTagAwareAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/MongoDbTagAwareAdapter.php
@@ -1,0 +1,120 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Adapter;
+
+use Symfony\Component\Cache\Marshaller\MarshallerInterface;
+use Symfony\Component\Cache\Marshaller\TagAwareMarshaller;
+use Symfony\Component\Cache\PruneableInterface;
+use Symfony\Component\Cache\Traits\MongoDbTrait;
+
+/**
+ * A tag aware cache adapter storing items and their tags in a MongoDB collection.
+ *
+ * Tags are stored as an array on each item document, so invalidating a tag is a
+ * single delete query on the "tags" field. Create the indexes with setup().
+ *
+ * @author Jérôme Tamarelle <jerome@tamarelle.net>
+ */
+class MongoDbTagAwareAdapter extends AbstractTagAwareAdapter implements PruneableInterface
+{
+    use MongoDbTrait {
+        setup as private setupExpiresAtIndex;
+    }
+
+    private function createMarshaller(?MarshallerInterface $marshaller): MarshallerInterface
+    {
+        return new TagAwareMarshaller($marshaller);
+    }
+
+    public function setup(): void
+    {
+        $this->setupExpiresAtIndex();
+
+        // A partial multikey index skips items stored without any tag.
+        $this->collection->createIndex(
+            ['tags' => 1],
+            ['partialFilterExpression' => ['tags' => ['$exists' => true]]],
+        );
+    }
+
+    protected function doSave(array $values, int $lifetime, array $addTagData = [], array $removeTagData = []): array
+    {
+        if (!$values = $this->marshaller->marshall($values, $failed)) {
+            return $failed ?? [];
+        }
+
+        $expiresAt = $this->expiry($lifetime);
+
+        // group the tags to add per item id
+        $addedTags = [];
+        foreach ($addTagData as $tagId => $ids) {
+            foreach ($ids as $id) {
+                if (!$failed || !\in_array($id, $failed, true)) {
+                    $addedTags[$id][] = $tagId;
+                }
+            }
+        }
+
+        $operations = [];
+        foreach ($values as $id => $value) {
+            $set = ['data' => self::createBinary($value)];
+            $update = ['$setOnInsert' => ['_id' => $id]];
+
+            if (null !== $expiresAt) {
+                $set['expires_at'] = $expiresAt;
+            } else {
+                $update['$unset'] = ['expires_at' => ''];
+            }
+            $update['$set'] = $set;
+
+            if ($addedTags[$id] ?? false) {
+                $update['$addToSet'] = ['tags' => ['$each' => $addedTags[$id]]];
+            }
+
+            $operations[] = ['updateOne' => [
+                ['_id' => ['$eq' => $id]],
+                $update,
+                ['upsert' => true],
+            ]];
+        }
+
+        foreach ($removeTagData as $tagId => $ids) {
+            if ($failed) {
+                $ids = array_diff($ids, $failed);
+            }
+            if ($ids) {
+                $operations[] = ['updateMany' => [
+                    ['_id' => ['$in' => array_values($ids)]],
+                    ['$pull' => ['tags' => ['$in' => [$tagId]]]],
+                ]];
+            }
+        }
+
+        $this->collection->bulkWrite($operations);
+
+        return $failed ?? [];
+    }
+
+    protected function doDeleteTagRelations(array $tagData): bool
+    {
+        // Tags are embedded in the item documents, so deleting an item removes
+        // its tag relations at the same time. Nothing to do here.
+        return true;
+    }
+
+    protected function doInvalidate(array $tagIds): bool
+    {
+        $this->collection->deleteMany(['tags' => ['$in' => array_values($tagIds)]]);
+
+        return true;
+    }
+}

--- a/src/Symfony/Component/Cache/CHANGELOG.md
+++ b/src/Symfony/Component/Cache/CHANGELOG.md
@@ -5,6 +5,8 @@ CHANGELOG
 ---
 
  * Add `AbstractAdapter::createAdapter()` to create the adapter matching a connection
+ * Add `MongoDbAdapter` and `MongoDbTagAwareAdapter`
+ * Support the `mongodb:` and `mongodb+srv:` DSN in `AbstractAdapter::createConnection()`
  * Implement `PruneableInterface` on `RedisTagAwareAdapter` to garbage-collect its tag Sets
  * Add `PdoTagAwareAdapter`
 

--- a/src/Symfony/Component/Cache/LockRegistry.php
+++ b/src/Symfony/Component/Cache/LockRegistry.php
@@ -46,6 +46,8 @@ final class LockRegistry
         __DIR__.\DIRECTORY_SEPARATOR.'Adapter'.\DIRECTORY_SEPARATOR.'FilesystemAdapter.php',
         __DIR__.\DIRECTORY_SEPARATOR.'Adapter'.\DIRECTORY_SEPARATOR.'FilesystemTagAwareAdapter.php',
         __DIR__.\DIRECTORY_SEPARATOR.'Adapter'.\DIRECTORY_SEPARATOR.'MemcachedAdapter.php',
+        __DIR__.\DIRECTORY_SEPARATOR.'Adapter'.\DIRECTORY_SEPARATOR.'MongoDbAdapter.php',
+        __DIR__.\DIRECTORY_SEPARATOR.'Adapter'.\DIRECTORY_SEPARATOR.'MongoDbTagAwareAdapter.php',
         __DIR__.\DIRECTORY_SEPARATOR.'Adapter'.\DIRECTORY_SEPARATOR.'NullAdapter.php',
         __DIR__.\DIRECTORY_SEPARATOR.'Adapter'.\DIRECTORY_SEPARATOR.'ParameterNormalizer.php',
         __DIR__.\DIRECTORY_SEPARATOR.'Adapter'.\DIRECTORY_SEPARATOR.'PdoAdapter.php',

--- a/src/Symfony/Component/Cache/Tests/Adapter/MongoDbAdapterDsnTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/MongoDbAdapterDsnTest.php
@@ -1,0 +1,177 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Tests\Adapter;
+
+use MongoDB\Client;
+use MongoDB\Collection;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\MongoDbAdapter;
+use Symfony\Component\Cache\Exception\InvalidArgumentException;
+
+require_once __DIR__.'/stubs/mongodb.php';
+
+/**
+ * DSN parsing and constructor validation, run without a MongoDB server.
+ */
+class MongoDbAdapterDsnTest extends TestCase
+{
+    #[DataProvider('provideValidDsn')]
+    public function testParseDsn(string $dsn, array $options, string $expectedDatabase, string $expectedCollection, string $expectedNamespace, string $expectedUri)
+    {
+        [$parsedOptions, $uri] = (new \ReflectionMethod(MongoDbAdapter::class, 'parseDsn'))->invoke(null, $dsn, $options);
+
+        $this->assertSame($expectedDatabase, $parsedOptions['database_name']);
+        $this->assertSame($expectedCollection, $parsedOptions['collection_name']);
+        $this->assertSame($expectedNamespace, $parsedOptions['namespace']);
+        $this->assertSame($expectedUri, $uri);
+    }
+
+    public static function provideValidDsn(): iterable
+    {
+        yield 'database from path, collection from query' => [
+            'mongodb://localhost/mydb?collection_name=cache',
+            [],
+            'mydb',
+            'cache',
+            '',
+            'mongodb://localhost/mydb',
+        ];
+
+        yield 'default collection when only the database is given' => [
+            'mongodb://localhost/mydb',
+            [],
+            'mydb',
+            'cache_items',
+            '',
+            'mongodb://localhost/mydb',
+        ];
+
+        yield 'default database and collection when the DSN carries neither' => [
+            'mongodb://localhost',
+            [],
+            'app',
+            'cache_items',
+            '',
+            'mongodb://localhost',
+        ];
+
+        yield 'namespace read from the query' => [
+            'mongodb://user:pass@host:27017/db_name?collection_name=cache&namespace=thecacheprefix',
+            [],
+            'db_name',
+            'cache',
+            'thecacheprefix',
+            'mongodb://user:pass@host:27017/db_name',
+        ];
+
+        yield 'other query parameters are kept for the driver' => [
+            'mongodb://localhost/mydb?collection_name=cache&replicaSet=rs0',
+            [],
+            'mydb',
+            'cache',
+            '',
+            'mongodb://localhost/mydb?replicaSet=rs0',
+        ];
+
+        yield 'adapter options stripped from the middle of the query' => [
+            'mongodb://localhost/mydb?replicaSet=rs0&collection_name=cache&namespace=p&readPreference=secondaryPreferred',
+            [],
+            'mydb',
+            'cache',
+            'p',
+            'mongodb://localhost/mydb?replicaSet=rs0&readPreference=secondaryPreferred',
+        ];
+
+        yield 'options take precedence over the DSN' => [
+            'mongodb://localhost/mydb?collection_name=cache',
+            ['database_name' => 'from_option', 'collection_name' => 'from_option'],
+            'from_option',
+            'from_option',
+            '',
+            'mongodb://localhost/mydb',
+        ];
+
+        yield 'mongodb+srv scheme' => [
+            'mongodb+srv://localhost/mydb?collection_name=cache',
+            [],
+            'mydb',
+            'cache',
+            '',
+            'mongodb+srv://localhost/mydb',
+        ];
+    }
+
+    public function testCreateConnectionReturnsConfiguredCollection()
+    {
+        if (str_contains((new \ReflectionClass(Client::class))->getFileName(), \DIRECTORY_SEPARATOR.'stubs'.\DIRECTORY_SEPARATOR)) {
+            $this->markTestSkipped('The "mongodb/mongodb" package is required.');
+        }
+
+        // The client connects lazily, so no server is needed to build the collection.
+        $collection = MongoDbAdapter::createConnection('mongodb://localhost/mydb?collection_name=cache');
+
+        $this->assertInstanceOf(Collection::class, $collection);
+        $this->assertSame('mydb', $collection->getDatabaseName());
+        $this->assertSame('cache', $collection->getCollectionName());
+        $this->assertSame(['root' => 'bson'], $collection->__debugInfo()['typeMap']);
+        $this->assertNull($collection->__debugInfo()['codec']);
+    }
+
+    public function testDriverInfoIdentifiesTheAdapter()
+    {
+        $driverOptions = (new \ReflectionMethod(MongoDbAdapter::class, 'addDriverInfo'))->invoke(null, []);
+
+        $this->assertSame('sfcache', $driverOptions['driver']['name']);
+        $this->assertNotSame('', $driverOptions['driver']['version']);
+    }
+
+    public function testDriverInfoKeepsTheOneGivenByTheApplication()
+    {
+        $driverOptions = (new \ReflectionMethod(MongoDbAdapter::class, 'addDriverInfo'))
+            ->invoke(null, ['driver' => ['name' => 'myapp', 'version' => '1.2', 'platform' => 'my platform']]);
+
+        $this->assertSame('sfcache/myapp', $driverOptions['driver']['name']);
+        $this->assertStringEndsWith('/1.2', $driverOptions['driver']['version']);
+        $this->assertSame('my platform', $driverOptions['driver']['platform']);
+    }
+
+    public function testInvalidScheme()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Expecting "mongodb://" or "mongodb+srv://".');
+
+        new MongoDbAdapter('redis://localhost');
+    }
+
+    public function testClientUsesTheDefaultCollection()
+    {
+        $client = $this->createMock(Client::class);
+        $client->expects($this->once())
+            ->method('getCollection')
+            ->with('mydb', 'cache_items', $this->anything())
+            ->willReturn($this->createStub(Collection::class));
+
+        new MongoDbAdapter($client, options: ['database_name' => 'mydb']);
+    }
+
+    public function testClientUsesTheDefaultDatabaseAndCollection()
+    {
+        $client = $this->createMock(Client::class);
+        $client->expects($this->once())
+            ->method('getCollection')
+            ->with('app', 'cache_items', $this->anything())
+            ->willReturn($this->createStub(Collection::class));
+
+        new MongoDbAdapter($client);
+    }
+}

--- a/src/Symfony/Component/Cache/Tests/Adapter/MongoDbAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/MongoDbAdapterTest.php
@@ -1,0 +1,232 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Tests\Adapter;
+
+use MongoDB\BSON\Regex;
+use MongoDB\BSON\UTCDateTime;
+use MongoDB\Client;
+use MongoDB\Collection;
+use MongoDB\Database;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+use Psr\Cache\CacheItemPoolInterface;
+use Psr\Clock\ClockInterface;
+use Symfony\Bridge\PhpUnit\Attribute\TimeSensitive;
+use Symfony\Component\Cache\Adapter\AbstractAdapter;
+use Symfony\Component\Cache\Adapter\MongoDbAdapter;
+use Symfony\Component\Cache\Adapter\MongoDbTagAwareAdapter;
+use Symfony\Component\Cache\Exception\InvalidArgumentException;
+use Symfony\Component\Cache\PruneableInterface;
+use Symfony\Component\Cache\Traits\MongoDbTrait;
+use Symfony\Component\Clock\MockClock;
+
+require_once __DIR__.'/stubs/mongodb.php';
+
+#[RequiresPhpExtension('mongodb')]
+#[Group('integration')]
+#[TimeSensitive]
+#[TimeSensitive(AbstractAdapter::class)]
+#[TimeSensitive(MongoDbTrait::class)]
+class MongoDbAdapterTest extends AdapterTestCase
+{
+    protected const DATABASE = 'symfony_cache_test';
+    protected const COLLECTION = 'cache';
+
+    protected const OPTIONS = ['database_name' => self::DATABASE, 'collection_name' => self::COLLECTION];
+
+    protected static Client $client;
+
+    public static function setUpBeforeClass(): void
+    {
+        if (str_contains((new \ReflectionClass(Client::class))->getFileName(), \DIRECTORY_SEPARATOR.'stubs'.\DIRECTORY_SEPARATOR)) {
+            self::markTestSkipped('The "mongodb/mongodb" package is required.');
+        }
+
+        self::$client = new Client(getenv('MONGODB_URI') ?: 'mongodb://localhost:27017', ['serverSelectionTimeoutMS' => 3000]);
+
+        try {
+            self::$client->getDatabase(self::DATABASE)->command(['ping' => 1]);
+        } catch (\Throwable $e) {
+            self::markTestSkipped(\sprintf('MongoDB server "%s" not reachable: %s', getenv('MONGODB_URI') ?: 'mongodb://localhost:27017', $e->getMessage()));
+        }
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // start each test from a clean collection, indexes included
+        self::$client->getCollection(self::DATABASE, self::COLLECTION)->drop();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        if (isset(self::$client)) {
+            self::$client->getCollection(self::DATABASE, self::COLLECTION)->drop();
+        }
+    }
+
+    public function createCachePool(int $defaultLifetime = 0, ?string $testMethod = null): CacheItemPoolInterface
+    {
+        return $this->createAdapter(self::$client, str_replace('\\', '.', static::class), $defaultLifetime, self::OPTIONS);
+    }
+
+    protected function isPruned(MongoDbAdapter|MongoDbTagAwareAdapter $cache, string $name): bool
+    {
+        $collection = (new \ReflectionProperty($cache, 'collection'))->getValue($cache);
+        self::assertInstanceOf(Collection::class, $collection);
+
+        return 0 === $collection->countDocuments(['_id' => new Regex(':'.preg_quote($name, '').'$')]);
+    }
+
+    /**
+     * Overridden by the tag aware test case so that the inherited tests build the right adapter.
+     */
+    protected function createAdapter(Collection|Client|Database|string $mongo, string $namespace = '', int $defaultLifetime = 0, array $options = [], ?ClockInterface $clock = null): MongoDbAdapter|MongoDbTagAwareAdapter
+    {
+        return new MongoDbAdapter($mongo, $namespace, $defaultLifetime, $options, null, $clock);
+    }
+
+    /**
+     * Adds the database and the collection to the server URI, which may already
+     * carry a path and query parameters such as "replicaSet".
+     */
+    protected static function dsn(): string
+    {
+        $uri = getenv('MONGODB_URI') ?: 'mongodb://localhost:27017';
+        [$hosts, $query] = explode('?', $uri, 2) + [1 => ''];
+
+        return rtrim($hosts, '/').'/'.self::DATABASE.'?'.($query ? $query.'&' : '').'collection_name='.self::COLLECTION;
+    }
+
+    public function testCreateConnectionFromDsnAcceptsDatabaseAndCollection()
+    {
+        $adapter = $this->createAdapter(self::dsn());
+
+        $item = $adapter->getItem('foo');
+        $item->set('bar');
+        $this->assertTrue($adapter->save($item));
+        $this->assertSame('bar', $adapter->getItem('foo')->get());
+    }
+
+    public function testExpiryUsesInjectedClock()
+    {
+        $clock = new MockClock();
+        $adapter = $this->createAdapter(self::$client, str_replace('\\', '.', static::class), 0, self::OPTIONS, $clock);
+
+        $item = $adapter->getItem('foo');
+        $item->set('bar')->expiresAfter(10);
+        $adapter->save($item);
+
+        $this->assertTrue($adapter->hasItem('foo'));
+
+        $clock->sleep(20);
+
+        $this->assertFalse($adapter->hasItem('foo'));
+        $this->assertFalse($adapter->getItem('foo')->isHit());
+    }
+
+    public function testClearOnlyRemovesTheNamespacePrefix()
+    {
+        $cache = $this->createCachePool();
+        $namespace = str_replace('\\', '.', static::class);
+
+        $item = $cache->getItem('foo');
+        $cache->save($item->set('bar'));
+
+        // an id holding the namespace anywhere but at the start, as another pool would write
+        $collection = self::$client->getCollection(self::DATABASE, self::COLLECTION);
+        $collection->insertOne(['_id' => 'other.'.$namespace.':foo', 'data' => 'kept']);
+
+        $this->assertTrue($cache->clear());
+        $this->assertFalse($cache->getItem('foo')->isHit());
+        $this->assertSame(1, $collection->countDocuments(['_id' => 'other.'.$namespace.':foo']));
+    }
+
+    public function testExpirationIsStoredAsADate()
+    {
+        $cache = $this->createCachePool();
+
+        $item = $cache->getItem('foo');
+        $cache->save($item->set('bar')->expiresAfter(300));
+
+        $document = self::findOne();
+
+        $this->assertInstanceOf(UTCDateTime::class, $document['expires_at']);
+        $this->assertEqualsWithDelta(time() + 300, $document['expires_at']->toDateTime()->getTimestamp(), 5);
+    }
+
+    public function testItemWithoutLifetimeIsStoredWithoutExpiration()
+    {
+        $cache = $this->createCachePool();
+
+        $item = $cache->getItem('foo');
+        $cache->save($item->set('bar'));
+
+        // no "expires_at" at all, so the partial TTL index does not index the item
+        $this->assertArrayNotHasKey('expires_at', self::findOne());
+    }
+
+    public function testCollectionReadsRawBson()
+    {
+        $cache = $this->createCachePool();
+        $collection = (new \ReflectionProperty($cache, 'collection'))->getValue($cache);
+
+        $this->assertSame(['root' => 'bson'], $collection->__debugInfo()['typeMap']);
+        $this->assertNull($collection->__debugInfo()['codec']);
+    }
+
+    public function testNamespaceLongerThanTheMaxIdLengthIsRejected()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Namespace must be');
+
+        $this->createAdapter(self::$client, str_repeat('a', 1500), 0, self::OPTIONS);
+    }
+
+    public function testSetupCreatesTtlIndex()
+    {
+        $adapter = $this->createCachePool();
+        $this->assertInstanceOf(PruneableInterface::class, $adapter);
+        $adapter->setup();
+
+        $indexes = self::listIndexes();
+
+        $this->assertArrayHasKey('expires_at_1', $indexes);
+        $this->assertSame(0, $indexes['expires_at_1']['expireAfterSeconds']);
+        $this->assertSame('{"expires_at":{"$exists":true}}', json_encode($indexes['expires_at_1']['partialFilterExpression']));
+    }
+
+    /**
+     * The single stored document, as a plain array.
+     */
+    protected static function findOne(): array
+    {
+        return self::$client->getCollection(self::DATABASE, self::COLLECTION)->findOne(
+            [],
+            ['typeMap' => ['root' => 'array', 'document' => 'array']]
+        );
+    }
+
+    /**
+     * @return array<string, \MongoDB\Model\IndexInfo>
+     */
+    protected static function listIndexes(): array
+    {
+        $indexes = [];
+        foreach (self::$client->getCollection(self::DATABASE, self::COLLECTION)->listIndexes() as $index) {
+            $indexes[$index->getName()] = $index;
+        }
+
+        return $indexes;
+    }
+}

--- a/src/Symfony/Component/Cache/Tests/Adapter/MongoDbTagAwareAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/MongoDbTagAwareAdapterTest.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Tests\Adapter;
+
+use MongoDB\Client;
+use MongoDB\Collection;
+use MongoDB\Database;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+use Psr\Clock\ClockInterface;
+use Symfony\Bridge\PhpUnit\Attribute\TimeSensitive;
+use Symfony\Component\Cache\Adapter\AbstractAdapter;
+use Symfony\Component\Cache\Adapter\MongoDbAdapter;
+use Symfony\Component\Cache\Adapter\MongoDbTagAwareAdapter;
+use Symfony\Component\Cache\Traits\MongoDbTrait;
+
+require_once __DIR__.'/stubs/mongodb.php';
+
+#[RequiresPhpExtension('mongodb')]
+#[Group('integration')]
+#[TimeSensitive]
+#[TimeSensitive(AbstractAdapter::class)]
+#[TimeSensitive(MongoDbTrait::class)]
+class MongoDbTagAwareAdapterTest extends MongoDbAdapterTest
+{
+    use TagAwareTestTrait;
+
+    protected function createAdapter(Collection|Client|Database|string $mongo, string $namespace = '', int $defaultLifetime = 0, array $options = [], ?ClockInterface $clock = null): MongoDbAdapter|MongoDbTagAwareAdapter
+    {
+        return new MongoDbTagAwareAdapter($mongo, $namespace, $defaultLifetime, $options, null, $clock);
+    }
+
+    public function testInvalidateSeveralTagsAtOnce()
+    {
+        $cache = $this->createCachePool();
+
+        foreach (['foo' => 'tag1', 'bar' => 'tag2', 'baz' => 'tag3'] as $key => $tag) {
+            $item = $cache->getItem($key);
+            $cache->save($item->set($key)->tag($tag));
+        }
+
+        $this->assertTrue($cache->invalidateTags(['tag1', 'tag2']));
+
+        $this->assertFalse($cache->getItem('foo')->isHit());
+        $this->assertFalse($cache->getItem('bar')->isHit());
+        $this->assertTrue($cache->getItem('baz')->isHit());
+    }
+
+    public function testDeletingATaggedItemSucceeds()
+    {
+        $cache = $this->createCachePool();
+
+        $item = $cache->getItem('foo');
+        $cache->save($item->set('bar')->tag('tag1'));
+
+        $this->assertTrue($cache->deleteItem('foo'));
+        $this->assertFalse($cache->getItem('foo')->isHit());
+    }
+
+    public function testUntaggedItemIsStoredWithoutTags()
+    {
+        $cache = $this->createCachePool();
+
+        $item = $cache->getItem('foo');
+        $cache->save($item->set('bar'));
+
+        // no "tags" at all, not even an empty array, so the partial index does not index the item
+        $this->assertArrayNotHasKey('tags', self::findOne());
+    }
+
+    public function testSavingWithoutLifetimeRemovesTheExpiration()
+    {
+        $cache = $this->createCachePool();
+
+        $item = $cache->getItem('foo');
+        $cache->save($item->set('bar')->expiresAfter(300));
+
+        $item = $cache->getItem('foo');
+        $cache->save($item->set('baz')->expiresAfter(null));
+
+        $this->assertArrayNotHasKey('expires_at', self::findOne());
+    }
+
+    public function testSetupCreatesTagsIndex()
+    {
+        $adapter = $this->createCachePool();
+        $adapter->setup();
+
+        $indexes = self::listIndexes();
+
+        $this->assertArrayHasKey('tags_1', $indexes);
+        $this->assertSame('{"tags":{"$exists":true}}', json_encode($indexes['tags_1']['partialFilterExpression']));
+    }
+}

--- a/src/Symfony/Component/Cache/Tests/Adapter/stubs/mongodb.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/stubs/mongodb.php
@@ -1,0 +1,156 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/*
+ * The autoload attempts are gated on the extension being loaded: without it,
+ * the classes of the mongodb/mongodb library cannot be loaded anyway, as some
+ * of them implement interfaces provided by the extension.
+ */
+
+namespace MongoDB {
+    if (!class_exists(Client::class, \extension_loaded('mongodb'))) {
+        class Client
+        {
+            public function __construct(?string $uri = null, array $uriOptions = [], array $driverOptions = [])
+            {
+            }
+
+            public function getCollection(string $databaseName, string $collectionName, array $options = [])
+            {
+                return new Collection();
+            }
+
+            public function getDatabase(string $databaseName, array $options = [])
+            {
+                return new Database();
+            }
+        }
+    }
+
+    if (!class_exists(Database::class, \extension_loaded('mongodb'))) {
+        class Database
+        {
+            public function getCollection(string $collectionName, array $options = [])
+            {
+                return new Collection();
+            }
+
+            public function command($command, array $options = [])
+            {
+            }
+        }
+    }
+
+    if (!class_exists(Collection::class, \extension_loaded('mongodb'))) {
+        class Collection
+        {
+            public function bulkWrite(array $operations, array $options = [])
+            {
+            }
+
+            public function countDocuments($filter = [], array $options = [])
+            {
+            }
+
+            public function createIndex($key, array $options = [])
+            {
+            }
+
+            public function deleteMany($filter, array $options = [])
+            {
+            }
+
+            public function find($filter = [], array $options = [])
+            {
+            }
+
+            public function findOne($filter = [], array $options = [])
+            {
+            }
+
+            public function updateMany($filter, $update, array $options = [])
+            {
+            }
+        }
+    }
+}
+
+namespace MongoDB\BSON {
+    if (!class_exists(Binary::class, \extension_loaded('mongodb'))) {
+        class Binary
+        {
+            public const TYPE_GENERIC = 0;
+
+            public function __construct(
+                private string $data = '',
+                private int $type = self::TYPE_GENERIC,
+            ) {
+            }
+
+            public function getData(): string
+            {
+                return $this->data;
+            }
+
+            public function getType(): int
+            {
+                return $this->type;
+            }
+        }
+    }
+
+    if (!class_exists(UTCDateTime::class, \extension_loaded('mongodb'))) {
+        class UTCDateTime
+        {
+            public readonly string $milliseconds;
+
+            public function __construct(int|string|\DateTimeInterface|null $milliseconds = null)
+            {
+                if ($milliseconds instanceof \DateTimeInterface) {
+                    $milliseconds = $milliseconds->format('Uv');
+                }
+
+                $this->milliseconds = (string) ($milliseconds ?? (new \DateTimeImmutable())->format('Uv'));
+            }
+
+            public function __toString(): string
+            {
+                return $this->milliseconds;
+            }
+        }
+    }
+
+    if (!class_exists(Regex::class, \extension_loaded('mongodb'))) {
+        class Regex
+        {
+            public function __construct(
+                private string $pattern,
+                private string $flags = '',
+            ) {
+            }
+
+            public function getPattern(): string
+            {
+                return $this->pattern;
+            }
+
+            public function getFlags(): string
+            {
+                return $this->flags;
+            }
+
+            public function __toString(): string
+            {
+                return \sprintf('/%s/%s', $this->pattern, $this->flags);
+            }
+        }
+    }
+}

--- a/src/Symfony/Component/Cache/Traits/MongoDbTrait.php
+++ b/src/Symfony/Component/Cache/Traits/MongoDbTrait.php
@@ -1,0 +1,339 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Traits;
+
+use Composer\InstalledVersions;
+use MongoDB\BSON\Binary;
+use MongoDB\BSON\Regex;
+use MongoDB\BSON\UTCDateTime;
+use MongoDB\Client;
+use MongoDB\Collection;
+use MongoDB\Database;
+use Psr\Clock\ClockInterface;
+use Symfony\Component\Cache\Exception\InvalidArgumentException;
+use Symfony\Component\Cache\Exception\LogicException;
+use Symfony\Component\Cache\Marshaller\MarshallerInterface;
+
+/**
+ * Code shared by the MongoDB cache adapters.
+ *
+ * All I/O goes through the mongodb/mongodb library so that the read/write
+ * concerns and the read preference configured on the connection string or on
+ * the injected collection are inherited, unless they are set in the options.
+ *
+ * @author Jérôme Tamarelle <jerome@tamarelle.net>
+ *
+ * @internal
+ */
+trait MongoDbTrait
+{
+    private Collection $collection;
+    private MarshallerInterface $marshaller;
+    private ?ClockInterface $clock;
+
+    /**
+     * The adapter options that are read from the DSN query string and must not
+     * be forwarded to the driver.
+     */
+    private const DSN_OPTIONS = [
+        'namespace' => '',
+        'database_name' => 'app',
+        'collection_name' => 'cache_items',
+    ];
+
+    /**
+     * @param string $namespace Prefix prepended to every cache key. When empty, it falls back to the DSN "namespace" query parameter.
+     *
+     * Available options:
+     *  * database_name:   The name of the database, also read from the DSN path [default: app]
+     *  * collection_name: The name of the collection, also read from the DSN "collection_name" query parameter [default: cache_items]
+     *  * driverOptions:   Array of driver options passed to MongoDB\Client [used when a DSN is given]
+     *
+     * Any other option is forwarded to the collection, typically a "readPreference", "readConcern" or
+     * "writeConcern" given as a MongoDB\Driver\* object. Connection string options (as strings) are read
+     * from the DSN query string instead.
+     *
+     * @see https://www.mongodb.com/docs/php-library/current/reference/method/MongoDBCollection-withOptions/
+     */
+    public function __construct(#[\SensitiveParameter] Collection|Client|Database|string $mongo, string $namespace = '', int $defaultLifetime = 0, array $options = [], ?MarshallerInterface $marshaller = null, ?ClockInterface $clock = null)
+    {
+        self::checkLibrary();
+
+        if (\is_string($mongo)) {
+            [$options, $mongo] = self::parseDsn($mongo, $options);
+        }
+
+        $options += self::DSN_OPTIONS + ['driverOptions' => []];
+
+        // Set before the parent constructor so that it can check the namespace length.
+        $this->maxIdLength = 1024;
+
+        // The positional namespace wins; fall back to the DSN "namespace" query parameter.
+        parent::__construct($namespace ?: $options['namespace'], $defaultLifetime);
+
+        // Every option that is not consumed by the adapter is forwarded to the
+        // collection (read/write concerns, read preference). The raw BSON type
+        // map and the disabled codec are then forced, since the adapter reads
+        // and writes plain documents itself.
+        $collectionOptions = array_diff_key($options, self::DSN_OPTIONS + ['driverOptions' => null]);
+        $collectionOptions['typeMap'] = ['root' => 'bson'];
+        $collectionOptions['codec'] = null;
+
+        if ($mongo instanceof Collection) {
+            $this->collection = $mongo->withOptions($collectionOptions);
+        } elseif ($mongo instanceof Database) {
+            $this->collection = $mongo->getCollection($options['collection_name'], $collectionOptions);
+        } elseif ($mongo instanceof Client) {
+            $this->collection = $mongo->getCollection($options['database_name'], $options['collection_name'], $collectionOptions);
+        } else {
+            // $mongo is the connection string stripped from the adapter options by parseDsn().
+            // Connection options are read from the DSN query string.
+            $client = new Client($mongo, [], self::addDriverInfo($options['driverOptions']));
+            $this->collection = $client->getCollection($options['database_name'], $options['collection_name'], $collectionOptions);
+        }
+
+        $this->marshaller = $this->createMarshaller($marshaller);
+        $this->clock = $clock;
+    }
+
+    /**
+     * Wraps the marshaller given to the constructor, so that the tag aware
+     * adapter can store the tags next to the value.
+     */
+    abstract private function createMarshaller(?MarshallerInterface $marshaller): MarshallerInterface;
+
+    /**
+     * Builds a MongoDB collection from a DSN, ready to back a cache adapter.
+     *
+     * This is the entry point used by AbstractAdapter::createConnection() so
+     * that a "mongodb:" cache DSN produces a connection service.
+     */
+    public static function createConnection(#[\SensitiveParameter] string $dsn, array $options = []): Collection
+    {
+        self::checkLibrary();
+
+        [$options, $uri] = self::parseDsn($dsn, $options);
+
+        $driverOptions = $options['driverOptions'] ?? [];
+
+        // Any remaining option is forwarded as a client URI option (for example
+        // "readPreference", "readConcernLevel" or "w"), on top of what the DSN
+        // already carries. The adapter and cache-pool specific keys are dropped,
+        // including the "lazy" flag (the client only connects on first use). The
+        // raw BSON type map is forced, since the adapter reads and writes plain
+        // documents itself.
+        $uriOptions = array_diff_key($options, self::DSN_OPTIONS + ['driverOptions' => null, 'lazy' => null]);
+
+        $client = new Client($uri, $uriOptions, self::addDriverInfo($driverOptions));
+
+        return $client->getCollection($options['database_name'], $options['collection_name'], ['typeMap' => ['root' => 'bson'], 'codec' => null]);
+    }
+
+    /**
+     * Creates a TTL index on the "expires_at" field so that the server removes
+     * expired entries by itself. Call it once during setup.
+     */
+    public function setup(): void
+    {
+        // The index is partial so that entries stored without an expiration
+        // (a zero lifetime) are not indexed at all.
+        $this->collection->createIndex(
+            ['expires_at' => 1],
+            ['expireAfterSeconds' => 0, 'partialFilterExpression' => ['expires_at' => ['$exists' => true]]],
+        );
+    }
+
+    public function prune(): bool
+    {
+        // Deleting every expired document (the same criterion a TTL index uses)
+        // relies on the "expires_at" index instead of a key-prefix scan.
+        $this->collection->deleteMany(['expires_at' => ['$lte' => $this->createUtcDateTime()]]);
+
+        return true;
+    }
+
+    protected function doFetch(array $ids): iterable
+    {
+        $cursor = $this->collection->find(
+            [
+                '_id' => ['$in' => array_values($ids)],
+                '$or' => [
+                    ['expires_at' => ['$exists' => false]],
+                    ['expires_at' => ['$gt' => $this->createUtcDateTime()]],
+                ],
+            ],
+            ['projection' => ['_id' => 1, 'data' => 1]]
+        );
+
+        /** @var \MongoDB\BSON\Document $document */
+        foreach ($cursor as $document) {
+            yield (string) $document['_id'] => $this->marshaller->unmarshall($document['data']->getData());
+        }
+    }
+
+    protected function doHave(string $id): bool
+    {
+        return 0 < $this->collection->countDocuments(
+            [
+                '_id' => ['$eq' => $id],
+                '$or' => [
+                    ['expires_at' => ['$exists' => false]],
+                    ['expires_at' => ['$gt' => $this->createUtcDateTime()]],
+                ],
+            ],
+            ['limit' => 1]
+        );
+    }
+
+    protected function doClear(string $namespace): bool
+    {
+        if ('' === $namespace) {
+            $this->collection->deleteMany([]);
+        } else {
+            $this->collection->deleteMany(['_id' => new Regex('^'.preg_quote($namespace))]);
+        }
+
+        return true;
+    }
+
+    protected function doDelete(array $ids): bool
+    {
+        $this->collection->deleteMany(['_id' => ['$in' => array_values($ids)]]);
+
+        return true;
+    }
+
+    private static function checkLibrary(): void
+    {
+        if (!class_exists(Client::class)) {
+            throw new LogicException(\sprintf('Using "%s" requires the "mongodb/mongodb" package; try running "composer require mongodb/mongodb".', static::class));
+        }
+    }
+
+    private static function addDriverInfo(array $driverOptions): array
+    {
+        $driver = $driverOptions['driver'] ?? [];
+
+        $name = 'sfcache';
+        $version = self::getVersion();
+
+        if (isset($driver['name'])) {
+            $name .= '/'.$driver['name'];
+        }
+        if (isset($driver['version'])) {
+            $version .= '/'.$driver['version'];
+        }
+
+        $driverOptions['driver'] = ['name' => $name, 'version' => $version] + $driver;
+
+        return $driverOptions;
+    }
+
+    private static function getVersion(): string
+    {
+        if (!class_exists(InstalledVersions::class)) {
+            return 'unknown';
+        }
+
+        try {
+            return InstalledVersions::getPrettyVersion('symfony/cache') ?? 'unknown';
+        } catch (\OutOfBoundsException) {
+            return 'unknown';
+        }
+    }
+
+    /**
+     * Reads the adapter options from the DSN and returns them along with the
+     * connection string stripped from those options, ready for MongoDB\Client.
+     *
+     * The database is read from the DSN path, the collection from the
+     * "collection_name" query parameter and the key prefix from the
+     * "namespace" query parameter. Explicit options take precedence. Any
+     * other query parameter is kept and passed to the driver.
+     *
+     * @return array{0: array, 1: string}
+     */
+    private static function parseDsn(#[\SensitiveParameter] string $dsn, array $options): array
+    {
+        if (!str_starts_with($dsn, 'mongodb://') && !str_starts_with($dsn, 'mongodb+srv://')) {
+            throw new InvalidArgumentException('The given MongoDB DSN is invalid. Expecting "mongodb://" or "mongodb+srv://".');
+        }
+
+        if (false === $params = parse_url($dsn)) {
+            throw new InvalidArgumentException('The given MongoDB DSN is invalid.');
+        }
+
+        $query = [];
+        if (isset($params['query'])) {
+            parse_str($params['query'], $query);
+        }
+
+        $options['database_name'] ??= $query['database_name'] ?? (ltrim($params['path'] ?? '', '/') ?: self::DSN_OPTIONS['database_name']);
+        $options['collection_name'] ??= $query['collection_name'] ?? self::DSN_OPTIONS['collection_name'];
+        $options['namespace'] ??= $query['namespace'] ?? '';
+
+        return [$options, self::stripDsnOptions($dsn)];
+    }
+
+    /**
+     * Removes the adapter's query parameters from the DSN in a single pass,
+     * keeping the other parameters (including repeated driver parameters such
+     * as "readPreferenceTags") and fixing the query separators.
+     */
+    private static function stripDsnOptions(#[\SensitiveParameter] string $dsn): string
+    {
+        $first = true;
+
+        return preg_replace_callback(
+            '/[?&]([^=&#]++)=[^&#]*+/',
+            static function (array $matches) use (&$first): string {
+                if (\array_key_exists($matches[1], self::DSN_OPTIONS)) {
+                    return '';
+                }
+
+                $separator = $first ? '?' : '&';
+                $first = false;
+
+                return $separator.substr($matches[0], 1);
+            },
+            $dsn,
+        ) ?? throw new InvalidArgumentException('The given MongoDB DSN is invalid.');
+    }
+
+    private function now(): float
+    {
+        if (null !== $this->clock) {
+            return (float) $this->clock->now()->format('U.u');
+        }
+
+        return microtime(true);
+    }
+
+    private function createUtcDateTime(?float $seconds = null): UTCDateTime
+    {
+        return new UTCDateTime((int) (($seconds ?? $this->now()) * 1000));
+    }
+
+    /**
+     * The absolute expiry date for the given lifetime, or null to persist until
+     * manual cleaning.
+     */
+    private function expiry(int $lifetime): ?UTCDateTime
+    {
+        return 0 < $lifetime ? $this->createUtcDateTime($this->now() + $lifetime) : null;
+    }
+
+    private static function createBinary(string $data): Binary
+    {
+        return new Binary($data, Binary::TYPE_GENERIC);
+    }
+}

--- a/src/Symfony/Component/Cache/composer.json
+++ b/src/Symfony/Component/Cache/composer.json
@@ -29,9 +29,10 @@
         "symfony/var-exporter": "^8.1"
     },
     "require-dev": {
-        "cache/integration-tests": "^1.0.3",
+        "cache/integration-tests": "^1.0.5",
         "doctrine/dbal": "^4.3",
         "predis/predis": "^1.1|^2.0",
+        "psr/clock": "^1.0",
         "psr/simple-cache": "^1.0|^2.0|^3.0",
         "symfony/clock": "^7.4|^8.0",
         "symfony/config": "^7.4|^8.0",

--- a/src/Symfony/Component/Cache/phpunit.xml.dist
+++ b/src/Symfony/Component/Cache/phpunit.xml.dist
@@ -17,6 +17,7 @@
         <env name="COUCHBASE_HOST" value="localhost" />
         <env name="COUCHBASE_USER" value="Administrator" />
         <env name="COUCHBASE_PASS" value="111111@" />
+        <env name="MONGODB_URI" value="mongodb://localhost:27017" />
     </php>
 
     <testsuites>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Alternative to #65468. Same two MongoDB cache adapters, shipped directly in `symfony/cache` instead of in a new `symfony/mongodb-cache` bridge, following the question asked there:

> Do we really need a separate package? symfony/cache ships all adapters and I feel like we could do the same here, the added classes are not that big (tests are)

Only the packaging differs. The adapters, their behaviour, the FrameworkBundle integration and the tests are the ones reviewed on #65468, so the design notes there (raw BSON, partial indexes, tags stored on the item document, string `_id`, injectable clock, MQL injection) still apply. One of the two PRs should be closed.

## What changes compared to #65468

`MongoDbAdapter`, `MongoDbTagAwareAdapter` and `MongoDbTrait` move to `Symfony\Component\Cache\Adapter`, their tests to `Symfony\Component\Cache\Tests\Adapter`. Everything the bridge needed only because it was a separate package goes away:

 * no `class_exists()` guard on the `mongodb:` DSN branch of `AbstractAdapter::createConnection()` and on the `\MongoDB\Collection` arm of `createAdapter()`; the wiring is now the same as `couchbase:`, and there is no "run composer require symfony/mongodb-cache" error path;
 * `AdapterTestCase` and `TagAwareTestTrait` stay in `Tests/`, so no new public `Symfony\Component\Cache\Test` namespace and no `use` statement added to the twenty-five other adapter tests;
 * no package scaffolding: no `composer.json`, `phpunit.xml.dist`, `README.md`, `LICENSE`, `CHANGELOG.md`, no `splitsh.json` entry.

Two things follow the `Lock\Store\MongoDbStore` precedent rather than the bridge one. `mongodb/mongodb` is not declared anywhere: `ext-mongodb` is absent from the Windows and unit test jobs, so requiring the library at the root would break `composer update` there, and the integration job already installs it on the fly. The `MongoDB` class stubs are therefore kept, moved to `Tests/Adapter/stubs/mongodb.php`, next to the existing `Lock/Tests/Store/stubs/mongodb.php` and `HttpFoundation/Tests/Session/Storage/Handler/stubs/mongodb.php`. Without the library, the DSN parsing tests still run against the stubs and the rest is skipped.

`cache.adapter.mongodb` and `cache.adapter.mongodb_tag_aware` are registered unconditionally, like `cache.adapter.memcached` and `cache.adapter.redis`, which are not removed either when their extension is missing. The FrameworkBundle tests therefore run in every job.

`LockRegistry` gets three new entries: it holds a hardcoded list of the files under `Adapter/`, used as its pool of lock files, and `LockRegistryTest` asserts that the list matches the directory.

The diff is 12 modified files and 8 new ones, against 58 files for the bridge.

## The packaging trade off

This is the only thing being decided here, so both sides, as fairly as I can put them.

### For a separate `symfony/mongodb-cache` package

 * **The dependency is declared where it is used.** The adapters need `mongodb/mongodb`, a library with its own release cycle and its own range of supported server versions, not just a PHP extension. A bridge puts `"mongodb/mongodb": "^1.21|^2.0"` in `require`, so Composer resolves and enforces it for the people who installed the bridge. In the component it cannot be declared at all, not even as a `require-dev`, because `ext-mongodb` is missing from several CI jobs: users install `symfony/cache`, get `MongoDbAdapter` in their autoloader, and discover at runtime that a library was needed, in a version range nothing enforces. That is also why the class stubs have to stay. Widening or narrowing that range later has no place to be expressed either.
 * **Packagist download counts.** A separate package measures the adoption of the MongoDB integration itself. Merged into `symfony/cache`, usage is invisible, which makes it harder to justify maintenance effort later, or to decide when a library major can be dropped.
 * **Consistency with the recent MongoDB work.** `symfony/mongodb-messenger` was just added as a bridge, and the Messenger transports for Redis, AMQP, SQS and Beanstalkd are separate packages too. Someone adding MongoDB support to an app already installs one MongoDB flavoured Symfony package.

### For shipping in `symfony/cache`

 * **That is what the component already does.** Every other adapter lives there, including `DoctrineDbalAdapter`, which also needs an external library. And Symfony already ships MongoDB code inside components: `Lock\Store\MongoDbStore` and `HttpFoundation`'s `MongoDbSessionHandler`, both built on `mongodb/mongodb`, neither declared in their component's `composer.json`.
 * **The code is small.** Three classes, under 500 lines. A package with its own `composer.json`, CI, README, CHANGELOG, split target and branch maintenance on every supported branch is a lot of ceremony around that, and it is a recurring cost, not a one off.
 * **No compatibility risk with `symfony/cache`.** Everything in symfony/symfony is released at the same time, so a bridge buys no release independence; what it does buy is a package that declares `"symfony/cache": "^8.2"` and can then be installed next to a later cache version, while it extends `AbstractAdapter` and `AbstractTagAwareAdapter`. Any change to those base classes has to be mirrored in a second repository, and a mismatched pair only breaks at runtime. In the component, adapters and base classes are always the same version and a refactoring stays a single atomic commit.
 * **No soft coupling to work around.** `CachePoolPass` routes every provider DSN through `AbstractAdapter::createConnection()`, so the component has to know the `mongodb:` scheme either way. With a bridge that means `symfony/cache` naming a class it does not depend on, behind `class_exists()`. Here it is one branch, like `couchbase:`.
 * **No new public test surface.** The bridge had to promote `AdapterTestCase` and `TagAwareTestTrait` out of `Tests/` into a shipped namespace to reuse them, which is API to maintain afterwards.

The dependency declaration and the download counts favour the bridge. The maintenance cost of one more package, the compatibility risk between two repositories that share base classes, the existing precedent in Lock and HttpFoundation and the size of the code favour this PR. Your call.
