### PR TITLE
[Console] Add docker-style sub-commands, resolved as command trees from registered names

### DIFF
--- a/UPGRADE-8.2.md
+++ b/UPGRADE-8.2.md
@@ -13,6 +13,20 @@ AssetMapper
 
  * Add argument `$useEsm` to `ImportMapConfigReader::createRemoteEntry()`
 
+Console
+-------
+
+ * [BC BREAK] A token that names a registered sub-command runs it instead of binding to an argument of its
+   parent: with both `app:import` and `app:import:users` registered, `app:import users` and `app import users`
+   now run `app:import:users`, where `users` was bound to the `file` argument of `app:import`. Write
+   `app:import -- users` to bind it as an argument
+ * [BC BREAK] Positional `ArrayInput` parameters bind to the argument slots in order, where they were validated
+   by index and never read: `new ArrayInput(['foo'])` binds `foo` to the first argument of the definition
+ * A bare namespace does not dispatch `ConsoleEvents::ERROR` anymore when it lists its commands: nothing fails,
+   the listing is still written on the error output and the exit code is still `1`
+ * The application listing collapses the commands below a registered command to that command's own line;
+   `list <namespace>`, the `--raw` option and the `json` and `md` formats keep listing every command
+
 Crowdin Translation Provider
 ----------------------------
 

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -76,8 +76,8 @@ use Symfony\Contracts\Service\ResetInterface;
 class Application implements ResetInterface
 {
     private array $commands = [];
-    private bool $wantHelps = false;
     private ?Command $runningCommand = null;
+    private ?CommandChain $commandChain = null;
     private ?CommandLoaderInterface $commandLoader = null;
     private bool $catchExceptions = true;
     private bool $catchErrors = false;
@@ -118,6 +118,15 @@ class Application implements ResetInterface
     public function getDispatcher(): ?EventDispatcherInterface
     {
         return $this->dispatcher;
+    }
+
+    /**
+     * Returns the commands resolved for the current invocation and their bound
+     * inputs, or null when no command is running.
+     */
+    public function getCommandChain(): ?CommandChain
+    {
+        return $this->commandChain;
     }
 
     /**
@@ -295,12 +304,13 @@ class Application implements ResetInterface
         }
 
         $name = $this->getCommandName($input);
+        $wantHelps = false;
         if ($input->hasParameterOption(['--help', '-h'], true)) {
             if (!$name) {
                 $name = 'help';
                 $input = new ArrayInput(['command_name' => $this->defaultCommand]);
             } else {
-                $this->wantHelps = true;
+                $wantHelps = true;
             }
         }
 
@@ -320,7 +330,11 @@ class Application implements ResetInterface
             // the command name MUST be the first element of the input
             $command = $this->find($name);
         } catch (\Throwable $e) {
-            if (($e instanceof CommandNotFoundException && !$e instanceof NamespaceNotFoundException) && 1 === \count($alternatives = $e->getAlternatives()) && $input->isInteractive()) {
+            if ($e instanceof CommandNotFoundException && !$e instanceof NamespaceNotFoundException && ($input instanceof ArgvInput || $input instanceof ArrayInput) && $this->getTreeDescendants($name)) {
+                // the name is a namespace: an implicit node roots the walk, and lists when invoked bare
+                $command = new Command($name);
+                $command->setApplication($this);
+            } elseif (($e instanceof CommandNotFoundException && !$e instanceof NamespaceNotFoundException) && 1 === \count($alternatives = $e->getAlternatives()) && $input->isInteractive()) {
                 $alternative = $alternatives[0];
 
                 $style = new SymfonyStyle($input, $output);
@@ -375,8 +389,52 @@ class Application implements ResetInterface
             $command = $command->getCommand();
         }
 
+        $chain = null;
+        if ($input instanceof ArgvInput || $input instanceof ArrayInput) {
+            try {
+                $resolved = $this->resolveCommandTree($command, $input);
+            } catch (CommandNotFoundException $e) {
+                if (null !== $this->dispatcher) {
+                    $event = new ConsoleErrorEvent($input, $output, $e);
+                    $this->dispatcher->dispatch($event, ConsoleEvents::ERROR);
+
+                    if (0 === $event->getExitCode()) {
+                        return 0;
+                    }
+
+                    $e = $event->getError();
+                }
+
+                throw $e;
+            }
+
+            if ($resolved) {
+                [$command, $input, $chain] = $resolved;
+            }
+        }
+
+        if ($wantHelps) {
+            $helpCommand = $this->get('help');
+            if ($helpCommand instanceof LazyCommand) {
+                $helpCommand = $helpCommand->getCommand();
+            }
+            if ($helpCommand instanceof HelpCommand) {
+                $helpCommand->setCommand($command);
+            }
+            $command = $helpCommand;
+        }
+
+        $previousChain = $this->commandChain;
         $this->runningCommand = $command;
-        $exitCode = $this->doRunCommand($command, $input, $output);
+        $this->commandChain = $chain ?? new CommandChain([[$command, $input]]);
+
+        try {
+            $exitCode = $this->doRunCommand($command, $input, $output);
+        } finally {
+            // $runningCommand is left as is: renderThrowable() reports the synopsis of the command that failed
+            $this->commandChain = $previousChain;
+        }
+
         $this->runningCommand = null;
 
         return $exitCode;
@@ -642,15 +700,6 @@ class Application implements ResetInterface
 
         $command = $this->commands[$name];
 
-        if ($this->wantHelps) {
-            $this->wantHelps = false;
-
-            $helpCommand = $this->get('help');
-            $helpCommand->setCommand($command);
-
-            return $helpCommand;
-        }
-
         return $command;
     }
 
@@ -772,14 +821,10 @@ class Application implements ResetInterface
             $message = \sprintf('Command "%s" is not defined.', $name);
 
             if ($alternatives = $this->findAlternatives($name, $allCommands)) {
-                $wantHelps = $this->wantHelps;
-                $this->wantHelps = false;
-
                 // remove hidden commands
                 if ($alternatives = array_filter($alternatives, fn ($name) => !$this->get($name)->isHidden())) {
                     $message .= \sprintf("\n\nDid you mean %s?\n    %s", 1 === \count($alternatives) ? 'this' : 'one of these', implode("\n    ", $alternatives));
                 }
-                $this->wantHelps = $wantHelps;
             }
 
             throw new CommandNotFoundException($message, array_values($alternatives));
@@ -1417,5 +1462,186 @@ class Application implements ResetInterface
                 $this->addCommand($this->container->get($id));
             }
         }
+    }
+
+    /**
+     * Resolves a spaced sub-command invocation through the tree derived from registered names.
+     *
+     * Returns the leaf command, the input it must run with and the resolved chain,
+     * or null when the resolved command has no registered descendants and the
+     * regular, flat pipeline applies.
+     *
+     * @return array{0: Command, 1: InputInterface, 2: CommandChain}|null
+     */
+    private function resolveCommandTree(Command $command, ArgvInput|ArrayInput $input): ?array
+    {
+        $path = $command->getName();
+        if ($this->singleCommand || !$path || !$this->getTreeDescendants($path)) {
+            return null;
+        }
+
+        $tokens = $input instanceof ArgvInput ? $input->getRawTokens() : null;
+        $node = $this->has($path) ? $command : null;
+        $isRoot = true;
+        $applicationOptions = [];
+        $levels = [];
+
+        while (true) {
+            $definition = new InputDefinition();
+            if ($node) {
+                $definition->setOptions($node->getNativeDefinition()->getOptions());
+                $definition->addOptions($this->getDefinition()->getOptions());
+            } else {
+                $definition->setOptions($this->getDefinition()->getOptions());
+            }
+            if ($isRoot) {
+                $definition->setArguments($this->getDefinition()->getArguments());
+            }
+            $definition->setIgnoreExtraArguments(true);
+
+            $levelInput = null === $tokens ? clone $input : new ArgvInput(['', ...$tokens]);
+            $levelInput->bind($definition);
+            $unparsed = $levelInput->getUnparsedTokens();
+            $consumed = null === $tokens ? [] : \array_slice($tokens, 0, \count($tokens) - \count($unparsed));
+
+            if (!$unparsed || '--' === end($consumed) || '--' === $unparsed[0]) {
+                // no sub-command given, or "--" marked the remaining tokens as this node's own arguments
+                break;
+            }
+
+            $segment = array_shift($unparsed);
+            $childPath = $path.':'.$segment;
+            // an alias of the current node is not a sub-command
+            $has = $this->has($childPath) && $this->get($childPath)->getName() !== $path;
+
+            if (!$has && !$this->getTreeDescendants($childPath)) {
+                if (!$node?->getNativeDefinition()->getArguments()) {
+                    throw $this->createUnknownSegmentException($segment, $path);
+                }
+
+                // the segment names no sub-command: it starts the node's own arguments
+                break;
+            }
+
+            $applicationOptions = [...$applicationOptions, ...$this->getApplicationOptionTokens($levelInput, $consumed)];
+            if ($node) {
+                $levels[] = [$node instanceof LazyCommand ? $node->getCommand() : $node, $levelInput];
+            }
+
+            if ($has) {
+                $node = $this->get($childPath);
+                if ($this->getTreeDescendants($name = $node->getName()) || !$this->getTreeDescendants($childPath)) {
+                    // an alias names the command it points to, unless that would orphan the sub-commands registered under it
+                    $childPath = $name;
+                }
+            } else {
+                $node = null;
+            }
+
+            $path = $childPath;
+            $tokens = $unparsed;
+            $isRoot = false;
+
+            if ($has && !$this->getTreeDescendants($childPath)) {
+                break;
+            }
+        }
+
+        if ($isRoot) {
+            return null;
+        }
+
+        if ($this->has($path)) {
+            $command = $this->get($path);
+            if ($command instanceof LazyCommand) {
+                $command = $command->getCommand();
+            }
+        } else {
+            // implicit node: no command is registered at this level, its default behavior applies
+            $command = new Command($path);
+            $command->setApplication($this);
+        }
+
+        $leafInput = new ArgvInput(['', $path, ...$applicationOptions, ...$tokens]);
+        $leafInput->setInteractive($input->isInteractive());
+        if (\is_resource($stream = $input->getStream())) {
+            $leafInput->setStream($stream);
+        }
+
+        $levels[] = [$command, $leafInput];
+
+        return [$command, $leafInput, new CommandChain($levels)];
+    }
+
+    /**
+     * Lists the registered command names below the given path, "$path:" excluded.
+     *
+     * @return list<string>
+     */
+    private function getTreeDescendants(string $path): array
+    {
+        $names = array_keys($this->commands);
+        if ($this->commandLoader) {
+            $names = array_merge($names, $this->commandLoader->getNames());
+        }
+
+        $prefix = $path.':';
+        $descendants = [];
+        foreach ($names as $name) {
+            if (str_starts_with($name, $prefix) && $prefix !== $name && (!isset($this->commands[$name]) || $this->commands[$name]->getName() !== $path)) {
+                $descendants[] = $name;
+            }
+        }
+
+        return $descendants;
+    }
+
+    private function createUnknownSegmentException(string $segment, string $path): CommandNotFoundException
+    {
+        $message = \sprintf('There is no command "%s" under "%s".', $segment, str_replace(':', ' ', $path));
+
+        $children = [];
+        $prefixLength = \strlen($path) + 1;
+        foreach ($this->getTreeDescendants($path) as $name) {
+            $childSegment = explode(':', substr($name, $prefixLength))[0];
+            $children[$childSegment] = $path.':'.$childSegment;
+        }
+
+        $alternatives = array_values(array_intersect_key($children, array_flip($this->findAlternatives($segment, array_keys($children)))));
+        if ($alternatives) {
+            $message .= \sprintf("\n\nDid you mean one of these?\n    %s", implode("\n    ", $alternatives));
+        }
+
+        return new CommandNotFoundException($message, $alternatives);
+    }
+
+    /**
+     * Re-emits the application options bound at a tree level as tokens, so that the leaf input carries them too.
+     *
+     * @return list<string>
+     */
+    private function getApplicationOptionTokens(InputInterface $input, array $consumed): array
+    {
+        $tokens = [];
+        foreach ($this->getDefinition()->getOptions() as $option) {
+            $name = $option->getName();
+            if (($value = $input->getOption($name)) === $option->getDefault()) {
+                continue;
+            }
+
+            if (!$option->acceptValue()) {
+                // the token is replayed as it was given, so that a repeated shortcut such as "-vv" keeps its meaning
+                $given = array_map(static fn ($shortcut) => '-'.$shortcut, array_filter(explode('|', $option->getShortcut() ?? '')));
+                $tokens[] = $value ? (array_values(array_intersect($consumed, ['--'.$name, ...$given]))[0] ?? '--'.$name) : '--no-'.$name;
+            } elseif (null === $value) {
+                $tokens[] = '--'.$name;
+            } else {
+                foreach ((array) $value as $v) {
+                    $tokens[] = '--'.$name.'='.$v;
+                }
+            }
+        }
+
+        return $tokens;
     }
 }

--- a/src/Symfony/Component/Console/ArgumentResolver/ArgumentResolver.php
+++ b/src/Symfony/Component/Console/ArgumentResolver/ArgumentResolver.php
@@ -22,6 +22,7 @@ use Symfony\Component\Console\Attribute\Option;
 use Symfony\Component\Console\Attribute\Reflection\ReflectionMember;
 use Symfony\Component\Console\Attribute\ValueResolver;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\CommandChain;
 use Symfony\Component\Console\Cursor;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\RawInputInterface;
@@ -43,6 +44,7 @@ final class ArgumentResolver implements ArgumentResolverInterface
         SymfonyStyle::class,
         Cursor::class,
         Application::class,
+        CommandChain::class,
         Command::class,
     ];
 

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -4,6 +4,16 @@ CHANGELOG
 8.2
 ---
 
+ * Resolve spaced sub-command invocations through the tree derived from registered command names, with per-level options and `--` binding the remaining tokens to the current command
+ * List the sub-commands of a command invoked bare when it has no code of its own, on the error output and with exit code 1 like a bare namespace
+ * Walk namespaces without a registered root command the same way: `cache clear` runs `cache:clear`
+ * Show the help of the deepest resolved command when `--help` is used on a spaced sub-command invocation
+ * Add `CommandChain` to read the resolved commands and each level's bound input, injectable into invokable commands and exposed by `Application::getCommandChain()`
+ * Complete sub-command segments, per-level options and the node's own argument values when the completion cursor sits inside a command tree
+ * Collapse the commands below a registered command to that command's line in the application listing, and list a command's sub-commands in its help
+ * Add `InputDefinition::setIgnoreExtraArguments()`, `ArgvInput::getUnparsedTokens()` and `ArrayInput::getUnparsedTokens()` to stop parsing on the first extra argument and retrieve the remaining tokens
+ * Add `UnexpectedArgumentException`, thrown when an input has more arguments than its definition expects
+ * Bind positional `ArrayInput` parameters to the argument slots in order
  * Allow reading several files at once through a variadic `InputFile` or `InputFile[]`-typed `#[Argument]`/`#[Option]`, the `FileQuestion` `multiple` option, and `SymfonyStyle::askFiles()`
  * Add `InputOption::HIDDEN` and `InputOption::DEPRECATED` modes
  * Allow a callable for the `description` and `help` options of `#[AsCommand]`, and for the `description` option of `#[Argument]` and `#[Option]`

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -19,6 +19,7 @@ use Symfony\Component\Console\Completion\Suggestion;
 use Symfony\Component\Console\Exception\ExceptionInterface;
 use Symfony\Component\Console\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Exception\LogicException;
+use Symfony\Component\Console\Helper\DescriptorHelper;
 use Symfony\Component\Console\Helper\FormatterHelper;
 use Symfony\Component\Console\Helper\HelperInterface;
 use Symfony\Component\Console\Helper\HelperSet;
@@ -26,6 +27,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -188,6 +190,15 @@ class Command implements SignalableCommandInterface
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        if (null !== $this->name && ($application = $this->getApplication()) && $application->all($this->name)) {
+            // a command with sub-commands and no code of its own lists them, like a bare namespace
+            $buffer = new BufferedOutput($output->getVerbosity(), $output->isDecorated(), $output->getFormatter());
+            (new DescriptorHelper())->describe($buffer, $application, ['namespace' => $this->name]);
+            ($output instanceof ConsoleOutputInterface ? $output->getErrorOutput() : $output)->write($buffer->fetch(), false, OutputInterface::OUTPUT_RAW);
+
+            return 1;
+        }
+
         throw new LogicException('You must override the execute() method in the concrete command class.');
     }
 
@@ -356,6 +367,7 @@ class Command implements SignalableCommandInterface
         $this->fullDefinition = new InputDefinition();
         $this->fullDefinition->setOptions($this->definition->getOptions());
         $this->fullDefinition->addOptions($this->application->getDefinition()->getOptions());
+        $this->fullDefinition->setIgnoreExtraArguments($this->definition->ignoresExtraArguments());
 
         if ($mergeArgs) {
             $this->fullDefinition->setArguments($this->application->getDefinition()->getArguments());

--- a/src/Symfony/Component/Console/Command/CompleteCommand.php
+++ b/src/Symfony/Component/Console/Command/CompleteCommand.php
@@ -18,8 +18,12 @@ use Symfony\Component\Console\Completion\Output\BashCompletionOutput;
 use Symfony\Component\Console\Completion\Output\CompletionOutputInterface;
 use Symfony\Component\Console\Completion\Output\FishCompletionOutput;
 use Symfony\Component\Console\Completion\Output\ZshCompletionOutput;
+use Symfony\Component\Console\Completion\Suggestion;
 use Symfony\Component\Console\Exception\CommandNotFoundException;
 use Symfony\Component\Console\Exception\ExceptionInterface;
+use Symfony\Component\Console\Exception\InvalidArgumentException;
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -104,11 +108,31 @@ final class CompleteCommand extends Command
                 '<info>Messages:</>',
             ]);
 
-            if ($command = $this->findCommand($completionInput)) {
+            $treeSuggested = false;
+            $command = $this->findCommand($completionInput);
+            $node = $command;
+            if (null === $node && $first = $completionInput->getFirstArgument()) {
+                try {
+                    $node = new Command($first);
+                    $node->setApplication($this->getApplication());
+                } catch (InvalidArgumentException) {
+                    // the first argument is not a valid command name, nothing to walk
+                }
+            }
+            if ($node && $tree = $this->completeCommandTree($node, $input, $suggestions)) {
+                if (\is_array($tree)) {
+                    [$command, $completionInput] = $tree;
+                } else {
+                    $treeSuggested = true;
+                }
+            }
+            if ($command && !$treeSuggested) {
                 $command->mergeApplicationDefinition();
                 $completionInput->bind($command->getDefinition());
             }
-            if (null === $command) {
+            if ($treeSuggested) {
+                $this->log('  Suggesting the sub-commands and options of a command tree level.');
+            } elseif (null === $command) {
                 $this->log('  No command found, completing using the Application class.');
 
                 $this->getApplication()->complete($completionInput, $suggestions);
@@ -188,6 +212,131 @@ final class CompleteCommand extends Command
         }
 
         return $completionInput;
+    }
+
+    /**
+     * Completes an input that walks into the tree below the found command.
+     *
+     * Returns true when suggestions for a branch level were added, a rebased
+     * command and input when the cursor sits at leaf level, or null when the
+     * regular completion flow applies.
+     *
+     * @return array{Command, CompletionInput}|true|null
+     */
+    private function completeCommandTree(Command $command, InputInterface $input, CompletionSuggestions $suggestions): array|bool|null
+    {
+        $application = $this->getApplication();
+        $path = $command->getName();
+        $getDescendants = static fn (string $p) => array_keys($application->all($p));
+
+        if (!$path || !$getDescendants($path)) {
+            return null;
+        }
+
+        $words = $input->getOption('input') ?? [];
+        $current = (int) $input->getOption('current');
+        $tokens = \array_slice($words, 1, max(0, $current - 1));
+        $cursorWord = $words[$current] ?? '';
+
+        if (!$tokens) {
+            return null;
+        }
+
+        $node = $command;
+        $isRoot = true;
+
+        while (true) {
+            $definition = new InputDefinition();
+            if ($node) {
+                $definition->setOptions($node->getNativeDefinition()->getOptions());
+                $definition->addOptions($application->getDefinition()->getOptions());
+            } else {
+                $definition->setOptions($application->getDefinition()->getOptions());
+            }
+            if ($isRoot) {
+                $definition->setArguments($application->getDefinition()->getArguments());
+            }
+            $definition->setIgnoreExtraArguments(true);
+
+            $levelInput = new ArgvInput(['', ...$tokens]);
+            try {
+                $levelInput->bind($definition);
+            } catch (ExceptionInterface) {
+                return null;
+            }
+            $unparsed = $levelInput->getUnparsedTokens();
+            $consumed = \array_slice($tokens, 0, \count($tokens) - \count($unparsed));
+
+            if ('--' === end($consumed)) {
+                // the remaining tokens are the current node's own arguments
+                if ($isRoot) {
+                    return null;
+                }
+
+                return $node ? $this->rebaseCompletion($node, $path, $tokens, $words, $current) : true;
+            }
+
+            if (!$unparsed) {
+                if (str_starts_with($cursorWord, '-')) {
+                    $suggestions->suggestOptions($definition->getOptions());
+
+                    return true;
+                }
+
+                $prefixLength = \strlen($path) + 1;
+                $segments = [];
+                foreach ($getDescendants($path) as $name) {
+                    $segments[explode(':', substr($name, $prefixLength))[0]] = true;
+                }
+                foreach (array_keys($segments) as $segment) {
+                    $childPath = $path.':'.$segment;
+                    $suggestions->suggestValue(new Suggestion($segment, $application->has($childPath) ? $application->get($childPath)->getDescription() : ''));
+                }
+
+                if (!$node?->getNativeDefinition()->getArguments()) {
+                    return true;
+                }
+
+                // the node's own argument values complete next to its sub-commands
+                return $isRoot ? null : $this->rebaseCompletion($node, $path, $tokens, $words, $current);
+            }
+
+            $segment = array_shift($unparsed);
+            $childPath = $path.':'.$segment;
+            // an alias of the current node is not a sub-command
+            if ($registered = $application->has($childPath) && $application->get($childPath)->getName() !== $path) {
+                $childPath = $application->get($childPath)->getName();
+            }
+            $childDescendants = $getDescendants($childPath);
+
+            if (!$registered && !$childDescendants) {
+                // the segment names no sub-command: it starts the node's own arguments, if it has any
+                if (!$node?->getNativeDefinition()->getArguments()) {
+                    return true;
+                }
+
+                return $isRoot ? null : $this->rebaseCompletion($node, $path, $tokens, $words, $current);
+            }
+
+            if ($registered && !$childDescendants) {
+                return $this->rebaseCompletion($application->get($childPath), $childPath, $unparsed, $words, $current);
+            }
+
+            $node = $registered ? $application->get($childPath) : null;
+            $path = $childPath;
+            $tokens = $unparsed;
+            $isRoot = false;
+        }
+    }
+
+    /**
+     * Rebases the completion input on a tree node, so that its own definition completes the remaining words.
+     *
+     * @return array{Command, CompletionInput}
+     */
+    private function rebaseCompletion(Command $node, string $path, array $tokens, array $words, int $current): array
+    {
+        return [$node instanceof LazyCommand ? $node->getCommand() : $node, CompletionInput::fromTokens([$words[0], $path, ...$tokens, ...\array_slice($words, $current)], 2 + \count($tokens))];
     }
 
     private function findCommand(CompletionInput $completionInput): ?Command

--- a/src/Symfony/Component/Console/Command/HelpCommand.php
+++ b/src/Symfony/Component/Console/Command/HelpCommand.php
@@ -13,6 +13,8 @@ namespace Symfony\Component\Console\Command;
 
 use Symfony\Component\Console\Descriptor\ApplicationDescription;
 use Symfony\Component\Console\Helper\DescriptorHelper;
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -53,6 +55,8 @@ class HelpCommand extends Command
                 EOF
             )
         ;
+
+        $this->getDefinition()->setIgnoreExtraArguments();
     }
 
     public function setCommand(Command $command): void
@@ -62,7 +66,30 @@ class HelpCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $this->command ??= $this->getApplication()->find($input->getArgument('command_name'));
+        if (!isset($this->command)) {
+            $application = $this->getApplication();
+            $name = $input->getArgument('command_name');
+            // only the commands below the path are resolved, unlike getNamespaces() which resolves them all
+            $isNamespace = static fn (string $path) => (bool) array_filter($application->all($path), static fn (Command $command) => !$command->isHidden());
+
+            if ($input instanceof ArgvInput || $input instanceof ArrayInput) {
+                // a spaced path names a command in a tree: "help docker compose"
+                foreach ($input->getUnparsedTokens() as $token) {
+                    $childPath = ($application->has($name) ? $application->get($name)->getName() : $name).':'.$token;
+                    if (!$application->has($childPath) && !$isNamespace($childPath)) {
+                        break;
+                    }
+                    $name = $childPath;
+                }
+            }
+
+            if (!$application->has($name) && $isNamespace($name)) {
+                $this->command = new Command($name);
+                $this->command->setApplication($application);
+            } else {
+                $this->command = $application->find($name);
+            }
+        }
 
         $helper = new DescriptorHelper();
         $helper->describe($output, $this->command, [

--- a/src/Symfony/Component/Console/Command/InvokableCommand.php
+++ b/src/Symfony/Component/Console/Command/InvokableCommand.php
@@ -18,6 +18,7 @@ use Symfony\Component\Console\Attribute\Argument;
 use Symfony\Component\Console\Attribute\Interact;
 use Symfony\Component\Console\Attribute\MapInput;
 use Symfony\Component\Console\Attribute\Option;
+use Symfony\Component\Console\CommandChain;
 use Symfony\Component\Console\Cursor;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputDefinition;
@@ -150,6 +151,7 @@ class InvokableCommand implements SignalableCommandInterface
                     SymfonyStyle::class => new SymfonyStyle($input, $output, $this->command->getApplication()?->getDispatcher()),
                     Cursor::class => new Cursor($output),
                     Application::class => $this->command->getApplication(),
+                    CommandChain::class => $this->getCommandChain($input),
                     Command::class, self::class => $this->command,
                     default => false,
                 };
@@ -252,5 +254,22 @@ class InvokableCommand implements SignalableCommandInterface
                 $this->interactions[] = new Interaction($invokableThis, $attribute);
             }
         }
+    }
+
+    /**
+     * The application's chain is stale when the command runs from another one, itself included.
+     */
+    private function getCommandChain(InputInterface $input): CommandChain
+    {
+        if ($chain = $this->command->getApplication()?->getCommandChain()) {
+            $commands = $chain->getCommands();
+            $inputs = $chain->getInputs();
+
+            if ($this->command === end($commands) && $input === end($inputs)) {
+                return $chain;
+            }
+        }
+
+        return new CommandChain([[$this->command, $input]]);
     }
 }

--- a/src/Symfony/Component/Console/CommandChain.php
+++ b/src/Symfony/Component/Console/CommandChain.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+
+/**
+ * The commands resolved for the current invocation, from the root to the leaf,
+ * together with the input bound at each level.
+ *
+ * Implicit tree levels have no registered command and do not appear, except
+ * when the invocation ends on one: the running command is always the last level.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+final class CommandChain
+{
+    /**
+     * @param list<array{Command, InputInterface}> $levels
+     */
+    public function __construct(
+        private array $levels,
+    ) {
+    }
+
+    /**
+     * @return list<Command>
+     */
+    public function getCommands(): array
+    {
+        return array_column($this->levels, 0);
+    }
+
+    /**
+     * @return list<InputInterface>
+     */
+    public function getInputs(): array
+    {
+        return array_column($this->levels, 1);
+    }
+
+    /**
+     * Returns the input bound at the level named by a command name, or by the
+     * class of the command or of its invokable code.
+     */
+    /**
+     * The input of an ancestor level holds the options bound at that level; the
+     * running command has the input it was given, arguments included.
+     */
+    public function getInput(string $commandNameOrClass): ?InputInterface
+    {
+        return $this->getLevel($commandNameOrClass)[1] ?? null;
+    }
+
+    /**
+     * Returns the command of the level named by a command name, or by the class
+     * of the command or of its invokable code.
+     */
+    public function getCommand(string $commandNameOrClass): ?Command
+    {
+        return $this->getLevel($commandNameOrClass)[0] ?? null;
+    }
+
+    /**
+     * @return array{Command, InputInterface}|null
+     */
+    private function getLevel(string $commandNameOrClass): ?array
+    {
+        foreach (array_reverse($this->levels) as $level) {
+            if ($level[0]->getName() === $commandNameOrClass || $level[0] instanceof $commandNameOrClass || self::getInvokable($level[0]) instanceof $commandNameOrClass) {
+                return $level;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns the object behind the code of a command, which a container wraps in a closure.
+     */
+    private static function getInvokable(Command $command): ?object
+    {
+        $code = $command->getCode();
+
+        if ($code instanceof \Closure) {
+            $code = new \ReflectionFunction($code)->getClosureThis();
+        } elseif (\is_array($code)) {
+            $code = $code[0];
+        }
+
+        return \is_object($code) ? $code : null;
+    }
+}

--- a/src/Symfony/Component/Console/Completion/CompletionInput.php
+++ b/src/Symfony/Component/Console/Completion/CompletionInput.php
@@ -69,7 +69,7 @@ final class CompletionInput extends ArgvInput
         parent::bind($definition);
 
         $relevantToken = $this->getRelevantToken();
-        if ('-' === $relevantToken[0]) {
+        if (str_starts_with($relevantToken, '-')) {
             // the current token is an input option: complete either option name or option value
             [$optionToken, $optionValue] = explode('=', $relevantToken, 2) + ['', ''];
 

--- a/src/Symfony/Component/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/TextDescriptor.php
@@ -185,6 +185,39 @@ class TextDescriptor extends Descriptor
             $this->writeText('  '.$this->wrapText($help, $terminalWidth - 2, 2), $options);
             $this->writeText("\n");
         }
+
+        if (($application = $command->getApplication()) && ($path = $command->getName()) && $children = $this->getSubCommands($application, $path)) {
+            $width = max(array_map(Helper::width(...), array_keys($children)));
+
+            $this->writeText("\n<comment>Available sub-commands:</comment>", $options);
+            foreach ($children as $segment => $childDescription) {
+                $this->writeText("\n");
+                $this->writeText(\sprintf('  <info>%s</info>%s%s', $segment, str_repeat(' ', $width - Helper::width($segment) + 2), $childDescription), $options);
+            }
+            $this->writeText("\n");
+        }
+    }
+
+    /**
+     * @return array<string, string> the sub-command segments below the given path, with their description
+     */
+    private function getSubCommands(Application $application, string $path): array
+    {
+        $prefix = $path.':';
+        $children = [];
+        foreach ($application->all($path) as $name => $child) {
+            if ($name !== $child->getName() || $child->isHidden()) {
+                continue;
+            }
+            $segment = explode(':', substr($name, \strlen($prefix)))[0];
+            if ($prefix.$segment === $name) {
+                $children[$segment] = $child->getDescription();
+            } else {
+                $children[$segment] ??= '';
+            }
+        }
+
+        return $children;
     }
 
     protected function describeApplication(Application $application, array $options = []): void
@@ -216,6 +249,21 @@ class TextDescriptor extends Descriptor
 
             $commands = $description->getCommands();
             $namespaces = $description->getNamespaces();
+
+            if (!$describedNamespace) {
+                // a registered command collapses the tree below its name
+                foreach (array_keys($commands) as $name) {
+                    $prefix = '';
+                    foreach (explode(':', $name) as $segment) {
+                        if ('' !== $prefix && isset($commands[$prefix])) {
+                            unset($commands[$name]);
+                            break;
+                        }
+                        $prefix = '' === $prefix ? $segment : $prefix.':'.$segment;
+                    }
+                }
+            }
+
             if ($describedNamespace && $namespaces) {
                 // make sure all alias commands are included when describing a specific namespace
                 $describedNamespaceInfo = reset($namespaces);

--- a/src/Symfony/Component/Console/Exception/UnexpectedArgumentException.php
+++ b/src/Symfony/Component/Console/Exception/UnexpectedArgumentException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Exception;
+
+/**
+ * Represents an argument received while the input definition expects no more of them.
+ *
+ * @author Daniel Leech <daniel@dantleech.com>
+ */
+class UnexpectedArgumentException extends RuntimeException implements ExceptionInterface
+{
+}

--- a/src/Symfony/Component/Console/Input/ArgvInput.php
+++ b/src/Symfony/Component/Console/Input/ArgvInput.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Console\Input;
 
 use Symfony\Component\Console\Exception\RuntimeException;
+use Symfony\Component\Console\Exception\UnexpectedArgumentException;
 
 /**
  * ArgvInput represents an input coming from the CLI arguments.
@@ -42,7 +43,7 @@ class ArgvInput extends Input
 {
     /** @var list<string> */
     private array $tokens;
-    private array $parsed;
+    private array $parsed = [];
 
     /** @param list<string>|null $argv */
     public function __construct(?array $argv = null, ?InputDefinition $definition = null)
@@ -74,7 +75,16 @@ class ArgvInput extends Input
         $parseOptions = true;
         $this->parsed = $this->tokens;
         while (null !== $token = array_shift($this->parsed)) {
-            $parseOptions = $this->parseToken($token, $parseOptions);
+            try {
+                $parseOptions = $this->parseToken($token, $parseOptions);
+            } catch (UnexpectedArgumentException $e) {
+                if (!$this->definition->ignoresExtraArguments()) {
+                    throw $e;
+                }
+
+                array_unshift($this->parsed, $token);
+                break;
+            }
         }
     }
 
@@ -159,7 +169,7 @@ class ArgvInput extends Input
     /**
      * Parses an argument.
      *
-     * @throws RuntimeException When too many arguments are given
+     * @throws UnexpectedArgumentException When too many arguments are given
      */
     private function parseArgument(string $token): void
     {
@@ -196,7 +206,7 @@ class ArgvInput extends Input
                 $message = \sprintf('No arguments expected, got "%s".', $token);
             }
 
-            throw new RuntimeException($message);
+            throw new UnexpectedArgumentException($message);
         }
     }
 
@@ -378,6 +388,18 @@ class ArgvInput extends Input
         }
 
         return $parameters;
+    }
+
+    /**
+     * Returns the tokens left unparsed when the definition ignores extra arguments.
+     *
+     * @see InputDefinition::setIgnoreExtraArguments()
+     *
+     * @return list<string>
+     */
+    public function getUnparsedTokens(): array
+    {
+        return $this->parsed;
     }
 
     /**

--- a/src/Symfony/Component/Console/Input/ArrayInput.php
+++ b/src/Symfony/Component/Console/Input/ArrayInput.php
@@ -21,10 +21,16 @@ use Symfony\Component\Console\Exception\InvalidOptionException;
  *
  *     $input = new ArrayInput(['command' => 'foo:bar', 'foo' => 'bar', '--bar' => 'foobar']);
  *
+ * Values without a key fill the argument slots in order:
+ *
+ *     $input = new ArrayInput(['foo:bar', 'bar', '--bar' => 'foobar']);
+ *
  * @author Fabien Potencier <fabien@symfony.com>
  */
 class ArrayInput extends Input
 {
+    private array $unparsedParameters = [];
+
     public function __construct(
         private array $parameters,
         ?InputDefinition $definition = null,
@@ -113,18 +119,73 @@ class ArrayInput extends Input
 
     protected function parse(): void
     {
+        $this->unparsedParameters = [];
+        $ignoresExtraArguments = $this->definition->ignoresExtraArguments();
+        $remaining = $this->parameters;
+
         foreach ($this->parameters as $key => $value) {
             if ('--' === $key) {
                 return;
             }
-            if (str_starts_with($key, '--')) {
+            if (\is_string($key) && str_starts_with($key, '--')) {
                 $this->addLongOption(substr($key, 2), $value);
-            } elseif (str_starts_with($key, '-')) {
+            } elseif (\is_string($key) && str_starts_with($key, '-')) {
                 $this->addShortOption(substr($key, 1), $value);
-            } else {
+            } elseif ($ignoresExtraArguments && ((\is_int($key) && '--' === $value) || !$this->findArgument($key))) {
+                // the remaining parameters are for something else: a sub-command, or the arguments after a "--"
+                $this->unparsedParameters = $remaining;
+
+                return;
+            } elseif (!\is_int($key) || '--' !== $value) {
+                // a positional "--" is the argv separator, it binds to nothing
                 $this->addArgument($key, $value);
             }
+            unset($remaining[$key]);
         }
+    }
+
+    /**
+     * Returns the parameters left unparsed when the definition ignores extra
+     * arguments, converted to argv-shaped tokens.
+     *
+     * @see InputDefinition::setIgnoreExtraArguments()
+     *
+     * @return list<string>
+     */
+    public function getUnparsedTokens(): array
+    {
+        $tokens = [];
+        $arguments = [];
+        $escaped = false;
+
+        foreach ($this->unparsedParameters as $key => $value) {
+            if (\is_string($key) && str_starts_with($key, '-')) {
+                foreach ($this->unparseOption($key, $value) as $token) {
+                    $tokens[] = $token;
+                }
+
+                continue;
+            }
+
+            if ('--' === $key || '--' === $value) {
+                $escaped = true;
+
+                continue;
+            }
+
+            // a named parameter targets an argument of the command itself, it can never name a sub-command
+            $escaped = $escaped || \is_string($key);
+
+            foreach (\is_array($value) ? $value : [$value] as $v) {
+                if ($escaped) {
+                    $arguments[] = $v;
+                } else {
+                    $tokens[] = $v;
+                }
+            }
+        }
+
+        return $escaped ? [...$tokens, '--', ...$arguments] : $tokens;
     }
 
     /**
@@ -182,10 +243,74 @@ class ArrayInput extends Input
      */
     private function addArgument(string|int $name, mixed $value): void
     {
-        if (!$this->definition->hasArgument($name)) {
-            throw new InvalidArgumentException(\sprintf('The "%s" argument does not exist.', $name));
+        if (!$argument = $this->findArgument($name)) {
+            if (\is_string($name) || !$this->definition->hasArgument($name)) {
+                throw new InvalidArgumentException(\sprintf('The "%s" argument does not exist.', $name));
+            }
+
+            // no free slot left: the value is ignored, as it was when positional values did not bind
+            return;
         }
 
-        $this->arguments[$name] = $value;
+        if (\is_int($name) && $argument->isArray()) {
+            $this->arguments[$argument->getName()][] = $value;
+        } else {
+            $this->arguments[$argument->getName()] = $value;
+        }
+    }
+
+    /**
+     * Turns an option parameter back into tokens, the way unparse() does.
+     *
+     * @return list<string>
+     */
+    private function unparseOption(string $key, mixed $value): array
+    {
+        $short = !str_starts_with($key, '--');
+        $name = ltrim($key, '-');
+        $option = match (true) {
+            !$short && $this->definition->hasOption($name) => $this->definition->getOption($name),
+            $short && $this->definition->hasShortcut($name) => $this->definition->getOptionForShortcut($name),
+            default => null,
+        };
+
+        $tokens = [];
+        foreach (\is_array($value) ? $value : [$value] as $v) {
+            if ($option?->isNegatable()) {
+                $tokens[] = \sprintf('--%s%s', $v ? '' : 'no-', $option->getName());
+            } elseif ($option && !$option->acceptValue()) {
+                // a value-less option set to false was not passed
+                if ($v) {
+                    $tokens[] = $key;
+                }
+            } elseif (\in_array($v, [true, null, ''], true)) {
+                $tokens[] = $key;
+            } elseif ($short) {
+                $tokens[] = $key;
+                $tokens[] = $v;
+            } else {
+                $tokens[] = $key.'='.$v;
+            }
+        }
+
+        return $tokens;
+    }
+
+    /**
+     * Returns the argument a parameter binds to: by name, or the first free slot for a positional one.
+     */
+    private function findArgument(string|int $name): ?InputArgument
+    {
+        if (\is_string($name)) {
+            return $this->definition->hasArgument($name) ? $this->definition->getArgument($name) : null;
+        }
+
+        foreach ($this->definition->getArguments() as $argument) {
+            if ($argument->isArray() || !\array_key_exists($argument->getName(), $this->arguments)) {
+                return $argument;
+            }
+        }
+
+        return null;
     }
 }

--- a/src/Symfony/Component/Console/Input/InputDefinition.php
+++ b/src/Symfony/Component/Console/Input/InputDefinition.php
@@ -35,6 +35,7 @@ class InputDefinition
     private array $options = [];
     private array $negations = [];
     private array $shortcuts = [];
+    private bool $ignoreExtraArguments = false;
 
     /**
      * @param array $definition An array of InputArgument and InputOption instance
@@ -349,6 +350,23 @@ class InputDefinition
         }
 
         return $this->negations[$negation];
+    }
+
+    /**
+     * Makes the parser stop on the first extra argument instead of throwing,
+     * leaving it and the following tokens available through ArgvInput::getUnparsedTokens().
+     *
+     * On a command, set the flag in configure(): the definition merged with the
+     * application's one is rebuilt from the command's own definition on every run.
+     */
+    public function setIgnoreExtraArguments(bool $ignore = true): void
+    {
+        $this->ignoreExtraArguments = $ignore;
+    }
+
+    public function ignoresExtraArguments(): bool
+    {
+        return $this->ignoreExtraArguments;
     }
 
     /**

--- a/src/Symfony/Component/Console/Tests/ApplicationCommandTreeTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationCommandTreeTest.php
@@ -1,0 +1,970 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Command\CompleteCommand;
+use Symfony\Component\Console\Command\HelpCommand;
+use Symfony\Component\Console\Command\LazyCommand;
+use Symfony\Component\Console\CommandChain;
+use Symfony\Component\Console\CommandLoader\FactoryCommandLoader;
+use Symfony\Component\Console\ConsoleEvents;
+use Symfony\Component\Console\Event\ConsoleErrorEvent;
+use Symfony\Component\Console\Exception\CommandNotFoundException;
+use Symfony\Component\Console\Exception\NamespaceNotFoundException;
+use Symfony\Component\Console\Exception\RuntimeException;
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
+use Symfony\Component\Console\Output\ConsoleSectionOutput;
+use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Tester\ApplicationTester;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+class ApplicationCommandTreeTest extends TestCase
+{
+    private array $runs = [];
+
+    private function createTreeApplication(): Application
+    {
+        $this->runs = [];
+
+        $application = new Application();
+        $application->setAutoExit(false);
+        $application->setCatchExceptions(false);
+
+        $docker = new Command('docker');
+        $docker->addOption('context', 'c', InputOption::VALUE_REQUIRED);
+
+        $compose = new Command('docker:compose');
+        $compose->addOption('file', 'f', InputOption::VALUE_REQUIRED);
+        $compose->addArgument('project', InputArgument::OPTIONAL, '', null, ['api', 'web']);
+
+        $up = new Command('docker:compose:up');
+        $up->addArgument('service', InputArgument::OPTIONAL, '', null, ['web', 'db']);
+        $up->addOption('detach', 'd', InputOption::VALUE_NONE);
+        $up->setCode(function (InputInterface $input) {
+            $this->runs['docker:compose:up'] = $input;
+
+            return 0;
+        });
+
+        $deploy = new Command('deploy');
+        $deploy->addArgument('target', InputArgument::OPTIONAL, '', null, ['prod', 'staging']);
+        $deploy->setCode(function (InputInterface $input) {
+            $this->runs['deploy'] = $input;
+
+            return 0;
+        });
+
+        $rollback = new Command('deploy:rollback');
+        $rollback->setCode(function (InputInterface $input) {
+            $this->runs['deploy:rollback'] = $input;
+
+            return 0;
+        });
+
+        $leafB = new Command('tree:a:b');
+        $leafB->addOption('fast', null, InputOption::VALUE_NONE);
+        $leafB->setCode(function (InputInterface $input) {
+            $this->runs['tree:a:b'] = $input;
+
+            return 0;
+        });
+
+        $application->addCommand($docker);
+        $application->addCommand($compose);
+        $application->addCommand($up);
+        $application->addCommand($deploy);
+        $application->addCommand($rollback);
+        $application->addCommand(new Command('tree'));
+        $application->addCommand($leafB);
+
+        $nsLeaf = new Command('ns:sub');
+        $nsLeaf->setDescription('A leaf without a registered root');
+        $nsLeaf->addOption('fast', null, InputOption::VALUE_NONE);
+        $nsLeaf->setCode(function (InputInterface $input) {
+            $this->runs['ns:sub'] = $input;
+
+            return 0;
+        });
+        $application->addCommand($nsLeaf);
+
+        return $application;
+    }
+
+    private function createConsoleOutput(): BufferedOutput&ConsoleOutputInterface
+    {
+        return new class extends BufferedOutput implements ConsoleOutputInterface {
+            public BufferedOutput $errorOutput;
+
+            public function __construct()
+            {
+                parent::__construct();
+                $this->errorOutput = new BufferedOutput();
+            }
+
+            public function getErrorOutput(): OutputInterface
+            {
+                return $this->errorOutput;
+            }
+
+            public function setErrorOutput(OutputInterface $error): void
+            {
+                throw new \LogicException('Not supported.');
+            }
+
+            public function section(): ConsoleSectionOutput
+            {
+                throw new \LogicException('Not supported.');
+            }
+        };
+    }
+
+    public function testSpacedInvocationRunsTheLeaf()
+    {
+        $application = $this->createTreeApplication();
+
+        $exitCode = $application->run(new ArgvInput(['cli.php', 'docker', 'compose', 'up', 'web', '--detach']), new NullOutput());
+
+        $this->assertSame(0, $exitCode);
+        $this->assertArrayHasKey('docker:compose:up', $this->runs);
+        $this->assertSame('web', $this->runs['docker:compose:up']->getArgument('service'));
+        $this->assertTrue($this->runs['docker:compose:up']->getOption('detach'));
+    }
+
+    public function testEachLevelParsesItsOwnOptions()
+    {
+        $application = $this->createTreeApplication();
+
+        $exitCode = $application->run(new ArgvInput(['cli.php', 'docker', '--context=prod', 'compose', '-f', 'app.yaml', 'up', 'web']), new NullOutput());
+
+        $this->assertSame(0, $exitCode);
+        $this->assertSame('web', $this->runs['docker:compose:up']->getArgument('service'));
+        $this->assertFalse($this->runs['docker:compose:up']->hasOption('file'));
+    }
+
+    public function testApplicationOptionsBoundAtAnAncestorLevelReachTheLeaf()
+    {
+        $application = $this->createTreeApplication();
+        $application->getDefinition()->addOption(new InputOption('stage', null, InputOption::VALUE_REQUIRED));
+
+        $application->run(new ArgvInput(['cli.php', 'docker', '-v', '--stage=blue', 'compose', '--no-ansi', 'up']), new NullOutput());
+
+        $input = $this->runs['docker:compose:up'];
+        $this->assertTrue($input->getOption('verbose'));
+        $this->assertSame('blue', $input->getOption('stage'));
+        $this->assertFalse($input->getOption('ansi'));
+        $this->assertTrue($input->hasParameterOption('--stage'));
+        $this->assertStringContainsString('-v --stage=blue --no-ansi', (string) $input);
+    }
+
+    public function testARepeatedShortcutIsReplayedAsGiven()
+    {
+        $application = $this->createTreeApplication();
+
+        $application->run(new ArgvInput(['cli.php', 'docker', '-vv', 'compose', 'up']), new NullOutput());
+
+        $input = $this->runs['docker:compose:up'];
+        $this->assertTrue($input->hasParameterOption('-vv'));
+        $this->assertStringContainsString('-vv', (string) $input);
+    }
+
+    public function testUnknownOptionBeforeABranchFailsOnThatLevel()
+    {
+        $application = $this->createTreeApplication();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The "--nope" option does not exist.');
+
+        $application->run(new ArgvInput(['cli.php', 'docker', '--nope', 'compose', 'up']), new NullOutput());
+    }
+
+    public function testLeafKeepsStrictParsing()
+    {
+        $application = $this->createTreeApplication();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Too many arguments');
+
+        $application->run(new ArgvInput(['cli.php', 'docker', 'compose', 'up', 'web', 'extra']), new NullOutput());
+    }
+
+    public function testSubCommandsBindBeforeArgumentSlots()
+    {
+        $application = $this->createTreeApplication();
+
+        $exitCode = $application->run(new ArgvInput(['cli.php', 'deploy', 'rollback']), new NullOutput());
+
+        $this->assertSame(0, $exitCode);
+        $this->assertArrayHasKey('deploy:rollback', $this->runs);
+        $this->assertArrayNotHasKey('deploy', $this->runs);
+    }
+
+    public function testDoubleDashBindsArgumentsToTheCurrentNode()
+    {
+        $application = $this->createTreeApplication();
+
+        $exitCode = $application->run(new ArgvInput(['cli.php', 'deploy', '--', 'rollback']), new NullOutput());
+
+        $this->assertSame(0, $exitCode);
+        $this->assertArrayHasKey('deploy', $this->runs);
+        $this->assertSame('rollback', $this->runs['deploy']->getArgument('target'));
+        $this->assertArrayNotHasKey('deploy:rollback', $this->runs);
+    }
+
+    public function testNodeWithCodeStillRunsWhenNoSubCommandIsGiven()
+    {
+        $application = $this->createTreeApplication();
+
+        $exitCode = $application->run(new ArgvInput(['cli.php', 'deploy']), new NullOutput());
+
+        $this->assertSame(0, $exitCode);
+        $this->assertArrayHasKey('deploy', $this->runs);
+        $this->assertNull($this->runs['deploy']->getArgument('target'));
+    }
+
+    public function testATokenNamingNoSubCommandIsTheNodeArgument()
+    {
+        $application = $this->createTreeApplication();
+
+        $exitCode = $application->run(new ArgvInput(['cli.php', 'deploy', 'prod']), new NullOutput());
+
+        $this->assertSame(0, $exitCode);
+        $this->assertSame('prod', $this->runs['deploy']->getArgument('target'));
+        $this->assertArrayNotHasKey('deploy:rollback', $this->runs);
+    }
+
+    public function testATokenNamingNoSubCommandBelowTheRootIsThatNodeArgument()
+    {
+        $application = $this->createTreeApplication();
+        $application->get('docker:compose')->setCode(function (InputInterface $input) {
+            $this->runs['docker:compose'] = $input;
+
+            return 0;
+        });
+
+        $exitCode = $application->run(new ArgvInput(['cli.php', 'docker', 'compose', '-f', 'app.yaml', 'api']), new NullOutput());
+
+        $this->assertSame(0, $exitCode);
+        $this->assertSame('api', $this->runs['docker:compose']->getArgument('project'));
+        $this->assertSame('app.yaml', $this->runs['docker:compose']->getOption('file'));
+        $this->assertArrayNotHasKey('docker:compose:up', $this->runs);
+    }
+
+    public function testUnknownSegmentGetsScopedAlternatives()
+    {
+        $application = $this->createTreeApplication();
+
+        try {
+            $application->run(new ArgvInput(['cli.php', 'docker', 'compos']), new NullOutput());
+            $this->fail('A CommandNotFoundException should have been thrown.');
+        } catch (CommandNotFoundException $e) {
+            $this->assertStringContainsString('There is no command "compos" under "docker".', $e->getMessage());
+            $this->assertStringNotContainsString(' -- ', $e->getMessage());
+            $this->assertSame(['docker:compose'], $e->getAlternatives());
+        }
+    }
+
+    public function testImplicitIntermediateLevelsRoute()
+    {
+        $application = $this->createTreeApplication();
+
+        $exitCode = $application->run(new ArgvInput(['cli.php', 'tree', 'a', 'b', '--fast']), new NullOutput());
+
+        $this->assertSame(0, $exitCode);
+        $this->assertArrayHasKey('tree:a:b', $this->runs);
+        $this->assertTrue($this->runs['tree:a:b']->getOption('fast'));
+    }
+
+    public function testColonInvocationIsUnchanged()
+    {
+        $application = $this->createTreeApplication();
+
+        $exitCode = $application->run(new ArgvInput(['cli.php', 'deploy:rollback']), new NullOutput());
+
+        $this->assertSame(0, $exitCode);
+        $this->assertArrayHasKey('deploy:rollback', $this->runs);
+    }
+
+    public function testBareGroupWithoutCodeListsItsSubCommands()
+    {
+        $application = $this->createTreeApplication();
+
+        $output = $this->createConsoleOutput();
+        $exitCode = $application->run(new ArgvInput(['cli.php', 'docker']), $output);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('', $output->fetch());
+        $this->assertStringContainsString('docker:compose:up', $output->errorOutput->fetch());
+    }
+
+    public function testTerminalMidNodeWithoutCodeListsItsScope()
+    {
+        $application = $this->createTreeApplication();
+
+        $output = $this->createConsoleOutput();
+        $exitCode = $application->run(new ArgvInput(['cli.php', 'docker', 'compose']), $output);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('', $output->fetch());
+        $this->assertStringContainsString('docker:compose:up', $output->errorOutput->fetch());
+    }
+
+    public function testImplicitNodeListsItsScope()
+    {
+        $application = $this->createTreeApplication();
+
+        $output = $this->createConsoleOutput();
+        $exitCode = $application->run(new ArgvInput(['cli.php', 'tree', 'a']), $output);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('', $output->fetch());
+        $this->assertStringContainsString('tree:a:b', $output->errorOutput->fetch());
+    }
+
+    public function testCodelessCommandWithoutDescendantsStillThrows()
+    {
+        $application = $this->createTreeApplication();
+        $application->addCommand(new Command('solo'));
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('You must override the execute() method');
+
+        $application->run(new ArgvInput(['cli.php', 'solo']), new NullOutput());
+    }
+
+    public function testHelpOnALeafShowsThatLeaf()
+    {
+        $application = $this->createTreeApplication();
+
+        $output = new BufferedOutput();
+        $exitCode = $application->run(new ArgvInput(['cli.php', 'docker', 'compose', 'up', '--help']), $output);
+        $display = $output->fetch();
+
+        $this->assertSame(0, $exitCode);
+        $this->assertStringContainsString('docker:compose:up', $display);
+        $this->assertStringContainsString('--detach', $display);
+        $this->assertStringNotContainsString('--context', $display);
+    }
+
+    public function testHelpOnAMidNodeShowsThatNode()
+    {
+        $application = $this->createTreeApplication();
+
+        $output = new BufferedOutput();
+        $exitCode = $application->run(new ArgvInput(['cli.php', 'docker', 'compose', '--help']), $output);
+        $display = $output->fetch();
+
+        $this->assertSame(0, $exitCode);
+        $this->assertStringContainsString('--file', $display);
+        $this->assertStringNotContainsString('--context', $display);
+    }
+
+    public function testHelpOnATreeRootShowsTheRoot()
+    {
+        $application = $this->createTreeApplication();
+
+        $output = new BufferedOutput();
+        $exitCode = $application->run(new ArgvInput(['cli.php', 'docker', '--help']), $output);
+        $display = $output->fetch();
+
+        $this->assertSame(0, $exitCode);
+        $this->assertStringContainsString('--context', $display);
+    }
+
+    public function testTheLeafCanReadAncestorInputThroughTheChain()
+    {
+        $application = $this->createTreeApplication();
+
+        $context = null;
+        $application->get('docker:compose:up')->setCode(static function (CommandChain $chain) use (&$context): int {
+            $context = $chain->getInput('docker')?->getOption('context');
+
+            return 0;
+        });
+
+        $application->run(new ArgvInput(['cli.php', 'docker', '--context=prod', 'compose', 'up']), new NullOutput());
+
+        $this->assertSame('prod', $context);
+    }
+
+    public function testTheChainIsExposedWhileACommandRuns()
+    {
+        $application = $this->createTreeApplication();
+
+        $observed = [];
+        $application->get('docker:compose:up')->setCode(static function () use ($application, &$observed): int {
+            $chain = $application->getCommandChain();
+            $observed['names'] = array_map(static fn ($c) => $c->getName(), $chain->getCommands());
+            $observed['file'] = $chain->getInput('docker:compose')?->getOption('file');
+
+            return 0;
+        });
+
+        $application->run(new ArgvInput(['cli.php', 'docker', 'compose', '-f', 'app.yaml', 'up']), new NullOutput());
+
+        $this->assertSame(['docker', 'docker:compose', 'docker:compose:up'], $observed['names']);
+        $this->assertSame('app.yaml', $observed['file']);
+        $this->assertNull($application->getCommandChain());
+    }
+
+    public function testAFlatRunExposesASingleLevelChain()
+    {
+        $application = $this->createTreeApplication();
+
+        $observed = null;
+        $application->get('deploy:rollback')->setCode(static function () use ($application, &$observed): int {
+            $observed = array_map(static fn ($c) => $c->getName(), $application->getCommandChain()->getCommands());
+
+            return 0;
+        });
+
+        $application->run(new ArgvInput(['cli.php', 'deploy:rollback']), new NullOutput());
+
+        $this->assertSame(['deploy:rollback'], $observed);
+    }
+
+    public function testCompletionSuggestsChildSegments()
+    {
+        $this->assertSame(['compose'], $this->complete(['bin/console', 'docker', ''], 2));
+        $this->assertSame(['compose'], $this->complete(['bin/console', 'docker', 'comp'], 2));
+        $this->assertSame(['b'], $this->complete(['bin/console', 'tree', 'a', ''], 3));
+    }
+
+    public function testCompletionOffersTheNodeArgumentValuesNextToTheSegments()
+    {
+        $this->assertSame(['rollback', 'prod', 'staging'], $this->complete(['bin/console', 'deploy', ''], 2));
+        $this->assertSame(['up', 'api', 'web'], $this->complete(['bin/console', 'docker', 'compose', ''], 3));
+        $this->assertSame(['up', 'api', 'web'], $this->complete(['bin/console', 'docker', 'compose', 'u'], 3));
+    }
+
+    public function testCompletionSuggestsTheCurrentLevelOptions()
+    {
+        $this->assertContains('--context', $this->complete(['bin/console', 'docker', '-'], 2));
+    }
+
+    public function testCompletionOfALeafUsesTheLeafDefinition()
+    {
+        $suggestions = $this->complete(['bin/console', 'docker', 'compose', 'up', ''], 4);
+
+        $this->assertContains('web', $suggestions);
+        $this->assertContains('db', $suggestions);
+    }
+
+    private function complete(array $words, int $current, ?Application $application = null): array
+    {
+        $application ??= $this->createTreeApplication();
+        $tester = new CommandTester($application->get('_complete'));
+        $tester->execute(['--shell' => 'bash', '--api-version' => CompleteCommand::COMPLETION_API_VERSION, '--input' => $words, '--current' => (string) $current]);
+
+        return array_values(array_filter(array_map(static fn ($s) => explode("\t", $s)[0], explode("\n", $tester->getDisplay(true)))));
+    }
+
+    public function testTheRootListingCollapsesTrees()
+    {
+        $application = $this->createTreeApplication();
+
+        $output = new BufferedOutput();
+        $application->run(new ArgvInput(['cli.php', 'list']), $output);
+        $display = $output->fetch();
+
+        $this->assertStringContainsString('docker', $display);
+        $this->assertStringContainsString('deploy', $display);
+        $this->assertStringNotContainsString('docker:compose', $display);
+        $this->assertStringNotContainsString('deploy:rollback', $display);
+    }
+
+    public function testTheNamespaceListingKeepsTreeCommands()
+    {
+        $application = $this->createTreeApplication();
+
+        $output = new BufferedOutput();
+        $application->run(new ArgvInput(['cli.php', 'list', 'docker']), $output);
+
+        $this->assertStringContainsString('docker:compose:up', $output->fetch());
+    }
+
+    public function testTheHelpOfANodeListsItsSubCommands()
+    {
+        $application = $this->createTreeApplication();
+
+        $output = new BufferedOutput();
+        $application->run(new ArgvInput(['cli.php', 'help', 'docker:compose']), $output);
+        $display = $output->fetch();
+
+        $this->assertStringContainsString('Available sub-commands:', $display);
+        $this->assertStringContainsString('up', $display);
+    }
+
+    public function testSpacedInvocationThroughApplicationTester()
+    {
+        $application = $this->createTreeApplication();
+
+        $tester = new ApplicationTester($application);
+        $statusCode = $tester->run(['command' => 'docker', '--context' => 'prod', 'compose', 'up', 'web']);
+
+        $this->assertSame(0, $statusCode);
+        $this->assertArrayHasKey('docker:compose:up', $this->runs);
+        $this->assertSame('web', $this->runs['docker:compose:up']->getArgument('service'));
+    }
+
+    public function testANamespaceWithoutARegisteredRootIsWalkable()
+    {
+        $application = $this->createTreeApplication();
+
+        $exitCode = $application->run(new ArgvInput(['cli.php', 'ns', 'sub', '--fast']), new NullOutput());
+
+        $this->assertSame(0, $exitCode);
+        $this->assertArrayHasKey('ns:sub', $this->runs);
+        $this->assertTrue($this->runs['ns:sub']->getOption('fast'));
+    }
+
+    public function testABareNamespaceWithoutARegisteredRootListsItsCommands()
+    {
+        $application = $this->createTreeApplication();
+
+        $output = $this->createConsoleOutput();
+        $exitCode = $application->run(new ArgvInput(['cli.php', 'ns']), $output);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('', $output->fetch());
+        $this->assertStringContainsString('ns:sub', $output->errorOutput->fetch());
+    }
+
+    public function testAnUnknownSegmentUnderANamespaceGetsScopedSuggestions()
+    {
+        $application = $this->createTreeApplication();
+
+        try {
+            $application->run(new ArgvInput(['cli.php', 'ns', 'subb']), new NullOutput());
+            $this->fail('A CommandNotFoundException should have been thrown.');
+        } catch (CommandNotFoundException $e) {
+            $this->assertStringContainsString('There is no command "subb" under "ns"', $e->getMessage());
+            $this->assertSame(['ns:sub'], $e->getAlternatives());
+        }
+    }
+
+    public function testCompletionWorksUnderANamespaceWithoutARegisteredRoot()
+    {
+        $this->assertSame(['sub'], $this->complete(['bin/console', 'ns', 's'], 2));
+    }
+
+    public function testCompletionOfAPartialCommandNameEndingWithAColon()
+    {
+        $suggestions = $this->complete(['bin/console', 'docker:'], 1);
+
+        $this->assertContains('docker:compose', $suggestions);
+        $this->assertContains('docker:compose:up', $suggestions);
+    }
+
+    public function testLeafInputInheritsInteractivity()
+    {
+        $application = $this->createTreeApplication();
+
+        $input = new ArgvInput(['cli.php', 'docker', 'compose', 'up']);
+        $input->setInteractive(false);
+        $application->run($input, new NullOutput());
+
+        $this->assertFalse($this->runs['docker:compose:up']->isInteractive());
+    }
+
+    public function testAnAliasAtAnIntermediateLevelWalksTheCanonicalName()
+    {
+        $application = new Application();
+        $application->setAutoExit(false);
+        $application->setCatchExceptions(false);
+        $application->addCommand(new Command('docker'));
+        $application->addCommand((new Command('docker:compose'))->setAliases(['docker:c']));
+        $application->addCommand((new Command('docker:compose:up'))->setCode(function (InputInterface $input) {
+            $this->runs['docker:compose:up'] = $input;
+
+            return 0;
+        }));
+
+        $application->run(new ArgvInput(['cli.php', 'docker', 'c', 'up']), new NullOutput());
+
+        $this->assertArrayHasKey('docker:compose:up', $this->runs);
+        $this->assertSame(['up'], $this->complete(['bin/console', 'docker', 'c', 'u'], 3, $application));
+    }
+
+    public function testAnAliasUnderTheCommandOwnNameIsNotADescendant()
+    {
+        $application = new Application();
+        $application->setAutoExit(false);
+        $application->setCatchExceptions(false);
+        $deploy = new Command('deploy');
+        $deploy->setAliases(['deploy:prod']);
+        $deploy->addArgument('target', InputArgument::OPTIONAL);
+        $deploy->setCode(function (InputInterface $input) {
+            $this->runs['deploy'] = $input;
+
+            return 0;
+        });
+        $application->addCommand($deploy);
+
+        $application->run(new ArgvInput(['cli.php', 'deploy', 'prod']), new NullOutput());
+        $this->assertSame('prod', $this->runs['deploy']->getArgument('target'));
+
+        $application->run(new ArgvInput(['cli.php', 'deploy:prod', 'staging']), new NullOutput());
+        $this->assertSame('staging', $this->runs['deploy']->getArgument('target'));
+
+        $application = new Application();
+        $application->setAutoExit(false);
+        $application->setCatchExceptions(false);
+        $application->setCommandLoader(new FactoryCommandLoader(['deploy' => static fn () => $deploy, 'deploy:prod' => static fn () => $deploy]));
+
+        $application->run(new ArgvInput(['cli.php', 'deploy', 'prod']), new NullOutput());
+        $this->assertSame('prod', $this->runs['deploy']->getArgument('target'));
+    }
+
+    public function testAnAliasResolvingOutsideTheTreeKeepsItsSubCommandsReachable()
+    {
+        $application = new Application();
+        $application->setAutoExit(false);
+        $application->setCatchExceptions(false);
+
+        $other = new Command('other');
+        $other->setAliases(['docker:compose']);
+        $other->addArgument('what', InputArgument::OPTIONAL);
+        $other->setCode(function (InputInterface $input): int {
+            $this->runs['other'] = $input;
+
+            return 0;
+        });
+        $application->addCommand($other);
+        $application->addCommand((new Command('docker:compose:up'))->setCode(function (InputInterface $input): int {
+            $this->runs['docker:compose:up'] = $input;
+
+            return 0;
+        }));
+
+        $application->run(new ArgvInput(['cli.php', 'docker', 'compose', 'up']), new NullOutput());
+        $this->assertArrayHasKey('docker:compose:up', $this->runs);
+        $this->assertArrayNotHasKey('other', $this->runs);
+
+        $application->run(new ArgvInput(['cli.php', 'docker', 'compose']), new NullOutput());
+        $this->assertArrayHasKey('other', $this->runs);
+    }
+
+    public function testAnUnknownSegmentDispatchesTheErrorEvent()
+    {
+        $application = $this->createTreeApplication();
+        $application->setCatchExceptions(true);
+        $dispatcher = new EventDispatcher();
+        $errors = [];
+        $dispatcher->addListener(ConsoleEvents::ERROR, static function (ConsoleErrorEvent $event) use (&$errors) {
+            $errors[] = $event->getError();
+        });
+        $application->setDispatcher($dispatcher);
+
+        $exitCode = $application->run(new ArgvInput(['cli.php', 'docker', 'compos']), new BufferedOutput());
+
+        $this->assertSame(1, $exitCode);
+        $this->assertCount(1, $errors);
+        $this->assertInstanceOf(CommandNotFoundException::class, $errors[0]);
+    }
+
+    public function testABareNamespaceHoldingOnlyHiddenCommandsReportsTheNamespace()
+    {
+        $application = new Application();
+        $application->setAutoExit(false);
+        $application->setCatchExceptions(false);
+        $application->addCommand(new Command('ns'));
+        $application->addCommand((new Command('ns:secret'))->setHidden(true)->setCode(static fn () => 0));
+
+        $output = $this->createConsoleOutput();
+
+        try {
+            $application->run(new ArgvInput(['cli.php', 'ns']), $output);
+            $this->fail('A NamespaceNotFoundException should have been thrown.');
+        } catch (NamespaceNotFoundException $e) {
+            $this->assertSame('There are no commands defined in the "ns" namespace.', $e->getMessage());
+        }
+
+        $this->assertSame('', $output->fetch());
+        $this->assertSame('', $output->errorOutput->fetch());
+    }
+
+    public function testHelpAcceptsASpacedPath()
+    {
+        $application = $this->createTreeApplication();
+
+        $output = new BufferedOutput();
+        $exitCode = $application->run(new ArgvInput(['cli.php', 'help', 'docker', 'compose']), $output);
+        $display = $output->fetch();
+
+        $this->assertSame(0, $exitCode);
+        $this->assertStringContainsString('docker:compose', $display);
+        $this->assertStringContainsString('--file', $display);
+        $this->assertStringNotContainsString('--context', $display);
+    }
+
+    public function testHelpAcceptsASpacedPathToAnImplicitNode()
+    {
+        $application = $this->createTreeApplication();
+
+        $output = new BufferedOutput();
+        $exitCode = $application->run(new ArgvInput(['cli.php', 'help', 'tree', 'a']), $output);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertStringContainsString('tree:a', $output->fetch());
+    }
+
+    public function testHelpKeepsIgnoringTokensThatNameNoSubCommand()
+    {
+        $application = $this->createTreeApplication();
+
+        $output = new BufferedOutput();
+        $exitCode = $application->run(new ArgvInput(['cli.php', 'help', 'deploy:rollback', 'now']), $output);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertStringContainsString('deploy:rollback', $output->fetch());
+    }
+
+    public function testHelpWrapsALazilyRegisteredHelpCommand()
+    {
+        $application = $this->createTreeApplication();
+        $application->addCommand(new LazyCommand('help', [], '', false, static fn () => new HelpCommand()));
+
+        $output = new BufferedOutput();
+        $exitCode = $application->run(new ArgvInput(['cli.php', 'docker', 'compose', '--help']), $output);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertStringContainsString('docker:compose', $output->fetch());
+    }
+
+    public function testANestedRunRestoresTheChain()
+    {
+        $application = $this->createTreeApplication();
+
+        $observed = null;
+        $application->get('docker:compose:up')->setCode(static function () use ($application, &$observed): int {
+            $application->doRun(new ArrayInput(['command' => 'list']), new NullOutput());
+            $observed = array_map(static fn ($c) => $c->getName(), $application->getCommandChain()->getCommands());
+
+            return 0;
+        });
+
+        $application->run(new ArgvInput(['cli.php', 'docker', 'compose', 'up']), new NullOutput());
+
+        $this->assertSame(['docker', 'docker:compose', 'docker:compose:up'], $observed);
+    }
+
+    public function testACommandRunFromAnotherOneGetsItsOwnChain()
+    {
+        $application = $this->createTreeApplication();
+
+        $observed = null;
+        $application->addCommand((new Command('inner'))->setCode(static function (CommandChain $chain) use (&$observed): int {
+            $observed = [array_map(static fn ($c) => $c->getName(), $chain->getCommands()), null !== $chain->getInput('inner')];
+
+            return 0;
+        }));
+        $application->get('docker:compose:up')->setCode(static fn (OutputInterface $output) => $application->find('inner')->run(new ArrayInput([]), $output));
+
+        $application->run(new ArgvInput(['cli.php', 'docker', 'compose', 'up']), new NullOutput());
+
+        $this->assertSame([['inner'], true], $observed);
+    }
+
+    public function testACommandRerunningItselfGetsItsOwnChain()
+    {
+        $application = $this->createTreeApplication();
+
+        $observed = [];
+        $self = new Command('self');
+        $self->addArgument('depth', InputArgument::OPTIONAL);
+        $self->setCode(static function (CommandChain $chain, InputInterface $input, OutputInterface $output) use (&$observed, $self): int {
+            $observed[] = [$input->getArgument('depth'), $chain->getInput('self')?->getArgument('depth')];
+
+            if ('inner' !== $input->getArgument('depth')) {
+                $self->run(new ArrayInput(['depth' => 'inner']), $output);
+            }
+
+            return 0;
+        });
+        $application->addCommand($self);
+
+        $application->run(new ArgvInput(['cli.php', 'self', 'outer']), new NullOutput());
+
+        $this->assertSame([['outer', 'outer'], ['inner', 'inner']], $observed);
+    }
+
+    public function testTheChainIsResetWhenTheCommandThrows()
+    {
+        $application = $this->createTreeApplication();
+        $application->get('docker:compose:up')->setCode(static fn () => throw new \RuntimeException('boom'));
+
+        try {
+            $application->run(new ArgvInput(['cli.php', 'docker', 'compose', 'up']), new NullOutput());
+            $this->fail('A RuntimeException should have been thrown.');
+        } catch (\RuntimeException $e) {
+            $this->assertSame('boom', $e->getMessage());
+        }
+
+        $this->assertNull($application->getCommandChain());
+    }
+
+    public function testCompletionAfterTheDoubleDashUsesTheNodeArguments()
+    {
+        $this->assertSame(['prod', 'staging'], $this->complete(['bin/console', 'deploy', '--', ''], 3));
+        $this->assertSame(['api', 'web'], $this->complete(['bin/console', 'docker', 'compose', '--', ''], 4));
+    }
+
+    public function testCompletionKeepsUnrelatedLazyCommandsLazy()
+    {
+        $application = $this->createLazyApplication($instantiated);
+
+        $this->complete(['bin/console', 'app:one', ''], 2, $application);
+        $this->complete(['bin/console', 'app:one', '-'], 2, $application);
+
+        $this->assertSame(['app:one'], $instantiated);
+    }
+
+    private function createLazyApplication(?array &$instantiated): Application
+    {
+        $instantiated = [];
+        $factories = [];
+        foreach (['app:one', 'app:two', 'other:sub'] as $name) {
+            $factories[$name] = static function () use ($name, &$instantiated) {
+                $instantiated[] = $name;
+
+                return (new Command($name))->setCode(static fn () => 0);
+            };
+        }
+
+        $application = new Application();
+        $application->setAutoExit(false);
+        $application->setCommandLoader(new FactoryCommandLoader($factories));
+
+        return $application;
+    }
+
+    public function testTheHelpOfAnUnknownPathKeepsLazyCommandsLazy()
+    {
+        $application = $this->createLazyApplication($instantiated);
+
+        $application->run(new ArgvInput(['cli.php', 'help', 'app:one', 'nope']), new NullOutput());
+
+        $this->assertSame(['app:one'], $instantiated);
+    }
+
+    public function testTheHelpOfANamespaceKeepsUnrelatedLazyCommandsLazy()
+    {
+        $application = $this->createLazyApplication($instantiated);
+
+        $application->run(new ArgvInput(['cli.php', 'help', 'other']), new NullOutput());
+
+        $this->assertSame(['other:sub'], $instantiated);
+    }
+
+    public function testTheHelpOfACommandKeepsUnrelatedLazyCommandsLazy()
+    {
+        $application = $this->createLazyApplication($instantiated);
+
+        $application->run(new ArgvInput(['cli.php', 'app:one', '--help']), new NullOutput());
+
+        $this->assertSame(['app:one'], $instantiated);
+    }
+
+    public function testHelpAcceptsASpacedPathThroughApplicationTester()
+    {
+        $application = $this->createTreeApplication();
+
+        $tester = new ApplicationTester($application);
+        $exitCode = $tester->run(['command' => 'help', 'command_name' => 'docker', 'compose']);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertStringContainsString('--file', $tester->getDisplay());
+    }
+
+    public function testANamedParameterTargetsTheNodeItself()
+    {
+        $application = $this->createTreeApplication();
+
+        $tester = new ApplicationTester($application);
+        $this->assertSame(0, $tester->run(['command' => 'deploy', 'target' => 'prod']));
+        $this->assertSame('prod', $this->runs['deploy']->getArgument('target'));
+
+        $this->assertSame(0, $tester->run(['command' => 'deploy', 'rollback']));
+        $this->assertArrayHasKey('deploy:rollback', $this->runs);
+    }
+
+    public function testANamedParameterIsNeverASubCommand()
+    {
+        $application = $this->createTreeApplication();
+
+        $tester = new ApplicationTester($application);
+        $this->assertSame(0, $tester->run(['command' => 'deploy', 'target' => 'rollback']));
+
+        $this->assertSame('rollback', $this->runs['deploy']->getArgument('target'));
+        $this->assertArrayNotHasKey('deploy:rollback', $this->runs);
+    }
+
+    public function testANamedParameterBelowTheRootTargetsTheLeaf()
+    {
+        $application = $this->createTreeApplication();
+
+        $tester = new ApplicationTester($application);
+        $this->assertSame(0, $tester->run(['command' => 'docker', 'compose', 'up', 'service' => 'web']));
+
+        $this->assertSame('web', $this->runs['docker:compose:up']->getArgument('service'));
+    }
+
+    public function testAnOptionSetToFalseThroughArrayInputReachesTheLeaf()
+    {
+        $application = $this->createTreeApplication();
+
+        $tester = new ApplicationTester($application);
+        $this->assertSame(0, $tester->run(['command' => 'docker', 'compose', 'up', '--ansi' => false]));
+
+        $this->assertFalse($this->runs['docker:compose:up']->getOption('ansi'));
+    }
+
+    public function testAPositionalParameterNamingNoSubCommandIsTheNodeArgument()
+    {
+        $application = $this->createTreeApplication();
+
+        $tester = new ApplicationTester($application);
+        $this->assertSame(0, $tester->run(['command' => 'deploy', 'prod']));
+        $this->assertSame('prod', $this->runs['deploy']->getArgument('target'));
+
+        $this->assertSame(0, $tester->run(['command' => 'deploy', '--', 'rollback']));
+        $this->assertSame('rollback', $this->runs['deploy']->getArgument('target'));
+        $this->assertArrayNotHasKey('deploy:rollback', $this->runs);
+    }
+
+    public function testAnImplicitRootDoesNotAppearInTheChain()
+    {
+        $application = $this->createTreeApplication();
+
+        $observed = null;
+        $application->get('ns:sub')->setCode(static function (CommandChain $chain) use (&$observed): int {
+            $observed = [array_map(static fn ($c) => $c->getName(), $chain->getCommands()), $chain->getInput('ns')];
+
+            return 0;
+        });
+
+        $application->run(new ArgvInput(['cli.php', 'ns', 'sub']), new NullOutput());
+
+        $this->assertSame([['ns:sub'], null], $observed);
+    }
+}

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -400,13 +400,11 @@ class ApplicationTest extends TestCase
         $this->assertEquals($foo, $application->get('afoobar'), '->get() returns a command by alias');
 
         $application = new Application();
-        $application->addCommand($foo = new \FooCommand());
-        // simulate --help
-        $r = new \ReflectionObject($application);
-        $p = $r->getProperty('wantHelps');
-        $p->setValue($application, true);
-        $command = $application->get('foo:bar');
-        $this->assertInstanceOf(HelpCommand::class, $command, '->get() returns the help command if --help is provided as the input');
+        $application->setAutoExit(false);
+        $application->addCommand(new \FooCommand());
+        $tester = new ApplicationTester($application);
+        $tester->run(['command' => 'foo:bar', '--help' => true], ['decorated' => false]);
+        $this->assertStringContainsString('Display help for the given command.', $tester->getDisplay(), 'the help command runs if --help is provided as the input');
     }
 
     public function testHasGetWithCommandLoader()

--- a/src/Symfony/Component/Console/Tests/Command/CommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandTest.php
@@ -20,6 +20,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Exception\InvalidOptionException;
 use Symfony\Component\Console\Exception\LogicException;
 use Symfony\Component\Console\Helper\FormatterHelper;
+use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
@@ -354,6 +355,28 @@ class CommandTest extends TestCase
         $this->expectExceptionMessage('The "--bar" option does not exist.');
 
         $tester->execute(['--bar' => true]);
+    }
+
+    public function testIgnoreExtraArguments()
+    {
+        $unparsedTokens = null;
+        $command = new Command('docker');
+        $command->getDefinition()->setIgnoreExtraArguments();
+        $command->setCode(static function (InputInterface $input) use (&$unparsedTokens): int {
+            $unparsedTokens = $input->getUnparsedTokens();
+
+            return 0;
+        });
+
+        $application = new Application();
+        $application->setAutoExit(false);
+        $application->setCatchExceptions(false);
+        $application->addCommand($command);
+
+        $statusCode = $application->run(new ArgvInput(['cli.php', 'docker', 'compose', 'up', '--detach']), new NullOutput());
+
+        $this->assertSame(0, $statusCode);
+        $this->assertSame(['compose', 'up', '--detach'], $unparsedTokens);
     }
 
     public function testRunWithApplication()

--- a/src/Symfony/Component/Console/Tests/CommandChainTest.php
+++ b/src/Symfony/Component/Console/Tests/CommandChainTest.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\CommandChain;
+use Symfony\Component\Console\Input\ArrayInput;
+
+class CommandChainTest extends TestCase
+{
+    public function testChainAccess()
+    {
+        $docker = new Command('docker');
+        $up = new ChainTestUpCommand('docker:compose:up');
+        $dockerInput = new ArrayInput([]);
+        $upInput = new ArrayInput([]);
+
+        $chain = new CommandChain([[$docker, $dockerInput], [$up, $upInput]]);
+
+        $this->assertSame([$docker, $up], $chain->getCommands());
+        $this->assertSame([$dockerInput, $upInput], $chain->getInputs());
+
+        $this->assertSame($dockerInput, $chain->getInput('docker'));
+        $this->assertSame($upInput, $chain->getInput('docker:compose:up'));
+        $this->assertSame($upInput, $chain->getInput(ChainTestUpCommand::class));
+        $this->assertNull($chain->getInput('nope'));
+
+        $this->assertSame($docker, $chain->getCommand('docker'));
+        $this->assertSame($up, $chain->getCommand(ChainTestUpCommand::class));
+        $this->assertNull($chain->getCommand('nope'));
+    }
+
+    public function testClassLookupPrefersTheDeepestLevel()
+    {
+        $docker = new ChainTestUpCommand('docker');
+        $up = new ChainTestUpCommand('docker:compose:up');
+
+        $chain = new CommandChain([[$docker, new ArrayInput([])], [$up, new ArrayInput([])]]);
+
+        $this->assertSame($up, $chain->getCommand(ChainTestUpCommand::class));
+        $this->assertSame($up, $chain->getCommand(Command::class));
+        $this->assertSame($docker, $chain->getCommand('docker'));
+    }
+
+    public function testLookupByInvokableClass()
+    {
+        $up = new Command('docker:compose:up', new ChainTestInvokable());
+        $upInput = new ArrayInput([]);
+
+        $chain = new CommandChain([[new Command('docker'), new ArrayInput([])], [$up, $upInput]]);
+
+        $this->assertSame($up, $chain->getCommand(ChainTestInvokable::class));
+        $this->assertSame($upInput, $chain->getInput(ChainTestInvokable::class));
+    }
+
+    public function testLookupByTheClassBehindAClosure()
+    {
+        $service = new ChainTestInvokable();
+        $up = new Command('docker:compose:up')->setCode(\Closure::fromCallable($service));
+        $down = new Command('docker:compose:down')->setCode(\Closure::fromCallable([$service, 'down']));
+        $upInput = new ArrayInput([]);
+        $downInput = new ArrayInput([]);
+
+        $chain = new CommandChain([[new Command('docker'), new ArrayInput([])], [$up, $upInput], [$down, $downInput]]);
+
+        $this->assertSame($down, $chain->getCommand(ChainTestInvokable::class));
+        $this->assertSame($downInput, $chain->getInput(ChainTestInvokable::class));
+        $this->assertSame($upInput, $chain->getInput('docker:compose:up'));
+    }
+}
+
+class ChainTestUpCommand extends Command
+{
+}
+
+#[AsCommand(name: 'docker:compose:up')]
+class ChainTestInvokable
+{
+    public function __invoke(): int
+    {
+        return 0;
+    }
+
+    public function down(): int
+    {
+        return 0;
+    }
+}

--- a/src/Symfony/Component/Console/Tests/Input/ArgvInputTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/ArgvInputTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Console\Tests\Input;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Exception\UnexpectedArgumentException;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputDefinition;
@@ -588,6 +589,62 @@ class ArgvInputTest extends TestCase
         yield [['app/console', '--no-ansi', 'foo:bar', 'argument'], ['argument']];
         yield [['app/console', '--no-ansi', 'foo:bar', 'foo:bar'], ['foo:bar']];
         yield [['app/console', '--no-ansi', 'foo:bar', '--', 'argument'], ['--', 'argument']];
+    }
+
+    public function testGetUnparsedTokens()
+    {
+        $definition = new InputDefinition([new InputOption('verbose', 'v', InputOption::VALUE_NONE)]);
+        $definition->setIgnoreExtraArguments(true);
+
+        $input = new ArgvInput(['cli.php', '--verbose', 'compose', 'up', '--detach']);
+        $input->bind($definition);
+
+        $this->assertTrue($input->getOption('verbose'));
+        $this->assertSame([], $input->getArguments());
+        $this->assertSame(['compose', 'up', '--detach'], $input->getUnparsedTokens());
+    }
+
+    public function testGetUnparsedTokensAfterParsedArguments()
+    {
+        $definition = new InputDefinition([new InputArgument('name', InputArgument::REQUIRED)]);
+        $definition->setIgnoreExtraArguments(true);
+
+        $input = new ArgvInput(['cli.php', 'foo', 'sub', '--opt=1']);
+        $input->bind($definition);
+
+        $this->assertSame(['name' => 'foo'], $input->getArguments());
+        $this->assertSame(['sub', '--opt=1'], $input->getUnparsedTokens());
+    }
+
+    public function testGetUnparsedTokensWithFullyParsedInput()
+    {
+        $definition = new InputDefinition([new InputArgument('names', InputArgument::IS_ARRAY)]);
+        $definition->setIgnoreExtraArguments(true);
+
+        $input = new ArgvInput(['cli.php', 'foo', 'bar']);
+        $input->bind($definition);
+
+        $this->assertSame(['names' => ['foo', 'bar']], $input->getArguments());
+        $this->assertSame([], $input->getUnparsedTokens());
+    }
+
+    public function testIgnoreExtraArgumentsDoesNotIgnoreUnknownOptions()
+    {
+        $definition = new InputDefinition();
+        $definition->setIgnoreExtraArguments(true);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('The "--unknown" option does not exist.');
+
+        (new ArgvInput(['cli.php', '--unknown', 'sub']))->bind($definition);
+    }
+
+    public function testExtraArgumentsThrowUnexpectedArgumentException()
+    {
+        $this->expectException(UnexpectedArgumentException::class);
+        $this->expectExceptionMessage('No arguments expected, got "sub".');
+
+        (new ArgvInput(['cli.php', 'sub']))->bind(new InputDefinition());
     }
 
     #[DataProvider('unparseProvider')]

--- a/src/Symfony/Component/Console/Tests/Input/ArrayInputTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/ArrayInputTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Console\Tests\Input;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Exception\InvalidOptionException;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputDefinition;
@@ -20,6 +21,126 @@ use Symfony\Component\Console\Input\InputOption;
 
 class ArrayInputTest extends TestCase
 {
+    public function testGetUnparsedTokens()
+    {
+        $definition = new InputDefinition([new InputArgument('command', InputArgument::REQUIRED), new InputOption('verbose', 'v', InputOption::VALUE_NONE)]);
+        $definition->setIgnoreExtraArguments(true);
+
+        $input = new ArrayInput(['command' => 'docker', '--verbose' => true, 'compose', '--file' => 'app.yaml', 'up']);
+        $input->bind($definition);
+
+        $this->assertSame('docker', $input->getArgument('command'));
+        $this->assertTrue($input->getOption('verbose'));
+        $this->assertSame(['compose', '--file=app.yaml', 'up'], $input->getUnparsedTokens());
+    }
+
+    public function testGetUnparsedTokensFillsPositionalParametersInOrder()
+    {
+        $definition = new InputDefinition([new InputArgument('command', InputArgument::REQUIRED)]);
+        $definition->setIgnoreExtraArguments(true);
+
+        $input = new ArrayInput(['docker', 'compose', 'up']);
+        $input->bind($definition);
+
+        $this->assertSame('docker', $input->getArgument('command'));
+        $this->assertSame(['compose', 'up'], $input->getUnparsedTokens());
+    }
+
+    public function testGetUnparsedTokensSeparateNamedArguments()
+    {
+        $definition = new InputDefinition([new InputArgument('command')]);
+        $definition->setIgnoreExtraArguments(true);
+
+        $input = new ArrayInput(['deploy', 'target' => 'rollback']);
+        $input->bind($definition);
+
+        $this->assertSame(['--', 'rollback'], $input->getUnparsedTokens());
+    }
+
+    public function testGetUnparsedTokensKeepOptionsBeforeTheSeparator()
+    {
+        $definition = new InputDefinition([new InputArgument('command'), new InputOption('force', 'f', InputOption::VALUE_NONE)]);
+        $definition->setIgnoreExtraArguments(true);
+
+        $input = new ArrayInput(['docker', 'compose', 'name' => 'web', '--force' => true]);
+        $input->bind($definition);
+
+        $this->assertSame(['compose', '--force', '--', 'web'], $input->getUnparsedTokens());
+    }
+
+    public function testGetUnparsedTokensOfOptionsSetToFalse()
+    {
+        $definition = new InputDefinition([
+            new InputArgument('command'),
+            new InputOption('ansi', null, InputOption::VALUE_NEGATABLE),
+            new InputOption('none', null, InputOption::VALUE_NONE),
+            new InputOption('flag', null, InputOption::VALUE_REQUIRED),
+        ]);
+        $definition->setIgnoreExtraArguments(true);
+
+        $input = new ArrayInput(['deploy', 'extra', '--ansi' => false, '--none' => false, '--flag' => 'x']);
+        $input->bind($definition);
+
+        $this->assertSame(['extra', '--no-ansi', '--flag=x'], $input->getUnparsedTokens());
+    }
+
+    public function testGetUnparsedTokensStartAtAPositionalDoubleDash()
+    {
+        $definition = new InputDefinition([new InputArgument('command'), new InputArgument('name', InputArgument::OPTIONAL)]);
+        $definition->setIgnoreExtraArguments(true);
+
+        $input = new ArrayInput(['deploy', '--', 'prod']);
+        $input->bind($definition);
+
+        $this->assertSame(['command' => 'deploy', 'name' => null], $input->getArguments());
+        $this->assertSame(['--', 'prod'], $input->getUnparsedTokens());
+    }
+
+    public function testPositionalParametersFillTheFirstFreeArgument()
+    {
+        $definition = new InputDefinition([new InputArgument('command'), new InputArgument('command_name', InputArgument::OPTIONAL)]);
+        $definition->setIgnoreExtraArguments(true);
+
+        $input = new ArrayInput(['command_name' => 'docker', 'help']);
+        $input->bind($definition);
+
+        $this->assertSame(['command' => 'help', 'command_name' => 'docker'], $input->getArguments());
+        $this->assertSame([], $input->getUnparsedTokens());
+    }
+
+    public function testPositionalParametersAppendToAnArrayArgument()
+    {
+        $definition = new InputDefinition([new InputArgument('names', InputArgument::IS_ARRAY)]);
+        $definition->setIgnoreExtraArguments(true);
+
+        $input = new ArrayInput(['a', 'b', 'c']);
+        $input->bind($definition);
+
+        $this->assertSame(['a', 'b', 'c'], $input->getArgument('names'));
+        $this->assertSame([], $input->getUnparsedTokens());
+    }
+
+    public function testGetUnparsedTokensIsEmptyWhenEverythingParses()
+    {
+        $definition = new InputDefinition([new InputArgument('name')]);
+        $definition->setIgnoreExtraArguments(true);
+
+        $input = new ArrayInput(['name' => 'foo']);
+        $input->bind($definition);
+
+        $this->assertSame([], $input->getUnparsedTokens());
+    }
+
+    public function testIgnoreExtraArgumentsDoesNotIgnoreUnknownOptions()
+    {
+        $definition = new InputDefinition();
+        $definition->setIgnoreExtraArguments(true);
+
+        $this->expectException(InvalidOptionException::class);
+
+        (new ArrayInput(['--nope' => 1]))->bind($definition);
+    }
+
     public function testGetFirstArgument()
     {
         $input = new ArrayInput([]);
@@ -63,6 +184,30 @@ class ArrayInputTest extends TestCase
         $input = new ArrayInput(['name' => 'foo'], new InputDefinition([new InputArgument('name')]));
 
         $this->assertSame(['name' => 'foo'], $input->getArguments(), '->parse() parses required arguments');
+    }
+
+    public function testPositionalParametersFillTheArgumentSlots()
+    {
+        $definition = new InputDefinition([new InputArgument('command'), new InputArgument('name', InputArgument::OPTIONAL), new InputArgument('names', InputArgument::IS_ARRAY)]);
+
+        $input = new ArrayInput(['foo', 'bar', 'a', 'b'], $definition);
+        $this->assertSame(['command' => 'foo', 'name' => 'bar', 'names' => ['a', 'b']], $input->getArguments());
+
+        $input = new ArrayInput(['command' => 'foo', 'bar'], $definition);
+        $this->assertSame(['command' => 'foo', 'name' => 'bar', 'names' => []], $input->getArguments());
+
+        $input = new ArrayInput(['name' => 'bar', 'foo', 'a'], $definition);
+        $this->assertSame(['command' => 'foo', 'name' => 'bar', 'names' => ['a']], $input->getArguments());
+
+        $input = new ArrayInput(['name' => 'foo', 'bar'], new InputDefinition([new InputArgument('name')]));
+        $this->assertSame(['name' => 'foo'], $input->getArguments(), 'a positional value without a free slot is ignored when its index is in range');
+    }
+
+    public function testAPositionalDoubleDashIsSkipped()
+    {
+        $input = new ArrayInput(['--', 'foo'], new InputDefinition([new InputArgument('name')]));
+
+        $this->assertSame(['name' => 'foo'], $input->getArguments());
     }
 
     #[DataProvider('provideOptions')]
@@ -137,6 +282,11 @@ class ArrayInputTest extends TestCase
                 ['foo' => 'foo'],
                 new InputDefinition([new InputArgument('name')]),
                 'The "foo" argument does not exist.',
+            ],
+            [
+                ['foo', 'bar'],
+                new InputDefinition([new InputArgument('name')]),
+                'The "1" argument does not exist.',
             ],
             [
                 ['--foo' => null],

--- a/src/Symfony/Component/Console/Tests/Input/InputDefinitionTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/InputDefinitionTest.php
@@ -360,6 +360,18 @@ class InputDefinitionTest extends TestCase
         $this->assertSame($defaults, $definition->getOptionDefaults(), '->getOptionDefaults() returns the default values for all options');
     }
 
+    public function testSetIgnoreExtraArguments()
+    {
+        $definition = new InputDefinition();
+        $this->assertFalse($definition->ignoresExtraArguments());
+
+        $definition->setIgnoreExtraArguments();
+        $this->assertTrue($definition->ignoresExtraArguments());
+
+        $definition->setIgnoreExtraArguments(false);
+        $this->assertFalse($definition->ignoresExtraArguments());
+    }
+
     #[DataProvider('getGetSynopsisData')]
     public function testGetSynopsis(InputDefinition $definition, $expectedSynopsis, $message = null)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

This implements sub-commands for the console, the goal of the #64747 RFC, with a design worked out from that discussion: trees are derived entirely from the colon names Symfony already has, so there is no registration API. The parser primitives, `InputDefinition::setIgnoreExtraArguments()` and `getUnparsedTokens()`, are extracted from the RFC by @dantleech; the feature is built on them.

## Two syntaxes, one tree

Register plain commands named `docker`, `docker:compose`, `docker:compose:up`. There is nothing else to declare:

```php
#[AsCommand(name: 'docker', description: 'Manage containers')]
class DockerCommand extends Command
{
    protected function configure(): void
    {
        $this->addOption('context', 'c', InputOption::VALUE_REQUIRED);
    }
    // no execute(): invoking "docker" bare lists its sub-commands
}

#[AsCommand(name: 'docker:compose:up', description: 'Create and start containers')]
class UpCommand
{
    public function __invoke(
        OutputInterface $output,
        #[Argument] string $service = '',
        #[Option(shortcut: 'd')] bool $detach = false,
    ): int {
        // ...
    }
}
```

Because a registered command's name prefixes other registered names, the namespace below it becomes walkable:

```
bin/console docker --context=prod compose -f app.yaml up web --detach
```

Each level parses its own options, and only the leaf executes. The colon form stays what it is today, an exact registry hit: `bin/console docker:compose:up web --detach` binds everything after the name to the leaf. Whenever no tokens target intermediate levels, the two syntaxes are exactly equivalent, so to anyone who never passes per-level options a tree is indistinguishable from today's namespaces.

## Resolution rules

- The walk starts at a registered command, or at any namespace of registered names: `cache clear` runs `cache:clear` even without a `cache` command, through the same implicit-node rule as intermediate levels. Registering a root command is what adds options, a description, bare behavior and the collapsed listing. Only exact namespace matches walk; abbreviations keep the current error flow.
- A node with registered descendants binds leniently (parsing stops on the first extra token); the leaf binds strictly, so typos fail loudly at every depth, and an unknown option before a branch fails on the level that saw it.
- At a node with descendants, a token that names a sub-command walks down; any other token starts the node's own arguments, so `deploy prod` binds `prod` to the `target` argument of `deploy` exactly as today, while `deploy rollback` runs `deploy:rollback`. When a value collides with a sub-command name, `--` forces the argument form: `deploy -- rollback`. A token that names no sub-command under a node without arguments fails with suggestions scoped to that level.
- Intermediate levels need no registered command: with only `docker` and `docker:compose:up` registered, `docker compose up` routes through an implicit `compose` node.
- A command with descendants and no code of its own lists its scope on the error output and exits with code 1 when invoked bare, the way a bare namespace does today, which also lifts the requirement to override `execute()` for pure grouping commands. A node with code runs it.
- A child does not inherit its parent's options, and the application's options are accepted at every level: an application option bound at an ancestor level is replayed on the leaf input, with the token as it was given, so `docker -v compose up` and `docker compose up -v` reach the leaf and the listeners reading its input the same way.

## Help, list, completion

`docker compose --help` shows the help of the deepest resolved command: the `--help` wrap now happens after tree resolution (the private `Application::$wantHelps` state is gone; the wrap lives where the decision is made). `help docker compose` resolves the same spaced path, aliases and implicit nodes included; tokens that name no sub-command are ignored as before, so `help messenger:consume async` keeps showing the help of `messenger:consume`. The help of a command with descendants ends with an "Available sub-commands" section. The application listing collapses everything below a registered command to that command's single line, since decluttering large applications is the point; `list docker`, the `--raw` option and the machine-readable formats (`--format=json`, `--format=md`) keep showing every command. Completion walks the tree: `docker compose u<TAB>` offers `up` with its description, `docker -<TAB>` offers that level's options, a node with arguments offers its own argument values next to its sub-commands, and at leaf level the completion input is rebased on the leaf so its own completion applies. Completion and help resolve only the commands below the current path, so lazy commands elsewhere stay uninstantiated.

## Reading parent input from the leaf

The resolved chain is exposed as a read-only `CommandChain` holding the commands and each level's bound input. It is injectable into invokable commands like the other core utilities, and reachable from listeners through `Application::getCommandChain()` while a command runs; flat invocations expose a single-level chain, and a command run from inside another one gets its own. Levels are looked up by command name, or by the class of the command or of its invokable, the deepest match first; implicit levels have no entry, and the running command is always the last one.

```php
public function __invoke(CommandChain $chain, OutputInterface $output): int
{
    $context = $chain->getInput('docker')?->getOption('context');
    // ...
}
```

## Testing

Leaves are plain commands, so `CommandTester` and colon-form runs are unchanged. `ArrayInput` learns positional parameters: values without a key fill the argument slots in order and append to an `IS_ARRAY` argument, a positional `--` plays the argv separator, and a named key always binds by name. In the lenient mode of the parser primitives, the parameters left over from the first unexpected one are exposed as argv-shaped tokens. `ApplicationTester` therefore drives spaced runs, and `CommandTester::execute(['foo'])` binds `foo` to the first argument:

```php
$tester = new ApplicationTester($application);
$tester->run(['command' => 'docker', '--context' => 'prod', 'compose', 'up', 'web']);
$tester->run(['command' => 'deploy', 'target' => 'prod']);
$tester->run(['command' => 'deploy', '--', 'rollback']);
```

## Public surface

- Parser layer, usable on its own: `InputDefinition::setIgnoreExtraArguments()` / `ignoresExtraArguments()`, `ArgvInput::getUnparsedTokens()`, `ArrayInput::getUnparsedTokens()`, and `UnexpectedArgumentException`. A nested-application composition works with just these. On a command, the flag is set in `configure()`: like any other change made through `getDefinition()`, it must precede the merge with the application definition, which is rebuilt on every run.
- `CommandChain` and `Application::getCommandChain()`.
- Everything else is internal: resolution lives in `Application`.

## Behavior changes for existing applications

All confined to error paths or prefix-pair layouts; colon-form invocations of leaves are byte-identical. They are listed in `UPGRADE-8.2.md` as well.

- A token naming a registered sub-command, where both `foo` and `foo:bar` are registered and `bar` fits a free argument slot: `bar` was bound to the slot, it now runs `foo:bar`. This covers the colon form too, since the tree is the same: `app:import users` runs `app:import:users` as `app import users` does. `foo -- bar` keeps the old binding. No such layout exists in Symfony itself.
- `cache clear` without a `cache` command: was the namespace listing on the error output with exit code 1, now runs `cache:clear`. Bare `cache` keeps the listing on the error output and exit code 1, but no `ConsoleEvents::ERROR` event is dispatched for it anymore, since nothing fails.
- Error messages on extra tokens and the collapsed root listing change shape.
- Positional `ArrayInput` values were validated by index and never read; they now fill the free argument slots. A value that finds no free slot is still ignored, so every input the old parser accepted keeps being accepted.

For the docs: the two syntaxes and their equivalence, the sub-command-first rule with `--` for collisions, grouping through code-less commands, application options at any level, `CommandChain`, positional `ArrayInput` parameters in the testers, and the parser primitives (`InputDefinition::setIgnoreExtraArguments()` with `getUnparsedTokens()`) next to `ignoreValidationErrors()` for standalone use.


