### PR TITLE
[Mailer] Add PufferPost bridge

### DIFF
--- a/splitsh.json
+++ b/splitsh.json
@@ -61,6 +61,7 @@
         "microsoft-graph-mailer": "src/Symfony/Component/Mailer/Bridge/MicrosoftGraph",
         "postal-mailer": "src/Symfony/Component/Mailer/Bridge/Postal",
         "postmark-mailer": "src/Symfony/Component/Mailer/Bridge/Postmark",
+        "puffer-post-mailer": "src/Symfony/Component/Mailer/Bridge/PufferPost",
         "resend-mailer": "src/Symfony/Component/Mailer/Bridge/Resend",
         "scaleway-mailer": "src/Symfony/Component/Mailer/Bridge/Scaleway",
         "sendgrid-mailer": "src/Symfony/Component/Mailer/Bridge/Sendgrid",

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -3249,6 +3249,7 @@ class FrameworkExtension extends Extension
             MailerBridge\MicrosoftGraph\Transport\MicrosoftGraphTransportFactory::class => ['symfony/microsoft-graph-mailer', 'mailer.transport_factory.microsoftgraph'],
             MailerBridge\Postal\Transport\PostalTransportFactory::class => ['symfony/postal-mailer', 'mailer.transport_factory.postal'],
             MailerBridge\Postmark\Transport\PostmarkTransportFactory::class => ['symfony/postmark-mailer', 'mailer.transport_factory.postmark'],
+            MailerBridge\PufferPost\Transport\PufferPostTransportFactory::class => ['symfony/puffer-post-mailer', 'mailer.transport_factory.pufferpost'],
             MailerBridge\Mailtrap\Transport\MailtrapTransportFactory::class => ['symfony/mailtrap-mailer', 'mailer.transport_factory.mailtrap'],
             MailerBridge\Resend\Transport\ResendTransportFactory::class => ['symfony/resend-mailer', 'mailer.transport_factory.resend'],
             MailerBridge\Scaleway\Transport\ScalewayTransportFactory::class => ['symfony/scaleway-mailer', 'mailer.transport_factory.scaleway'],

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/mailer_transports.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/mailer_transports.php
@@ -29,6 +29,7 @@ use Symfony\Component\Mailer\Bridge\Mailtrap\Transport\MailtrapTransportFactory;
 use Symfony\Component\Mailer\Bridge\MicrosoftGraph\Transport\MicrosoftGraphTransportFactory;
 use Symfony\Component\Mailer\Bridge\Postal\Transport\PostalTransportFactory;
 use Symfony\Component\Mailer\Bridge\Postmark\Transport\PostmarkTransportFactory;
+use Symfony\Component\Mailer\Bridge\PufferPost\Transport\PufferPostTransportFactory;
 use Symfony\Component\Mailer\Bridge\Resend\Transport\ResendTransportFactory;
 use Symfony\Component\Mailer\Bridge\Scaleway\Transport\ScalewayTransportFactory;
 use Symfony\Component\Mailer\Bridge\Sendgrid\Transport\SendgridTransportFactory;
@@ -71,6 +72,7 @@ return static function (ContainerConfigurator $container) {
         'null' => NullTransportFactory::class,
         'postal' => PostalTransportFactory::class,
         'postmark' => PostmarkTransportFactory::class,
+        'pufferpost' => PufferPostTransportFactory::class,
         'mailtrap' => MailtrapTransportFactory::class,
         'resend' => ResendTransportFactory::class,
         'scaleway' => ScalewayTransportFactory::class,

--- a/src/Symfony/Component/Mailer/Bridge/PufferPost/.gitattributes
+++ b/src/Symfony/Component/Mailer/Bridge/PufferPost/.gitattributes
@@ -1,0 +1,3 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore
+/.git* export-ignore

--- a/src/Symfony/Component/Mailer/Bridge/PufferPost/.gitignore
+++ b/src/Symfony/Component/Mailer/Bridge/PufferPost/.gitignore
@@ -1,0 +1,3 @@
+vendor/
+composer.lock
+phpunit.xml

--- a/src/Symfony/Component/Mailer/Bridge/PufferPost/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/Bridge/PufferPost/CHANGELOG.md
@@ -1,0 +1,7 @@
+CHANGELOG
+=========
+
+8.2
+---
+
+ * Add the bridge

--- a/src/Symfony/Component/Mailer/Bridge/PufferPost/LICENSE
+++ b/src/Symfony/Component/Mailer/Bridge/PufferPost/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2026-present Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Symfony/Component/Mailer/Bridge/PufferPost/README.md
+++ b/src/Symfony/Component/Mailer/Bridge/PufferPost/README.md
@@ -1,0 +1,67 @@
+PufferPost Bridge
+=================
+
+Provides PufferPost integration for Symfony Mailer.
+
+Configuration example:
+
+```env
+# API
+MAILER_DSN=pufferpost+api://API_KEY@default
+
+# same thing, shorter
+MAILER_DSN=pufferpost://API_KEY@default
+```
+
+where `API_KEY` is your PufferPost API key.
+
+PufferPost has no SMTP relay, so the bridge is API-only and `pufferpost` is an alias for
+`pufferpost+api`. Sends go over HTTPS and report the error message returned by the API on a
+failed send.
+
+The transport carries what the send endpoint accepts: sender, recipients, subject, text and HTML
+bodies, a single reply-to address, attachments and custom `X-` headers. Inline (`cid:`) attachments
+are rejected, because the API has no `Content-ID` support and the reference would silently break.
+
+The API addresses one recipient per message, so an email with several recipients is submitted as a
+batch: one request, one message per envelope recipient. Cc and Bcc are attached to the first
+message only, because each item is delivered as an independent email.
+
+## Templates
+
+A template stored in PufferPost is rendered server side, through the component's
+`RemoteTemplateEmail`:
+
+```php
+use Symfony\Component\Mailer\RemoteTemplateEmail;
+
+$email = (new RemoteTemplateEmail())
+    ->from('shop@example.com')
+    ->to('jane@example.com')
+    ->template('tpl_welcome', ['name' => 'Jane']);
+```
+
+Such an email carries no body of its own, and the subject belongs to the template, so setting one
+is refused rather than silently dropped.
+
+## Provider options
+
+The remaining options are set as headers, so a plain `Email` carries them and `$mailer->send()`
+keeps working: `X-PufferPost-Metadata` (JSON), `X-PufferPost-Unsubscribe-Group`,
+`X-PufferPost-Locale` and `X-PufferPost-Timezone`. The transport reads them into their own payload
+fields and never sends them on as headers.
+
+Only other `X-` headers are forwarded; the API allow-lists the headers map to those names. An email
+with several reply-to addresses keeps the first, since the others cannot be passed as a raw header.
+
+A batch is one request, so if some messages are accepted and others refused the transport reports
+the failure while the accepted ones are already queued. A Messenger retry of that send would
+deliver those again; `pufferpost/sdk` sends per recipient with idempotency keys where that matters.
+
+Resources
+---------
+
+ * [Contributing](https://symfony.com/doc/current/contributing/index.html)
+ * [Report issues](https://github.com/symfony/symfony/issues) and
+   [send Pull Requests](https://github.com/symfony/symfony/pulls)
+   in the [main Symfony repository](https://github.com/symfony/symfony)

--- a/src/Symfony/Component/Mailer/Bridge/PufferPost/Tests/Transport/PufferPostApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/PufferPost/Tests/Transport/PufferPostApiTransportTest.php
@@ -1,0 +1,455 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\PufferPost\Tests\Transport;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\JsonMockResponse;
+use Symfony\Component\Mailer\Bridge\PufferPost\Transport\PufferPostApiTransport;
+use Symfony\Component\Mailer\Envelope;
+use Symfony\Component\Mailer\Exception\HttpTransportException;
+use Symfony\Component\Mailer\Exception\InvalidArgumentException;
+use Symfony\Component\Mailer\Exception\TransportException;
+use Symfony\Component\Mailer\RemoteTemplateEmail;
+use Symfony\Component\Mailer\Transport\RemoteTemplateTransportInterface;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\Email;
+use Symfony\Component\Mime\Part\DataPart;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+class PufferPostApiTransportTest extends TestCase
+{
+    #[DataProvider('getTransportData')]
+    public function testToString(PufferPostApiTransport $transport, string $expected)
+    {
+        $this->assertSame($expected, (string) $transport);
+    }
+
+    public static function getTransportData(): array
+    {
+        return [
+            [
+                new PufferPostApiTransport('KEY'),
+                'pufferpost+api://pufferpost.com',
+            ],
+            [
+                (new PufferPostApiTransport('KEY'))->setHost('example.com'),
+                'pufferpost+api://example.com',
+            ],
+            [
+                (new PufferPostApiTransport('KEY'))->setHost('example.com')->setPort(99),
+                'pufferpost+api://example.com:99',
+            ],
+        ];
+    }
+
+    public function testSend()
+    {
+        $email = new Email();
+        $email->from(new Address('foo@example.com', 'Ms. Foo Bar'))
+            ->to(new Address('bar@example.com', 'Mr. Recipient'))
+            ->cc('cc@example.com')
+            ->bcc('baz@example.com')
+            ->replyTo(new Address('reply@example.com', 'Ms. Reply'))
+            ->subject('Hello!')
+            ->text('Hello There!')
+            ->html('<p>Hello There!</p>');
+
+        $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
+            $this->assertSame('POST', $method);
+            $this->assertSame('https://pufferpost.com/api/v1/messages/batch', $url);
+            $this->assertContains('Authorization: Bearer KEY', $options['headers']);
+
+            $body = json_decode($options['body'], true);
+            $this->assertCount(1, $body['messages']);
+            $message = $body['messages'][0];
+            $this->assertSame('foo@example.com', $message['from']);
+            $this->assertSame('bar@example.com', $message['to']);
+            $this->assertSame(['cc@example.com'], $message['cc']);
+            $this->assertSame(['baz@example.com'], $message['bcc']);
+            $this->assertSame('reply@example.com', $message['replyTo']);
+            $this->assertSame('Hello!', $message['subject']);
+            $this->assertSame('Hello There!', $message['text']);
+            $this->assertSame('<p>Hello There!</p>', $message['html']);
+
+            return new JsonMockResponse(['data' => [['index' => 0, 'status' => 'accepted', 'id' => 'msg_foobar']]], ['http_code' => 200]);
+        });
+
+        $transport = new PufferPostApiTransport('KEY', $client);
+        $sentMessage = $transport->send($email);
+
+        $this->assertSame('msg_foobar', $sentMessage->getMessageId());
+    }
+
+    public function testSendFansOutOverEveryToRecipient()
+    {
+        $email = (new Email())
+            ->from('foo@example.com')
+            ->to('one@example.com', 'two@example.com')
+            ->cc('cc@example.com')
+            ->subject('Hello!')
+            ->text('Hello There!');
+
+        $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
+            $body = json_decode($options['body'], true);
+            $this->assertCount(2, $body['messages']);
+            $this->assertSame('one@example.com', $body['messages'][0]['to']);
+            $this->assertSame('two@example.com', $body['messages'][1]['to']);
+            // Cc rides on the first message only: each item is an independent email, so repeating
+            // it would deliver a copy per recipient.
+            $this->assertSame(['cc@example.com'], $body['messages'][0]['cc']);
+            $this->assertArrayNotHasKey('cc', $body['messages'][1]);
+
+            return new JsonMockResponse(['data' => [
+                ['index' => 0, 'status' => 'accepted', 'id' => 'msg_1'],
+                ['index' => 1, 'status' => 'accepted', 'id' => 'msg_2'],
+            ]], ['http_code' => 200]);
+        });
+
+        (new PufferPostApiTransport('KEY', $client))->send($email);
+    }
+
+    public function testHonoursAnEnvelopeThatRedirectsAwayFromTheHeaders()
+    {
+        // framework.mailer.envelope.recipients rewrites the envelope and not the headers, so a
+        // staging redirect must win over the To header or real customers receive the mail.
+        $email = (new Email())
+            ->from('foo@example.com')
+            ->to('customer1@example.com', 'customer2@example.com')
+            ->subject('Hello!')
+            ->text('Hello There!');
+        $envelope = new Envelope(new Address('foo@example.com'), [new Address('dev@example.com')]);
+
+        $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
+            $messages = json_decode($options['body'], true)['messages'];
+
+            $this->assertCount(1, $messages);
+            $this->assertSame('dev@example.com', $messages[0]['to']);
+
+            return new JsonMockResponse(['data' => [['index' => 0, 'status' => 'accepted', 'id' => 'msg_1']]], ['http_code' => 200]);
+        });
+
+        (new PufferPostApiTransport('KEY', $client))->send($email, $envelope);
+    }
+
+    public function testSendsABccOnlyMessageOncePerRecipient()
+    {
+        // No To header at all: every envelope recipient becomes its own message, and Bcc is not
+        // repeated onto each one.
+        $email = (new Email())
+            ->from('foo@example.com')
+            ->bcc('x@example.com', 'y@example.com')
+            ->subject('Hello!')
+            ->text('Hello There!');
+
+        $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
+            $messages = json_decode($options['body'], true)['messages'];
+
+            $this->assertCount(2, $messages);
+            $this->assertSame(['x@example.com', 'y@example.com'], array_column($messages, 'to'));
+            $this->assertArrayNotHasKey('bcc', $messages[0]);
+            $this->assertArrayNotHasKey('bcc', $messages[1]);
+
+            return new JsonMockResponse(['data' => [
+                ['index' => 0, 'status' => 'accepted', 'id' => 'msg_1'],
+                ['index' => 1, 'status' => 'accepted', 'id' => 'msg_2'],
+            ]], ['http_code' => 200]);
+        });
+
+        (new PufferPostApiTransport('KEY', $client))->send($email);
+    }
+
+    public function testSendsACcOnlyMessageOncePerRecipient()
+    {
+        $email = (new Email())
+            ->from('foo@example.com')
+            ->cc('cc1@example.com', 'cc2@example.com')
+            ->subject('Hello!')
+            ->text('Hello There!');
+
+        $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
+            $messages = json_decode($options['body'], true)['messages'];
+
+            $this->assertCount(2, $messages);
+            $this->assertSame(['cc1@example.com', 'cc2@example.com'], array_column($messages, 'to'));
+            $this->assertArrayNotHasKey('cc', $messages[0]);
+
+            return new JsonMockResponse(['data' => [
+                ['index' => 0, 'status' => 'accepted', 'id' => 'msg_1'],
+                ['index' => 1, 'status' => 'accepted', 'id' => 'msg_2'],
+            ]], ['http_code' => 200]);
+        });
+
+        (new PufferPostApiTransport('KEY', $client))->send($email);
+    }
+
+    public function testDropsCopyRecipientsTheEnvelopeNoLongerCarries()
+    {
+        // A redirected envelope must not keep mailing the original Cc.
+        $email = (new Email())
+            ->from('foo@example.com')
+            ->to('customer@example.com')
+            ->cc('cc@example.com')
+            ->subject('Hello!')
+            ->text('Hello There!');
+        $envelope = new Envelope(new Address('foo@example.com'), [new Address('dev@example.com')]);
+
+        $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
+            $messages = json_decode($options['body'], true)['messages'];
+
+            $this->assertCount(1, $messages);
+            $this->assertSame('dev@example.com', $messages[0]['to']);
+            $this->assertArrayNotHasKey('cc', $messages[0]);
+
+            return new JsonMockResponse(['data' => [['index' => 0, 'status' => 'accepted', 'id' => 'msg_1']]], ['http_code' => 200]);
+        });
+
+        (new PufferPostApiTransport('KEY', $client))->send($email, $envelope);
+    }
+
+    public function testSendsAStoredTemplateInsteadOfTheBody()
+    {
+        $email = (new RemoteTemplateEmail())
+            ->from('foo@example.com')
+            ->to('bar@example.com')
+            ->template('tpl_welcome', ['name' => 'Jane']);
+
+        $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
+            $message = json_decode($options['body'], true)['messages'][0];
+
+            $this->assertSame('tpl_welcome', $message['templateId']);
+            $this->assertSame(['name' => 'Jane'], $message['data']);
+            // The API refuses a message carrying both a template and inline content.
+            $this->assertArrayNotHasKey('subject', $message);
+            $this->assertArrayNotHasKey('html', $message);
+            $this->assertArrayNotHasKey('text', $message);
+            $this->assertArrayNotHasKey('headers', $message);
+
+            return new JsonMockResponse(['data' => [['index' => 0, 'status' => 'accepted', 'id' => 'msg_1']]], ['http_code' => 200]);
+        });
+
+        (new PufferPostApiTransport('KEY', $client))->send($email);
+    }
+
+    public function testSendsTheRemainingProviderOptions()
+    {
+        $email = (new Email())
+            ->from('foo@example.com')
+            ->to('bar@example.com')
+            ->subject('Hello!')
+            ->text('Hello There!');
+        $email->getHeaders()->addTextHeader('X-PufferPost-Metadata', '{"order_id":"o_9"}');
+        $email->getHeaders()->addTextHeader('X-PufferPost-Unsubscribe-Group', 'receipts');
+        $email->getHeaders()->addTextHeader('X-PufferPost-Locale', 'nl');
+        $email->getHeaders()->addTextHeader('X-PufferPost-Timezone', 'Europe/Amsterdam');
+
+        $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
+            $message = json_decode($options['body'], true)['messages'][0];
+
+            $this->assertSame(['order_id' => 'o_9'], $message['metadata']);
+            $this->assertSame('receipts', $message['unsubscribeGroup']);
+            $this->assertSame('nl', $message['locale']);
+            $this->assertSame('Europe/Amsterdam', $message['timezone']);
+
+            return new JsonMockResponse(['data' => [['index' => 0, 'status' => 'accepted', 'id' => 'msg_1']]], ['http_code' => 200]);
+        });
+
+        (new PufferPostApiTransport('KEY', $client))->send($email);
+    }
+
+    public function testRejectsMalformedMetadata()
+    {
+        $email = (new Email())
+            ->from('foo@example.com')
+            ->to('bar@example.com')
+            ->subject('Hello!')
+            ->text('Hello There!');
+        $email->getHeaders()->addTextHeader('X-PufferPost-Metadata', 'not json');
+
+        $client = new MockHttpClient(static fn (): ResponseInterface => new JsonMockResponse(['data' => []], ['http_code' => 200]));
+
+        $this->expectException(TransportException::class);
+        $this->expectExceptionMessage('must contain a JSON object');
+
+        (new PufferPostApiTransport('KEY', $client))->send($email);
+    }
+
+    public function testRejectsASubjectAlongsideATemplate()
+    {
+        $email = (new RemoteTemplateEmail())
+            ->from('foo@example.com')
+            ->to('bar@example.com')
+            ->subject('overridden')
+            ->template('tpl_welcome');
+
+        $client = new MockHttpClient(static fn (): ResponseInterface => new JsonMockResponse(['data' => []], ['http_code' => 200]));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('does not support overriding the subject of a template');
+
+        (new PufferPostApiTransport('KEY', $client))->send($email);
+    }
+
+    public function testAcceptsAnEmailRenderedFromARemoteTemplate()
+    {
+        // AbstractTransport refuses a RemoteTemplateEmail unless the transport declares support.
+        $this->assertInstanceOf(RemoteTemplateTransportInterface::class, new PufferPostApiTransport('KEY'));
+    }
+
+    public function testSendWithAttachment()
+    {
+        $email = (new Email())
+            ->from('foo@example.com')
+            ->to('bar@example.com')
+            ->subject('Hello!')
+            ->text('Hello There!')
+            ->addPart(new DataPart('body', 'attachment.txt', 'text/plain'));
+
+        $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
+            $body = json_decode($options['body'], true);
+            $attachment = $body['messages'][0]['attachments'][0];
+
+            $this->assertSame('attachment.txt', $attachment['filename']);
+            $this->assertSame('text/plain', $attachment['contentType']);
+            $this->assertSame(base64_encode('body'), $attachment['content']);
+
+            return new JsonMockResponse(['data' => [['index' => 0, 'status' => 'accepted', 'id' => 'msg_1']]], ['http_code' => 200]);
+        });
+
+        (new PufferPostApiTransport('KEY', $client))->send($email);
+    }
+
+    public function testSendWithInlineAttachmentThrows()
+    {
+        $email = (new Email())
+            ->from('foo@example.com')
+            ->to('bar@example.com')
+            ->subject('Hello!')
+            ->text('Hello There!')
+            ->addPart((new DataPart('body', 'logo.png', 'image/png'))->asInline());
+
+        $client = new MockHttpClient(static fn (): ResponseInterface => new JsonMockResponse(['data' => []], ['http_code' => 200]));
+
+        $this->expectException(TransportException::class);
+        $this->expectExceptionMessage('PufferPost does not support inline (cid-embedded) attachments');
+
+        (new PufferPostApiTransport('KEY', $client))->send($email);
+    }
+
+    public function testKeepsOnlyTheFirstReplyToAddress()
+    {
+        $email = (new Email())
+            ->from('foo@example.com')
+            ->to('bar@example.com')
+            ->replyTo('a@example.com', 'b@example.com')
+            ->subject('Hello!')
+            ->text('Hello There!');
+
+        $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
+            $message = json_decode($options['body'], true)['messages'][0];
+
+            // The headers map is allow-listed to X- names, so extra reply-to addresses cannot be
+            // smuggled through it; the first is used.
+            $this->assertSame('a@example.com', $message['replyTo']);
+            $this->assertArrayNotHasKey('headers', $message);
+
+            return new JsonMockResponse(['data' => [['index' => 0, 'status' => 'accepted', 'id' => 'msg_1']]], ['http_code' => 200]);
+        });
+
+        (new PufferPostApiTransport('KEY', $client))->send($email);
+    }
+
+    public function testSendWithCustomHeader()
+    {
+        $email = (new Email())
+            ->from('foo@example.com')
+            ->to('bar@example.com')
+            ->subject('Hello!')
+            ->text('Hello There!');
+        $email->getHeaders()->addTextHeader('X-Campaign', 'welcome');
+        $email->getHeaders()->addTextHeader('In-Reply-To', '<prev@example.com>');
+
+        $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
+            $message = json_decode($options['body'], true)['messages'][0];
+
+            $this->assertSame('welcome', $message['headers']['X-Campaign']);
+            // Only X- names are forwarded; anything else the API would refuse.
+            $this->assertArrayNotHasKey('Subject', $message['headers']);
+            $this->assertArrayNotHasKey('In-Reply-To', $message['headers']);
+
+            return new JsonMockResponse(['data' => [['index' => 0, 'status' => 'accepted', 'id' => 'msg_1']]], ['http_code' => 200]);
+        });
+
+        (new PufferPostApiTransport('KEY', $client))->send($email);
+    }
+
+    public function testSendWithCustomEnvelopeSender()
+    {
+        $email = (new Email())
+            ->from('foo@example.com')
+            ->to('bar@example.com')
+            ->subject('Hello!')
+            ->text('Hello There!');
+        $envelope = new Envelope(new Address('sender@example.com'), [new Address('bar@example.com')]);
+
+        $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
+            $message = json_decode($options['body'], true)['messages'][0];
+
+            // The From header is the visible sender the API verifies, not the envelope sender.
+            $this->assertSame('foo@example.com', $message['from']);
+            $this->assertSame('bar@example.com', $message['to']);
+
+            return new JsonMockResponse(['data' => [['index' => 0, 'status' => 'accepted', 'id' => 'msg_1']]], ['http_code' => 200]);
+        });
+
+        (new PufferPostApiTransport('KEY', $client))->send($email, $envelope);
+    }
+
+    public function testSendThrowsForErrorResponse()
+    {
+        $client = new MockHttpClient(static fn (): ResponseInterface => new JsonMockResponse(
+            ['error' => ['code' => 'sending_paused', 'message' => 'Sending is paused for this workspace.']],
+            ['http_code' => 403],
+        ));
+
+        $email = (new Email())
+            ->from('foo@example.com')
+            ->to('bar@example.com')
+            ->subject('Hello!')
+            ->text('Hello There!');
+
+        $this->expectException(HttpTransportException::class);
+        $this->expectExceptionMessage('Unable to send an email: Sending is paused for this workspace. (code 403).');
+
+        (new PufferPostApiTransport('KEY', $client))->send($email);
+    }
+
+    public function testSendThrowsWhenABatchItemIsRejected()
+    {
+        // A batch answers 200 even when a message is refused, so the rejection must still surface.
+        $client = new MockHttpClient(static fn (): ResponseInterface => new JsonMockResponse(['data' => [
+            ['index' => 0, 'status' => 'error', 'error' => ['code' => 'recipient_suppressed', 'message' => 'The recipient is suppressed.']],
+        ]], ['http_code' => 200]));
+
+        $email = (new Email())
+            ->from('foo@example.com')
+            ->to('bar@example.com')
+            ->subject('Hello!')
+            ->text('Hello There!');
+
+        $this->expectException(HttpTransportException::class);
+        $this->expectExceptionMessage('Unable to send an email: The recipient is suppressed. (code 200).');
+
+        (new PufferPostApiTransport('KEY', $client))->send($email);
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/PufferPost/Tests/Transport/PufferPostTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/PufferPost/Tests/Transport/PufferPostTransportFactoryTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\PufferPost\Tests\Transport;
+
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\Mailer\Bridge\PufferPost\Transport\PufferPostApiTransport;
+use Symfony\Component\Mailer\Bridge\PufferPost\Transport\PufferPostTransportFactory;
+use Symfony\Component\Mailer\Test\AbstractTransportFactoryTestCase;
+use Symfony\Component\Mailer\Test\IncompleteDsnTestTrait;
+use Symfony\Component\Mailer\Transport\Dsn;
+use Symfony\Component\Mailer\Transport\TransportFactoryInterface;
+
+class PufferPostTransportFactoryTest extends AbstractTransportFactoryTestCase
+{
+    use IncompleteDsnTestTrait;
+
+    public function getFactory(): TransportFactoryInterface
+    {
+        return new PufferPostTransportFactory(null, new MockHttpClient(), new NullLogger());
+    }
+
+    public static function supportsProvider(): iterable
+    {
+        yield [
+            new Dsn('pufferpost', 'default'),
+            true,
+        ];
+
+        yield [
+            new Dsn('pufferpost+api', 'default'),
+            true,
+        ];
+    }
+
+    public static function createProvider(): iterable
+    {
+        $logger = new NullLogger();
+
+        yield [
+            new Dsn('pufferpost', 'default', self::USER),
+            new PufferPostApiTransport(self::USER, new MockHttpClient(), null, $logger),
+        ];
+
+        yield [
+            new Dsn('pufferpost+api', 'default', self::USER),
+            new PufferPostApiTransport(self::USER, new MockHttpClient(), null, $logger),
+        ];
+
+        yield [
+            new Dsn('pufferpost+api', 'example.com', self::USER),
+            (new PufferPostApiTransport(self::USER, new MockHttpClient(), null, $logger))->setHost('example.com'),
+        ];
+
+        yield [
+            new Dsn('pufferpost+api', 'example.com', self::USER, null, 8080),
+            (new PufferPostApiTransport(self::USER, new MockHttpClient(), null, $logger))->setHost('example.com')->setPort(8080),
+        ];
+    }
+
+    public static function unsupportedSchemeProvider(): iterable
+    {
+        yield [
+            new Dsn('pufferpost+foo', 'default'),
+            'The "pufferpost+foo" scheme is not supported; supported schemes for mailer "pufferpost" are: "pufferpost", "pufferpost+api".',
+        ];
+    }
+
+    public static function incompleteDsnProvider(): iterable
+    {
+        yield [new Dsn('pufferpost+api', 'default')];
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/PufferPost/Transport/PufferPostApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/PufferPost/Transport/PufferPostApiTransport.php
@@ -1,0 +1,282 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\PufferPost\Transport;
+
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Mailer\Envelope;
+use Symfony\Component\Mailer\Exception\HttpTransportException;
+use Symfony\Component\Mailer\Exception\InvalidArgumentException;
+use Symfony\Component\Mailer\Exception\TransportException;
+use Symfony\Component\Mailer\RemoteTemplateEmail;
+use Symfony\Component\Mailer\SentMessage;
+use Symfony\Component\Mailer\Transport\AbstractApiTransport;
+use Symfony\Component\Mailer\Transport\RemoteTemplateTransportInterface;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\Email;
+use Symfony\Contracts\HttpClient\Exception\DecodingExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * @author Jeroen Moonen (PufferPost) <info@jeroenmoonen.nl>
+ */
+final class PufferPostApiTransport extends AbstractApiTransport implements RemoteTemplateTransportInterface
+{
+    private const HOST = 'pufferpost.com';
+
+    /**
+     * Provider-specific options, set as headers so a plain Symfony Email carries them and
+     * `$mailer->send()` keeps working. The transport reads them into their own payload fields and
+     * skips them when building the API's header map, so they are never sent on as headers.
+     */
+    private const METADATA = 'x-pufferpost-metadata';
+    private const UNSUBSCRIBE_GROUP = 'x-pufferpost-unsubscribe-group';
+    private const LOCALE = 'x-pufferpost-locale';
+    private const TIMEZONE = 'x-pufferpost-timezone';
+
+    public function __construct(
+        #[\SensitiveParameter] private readonly string $key,
+        ?HttpClientInterface $client = null,
+        ?EventDispatcherInterface $dispatcher = null,
+        ?LoggerInterface $logger = null,
+    ) {
+        parent::__construct($client, $dispatcher, $logger);
+    }
+
+    public function __toString(): string
+    {
+        return \sprintf('pufferpost+api://%s', $this->getEndpoint());
+    }
+
+    protected function doSendApi(SentMessage $sentMessage, Email $email, Envelope $envelope): ResponseInterface
+    {
+        // The API addresses one primary recipient per message, so a fan-out is submitted as a
+        // batch: one request, one message per To address, each accepted or rejected on its own.
+        $response = $this->client->request('POST', 'https://'.$this->getEndpoint().'/api/v1/messages/batch', [
+            'auth_bearer' => $this->key,
+            'json' => ['messages' => $this->getPayload($email, $envelope)],
+        ]);
+
+        try {
+            $statusCode = $response->getStatusCode();
+            $result = $response->toArray(false);
+        } catch (DecodingExceptionInterface) {
+            throw new HttpTransportException('Unable to send an email: '.$response->getContent(false).\sprintf(' (code %d).', $response->getStatusCode()), $response);
+        } catch (TransportExceptionInterface $e) {
+            throw new HttpTransportException('Could not reach the remote PufferPost server.', $response, 0, $e);
+        }
+
+        if (200 !== $statusCode && 202 !== $statusCode) {
+            throw new HttpTransportException('Unable to send an email: '.($result['error']['message'] ?? $response->getContent(false)).\sprintf(' (code %d).', $statusCode), $response);
+        }
+
+        // A batch answers 200 even when individual messages were refused, so surface the first
+        // rejection rather than reporting a send that never happened.
+        $items = $result['data'] ?? [];
+        foreach ($items as $item) {
+            if ('accepted' !== ($item['status'] ?? null)) {
+                throw new HttpTransportException('Unable to send an email: '.($item['error']['message'] ?? 'the message was rejected').\sprintf(' (code %d).', $statusCode), $response);
+            }
+        }
+
+        // A fan-out produces one id per recipient; SentMessage holds a single value, so keep the
+        // first and leave the rest to the batch response the caller can read.
+        if (isset($items[0]['id'])) {
+            $sentMessage->setMessageId((string) $items[0]['id']);
+        }
+
+        return $response;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>> one message per recipient
+     */
+    private function getPayload(Email $email, Envelope $envelope): array
+    {
+        // The visible sender, which the API matches against a verified sender identity. The
+        // envelope sender resolves to Sender or Return-Path first, so it can be a bounce address
+        // the API would refuse.
+        $from = $email->getFrom();
+        $shared = [
+            'from' => $from ? $from[0]->getAddress() : $envelope->getSender()->getAddress(),
+        ];
+
+        // A stored template renders server side, and the API refuses a message that carries both a
+        // template and inline content, so the body is sent only when no template was asked for.
+        // RemoteTemplateEmail already forbids a text or HTML part alongside a template; the subject
+        // is the one piece it cannot refuse, so reject it here rather than dropping it silently.
+        $template = $email instanceof RemoteTemplateEmail ? $email->getRemoteTemplate() : null;
+        if (null !== $template) {
+            if (null !== $email->getSubject()) {
+                throw new InvalidArgumentException('PufferPost does not support overriding the subject of a template; define the subject in the template itself.');
+            }
+
+            $shared['templateId'] = $template->getReference();
+            if ($variables = $template->getVariables()) {
+                $shared['data'] = $variables;
+            }
+        } else {
+            if (null !== $email->getSubject()) {
+                $shared['subject'] = $email->getSubject();
+            }
+
+            if (null !== $text = $email->getTextBody()) {
+                $shared['text'] = $text;
+            }
+
+            if (null !== $html = $email->getHtmlBody()) {
+                $shared['html'] = $html;
+            }
+        }
+
+        if (null !== $metadata = $this->jsonOption($email, self::METADATA)) {
+            $shared['metadata'] = $metadata;
+        }
+
+        foreach ([self::UNSUBSCRIBE_GROUP => 'unsubscribeGroup', self::LOCALE => 'locale', self::TIMEZONE => 'timezone'] as $header => $field) {
+            if (null !== $value = $this->option($email, $header)) {
+                $shared[$field] = $value;
+            }
+        }
+
+        // The API carries a single reply-to; the rest cannot be passed as a raw Reply-To header
+        // because the headers map is allow-listed to X- names and would refuse the message.
+        if ($replyTo = $email->getReplyTo()) {
+            $shared['replyTo'] = $replyTo[0]->getAddress();
+        }
+
+        if ($attachments = $this->getAttachments($email)) {
+            $shared['attachments'] = $attachments;
+        }
+
+        foreach ($email->getHeaders()->all() as $name => $header) {
+            // Only custom X- headers; anything else is either carried by a payload field or
+            // rejected by the API. The provider's own options are consumed above.
+            if (!str_starts_with($name, 'x-') || str_starts_with($name, 'x-pufferpost-')) {
+                continue;
+            }
+
+            $shared['headers'][$header->getName()] = $header->getBodyAsString();
+        }
+
+        // The envelope is the delivery truth: framework.mailer.envelope.recipients rewrites it and
+        // not the headers, so honouring the headers here would ignore a staging redirect and mail
+        // real customers. Cc and Bcc ride on the first message only, because each item is an
+        // independent email and repeating them would deliver a copy per recipient.
+        $recipients = $this->getRecipients($email, $envelope);
+        $cc = $this->addressList($email->getCc(), $envelope);
+        $bcc = $this->addressList($email->getBcc(), $envelope);
+        if (!$recipients) {
+            // Nothing but Cc/Bcc: every envelope recipient becomes its own message instead, so the
+            // send is not silently empty.
+            $recipients = $envelope->getRecipients();
+            $cc = $bcc = [];
+        }
+
+        $messages = [];
+        foreach ($recipients as $index => $recipient) {
+            $message = ['to' => $recipient->getAddress()] + $shared;
+            if (0 === $index) {
+                if ($cc) {
+                    $message['cc'] = $cc;
+                }
+                if ($bcc) {
+                    $message['bcc'] = $bcc;
+                }
+            }
+            $messages[] = $message;
+        }
+
+        return $messages;
+    }
+
+    private function option(Email $email, string $name): ?string
+    {
+        $body = $email->getHeaders()->getHeaderBody($name);
+
+        return \is_string($body) && '' !== $body ? $body : null;
+    }
+
+    /**
+     * A JSON-valued option. A malformed value is an error rather than a silent drop: sending the
+     * message without its render variables would deliver a half-rendered template.
+     *
+     * @return array<array-key, mixed>|null
+     */
+    private function jsonOption(Email $email, string $name): ?array
+    {
+        if (null === $raw = $this->option($email, $name)) {
+            return null;
+        }
+
+        $decoded = json_decode($raw, true);
+        if (!\is_array($decoded)) {
+            throw new TransportException(\sprintf('The "%s" header must contain a JSON object.', $name));
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * Cc/Bcc addresses, dropped when the envelope no longer carries them, so a redirected envelope
+     * does not keep mailing the original copy recipients.
+     *
+     * @param Address[] $addresses
+     *
+     * @return list<string>
+     */
+    private function addressList(array $addresses, Envelope $envelope): array
+    {
+        $allowed = array_map(static fn (Address $a): string => $a->getAddress(), $envelope->getRecipients());
+
+        $list = [];
+        foreach ($addresses as $address) {
+            if (\in_array($address->getAddress(), $allowed, true)) {
+                $list[] = $address->getAddress();
+            }
+        }
+
+        return $list;
+    }
+
+    /**
+     * @return array<int, array<string, string>>
+     */
+    private function getAttachments(Email $email): array
+    {
+        $attachments = [];
+        foreach ($email->getAttachments() as $attachment) {
+            $headers = $attachment->getPreparedHeaders();
+
+            // The API has no Content-ID support, so an inline part would be delivered as a plain
+            // attachment and its cid: reference would break silently. Fail loudly instead.
+            if ('inline' === $headers->getHeaderBody('Content-Disposition')) {
+                throw new TransportException('PufferPost does not support inline (cid-embedded) attachments; attach the file or host the image at a URL instead.');
+            }
+
+            $attachments[] = [
+                'filename' => $headers->getHeaderParameter('Content-Disposition', 'filename'),
+                'contentType' => $headers->get('Content-Type')->getBody(),
+                'content' => base64_encode($attachment->getBody()),
+            ];
+        }
+
+        return $attachments;
+    }
+
+    private function getEndpoint(): string
+    {
+        return ($this->host ?: self::HOST).($this->port ? ':'.$this->port : '');
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/PufferPost/Transport/PufferPostTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Bridge/PufferPost/Transport/PufferPostTransportFactory.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\PufferPost\Transport;
+
+use Symfony\Component\Mailer\Exception\UnsupportedSchemeException;
+use Symfony\Component\Mailer\Transport\AbstractTransportFactory;
+use Symfony\Component\Mailer\Transport\Dsn;
+use Symfony\Component\Mailer\Transport\TransportInterface;
+
+/**
+ * @author Jeroen Moonen (PufferPost) <info@jeroenmoonen.nl>
+ */
+final class PufferPostTransportFactory extends AbstractTransportFactory
+{
+    public function create(Dsn $dsn): TransportInterface
+    {
+        $scheme = $dsn->getScheme();
+
+        if ('pufferpost' === $scheme || 'pufferpost+api' === $scheme) {
+            $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
+
+            return (new PufferPostApiTransport($this->getUser($dsn), $this->client, $this->dispatcher, $this->logger))
+                ->setHost($host)
+                ->setPort($dsn->getPort());
+        }
+
+        throw new UnsupportedSchemeException($dsn, 'pufferpost', $this->getSupportedSchemes());
+    }
+
+    protected function getSupportedSchemes(): array
+    {
+        return ['pufferpost', 'pufferpost+api'];
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/PufferPost/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/PufferPost/composer.json
@@ -1,0 +1,33 @@
+{
+    "name": "symfony/puffer-post-mailer",
+    "type": "symfony-mailer-bridge",
+    "description": "Symfony PufferPost Mailer Bridge",
+    "keywords": [],
+    "homepage": "https://symfony.com",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Jeroen Moonen",
+            "email": "info@jeroenmoonen.nl"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "https://symfony.com/contributors"
+        }
+    ],
+    "require": {
+        "php": ">=8.4.1",
+        "psr/event-dispatcher": "^1",
+        "symfony/mailer": "^8.2"
+    },
+    "require-dev": {
+        "symfony/http-client": "^7.4|^8.0"
+    },
+    "autoload": {
+        "psr-4": { "Symfony\\Component\\Mailer\\Bridge\\PufferPost\\": "" },
+        "exclude-from-classmap": [
+            "/Tests/"
+        ]
+    },
+    "minimum-stability": "dev"
+}

--- a/src/Symfony/Component/Mailer/Bridge/PufferPost/phpunit.xml.dist
+++ b/src/Symfony/Component/Mailer/Bridge/PufferPost/phpunit.xml.dist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/13.1/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+         failOnDeprecation="true"
+         failOnRisky="true"
+         failOnWarning="true"
+>
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Symfony PufferPost Mailer Bridge Test Suite">
+            <directory>./Tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <source ignoreSuppressionOfDeprecations="true">
+        <include>
+            <directory>./</directory>
+        </include>
+        <exclude>
+            <directory>./Resources</directory>
+            <directory>./Tests</directory>
+            <directory>./vendor</directory>
+        </exclude>
+    </source>
+
+    <extensions>
+        <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension" />
+    </extensions>
+</phpunit>

--- a/src/Symfony/Component/Mailer/Exception/UnsupportedSchemeException.php
+++ b/src/Symfony/Component/Mailer/Exception/UnsupportedSchemeException.php
@@ -80,6 +80,10 @@ class UnsupportedSchemeException extends LogicException
             'class' => Bridge\Postmark\Transport\PostmarkTransportFactory::class,
             'package' => 'symfony/postmark-mailer',
         ],
+        'pufferpost' => [
+            'class' => Bridge\PufferPost\Transport\PufferPostTransportFactory::class,
+            'package' => 'symfony/puffer-post-mailer',
+        ],
         'mailtrap' => [
             'class' => Bridge\Mailtrap\Transport\MailtrapTransportFactory::class,
             'package' => 'symfony/mailtrap-mailer',

--- a/src/Symfony/Component/Mailer/Tests/Exception/UnsupportedSchemeExceptionTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Exception/UnsupportedSchemeExceptionTest.php
@@ -32,6 +32,7 @@ use Symfony\Component\Mailer\Bridge\MailPace\Transport\MailPaceTransportFactory;
 use Symfony\Component\Mailer\Bridge\Mailtrap\Transport\MailtrapTransportFactory;
 use Symfony\Component\Mailer\Bridge\Postal\Transport\PostalTransportFactory;
 use Symfony\Component\Mailer\Bridge\Postmark\Transport\PostmarkTransportFactory;
+use Symfony\Component\Mailer\Bridge\PufferPost\Transport\PufferPostTransportFactory;
 use Symfony\Component\Mailer\Bridge\Resend\Transport\ResendTransportFactory;
 use Symfony\Component\Mailer\Bridge\Scaleway\Transport\ScalewayTransportFactory;
 use Symfony\Component\Mailer\Bridge\Sendgrid\Transport\SendgridTransportFactory;
@@ -62,6 +63,7 @@ final class UnsupportedSchemeExceptionTest extends TestCase
             MandrillTransportFactory::class => false,
             PostalTransportFactory::class => false,
             PostmarkTransportFactory::class => false,
+            PufferPostTransportFactory::class => false,
             MailtrapTransportFactory::class => false,
             ResendTransportFactory::class => false,
             ScalewayTransportFactory::class => false,
@@ -100,6 +102,7 @@ final class UnsupportedSchemeExceptionTest extends TestCase
         yield ['mandrill', 'symfony/mailchimp-mailer'];
         yield ['postal', 'symfony/postal-mailer'];
         yield ['postmark', 'symfony/postmark-mailer'];
+        yield ['pufferpost', 'symfony/puffer-post-mailer'];
         yield ['mailtrap', 'symfony/mailtrap-mailer'];
         yield ['resend', 'symfony/resend-mailer'];
         yield ['scaleway', 'symfony/scaleway-mailer'];

--- a/src/Symfony/Component/Mailer/Transport.php
+++ b/src/Symfony/Component/Mailer/Transport.php
@@ -33,6 +33,7 @@ use Symfony\Component\Mailer\Bridge\Mailtrap\Transport\MailtrapTransportFactory;
 use Symfony\Component\Mailer\Bridge\MicrosoftGraph\Transport\MicrosoftGraphTransportFactory;
 use Symfony\Component\Mailer\Bridge\Postal\Transport\PostalTransportFactory;
 use Symfony\Component\Mailer\Bridge\Postmark\Transport\PostmarkTransportFactory;
+use Symfony\Component\Mailer\Bridge\PufferPost\Transport\PufferPostTransportFactory;
 use Symfony\Component\Mailer\Bridge\Resend\Transport\ResendTransportFactory;
 use Symfony\Component\Mailer\Bridge\Scaleway\Transport\ScalewayTransportFactory;
 use Symfony\Component\Mailer\Bridge\Sendgrid\Transport\SendgridTransportFactory;
@@ -76,6 +77,7 @@ final class Transport
         MandrillTransportFactory::class,
         PostalTransportFactory::class,
         PostmarkTransportFactory::class,
+        PufferPostTransportFactory::class,
         MailtrapTransportFactory::class,
         MicrosoftGraphTransportFactory::class,
         ResendTransportFactory::class,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Adds a Mailer bridge for [PufferPost](https://pufferpost.com), a transactional email service.

```env
MAILER_DSN=pufferpost+api://API_KEY@default
```

The service has no SMTP relay, so the bridge is API-only and `pufferpost` is an alias for
`pufferpost+api`.

The transport carries what the send endpoint accepts: sender, recipients, subject, text and HTML
bodies, a single reply-to address (several are sent as a raw `Reply-To` header), attachments and
custom headers.

Two places the API differs from the services already bridged here, both handled in the transport:

* **One primary recipient per message.** `to` is a single address, so an email with several `To`
  addresses is submitted to the batch endpoint — one request, one message per recipient, each
  carrying the same Cc and Bcc. A batch answers `200` even when an individual message is refused,
  so the transport surfaces the first rejection rather than reporting a send that never happened.
* **No `Content-ID` support**, so inline (`cid:`) attachments are rejected with a clear message
  instead of arriving as plain attachments with a silently broken reference.

API reference: https://docs.pufferpost.com/reference/api/