### PR TITLE
[Security] Deprecate passing more than one attribute to AccessDecisionManager::decide()

### DIFF
--- a/UPGRADE-8.2.md
+++ b/UPGRADE-8.2.md
@@ -198,6 +198,8 @@ Security
    extends `AuthenticationException`. The firewall no longer turns the failure into a login redirect or a 401, and
    code catching the `Security\Core` exception for this case must catch the `Security\Http` one instead
  * Add argument `$targetUri` to `ImpersonateUrlGenerator::generateImpersonationPath()` and `ImpersonateUrlGenerator::generateImpersonationUrl()`
+ * Deprecate passing more than one Security attribute to `AccessDecisionManager::decide()`, pass a single attribute instead.
+   The `$allowMultipleAttributes` argument will be removed in 9.0
  * Add argument `$parameters` to `LoginLinkHandlerInterface::createLoginLink()`
  * Add argument `$parameters` to `SignatureHasher::computeSignatureHash()`, `SignatureHasher::acceptSignatureHash()` and `SignatureHasher::verifySignatureHash()`
 

--- a/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManager.php
+++ b/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManager.php
@@ -51,6 +51,7 @@ final class AccessDecisionManager implements AccessDecisionManagerInterface
 
     /**
      * @param bool $allowMultipleAttributes Whether to allow passing multiple values to the $attributes array
+     *                                      This argument is deprecated since Symfony 8.2 and will be removed in 9.0
      */
     public function decide(TokenInterface $token, array $attributes, mixed $object = null, bool|AccessDecision|null $accessDecision = null, bool $allowMultipleAttributes = false): bool
     {
@@ -60,8 +61,12 @@ final class AccessDecisionManager implements AccessDecisionManagerInterface
         }
 
         // Special case for AccessListener, which passes all attributes of the matched access_control rule at once
-        if (\count($attributes) > 1 && !$allowMultipleAttributes) {
-            throw new InvalidArgumentException(\sprintf('Passing more than one Security attribute to "%s()" is not supported.', __METHOD__));
+        if (\count($attributes) > 1) {
+            if (!$allowMultipleAttributes) {
+                throw new InvalidArgumentException(\sprintf('Passing more than one Security attribute to "%s()" is not supported.', __METHOD__));
+            }
+
+            trigger_deprecation('symfony/security-core', '8.2', 'Passing more than one Security attribute to "%s()" is deprecated, pass a single attribute instead. For an "access_control" rule, move the roles to "allow_if" or to the role hierarchy. The "$allowMultipleAttributes" argument will be removed in 9.0.', __METHOD__);
         }
 
         $accessDecision ??= end($this->accessDecisionStack) ?: new AccessDecision();

--- a/src/Symfony/Component/Security/Core/Authorization/TraceableAccessDecisionManager.php
+++ b/src/Symfony/Component/Security/Core/Authorization/TraceableAccessDecisionManager.php
@@ -36,6 +36,9 @@ class TraceableAccessDecisionManager implements AccessDecisionManagerInterface
     ) {
     }
 
+    /**
+     * @param bool $allowMultipleAttributes This argument is deprecated since Symfony 8.2 and will be removed in 9.0
+     */
     public function decide(TokenInterface $token, array $attributes, mixed $object = null, bool|AccessDecision|null $accessDecision = null, bool $allowMultipleAttributes = false): bool
     {
         if (\is_bool($accessDecision)) {

--- a/src/Symfony/Component/Security/Core/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Core/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.2
 ---
 
+ * Deprecate passing more than one Security attribute to `AccessDecisionManager::decide()`, the `$allowMultipleAttributes` argument will be removed in 9.0
  * Allow using wildcards as placeholders in the keys of the `RoleHierarchy` map
  * Add argument `$parameters` to `SignatureHasher::computeSignatureHash()`, `acceptSignatureHash()` and `verifySignatureHash()`
  * Add `OidcUser::fromClaims()` to build a user from the claims returned by an OIDC provider

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/AccessDecisionManagerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/AccessDecisionManagerTest.php
@@ -12,9 +12,11 @@
 namespace Symfony\Component\Security\Core\Tests\Authorization;
 
 use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectUserDeprecationMessageTrait;
 use Symfony\Component\Security\Core\Authentication\Token\NullToken;
-use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\AccessDecision;
 use Symfony\Component\Security\Core\Authorization\AccessDecisionManager;
 use Symfony\Component\Security\Core\Authorization\Strategy\AccessDecisionStrategyInterface;
@@ -23,6 +25,8 @@ use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
 class AccessDecisionManagerTest extends TestCase
 {
+    use ExpectUserDeprecationMessageTrait;
+
     public function provideBadVoterResults(): array
     {
         return [
@@ -112,6 +116,8 @@ class AccessDecisionManagerTest extends TestCase
         $this->assertTrue($manager->decide($token, [1337], 'bar'));
     }
 
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
     public function testCacheableVotersWithMultipleAttributes()
     {
         $token = new NullToken();
@@ -212,6 +218,8 @@ class AccessDecisionManagerTest extends TestCase
         $this->assertFalse($manager->decide($token, ['foo'], 'bar'));
     }
 
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
     public function testCacheableVotersWithMultipleAttributesAndNonString()
     {
         $token = new NullToken();
@@ -237,37 +245,22 @@ class AccessDecisionManagerTest extends TestCase
         $this->assertTrue($manager->decide($token, ['foo', 1337], 'bar', true));
     }
 
-    protected static function getVoters($grants, $denies, $abstains): array
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
+    public function testPassingMultipleAttributesIsDeprecated()
     {
-        $voters = [];
-        for ($i = 0; $i < $grants; ++$i) {
-            $voters[] = self::getVoter(VoterInterface::ACCESS_GRANTED);
-        }
-        for ($i = 0; $i < $denies; ++$i) {
-            $voters[] = self::getVoter(VoterInterface::ACCESS_DENIED);
-        }
-        for ($i = 0; $i < $abstains; ++$i) {
-            $voters[] = self::getVoter(VoterInterface::ACCESS_ABSTAIN);
-        }
+        $manager = new AccessDecisionManager([$this->getExpectedVoter(VoterInterface::ACCESS_GRANTED)]);
 
-        return $voters;
+        $this->expectUserDeprecationMessage('Since symfony/security-core 8.2: Passing more than one Security attribute to "Symfony\\Component\\Security\\Core\\Authorization\\AccessDecisionManager::decide()" is deprecated, pass a single attribute instead. For an "access_control" rule, move the roles to "allow_if" or to the role hierarchy. The "$allowMultipleAttributes" argument will be removed in 9.0.');
+
+        $this->assertTrue($manager->decide(new NullToken(), ['ROLE_FOO', 'ROLE_BAR'], null, true));
     }
 
-    protected static function getVoter($vote)
+    public function testPassingASingleAttributeIsNotDeprecated()
     {
-        return new class($vote) implements VoterInterface {
-            private int $vote;
+        $manager = new AccessDecisionManager([$this->getExpectedVoter(VoterInterface::ACCESS_GRANTED)]);
 
-            public function __construct(int $vote)
-            {
-                $this->vote = $vote;
-            }
-
-            public function vote(TokenInterface $token, $subject, array $attributes)
-            {
-                return $this->vote;
-            }
-        };
+        $this->assertTrue($manager->decide(new NullToken(), ['ROLE_FOO'], null, true));
     }
 
     private function getExpectedVoter(int $vote): VoterInterface

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/TraceableAccessDecisionManagerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/TraceableAccessDecisionManagerTest.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\Security\Core\Tests\Authorization;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Authentication\Token\NullToken;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
@@ -275,6 +277,8 @@ class TraceableAccessDecisionManagerTest extends TestCase
         $traceableAccessDecisionManager->decide(new NullToken(), ['attr1', 'attr2']);
     }
 
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
     #[DataProvider('allowMultipleAttributesProvider')]
     public function testAllowMultipleAttributes(array $attributes, bool $allowMultipleAttributes)
     {

--- a/src/Symfony/Component/Security/Core/composer.json
+++ b/src/Symfony/Component/Security/Core/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=8.4.1",
+        "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/event-dispatcher-contracts": "^2.5|^3",
         "symfony/password-hasher": "^7.4|^8.0",
         "symfony/service-contracts": "^2.5|^3"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Issues        | Part of #54060
| License       | MIT

`AccessDecisionManager::decide()` takes an array of attributes but decides on one of them. Passing more than one is refused unless the caller opts in through `$allowMultipleAttributes`, an argument that exists for `AccessListener` alone. Passing more than one now triggers a deprecation, so the argument can go in 9.0 and `decide()` can take a single attribute.

```php
$manager->decide($token, ['ROLE_A', 'ROLE_B'], null, true);
// Since symfony/security-core 8.2: Passing more than one Security attribute to
// "…\AccessDecisionManager::decide()" is deprecated, pass a single attribute instead.
// For an "access_control" rule, move the roles to "allow_if" or to the role hierarchy.
// The "$allowMultipleAttributes" argument will be removed in 9.0.
```

The behaviour does not change: more than one attribute without the opt-in still throws `InvalidArgumentException`, and with it still works. The deprecation fires on the attribute count rather than on the argument being `true`, since a single attribute with `$allowMultipleAttributes = true` behaves the same today and in 9.0. A test covers that it stays silent.

**`AccessListener` keeps passing `true` on purpose.** #65056 only deprecates multi-attribute `access_control` rules on 8.2, so making the listener stop would turn a configuration that is merely deprecated into an `InvalidArgumentException`. It stops in 9.0, when those rules go away.

The two are exactly aligned. `SecurityExtension` builds the attributes as `$roles`, plus the `allow_if` expression when there is one, so the listener passes more than one attribute in precisely the two cases #65056 deprecates: several `roles`, or `roles` together with `allow_if`. Every configuration that stays supported produces at most one attribute, so none of them reaches the deprecated path.

An application whose `access_control` still carries such a rule therefore sees this deprecation on every matched request, next to the build-time one from #65056, so the message points that audience to the same fix the bundle recommends. Splitting the rule into one entry per role does not work: only the first matching `access_control` rule applies, so a user holding only the second role would be denied. Move the roles to `allow_if` (`is_granted("ROLE_A") or is_granted("ROLE_B")`) or to the role hierarchy instead, which clears both deprecations.

`symfony/security-core` gains `symfony/deprecation-contracts`, which it did not require yet as it had no deprecation of its own.

Two existing tests that pass several attributes are now marked legacy, as is `TraceableAccessDecisionManagerTest::testAllowMultipleAttributes`.

Tests: Security\Core 431, Security\Http 899, SecurityBundle 543, all green.

