### PR TITLE
[Filesystem] Deprecate passing an empty string as the base path to Path::isBasePath()

### DIFF
--- a/UPGRADE-8.2.md
+++ b/UPGRADE-8.2.md
@@ -37,6 +37,12 @@ DoctrineBridge
    Also note that `DoctrineDbalPingConnectionMiddleware` does not reset closed entity managers as its deprecated
    counterpart did: workers already reset them between messages
 
+Filesystem
+----------
+
+ * Deprecate passing an empty string as the base path to `Path::isBasePath()`, pass `"/"` instead.
+   Both answer identically today, an empty base path being treated as the root
+
 Form
 ----
 

--- a/src/Symfony/Component/Filesystem/CHANGELOG.md
+++ b/src/Symfony/Component/Filesystem/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Deprecate passing an empty string as the base path to `Path::isBasePath()`, pass `"/"` instead
+
 8.1
 ---
 

--- a/src/Symfony/Component/Filesystem/Path.php
+++ b/src/Symfony/Component/Filesystem/Path.php
@@ -728,6 +728,10 @@ final class Path
      */
     public static function isBasePath(string $basePath, string $ofPath): bool
     {
+        if ('' === $basePath) {
+            trigger_deprecation('symfony/filesystem', '8.2', 'Passing an empty string as the base path to "%s()" is deprecated, pass "/" instead.', __METHOD__);
+        }
+
         $basePath = self::canonicalize($basePath);
         $ofPath = self::canonicalize($ofPath);
 

--- a/src/Symfony/Component/Filesystem/Tests/PathTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/PathTest.php
@@ -12,7 +12,10 @@
 namespace Symfony\Component\Filesystem\Tests;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectUserDeprecationMessageTrait;
 use Symfony\Component\Filesystem\Path;
 
 /**
@@ -22,6 +25,8 @@ use Symfony\Component\Filesystem\Path;
  */
 class PathTest extends TestCase
 {
+    use ExpectUserDeprecationMessageTrait;
+
     protected array $storedEnv = [];
 
     protected function setUp(): void
@@ -1004,6 +1009,41 @@ class PathTest extends TestCase
     public function testIsBasePath(string $path, string $ofPath, bool $result)
     {
         $this->assertSame($result, Path::isBasePath($path, $ofPath));
+    }
+
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
+    #[DataProvider('provideEmptyBasePathTests')]
+    public function testEmptyBasePathIsDeprecated(string $ofPath, bool $result)
+    {
+        $this->expectUserDeprecationMessage('Since symfony/filesystem 8.2: Passing an empty string as the base path to "Symfony\\Component\\Filesystem\\Path::isBasePath()" is deprecated, pass "/" instead.');
+
+        $this->assertSame($result, Path::isBasePath('', $ofPath));
+    }
+
+    /**
+     * "/" is offered as the replacement, so it has to answer exactly like the empty base path does.
+     */
+    #[DataProvider('provideEmptyBasePathTests')]
+    public function testRootIsEquivalentToTheEmptyBasePath(string $ofPath, bool $result)
+    {
+        $this->assertSame($result, Path::isBasePath('/', $ofPath));
+    }
+
+    public static function provideEmptyBasePathTests(): \Generator
+    {
+        yield ['/file', true];
+        yield ['/', true];
+        yield ['/base/path', true];
+        yield ['', true];
+        yield ['.', true];
+        yield ['./', true];
+        yield ['a/..', true];
+        yield ['file', false];
+        yield ['./file', false];
+        yield ['../file', false];
+        yield ['base/path', false];
+        yield ['C:/file', false];
     }
 
     public static function provideJoinTests(): \Generator


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Issues        | Ref #62131
| License       | MIT

`Path::isBasePath('', $ofPath)` silently treats the empty base as the root: `canonicalize('')` returns `''`, and the comparison then appends a slash, so the base becomes the literal `"/"`.

```php
Path::isBasePath('', '/file'); // true
Path::isBasePath('', 'file');  // false
```

Passing an empty string now triggers a deprecation:

> Since symfony/filesystem 8.2: Passing an empty string as the base path to "Symfony\Component\Filesystem\Path::isBasePath()" is deprecated, pass "/" instead.

**`"/"` is an exact replacement, not merely a close one.** Both bases produce the same comparison prefix, so the answer cannot depend on the second argument. Checked against `/file`, `/`, `/base/path`, `''`, `.`, `./`, `a/..`, `file`, `./file`, `../file`, `base/path` and `C:/file`: the same answer every time. A test pins that equivalence on the same data provider as the deprecation test, so the two cannot drift apart.

Nothing inside Symfony calls `isBasePath()`, so the deprecation only reaches userland.

**Scope.** The check is on the raw argument, so only `''` deprecates. `'.'`, `'./'` and anything else canonicalizing to `''` are treated as the root too, which the reporter of #62131 also found surprising, but those are meaningful paths: what is odd there is how a relative base is treated, not the input, and `"/"` would be the wrong advice for them. Same for the second argument, where `isBasePath('/', '')` returns `true`. Both belong to a separate behaviour decision on the dev branch, so #62131 stays open.

Tests: Filesystem 517 green on PHP 8.4 and 8.5.
