### PR TITLE
[String] Add ucfirst() and lcfirst() methods

### DIFF
--- a/src/Symfony/Component/String/AbstractString.php
+++ b/src/Symfony/Component/String/AbstractString.php
@@ -390,6 +390,8 @@ abstract class AbstractString implements \Stringable, \JsonSerializable
         return $this->string;
     }
 
+    abstract public function lcfirst(): static;
+
     abstract public function length(): int;
 
     abstract public function lower(): static;
@@ -655,6 +657,8 @@ abstract class AbstractString implements \Stringable, \JsonSerializable
 
         return $ellipsisLength ? $str->trimEnd()->append($ellipsis) : $str;
     }
+
+    abstract public function ucfirst(): static;
 
     abstract public function upper(): static;
 

--- a/src/Symfony/Component/String/AbstractUnicodeString.php
+++ b/src/Symfony/Component/String/AbstractUnicodeString.php
@@ -218,6 +218,14 @@ abstract class AbstractUnicodeString extends AbstractString
         return $str;
     }
 
+    public function lcfirst(): static
+    {
+        $str = clone $this;
+        $str->string = preg_replace_callback('/^./u', static fn (array $m): string => 'İ' === $m[0] ? 'i̇' : mb_strtolower($m[0], 'UTF-8'), $str->string);
+
+        return $str;
+    }
+
     public function lower(): static
     {
         $str = clone $this;
@@ -477,6 +485,14 @@ abstract class AbstractUnicodeString extends AbstractString
 
         $suffix = implode('|', array_map('preg_quote', (array) $suffix));
         $str->string = preg_replace("{(?:$suffix)$}iuD", '', $this->string);
+
+        return $str;
+    }
+
+    public function ucfirst(): static
+    {
+        $str = clone $this;
+        $str->string = preg_replace_callback('/^./u', static fn (array $m): string => mb_convert_case($m[0], \MB_CASE_TITLE, 'UTF-8'), $str->string);
 
         return $str;
     }

--- a/src/Symfony/Component/String/ByteString.php
+++ b/src/Symfony/Component/String/ByteString.php
@@ -197,6 +197,14 @@ class ByteString extends AbstractString
         return $str;
     }
 
+    public function lcfirst(): static
+    {
+        $str = clone $this;
+        $str->string = lcfirst($str->string);
+
+        return $str;
+    }
+
     public function length(): int
     {
         return \strlen($this->string);
@@ -449,6 +457,14 @@ class ByteString extends AbstractString
     {
         $str = clone $this;
         $str->string = ltrim($str->string, $chars);
+
+        return $str;
+    }
+
+    public function ucfirst(): static
+    {
+        $str = clone $this;
+        $str->string = ucfirst($str->string);
 
         return $str;
     }

--- a/src/Symfony/Component/String/CHANGELOG.md
+++ b/src/Symfony/Component/String/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add `AbstractString::ucfirst()` and `AbstractString::lcfirst()` methods
+
 8.0
 ---
 

--- a/src/Symfony/Component/String/Tests/AbstractAsciiTestCase.php
+++ b/src/Symfony/Component/String/Tests/AbstractAsciiTestCase.php
@@ -502,6 +502,29 @@ abstract class AbstractAsciiTestCase extends TestCase
         ];
     }
 
+    #[DataProvider('provideLcfirst')]
+    public function testLcfirst(string $expected, string $origin)
+    {
+        $instance = static::createFromString($origin)->lcfirst();
+
+        $this->assertNotSame(static::createFromString($origin), $instance);
+        $this->assertEquals(static::createFromString($expected), $instance);
+        $this->assertSame($expected, (string) $instance);
+    }
+
+    public static function provideLcfirst()
+    {
+        return [
+            ['', ''],
+            ['hello world', 'Hello world'],
+            ['hELLO WORLD', 'HELLO WORLD'],
+            ['symfony', 'Symfony'],
+            ['symfony', 'symfony'],
+            [' Symfony', ' Symfony'],
+            ['1symfony', '1symfony'],
+        ];
+    }
+
     #[DataProvider('provideLower')]
     public function testLower(string $expected, string $origin)
     {
@@ -521,6 +544,29 @@ abstract class AbstractAsciiTestCase extends TestCase
             ['symfony', 'symfony'],
             ['symfony', 'Symfony'],
             ['symfony', 'sYmFOny'],
+        ];
+    }
+
+    #[DataProvider('provideUcfirst')]
+    public function testUcfirst(string $expected, string $origin)
+    {
+        $instance = static::createFromString($origin)->ucfirst();
+
+        $this->assertNotSame(static::createFromString($origin), $instance);
+        $this->assertEquals(static::createFromString($expected), $instance);
+        $this->assertSame($expected, (string) $instance);
+    }
+
+    public static function provideUcfirst()
+    {
+        return [
+            ['', ''],
+            ['Hello world', 'hello world'],
+            ['HELLO WORLD', 'HELLO WORLD'],
+            ['Symfony', 'symfony'],
+            ['Symfony', 'Symfony'],
+            [' symfony', ' symfony'],
+            ['1symfony', '1symfony'],
         ];
     }
 

--- a/src/Symfony/Component/String/Tests/AbstractUnicodeTestCase.php
+++ b/src/Symfony/Component/String/Tests/AbstractUnicodeTestCase.php
@@ -326,6 +326,20 @@ END'],
         static::createFromString('Symfony')->trimEnd("\xE9");
     }
 
+    public static function provideLcfirst(): array
+    {
+        return array_merge(
+            parent::provideLcfirst(),
+            [
+                // French
+                ['éveil', 'Éveil'],
+
+                // Random symbols
+                ['i̇IIıi', 'İIIıi'],
+            ]
+        );
+    }
+
     public static function provideLower(): array
     {
         return array_merge(
@@ -418,6 +432,20 @@ END'],
             // Default casing rules
             ['en', 'Ijssel', 'ijssel'],
         ];
+    }
+
+    public static function provideUcfirst(): array
+    {
+        return array_merge(
+            parent::provideUcfirst(),
+            [
+                // French
+                ['Éveil', 'éveil'],
+
+                // Random symbols
+                ['Σσς', 'σσς'],
+            ]
+        );
     }
 
     public static function provideUpper(): array


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | N/A
| License       | MIT

I often find myself creating ucfirst()/lcfirst()-like methods (e.g. for Twig) in my projects, I guess I'm not the only one? 😅 

I'm not sure about the BC policy, about what should be done in AbstractString, as it's not marked as internal.