### PR TITLE
[Security] Let an authenticator tell why it did not support the request

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.2
 ---
 
+ * Show why an authenticator did not support the request in the security profiler panel
  * Add the `debug:roles` command to inspect the role hierarchy
  * Add `allowed_time_drift` option to the OIDC token handler configuration
  * Allow disabling the redirection on successful logout by passing `null` to the `target` option

--- a/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
@@ -479,7 +479,12 @@
                                         <div id="authenticator-{{ i }}" class="font-normal">
                                             {% if authenticator.supports is same as(false) %}
                                                 <div class="empty">
-                                                    <p>This authenticator did not support the request.</p>
+                                                    <p>
+                                                        This authenticator did not support the request.
+                                                        {%- if authenticator.unsupportedReason is defined and authenticator.unsupportedReason %}
+                                                            <br>Reason: {{ authenticator.unsupportedReason }}.
+                                                        {%- endif %}
+                                                    </p>
                                                 </div>
                                             {% elseif authenticator.authenticated is null %}
                                                 <div class="empty">

--- a/src/Symfony/Component/Ldap/CHANGELOG.md
+++ b/src/Symfony/Component/Ldap/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add the `$ldapUsersOnly` argument to `CheckLdapCredentialsListener`, to bind only `LdapUser` instances against the LDAP server
+ * Make `LdapAuthenticator` forward `UnsupportedReasonProviderInterface::getUnsupportedReason()` to the decorated authenticator
 
 8.0
 ---

--- a/src/Symfony/Component/Ldap/Security/LdapAuthenticator.php
+++ b/src/Symfony/Component/Ldap/Security/LdapAuthenticator.php
@@ -18,6 +18,7 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
 use Symfony\Component\Security\Http\Authenticator\InteractiveAuthenticatorInterface;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
+use Symfony\Component\Security\Http\Authenticator\UnsupportedReasonProviderInterface;
 use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
 use Symfony\Component\Security\Http\EntryPoint\Exception\NotAnEntryPointException;
 
@@ -32,7 +33,7 @@ use Symfony\Component\Security\Http\EntryPoint\Exception\NotAnEntryPointExceptio
  *
  * @final
  */
-class LdapAuthenticator implements AuthenticationEntryPointInterface, InteractiveAuthenticatorInterface
+class LdapAuthenticator implements AuthenticationEntryPointInterface, InteractiveAuthenticatorInterface, UnsupportedReasonProviderInterface
 {
     public function __construct(
         private AuthenticatorInterface $authenticator,
@@ -47,6 +48,11 @@ class LdapAuthenticator implements AuthenticationEntryPointInterface, Interactiv
     public function supports(Request $request): ?bool
     {
         return $this->authenticator->supports($request);
+    }
+
+    public function getUnsupportedReason(Request $request): ?string
+    {
+        return $this->authenticator instanceof UnsupportedReasonProviderInterface ? $this->authenticator->getUnsupportedReason($request) : null;
     }
 
     public function authenticate(Request $request): Passport

--- a/src/Symfony/Component/Ldap/Tests/Security/LdapAuthenticatorTest.php
+++ b/src/Symfony/Component/Ldap/Tests/Security/LdapAuthenticatorTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Credentials\PasswordCredentials;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
+use Symfony\Component\Security\Http\Authenticator\UnsupportedReasonProviderInterface;
 
 class LdapAuthenticatorTest extends TestCase
 {
@@ -42,4 +43,30 @@ class LdapAuthenticatorTest extends TestCase
         $this->assertNotNull($badge);
         $this->assertSame('serviceId', $badge->getLdapServiceId());
     }
+
+    public function testGetUnsupportedReasonIsForwarded()
+    {
+        $request = new Request();
+
+        $decorated = $this->createMock(ExplainingAuthenticator::class);
+        $decorated
+            ->expects($this->once())
+            ->method('getUnsupportedReason')
+            ->with($request)
+            ->willReturn('the "X-Tenant" header is missing')
+        ;
+
+        $this->assertSame('the "X-Tenant" header is missing', (new LdapAuthenticator($decorated, 'serviceId'))->getUnsupportedReason($request));
+    }
+
+    public function testGetUnsupportedReasonIsNullWhenTheDecoratedAuthenticatorCannotExplain()
+    {
+        $decorated = $this->createStub(AuthenticatorInterface::class);
+
+        $this->assertNull((new LdapAuthenticator($decorated, 'serviceId'))->getUnsupportedReason(new Request()));
+    }
+}
+
+interface ExplainingAuthenticator extends AuthenticatorInterface, UnsupportedReasonProviderInterface
+{
 }

--- a/src/Symfony/Component/Ldap/composer.json
+++ b/src/Symfony/Component/Ldap/composer.json
@@ -22,10 +22,11 @@
     },
     "require-dev": {
         "symfony/security-core": "^8.0",
-        "symfony/security-http": "^7.4|^8.0"
+        "symfony/security-http": "^8.2"
     },
     "conflict": {
-        "symfony/security-core": "<8.0"
+        "symfony/security-core": "<8.0",
+        "symfony/security-http": "<8.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Ldap\\": "" },

--- a/src/Symfony/Component/Security/Http/Authenticator/Debug/TraceableAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Debug/TraceableAuthenticator.php
@@ -19,6 +19,7 @@ use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
 use Symfony\Component\Security\Http\Authenticator\InteractiveAuthenticatorInterface;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\BadgeInterface;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
+use Symfony\Component\Security\Http\Authenticator\UnsupportedReasonProviderInterface;
 use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
 use Symfony\Component\Security\Http\EntryPoint\Exception\NotAnEntryPointException;
 use Symfony\Component\VarDumper\Caster\ClassStub;
@@ -28,9 +29,10 @@ use Symfony\Component\VarDumper\Caster\ClassStub;
  *
  * @author Robin Chalas <robin.chalas@gmail.com>
  */
-final class TraceableAuthenticator implements AuthenticatorInterface, InteractiveAuthenticatorInterface, AuthenticationEntryPointInterface
+final class TraceableAuthenticator implements AuthenticatorInterface, InteractiveAuthenticatorInterface, AuthenticationEntryPointInterface, UnsupportedReasonProviderInterface
 {
     private ?bool $supports = false;
+    private ?string $unsupportedReason = null;
     private ?Passport $passport = null;
     private ?float $duration = null;
     private ClassStub|string $stub;
@@ -45,6 +47,7 @@ final class TraceableAuthenticator implements AuthenticatorInterface, Interactiv
     {
         return [
             'supports' => $this->supports,
+            'unsupportedReason' => $this->unsupportedReason,
             'passport' => $this->passport,
             'duration' => $this->duration,
             'stub' => $this->stub ??= class_exists(ClassStub::class) ? new ClassStub($this->authenticator::class) : $this->authenticator::class,
@@ -62,7 +65,18 @@ final class TraceableAuthenticator implements AuthenticatorInterface, Interactiv
 
     public function supports(Request $request): ?bool
     {
-        return $this->supports = $this->authenticator->supports($request);
+        $this->unsupportedReason = null;
+
+        if (false === $this->supports = $this->authenticator->supports($request)) {
+            $this->unsupportedReason = $this->getUnsupportedReason($request);
+        }
+
+        return $this->supports;
+    }
+
+    public function getUnsupportedReason(Request $request): ?string
+    {
+        return $this->authenticator instanceof UnsupportedReasonProviderInterface ? $this->authenticator->getUnsupportedReason($request) : null;
     }
 
     public function authenticate(Request $request): Passport

--- a/src/Symfony/Component/Security/Http/Authenticator/FormLoginAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/FormLoginAuthenticator.php
@@ -39,7 +39,7 @@ use Symfony\Component\Security\Http\SecurityRequestAttributes;
  *
  * @final
  */
-class FormLoginAuthenticator extends AbstractLoginFormAuthenticator
+class FormLoginAuthenticator extends AbstractLoginFormAuthenticator implements UnsupportedReasonProviderInterface
 {
     private array $options;
     private HttpKernelInterface $httpKernel;
@@ -73,6 +73,27 @@ class FormLoginAuthenticator extends AbstractLoginFormAuthenticator
         return ($this->options['post_only'] ? $request->isMethod('POST') : true)
             && $this->httpUtils->checkRequestPath($request, $this->options['check_path'])
             && ($this->options['form_only'] ? 'form' === $request->getContentTypeFormat() : true);
+    }
+
+    public function getUnsupportedReason(Request $request): ?string
+    {
+        if ($this->options['post_only'] && !$request->isMethod('POST')) {
+            return \sprintf('the request method is "%s", and the "post_only" option requires POST', $request->getMethod());
+        }
+
+        if (!$this->httpUtils->checkRequestPath($request, $this->options['check_path'])) {
+            return \sprintf('the request path "%s" does not match the "check_path" option "%s"', $request->getPathInfo(), $this->options['check_path']);
+        }
+
+        if ($this->options['form_only'] && 'form' !== $request->getContentTypeFormat()) {
+            $contentType = $request->headers->get('Content-Type');
+
+            return $contentType
+                ? \sprintf('the "Content-Type" header "%s" is not a form one, and the "form_only" option requires one', $contentType)
+                : 'the request has no "Content-Type" header, and the "form_only" option requires a form one';
+        }
+
+        return null;
     }
 
     public function authenticate(Request $request): Passport

--- a/src/Symfony/Component/Security/Http/Authenticator/JsonLoginAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/JsonLoginAuthenticator.php
@@ -43,7 +43,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  *
  * @final
  */
-class JsonLoginAuthenticator implements InteractiveAuthenticatorInterface
+class JsonLoginAuthenticator implements InteractiveAuthenticatorInterface, UnsupportedReasonProviderInterface
 {
     private array $options;
     private PropertyAccessorInterface $propertyAccessor;
@@ -75,6 +75,26 @@ class JsonLoginAuthenticator implements InteractiveAuthenticatorInterface
         }
 
         return true;
+    }
+
+    public function getUnsupportedReason(Request $request): ?string
+    {
+        if (
+            !str_contains($request->getRequestFormat() ?? '', 'json')
+            && !str_contains($request->getContentTypeFormat() ?? '', 'json')
+        ) {
+            $contentType = $request->headers->get('Content-Type');
+
+            return $contentType
+                ? \sprintf('neither the request format "%s" nor the "Content-Type" header "%s" is a JSON one', $request->getRequestFormat(), $contentType)
+                : \sprintf('the request format "%s" is not a JSON one, and the request has no "Content-Type" header', $request->getRequestFormat());
+        }
+
+        if (isset($this->options['check_path']) && !$this->httpUtils->checkRequestPath($request, $this->options['check_path'])) {
+            return \sprintf('the request path "%s" does not match the "check_path" option "%s"', $request->getPathInfo(), $this->options['check_path']);
+        }
+
+        return null;
     }
 
     public function authenticate(Request $request): Passport

--- a/src/Symfony/Component/Security/Http/Authenticator/RememberMeAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/RememberMeAuthenticator.php
@@ -41,7 +41,7 @@ use Symfony\Component\Security\Http\RememberMe\ResponseListener;
  *
  * @final
  */
-class RememberMeAuthenticator implements InteractiveAuthenticatorInterface
+class RememberMeAuthenticator implements InteractiveAuthenticatorInterface, UnsupportedReasonProviderInterface
 {
     public function __construct(
         private RememberMeHandlerInterface $rememberMeHandler,
@@ -69,6 +69,27 @@ class RememberMeAuthenticator implements InteractiveAuthenticatorInterface
         $this->logger?->debug('Remember-me cookie detected.');
 
         // the `null` return value indicates that this authenticator supports lazy firewalls
+        return null;
+    }
+
+    public function getUnsupportedReason(Request $request): ?string
+    {
+        if (null !== $this->tokenStorage->getToken()) {
+            return 'a token is already stored, so this request is already authenticated';
+        }
+
+        if (($cookie = $request->attributes->get(ResponseListener::COOKIE_ATTR_NAME)) && null === $cookie->getValue()) {
+            return \sprintf('the "%s" cookie is being cleared by this request', $this->cookieName);
+        }
+
+        if (!$request->cookies->has($this->cookieName)) {
+            return \sprintf('the request has no "%s" cookie', $this->cookieName);
+        }
+
+        if (!\is_scalar($request->cookies->all()[$this->cookieName] ?: null)) {
+            return \sprintf('the "%s" cookie is empty or not a scalar', $this->cookieName);
+        }
+
         return null;
     }
 

--- a/src/Symfony/Component/Security/Http/Authenticator/UnsupportedReasonProviderInterface.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/UnsupportedReasonProviderInterface.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Authenticator;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Lets an authenticator tell why it did not support a request.
+ *
+ * When an authenticator declines a request, nothing says which of its conditions
+ * was not met. Implementing this interface makes that reason visible in the
+ * profiler, next to the authenticator that was skipped.
+ *
+ * The reason is only ever asked for when the profiler is enabled, so nothing is
+ * computed in production.
+ *
+ * @author Pascal Cescon <pascal.cescon@gmail.com>
+ */
+interface UnsupportedReasonProviderInterface
+{
+    /**
+     * Returns why supports() returned false for this request, or null when there is nothing useful to say.
+     *
+     * This is only called after supports() returned false, and only when the profiler is enabled.
+     * It must not have side effects.
+     */
+    public function getUnsupportedReason(Request $request): ?string;
+}

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.2
 ---
 
+ * Add `UnsupportedReasonProviderInterface` so an authenticator can tell why it did not support a request, and expose it in the profiler
  * Add `allowed_time_drift` option to `OidcTokenHandler` to configure time tolerance for token validation (`iat`, `nbf`, `exp` claims)
  * Throw a 403 `Symfony\Component\Security\Http\Exception\InvalidCsrfTokenException` instead of the `Security\Core` one when the `#[IsCsrfTokenValid]` attribute fails, so the failure is no longer handled as an authentication failure
  * Add the deauthentication reason and the responsible user providers to `TokenDeauthenticatedEvent`

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/Debug/TraceableAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/Debug/TraceableAuthenticatorTest.php
@@ -17,9 +17,75 @@ use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
 use Symfony\Component\Security\Http\Authenticator\Debug\TraceableAuthenticator;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
+use Symfony\Component\Security\Http\Authenticator\UnsupportedReasonProviderInterface;
 
 class TraceableAuthenticatorTest extends TestCase
 {
+    public function testUnsupportedReasonIsCollected()
+    {
+        $request = new Request();
+
+        $authenticator = $this->createMock(ExplainingAuthenticator::class);
+        $authenticator->method('supports')->willReturn(false);
+        $authenticator->expects($this->once())
+            ->method('getUnsupportedReason')
+            ->with($request)
+            ->willReturn('the moon is not full');
+
+        $traceable = new TraceableAuthenticator($authenticator);
+
+        $this->assertFalse($traceable->supports($request));
+        $this->assertSame('the moon is not full', $traceable->getInfo()['unsupportedReason']);
+    }
+
+    public function testUnsupportedReasonIsNullWhenTheAuthenticatorCannotExplain()
+    {
+        $authenticator = $this->createStub(AuthenticatorInterface::class);
+        $authenticator->method('supports')->willReturn(false);
+
+        $traceable = new TraceableAuthenticator($authenticator);
+
+        $this->assertFalse($traceable->supports(new Request()));
+        $this->assertArrayHasKey('unsupportedReason', $traceable->getInfo());
+        $this->assertNull($traceable->getInfo()['unsupportedReason']);
+    }
+
+    public function testUnsupportedReasonIsNotAskedForWhenTheRequestIsSupported()
+    {
+        $authenticator = $this->createMock(ExplainingAuthenticator::class);
+        $authenticator->method('supports')->willReturn(true);
+        $authenticator->expects($this->never())->method('getUnsupportedReason');
+
+        $traceable = new TraceableAuthenticator($authenticator);
+
+        $this->assertTrue($traceable->supports(new Request()));
+        $this->assertArrayHasKey('unsupportedReason', $traceable->getInfo());
+        $this->assertNull($traceable->getInfo()['unsupportedReason']);
+    }
+
+    public function testUnsupportedReasonIsForwardedByTheDecorator()
+    {
+        $request = new Request();
+
+        $authenticator = $this->createMock(ExplainingAuthenticator::class);
+        $authenticator->expects($this->once())
+            ->method('getUnsupportedReason')
+            ->with($request)
+            ->willReturn('the moon is not full');
+
+        $traceable = new TraceableAuthenticator($authenticator);
+
+        $this->assertInstanceOf(UnsupportedReasonProviderInterface::class, $traceable);
+        $this->assertSame('the moon is not full', $traceable->getUnsupportedReason($request));
+    }
+
+    public function testUnsupportedReasonIsNullWhenTheDecoratedAuthenticatorCannotExplain()
+    {
+        $traceable = new TraceableAuthenticator($this->createStub(AuthenticatorInterface::class));
+
+        $this->assertNull($traceable->getUnsupportedReason(new Request()));
+    }
+
     public function testGetInfo()
     {
         $request = new Request();
@@ -59,4 +125,8 @@ class TraceableAuthenticatorTest extends TestCase
         $this->assertIsArray($traceable->getInfo()['badges']);
         $this->assertSame([], $traceable->getInfo()['badges']);
     }
+}
+
+interface ExplainingAuthenticator extends AuthenticatorInterface, UnsupportedReasonProviderInterface
+{
 }

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/FormLoginAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/FormLoginAuthenticatorTest.php
@@ -271,6 +271,85 @@ class FormLoginAuthenticatorTest extends TestCase
         yield ['application/x-www-form-urlencoded', true];
     }
 
+    #[DataProvider('provideUnsupportedReasons')]
+    public function testUnsupportedReasonNamesTheFailingCondition(array $options, Request $request, string $expected)
+    {
+        $this->setUpAuthenticator($options);
+
+        $this->assertSame($expected, $this->authenticator->getUnsupportedReason($request));
+    }
+
+    public static function provideUnsupportedReasons(): iterable
+    {
+        yield 'method' => [
+            ['check_path' => '/login_check', 'post_only' => true],
+            Request::create('/login_check', 'GET'),
+            'the request method is "GET", and the "post_only" option requires POST',
+        ];
+
+        yield 'path' => [
+            ['check_path' => '/login_check', 'post_only' => true],
+            Request::create('/elsewhere', 'POST'),
+            'the request path "/elsewhere" does not match the "check_path" option "/login_check"',
+        ];
+
+        yield 'format' => [
+            ['check_path' => '/login_check', 'post_only' => true, 'form_only' => true],
+            Request::create('/login_check', 'POST', [], [], [], ['CONTENT_TYPE' => 'application/json']),
+            'the "Content-Type" header "application/json" is not a form one, and the "form_only" option requires one',
+        ];
+
+        // an unmapped content type has no format at all, so the header is what must be named
+        yield 'unmapped format' => [
+            ['check_path' => '/login_check', 'post_only' => true, 'form_only' => true],
+            Request::create('/login_check', 'POST', [], [], [], ['CONTENT_TYPE' => 'application/text']),
+            'the "Content-Type" header "application/text" is not a form one, and the "form_only" option requires one',
+        ];
+
+        yield 'missing content type' => [
+            ['check_path' => '/login_check', 'post_only' => false, 'form_only' => true],
+            Request::create('/login_check', 'GET'),
+            'the request has no "Content-Type" header, and the "form_only" option requires a form one',
+        ];
+    }
+
+    /**
+     * supports() and getUnsupportedReason() evaluate the same conditions separately, so they must
+     * be kept in step over every combination of the options: a declined request always has a
+     * reason, an accepted one never does.
+     */
+    #[DataProvider('provideRequestsForReasonAgreement')]
+    public function testUnsupportedReasonAgreesWithSupports(array $options, Request $request)
+    {
+        $this->setUpAuthenticator($options);
+
+        $this->assertSame(
+            false === $this->authenticator->supports($request),
+            null !== $this->authenticator->getUnsupportedReason($request),
+        );
+    }
+
+    public static function provideRequestsForReasonAgreement(): iterable
+    {
+        foreach ([true, false] as $postOnly) {
+            foreach ([true, false] as $formOnly) {
+                foreach (['POST', 'GET'] as $method) {
+                    foreach (['/login_check', '/elsewhere'] as $path) {
+                        foreach ([null, 'application/x-www-form-urlencoded', 'application/json', 'application/text'] as $contentType) {
+                            $options = ['check_path' => '/login_check', 'post_only' => $postOnly, 'form_only' => $formOnly];
+                            $server = null === $contentType ? [] : ['CONTENT_TYPE' => $contentType];
+
+                            yield \sprintf('post_only: %s, form_only: %s, %s %s, Content-Type: %s', var_export($postOnly, true), var_export($formOnly, true), $method, $path, $contentType ?? 'none') => [
+                                $options,
+                                Request::create($path, $method, [], [], [], $server),
+                            ];
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     private function setUpAuthenticator(array $options = [])
     {
         $this->authenticator = new FormLoginAuthenticator(new HttpUtils(), $this->userProvider, $this->successHandler, $this->failureHandler, $options);

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/JsonLoginAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/JsonLoginAuthenticatorTest.php
@@ -66,6 +66,72 @@ class JsonLoginAuthenticatorTest extends TestCase
         yield [Request::create('/login', 'GET', [], [], [], ['HTTP_CONTENT_TYPE' => 'application/json']), false];
     }
 
+    public function testUnsupportedReasonNamesTheContentType()
+    {
+        $this->setUpAuthenticator();
+
+        $this->assertSame(
+            'neither the request format "html" nor the "Content-Type" header "application/text" is a JSON one',
+            $this->authenticator->getUnsupportedReason(Request::create('/login', 'GET', [], [], [], ['HTTP_CONTENT_TYPE' => 'application/text'])),
+        );
+    }
+
+    public function testUnsupportedReasonWhenTheContentTypeHeaderIsMissing()
+    {
+        $this->setUpAuthenticator();
+
+        $this->assertSame(
+            'the request format "html" is not a JSON one, and the request has no "Content-Type" header',
+            $this->authenticator->getUnsupportedReason(Request::create('/login', 'GET')),
+        );
+    }
+
+    public function testUnsupportedReasonNamesTheCheckPath()
+    {
+        $this->setUpAuthenticator(['check_path' => '/api/login']);
+
+        $this->assertSame(
+            'the request path "/login" does not match the "check_path" option "/api/login"',
+            $this->authenticator->getUnsupportedReason(Request::create('/login', 'GET', [], [], [], ['HTTP_CONTENT_TYPE' => 'application/json'])),
+        );
+    }
+
+    /**
+     * supports() and getUnsupportedReason() evaluate the same conditions separately, so they must
+     * be kept in step over every combination of the options: a declined request always has a
+     * reason, an accepted one never does.
+     */
+    #[DataProvider('provideRequestsForReasonAgreement')]
+    public function testUnsupportedReasonAgreesWithSupports(array $options, Request $request)
+    {
+        $this->setUpAuthenticator($options);
+
+        $this->assertSame(
+            false === $this->authenticator->supports($request),
+            null !== $this->authenticator->getUnsupportedReason($request),
+        );
+    }
+
+    public static function provideRequestsForReasonAgreement(): iterable
+    {
+        foreach ([[], ['check_path' => '/api/login']] as $options) {
+            foreach (['/api/login', '/login'] as $path) {
+                foreach ([null, 'json'] as $format) {
+                    foreach ([null, 'application/json', 'application/text', 'text/html'] as $contentType) {
+                        $server = null === $contentType ? [] : ['HTTP_CONTENT_TYPE' => $contentType];
+                        $request = Request::create($path, 'GET', [], [], [], $server);
+
+                        if (null !== $format) {
+                            $request->setRequestFormat($format);
+                        }
+
+                        yield \sprintf('check_path: %s, %s, format: %s, Content-Type: %s', $options['check_path'] ?? 'none', $path, $format ?? 'default', $contentType ?? 'none') => [$options, $request];
+                    }
+                }
+            }
+        }
+    }
+
     public function testAuthenticate()
     {
         $this->setUpAuthenticator();

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/RememberMeAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/RememberMeAuthenticatorTest.php
@@ -65,6 +65,50 @@ class RememberMeAuthenticatorTest extends TestCase
         yield [$request, false];
     }
 
+    #[DataProvider('provideUnsupportedReasons')]
+    public function testUnsupportedReasonNamesTheFailingCondition(Request $request, ?string $expected)
+    {
+        $this->assertSame($expected, $this->authenticator->getUnsupportedReason($request));
+    }
+
+    public static function provideUnsupportedReasons(): iterable
+    {
+        yield 'no cookie' => [Request::create('/'), 'the request has no "_remember_me_cookie" cookie'];
+
+        $request = Request::create('/', 'GET', [], ['_remember_me_cookie' => 'rememberme']);
+        $request->attributes->set(ResponseListener::COOKIE_ATTR_NAME, new Cookie('_remember_me_cookie', null));
+        yield 'cookie being cleared' => [$request, 'the "_remember_me_cookie" cookie is being cleared by this request'];
+
+        yield 'empty cookie' => [
+            Request::create('/', 'GET', [], ['_remember_me_cookie' => '0']),
+            'the "_remember_me_cookie" cookie is empty or not a scalar',
+        ];
+
+        yield 'supported' => [Request::create('/', 'GET', [], ['_remember_me_cookie' => 'rememberme']), null];
+    }
+
+    public function testUnsupportedReasonWhenAlreadyAuthenticated()
+    {
+        $this->tokenStorage->setToken(new UsernamePasswordToken(new InMemoryUser('username', 'credentials'), 'main'));
+
+        $this->assertSame(
+            'a token is already stored, so this request is already authenticated',
+            $this->authenticator->getUnsupportedReason(Request::create('/', 'GET', [], ['_remember_me_cookie' => 'rememberme'])),
+        );
+    }
+
+    /**
+     * supports() and getUnsupportedReason() evaluate the same conditions separately, so they must
+     * be kept in step: a declined request always has a reason, and a supported one never does.
+     * supports() returns null, not true, when it supports the request, since this authenticator
+     * supports lazy firewalls.
+     */
+    #[DataProvider('provideSupportsData')]
+    public function testUnsupportedReasonAgreesWithSupports(Request $request, ?bool $support)
+    {
+        $this->assertSame(false === $support, null !== $this->authenticator->getUnsupportedReason($request));
+    }
+
     public function testAuthenticate()
     {
         $rememberMeHandler = $this->createMock(RememberMeHandlerInterface::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #64993
| License       | MIT

This is shape **A** of the two I described on the issue, opened as a proposal rather than a settled design: happy to switch to B, or to drop it, on your word @nicolas-grekas. @dakri1 raised the same API question in July and I would gladly hand this over.

An authenticator can now say why it declined a request, and the profiler shows it next to the one that was skipped:

```php
final class MyAuthenticator implements AuthenticatorInterface, UnsupportedReasonProviderInterface
{
    public function getUnsupportedReason(Request $request): ?string
    {
        return 'the "X-Tenant" header is missing';
    }
}
```

Everything stays inside `TraceableAuthenticator`, which only exists when the profiler is enabled, so **nothing is paid in production**:

```php
if (false === $this->supports = $this->authenticator->supports($request)) {
    $this->unsupportedReason = $this->getUnsupportedReason($request);
}
```

The reason is asked for only after `supports()` returned false, and never when it returned true, which a test pins.

**`supports()` is deliberately left untouched** in the authenticators. Making it delegate to `getUnsupportedReason()` would remove the duplication, but it would also build a message on the request path of every unauthenticated request. The price is that the conditions are written twice, so each authenticator carries a test asserting the two agree over every combination of its options: a declined request always has a reason, an accepted one never does.

Correction to what I first wrote here about #60538, thanks to @nicolas-grekas: it was closed by @MatTheCat himself, and it built its reasons only when the debug decorator passed a `RequestDecision`, so a per-request cost was not what closed it. The objection on record there is @chalasr's, that it is not worth complicating the authenticator API for a debug purpose, and it applies to this PR too.

The case from #48277 now reads, in the Security panel:

> This authenticator did not support the request.
> Reason: neither the request format "html" nor the "Content-Type" header "application/text" is a JSON one.

**Scope.** `json_login`, `form_login` and `remember_me` implement the interface. `LdapAuthenticator` forwards it to the authenticator it decorates, so `form_login_ldap` and `json_login_ldap` show the reason too; that one costs a `"symfony/security-http": "<8.2"` entry in `symfony/ldap`'s `conflict`, since implementing an interface requires it to exist. `LoginLinkAuthenticator`, `AccessTokenAuthenticator` and `HttpBasicAuthenticator` are a follow-up, or I can add them here if you prefer one pass.

**The one effect outside the component**, spelled out for anyone reading this later: from 8.2, an application that has both `symfony/ldap` and `symfony/security-http` moves them together. `symfony/ldap` gains `"symfony/security-http": "<8.2"` in its `conflict`, and its `require-dev` follows, matching the `"symfony/security-core": "<8.0"` entry already there. This is not optional once `LdapAuthenticator` declares the interface, since implementing an interface that does not exist is a fatal at class load.

Tests: Security\Http 1017, SecurityBundle 543, Ldap 73, green, and on PHP 8.5 too. The docs note you mentioned on the issue, that `json_login` needs a JSON content type and that a skipped authenticator is visible in the profiler, will follow once the shape is settled.

