### PR TITLE
[Validator] Complete Traditional Chinese translations

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.zh_TW.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.zh_TW.xlf
@@ -572,11 +572,11 @@
             </trans-unit>
             <trans-unit id="147">
                 <source>The referenced entity does not exist.</source>
-                <target state="needs-review-translation">引用的實體不存在。</target>
+                <target>引用的實體不存在。</target>
             </trans-unit>
             <trans-unit id="148" resname="This is not a valid ULID.">
                 <source>This value is not a valid ULID.</source>
-                <target state="needs-review-translation">這個值不是有效的 ULID。</target>
+                <target>這個值不是有效的 ULID。</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A |
| ------------- | --- |
| Branch?       | 6.4 |
| Bug fix?      | yes |
| New feature?  | no |
| Deprecations? | no |
| Issues        | Fix #65552 |
| License       | MIT |

Complete the Traditional Chinese translations for two Validator messages by removing their `needs-review-translation` state. The translated text, message IDs, source strings, and placeholders are unchanged.

The human submitter is a native Traditional/Simplified Chinese speaker and manually reviewed the Traditional Chinese wording.

## Tests

- All Validator XLIFF files parse as XML.
- XLIFF schema validation passed.
- Placeholder consistency check passed.
- `git diff --check` passed.
- Symfony unit tests and static analysis passed in GitHub Actions.

## AI Disclosure

OpenCode using the gpt-5.6-sol model assisted with repository research and prepared the initial translation patch. The human submitter reviewed the resulting changes, translation wording, and validation details before submission.