### PR TITLE
[VarDumper] Fix dumping class names to the dump server

### DIFF
--- a/src/Symfony/Component/VarDumper/Server/DumpServer.php
+++ b/src/Symfony/Component/VarDumper/Server/DumpServer.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\VarDumper\Server;
 
 use Psr\Log\LoggerInterface;
+use Symfony\Component\VarDumper\Caster\ClassDumpStub;
 use Symfony\Component\VarDumper\Cloner\Data;
 use Symfony\Component\VarDumper\Cloner\Stub;
 
@@ -61,7 +62,7 @@ class DumpServer
         foreach ($this->getMessages() as $clientId => $message) {
             $this->logger?->info('Received a payload from client {clientId}', ['clientId' => $clientId]);
 
-            $payload = @unserialize(base64_decode($message), ['allowed_classes' => [Data::class, Stub::class]]);
+            $payload = @unserialize(base64_decode($message), ['allowed_classes' => [Data::class, Stub::class, ClassDumpStub::class]]);
 
             // Impossible to decode the message, give up.
             if (false === $payload) {

--- a/src/Symfony/Component/VarDumper/Tests/Server/ConnectionTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Server/ConnectionTest.php
@@ -14,9 +14,11 @@ namespace Symfony\Component\VarDumper\Tests\Server;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Process\PhpProcess;
 use Symfony\Component\Process\Process;
+use Symfony\Component\VarDumper\Cloner\Data;
 use Symfony\Component\VarDumper\Cloner\VarCloner;
 use Symfony\Component\VarDumper\Dumper\ContextProvider\ContextProviderInterface;
 use Symfony\Component\VarDumper\Server\Connection;
+use Symfony\Component\VarDumper\Tests\Fixtures\ClassStringFixture;
 
 class ConnectionTest extends TestCase
 {
@@ -39,7 +41,58 @@ class ConnectionTest extends TestCase
             },
         ]);
 
-        $dumped = null;
+        $this->assertStringMatchesFormat(<<<'DUMP'
+            (3) "foo"
+            [
+              "timestamp" => %d.%d
+              "foo_provider" => [
+                (3) "foo"
+              ]
+            ]
+            %d
+
+            DUMP,
+            $this->dumpThroughServer($connection, $data)
+        );
+    }
+
+    public function testDumpClassString()
+    {
+        if ('\\' === \DIRECTORY_SEPARATOR) {
+            $this->markTestSkipped('Skip transient test on Windows');
+        }
+
+        class_exists(ClassStringFixture::class);
+
+        $cloner = new VarCloner();
+        $data = $cloner->cloneVar(ClassStringFixture::class);
+        $connection = new Connection(self::VAR_DUMPER_SERVER);
+
+        $this->assertStringMatchesFormat(<<<'DUMP'
+            (%d) "Symfony\Component\VarDumper\Tests\Fixtures\ClassStringFixture (count=%d)"
+            [
+              "timestamp" => %d.%d
+            ]
+            %d
+
+            DUMP,
+            $this->dumpThroughServer($connection, $data)
+        );
+    }
+
+    public function testNoServer()
+    {
+        $cloner = new VarCloner();
+        $data = $cloner->cloneVar('foo');
+        $connection = new Connection(self::VAR_DUMPER_SERVER);
+        $start = microtime(true);
+        $this->assertFalse($connection->write($data));
+        $this->assertLessThan(4, microtime(true) - $start);
+    }
+
+    private function dumpThroughServer(Connection $connection, Data $data): string
+    {
+        $dumped = '';
         $process = $this->getServerProcess();
         $process->start(function ($type, $buffer) use ($process, &$dumped, $connection, $data) {
             if (Process::ERR === $type) {
@@ -55,29 +108,8 @@ class ConnectionTest extends TestCase
         $process->wait();
 
         $this->assertTrue($process->isSuccessful());
-        $this->assertStringMatchesFormat(<<<'DUMP'
-            (3) "foo"
-            [
-              "timestamp" => %d.%d
-              "foo_provider" => [
-                (3) "foo"
-              ]
-            ]
-            %d
 
-            DUMP,
-            $dumped
-        );
-    }
-
-    public function testNoServer()
-    {
-        $cloner = new VarCloner();
-        $data = $cloner->cloneVar('foo');
-        $connection = new Connection(self::VAR_DUMPER_SERVER);
-        $start = microtime(true);
-        $this->assertFalse($connection->write($data));
-        $this->assertLessThan(4, microtime(true) - $start);
+        return $dumped;
     }
 
     private function getServerProcess(): Process


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65833
| License       | MIT

Dumping the name of a user-defined class over the dump server kills the server with:

```
Symfony\Component\VarDumper\Dumper\CliDumper::dumpScalar(): Argument #3 ($value) must be of type string|int|float|bool|null, __PHP_Incomplete_Class given
```

`VarCloner` stores a `ClassDumpStub` for such strings, but `allowed_classes` does not take inheritance into account, so the stub is restored as an `__PHP_Incomplete_Class` and blows up on the first dump. Listing it next to `Data` and `Stub` is enough; every other stub the cloner produces is already flattened to a plain `Stub`.
