### PR TITLE
[HttpFoundation] Fix hitting the PCRE size limit with many trusted host patterns

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -223,9 +223,14 @@ class Request
     private static $trustedHeaderSet = -1;
 
     /**
-     * @var string|null
+     * @var array<string, true>
      */
-    private static $trustedHostsRegexp;
+    private static $trustedHostsLiterals = [];
+
+    /**
+     * @var string[]
+     */
+    private static $trustedHostsRegexps = [];
 
     private const FORWARDED_PARAMS = [
         self::HEADER_X_FORWARDED_FOR => 'for',
@@ -674,8 +679,19 @@ class Request
         self::$trustedHostPatterns = array_map(function ($hostPattern) {
             return sprintf('{%s}i', $hostPattern);
         }, $hostPatterns);
-        // the branch reset group keeps capturing groups, back references and inline modifiers local to each pattern
-        self::$trustedHostsRegexp = $hostPatterns ? sprintf('{(?|(?:%s))}i', implode(')|(?:', $hostPatterns)) : null;
+        self::$trustedHostsLiterals = [];
+        $regexpPatterns = [];
+
+        foreach ($hostPatterns as $hostPattern) {
+            // constant patterns are matched by a hash lookup in getHost(), where the host is lowercase and free of newlines
+            if (preg_match('{^\^((?:[a-z0-9_:-]|\\\\[^a-z0-9])++)\$$}Di', $hostPattern, $m)) {
+                self::$trustedHostsLiterals[strtolower(preg_replace('{\\\\(.)}s', '$1', $m[1]))] = true;
+            } else {
+                $regexpPatterns[] = $hostPattern;
+            }
+        }
+
+        self::$trustedHostsRegexps = self::compileHostPatterns($regexpPatterns);
     }
 
     /**
@@ -1249,11 +1265,17 @@ class Request
             throw new SuspiciousOperationException(sprintf('Invalid Host "%s".', $host));
         }
 
-        if (self::$trustedHostsRegexp) {
+        if (self::$trustedHostsLiterals || self::$trustedHostsRegexps) {
             // to avoid host header injection attacks, you should provide a list of trusted host patterns
 
-            if (preg_match(self::$trustedHostsRegexp, $host)) {
+            if (isset(self::$trustedHostsLiterals[$host])) {
                 return $host;
+            }
+
+            foreach (self::$trustedHostsRegexps as $regexp) {
+                if (preg_match($regexp, $host)) {
+                    return $host;
+                }
             }
 
             if (!$this->isHostValid) {
@@ -2214,5 +2236,32 @@ class Request
 
         // use preg_replace() instead of preg_match() to prevent DoS attacks with long host names
         return '' === preg_replace('/[-a-zA-Z0-9_]++\.?/', '', $host);
+    }
+
+    /**
+     * Combines host patterns into as few regexps as PCRE can compile.
+     *
+     * @return string[]
+     */
+    private static function compileHostPatterns(array $hostPatterns): array
+    {
+        if (!$hostPatterns) {
+            return [];
+        }
+
+        // the branch reset group keeps capturing groups, back references and inline modifiers local to each pattern
+        $regexp = sprintf('{(?|(?:%s))}i', implode(')|(?:', $hostPatterns));
+
+        if (1 === \count($hostPatterns) || false !== @preg_match($regexp, '')) {
+            return [$regexp];
+        }
+
+        // the combined pattern exceeds the maximum size PCRE accepts, split it in half
+        $half = intdiv(\count($hostPatterns), 2);
+
+        return array_merge(
+            self::compileHostPatterns(\array_slice($hostPatterns, 0, $half)),
+            self::compileHostPatterns(\array_slice($hostPatterns, $half))
+        );
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -2253,6 +2253,67 @@ class RequestTest extends TestCase
         $request->getHost();
     }
 
+    public function testTrustedHostsWithManyPatterns()
+    {
+        $hostPatterns = [];
+        for ($i = 0; $i < 5000; ++$i) {
+            $hostPatterns[] = '^customer-'.$i.'\.[a-z]+\.example\.com$';
+        }
+        Request::setTrustedHosts($hostPatterns);
+
+        $request = Request::create('/');
+        $request->headers->set('host', 'customer-0.eu.example.com');
+        $this->assertSame('customer-0.eu.example.com', $request->getHost());
+        $request->headers->set('host', 'customer-4999.eu.example.com');
+        $this->assertSame('customer-4999.eu.example.com', $request->getHost());
+
+        $request = Request::create('/');
+        $request->headers->set('host', 'evil.com');
+
+        $this->expectException(SuspiciousOperationException::class);
+        $this->expectExceptionMessage('Untrusted Host "evil.com".');
+
+        $request->getHost();
+    }
+
+    public function testTrustedHostsWithManyConstantPatterns()
+    {
+        $hostPatterns = [];
+        for ($i = 0; $i < 5000; ++$i) {
+            $hostPatterns[] = '^customer-'.$i.'\.example\.com$';
+        }
+        Request::setTrustedHosts($hostPatterns);
+
+        $trustedHostsRegexps = new \ReflectionProperty(Request::class, 'trustedHostsRegexps');
+        $trustedHostsRegexps->setAccessible(true);
+        $this->assertSame([], $trustedHostsRegexps->getValue());
+
+        $request = Request::create('/');
+        $request->headers->set('host', 'customer-0.example.com');
+        $this->assertSame('customer-0.example.com', $request->getHost());
+        $request->headers->set('host', 'CUSTOMER-4999.EXAMPLE.COM');
+        $this->assertSame('customer-4999.example.com', $request->getHost());
+
+        $request = Request::create('/');
+        $request->headers->set('host', 'evil.com');
+
+        $this->expectException(SuspiciousOperationException::class);
+        $this->expectExceptionMessage('Untrusted Host "evil.com".');
+
+        $request->getHost();
+    }
+
+    public function testTrustedHostsWithMetaCharactersAreMatchedAsRegexps()
+    {
+        Request::setTrustedHosts(['^a.example\.com$', '^customer-\d+\.example\.org$']);
+
+        $request = Request::create('/');
+        $request->headers->set('host', 'axexample.com');
+        $this->assertSame('axexample.com', $request->getHost());
+        $request->headers->set('host', 'customer-42.example.org');
+        $this->assertSame('customer-42.example.org', $request->getHost());
+    }
+
     public function testFactory()
     {
         Request::setFactory(function (array $query = [], array $request = [], array $attributes = [], array $cookies = [], array $files = [], array $server = [], $content = null) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65834
| License       | MIT

Since #65252, `Request::setTrustedHosts()` combines all patterns into a single regexp. PCRE refuses to compile a pattern above its maximum size, so a long list of trusted hosts makes the check fail:

```
preg_match(): Compilation failed: regular expression is too large at offset 168893
```

Two things make this worse than a plain limit. The failure happens in `Request::getHost()`, not when the hosts are set, so the report points at the host instead of at the configuration. And `preg_match()` returns `false`, which reads as "no match", so every request is rejected with `Untrusted Host` and every request logs a warning. With patterns of about 30 characters, PHP 8.5 stops compiling at around 1200 of them.

This PR does two things.

First, `setTrustedHosts()` recognizes the patterns that describe one constant host, `^customer-1\.example\.com$` for example, and collects them in a hash set. `getHost()` looks the host up there before it tries any regexp. A pattern is taken for a constant only when it is anchored on both ends and made of literal characters, where `\.` counts as one but `.`, `\d` and `[a-z]` do not. A list of customer domains is made of such patterns, so it produces no regexp at all, which is why the case reported in #65834 now costs one hash lookup per request.

Second, the patterns that are left are combined into as few regexps as PCRE accepts, instead of always one. `setTrustedHosts()` compiles the combined pattern, and splits the list in half when the compilation fails, recursively. `getHost()` matches the host against each of the resulting regexps and stops at the first one that matches.

The compilation is paid once, when the hosts are set. A list that already worked keeps the same behavior, and matching it never becomes slower:

| trusted hosts | hash entries | regexps | `setTrustedHosts()` | `getHost()`, worst case |
| --- | --- | --- | --- | --- |
| 3 constants | 3 | 0 | 0.0 ms | 0.02 µs |
| 1 000 constants | 1 000 | 0 | 0.7 ms | 0.02 µs |
| 5 000 constants | 5 000 | 0 | 3.6 ms | 0.02 µs |
| 20 000 constants | 20 000 | 0 | 33.1 ms | 0.04 µs |
| 1 000 wildcards | 0 | 2 | 11.0 ms | 9.09 µs |
| 5 000 wildcards | 0 | 8 | 70.9 ms | 82.49 µs |
| 20 000 wildcards | 0 | 32 | 180.9 ms | 986.56 µs |

The hash lookup is exact because `getHost()` lowercases the host and validates it before the check, so the host cannot contain the newline that `$` also accepts, and the case folding of the `i` modifier is covered by the same `strtolower()` call on both sides.

As a side effect, a single pattern that PCRE cannot compile at all, a typo in a pattern for example, no longer disables the whole list. It ends up alone in its own regexp, and the other patterns keep working, which is what 5.4 did before #65252.

`Request::getTrustedHosts()` still returns the list of individual patterns, unchanged.

Merge-up to 6.4 and above: the same edits, with the style of those branches. The two new properties are `private static array $trustedHostsLiterals = [];` and `private static array $trustedHostsRegexps = [];`, `\sprintf()`, `\count()` and `\array_slice()` keep their leading backslash, while `preg_match()` and `strtolower()` do not, and on 8.1 and above the deprecation notice about the `$trustedHosts` property stays where it is, before the new hash lookup.
