### PR TITLE
[PropertyInfo] Do not prefer a method returning the declaring class as the property accessor

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -272,13 +272,15 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
             array_splice($accessorMethods, false === $getterPosition ? \count($accessorMethods) : $getterPosition + 1, 0, [$getsetter]);
         }
 
-        $staticGetsetter = null;
+        $deferredGetsetter = null;
 
         foreach ($accessorMethods as $methodName) {
             if ($reflClass->hasMethod($methodName) && ($m = $reflClass->getMethod($methodName))->getModifiers() & $this->methodReflectionFlags && !$m->getNumberOfRequiredParameters() && !\in_array((string) $m->getReturnType(), ['void', 'never'], true)) {
-                if ($allowGetterSetter && $methodName === $getsetter && $m->isStatic()) {
-                    // a static method named after the property, e.g. a named constructor, must not win over any instance-based candidate; try it last
-                    $staticGetsetter = $m;
+                if ($allowGetterSetter && $methodName === $getsetter && ($m->isStatic() || $this->isDeclaringClassType($m->getReturnType(), $m->getDeclaringClass()))) {
+                    // a method named after the property that hands back an object of the same class,
+                    // e.g. a named constructor or a derived value, cannot report the state of the
+                    // object being read; it must not win over any instance-based candidate; try it last
+                    $deferredGetsetter = $m;
                     continue;
                 }
 
@@ -298,8 +300,8 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
             return new PropertyReadInfo(PropertyReadInfo::TYPE_METHOD, 'get'.$camelProp, PropertyReadInfo::VISIBILITY_PUBLIC, false, false);
         }
 
-        if ($staticGetsetter) {
-            return new PropertyReadInfo(PropertyReadInfo::TYPE_METHOD, $getsetter, $this->getReadVisibilityForMethod($staticGetsetter), true, false);
+        if ($deferredGetsetter) {
+            return new PropertyReadInfo(PropertyReadInfo::TYPE_METHOD, $getsetter, $this->getReadVisibilityForMethod($deferredGetsetter), $deferredGetsetter->isStatic(), false);
         }
 
         return null;
@@ -621,6 +623,27 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
         }
 
         return $name;
+    }
+
+    private function isDeclaringClassType(?\ReflectionType $reflectionType, \ReflectionClass $declaringClass): bool
+    {
+        if ($reflectionType instanceof \ReflectionUnionType || $reflectionType instanceof \ReflectionIntersectionType) {
+            foreach ($reflectionType->getTypes() as $type) {
+                if ($this->isDeclaringClassType($type, $declaringClass)) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        if (!$reflectionType instanceof \ReflectionNamedType || $reflectionType->isBuiltin()) {
+            return false;
+        }
+
+        $name = $this->resolveTypeName($reflectionType->getName(), $declaringClass);
+
+        return 'static' === $name || is_a($declaringClass->name, $name, true);
     }
 
     private function isNullableProperty(string $class, string $property): bool

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
@@ -17,11 +17,13 @@ use Symfony\Component\PropertyInfo\PropertyReadInfo;
 use Symfony\Component\PropertyInfo\PropertyWriteInfo;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\AdderRemoverDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\AsymmetricVisibility;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\ChildDummyWithSelfReturningAccessor;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\DefaultValue;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\DummyWithGetterSetter;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\DummyWithHasser;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\DummyWithNonAsciiStaticAccessor;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\DummyWithSelfReturningAccessor;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\DummyWithStaticConstructorAndAccessor;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\DummyWithStaticMutator;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\MultiParameterAdderDummy;
@@ -645,6 +647,46 @@ class ReflectionExtractorTest extends TestCase
 
         $this->assertSame(PropertyReadInfo::TYPE_PROPERTY, $readAccessor->getType());
         $this->assertSame('positive', $readAccessor->getName());
+    }
+
+    /**
+     * @dataProvider selfReturningAccessorProvider
+     */
+    public function testGetReadAccessorDoesNotPreferAMethodReturningTheDeclaringClass(string $class, string $property, string $expectedAccessor)
+    {
+        $readAccessor = $this->extractor->getReadInfo($class, $property, ['enable_getter_setter_extraction' => true]);
+
+        $this->assertSame(PropertyReadInfo::TYPE_METHOD, $readAccessor->getType());
+        $this->assertSame($expectedAccessor, $readAccessor->getName());
+    }
+
+    public static function selfReturningAccessorProvider()
+    {
+        return [
+            'self' => [DummyWithSelfReturningAccessor::class, 'negative', 'isNegative'],
+            'static' => [DummyWithSelfReturningAccessor::class, 'positive', 'isPositive'],
+            'implemented interface' => [DummyWithSelfReturningAccessor::class, 'halved', 'isHalved'],
+            'union member' => [DummyWithSelfReturningAccessor::class, 'incremented', 'isIncremented'],
+            'parent' => [ChildDummyWithSelfReturningAccessor::class, 'tripled', 'isTripled'],
+            'unrelated class' => [DummyWithSelfReturningAccessor::class, 'truncated', 'truncated'],
+        ];
+    }
+
+    public function testGetReadAccessorPrefersThePropertyOverTheMethodReturningTheDeclaringClass()
+    {
+        $readAccessor = $this->extractor->getReadInfo(DummyWithSelfReturningAccessor::class, 'rounded', ['enable_getter_setter_extraction' => true]);
+
+        $this->assertSame(PropertyReadInfo::TYPE_PROPERTY, $readAccessor->getType());
+        $this->assertSame('rounded', $readAccessor->getName());
+    }
+
+    public function testGetReadAccessorTriesTheMethodReturningTheDeclaringClassLast()
+    {
+        $readAccessor = $this->extractor->getReadInfo(DummyWithSelfReturningAccessor::class, 'doubled', ['enable_getter_setter_extraction' => true]);
+
+        $this->assertSame(PropertyReadInfo::TYPE_METHOD, $readAccessor->getType());
+        $this->assertSame('doubled', $readAccessor->getName());
+        $this->assertFalse($readAccessor->isStatic());
     }
 
     /**

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/ChildDummyWithSelfReturningAccessor.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/ChildDummyWithSelfReturningAccessor.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
+
+class ChildDummyWithSelfReturningAccessor extends DummyWithSelfReturningAccessor
+{
+    public function isTripled(): bool
+    {
+        return false;
+    }
+
+    public function tripled(): parent
+    {
+        return new parent(3);
+    }
+}

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/DummyWithSelfReturningAccessor.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/DummyWithSelfReturningAccessor.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
+
+interface AmountInterface
+{
+}
+
+class DummyWithSelfReturningAccessor implements AmountInterface
+{
+    public bool $rounded = false;
+
+    public function __construct(private readonly int $value = 1)
+    {
+    }
+
+    public function isNegative(): bool
+    {
+        return 0 > $this->value;
+    }
+
+    public function negative(): self
+    {
+        return new self(-$this->value);
+    }
+
+    public function isPositive(): bool
+    {
+        return 0 < $this->value;
+    }
+
+    public function positive(): static
+    {
+        return $this->isPositive() ? $this : new static(-$this->value);
+    }
+
+    public function isHalved(): bool
+    {
+        return 0 === $this->value % 2;
+    }
+
+    public function halved(): AmountInterface
+    {
+        return new self(intdiv($this->value, 2));
+    }
+
+    public function isIncremented(): bool
+    {
+        return 0 !== $this->value;
+    }
+
+    public function incremented(): self|int
+    {
+        return new self($this->value + 1);
+    }
+
+    public function isTruncated(): bool
+    {
+        return false;
+    }
+
+    public function truncated(): \ArrayObject
+    {
+        return new \ArrayObject([$this->value]);
+    }
+
+    public function rounded(): self
+    {
+        return $this;
+    }
+
+    public function doubled(): self
+    {
+        return new self($this->value * 2);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65831
| License       | MIT

#65619 pushed a *static* method named after the property behind every instance-based candidate, since a named constructor hands back a new object instead of reporting state. An instance method can do exactly the same thing, and `Money\Money` from `moneyphp/money` is the case that hurts: it carries both `isNegative()` and `negative(): Money`, so since #65501 the `negative` property is read through `negative()` and the Serializer walks into a fresh `Money` at every level until memory runs out.

```php
final class Amount
{
    public function __construct(private readonly int $value) {}
    public function getValue(): int { return $this->value; }
    public function isNegative(): bool { return $this->value < 0; }
    public function negative(): self { return new self(-$this->value); }
}
```

This patch widens the #65619 demotion: the method named after the property is tried last when it is static **or** when its return type is the class it is declared in, covering `self`, `static`, the class named explicitly, a parent, an implemented interface, and any member of a union or intersection. Such a method builds or derives an object, so it can never say what state the object being read is in. `getTypes()` skips the bare method entirely and answers `bool` here from `isNegative()`, so read info and type info line up again.

Neither suggestion from the issue holds up, unfortunately, since both undo #65501. Refusing `foo()` when the property was discovered from `isFoo()` reverts it outright: `payments` is discovered from `hasPayments()` there too, the backing property being private. Comparing the return type against the property type breaks on the same class as soon as the property has no typed field behind it, which is the ordinary shape for a jQuery-style accessor. `getTypes()` then falls back to the hasser and reports `bool`, so `payments(): array` reads as a mismatch and gets rejected. In the case reported here there is no property type to compare against at all, `negative` takes its `bool` from `isNegative()` itself.

The demotion remains a demotion. A class exposing only `negative(): self` still resolves to it, and `isReadable()` still answers true. It also stays scoped to the candidate `enable_getter_setter_extraction` adds, so accessors found through the configured prefixes are left alone.

Read priority for property `foo` with `enable_getter_setter_extraction` on: `getFoo()`, `foo()` unless it is static or returns the declaring class, `isFoo()`, `hasFoo()`, `canFoo()`, then `__get()`, the `foo` property, `__call()`, and `foo()` last.

Checks run on this branch with PHP 8.5 and PHPUnit 9.6:

* `./phpunit src/Symfony/Component/PropertyInfo/Tests`: OK, 566 tests, 920 assertions.
* `./phpunit src/Symfony/Component/PropertyAccess/Tests`: OK, 482 tests, 557 assertions.
* `./phpunit src/Symfony/Component/Serializer/Tests`: OK, 1172 tests, 2364 assertions, 11 skipped.
* `./phpunit src/Symfony/Component/Form/Tests`: OK, 4801 tests, 9413 assertions, 366 skipped, 8 incomplete.
* `./phpunit src/Symfony/Component/Validator/Tests`: OK, 4807 tests, 8514 assertions, 60 skipped.
* Source change reverted, new tests kept: only `testGetReadAccessorDoesNotPreferAMethodReturningTheDeclaringClass` fails, on `'negative'` vs `'isNegative'`.
