### PR TITLE
[Security] Tell why an authenticator did not support the request in the profiler

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -24,6 +24,7 @@ CHANGELOG
  * Add `user_data_source` and `user_identifier_claim` options to the `oidc_login` authenticator
  * Add `enable_end_session` and `post_logout_redirect_path` options to the `oidc_login` authenticator for RP-Initiated Logout
  * Allow passing a null user to `Security::isGrantedForUser()` and `Security::getAccessDecisionForUser()` to check guest permissions
+ * Show why an authenticator did not support the request in the security profiler panel
 
 8.1
 ---

--- a/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
@@ -480,6 +480,9 @@
                                             {% if authenticator.supports is same as(false) %}
                                                 <div class="empty">
                                                     <p>This authenticator did not support the request.</p>
+                                                    {% if authenticator.unsupportedReasons is defined and authenticator.unsupportedReasons|length %}
+                                                        <p>Reason: {{ authenticator.unsupportedReasons|join(', ') }}</p>
+                                                    {% endif %}
                                                 </div>
                                             {% elseif authenticator.authenticated is null %}
                                                 <div class="empty">

--- a/src/Symfony/Component/Security/Http/Authenticator/AbstractLoginFormAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/AbstractLoginFormAuthenticator.php
@@ -47,7 +47,24 @@ abstract class AbstractLoginFormAuthenticator extends AbstractAuthenticator impl
      */
     public function supports(Request $request): bool
     {
-        return $request->isMethod('POST') && $this->getLoginUrl($request) === $request->getBaseUrl().$request->getPathInfo();
+        $reasons = $request->attributes->get(SecurityRequestAttributes::UNSUPPORTED_REASONS);
+
+        if (!$request->isMethod('POST')) {
+            $reasons?->add(\sprintf('the request method is "%s", and only POST is supported', $request->getMethod()));
+
+            return false;
+        }
+
+        $loginUrl = $this->getLoginUrl($request);
+        $path = $request->getBaseUrl().$request->getPathInfo();
+
+        if ($loginUrl !== $path) {
+            $reasons?->add(\sprintf('the request path "%s" does not match the login URL "%s"', $path, $loginUrl));
+
+            return false;
+        }
+
+        return true;
     }
 
     /**

--- a/src/Symfony/Component/Security/Http/Authenticator/AbstractPreAuthenticatedAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/AbstractPreAuthenticatedAuthenticator.php
@@ -24,6 +24,7 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Badge\PreAuthenticate
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
+use Symfony\Component\Security\Http\SecurityRequestAttributes;
 
 /**
  * The base authenticator for authenticators to use pre-authenticated
@@ -54,18 +55,22 @@ abstract class AbstractPreAuthenticatedAuthenticator implements InteractiveAuthe
 
     public function supports(Request $request): ?bool
     {
+        $reasons = $request->attributes->get(SecurityRequestAttributes::UNSUPPORTED_REASONS);
+
         try {
             $username = $this->extractUsername($request);
         } catch (BadCredentialsException $e) {
             $this->clearToken($e);
 
             $this->logger?->debug('Skipping pre-authenticated authenticator as a BadCredentialsException is thrown.', ['exception' => $e, 'authenticator' => static::class]);
+            $reasons?->add($e->getMessage());
 
             return false;
         }
 
         if (null === $username) {
             $this->logger?->debug('Skipping pre-authenticated authenticator no username could be extracted.', ['authenticator' => static::class]);
+            $reasons?->add('no user identifier was found in the request');
 
             return false;
         }
@@ -75,6 +80,7 @@ abstract class AbstractPreAuthenticatedAuthenticator implements InteractiveAuthe
 
         if ($token instanceof PreAuthenticatedToken && $this->firewallName === $token->getFirewallName() && $token->getUserIdentifier() === $username) {
             $this->logger?->debug('Skipping pre-authenticated authenticator as the user already has an existing session.', ['authenticator' => static::class]);
+            $reasons?->add(\sprintf('the user "%s" already has a pre-authenticated token for this firewall', $username));
 
             return false;
         }

--- a/src/Symfony/Component/Security/Http/Authenticator/AccessTokenAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/AccessTokenAuthenticator.php
@@ -24,6 +24,7 @@ use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerI
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
 use Symfony\Component\Security\Http\Authenticator\Token\PostAuthenticationToken;
+use Symfony\Component\Security\Http\SecurityRequestAttributes;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
@@ -48,7 +49,13 @@ class AccessTokenAuthenticator implements AuthenticatorInterface
 
     public function supports(Request $request): ?bool
     {
-        return null === $this->accessTokenExtractor->extractAccessToken($request) ? false : null;
+        if (null === $this->accessTokenExtractor->extractAccessToken($request)) {
+            $request->attributes->get(SecurityRequestAttributes::UNSUPPORTED_REASONS)?->add(\sprintf('the "%s" extractor found no access token in the request', get_debug_type($this->accessTokenExtractor)));
+
+            return false;
+        }
+
+        return null;
     }
 
     public function authenticate(Request $request): Passport

--- a/src/Symfony/Component/Security/Http/Authenticator/Debug/TraceableAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Debug/TraceableAuthenticator.php
@@ -21,6 +21,7 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Badge\BadgeInterface;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
 use Symfony\Component\Security\Http\EntryPoint\Exception\NotAnEntryPointException;
+use Symfony\Component\Security\Http\SecurityRequestAttributes;
 use Symfony\Component\VarDumper\Caster\ClassStub;
 
 /**
@@ -31,6 +32,7 @@ use Symfony\Component\VarDumper\Caster\ClassStub;
 final class TraceableAuthenticator implements AuthenticatorInterface, InteractiveAuthenticatorInterface, AuthenticationEntryPointInterface
 {
     private ?bool $supports = false;
+    private array $unsupportedReasons = [];
     private ?Passport $passport = null;
     private ?float $duration = null;
     private ClassStub|string $stub;
@@ -45,6 +47,7 @@ final class TraceableAuthenticator implements AuthenticatorInterface, Interactiv
     {
         return [
             'supports' => $this->supports,
+            'unsupportedReasons' => $this->unsupportedReasons,
             'passport' => $this->passport,
             'duration' => $this->duration,
             'stub' => $this->stub ??= class_exists(ClassStub::class) ? new ClassStub($this->authenticator::class) : $this->authenticator::class,
@@ -62,7 +65,14 @@ final class TraceableAuthenticator implements AuthenticatorInterface, Interactiv
 
     public function supports(Request $request): ?bool
     {
-        return $this->supports = $this->authenticator->supports($request);
+        $request->attributes->set(SecurityRequestAttributes::UNSUPPORTED_REASONS, $reasons = new UnsupportedReasons());
+
+        try {
+            return $this->supports = $this->authenticator->supports($request);
+        } finally {
+            $request->attributes->remove(SecurityRequestAttributes::UNSUPPORTED_REASONS);
+            $this->unsupportedReasons = $reasons->all();
+        }
     }
 
     public function authenticate(Request $request): Passport

--- a/src/Symfony/Component/Security/Http/Authenticator/Debug/UnsupportedReasons.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Debug/UnsupportedReasons.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Authenticator\Debug;
+
+/**
+ * Collects the reasons why an authenticator did not support a request.
+ *
+ * When the profiler is enabled, an instance is stored in the
+ * SecurityRequestAttributes::UNSUPPORTED_REASONS request attribute for the
+ * duration of an authenticator's supports() call, so that the method can
+ * explain a negative answer:
+ *
+ *     $request->attributes->get(SecurityRequestAttributes::UNSUPPORTED_REASONS)?->add('the request is not a POST');
+ *
+ * The attribute is absent otherwise, so this costs nothing in production.
+ */
+final class UnsupportedReasons
+{
+    /**
+     * @var string[]
+     */
+    private array $reasons = [];
+
+    public function add(string $reason): void
+    {
+        $this->reasons[] = $reason;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function all(): array
+    {
+        return $this->reasons;
+    }
+}

--- a/src/Symfony/Component/Security/Http/Authenticator/FormLoginAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/FormLoginAuthenticator.php
@@ -70,9 +70,27 @@ class FormLoginAuthenticator extends AbstractLoginFormAuthenticator
 
     public function supports(Request $request): bool
     {
-        return ($this->options['post_only'] ? $request->isMethod('POST') : true)
-            && $this->httpUtils->checkRequestPath($request, $this->options['check_path'])
-            && ($this->options['form_only'] ? 'form' === $request->getContentTypeFormat() : true);
+        $reasons = $request->attributes->get(SecurityRequestAttributes::UNSUPPORTED_REASONS);
+
+        if ($this->options['post_only'] && !$request->isMethod('POST')) {
+            $reasons?->add(\sprintf('the request method is "%s", and the "post_only" option requires POST', $request->getMethod()));
+
+            return false;
+        }
+
+        if (!$this->httpUtils->checkRequestPath($request, $this->options['check_path'])) {
+            $reasons?->add(\sprintf('the request path "%s" does not match the "check_path" option "%s"', $request->getPathInfo(), $this->options['check_path']));
+
+            return false;
+        }
+
+        if ($this->options['form_only'] && 'form' !== $request->getContentTypeFormat()) {
+            $reasons?->add(\sprintf('the "Content-Type" header is %s, and the "form_only" option requires a form one', ($contentType = $request->headers->get('Content-Type')) ? '"'.$contentType.'"' : 'missing'));
+
+            return false;
+        }
+
+        return true;
     }
 
     public function authenticate(Request $request): Passport

--- a/src/Symfony/Component/Security/Http/Authenticator/HttpBasicAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/HttpBasicAuthenticator.php
@@ -24,6 +24,7 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Credentials\PasswordCredentials;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
+use Symfony\Component\Security\Http\SecurityRequestAttributes;
 
 /**
  * @author Wouter de Jong <wouter@wouterj.nl>
@@ -51,7 +52,13 @@ class HttpBasicAuthenticator implements AuthenticatorInterface, AuthenticationEn
 
     public function supports(Request $request): ?bool
     {
-        return $request->headers->has('PHP_AUTH_USER');
+        if (!$request->headers->has('PHP_AUTH_USER')) {
+            $request->attributes->get(SecurityRequestAttributes::UNSUPPORTED_REASONS)?->add('the request has no HTTP basic credentials, as "PHP_AUTH_USER" is not set');
+
+            return false;
+        }
+
+        return true;
     }
 
     public function authenticate(Request $request): Passport

--- a/src/Symfony/Component/Security/Http/Authenticator/JsonLoginAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/JsonLoginAuthenticator.php
@@ -32,6 +32,7 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Credentials\PasswordCredentials;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\HttpUtils;
+use Symfony\Component\Security\Http\SecurityRequestAttributes;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
@@ -63,14 +64,20 @@ class JsonLoginAuthenticator implements InteractiveAuthenticatorInterface
 
     public function supports(Request $request): ?bool
     {
+        $reasons = $request->attributes->get(SecurityRequestAttributes::UNSUPPORTED_REASONS);
+
         if (
             !str_contains($request->getRequestFormat() ?? '', 'json')
             && !str_contains($request->getContentTypeFormat() ?? '', 'json')
         ) {
+            $reasons?->add(($contentType = $request->headers->get('Content-Type')) ? \sprintf('neither the request format "%s" nor the "Content-Type" header "%s" is a JSON one', $request->getRequestFormat(), $contentType) : \sprintf('the request format "%s" is not a JSON one, and the request has no "Content-Type" header', $request->getRequestFormat()));
+
             return false;
         }
 
         if (isset($this->options['check_path']) && !$this->httpUtils->checkRequestPath($request, $this->options['check_path'])) {
+            $reasons?->add(\sprintf('the request path "%s" does not match the "check_path" option "%s"', $request->getPathInfo(), $this->options['check_path']));
+
             return false;
         }
 

--- a/src/Symfony/Component/Security/Http/Authenticator/LoginLinkAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/LoginLinkAuthenticator.php
@@ -25,6 +25,7 @@ use Symfony\Component\Security\Http\HttpUtils;
 use Symfony\Component\Security\Http\LoginLink\Exception\InvalidLoginLinkAuthenticationException;
 use Symfony\Component\Security\Http\LoginLink\Exception\InvalidLoginLinkExceptionInterface;
 use Symfony\Component\Security\Http\LoginLink\LoginLinkHandlerInterface;
+use Symfony\Component\Security\Http\SecurityRequestAttributes;
 
 /**
  * @author Ryan Weaver <ryan@symfonycasts.com>
@@ -45,8 +46,21 @@ final class LoginLinkAuthenticator extends AbstractAuthenticator implements Inte
 
     public function supports(Request $request): ?bool
     {
-        return ($this->options['check_post_only'] ? $request->isMethod('POST') : true)
-            && $this->httpUtils->checkRequestPath($request, $this->options['check_route']);
+        $reasons = $request->attributes->get(SecurityRequestAttributes::UNSUPPORTED_REASONS);
+
+        if ($this->options['check_post_only'] && !$request->isMethod('POST')) {
+            $reasons?->add(\sprintf('the request method is "%s", and the "check_post_only" option requires POST', $request->getMethod()));
+
+            return false;
+        }
+
+        if (!$this->httpUtils->checkRequestPath($request, $this->options['check_route'])) {
+            $reasons?->add(\sprintf('the request path "%s" does not match the "check_route" option "%s"', $request->getPathInfo(), $this->options['check_route']));
+
+            return false;
+        }
+
+        return true;
     }
 
     public function authenticate(Request $request): Passport

--- a/src/Symfony/Component/Security/Http/Authenticator/OidcLoginAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/OidcLoginAuthenticator.php
@@ -30,6 +30,7 @@ use Symfony\Component\Security\Http\Authenticator\Token\PostAuthenticationToken;
 use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
 use Symfony\Component\Security\Http\HttpUtils;
 use Symfony\Component\Security\Http\Oidc\OidcDiscovery;
+use Symfony\Component\Security\Http\SecurityRequestAttributes;
 
 /**
  * Authenticator for the OpenID Connect Authorization Code Flow.
@@ -95,7 +96,13 @@ final class OidcLoginAuthenticator extends AbstractAuthenticator implements Auth
         // every request on the callback path is handled here: the route declared for it
         // carries no controller, so one passing through would end up reported as a routing
         // error instead of the authentication failure it is
-        return $this->httpUtils->checkRequestPath($request, $this->options['check_path']);
+        if (!$this->httpUtils->checkRequestPath($request, $this->options['check_path'])) {
+            $request->attributes->get(SecurityRequestAttributes::UNSUPPORTED_REASONS)?->add(\sprintf('the request path "%s" does not match the "check_path" option "%s"', $request->getPathInfo(), $this->options['check_path']));
+
+            return false;
+        }
+
+        return true;
     }
 
     public function start(Request $request, ?AuthenticationException $authException = null): Response

--- a/src/Symfony/Component/Security/Http/Authenticator/RememberMeAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/RememberMeAuthenticator.php
@@ -27,6 +27,7 @@ use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPasspor
 use Symfony\Component\Security\Http\RememberMe\RememberMeDetails;
 use Symfony\Component\Security\Http\RememberMe\RememberMeHandlerInterface;
 use Symfony\Component\Security\Http\RememberMe\ResponseListener;
+use Symfony\Component\Security\Http\SecurityRequestAttributes;
 
 /**
  * The RememberMe *Authenticator* performs remember me authentication.
@@ -53,16 +54,30 @@ class RememberMeAuthenticator implements InteractiveAuthenticatorInterface
 
     public function supports(Request $request): ?bool
     {
+        $reasons = $request->attributes->get(SecurityRequestAttributes::UNSUPPORTED_REASONS);
+
         // do not overwrite already stored tokens (i.e. from the session)
         if (null !== $this->tokenStorage->getToken()) {
+            $reasons?->add('a token is already stored, so the request is already authenticated');
+
             return false;
         }
 
         if (($cookie = $request->attributes->get(ResponseListener::COOKIE_ATTR_NAME)) && null === $cookie->getValue()) {
+            $reasons?->add(\sprintf('the "%s" cookie is being cleared by this request', $this->cookieName));
+
             return false;
         }
 
-        if (!$request->cookies->has($this->cookieName) || !\is_scalar($request->cookies->all()[$this->cookieName] ?: null)) {
+        if (!$request->cookies->has($this->cookieName)) {
+            $reasons?->add(\sprintf('the request has no "%s" cookie', $this->cookieName));
+
+            return false;
+        }
+
+        if (!\is_scalar($request->cookies->all()[$this->cookieName] ?: null)) {
+            $reasons?->add(\sprintf('the "%s" cookie is empty or not a scalar', $this->cookieName));
+
             return false;
         }
 

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -24,6 +24,7 @@ CHANGELOG
  * Add the `pkce_enabled`, `pkce_method` and `max_age` options and the `$authorizationParams` argument to `OidcLoginAuthenticator`, which checks the ID token `auth_time` claim when `max_age` is used
  * Add the `user_data_source` and `user_identifier_claim` options to `OidcLoginAuthenticator` to pick where the user claims are read from and the claim the user identifier is read from
  * Add `OidcEndSessionListener` for RP-Initiated Logout via the OIDC `end_session_endpoint`
+ * Add `UnsupportedReasons`, held by the `SecurityRequestAttributes::UNSUPPORTED_REASONS` request attribute while the profiler is enabled, so that `supports()` can tell why an authenticator did not support a request
 
 8.1
 ---

--- a/src/Symfony/Component/Security/Http/SecurityRequestAttributes.php
+++ b/src/Symfony/Component/Security/Http/SecurityRequestAttributes.php
@@ -21,4 +21,11 @@ final class SecurityRequestAttributes
     public const ACCESS_DENIED_ERROR = '_security.403_error';
     public const AUTHENTICATION_ERROR = '_security.last_error';
     public const LAST_USERNAME = '_security.last_username';
+
+    /**
+     * Holds an UnsupportedReasons collector while an authenticator's supports() method runs, when the profiler is enabled.
+     *
+     * @see Authenticator\Debug\UnsupportedReasons
+     */
+    public const UNSUPPORTED_REASONS = '_security.unsupported_reasons';
 }

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/AbstractLoginFormAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/AbstractLoginFormAuthenticatorTest.php
@@ -17,9 +17,11 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Http\Authenticator\AbstractLoginFormAuthenticator;
+use Symfony\Component\Security\Http\Authenticator\Debug\UnsupportedReasons;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
+use Symfony\Component\Security\Http\SecurityRequestAttributes;
 
 class AbstractLoginFormAuthenticatorTest extends TestCase
 {
@@ -92,6 +94,29 @@ class AbstractLoginFormAuthenticatorTest extends TestCase
             ]),
             false,
         ];
+    }
+
+    public function testUnsupportedReasons()
+    {
+        $authenticator = new ConcreteFormAuthenticator('/login');
+
+        $request = Request::create('/login', 'GET');
+        $request->attributes->set(SecurityRequestAttributes::UNSUPPORTED_REASONS, $reasons = new UnsupportedReasons());
+
+        $this->assertFalse($authenticator->supports($request));
+        $this->assertSame(['the request method is "GET", and only POST is supported'], $reasons->all());
+
+        $request = Request::create('/somepath', 'POST');
+        $request->attributes->set(SecurityRequestAttributes::UNSUPPORTED_REASONS, $reasons = new UnsupportedReasons());
+
+        $this->assertFalse($authenticator->supports($request));
+        $this->assertSame(['the request path "/somepath" does not match the login URL "/login"'], $reasons->all());
+
+        $request = Request::create('/login', 'POST');
+        $request->attributes->set(SecurityRequestAttributes::UNSUPPORTED_REASONS, $reasons = new UnsupportedReasons());
+
+        $this->assertTrue($authenticator->supports($request));
+        $this->assertSame([], $reasons->all());
     }
 }
 

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/AccessTokenAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/AccessTokenAuthenticatorTest.php
@@ -21,8 +21,10 @@ use Symfony\Component\Security\Http\AccessToken\AccessTokenExtractorInterface;
 use Symfony\Component\Security\Http\AccessToken\AccessTokenHandlerInterface;
 use Symfony\Component\Security\Http\AccessToken\HeaderAccessTokenExtractor;
 use Symfony\Component\Security\Http\Authenticator\AccessTokenAuthenticator;
+use Symfony\Component\Security\Http\Authenticator\Debug\UnsupportedReasons;
 use Symfony\Component\Security\Http\Authenticator\FallbackUserLoader;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+use Symfony\Component\Security\Http\SecurityRequestAttributes;
 
 class AccessTokenAuthenticatorTest extends TestCase
 {
@@ -190,5 +192,22 @@ class AccessTokenAuthenticatorTest extends TestCase
             ['Bearer Not Valid', null],
             ['Bearer (NotOK123)', null],
         ];
+    }
+
+    public function testUnsupportedReasons()
+    {
+        $authenticator = new AccessTokenAuthenticator($this->createStub(AccessTokenHandlerInterface::class), new HeaderAccessTokenExtractor());
+
+        $request = Request::create('/test');
+        $request->attributes->set(SecurityRequestAttributes::UNSUPPORTED_REASONS, $reasons = new UnsupportedReasons());
+
+        $this->assertFalse($authenticator->supports($request));
+        $this->assertSame([\sprintf('the "%s" extractor found no access token in the request', HeaderAccessTokenExtractor::class)], $reasons->all());
+
+        $request = Request::create('/test', server: ['HTTP_AUTHORIZATION' => 'Bearer VALID_ACCESS_TOKEN']);
+        $request->attributes->set(SecurityRequestAttributes::UNSUPPORTED_REASONS, $reasons = new UnsupportedReasons());
+
+        $this->assertNull($authenticator->supports($request));
+        $this->assertSame([], $reasons->all());
     }
 }

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/Debug/TraceableAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/Debug/TraceableAuthenticatorTest.php
@@ -15,8 +15,10 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
 use Symfony\Component\Security\Http\Authenticator\Debug\TraceableAuthenticator;
+use Symfony\Component\Security\Http\Authenticator\Debug\UnsupportedReasons;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
+use Symfony\Component\Security\Http\SecurityRequestAttributes;
 
 class TraceableAuthenticatorTest extends TestCase
 {
@@ -58,5 +60,98 @@ class TraceableAuthenticatorTest extends TestCase
         $this->assertNull($traceable->getInfo()['passport']);
         $this->assertIsArray($traceable->getInfo()['badges']);
         $this->assertSame([], $traceable->getInfo()['badges']);
+    }
+
+    public function testUnsupportedReasonsAreCollected()
+    {
+        $request = new Request();
+
+        $authenticator = $this->createStub(AuthenticatorInterface::class);
+        $authenticator->method('supports')->willReturnCallback(static function (Request $request): bool {
+            $request->attributes->get(SecurityRequestAttributes::UNSUPPORTED_REASONS)->add('the moon is not full');
+
+            return false;
+        });
+
+        $traceable = new TraceableAuthenticator($authenticator);
+        $this->assertFalse($traceable->supports($request));
+        $this->assertSame(['the moon is not full'], $traceable->getInfo()['unsupportedReasons']);
+        $this->assertFalse($request->attributes->has(SecurityRequestAttributes::UNSUPPORTED_REASONS));
+    }
+
+    public function testUnsupportedReasonsAreEmptyWhenTheAuthenticatorGivesNone()
+    {
+        $request = new Request();
+
+        $authenticator = $this->createStub(AuthenticatorInterface::class);
+        $authenticator->method('supports')->willReturn(false);
+
+        $traceable = new TraceableAuthenticator($authenticator);
+        $this->assertSame([], $traceable->getInfo()['unsupportedReasons']);
+
+        $this->assertFalse($traceable->supports($request));
+        $this->assertSame([], $traceable->getInfo()['unsupportedReasons']);
+        $this->assertFalse($request->attributes->has(SecurityRequestAttributes::UNSUPPORTED_REASONS));
+    }
+
+    public function testUnsupportedReasonsAreResetOnEachCall()
+    {
+        $request = new Request();
+        $calls = 0;
+
+        $authenticator = $this->createStub(AuthenticatorInterface::class);
+        $authenticator->method('supports')->willReturnCallback(static function (Request $request) use (&$calls): bool {
+            if (1 === ++$calls) {
+                $request->attributes->get(SecurityRequestAttributes::UNSUPPORTED_REASONS)->add('the moon is not full');
+
+                return false;
+            }
+
+            return true;
+        });
+
+        $traceable = new TraceableAuthenticator($authenticator);
+        $traceable->supports($request);
+        $this->assertSame(['the moon is not full'], $traceable->getInfo()['unsupportedReasons']);
+
+        $this->assertTrue($traceable->supports($request));
+        $this->assertSame([], $traceable->getInfo()['unsupportedReasons']);
+    }
+
+    public function testTheCollectorIsRemovedFromTheRequestWhenSupportsThrows()
+    {
+        $request = new Request();
+
+        $authenticator = $this->createStub(AuthenticatorInterface::class);
+        $authenticator->method('supports')->willThrowException(new \RuntimeException('boom'));
+
+        $traceable = new TraceableAuthenticator($authenticator);
+
+        try {
+            $traceable->supports($request);
+            $this->fail('An exception should have been thrown.');
+        } catch (\RuntimeException $e) {
+            $this->assertSame('boom', $e->getMessage());
+        }
+
+        $this->assertFalse($request->attributes->has(SecurityRequestAttributes::UNSUPPORTED_REASONS));
+    }
+
+    public function testTheCollectorIsOnlyPresentDuringSupports()
+    {
+        $request = new Request();
+        $seen = null;
+
+        $authenticator = $this->createStub(AuthenticatorInterface::class);
+        $authenticator->method('supports')->willReturnCallback(static function (Request $request) use (&$seen): bool {
+            $seen = $request->attributes->get(SecurityRequestAttributes::UNSUPPORTED_REASONS);
+
+            return true;
+        });
+
+        $this->assertFalse($request->attributes->has(SecurityRequestAttributes::UNSUPPORTED_REASONS));
+        (new TraceableAuthenticator($authenticator))->supports($request);
+        $this->assertInstanceOf(UnsupportedReasons::class, $seen);
+        $this->assertFalse($request->attributes->has(SecurityRequestAttributes::UNSUPPORTED_REASONS));
     }
 }

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/Debug/UnsupportedReasonsTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/Debug/UnsupportedReasonsTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Tests\Authenticator\Debug;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Http\Authenticator\Debug\UnsupportedReasons;
+
+class UnsupportedReasonsTest extends TestCase
+{
+    public function testEmptyByDefault()
+    {
+        $this->assertSame([], (new UnsupportedReasons())->all());
+    }
+
+    public function testAddKeepsTheOrder()
+    {
+        $reasons = new UnsupportedReasons();
+        $reasons->add('the request is not a POST');
+        $reasons->add('the request has no "Content-Type" header');
+
+        $this->assertSame(['the request is not a POST', 'the request has no "Content-Type" header'], $reasons->all());
+    }
+}

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/FormLoginAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/FormLoginAuthenticatorTest.php
@@ -21,12 +21,14 @@ use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\Security\Core\User\InMemoryUserProvider;
 use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface;
 use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface;
+use Symfony\Component\Security\Http\Authenticator\Debug\UnsupportedReasons;
 use Symfony\Component\Security\Http\Authenticator\FormLoginAuthenticator;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\CsrfTokenBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\PasswordUpgradeBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Credentials\PasswordCredentials;
 use Symfony\Component\Security\Http\HttpUtils;
+use Symfony\Component\Security\Http\SecurityRequestAttributes;
 use Symfony\Component\Security\Http\Tests\Authenticator\Fixtures\PasswordUpgraderProvider;
 
 class FormLoginAuthenticatorTest extends TestCase
@@ -269,6 +271,30 @@ class FormLoginAuthenticatorTest extends TestCase
     {
         yield ['application/json', false];
         yield ['application/x-www-form-urlencoded', true];
+    }
+
+    #[DataProvider('provideUnsupportedReasons')]
+    public function testUnsupportedReasons(array $options, Request $request, array $expectedReasons)
+    {
+        $request->attributes->set(SecurityRequestAttributes::UNSUPPORTED_REASONS, $reasons = new UnsupportedReasons());
+        $this->setUpAuthenticator($options);
+
+        $this->assertSame([] === $expectedReasons, $this->authenticator->supports($request));
+        $this->assertSame($expectedReasons, $reasons->all());
+    }
+
+    public static function provideUnsupportedReasons(): iterable
+    {
+        yield 'not a POST' => [[], Request::create('/login_check', 'GET'), ['the request method is "GET", and the "post_only" option requires POST']];
+        yield 'other path' => [[], Request::create('/other', 'POST'), ['the request path "/other" does not match the "check_path" option "/login_check"']];
+        yield 'not a form' => [['form_only' => true], Request::create('/login_check', 'POST', server: ['CONTENT_TYPE' => 'application/json']), ['the "Content-Type" header is "application/json", and the "form_only" option requires a form one']];
+
+        $request = Request::create('/login_check', 'POST');
+        $request->headers->remove('Content-Type');
+        yield 'no content type' => [['form_only' => true], $request, ['the "Content-Type" header is missing, and the "form_only" option requires a form one']];
+
+        yield 'post_only disabled' => [['post_only' => false], Request::create('/login_check', 'GET'), []];
+        yield 'supported' => [['form_only' => true], Request::create('/login_check', 'POST'), []];
     }
 
     private function setUpAuthenticator(array $options = [])

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/HttpBasicAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/HttpBasicAuthenticatorTest.php
@@ -16,9 +16,11 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\User\InMemoryUser;
 use Symfony\Component\Security\Core\User\InMemoryUserProvider;
+use Symfony\Component\Security\Http\Authenticator\Debug\UnsupportedReasons;
 use Symfony\Component\Security\Http\Authenticator\HttpBasicAuthenticator;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\PasswordUpgradeBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Credentials\PasswordCredentials;
+use Symfony\Component\Security\Http\SecurityRequestAttributes;
 use Symfony\Component\Security\Http\Tests\Authenticator\Fixtures\PasswordUpgraderProvider;
 
 class HttpBasicAuthenticatorTest extends TestCase
@@ -78,5 +80,20 @@ class HttpBasicAuthenticatorTest extends TestCase
         $this->assertTrue($passport->hasBadge(PasswordUpgradeBadge::class));
         $badge = $passport->getBadge(PasswordUpgradeBadge::class);
         $this->assertEquals('ThePassword', $badge->getAndErasePlaintextPassword());
+    }
+
+    public function testUnsupportedReasons()
+    {
+        $request = new Request();
+        $request->attributes->set(SecurityRequestAttributes::UNSUPPORTED_REASONS, $reasons = new UnsupportedReasons());
+
+        $this->assertFalse($this->authenticator->supports($request));
+        $this->assertSame(['the request has no HTTP basic credentials, as "PHP_AUTH_USER" is not set'], $reasons->all());
+
+        $request = new Request([], [], [], [], [], ['PHP_AUTH_USER' => 'TheUsername', 'PHP_AUTH_PW' => 'ThePassword']);
+        $request->attributes->set(SecurityRequestAttributes::UNSUPPORTED_REASONS, $reasons = new UnsupportedReasons());
+
+        $this->assertTrue($this->authenticator->supports($request));
+        $this->assertSame([], $reasons->all());
     }
 }

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/JsonLoginAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/JsonLoginAuthenticatorTest.php
@@ -18,10 +18,12 @@ use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\Security\Core\User\InMemoryUserProvider;
+use Symfony\Component\Security\Http\Authenticator\Debug\UnsupportedReasons;
 use Symfony\Component\Security\Http\Authenticator\JsonLoginAuthenticator;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Credentials\PasswordCredentials;
 use Symfony\Component\Security\Http\HttpUtils;
+use Symfony\Component\Security\Http\SecurityRequestAttributes;
 use Symfony\Component\Translation\Loader\ArrayLoader;
 use Symfony\Component\Translation\Translator;
 
@@ -164,6 +166,24 @@ class JsonLoginAuthenticatorTest extends TestCase
         });
 
         $this->assertSame(['error' => 'Session locked after 3 failed attempts.'], json_decode($response->getContent(), true));
+    }
+
+    #[DataProvider('provideUnsupportedReasons')]
+    public function testUnsupportedReasons(array $options, Request $request, array $expectedReasons)
+    {
+        $request->attributes->set(SecurityRequestAttributes::UNSUPPORTED_REASONS, $reasons = new UnsupportedReasons());
+        $this->setUpAuthenticator($options);
+
+        $this->assertSame([] === $expectedReasons, $this->authenticator->supports($request));
+        $this->assertSame($expectedReasons, $reasons->all());
+    }
+
+    public static function provideUnsupportedReasons(): iterable
+    {
+        yield 'not JSON' => [[], Request::create('/api/login', 'POST', server: ['CONTENT_TYPE' => 'text/plain']), ['neither the request format "html" nor the "Content-Type" header "text/plain" is a JSON one']];
+        yield 'no content type' => [[], Request::create('/api/login'), ['the request format "html" is not a JSON one, and the request has no "Content-Type" header']];
+        yield 'other path' => [['check_path' => '/api/login'], Request::create('/other', 'POST', server: ['CONTENT_TYPE' => 'application/json']), ['the request path "/other" does not match the "check_path" option "/api/login"']];
+        yield 'supported' => [['check_path' => '/api/login'], Request::create('/api/login', 'POST', server: ['CONTENT_TYPE' => 'application/json']), []];
     }
 
     private function setUpAuthenticator(array $options = [])

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/LoginLinkAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/LoginLinkAuthenticatorTest.php
@@ -17,6 +17,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\User\InMemoryUser;
 use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface;
 use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface;
+use Symfony\Component\Security\Http\Authenticator\Debug\UnsupportedReasons;
 use Symfony\Component\Security\Http\Authenticator\LoginLinkAuthenticator;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\RememberMeBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
@@ -25,6 +26,7 @@ use Symfony\Component\Security\Http\HttpUtils;
 use Symfony\Component\Security\Http\LoginLink\Exception\ExpiredLoginLinkException;
 use Symfony\Component\Security\Http\LoginLink\Exception\InvalidLoginLinkAuthenticationException;
 use Symfony\Component\Security\Http\LoginLink\LoginLinkHandlerInterface;
+use Symfony\Component\Security\Http\SecurityRequestAttributes;
 
 class LoginLinkAuthenticatorTest extends TestCase
 {
@@ -116,6 +118,23 @@ class LoginLinkAuthenticatorTest extends TestCase
         $passport = $this->authenticator->authenticate($request);
 
         $this->assertTrue($passport->hasBadge(RememberMeBadge::class));
+    }
+
+    #[DataProvider('provideUnsupportedReasons')]
+    public function testUnsupportedReasons(array $options, Request $request, array $expectedReasons)
+    {
+        $request->attributes->set(SecurityRequestAttributes::UNSUPPORTED_REASONS, $reasons = new UnsupportedReasons());
+        $this->setUpAuthenticator($options);
+
+        $this->assertSame([] === $expectedReasons, $this->authenticator->supports($request));
+        $this->assertSame($expectedReasons, $reasons->all());
+    }
+
+    public static function provideUnsupportedReasons(): iterable
+    {
+        yield 'other path' => [['check_route' => '/validate_link'], Request::create('/login?hash=abc123'), ['the request path "/login" does not match the "check_route" option "/validate_link"']];
+        yield 'not a POST' => [['check_route' => '/validate_link', 'check_post_only' => true], Request::create('/validate_link?hash=abc123'), ['the request method is "GET", and the "check_post_only" option requires POST']];
+        yield 'supported' => [['check_route' => '/validate_link'], Request::create('/validate_link?hash=abc123'), []];
     }
 
     private function setUpAuthenticator(array $options = [])

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/OidcLoginAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/OidcLoginAuthenticatorTest.php
@@ -37,6 +37,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface;
 use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface;
+use Symfony\Component\Security\Http\Authenticator\Debug\UnsupportedReasons;
 use Symfony\Component\Security\Http\Authenticator\Oidc\OidcClient;
 use Symfony\Component\Security\Http\Authenticator\Oidc\OidcIdToken;
 use Symfony\Component\Security\Http\Authenticator\Oidc\OidcSignatureVerifier;
@@ -46,6 +47,7 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
 use Symfony\Component\Security\Http\HttpUtils;
 use Symfony\Component\Security\Http\Oidc\OidcDiscovery;
+use Symfony\Component\Security\Http\SecurityRequestAttributes;
 
 #[AllowMockObjectsWithoutExpectations]
 class OidcLoginAuthenticatorTest extends TestCase
@@ -102,6 +104,23 @@ class OidcLoginAuthenticatorTest extends TestCase
         $authenticator = $this->createAuthenticator();
 
         $this->assertFalse($authenticator->supports(Request::create('/other-path?code=abc')));
+    }
+
+    public function testUnsupportedReasons()
+    {
+        $authenticator = $this->createAuthenticator();
+
+        $request = Request::create('/other-path?code=abc');
+        $request->attributes->set(SecurityRequestAttributes::UNSUPPORTED_REASONS, $reasons = new UnsupportedReasons());
+
+        $this->assertFalse($authenticator->supports($request));
+        $this->assertSame(['the request path "/other-path" does not match the "check_path" option "/oidc/callback"'], $reasons->all());
+
+        $request = Request::create('/oidc/callback?code=abc');
+        $request->attributes->set(SecurityRequestAttributes::UNSUPPORTED_REASONS, $reasons = new UnsupportedReasons());
+
+        $this->assertTrue($authenticator->supports($request));
+        $this->assertSame([], $reasons->all());
     }
 
     public function testSupportsTheCallbackPathWithoutAnyParameter()

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/RememberMeAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/RememberMeAuthenticatorTest.php
@@ -19,10 +19,12 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\User\InMemoryUser;
+use Symfony\Component\Security\Http\Authenticator\Debug\UnsupportedReasons;
 use Symfony\Component\Security\Http\Authenticator\RememberMeAuthenticator;
 use Symfony\Component\Security\Http\RememberMe\RememberMeDetails;
 use Symfony\Component\Security\Http\RememberMe\RememberMeHandlerInterface;
 use Symfony\Component\Security\Http\RememberMe\ResponseListener;
+use Symfony\Component\Security\Http\SecurityRequestAttributes;
 
 class RememberMeAuthenticatorTest extends TestCase
 {
@@ -110,5 +112,37 @@ class RememberMeAuthenticatorTest extends TestCase
         $this->expectException(AuthenticationException::class);
 
         $this->authenticator->authenticate($request);
+    }
+
+    #[DataProvider('provideUnsupportedReasons')]
+    public function testUnsupportedReasons(Request $request, ?bool $supports, array $expectedReasons)
+    {
+        $request->attributes->set(SecurityRequestAttributes::UNSUPPORTED_REASONS, $reasons = new UnsupportedReasons());
+
+        $this->assertSame($supports, $this->authenticator->supports($request));
+        $this->assertSame($expectedReasons, $reasons->all());
+    }
+
+    public static function provideUnsupportedReasons(): iterable
+    {
+        yield 'no cookie' => [Request::create('/'), false, ['the request has no "_remember_me_cookie" cookie']];
+        yield 'empty cookie' => [Request::create('/', 'GET', [], ['_remember_me_cookie' => '']), false, ['the "_remember_me_cookie" cookie is empty or not a scalar']];
+        yield 'array cookie' => [Request::create('/', 'GET', [], ['_remember_me_cookie' => ['a' => 'b']]), false, ['the "_remember_me_cookie" cookie is empty or not a scalar']];
+
+        $request = Request::create('/', 'GET', [], ['_remember_me_cookie' => 'rememberme']);
+        $request->attributes->set(ResponseListener::COOKIE_ATTR_NAME, new Cookie('_remember_me_cookie', null));
+        yield 'cookie being cleared' => [$request, false, ['the "_remember_me_cookie" cookie is being cleared by this request']];
+
+        yield 'supported' => [Request::create('/', 'GET', [], ['_remember_me_cookie' => 'rememberme']), null, []];
+    }
+
+    public function testUnsupportedReasonWhenATokenIsStored()
+    {
+        $this->tokenStorage->setToken(new UsernamePasswordToken(new InMemoryUser('username', 'credentials'), 'main'));
+        $request = Request::create('/', 'GET', [], ['_remember_me_cookie' => 'rememberme']);
+        $request->attributes->set(SecurityRequestAttributes::UNSUPPORTED_REASONS, $reasons = new UnsupportedReasons());
+
+        $this->assertFalse($this->authenticator->supports($request));
+        $this->assertSame(['a token is already stored, so the request is already authenticated'], $reasons->all());
     }
 }

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/RemoteUserAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/RemoteUserAuthenticatorTest.php
@@ -18,7 +18,9 @@ use Symfony\Component\Security\Core\Authentication\Token\PreAuthenticatedToken;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
 use Symfony\Component\Security\Core\User\InMemoryUser;
 use Symfony\Component\Security\Core\User\InMemoryUserProvider;
+use Symfony\Component\Security\Http\Authenticator\Debug\UnsupportedReasons;
 use Symfony\Component\Security\Http\Authenticator\RemoteUserAuthenticator;
+use Symfony\Component\Security\Http\SecurityRequestAttributes;
 
 class RemoteUserAuthenticatorTest extends TestCase
 {
@@ -69,6 +71,37 @@ class RemoteUserAuthenticatorTest extends TestCase
 
         $userProvider = new InMemoryUserProvider();
         yield [$userProvider, new RemoteUserAuthenticator($userProvider, new TokenStorage(), 'main', 'CUSTOM_USER_PARAMETER'), 'CUSTOM_USER_PARAMETER'];
+    }
+
+    public function testUnsupportedReasons()
+    {
+        $tokenStorage = new TokenStorage();
+        $authenticator = new RemoteUserAuthenticator(new InMemoryUserProvider(), $tokenStorage, 'main');
+
+        $request = $this->createRequest([]);
+        $request->attributes->set(SecurityRequestAttributes::UNSUPPORTED_REASONS, $reasons = new UnsupportedReasons());
+
+        $this->assertFalse($authenticator->supports($request));
+        $this->assertSame(['User key was not found: "REMOTE_USER".'], $reasons->all());
+
+        $request = $this->createRequest(['REMOTE_USER' => '']);
+        $request->attributes->set(SecurityRequestAttributes::UNSUPPORTED_REASONS, $reasons = new UnsupportedReasons());
+
+        $this->assertFalse($authenticator->supports($request));
+        $this->assertSame(['no user identifier was found in the request'], $reasons->all());
+
+        $tokenStorage->setToken(new PreAuthenticatedToken(new InMemoryUser('username', null), 'main'));
+        $request = $this->createRequest(['REMOTE_USER' => 'username']);
+        $request->attributes->set(SecurityRequestAttributes::UNSUPPORTED_REASONS, $reasons = new UnsupportedReasons());
+
+        $this->assertFalse($authenticator->supports($request));
+        $this->assertSame(['the user "username" already has a pre-authenticated token for this firewall'], $reasons->all());
+
+        $request = $this->createRequest(['REMOTE_USER' => 'another_username']);
+        $request->attributes->set(SecurityRequestAttributes::UNSUPPORTED_REASONS, $reasons = new UnsupportedReasons());
+
+        $this->assertTrue($authenticator->supports($request));
+        $this->assertSame([], $reasons->all());
     }
 
     private function createRequest(array $server)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #64993
| License       | MIT

When a firewall has several authenticators, the security profiler panel lists each of them and says whether it supported the request. When it did not, the panel only says "This authenticator did not support the request", and the developer has to work out why: a `json_login` request sent without a JSON `Content-Type`, a `form_login` posted to the wrong path, a `remember_me` skipped because the session already carries a token.

This PR lets `supports()` say why, and shows it in the panel:

> This authenticator did not support the request.
> Reason: the "Content-Type" header is "application/text", and the "form_only" option requires a form one

**How it works.** When the profiler is enabled, `TraceableAuthenticator` stores an `UnsupportedReasons` collector in the request attributes, under `SecurityRequestAttributes::UNSUPPORTED_REASONS`, for the duration of the wrapped `supports()` call. It then removes it and keeps what was collected. An authenticator that wants to explain a `false` adds to the collector where it decides:

```php
public function supports(Request $request): ?bool
{
    if (!$request->headers->has('X-Tenant')) {
        $request->attributes->get(SecurityRequestAttributes::UNSUPPORTED_REASONS)?->add('the "X-Tenant" header is missing');

        return false;
    }

    return true;
}
```

Outside the profiler the attribute is absent, `?->` short-circuits, and nothing is built or stored. The cost in production is one array lookup on the declining path.

**Why through the request, rather than a new interface or a new parameter.** This is the alternative I proposed on #65830, which adds an optional `getUnsupportedReason()` interface, and it revisits #60538, which added a parameter to `supports()`.

* No new method on authenticators and no change to `AuthenticatorInterface::supports()`, so third-party authenticators have nothing to implement or migrate. They add a line when they want to explain, or do nothing.
* The reason is recorded where the decision is made. The predicate is not written twice, and `supports()` methods with side effects (the pre-authenticated ones clear the token and set a request attribute) can explain themselves without being run again.
* Decorators need nothing. `LdapAuthenticator` wraps the form and JSON login authenticators and forwards `supports()`, so the inner authenticator sees the same request and its reason lands in the same collector.
* Request attributes are already the side channel of the security flow: `RememberMeAuthenticator::supports()` reads `ResponseListener::COOKIE_ATTR_NAME`, the pre-authenticated authenticators set `_pre_authenticated_username`, and `SecurityRequestAttributes` lists the others.

The same mechanism can serve firewall listeners later (#36668): `TraceableFirewallListener` would set the same attribute around each listener.

**Covered.** Every built-in authenticator explains every `false` it returns: `form_login`, `json_login`, `http_basic`, `login_link`, `access_token`, `oidc_login`, `remember_me`, `x509` and `remote_user`. `AbstractLoginFormAuthenticator` does too, so custom authenticators extending it get it for free. Some of the sentences the panel shows:

* `the request method is "GET", and the "post_only" option requires POST`
* `the request path "/other" does not match the "check_path" option "/login_check"`
* `neither the request format "html" nor the "Content-Type" header "text/plain" is a JSON one`
* `a token is already stored, so the request is already authenticated`
* `the "_remember_me_cookie" cookie is being cleared by this request`
* `User key was not found: "REMOTE_USER".` (the pre-authenticated authenticators report the message of the `BadCredentialsException` thrown by `extractUsername()`)

Most of these sentences come from Amoifr's work on #65830.

**Public API.** One final class, `Security\Http\Authenticator\Debug\UnsupportedReasons`, with `add(string $reason): void` and `all(): array`. One constant, `SecurityRequestAttributes::UNSUPPORTED_REASONS`. One new key, `unsupportedReasons`, in `TraceableAuthenticator::getInfo()`. The template guards that key with `is defined`, so profiles stored before the upgrade still render under `strict_variables`.

**Tests.** Each authenticator has a test asserting the reason for each branch, and none when it supports the request. The `TraceableAuthenticator` tests cover collection, reset between calls (`AuthenticatorManager` calls `supports()` twice on a supported authenticator), and removal of the attribute after the call, including when `supports()` throws. Security\Http 930, SecurityBundle 543 and Ldap 71, all green on PHP 8.5. The template fragment was rendered through `cloneVar()` and a serialize round trip: escaping applies, an empty list shows nothing, and a pre-upgrade profile without the key renders the old sentence.

Not covered: no end-to-end render of the full panel in a booted kernel, and PHPStan and Psalm are left to CI. A symfony-docs PR will follow once the shape is settled, for the profiler section and for explaining a `false` in a custom authenticator.
