### PR TITLE
[Scheduler] Fix duplicated schedule message when multiple methods in a class use #[AsCronTask]

### DIFF
--- a/src/Symfony/Component/Scheduler/DependencyInjection/AddScheduleMessengerPass.php
+++ b/src/Symfony/Component/Scheduler/DependencyInjection/AddScheduleMessengerPass.php
@@ -61,10 +61,19 @@ class AddScheduleMessengerPass implements CompilerPassInterface
                 $serviceDefinition = $container->getDefinition($serviceId);
                 $scheduleName = $tagAttributes['schedule'] ?? 'default';
 
-                if ($commandTags = $serviceDefinition->getTag('console.command')) {
+                $commandTags = $serviceDefinition->getTag('console.command');
+                $method = $tagAttributes['method'] ?? '__invoke';
+                $commandTag = array_find($commandTags, static fn ($tag) => $method === ($tag['method'] ?? '__invoke'));
+
+                // with no method-level #[AsCommand], the class-level command applies to all tasks
+                if (null === $commandTag && !array_any($commandTags, static fn ($tag) => isset($tag['method']))) {
+                    $commandTag = $commandTags[0] ?? null;
+                }
+
+                if (null !== $commandTag) {
                     /** @var AsCommand|null $attribute */
                     $attribute = ($container->getReflectionClass($serviceDefinition->getClass())->getAttributes(AsCommand::class)[0] ?? null)?->newInstance();
-                    $aliases = explode('|', $commandTags[0]['command'] ?? $attribute?->name ?? '');
+                    $aliases = explode('|', $commandTag['command'] ?? $attribute?->name ?? '');
                     if ('' === $commandName = array_shift($aliases)) {
                         $commandName = array_shift($aliases) ?? '';
                     }

--- a/src/Symfony/Component/Scheduler/Tests/DependencyInjection/AddScheduleMessengerPassTest.php
+++ b/src/Symfony/Component/Scheduler/Tests/DependencyInjection/AddScheduleMessengerPassTest.php
@@ -14,9 +14,11 @@ namespace Symfony\Component\Scheduler\Tests\DependencyInjection;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Messenger\RunCommandMessage;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\Scheduler\DependencyInjection\AddScheduleMessengerPass;
+use Symfony\Component\Scheduler\Messenger\ServiceCallMessage;
 
 class AddScheduleMessengerPassTest extends TestCase
 {
@@ -67,6 +69,64 @@ class AddScheduleMessengerPassTest extends TestCase
         $this->assertSame($expectedCommand, $command);
     }
 
+    public function testProcessSchedulerTaskCommandWithMultipleCommandMethods()
+    {
+        $container = new ContainerBuilder();
+
+        $definition = new Definition(MultiCommandSchedulableCommand::class);
+        $definition->addTag('console.command', ['command' => 'schedulable:one', 'method' => 'command1']);
+        $definition->addTag('console.command', ['command' => 'schedulable:two', 'method' => 'command2']);
+        $definition->addTag('scheduler.task', ['trigger' => 'every', 'frequency' => '1 hour', 'method' => 'command1']);
+        $definition->addTag('scheduler.task', ['trigger' => 'every', 'frequency' => '1 hour', 'method' => 'command2']);
+        $container->setDefinition(MultiCommandSchedulableCommand::class, $definition);
+
+        (new AddScheduleMessengerPass())->process($container);
+
+        $schedulerProvider = $container->getDefinition('scheduler.provider.default');
+        $tasks = $schedulerProvider->getMethodCalls()[0][1];
+
+        $this->assertSame('schedulable:one', $tasks[0]->getArgument('$message')->getArgument(0));
+        $this->assertSame('schedulable:two', $tasks[1]->getArgument('$message')->getArgument(0));
+    }
+
+    public function testProcessSchedulerTaskCommandWithMixedCommandAndPlainMethods()
+    {
+        $container = new ContainerBuilder();
+
+        $definition = new Definition(MixedCommandAndPlainSchedulableCommand::class);
+        $definition->addTag('console.command', ['command' => 'schedulable:command', 'method' => 'command1']);
+        $definition->addTag('scheduler.task', ['trigger' => 'every', 'frequency' => '1 hour', 'method' => 'command1']);
+        $definition->addTag('scheduler.task', ['trigger' => 'every', 'frequency' => '1 hour', 'method' => 'plainTask']);
+        $container->setDefinition(MixedCommandAndPlainSchedulableCommand::class, $definition);
+
+        (new AddScheduleMessengerPass())->process($container);
+
+        $schedulerProvider = $container->getDefinition('scheduler.provider.default');
+        $tasks = $schedulerProvider->getMethodCalls()[0][1];
+
+        $this->assertSame(RunCommandMessage::class, $tasks[0]->getArgument('$message')->getClass());
+        $this->assertSame(ServiceCallMessage::class, $tasks[1]->getArgument('$message')->getClass());
+        $this->assertSame('plainTask', $tasks[1]->getArgument('$message')->getArgument(1));
+    }
+
+    public function testProcessSchedulerTaskCommandWithClassLevelCommandAndTaskMethod()
+    {
+        $container = new ContainerBuilder();
+
+        $definition = new Definition(SchedulableCommand::class);
+        $definition->addTag('console.command');
+        $definition->addTag('scheduler.task', ['trigger' => 'every', 'frequency' => '1 hour', 'method' => 'someMethod']);
+        $container->setDefinition(SchedulableCommand::class, $definition);
+
+        (new AddScheduleMessengerPass())->process($container);
+
+        $schedulerProvider = $container->getDefinition('scheduler.provider.default');
+        $tasks = $schedulerProvider->getMethodCalls()[0][1];
+
+        $this->assertSame(RunCommandMessage::class, $tasks[0]->getArgument('$message')->getClass());
+        $this->assertSame('schedulable', $tasks[0]->getArgument('$message')->getArgument(0));
+    }
+
     public static function processSchedulerTaskCommandNameFromTagProvider(): iterable
     {
         yield 'tag command attribute overrides attribute name' => [['command' => 'custom-name'], 'custom-name'];
@@ -102,6 +162,28 @@ class SchedulableCommand
 class SchedulableCommandWithAlias
 {
     public function __invoke(): void
+    {
+    }
+}
+
+class MultiCommandSchedulableCommand
+{
+    public function command1(): void
+    {
+    }
+
+    public function command2(): void
+    {
+    }
+}
+
+class MixedCommandAndPlainSchedulableCommand
+{
+    public function command1(): void
+    {
+    }
+
+    public function plainTask(): void
     {
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65838
| License       | MIT

When `#[AsCronTask]` decorates two methods on the same class, `AddScheduleMessengerPass` always reads index `0` of the `console.command` tags to build the `RunCommandMessage`, so every task on that class ends up pointing at the first method's command. Both tasks become identical, and `Schedule::doAdd()` throws "Duplicated schedule message" as soon as the second one is added.

The pass now picks the `console.command` tag whose `method` matches the current `scheduler.task` tag's `method`, falling back to the first tag only when none of the class's command tags carry a `method` key (a class-level `#[AsCommand]`). A method that has `#[AsCronTask]` but no `#[AsCommand]` on a class that also has command methods now correctly falls through to a `ServiceCallMessage` instead of being mistaken for a command too.
