### PR TITLE
[Cache][Lock][Messenger] Track the Symfony component in the MongoDB driver handshake

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -1558,7 +1558,7 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('default_memcached_provider')->defaultValue('memcached://localhost')->end()
                         ->scalarNode('default_doctrine_dbal_provider')->defaultValue('database_connection')->end()
                         ->scalarNode('default_pdo_provider')->defaultValue($willBeAvailable('doctrine/dbal', Connection::class) && class_exists(DoctrineAdapter::class) ? 'database_connection' : null)->end()
-			->scalarNode('default_mongodb_provider')->defaultValue('mongodb://localhost/app')->end()
+                        ->scalarNode('default_mongodb_provider')->defaultValue('mongodb://localhost/app')->end()
                         ->arrayNode('pools', 'pool')
                             ->useAttributeAsKey('name')
                             ->prototype('array')

--- a/src/Symfony/Component/Cache/Tests/Adapter/MongoDbAdapterDsnTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/MongoDbAdapterDsnTest.php
@@ -131,7 +131,7 @@ class MongoDbAdapterDsnTest extends TestCase
     {
         $driverOptions = (new \ReflectionMethod(MongoDbAdapter::class, 'addDriverInfo'))->invoke(null, []);
 
-        $this->assertSame('sfcache', $driverOptions['driver']['name']);
+        $this->assertSame('symfony-mongodb-cache', $driverOptions['driver']['name']);
         $this->assertNotSame('', $driverOptions['driver']['version']);
     }
 
@@ -140,9 +140,17 @@ class MongoDbAdapterDsnTest extends TestCase
         $driverOptions = (new \ReflectionMethod(MongoDbAdapter::class, 'addDriverInfo'))
             ->invoke(null, ['driver' => ['name' => 'myapp', 'version' => '1.2', 'platform' => 'my platform']]);
 
-        $this->assertSame('sfcache/myapp', $driverOptions['driver']['name']);
+        $this->assertSame('symfony-mongodb-cache/myapp', $driverOptions['driver']['name']);
         $this->assertStringEndsWith('/1.2', $driverOptions['driver']['version']);
         $this->assertSame('my platform', $driverOptions['driver']['platform']);
+    }
+
+    public function testDriverInfoIsNotAccumulatedAcrossCalls()
+    {
+        $addDriverInfo = new \ReflectionMethod(MongoDbAdapter::class, 'addDriverInfo');
+        $options = ['driver' => ['name' => 'myapp', 'version' => '1.2']];
+
+        $this->assertSame($addDriverInfo->invoke(null, $options), $addDriverInfo->invoke(null, $options));
     }
 
     public function testInvalidScheme()

--- a/src/Symfony/Component/Cache/Traits/MongoDbTrait.php
+++ b/src/Symfony/Component/Cache/Traits/MongoDbTrait.php
@@ -221,10 +221,14 @@ trait MongoDbTrait
 
     private static function addDriverInfo(array $driverOptions): array
     {
-        $driver = $driverOptions['driver'] ?? [];
+        try {
+            $version = (class_exists(InstalledVersions::class) ? InstalledVersions::getPrettyVersion('symfony/cache') : null) ?? 'unknown';
+        } catch (\OutOfBoundsException) {
+            $version = 'unknown';
+        }
 
-        $name = 'sfcache';
-        $version = self::getVersion();
+        $driver = $driverOptions['driver'] ?? [];
+        $name = 'symfony-mongodb-cache';
 
         if (isset($driver['name'])) {
             $name .= '/'.$driver['name'];
@@ -236,19 +240,6 @@ trait MongoDbTrait
         $driverOptions['driver'] = ['name' => $name, 'version' => $version] + $driver;
 
         return $driverOptions;
-    }
-
-    private static function getVersion(): string
-    {
-        if (!class_exists(InstalledVersions::class)) {
-            return 'unknown';
-        }
-
-        try {
-            return InstalledVersions::getPrettyVersion('symfony/cache') ?? 'unknown';
-        } catch (\OutOfBoundsException) {
-            return 'unknown';
-        }
     }
 
     /**

--- a/src/Symfony/Component/Lock/Store/MongoDbStore.php
+++ b/src/Symfony/Component/Lock/Store/MongoDbStore.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Lock\Store;
 
+use Composer\InstalledVersions;
 use MongoDB\BSON\UTCDateTime;
 use MongoDB\Client;
 use MongoDB\Collection;
@@ -360,7 +361,35 @@ class MongoDbStore implements PersistingStoreInterface
 
     private function getManager(): Manager
     {
-        return $this->manager ??= new Manager($this->uri, $this->options['uriOptions'], $this->options['driverOptions']);
+        return $this->manager ??= new Manager($this->uri, $this->options['uriOptions'], self::addDriverInfo($this->options['driverOptions']));
+    }
+
+    /**
+     * Identifies the component in the driver handshake, so that the server
+     * knows which part of the application opened the connection. A driver name
+     * set by the application is kept and appended to.
+     */
+    private static function addDriverInfo(array $driverOptions): array
+    {
+        try {
+            $version = (class_exists(InstalledVersions::class) ? InstalledVersions::getPrettyVersion('symfony/lock') : null) ?? 'unknown';
+        } catch (\OutOfBoundsException) {
+            $version = 'unknown';
+        }
+
+        $driver = $driverOptions['driver'] ?? [];
+        $name = 'symfony-mongodb-lock';
+
+        if (isset($driver['name'])) {
+            $name .= '/'.$driver['name'];
+        }
+        if (isset($driver['version'])) {
+            $version .= '/'.$driver['version'];
+        }
+
+        $driverOptions['driver'] = ['name' => $name, 'version' => $version] + $driver;
+
+        return $driverOptions;
     }
 
     /**

--- a/src/Symfony/Component/Messenger/Bridge/MongoDb/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/MongoDb/Transport/Connection.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Messenger\Bridge\MongoDb\Transport;
 
+use Composer\InstalledVersions;
 use MongoDB\BSON\ObjectId;
 use MongoDB\BSON\UTCDateTime;
 use MongoDB\Client;
@@ -46,17 +47,32 @@ class Connection
         private readonly int $redeliverTimeout = 3600,
         private readonly ?ClockInterface $clock = null,
     ) {
-        $this->uniqueId = uniqid('consumer_', true);
+        $this->uniqueId = 'consumer_'.bin2hex(random_bytes(16));
     }
 
     public static function fromDsn(#[\SensitiveParameter] string $dsn, array $options = [], ?Client $client = null, ?ClockInterface $clock = null): self
     {
         [$configuration, $uri] = self::buildConfiguration($dsn, $options);
 
-        $client ??= new Client($uri);
+        $client ??= new Client($uri, [], self::driverInfo());
         $collection = $client->getCollection($configuration['database'], $configuration['collection_name']);
 
         return new self($collection, $configuration['queue_name'], $configuration['redeliver_timeout'], $clock);
+    }
+
+    /**
+     * Identifies the component in the driver handshake, so that the server
+     * knows which part of the application opened the connection.
+     */
+    private static function driverInfo(): array
+    {
+        try {
+            $version = (class_exists(InstalledVersions::class) ? InstalledVersions::getPrettyVersion('symfony/mongodb-messenger') : null) ?? 'unknown';
+        } catch (\OutOfBoundsException) {
+            $version = 'unknown';
+        }
+
+        return ['driver' => ['name' => 'symfony-mongodb-messenger', 'version' => $version]];
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Follow-up to #65824, which added the MongoDB cache adapters. Those adapters report themselves to the server through the MongoDB driver handshake, so that a DBA reading the server logs or `$currentOp` can tell which part of an application opened a connection.

This extends the same tracking to the other Symfony integrations that build a MongoDB connection themselves, under a consistent `symfony-mongodb-<component>` name:

 * `symfony-mongodb-cache`, renamed from `sfcache`, which was cryptic and did not scale to other components;
 * `symfony-mongodb-lock`, in `MongoDbStore`, which builds a `MongoDB\Driver\Manager` directly, so there is no PHPLIB segment on that path;
 * `symfony-mongodb-messenger`, in the MongoDB transport.

In each case the connection is only tagged when Symfony builds it from a DSN. An application that injects its own `Collection`, `Database`, `Client` or `Manager` keeps full control. A driver name set by the application is kept and appended to, rather than overwritten.

Read from `currentOp` against a local server:

```
cache      mongoc / ext-mongodb:PHP / PHPLIB/symfony-mongodb-cache
lock       mongoc / ext-mongodb:PHP / symfony-mongodb-lock
messenger  mongoc / ext-mongodb:PHP / PHPLIB/symfony-mongodb-messenger
```

Nothing to do for sessions: `MongoDbSessionHandler` takes an already built `Client` or `Manager` and never builds one from a DSN, and `SessionHandlerFactory` has no `mongodb` case, so Symfony never owns that connection.

Two unrelated fixes ride along, both small enough not to deserve their own PR:

 * the `default_mongodb_provider` line was left indented with tab characters when #65824 was merged;
 * the MongoDB transport used `uniqid()` to build the consumer id that marks message ownership in `deliveredTo`. It was the last `uniqid()` call in the source tree, every other component uses `bin2hex(random_bytes())`. https://github.com/symfony/symfony/issues/57588

Note that the delimiter used to append the application name deviates from the handshake specification, which mandates `|`. This comes from the PHP driver and the PHP library, both of which use `/` and `" / "`, so this PR stays consistent with them for now. Reported upstream as [PHPC-2765](https://jira.mongodb.org/browse/PHPC-2765).
