### PR TITLE
[String] Add a $regexp argument to the case conversion methods

### DIFF
--- a/UPGRADE-8.2.md
+++ b/UPGRADE-8.2.md
@@ -219,6 +219,12 @@ Serializer
  * Deprecate denormalizing an array that is not a list into a `list`-typed property, in version 9.0 a `Symfony\Component\Serializer\Exception\NotNormalizableValueException` will be thrown when the input does not satisfy `array_is_list()`
  * Denormalize the elements of a union-typed collection, e.g. `array<Foo|Bar>`, instead of returning the raw data. An element that matches no member of the union, or a key whose type does not match, now throws instead of being returned as-is
 
+String
+------
+
+ * Add argument `$regexp` to `AbstractString::lower()`, `AbstractString::upper()`, `AbstractString::title()`,
+   `AbstractUnicodeString::localeLower()`, `AbstractUnicodeString::localeUpper()` and `AbstractUnicodeString::localeTitle()`
+
 Translation
 -----------
 

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -47,3 +47,8 @@ parameters:
         -
             message: '#^PHPDoc tag @param references unknown parameter\: \$fetchSize$#'
             path: src/Symfony/Component/Messenger/*
+        # the $regexp argument is a commented-out argument of the case conversion methods, documented
+        # with @param so that DebugClassLoader reports the implementations that do not declare it
+        -
+            message: '#^PHPDoc tag @param references unknown parameter\: \$regexp$#'
+            path: src/Symfony/Component/String/*

--- a/src/Symfony/Component/String/AbstractString.php
+++ b/src/Symfony/Component/String/AbstractString.php
@@ -392,7 +392,10 @@ abstract class AbstractString implements \Stringable, \JsonSerializable
 
     abstract public function length(): int;
 
-    abstract public function lower(): static;
+    /**
+     * @param string|null $regexp A pattern matching the parts to convert, or null to convert the whole string
+     */
+    abstract public function lower(/* ?string $regexp = null */): static;
 
     /**
      * Matches the string using a regular expression.
@@ -506,7 +509,11 @@ abstract class AbstractString implements \Stringable, \JsonSerializable
         return false;
     }
 
-    abstract public function title(bool $allWords = false): static;
+    /**
+     * @param string|null $regexp A pattern matching the parts to convert, or null to convert the whole string;
+     *                            when set, every match is converted and $allWords is ignored
+     */
+    abstract public function title(bool $allWords = false /* , ?string $regexp = null */): static;
 
     public function toByteString(?string $toEncoding = null): ByteString
     {
@@ -656,7 +663,10 @@ abstract class AbstractString implements \Stringable, \JsonSerializable
         return $ellipsisLength ? $str->trimEnd()->append($ellipsis) : $str;
     }
 
-    abstract public function upper(): static;
+    /**
+     * @param string|null $regexp A pattern matching the parts to convert, or null to convert the whole string
+     */
+    abstract public function upper(/* ?string $regexp = null */): static;
 
     /**
      * Returns the printable length on a terminal.

--- a/src/Symfony/Component/String/AbstractUnicodeString.php
+++ b/src/Symfony/Component/String/AbstractUnicodeString.php
@@ -218,8 +218,17 @@ abstract class AbstractUnicodeString extends AbstractString
         return $str;
     }
 
-    public function lower(): static
+    /**
+     * @param string|null $regexp A pattern matching the parts to convert, or null to convert the whole string
+     */
+    public function lower(/* ?string $regexp = null */): static
     {
+        $regexp = 1 <= \func_num_args() ? func_get_arg(0) : null;
+
+        if (null !== $regexp) {
+            return $this->replaceMatches($regexp, static fn (array $m): string => mb_strtolower(str_replace('İ', 'i̇', $m[0]), 'UTF-8'));
+        }
+
         $str = clone $this;
         $str->string = mb_strtolower(str_replace('İ', 'i̇', $str->string), 'UTF-8');
 
@@ -227,18 +236,25 @@ abstract class AbstractUnicodeString extends AbstractString
     }
 
     /**
-     * @param string $locale In the format language_region (e.g. tr_TR)
+     * @param string      $locale In the format language_region (e.g. tr_TR)
+     * @param string|null $regexp A pattern matching the parts to convert, or null to convert the whole string
      */
-    public function localeLower(string $locale): static
+    public function localeLower(string $locale /* , ?string $regexp = null */): static
     {
+        $regexp = 2 <= \func_num_args() ? func_get_arg(1) : null;
+
         if (null !== $transliterator = $this->getLocaleTransliterator($locale, 'Lower')) {
+            if (null !== $regexp) {
+                return $this->replaceMatches($regexp, static fn (array $m): string => $transliterator->transliterate($m[0]));
+            }
+
             $str = clone $this;
             $str->string = $transliterator->transliterate($str->string);
 
             return $str;
         }
 
-        return $this->lower();
+        return $this->lower($regexp);
     }
 
     public function match(string $regexp, int $flags = 0, int $offset = 0): array
@@ -376,8 +392,18 @@ abstract class AbstractUnicodeString extends AbstractString
         return $str;
     }
 
-    public function title(bool $allWords = false): static
+    /**
+     * @param string|null $regexp A pattern matching the parts to convert, or null to convert the whole string;
+     *                            when set, every match is converted and $allWords is ignored
+     */
+    public function title(bool $allWords = false /* , ?string $regexp = null */): static
     {
+        $regexp = 2 <= \func_num_args() ? func_get_arg(1) : null;
+
+        if (null !== $regexp) {
+            return $this->replaceMatches($regexp, static fn (array $m): string => mb_convert_case($m[0], \MB_CASE_TITLE, 'UTF-8'));
+        }
+
         $str = clone $this;
 
         $limit = $allWords ? -1 : 1;
@@ -388,18 +414,25 @@ abstract class AbstractUnicodeString extends AbstractString
     }
 
     /**
-     * @param string $locale In the format language_region (e.g. tr_TR)
+     * @param string      $locale In the format language_region (e.g. tr_TR)
+     * @param string|null $regexp A pattern matching the parts to convert, or null to convert the whole string
      */
-    public function localeTitle(string $locale): static
+    public function localeTitle(string $locale /* , ?string $regexp = null */): static
     {
+        $regexp = 2 <= \func_num_args() ? func_get_arg(1) : null;
+
         if (null !== $transliterator = $this->getLocaleTransliterator($locale, 'Title')) {
+            if (null !== $regexp) {
+                return $this->replaceMatches($regexp, static fn (array $m): string => $transliterator->transliterate($m[0]));
+            }
+
             $str = clone $this;
             $str->string = $transliterator->transliterate($str->string);
 
             return $str;
         }
 
-        return $this->title();
+        return $this->title(false, $regexp);
     }
 
     public function trim(string $chars = " \t\n\r\0\x0B\x0C\u{A0}\u{FEFF}"): static
@@ -481,8 +514,17 @@ abstract class AbstractUnicodeString extends AbstractString
         return $str;
     }
 
-    public function upper(): static
+    /**
+     * @param string|null $regexp A pattern matching the parts to convert, or null to convert the whole string
+     */
+    public function upper(/* ?string $regexp = null */): static
     {
+        $regexp = 1 <= \func_num_args() ? func_get_arg(0) : null;
+
+        if (null !== $regexp) {
+            return $this->replaceMatches($regexp, static fn (array $m): string => mb_strtoupper($m[0], 'UTF-8'));
+        }
+
         $str = clone $this;
         $str->string = mb_strtoupper($str->string, 'UTF-8');
 
@@ -490,18 +532,25 @@ abstract class AbstractUnicodeString extends AbstractString
     }
 
     /**
-     * @param string $locale In the format language_region (e.g. tr_TR)
+     * @param string      $locale In the format language_region (e.g. tr_TR)
+     * @param string|null $regexp A pattern matching the parts to convert, or null to convert the whole string
      */
-    public function localeUpper(string $locale): static
+    public function localeUpper(string $locale /* , ?string $regexp = null */): static
     {
+        $regexp = 2 <= \func_num_args() ? func_get_arg(1) : null;
+
         if (null !== $transliterator = $this->getLocaleTransliterator($locale, 'Upper')) {
+            if (null !== $regexp) {
+                return $this->replaceMatches($regexp, static fn (array $m): string => $transliterator->transliterate($m[0]));
+            }
+
             $str = clone $this;
             $str->string = $transliterator->transliterate($str->string);
 
             return $str;
         }
 
-        return $this->upper();
+        return $this->upper($regexp);
     }
 
     public function width(bool $ignoreAnsiDecoration = true): int

--- a/src/Symfony/Component/String/ByteString.php
+++ b/src/Symfony/Component/String/ByteString.php
@@ -202,8 +202,17 @@ class ByteString extends AbstractString
         return \strlen($this->string);
     }
 
-    public function lower(): static
+    /**
+     * @param string|null $regexp A pattern matching the parts to convert, or null to convert the whole string
+     */
+    public function lower(/* ?string $regexp = null */): static
     {
+        $regexp = 1 <= \func_num_args() ? func_get_arg(0) : null;
+
+        if (null !== $regexp) {
+            return $this->replaceMatches($regexp, static fn (array $m): string => strtolower($m[0]));
+        }
+
         $str = clone $this;
         $str->string = strtolower($str->string);
 
@@ -379,8 +388,18 @@ class ByteString extends AbstractString
         return '' !== $prefix && 0 === ($this->ignoreCase ? strncasecmp($this->string, $prefix, \strlen($prefix)) : strncmp($this->string, $prefix, \strlen($prefix)));
     }
 
-    public function title(bool $allWords = false): static
+    /**
+     * @param string|null $regexp A pattern matching the parts to convert, or null to convert the whole string;
+     *                            when set, every match is converted and $allWords is ignored
+     */
+    public function title(bool $allWords = false /* , ?string $regexp = null */): static
     {
+        $regexp = 2 <= \func_num_args() ? func_get_arg(1) : null;
+
+        if (null !== $regexp) {
+            return $this->replaceMatches($regexp, static fn (array $m): string => ucfirst(strtolower($m[0])));
+        }
+
         $str = clone $this;
         $str->string = $allWords ? ucwords($str->string) : ucfirst($str->string);
 
@@ -453,8 +472,17 @@ class ByteString extends AbstractString
         return $str;
     }
 
-    public function upper(): static
+    /**
+     * @param string|null $regexp A pattern matching the parts to convert, or null to convert the whole string
+     */
+    public function upper(/* ?string $regexp = null */): static
     {
+        $regexp = 1 <= \func_num_args() ? func_get_arg(0) : null;
+
+        if (null !== $regexp) {
+            return $this->replaceMatches($regexp, static fn (array $m): string => strtoupper($m[0]));
+        }
+
         $str = clone $this;
         $str->string = strtoupper($str->string);
 

--- a/src/Symfony/Component/String/CHANGELOG.md
+++ b/src/Symfony/Component/String/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add argument `$regexp` to `lower()`, `upper()`, `title()`, `localeLower()`, `localeUpper()` and `localeTitle()` to convert only the matching parts
+
 8.0
 ---
 

--- a/src/Symfony/Component/String/Tests/AbstractAsciiTestCase.php
+++ b/src/Symfony/Component/String/Tests/AbstractAsciiTestCase.php
@@ -524,6 +524,26 @@ abstract class AbstractAsciiTestCase extends TestCase
         ];
     }
 
+    #[DataProvider('provideLowerWithRegexp')]
+    public function testLowerWithRegexp(string $expected, string $origin, string $regexp)
+    {
+        $instance = static::createFromString($origin)->lower($regexp);
+
+        $this->assertNotSame(static::createFromString($origin), $instance);
+        $this->assertSame($expected, (string) $instance);
+    }
+
+    public static function provideLowerWithRegexp()
+    {
+        return [
+            ['hELLO WORLD', 'HELLO WORLD', '/^./'],
+            ['hello world', 'HELLO WORLD', '/./'],
+            ['hELLO wORLD', 'HELLO WORLD', '/\b./'],
+            ['HELLO WORLD', 'HELLO WORLD', '/^\d/'],
+            ['', '', '/^./'],
+        ];
+    }
+
     #[DataProvider('provideUpper')]
     public function testUpper(string $expected, string $origin)
     {
@@ -543,6 +563,26 @@ abstract class AbstractAsciiTestCase extends TestCase
             ['SYMFONY', 'symfony'],
             ['SYMFONY', 'Symfony'],
             ['SYMFONY', 'sYmFOny'],
+        ];
+    }
+
+    #[DataProvider('provideUpperWithRegexp')]
+    public function testUpperWithRegexp(string $expected, string $origin, string $regexp)
+    {
+        $instance = static::createFromString($origin)->upper($regexp);
+
+        $this->assertNotSame(static::createFromString($origin), $instance);
+        $this->assertSame($expected, (string) $instance);
+    }
+
+    public static function provideUpperWithRegexp()
+    {
+        return [
+            ['Hello world', 'hello world', '/^./'],
+            ['HELLO WORLD', 'hello world', '/./'],
+            ['HELLO world', 'hello world', '/^\w+/'],
+            ['hello world', 'hello world', '/^\d/'],
+            ['', '', '/^./'],
         ];
     }
 
@@ -567,6 +607,48 @@ abstract class AbstractAsciiTestCase extends TestCase
             ['Symfony', 'symfony', false],
             ['Symfony', 'Symfony', false],
             ['SYmFOny', 'sYmFOny', false],
+        ];
+    }
+
+    #[DataProvider('provideTitleWithRegexp')]
+    public function testTitleWithRegexp(string $expected, string $origin, string $regexp)
+    {
+        $instance = static::createFromString($origin)->title(false, $regexp);
+
+        $this->assertNotSame(static::createFromString($origin), $instance);
+        $this->assertSame($expected, (string) $instance);
+    }
+
+    public static function provideTitleWithRegexp()
+    {
+        return [
+            ['Hello world', 'hello world', '/^./'],
+            ['Hello World', 'hello world', '/\b./'],
+            ['Hello world', 'hELLO world', '/^\w+/'],
+            [' hello world', ' hello world', '/^./'],
+            ['', '', '/^./'],
+        ];
+    }
+
+    public function testTitleWithRegexpIgnoresAllWords()
+    {
+        $this->assertSame('Hello World', (string) static::createFromString('hello world')->title(false, '/\b./'));
+        $this->assertSame('Hello world', (string) static::createFromString('hello world')->title(true, '/^./'));
+    }
+
+    #[DataProvider('provideCaseWithInvalidRegexp')]
+    public function testCaseWithInvalidRegexp(string $method)
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        static::createFromString('hello world')->$method('/[/');
+    }
+
+    public static function provideCaseWithInvalidRegexp()
+    {
+        return [
+            ['lower'],
+            ['upper'],
         ];
     }
 

--- a/src/Symfony/Component/String/Tests/AbstractUnicodeTestCase.php
+++ b/src/Symfony/Component/String/Tests/AbstractUnicodeTestCase.php
@@ -93,6 +93,56 @@ END'],
         $this->assertSame($expected, (string) $instance);
     }
 
+    #[DataProvider('provideLocaleLowerWithRegexp')]
+    #[RequiresPhpExtension('intl')]
+    public function testLocaleLowerWithRegexp(string $locale, string $expected, string $origin, string $regexp)
+    {
+        $this->assertSame($expected, (string) static::createFromString($origin)->localeLower($locale, $regexp));
+    }
+
+    public static function provideLocaleLowerWithRegexp(): array
+    {
+        return [
+            // Turkish, the dotless i is only reachable with the locale
+            ['tr', 'ıSTANBUL', 'ISTANBUL', '/^./'],
+            ['en', 'iSTANBUL', 'ISTANBUL', '/^./'],
+
+            // Dutch, the IJ digraph is two characters
+            ['nl', 'ijSSEL', 'IJSSEL', '/^IJ|^./'],
+        ];
+    }
+
+    #[DataProvider('provideLocaleUpperWithRegexp')]
+    #[RequiresPhpExtension('intl')]
+    public function testLocaleUpperWithRegexp(string $locale, string $expected, string $origin, string $regexp)
+    {
+        $this->assertSame($expected, (string) static::createFromString($origin)->localeUpper($locale, $regexp));
+    }
+
+    public static function provideLocaleUpperWithRegexp(): array
+    {
+        return [
+            ['tr', 'İstanbul', 'istanbul', '/^./'],
+            ['en', 'Istanbul', 'istanbul', '/^./'],
+        ];
+    }
+
+    #[DataProvider('provideLocaleTitleWithRegexp')]
+    #[RequiresPhpExtension('intl')]
+    public function testLocaleTitleWithRegexp(string $locale, string $expected, string $origin, string $regexp)
+    {
+        $this->assertSame($expected, (string) static::createFromString($origin)->localeTitle($locale, $regexp));
+    }
+
+    public static function provideLocaleTitleWithRegexp(): array
+    {
+        return [
+            // Dutch, titlecasing 'ij' gives 'IJ' with the locale and 'Ij' without it
+            ['nl', 'IJssel is', 'ijssel is', '/^ij/'],
+            ['en', 'Ijssel is', 'ijssel is', '/^ij/'],
+        ];
+    }
+
     public static function provideCreateFromCodePoint(): array
     {
         return [
@@ -348,6 +398,24 @@ END'],
         );
     }
 
+    public static function provideLowerWithRegexp(): array
+    {
+        return array_merge(
+            parent::provideLowerWithRegexp(),
+            [
+                // French
+                ['éVEIL', 'ÉVEIL', '/^./'],
+
+                // Dutch, the IJ digraph is two characters
+                ['iJSSEL', 'IJSSEL', '/^./'],
+                ['ijSSEL', 'IJSSEL', '/^IJ|^./'],
+
+                // Random symbols
+                ['i̇IIıi', 'İIIıi', '/^./'],
+            ]
+        );
+    }
+
     public static function provideLocaleLower(): array
     {
         return [
@@ -445,6 +513,22 @@ END'],
         );
     }
 
+    public static function provideUpperWithRegexp(): array
+    {
+        return array_merge(
+            parent::provideUpperWithRegexp(),
+            [
+                // French
+                ['Éveil', 'éveil', '/^./'],
+
+                // Dutch, the IJ digraph is two characters
+                ['Ijssel', 'ijssel', '/^./'],
+                ['IJssel', 'ijssel', '/^ij|^./'],
+                ['Invoer', 'invoer', '/^ij|^./'],
+            ]
+        );
+    }
+
     public static function provideTitle(): array
     {
         return array_merge(
@@ -468,6 +552,20 @@ END'],
 
                 ['Última Prueba', 'última prueba', true],
                 ['ÚLTIMA PRUEBA', 'úLTIMA pRUEBA', true],
+            ]
+        );
+    }
+
+    public static function provideTitleWithRegexp(): array
+    {
+        return array_merge(
+            parent::provideTitleWithRegexp(),
+            [
+                // French
+                ['Éveil', 'éveil', '/^./'],
+
+                // The titlecase form of a digraph differs from its uppercase form
+                ['ǲenan', 'ǳenan', '/^./'],
             ]
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Issues        | Replaces #65829
| License       | MIT

`lower()`, `upper()` and `title()` convert the whole string. This PR adds a `$regexp` argument to select the parts to convert, so that the caller can say *which* characters change case instead of asking for a new method per selection:

```php
u('HELLO WORLD')->lower('/^./');        // 'hELLO WORLD', what lcfirst() does
u('hello world')->title(false, '/^./'); // 'Hello world', what ucfirst() does
u('hello world')->upper('/\b./');       // 'HELLO WORLD'
```

Every match is converted, so a caller who wants a single conversion anchors the pattern. The pattern follows the same rules as `replaceMatches()`: delimiters are part of it, the `u` flag is added by the unicode implementations, and the `i` flag is added when the string ignores case. An invalid pattern throws `InvalidArgumentException`.

The same argument is added to `localeLower()`, `localeUpper()` and `localeTitle()`, where the locale transliterator is applied to each match.

### Why a pattern and not `lcfirst()`/`ucfirst()` methods

Which characters make up "the first letter" is a language rule, and a fixed method cannot carry it. The pattern lets the caller express the rule for their own language, in both directions:

```php
u('IJsland')->lower('/^IJ|^./');  // 'ijsland', where '/^./' alone gives 'iJsland'
u('ijsland')->upper('/^ij|^./');  // 'IJsland', and 'invoer' stays 'Invoer'
u('ISTANBUL')->localeLower('tr', '/^./'); // 'ıSTANBUL', the dotless i Turkish needs
```

None of this is reachable with the existing API without reimplementing the case mapping of the component:

* `replaceMatches('/^./', fn ($m) => mb_strtoupper($m[0], 'UTF-8'))` turns `ǳenan` into `Ǳenan`, where titlecasing gives `ǲenan`;
* the locale variants cannot be reproduced at all, because `Transliterator::create('tr_TR-Lower')` returns `null`: the locale fallback to `tr` lives in the private `getLocaleTransliterator()`.

### Notes

* `title()` takes the pattern as its second argument, after `$allWords`. When a pattern is given, every match is converted and `$allWords` is not used.
* `title()` already behaves like `ucfirst()` by default, with a better anchor for text: it converts the first *word*, so `'"hello"'` gives `'"Hello"'` where `ucfirst()` would leave it untouched. The pattern is what makes the plain `^` anchor reachable.
* Titlecasing is not uppercasing. `title()` maps a match with `MB_CASE_TITLE`, so a multi-character match gets its first letter up and the rest down.
* Lowercasing the first letter of a translated label to fit it in a sentence stays a localization trap that no pattern fixes: German capitalizes all nouns, so a second translation key is the answer there.

### Documentation

The points the docs must carry: the pattern selects the parts to convert and every match is converted; the `replaceMatches()` conventions for delimiters and flags; the `$allWords` interaction on `title()`; the Dutch and Turkish examples above, with the warning that the component does not know these rules, the caller does.
