### PR TITLE
[HtmlSanitizer] Drop relative URLs whose first path segment contains a colon instead of throwing

### DIFF
--- a/src/Symfony/Component/HtmlSanitizer/Tests/HtmlSanitizerCustomTest.php
+++ b/src/Symfony/Component/HtmlSanitizer/Tests/HtmlSanitizerCustomTest.php
@@ -647,4 +647,24 @@ class HtmlSanitizerCustomTest extends TestCase
     {
         return (new HtmlSanitizer($config))->sanitize($input);
     }
+
+    public function testAllowRelativeLinksRejectsColonInFirstPathSegment()
+    {
+        $config = (new HtmlSanitizerConfig())
+            ->allowElement('a', ['href'])
+            ->allowRelativeLinks()
+        ;
+
+        foreach ([':', '::', ':link.php'] as $href) {
+            $this->assertSame(
+                '<a>Hello world</a>',
+                $this->sanitize($config, \sprintf('<a href="%s">Hello world</a>', $href))
+            );
+        }
+
+        $this->assertSame(
+            '<a href="./:link.php">Hello world</a>',
+            $this->sanitize($config, '<a href="./:link.php">Hello world</a>')
+        );
+    }
 }

--- a/src/Symfony/Component/HtmlSanitizer/Tests/TextSanitizer/UrlSanitizerTest.php
+++ b/src/Symfony/Component/HtmlSanitizer/Tests/TextSanitizer/UrlSanitizerTest.php
@@ -211,6 +211,42 @@ class UrlSanitizerTest extends TestCase
         ];
 
         yield [
+            'input' => ':',
+            'allowedSchemes' => ['https'],
+            'allowedHosts' => null,
+            'forceHttps' => false,
+            'allowRelative' => true,
+            'expected' => null,
+        ];
+
+        yield [
+            'input' => '::',
+            'allowedSchemes' => ['https'],
+            'allowedHosts' => null,
+            'forceHttps' => false,
+            'allowRelative' => true,
+            'expected' => null,
+        ];
+
+        yield [
+            'input' => ':link.php',
+            'allowedSchemes' => ['https'],
+            'allowedHosts' => null,
+            'forceHttps' => false,
+            'allowRelative' => true,
+            'expected' => null,
+        ];
+
+        yield [
+            'input' => './:link.php',
+            'allowedSchemes' => ['https'],
+            'allowedHosts' => null,
+            'forceHttps' => false,
+            'allowRelative' => true,
+            'expected' => './:link.php',
+        ];
+
+        yield [
             'input' => 'https://untrusted.com/link.php',
             'allowedSchemes' => ['https'],
             'allowedHosts' => ['trusted.com'],

--- a/src/Symfony/Component/HtmlSanitizer/TextSanitizer/UrlSanitizer.php
+++ b/src/Symfony/Component/HtmlSanitizer/TextSanitizer/UrlSanitizer.php
@@ -103,7 +103,18 @@ final class UrlSanitizer
             $url['scheme'] = 'https';
         }
 
-        return UriString::build($url);
+        // In absence of a scheme and of an authority, RFC 3986 forbids a colon in the
+        // first path segment, which would otherwise be read as a scheme. league/uri
+        // enforces this in UriString::build(), but only since version 7.
+        if (!$url['scheme'] && null === $url['host'] && preg_match('#^[^/:]*+:#', $url['path'])) {
+            return null;
+        }
+
+        try {
+            return UriString::build($url);
+        } catch (SyntaxError) {
+            return null;
+        }
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

With `allowRelativeLinks()` or `allowRelativeMedias()`, sanitizing `<a href=":">`, `<a href="::">` or `<a href=":link.php">` makes `HtmlSanitizer::sanitize()` throw:

```
League\Uri\Exceptions\SyntaxError: In absence of a scheme and an authority the first path segment cannot contain a colon (":") character.
```

`UrlSanitizer::parse()` catches `SyntaxError` around `UriString::parse()`, but `sanitize()` calls `UriString::build()` outside of any try/catch, and league/uri 7 validates the components again there: a relative URL whose first path segment contains a colon is refused, since RFC 3986 would read that segment as a scheme. For a component that takes untrusted HTML as input, an uncaught exception on a three-byte attribute value is a bug. The same value is dropped without an exception when relative URLs are not allowed, because the hostless check runs first.

The URL is now dropped in that case, like every other malformed input. `./:link.php`, the RFC 3986 spelling of such a relative link, keeps working and is covered by a test, next to the three throwing values in `UrlSanitizerTest` and end to end in `HtmlSanitizerCustomTest`.

league/uri 6.5, the lowest supported version, does not validate in `build()` and returned such a URL unchanged, which is what `low-deps` reported. The RFC 3986 rule is therefore checked by the sanitizer itself, so the outcome no longer depends on the installed version, and the `try`/`catch` stays as a safety net.

```
$ cd src/Symfony/Component/HtmlSanitizer && composer update --prefer-lowest --prefer-stable  # league/uri 6.5.0
$ ../../../../phpunit
OK (794 tests, 2661 assertions)

$ composer update  # league/uri dev-master
$ ../../../../phpunit
OK (794 tests, 2661 assertions)
```

