### PR TITLE
[Mime] Reject header names containing non-printable or non-ASCII characters

### DIFF
--- a/src/Symfony/Component/Mime/Header/AbstractHeader.php
+++ b/src/Symfony/Component/Mime/Header/AbstractHeader.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Mime\Header;
 
 use Symfony\Component\Mime\Encoder\QpMimeHeaderEncoder;
+use Symfony\Component\Mime\Exception\RfcComplianceException;
 
 /**
  * An abstract base MIME Header.
@@ -31,6 +32,10 @@ abstract class AbstractHeader implements HeaderInterface
 
     public function __construct(string $name)
     {
+        if (!preg_match('/^[\x21-\x7E]++$/D', $name)) {
+            throw new RfcComplianceException(sprintf('The header name "%s" contains characters that are not allowed in a header name.', $name));
+        }
+
         $this->name = $name;
     }
 

--- a/src/Symfony/Component/Mime/Tests/Header/HeadersTest.php
+++ b/src/Symfony/Component/Mime/Tests/Header/HeadersTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Mime\Tests\Header;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Mime\Exception\RfcComplianceException;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Header\DateHeader;
 use Symfony\Component\Mime\Header\Headers;
@@ -327,5 +328,27 @@ class HeadersTest extends TestCase
 
         $this->expectException(\LogicException::class);
         $headers->setHeaderParameter('Content-Disposition', 'name', 'foo');
+    }
+
+    /**
+     * @dataProvider provideHeaderMethods
+     */
+    public function testInvalidHeaderNameIsRejected(string $method, array $arguments)
+    {
+        $this->expectException(RfcComplianceException::class);
+
+        (new Headers())->$method("X-A\r\nX-Injected: value", ...$arguments);
+    }
+
+    public static function provideHeaderMethods()
+    {
+        yield ['addTextHeader', ['value']];
+        yield ['addParameterizedHeader', ['value', ['param' => 'foo']]];
+        yield ['addMailboxListHeader', [['fabien@symfony.com']]];
+        yield ['addMailboxHeader', ['fabien@symfony.com']];
+        yield ['addPathHeader', ['fabien@symfony.com']];
+        yield ['addDateHeader', [new \DateTimeImmutable()]];
+        yield ['addIdHeader', ['some@id']];
+        yield ['addHeader', ['value']];
     }
 }

--- a/src/Symfony/Component/Mime/Tests/Header/UnstructuredHeaderTest.php
+++ b/src/Symfony/Component/Mime/Tests/Header/UnstructuredHeaderTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Mime\Tests\Header;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Mime\Exception\RfcComplianceException;
 use Symfony\Component\Mime\Header\UnstructuredHeader;
 
 class UnstructuredHeaderTest extends TestCase
@@ -243,5 +244,36 @@ class UnstructuredHeaderTest extends TestCase
     {
         $header = new UnstructuredHeader('Subject', 'test');
         $this->assertEquals('test', $header->getBody());
+    }
+
+    /**
+     * @dataProvider provideInvalidNames
+     */
+    public function testInvalidNameIsRejected(string $name)
+    {
+        $this->expectException(RfcComplianceException::class);
+
+        new UnstructuredHeader($name, 'value');
+    }
+
+    public static function provideInvalidNames()
+    {
+        yield [""];
+        yield ["X-A\r\nX-Injected: value"];
+        yield ["X-A\nX-Injected: value"];
+        yield ["X-A\rX-Injected: value"];
+        yield ["X-A: value\r\nX-Injected"];
+        yield ["X A"];
+        yield ["X-A\t"];
+        yield ["X-\x00A"];
+        yield ["X-\x7fA"];
+        yield ["X-\xc3\xa9"];
+    }
+
+    public function testValidNamesAreAccepted()
+    {
+        foreach (['Subject', 'X-Custom-Header', 'x-lower', '!#$%&\'*+-.^_`|~', 'Header-With-Digits-123', 'h:X-Mailgun-Tag', 'o:tag', 'v:my-var'] as $name) {
+            $this->assertSame($name, (new UnstructuredHeader($name, 'value'))->getName());
+        }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Header values are encoded or validated before being serialized, and so are parameter values, but the header name itself was concatenated as-is by `AbstractHeader::tokensToString()`. A name holding a CRLF sequence therefore split the header and injected a new one:

```php
$headers = new Headers();
$headers->addTextHeader("X-A\r\nX-Injected: y", 'v');
echo $headers->toString();

// X-A
// X-Injected: y: v
```

The same applies to every `add*Header()` method and to the header constructors, since all of them funnel into `AbstractHeader::__construct()`.

Header names are usually literals written by the developer, so this is a hardening rather than a bypass of a security boundary. `AbstractHeader::__construct()` now rejects a name that is empty or contains a character outside printable ASCII with an `RfcComplianceException`, the exception already thrown for an invalid parameter name or address. That blocks CR, LF, other control characters, spaces and non-ASCII bytes. Colons are still accepted on purpose: the Mailgun bridge documents `h:`, `o:`, `v:` and `t:` prefixed header names, which it maps to API parameters instead of serializing them.

Tests cover the rejected forms through `UnstructuredHeader` and through every `Headers::add*Header()` method, and pin the accepted ones, including the Mailgun prefixes and the RFC 5322 field-name specials.

```
$ ./phpunit src/Symfony/Component/Mime
Tests: 397, Assertions: 1619, Skipped: 1.
$ ./phpunit src/Symfony/Component/Mailer
Tests: 376, Assertions: 776, Skipped: 8.
$ ./phpunit src/Symfony/Component/Notifier
Tests: 1206, Assertions: 1590, Skipped: 47.
```
