### PR TITLE
[String] Fix ByteString::title() titlecasing only the first word of a match

### DIFF
--- a/src/Symfony/Component/String/ByteString.php
+++ b/src/Symfony/Component/String/ByteString.php
@@ -397,7 +397,7 @@ class ByteString extends AbstractString
         $regexp = 2 <= \func_num_args() ? func_get_arg(1) : null;
 
         if (null !== $regexp) {
-            return $this->replaceMatches($regexp, static fn (array $m): string => ucfirst(strtolower($m[0])));
+            return $this->replaceMatches($regexp, static fn (array $m): string => ucwords(strtolower($m[0])));
         }
 
         $str = clone $this;

--- a/src/Symfony/Component/String/Tests/AbstractAsciiTestCase.php
+++ b/src/Symfony/Component/String/Tests/AbstractAsciiTestCase.php
@@ -625,6 +625,8 @@ abstract class AbstractAsciiTestCase extends TestCase
             ['Hello world', 'hello world', '/^./'],
             ['Hello World', 'hello world', '/\b./'],
             ['Hello world', 'hELLO world', '/^\w+/'],
+            ['Hello World', 'hello world', '/.+/'],
+            ['Hello World', 'hELLO wORLD', '/.+/'],
             [' hello world', ' hello world', '/^./'],
             ['', '', '/^./'],
         ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Follow-up to #65842, spotted in https://github.com/symfony/symfony/pull/65842#discussion_r3932540449.

When a match spans more than one word, `ByteString::title()` titlecased only the first word of it, while `UnicodeString` and `CodePointString` titlecase every word inside the match, because they use `MB_CASE_TITLE`:

```php
b('hello world')->title(false, '/.+/'); // 'Hello world'
u('hello world')->title(false, '/.+/'); // 'Hello World'
```

`ucfirst()` becomes `ucwords()` in `ByteString`, so the three classes now agree:

```php
b('hello world')->title(false, '/.+/'); // 'Hello World'
u('hello world')->title(false, '/.+/'); // 'Hello World'
```

The shared data provider only had single-word matches, which is why this was not caught. Two multi-word rows are added there, so all three classes are checked.

`ucwords()` splits on whitespace only, while `MB_CASE_TITLE` also splits on punctuation, so `b('foo-bar')` gives `Foo-bar` where `u('foo-bar')` gives `Foo-Bar`. That difference already exists for `title(true)` on the current code and is left as is.

The `$regexp` argument is not released yet, so there is nothing to deprecate and no changelog entry to add.
