### PR TITLE
[String] Fix localeTitle() titlecasing only the first word when the locale has no transliterator

### DIFF
--- a/src/Symfony/Component/String/AbstractUnicodeString.php
+++ b/src/Symfony/Component/String/AbstractUnicodeString.php
@@ -389,14 +389,15 @@ abstract class AbstractUnicodeString extends AbstractString
      */
     public function localeTitle(string $locale): static
     {
-        if (null !== $transliterator = $this->getLocaleTransliterator($locale, 'Title')) {
-            $str = clone $this;
-            $str->string = $transliterator->transliterate($str->string);
+        $str = clone $this;
 
-            return $str;
+        if (null !== $transliterator = $this->getLocaleTransliterator($locale, 'Title')) {
+            $str->string = $transliterator->transliterate($str->string);
+        } else {
+            $str->string = mb_convert_case($str->string, \MB_CASE_TITLE, 'UTF-8');
         }
 
-        return $this->title();
+        return $str;
     }
 
     public function trim(string $chars = " \t\n\r\0\x0B\x0C\u{A0}\u{FEFF}"): static

--- a/src/Symfony/Component/String/Tests/AbstractUnicodeTestCase.php
+++ b/src/Symfony/Component/String/Tests/AbstractUnicodeTestCase.php
@@ -408,6 +408,10 @@ END'],
 
             // Default casing rules
             ['en', 'Ijssel', 'ijssel'],
+
+            // Every word is titlecased, with or without a locale transliterator
+            ['nl', 'Hello World', 'hELLO wORLD'],
+            ['en', 'Hello World', 'hELLO wORLD'],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`localeTitle()` titlecases every word when ICU has a `Title` transliterator for the locale, and only the first word when it does not, because the fallback is `title()`:

```php
u('hELLO wORLD')->localeTitle('nl'); // 'Hello World'
u('hELLO wORLD')->localeTitle('en'); // 'HELLO wORLD'
```

The fallback is not a rare path. ICU ships a `Title` transliterator for five locales only:

```php
array_filter(['el', 'lt', 'tr', 'az', 'nl', 'en', 'de', 'fr', 'es'], fn ($l) => null !== Transliterator::create($l.'-Title'));
// ['el', 'lt', 'tr', 'az', 'nl']
```

So the method returns a titlecased string for those five and something close to `ucfirst()` for every other locale, including the most common ones.

The fallback now titlecases the whole string with `MB_CASE_TITLE`, which is what the transliterators do:

```php
u('hELLO wORLD')->localeTitle('en'); // 'Hello World'
```

`MB_CASE_TITLE` and ICU's own `Any-Title` agree on the strings I probed, including accents, digraphs, apostrophes, digits, non-breaking sequences and repeated spaces, so the two paths only differ where the locale rules differ, which is the point of the method. `localeLower()` and `localeUpper()` were already consistent: their `lower()` and `upper()` fallbacks match what the transliterators return.

Callers who want the first word only can still use `title()`.

Tests: String 2691, green. Two rows are added to `provideLocaleTitle()`, one with a transliterator and one without, so the two paths are checked against the same expectation. Before the fix the second one fails with `HELLO wORLD`.

Merge-up to 8.2: `localeTitle()` there takes the `$regexp` argument added in #65842, and the fallback for a given pattern is already right, since `title(false, $regexp)` maps each match with `MB_CASE_TITLE` just like the transliterator branch. Only the no-pattern case changes:

```php
        if (null !== $regexp) {
            return $this->title(false, $regexp);
        }

        $str = clone $this;
        $str->string = mb_convert_case($str->string, \MB_CASE_TITLE, 'UTF-8');

        return $str;
```

I ran that resolution on 8.2 with the same two test rows: String 2795, green.
