### PR TITLE
[Console] Make method-level `#[AsCommand]` names relative to the class-level one

### DIFF
--- a/src/Symfony/Component/Console/Attribute/AsCommand.php
+++ b/src/Symfony/Component/Console/Attribute/AsCommand.php
@@ -18,7 +18,7 @@ namespace Symfony\Component\Console\Attribute;
 final class AsCommand
 {
     /**
-     * @param string      $name        The name of the command, used when calling it (i.e. "cache:clear")
+     * @param string      $name        The name of the command, used when calling it (i.e. "cache:clear"); on a method, it is relative to the name of the class-level attribute, if any
      * @param string|null $description The description of the command, displayed with the help page
      * @param string[]    $aliases     The list of aliases of the command. The command will be executed when using one of them (i.e. "cache:clean")
      * @param bool        $hidden      If true, the command won't be shown when listing all the available commands, but it can still be run as any other command

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -696,6 +696,26 @@ class Command implements SignalableCommandInterface
         if (!$attribute && '__invoke' === $reflection->getName()) {
             /** @var AsCommand|null $attribute */
             $attribute = ($class->getAttributes(AsCommand::class)[0] ?? null)?->newInstance();
+        } elseif ($attribute && '__invoke' !== $reflection->getName() && $prefix = ($class->getAttributes(AsCommand::class)[0] ?? null)?->newInstance()->name) {
+            // the class-level name prefixes the names declared on methods
+            $hidden = str_starts_with($prefix, '|');
+            if ($prefix = explode('|', ltrim($prefix, '|'))[0]) {
+                $names = explode('|', $attribute->name);
+                if ($hidden && '' !== $names[0]) {
+                    // the method commands of a hidden class-level command are hidden too
+                    array_unshift($names, '');
+                }
+                $attribute->name = implode('|', array_map(static function (string $name) use ($prefix, $class, $reflection) {
+                    if ('' === $name) {
+                        return $name;
+                    }
+                    if (str_starts_with($name, $prefix.':')) {
+                        throw new LogicException(\sprintf('The name "%s" of the command "%s::%s()" repeats the class-level name "%s": method-level names are relative to it, use "%s" instead.', $name, $class->getName(), $reflection->getName(), $prefix, substr($name, \strlen($prefix) + 1)));
+                    }
+
+                    return $prefix.':'.$name;
+                }, $names));
+            }
         }
 
         if (!$attribute) {

--- a/src/Symfony/Component/Console/DependencyInjection/AddConsoleCommandPass.php
+++ b/src/Symfony/Component/Console/DependencyInjection/AddConsoleCommandPass.php
@@ -52,8 +52,21 @@ class AddConsoleCommandPass implements CompilerPassInterface
                 throw new InvalidArgumentException(\sprintf('Class "%s" used for service "%s" cannot be found.', $class, $id));
             }
 
-            foreach ($commands as $tags) {
-                $this->registerCommand($container, $r, $id, $class, $tags, $definition, $serviceIds, $lazyCommandMap, $lazyCommandRefs);
+            // the class-level name prefixes the names declared on methods
+            $prefix = $commands['__invoke'][0]['command'] ?? $this->getCommandAttribute($r)?->name;
+            if (null !== $prefix) {
+                $hidden = str_starts_with($prefix, '|') ? '|' : '';
+                $prefix = explode('|', ltrim($prefix, '|'))[0];
+                $prefix = '' === $prefix ? null : $hidden.$prefix;
+            }
+
+            foreach ($commands as $method => $tags) {
+                if ('__invoke' === $method && 1 < \count($commands) && !$r->hasMethod('__invoke') && !$r->isSubclassOf(Command::class)) {
+                    // the class-level attribute only names the prefix of the method-level commands
+                    continue;
+                }
+
+                $this->registerCommand($container, $r, $id, $class, $tags, $definition, $serviceIds, $lazyCommandMap, $lazyCommandRefs, '__invoke' === $method ? null : $prefix);
             }
         }
 
@@ -66,13 +79,13 @@ class AddConsoleCommandPass implements CompilerPassInterface
         $container->setParameter('console.command.ids', $serviceIds);
     }
 
-    private function registerCommand(ContainerBuilder $container, \ReflectionClass $reflection, string $id, string $class, array $tags, Definition $definition, array &$serviceIds, array &$lazyCommandMap, array &$lazyCommandRefs): void
+    private function registerCommand(ContainerBuilder $container, \ReflectionClass $reflection, string $id, string $class, array $tags, Definition $definition, array &$serviceIds, array &$lazyCommandMap, array &$lazyCommandRefs, ?string $prefix = null): void
     {
         if (!$reflection->isSubclassOf(Command::class)) {
             $method = $tags[0]['method'] ?? '__invoke';
 
             if (!$reflection->hasMethod($method)) {
-                throw new InvalidArgumentException(\sprintf('The service "%s" tagged "%s" must either be a subclass of "%s" or have an "%s()" method.', $id, 'console.command', Command::class, $method));
+                throw new InvalidArgumentException(\sprintf('The service "%s" tagged "%s" must either be a subclass of "%s", have an "%s()" method%s.', $id, 'console.command', Command::class, $method, '__invoke' === $method ? ', or declare method-level commands' : ''));
             }
 
             $reflection = $reflection->getMethod($method);
@@ -103,9 +116,30 @@ class AddConsoleCommandPass implements CompilerPassInterface
         $definition->addTag('container.no_preload');
 
         $attribute = $this->getCommandAttribute($reflection);
-        $defaultName = $attribute?->name;
-        $aliases = str_replace('%', '%%', $tags[0]['command'] ?? $defaultName ?? '');
-        $aliases = explode('|', $aliases);
+        $aliases = $tags[0]['command'] ?? $attribute?->name ?? '';
+
+        if (null !== $prefix && '' !== $aliases) {
+            $names = explode('|', $aliases);
+            if (str_starts_with($prefix, '|')) {
+                // the method commands of a hidden class-level command are hidden too
+                $prefix = substr($prefix, 1);
+                if ('' !== $names[0]) {
+                    array_unshift($names, '');
+                }
+            }
+            $aliases = implode('|', array_map(static function (string $name) use ($prefix, $reflection) {
+                if ('' === $name) {
+                    return $name;
+                }
+                if (str_starts_with($name, $prefix.':')) {
+                    throw new InvalidArgumentException(\sprintf('The name "%s" of the command "%s::%s()" repeats the class-level name "%s": method-level names are relative to it, use "%s" instead.', $name, $reflection->class, $reflection->name, $prefix, substr($name, \strlen($prefix) + 1)));
+                }
+
+                return $prefix.':'.$name;
+            }, $names));
+        }
+
+        $aliases = explode('|', str_replace('%', '%%', $aliases));
         $commandName = array_shift($aliases);
 
         if ($isHidden = '' === $commandName) {

--- a/src/Symfony/Component/Console/Tests/Command/CommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Exception\InvalidOptionException;
+use Symfony\Component\Console\Exception\LogicException;
 use Symfony\Component\Console\Helper\FormatterHelper;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputDefinition;
@@ -28,6 +29,7 @@ use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Console\Tests\Fixtures\InvokableTestCommand;
+use Symfony\Component\Console\Tests\Fixtures\MethodBasedTestCommand;
 
 class CommandTest extends TestCase
 {
@@ -471,6 +473,30 @@ class CommandTest extends TestCase
         $this->assertEquals('interact called'.\PHP_EOL.'not bound'.\PHP_EOL, $tester->getDisplay());
     }
 
+    public function testMethodCommandNameIsPrefixedWithTheClassLevelName()
+    {
+        $command = new Command(code: new MethodBasedTestCommand()->cmd1(...));
+        $this->assertSame('app:cmd0:cmd1', $command->getName());
+
+        $command = new Command(code: new MethodBasedTestCommand());
+        $this->assertSame('app:cmd0', $command->getName());
+    }
+
+    public function testMethodCommandsOfAHiddenClassLevelNameAreHidden()
+    {
+        $command = new Command(code: new HiddenGroupCommands()->one(...));
+        $this->assertSame('hidden-group:one', $command->getName());
+        $this->assertTrue($command->isHidden());
+    }
+
+    public function testMethodCommandNameMustNotRepeatTheClassLevelName()
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('The name "group:one" of the command "Symfony\Component\Console\Tests\Command\RepeatedPrefixCommands::one()" repeats the class-level name "group": method-level names are relative to it, use "one" instead.');
+
+        new Command(code: new RepeatedPrefixCommands()->one(...));
+    }
+
     public function testCommandAttribute()
     {
         $command = new Php8Command();
@@ -515,6 +541,26 @@ function createClosure()
 #[AsCommand(name: 'foo', description: 'desc', usages: ['usage1', 'usage2'], hidden: true, aliases: ['f'], help: 'help')]
 class Php8Command extends Command
 {
+}
+
+#[AsCommand(name: 'hidden-group', hidden: true)]
+class HiddenGroupCommands
+{
+    #[AsCommand(name: 'one')]
+    public function one(): int
+    {
+        return Command::SUCCESS;
+    }
+}
+
+#[AsCommand(name: 'group')]
+class RepeatedPrefixCommands
+{
+    #[AsCommand(name: 'group:one')]
+    public function one(): int
+    {
+        return Command::SUCCESS;
+    }
 }
 
 #[AsCommand(name: 'foo2', description: 'desc2', hidden: true)]

--- a/src/Symfony/Component/Console/Tests/DependencyInjection/AddConsoleCommandPassTest.php
+++ b/src/Symfony/Component/Console/Tests/DependencyInjection/AddConsoleCommandPassTest.php
@@ -209,7 +209,7 @@ class AddConsoleCommandPassTest extends TestCase
         $container->setDefinition('my-command', $definition);
 
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('The service "my-command" tagged "console.command" must either be a subclass of "Symfony\Component\Console\Command\Command" or have an "__invoke()" method');
+        $this->expectExceptionMessage('The service "my-command" tagged "console.command" must either be a subclass of "Symfony\Component\Console\Command\Command", have an "__invoke()" method, or declare method-level commands.');
 
         $container->compile();
     }
@@ -252,19 +252,79 @@ class AddConsoleCommandPassTest extends TestCase
         /** @var ContainerCommandLoader $loader */
         $loader = $container->get('console.command_loader');
 
-        $this->assertSame(['app:cmd0', 'app:cmd1', 'app:cmd2'], $loader->getNames());
+        $this->assertSame(['app:cmd0', 'app:cmd0:cmd1', 'app:cmd0:cmd2'], $loader->getNames());
 
         $commandTester = new CommandTester($loader->get('app:cmd0'));
         $this->assertSame(Command::SUCCESS, $commandTester->execute([]));
         $this->assertSame('cmd0', $commandTester->getDisplay());
 
-        $commandTester = new CommandTester($loader->get('app:cmd1'));
+        $commandTester = new CommandTester($loader->get('app:cmd0:cmd1'));
         $this->assertSame(Command::SUCCESS, $commandTester->execute([]));
         $this->assertSame('cmd1', $commandTester->getDisplay());
 
-        $commandTester = new CommandTester($loader->get('app:cmd2'));
+        $commandTester = new CommandTester($loader->get('app:cmd0:cmd2'));
         $this->assertSame(Command::SUCCESS, $commandTester->execute([]));
         $this->assertSame('cmd2', $commandTester->getDisplay());
+    }
+
+    public function testProcessPrefixesMethodCommandsWithTheClassLevelName()
+    {
+        $container = new ContainerBuilder();
+
+        $definition = new Definition(GroupedCommands::class);
+        $definition->addTag('console.command');
+        $definition->addTag('console.command', ['method' => 'one']);
+        $definition->addTag('console.command', ['method' => 'two']);
+        $definition->addTag('console.command', ['method' => 'three', 'command' => 'tagged|t']);
+        $container->setDefinition(GroupedCommands::class, $definition);
+
+        new AddConsoleCommandPass()->process($container);
+        $container->compile();
+
+        /** @var ContainerCommandLoader $loader */
+        $loader = $container->get('console.command_loader');
+
+        $this->assertSame(['group:one', 'group:1', 'group:sub:two', 'group:tagged', 'group:t'], $loader->getNames());
+        $this->assertFalse($container->has(GroupedCommands::class.'.command'), 'A class-level attribute without __invoke() only names the prefix.');
+        $this->assertTrue($loader->get('group:one')->isHidden());
+        $this->assertSame(['group:1'], $loader->get('group:one')->getAliases());
+        $this->assertSame('Sub two', $loader->get('group:sub:two')->getDescription());
+    }
+
+    public function testProcessHidesTheMethodCommandsOfAHiddenClassLevelName()
+    {
+        $container = new ContainerBuilder();
+
+        $definition = new Definition(HiddenGroupCommands::class);
+        $definition->addTag('console.command');
+        $definition->addTag('console.command', ['method' => 'one']);
+        $definition->addTag('console.command', ['method' => 'two']);
+        $container->setDefinition(HiddenGroupCommands::class, $definition);
+
+        new AddConsoleCommandPass()->process($container);
+        $container->compile();
+
+        /** @var ContainerCommandLoader $loader */
+        $loader = $container->get('console.command_loader');
+
+        $this->assertSame(['hidden-group:one', 'hidden-group:two'], $loader->getNames());
+        $this->assertTrue($loader->get('hidden-group:one')->isHidden());
+        $this->assertTrue($loader->get('hidden-group:two')->isHidden());
+    }
+
+    public function testProcessRejectsAMethodCommandRepeatingTheClassLevelName()
+    {
+        $container = new ContainerBuilder();
+
+        $definition = new Definition(RepeatedPrefixCommands::class);
+        $definition->addTag('console.command');
+        $definition->addTag('console.command', ['method' => 'one']);
+        $container->setDefinition(RepeatedPrefixCommands::class, $definition);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The name "group:one" of the command "Symfony\Component\Console\Tests\DependencyInjection\RepeatedPrefixCommands::one()" repeats the class-level name "group": method-level names are relative to it, use "one" instead.');
+
+        new AddConsoleCommandPass()->process($container);
     }
 
     public function testProcessOnChildDefinitionWithClass()
@@ -444,6 +504,53 @@ class DescriptionWithPercentageSignsCommand
 {
     public function __invoke(): void
     {
+    }
+}
+
+#[AsCommand(name: 'group', description: 'A group without code of its own')]
+class GroupedCommands
+{
+    #[AsCommand(name: 'one', aliases: ['1'], hidden: true)]
+    public function one(): int
+    {
+        return Command::SUCCESS;
+    }
+
+    #[AsCommand(name: 'sub:two', description: 'Sub two')]
+    public function two(): int
+    {
+        return Command::SUCCESS;
+    }
+
+    public function three(): int
+    {
+        return Command::SUCCESS;
+    }
+}
+
+#[AsCommand(name: 'hidden-group', hidden: true)]
+class HiddenGroupCommands
+{
+    #[AsCommand(name: 'one')]
+    public function one(): int
+    {
+        return Command::SUCCESS;
+    }
+
+    #[AsCommand(name: 'two', hidden: true)]
+    public function two(): int
+    {
+        return Command::SUCCESS;
+    }
+}
+
+#[AsCommand(name: 'group')]
+class RepeatedPrefixCommands
+{
+    #[AsCommand(name: 'group:one')]
+    public function one(): int
+    {
+        return Command::SUCCESS;
     }
 }
 

--- a/src/Symfony/Component/Console/Tests/Fixtures/MethodBasedTestCommand.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/MethodBasedTestCommand.php
@@ -26,7 +26,7 @@ class MethodBasedTestCommand
         return Command::SUCCESS;
     }
 
-    #[AsCommand('app:cmd1')]
+    #[AsCommand('cmd1')]
     public function cmd1(OutputInterface $o, #[Argument] ?string $name = null): int
     {
         $o->write('cmd1');
@@ -34,7 +34,7 @@ class MethodBasedTestCommand
         return Command::SUCCESS;
     }
 
-    #[AsCommand('app:cmd2')]
+    #[AsCommand('cmd2')]
     public function cmd2(OutputInterface $o): int
     {
         $o->write('cmd2');

--- a/src/Symfony/Component/Console/Tests/Tester/CommandTesterTest.php
+++ b/src/Symfony/Component/Console/Tests/Tester/CommandTesterTest.php
@@ -391,11 +391,11 @@ class CommandTesterTest extends TestCase
         $application->setAutoExit(false);
 
         $bufferedOutput = new BufferedOutput();
-        $statusCode = $application->run(new ArrayInput(['command' => 'help', 'command_name' => 'app:cmd1']), $bufferedOutput);
+        $statusCode = $application->run(new ArrayInput(['command' => 'help', 'command_name' => 'app:cmd0:cmd1']), $bufferedOutput);
 
         $expectedOutput = <<<TXT
             Usage:
-              app:cmd1 [<name>]
+              app:cmd0:cmd1 [<name>]
 
             Arguments:
               name %S


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Method-based commands, added in 8.1, ignore the `#[AsCommand]` attribute of their class: with `#[AsCommand('docker')]` on the class and `#[AsCommand('compose:up')]` on a method, the method registers `compose:up`, while a class-level attribute without `__invoke()` is rejected outright, even when the class declares commands on its methods. Every name in one class ends up unrelated to the class it lives in, unlike `#[Route]`, where the class-level attribute prefixes the methods'.

This makes the class-level name the prefix of every name declared on a method, command name and aliases alike, so the class above registers `docker:compose:up`. A class-level attribute without `__invoke()` is accepted as soon as the class declares method-level commands: it then only names the prefix. With `__invoke()`, the class command is registered as before, next to its prefixed methods. Classes without a class-level attribute, or with `__invoke()` only, are unchanged, and manual `console.command` tags carrying a `method` follow the same rule as the attribute.

A hidden class-level command hides its method commands too, since a hidden group has no visible part. The rule applies on both registration paths, the compiler pass and `Application::addCommand($object->method(...))`, so a method command has a single name however it is registered.

A method name that already starts with the class-level name fails at compile time with the corrected spelling in the message: a class that spelled full names on 8.1 gets an actionable error rather than a silently doubled prefix.

Fixing this on 8.1, where method-based commands shipped, so that the sub-command trees of #65825 and a class-as-group model on top of them build on one naming rule.

Docs: symfony/symfony-docs#22927

