### PR TITLE
[Console] Fix signal handling of invokable commands registered through the container

### DIFF
--- a/src/Symfony/Component/Console/Command/InvokableCommand.php
+++ b/src/Symfony/Component/Console/Command/InvokableCommand.php
@@ -50,8 +50,11 @@ class InvokableCommand implements SignalableCommandInterface
         private ?ArgumentResolverInterface $argumentResolver = null,
     ) {
         $this->code = $code;
-        $this->signalableCommand = $code instanceof SignalableCommandInterface ? $code : null;
         $this->invokable = new \ReflectionFunction($this->getClosure($code));
+
+        // the container wraps the service in a closure; a closure bound to the command itself must not handle its signals
+        $code = $this->invokable->getClosureThis();
+        $this->signalableCommand = $code instanceof SignalableCommandInterface && !$code instanceof Command ? $code : null;
     }
 
     /**

--- a/src/Symfony/Component/Console/Tests/Command/InvokableCommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/InvokableCommandTest.php
@@ -24,6 +24,7 @@ use Symfony\Component\Console\Attribute\MapDateTime;
 use Symfony\Component\Console\Attribute\Option;
 use Symfony\Component\Console\Attribute\Reflection\ReflectionMember;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Command\SignalableCommandInterface;
 use Symfony\Component\Console\Completion\CompletionInput;
 use Symfony\Component\Console\Completion\CompletionSuggestions;
 use Symfony\Component\Console\Completion\Suggestion;
@@ -741,6 +742,59 @@ class InvokableCommandTest extends TestCase
         self::assertStringContainsString('Enter a value:', $tester->getDisplay());
         self::assertStringContainsString('Value must be "valid"', $tester->getDisplay());
         self::assertStringContainsString('Value: valid', $tester->getDisplay());
+    }
+
+    public function testSignalsOfAnInvokableWrappedInAClosure()
+    {
+        $invokable = new class implements SignalableCommandInterface {
+            public array $handled = [];
+
+            public function __invoke(): int
+            {
+                return 0;
+            }
+
+            public function run(): int
+            {
+                return 0;
+            }
+
+            public function getSubscribedSignals(): array
+            {
+                return [1, 2];
+            }
+
+            public function handleSignal(int $signal, int|false $previousExitCode = 0): int|false
+            {
+                $this->handled[] = $signal;
+
+                return 3;
+            }
+        };
+
+        foreach ([\Closure::fromCallable($invokable), \Closure::fromCallable([$invokable, 'run']), $invokable->run(...)] as $code) {
+            $command = new Command('signal');
+            $command->setCode($code);
+
+            $this->assertSame([1, 2], $command->getSubscribedSignals());
+            $this->assertSame(3, $command->handleSignal(1));
+        }
+
+        $this->assertSame([1, 1, 1], $invokable->handled);
+    }
+
+    public function testAClosureBoundToTheCommandDoesNotHandleItsSignals()
+    {
+        $command = new class('signal') extends Command {
+            public function __construct(string $name)
+            {
+                parent::__construct($name);
+                $this->setCode(static fn () => 0);
+            }
+        };
+
+        $this->assertSame([], $command->getSubscribedSignals());
+        $this->assertFalse($command->handleSignal(1));
     }
 }
 

--- a/src/Symfony/Component/Console/Tests/DependencyInjection/AddConsoleCommandPassTest.php
+++ b/src/Symfony/Component/Console/Tests/DependencyInjection/AddConsoleCommandPassTest.php
@@ -401,6 +401,7 @@ class AddConsoleCommandPassTest extends TestCase
         self::assertTrue($container->has('invokable_signalable_command.command'));
         self::assertSame('The command description', $command->getDescription());
         self::assertSame('The %command.name% command help content.', $command->getHelp());
+        self::assertSame([15], $command->getCommand()->getSubscribedSignals());
     }
 }
 
@@ -456,7 +457,7 @@ class InvokableSignalableCommand implements SignalableCommandInterface
 
     public function getSubscribedSignals(): array
     {
-        return [];
+        return [15];
     }
 
     public function handleSignal(int $signal, false|int $previousExitCode = 0): int|false


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Since 8.1, `AddConsoleCommandPass` wraps a command service in a `Closure` before passing it to `Command::setCode()`: `Closure::fromCallable($service)` for an invokable class, `Closure::fromCallable([$service, $method])` for a method-based command. `InvokableCommand` tested `$code instanceof SignalableCommandInterface` on that closure, so an invokable command registered through the container and implementing `SignalableCommandInterface` subscribed to no signal at all: `getSubscribedSignals()` returned `[]` and `handleSignal()` was never called, while the same class passed as an object to `setCode()` worked. 7.4 is not affected, its pass passes the service object itself.

The invokable is now resolved through the object bound to the closure, which covers the two container shapes and first-class callables. A closure bound to the command itself, such as a `setCode(function () {})` in a `Command` subclass or an unbound closure that `InvokableCommand` binds to the command, is left out: `Command::getSubscribedSignals()` delegates to its code, so it would delegate to itself.

Tests: a unit test covers the `__invoke`, `[$object, 'method']` and first-class-callable shapes plus the command-bound closure; the compiler pass test now asserts the subscribed signals of the compiled command, unwrapping the `LazyCommand` the way `Application::doRun()` does before running a command.

Checks: the Console suite passes locally except the two `QuestionHelper` stdin tests that fail on every branch in my environment; the FrameworkBundle Console and Command tests pass; php-cs-fixer is clean.

Merge-up to 8.2: the `InvokableCommand` constructor has the same three lines there, no conflict expected.
