### PR TITLE
[Console] Register class-level `#[AsCommand]` groups and let the attribute list options

### DIFF
--- a/src/Symfony/Component/Console/Attribute/AsCommand.php
+++ b/src/Symfony/Component/Console/Attribute/AsCommand.php
@@ -11,6 +11,9 @@
 
 namespace Symfony\Component\Console\Attribute;
 
+use Symfony\Component\Console\Exception\InvalidArgumentException;
+use Symfony\Component\Console\Input\InputOption;
+
 /**
  * Service tag to autoconfigure commands.
  */
@@ -27,6 +30,7 @@ final class AsCommand
      * @param bool                            $hidden      If true, the command won't be shown when listing all the available commands, but it can still be run as any other command
      * @param string|(callable():string)|null $help        The help content of the command, displayed with the help page
      * @param string[]                        $usages      The list of usage examples, displayed with the help page
+     * @param InputOption[]                   $options     Options to add after the ones the parameters of the command declare
      */
     public function __construct(
         public string $name,
@@ -35,7 +39,14 @@ final class AsCommand
         bool $hidden = false,
         string|callable|null $help = null,
         public array $usages = [],
+        public array $options = [],
     ) {
+        foreach ($options as $option) {
+            if (!$option instanceof InputOption) {
+                throw new InvalidArgumentException(\sprintf('The "options" of the "%s" command must be "%s" instances, "%s" given.', $name, InputOption::class, get_debug_type($option)));
+            }
+        }
+
         $this->description = null === $description || \is_string($description) ? $description : $description();
         $this->help = null === $help || \is_string($help) ? $help : $help();
 

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG
 8.2
 ---
 
+ * Allow `#[AsCommand]` to list `InputOption`s to add after the ones the parameters of the command declare
+ * Register a class-level `#[AsCommand]` without `__invoke()` as the command grouping its method-level ones
  * Resolve spaced sub-command invocations through the tree derived from registered command names, with per-level options and `--` binding the remaining tokens to the current command
  * List the sub-commands of a command invoked bare when it has no code of its own, on the error output and with exit code 1 like a bare namespace
  * Walk namespaces without a registered root command the same way: `cache clear` runs `cache:clear`

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -111,6 +111,13 @@ class Command implements SignalableCommandInterface
         }
 
         $this->configure();
+
+        if (!$this->code) {
+            // the options listed in the attribute come last, after configure(), which a command with code gets from InvokableCommand
+            foreach ($attribute->options ?? [] as $option) {
+                $this->definition->addOption($option);
+            }
+        }
     }
 
     /**

--- a/src/Symfony/Component/Console/Command/InvokableCommand.php
+++ b/src/Symfony/Component/Console/Command/InvokableCommand.php
@@ -15,6 +15,7 @@ use Symfony\Component\Console\Application;
 use Symfony\Component\Console\ArgumentResolver\ArgumentResolver;
 use Symfony\Component\Console\ArgumentResolver\ArgumentResolverInterface;
 use Symfony\Component\Console\Attribute\Argument;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Attribute\Interact;
 use Symfony\Component\Console\Attribute\MapInput;
 use Symfony\Component\Console\Attribute\Option;
@@ -105,6 +106,19 @@ class InvokableCommand implements SignalableCommandInterface
                     $definition->addOption($option->toInputOption());
                 }
             }
+        }
+
+        // the options listed in the attribute come after the ones the parameters declare
+        $class = $this->invokable->getClosureScopeClass();
+        $name = $this->invokable->getName();
+        $attribute = $class?->hasMethod($name) ? ($class->getMethod($name)->getAttributes(AsCommand::class)[0] ?? null)?->newInstance() : null;
+
+        if (!$attribute && '__invoke' === $name) {
+            $attribute = ($class?->getAttributes(AsCommand::class)[0] ?? null)?->newInstance();
+        }
+
+        foreach ($attribute->options ?? [] as $option) {
+            $definition->addOption($option);
         }
     }
 

--- a/src/Symfony/Component/Console/DependencyInjection/AddConsoleCommandPass.php
+++ b/src/Symfony/Component/Console/DependencyInjection/AddConsoleCommandPass.php
@@ -15,6 +15,10 @@ use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Command\LazyCommand;
 use Symfony\Component\Console\CommandLoader\ContainerCommandLoader;
+use Symfony\Component\Console\Completion\CompletionInput;
+use Symfony\Component\Console\Completion\CompletionSuggestions;
+use Symfony\Component\Console\Completion\Suggestion;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
@@ -44,6 +48,8 @@ class AddConsoleCommandPass implements CompilerPassInterface
             }
         }
 
+        $groups = [];
+
         foreach ($commandServices as $id => $commands) {
             $definition = $container->getDefinition($id);
             $class = $container->getParameterBag()->resolveValue($definition->getClass());
@@ -61,13 +67,24 @@ class AddConsoleCommandPass implements CompilerPassInterface
             }
 
             foreach ($commands as $method => $tags) {
+                // a class-level attribute without __invoke() registers the command grouping the method-level ones
                 if ('__invoke' === $method && 1 < \count($commands) && !$r->hasMethod('__invoke') && !$r->isSubclassOf(Command::class)) {
-                    // the class-level attribute only names the prefix of the method-level commands
+                    $groups[] = [ltrim($prefix ?? '', '|'), $r, $id, $class, $tags, $definition];
+
                     continue;
                 }
 
                 $this->registerCommand($container, $r, $id, $class, $tags, $definition, $serviceIds, $lazyCommandMap, $lazyCommandRefs, '__invoke' === $method ? null : $prefix);
             }
+        }
+
+        // groups are registered last, so that a command registered under the same name keeps it
+        foreach ($groups as [$name, $r, $id, $class, $tags, $definition]) {
+            if (isset($lazyCommandMap[$name])) {
+                continue;
+            }
+
+            $this->registerCommand($container, $r, $id, $class, $tags, $definition, $serviceIds, $lazyCommandMap, $lazyCommandRefs, null, true);
         }
 
         $container
@@ -79,9 +96,11 @@ class AddConsoleCommandPass implements CompilerPassInterface
         $container->setParameter('console.command.ids', $serviceIds);
     }
 
-    private function registerCommand(ContainerBuilder $container, \ReflectionClass $reflection, string $id, string $class, array $tags, Definition $definition, array &$serviceIds, array &$lazyCommandMap, array &$lazyCommandRefs, ?string $prefix = null): void
+    private function registerCommand(ContainerBuilder $container, \ReflectionClass $reflection, string $id, string $class, array $tags, Definition $definition, array &$serviceIds, array &$lazyCommandMap, array &$lazyCommandRefs, ?string $prefix = null, bool $group = false): void
     {
-        if (!$reflection->isSubclassOf(Command::class)) {
+        if ($group) {
+            $definition = $container->register($id .= '.command', $class = Command::class);
+        } elseif (!$reflection->isSubclassOf(Command::class)) {
             $method = $tags[0]['method'] ?? '__invoke';
 
             if (!$reflection->hasMethod($method)) {
@@ -182,6 +201,12 @@ class AddConsoleCommandPass implements CompilerPassInterface
 
         $definition->addMethodCall('setName', [$commandName]);
 
+        if ($group) {
+            foreach ($attribute->options ?? [] as $option) {
+                $definition->addMethodCall('addOption', $this->getOptionCall($option));
+            }
+        }
+
         if ($aliases) {
             $definition->addMethodCall('setAliases', [$aliases]);
         }
@@ -227,5 +252,35 @@ class AddConsoleCommandPass implements CompilerPassInterface
         }
 
         return $attribute;
+    }
+
+    /**
+     * @return array{string, ?string, int, string, mixed, array}
+     */
+    private function getOptionCall(InputOption $option): array
+    {
+        $mode = ($option->acceptValue() ? ($option->isValueRequired() ? InputOption::VALUE_REQUIRED : InputOption::VALUE_OPTIONAL) : InputOption::VALUE_NONE)
+            | ($option->isArray() ? InputOption::VALUE_IS_ARRAY : 0)
+            | ($option->isNegatable() ? InputOption::VALUE_NEGATABLE : 0)
+            | ($option->isDeprecated() ? InputOption::DEPRECATED : 0)
+            | ($option->isHidden() ? InputOption::HIDDEN : 0);
+        $default = $option->acceptValue() || $option->isNegatable() ? $option->getDefault() : null;
+
+        return [$option->getName(), $option->getShortcut(), $mode, $option->getDescription(), $default, $this->getSuggestedValues($option)];
+    }
+
+    /**
+     * Turns the suggested values of an option into what the container can dump.
+     */
+    private function getSuggestedValues(InputOption $option): array
+    {
+        if (!$option->hasCompletion()) {
+            return [];
+        }
+
+        $suggestions = new CompletionSuggestions();
+        $option->complete(CompletionInput::fromTokens([], 0), $suggestions);
+
+        return array_map(static fn (Suggestion $suggestion) => '' === $suggestion->getDescription() ? $suggestion->getValue() : new Definition(Suggestion::class, [$suggestion->getValue(), $suggestion->getDescription()]), $suggestions->getValueSuggestions());
     }
 }

--- a/src/Symfony/Component/Console/Tests/Command/CommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandTest.php
@@ -15,7 +15,9 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Attribute\Argument;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Attribute\Option;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Exception\InvalidOptionException;
 use Symfony\Component\Console\Exception\LogicException;
@@ -583,6 +585,100 @@ class CommandTest extends TestCase
 
         $this->assertSame('define', $command->getDescription());
         $this->assertSame('define', $command->getHelp());
+    }
+
+    public function testAttributeListedOptionsComeAfterTheParameters()
+    {
+        $invokable = new #[AsCommand(name: 'foo', options: [new InputOption('flag', 'f', InputOption::VALUE_NONE, 'Flag')])] class {
+            public function __invoke(#[Argument] string $name = '', #[Option] bool $dryRun = false): int
+            {
+                return 0;
+            }
+        };
+
+        $definition = new Command(null, $invokable)->getDefinition();
+
+        $this->assertSame(['name'], array_keys($definition->getArguments()));
+        $this->assertSame(['dry-run', 'flag'], array_keys($definition->getOptions()));
+        $this->assertSame('f', $definition->getOption('flag')->getShortcut());
+        $this->assertSame('Flag', $definition->getOption('flag')->getDescription());
+    }
+
+    public function testAttributeListedOptionsOnAMethodCommand()
+    {
+        $object = new class {
+            #[AsCommand(name: 'foo', options: [new InputOption('flag')])]
+            public function run(#[Argument] string $name = ''): int
+            {
+                return 0;
+            }
+        };
+
+        $definition = new Command(null, $object->run(...))->getDefinition();
+
+        $this->assertSame(['name'], array_keys($definition->getArguments()));
+        $this->assertSame(['flag'], array_keys($definition->getOptions()));
+    }
+
+    public function testAttributeListedOptionsOnACommandSubclass()
+    {
+        $command = new #[AsCommand(name: 'foo', options: [new InputOption('flag')])] class extends Command {
+            protected function configure(): void
+            {
+                $this->addOption('configured');
+            }
+        };
+
+        $this->assertSame(['configured', 'flag'], array_keys($command->getDefinition()->getOptions()));
+    }
+
+    public function testAttributeListedOptionsSurviveASetDefinitionCall()
+    {
+        $command = new #[AsCommand(name: 'foo', options: [new InputOption('flag')])] class extends Command {
+            protected function configure(): void
+            {
+                $this->setDefinition([new InputArgument('arg')]);
+            }
+        };
+
+        $this->assertSame(['arg'], array_keys($command->getDefinition()->getArguments()));
+        $this->assertSame(['flag'], array_keys($command->getNativeDefinition()->getOptions()));
+    }
+
+    public function testAttributeListedOptionsOnAnInvokableCommandSubclass()
+    {
+        $command = new #[AsCommand(name: 'foo', options: [new InputOption('flag')])] class extends Command {
+            public function __invoke(#[Argument] string $name = ''): int
+            {
+                return 0;
+            }
+        };
+
+        $this->assertSame(['name'], array_keys($command->getDefinition()->getArguments()));
+        $this->assertSame(['flag'], array_keys($command->getDefinition()->getOptions()));
+    }
+
+    public function testAttributeListedOptionMustNotRepeatAParameter()
+    {
+        $invokable = new #[AsCommand(name: 'foo', options: [new InputOption('flag', null, InputOption::VALUE_REQUIRED)])] class {
+            public function __invoke(#[Option] bool $flag = false): int
+            {
+                return 0;
+            }
+        };
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('An option named "flag" already exists.');
+
+        new Command(null, $invokable)->getDefinition();
+    }
+
+    public function testAttributeListedOptionsMustBeInputOptions()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "options" of the "foo" command must be "Symfony\Component\Console\Input\InputOption" instances, "string" given.');
+
+        new AsCommand(name: 'foo', options: ['flag']);
     }
 
     public function testDefaultCommand()

--- a/src/Symfony/Component/Console/Tests/DependencyInjection/AddConsoleCommandPassTest.php
+++ b/src/Symfony/Component/Console/Tests/DependencyInjection/AddConsoleCommandPassTest.php
@@ -13,12 +13,21 @@ namespace Symfony\Component\Console\Tests\DependencyInjection;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Command\LazyCommand;
 use Symfony\Component\Console\Command\SignalableCommandInterface;
+use Symfony\Component\Console\CommandChain;
 use Symfony\Component\Console\CommandLoader\ContainerCommandLoader;
+use Symfony\Component\Console\Completion\CompletionInput;
+use Symfony\Component\Console\Completion\CompletionSuggestions;
+use Symfony\Component\Console\Completion\Suggestion;
 use Symfony\Component\Console\DependencyInjection\AddConsoleCommandPass;
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Console\Tests\Fixtures\MethodBasedTestCommand;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
@@ -26,6 +35,7 @@ use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Dumper\PhpDumper;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\TypedReference;
 
@@ -284,11 +294,79 @@ class AddConsoleCommandPassTest extends TestCase
         /** @var ContainerCommandLoader $loader */
         $loader = $container->get('console.command_loader');
 
-        $this->assertSame(['group:one', 'group:1', 'group:sub:two', 'group:tagged', 'group:t'], $loader->getNames());
-        $this->assertFalse($container->has(GroupedCommands::class.'.command'), 'A class-level attribute without __invoke() only names the prefix.');
+        $this->assertSame(['group:one', 'group:1', 'group:sub:two', 'group:tagged', 'group:t', 'group'], $loader->getNames());
+        $this->assertTrue($container->has(GroupedCommands::class.'.command'), 'A class-level attribute without __invoke() registers the group command.');
         $this->assertTrue($loader->get('group:one')->isHidden());
         $this->assertSame(['group:1'], $loader->get('group:one')->getAliases());
         $this->assertSame('Sub two', $loader->get('group:sub:two')->getDescription());
+
+        $group = $loader->get('group');
+        $this->assertSame('A group without code of its own', $group->getDescription());
+        $option = $group->getDefinition()->getOption('context');
+        $this->assertSame('c', $option->getShortcut());
+        $this->assertTrue($option->isValueRequired());
+        $this->assertSame('default', $option->getDefault());
+        $suggestions = new CompletionSuggestions();
+        $option->complete(CompletionInput::fromTokens([], 0), $suggestions);
+        $this->assertSame(['a', 'b'], array_map(static fn (Suggestion $s) => $s->getValue(), $suggestions->getValueSuggestions()));
+        $this->assertSame('B', $suggestions->getValueSuggestions()[1]->getDescription());
+        $this->assertStringContainsString("'context'", new PhpDumper($container)->dump(), 'The listed options are dumped as scalars.');
+    }
+
+    public function testProcessedGroupRunsAsACommandTree()
+    {
+        $container = new ContainerBuilder();
+
+        $definition = new Definition(DockerCommands::class);
+        $definition->addTag('console.command');
+        $definition->addTag('console.command', ['method' => 'up']);
+        $container->setDefinition(DockerCommands::class, $definition);
+
+        new AddConsoleCommandPass()->process($container);
+        $container->compile();
+
+        $application = new Application();
+        $application->setAutoExit(false);
+        $application->setCommandLoader($container->get('console.command_loader'));
+
+        $output = new BufferedOutput();
+        $this->assertSame(0, $application->run(new ArgvInput(['cli.php', 'docker', '-c', 'prod', 'compose', 'up']), $output));
+        $this->assertSame('prod', $output->fetch());
+
+        $this->assertSame(1, $application->run(new ArgvInput(['cli.php', 'docker']), $output));
+        $this->assertStringContainsString('docker:compose:up', $output->fetch());
+    }
+
+    #[DataProvider('groupRegistrationOrderProvider')]
+    public function testACommandRegisteredUnderTheGroupNameKeepsIt(bool $groupFirst)
+    {
+        $container = new ContainerBuilder();
+
+        $group = new Definition(GroupedCommands::class);
+        $group->addTag('console.command');
+        $group->addTag('console.command', ['method' => 'one']);
+
+        $explicit = new Definition(ExplicitGroupCommand::class);
+        $explicit->addTag('console.command');
+
+        foreach ($groupFirst ? ['group_service' => $group, 'explicit_service' => $explicit] : ['explicit_service' => $explicit, 'group_service' => $group] as $id => $definition) {
+            $container->setDefinition($id, $definition);
+        }
+
+        new AddConsoleCommandPass()->process($container);
+        $container->compile();
+
+        /** @var ContainerCommandLoader $loader */
+        $loader = $container->get('console.command_loader');
+
+        $this->assertSame('An explicit command', $loader->get('group')->getDescription());
+        $this->assertTrue($loader->has('group:one'));
+    }
+
+    public static function groupRegistrationOrderProvider(): iterable
+    {
+        yield 'group first' => [true];
+        yield 'explicit first' => [false];
     }
 
     public function testProcessHidesTheMethodCommandsOfAHiddenClassLevelName()
@@ -307,7 +385,8 @@ class AddConsoleCommandPassTest extends TestCase
         /** @var ContainerCommandLoader $loader */
         $loader = $container->get('console.command_loader');
 
-        $this->assertSame(['hidden-group:one', 'hidden-group:two'], $loader->getNames());
+        $this->assertSame(['hidden-group:one', 'hidden-group:two', 'hidden-group'], $loader->getNames());
+        $this->assertTrue($loader->get('hidden-group')->isHidden());
         $this->assertTrue($loader->get('hidden-group:one')->isHidden());
         $this->assertTrue($loader->get('hidden-group:two')->isHidden());
     }
@@ -523,7 +602,7 @@ class DescriptionWithPercentageSignsCommand
     }
 }
 
-#[AsCommand(name: 'group', description: 'A group without code of its own')]
+#[AsCommand(name: 'group', description: 'A group without code of its own', options: [new InputOption('context', 'c', InputOption::VALUE_REQUIRED, 'The context', 'default', ['a', new Suggestion('b', 'B')])])]
 class GroupedCommands
 {
     #[AsCommand(name: 'one', aliases: ['1'], hidden: true)]
@@ -542,6 +621,23 @@ class GroupedCommands
     {
         return Command::SUCCESS;
     }
+}
+
+#[AsCommand(name: 'docker', description: 'Manage containers', options: [new InputOption('context', 'c', InputOption::VALUE_REQUIRED)])]
+class DockerCommands
+{
+    #[AsCommand(name: 'compose:up')]
+    public function up(CommandChain $chain, OutputInterface $output): int
+    {
+        $output->write($chain->getInput('docker')->getOption('context'));
+
+        return Command::SUCCESS;
+    }
+}
+
+#[AsCommand(name: 'group', description: 'An explicit command')]
+class ExplicitGroupCommand extends Command
+{
 }
 
 #[AsCommand(name: 'hidden-group', hidden: true)]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Follows #65825, now merged.

This completes the class-as-group model for sub-commands. With #65851, the class-level `#[AsCommand]` prefixes the names declared on the methods of a class; with #65825, registered names form walkable trees. What was missing is a way for the group itself to carry a description and options without code, and a way for any command to declare options its code does not take as parameters.

## `#[AsCommand]` lists options

```php
#[AsCommand('docker', description: 'Manage containers', options: [
    new InputOption('context', 'c', InputOption::VALUE_REQUIRED, 'The docker context', 'default'),
])]
class DockerCommands
{
    public function __construct(private DockerClient $client) {}

    #[AsCommand('compose:up', description: 'Create and start containers')]
    public function up(CommandChain $chain, #[Argument] string $service = '', #[Option(shortcut: 'd')] bool $detach = false): int
    {
        $context = $chain->getInput('docker')?->getOption('context');
        // ...
    }
}
```

The `options` entry holds `InputOption` objects, the way Validator constraints nest in attributes. They are added after the options the parameters of the command declare, on any target: an invokable class, a method command, a `Command` subclass. A name declared both ways fails at definition time with the usual `InputDefinition` error. `#[Option]` parameters remain the way to receive a value in the code; the attribute list is for options the code reads from `$input`, or that sub-commands read through `CommandChain`. There is no `arguments` entry: a command with code declares its arguments on parameters, and at a group a positional token is a sub-command first.

## A class-level attribute without `__invoke()` registers the group

Since #65851, such a class-level attribute names the prefix of the method commands. It now also registers the group command itself, lazily, with the description, help, usages, aliases and hidden flag of the attribute, and with its listed options. Invoked bare, the group lists its sub-commands like any code-less command with descendants; `docker -c prod compose up` binds `--context` at the `docker` level and the leaf reads it through the chain; `docker --help` shows the group with its sub-commands. The compiler pass translates the listed options into `addOption()` calls made of scalars, so the container stays dumpable; suggested values are arrays of strings or `Suggestion` objects, closures being impossible in attributes anyway.

Manual registration keeps its shape: `Application::addCommand($object->method(...))` registers the method commands, and a group that needs a description or options by hand stays a `Command` subclass.

## Behavior change

A class with a class-level `#[AsCommand]`, method-level commands and no `__invoke()` now registers a command named after the class-level attribute, where 8.1 only used it as a prefix. In the application listing, the tree below it collapses to that one line, and the bare name lists the sub-commands on the error output with exit code 1, as a bare namespace does.

For the docs: the `options` entry and its order relative to the parameters, and the class-as-group model: class-level attribute as the group node, methods as sub-commands, shared services in the constructor, group options read through `CommandChain`.

Checks: the Console suite passes locally except the two `QuestionHelper` stdin tests that fail on every branch in my environment; the FrameworkBundle Console and Command tests pass; php-cs-fixer is clean; each of the two commits was written test-first.




