### PR TITLE
[Console] Reject `#[AsCommand]` on both a class and its `__invoke()` method

### DIFF
--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -693,10 +693,16 @@ class Command implements SignalableCommandInterface
         /** @var AsCommand|null $attribute */
         $attribute = ($reflection->getAttributes(AsCommand::class)[0] ?? null)?->newInstance();
 
-        if (!$attribute && '__invoke' === $reflection->getName()) {
+        if ('__invoke' === $reflection->getName()) {
+            $classAttribute = $class->getAttributes(AsCommand::class)[0] ?? null;
+
+            if ($attribute && $classAttribute) {
+                throw new LogicException(\sprintf('The "%s" class and its "__invoke()" method cannot both have the "%s" attribute.', $class->getName(), AsCommand::class));
+            }
+
             /** @var AsCommand|null $attribute */
-            $attribute = ($class->getAttributes(AsCommand::class)[0] ?? null)?->newInstance();
-        } elseif ($attribute && '__invoke' !== $reflection->getName() && $prefix = ($class->getAttributes(AsCommand::class)[0] ?? null)?->newInstance()->name) {
+            $attribute ??= $classAttribute?->newInstance();
+        } elseif ($attribute && $prefix = ($class->getAttributes(AsCommand::class)[0] ?? null)?->newInstance()->name) {
             // the class-level name prefixes the names declared on methods
             $hidden = str_starts_with($prefix, '|');
             if ($prefix = explode('|', ltrim($prefix, '|'))[0]) {

--- a/src/Symfony/Component/Console/DependencyInjection/AddConsoleCommandPass.php
+++ b/src/Symfony/Component/Console/DependencyInjection/AddConsoleCommandPass.php
@@ -214,14 +214,18 @@ class AddConsoleCommandPass implements CompilerPassInterface
     private function getCommandAttribute(\ReflectionClass|\ReflectionMethod $reflection): ?AsCommand
     {
         /** @var AsCommand|null $attribute */
-        if ($attribute = ($reflection->getAttributes(AsCommand::class)[0] ?? null)?->newInstance()) {
-            return $attribute;
-        }
+        $attribute = ($reflection->getAttributes(AsCommand::class)[0] ?? null)?->newInstance();
 
         if ($reflection instanceof \ReflectionMethod && '__invoke' === $reflection->getName()) {
-            return ($reflection->getDeclaringClass()->getAttributes(AsCommand::class)[0] ?? null)?->newInstance();
+            $classAttribute = $reflection->getDeclaringClass()->getAttributes(AsCommand::class)[0] ?? null;
+
+            if ($attribute && $classAttribute) {
+                throw new InvalidArgumentException(\sprintf('The "%s" class and its "__invoke()" method cannot both have the "%s" attribute.', $reflection->class, AsCommand::class));
+            }
+
+            $attribute ??= $classAttribute?->newInstance();
         }
 
-        return null;
+        return $attribute;
     }
 }

--- a/src/Symfony/Component/Console/Tests/Command/CommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandTest.php
@@ -489,6 +489,14 @@ class CommandTest extends TestCase
         $this->assertTrue($command->isHidden());
     }
 
+    public function testTheAttributeCannotBeOnBothTheClassAndItsInvokeMethod()
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('The "Symfony\Component\Console\Tests\Command\AttributeOnBothCommand" class and its "__invoke()" method cannot both have the "Symfony\Component\Console\Attribute\AsCommand" attribute.');
+
+        new Command(code: new AttributeOnBothCommand());
+    }
+
     public function testMethodCommandNameMustNotRepeatTheClassLevelName()
     {
         $this->expectException(LogicException::class);
@@ -548,6 +556,16 @@ class HiddenGroupCommands
 {
     #[AsCommand(name: 'one')]
     public function one(): int
+    {
+        return Command::SUCCESS;
+    }
+}
+
+#[AsCommand(name: 'both')]
+class AttributeOnBothCommand
+{
+    #[AsCommand(name: 'both-invoke')]
+    public function __invoke(): int
     {
         return Command::SUCCESS;
     }

--- a/src/Symfony/Component/Console/Tests/DependencyInjection/AddConsoleCommandPassTest.php
+++ b/src/Symfony/Component/Console/Tests/DependencyInjection/AddConsoleCommandPassTest.php
@@ -312,6 +312,21 @@ class AddConsoleCommandPassTest extends TestCase
         $this->assertTrue($loader->get('hidden-group:two')->isHidden());
     }
 
+    public function testProcessRejectsTheAttributeOnBothTheClassAndItsInvokeMethod()
+    {
+        $container = new ContainerBuilder();
+
+        $definition = new Definition(AttributeOnBothCommand::class);
+        $definition->addTag('console.command');
+        $definition->addTag('console.command', ['method' => '__invoke']);
+        $container->setDefinition(AttributeOnBothCommand::class, $definition);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "Symfony\Component\Console\Tests\DependencyInjection\AttributeOnBothCommand" class and its "__invoke()" method cannot both have the "Symfony\Component\Console\Attribute\AsCommand" attribute.');
+
+        new AddConsoleCommandPass()->process($container);
+    }
+
     public function testProcessRejectsAMethodCommandRepeatingTheClassLevelName()
     {
         $container = new ContainerBuilder();
@@ -540,6 +555,16 @@ class HiddenGroupCommands
 
     #[AsCommand(name: 'two', hidden: true)]
     public function two(): int
+    {
+        return Command::SUCCESS;
+    }
+}
+
+#[AsCommand(name: 'both')]
+class AttributeOnBothCommand
+{
+    #[AsCommand(name: 'both-invoke')]
+    public function __invoke(): int
     {
         return Command::SUCCESS;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Follow-up to #65851. When `#[AsCommand]` is on both a class and its `__invoke()` method, the two registration paths disagree: the compiler pass registers the class-level name and turns the method-level one into an alias of it, while `Application::addCommand($object)` uses the method-level attribute and ignores the class-level one. Since the two attributes compete for the same command and neither precedence is obvious, both paths now reject the combination with the same message.
