### PR TITLE
[Security] Reset the login rate limiter on successful login with a peekable limiter

### DIFF
--- a/src/Symfony/Component/Security/Http/EventListener/LoginThrottlingListener.php
+++ b/src/Symfony/Component/Security/Http/EventListener/LoginThrottlingListener.php
@@ -27,6 +27,8 @@ use Symfony\Component\Security\Http\SecurityRequestAttributes;
  */
 final class LoginThrottlingListener implements EventSubscriberInterface
 {
+    private const UNTOUCHED_LIMITER_ATTRIBUTE = '_security_login_throttling_untouched';
+
     private RequestStack $requestStack;
     private RequestRateLimiterInterface $limiter;
 
@@ -54,6 +56,9 @@ final class LoginThrottlingListener implements EventSubscriberInterface
             if (!$limit->isAccepted() || 0 === $limit->getRemainingTokens()) {
                 throw new TooManyLoginAttemptsAuthenticationException(ceil(($limit->getRetryAfter()->getTimestamp() - time()) / 60));
             }
+
+            // Remember an untouched window, a successful login then has nothing to reset.
+            $request->attributes->set(self::UNTOUCHED_LIMITER_ATTRIBUTE, $limit->getRemainingTokens() === $limit->getLimit());
         } else {
             $limit = $this->limiter->consume($request);
             if (!$limit->isAccepted()) {
@@ -64,9 +69,11 @@ final class LoginThrottlingListener implements EventSubscriberInterface
 
     public function onSuccessfulLogin(LoginSuccessEvent $event): void
     {
-        if (!$this->limiter instanceof PeekableRequestRateLimiterInterface) {
-            $this->limiter->reset($event->getRequest());
+        if ($this->limiter instanceof PeekableRequestRateLimiterInterface && $event->getRequest()->attributes->get(self::UNTOUCHED_LIMITER_ATTRIBUTE, false)) {
+            return;
         }
+
+        $this->limiter->reset($event->getRequest());
     }
 
     public function onFailedLogin(LoginFailureEvent $event): void

--- a/src/Symfony/Component/Security/Http/RateLimiter/DefaultLoginRateLimiter.php
+++ b/src/Symfony/Component/Security/Http/RateLimiter/DefaultLoginRateLimiter.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Security\Http\RateLimiter;
 
 use Symfony\Component\HttpFoundation\RateLimiter\AbstractRequestRateLimiter;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\RateLimiter\LimiterInterface;
 use Symfony\Component\RateLimiter\RateLimiterFactory;
 use Symfony\Component\Security\Core\Exception\InvalidArgumentException;
 use Symfony\Component\Security\Http\SecurityRequestAttributes;
@@ -45,15 +46,31 @@ final class DefaultLoginRateLimiter extends AbstractRequestRateLimiter
         $this->secret = $secret;
     }
 
+    /**
+     * Clears the username+IP limit only.
+     *
+     * The IP limit bounds how many usernames a single client may try, so it
+     * must survive the successful login of any one of them.
+     */
+    public function reset(Request $request): void
+    {
+        $this->createLocalLimiter($request)->reset();
+    }
+
     protected function getLimiters(Request $request): array
+    {
+        return [
+            $this->globalFactory->create($this->hash($request->getClientIp())),
+            $this->createLocalLimiter($request),
+        ];
+    }
+
+    private function createLocalLimiter(Request $request): LimiterInterface
     {
         $username = $request->attributes->get(SecurityRequestAttributes::LAST_USERNAME, '');
         $username = preg_match('//u', $username) ? mb_strtolower($username, 'UTF-8') : strtolower($username);
 
-        return [
-            $this->globalFactory->create($this->hash($request->getClientIp())),
-            $this->localFactory->create($this->hash($username.'-'.$request->getClientIp())),
-        ];
+        return $this->localFactory->create($this->hash($username.'-'.$request->getClientIp()));
     }
 
     private function hash(string $data): string

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/LoginThrottlingListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/LoginThrottlingListenerTest.php
@@ -12,16 +12,20 @@
 namespace Symfony\Component\Security\Http\Tests\EventListener;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\RateLimiter\PeekableRequestRateLimiterInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\RateLimiter\RateLimit;
 use Symfony\Component\RateLimiter\RateLimiterFactory;
 use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
+use Symfony\Component\Security\Core\Authentication\Token\NullToken;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Exception\TooManyLoginAttemptsAuthenticationException;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
 use Symfony\Component\Security\Http\Event\CheckPassportEvent;
 use Symfony\Component\Security\Http\Event\LoginFailureEvent;
+use Symfony\Component\Security\Http\Event\LoginSuccessEvent;
 use Symfony\Component\Security\Http\EventListener\LoginThrottlingListener;
 use Symfony\Component\Security\Http\RateLimiter\DefaultLoginRateLimiter;
 use Symfony\Component\Security\Http\Tests\Fixtures\DummyAuthenticator;
@@ -100,6 +104,73 @@ class LoginThrottlingListenerTest extends TestCase
         $this->listener->checkPassport($this->createCheckPassportEvent($passports[0]));
     }
 
+    public function testSuccessfulLoginResetsThrottling()
+    {
+        $request = $this->createRequest();
+        $passport = $this->createPassport('wouter');
+
+        $this->requestStack->push($request);
+
+        for ($i = 0; $i < 2; ++$i) {
+            $this->listener->checkPassport($this->createCheckPassportEvent($passport));
+            $this->listener->onFailedLogin($this->createLoginFailedEvent($passport));
+        }
+
+        $this->listener->checkPassport($this->createCheckPassportEvent($passport));
+        $this->listener->onSuccessfulLogin($this->createLoginSuccessEvent($passport));
+
+        for ($i = 0; $i < 3; ++$i) {
+            $this->listener->checkPassport($this->createCheckPassportEvent($passport));
+            $this->listener->onFailedLogin($this->createLoginFailedEvent($passport));
+        }
+
+        $this->expectException(TooManyLoginAttemptsAuthenticationException::class);
+        $this->listener->checkPassport($this->createCheckPassportEvent($passport));
+    }
+
+    public function testSuccessfulLoginDoesNotResetUntouchedPeekableLimiter()
+    {
+        $request = $this->createRequest();
+        $passport = $this->createPassport('wouter');
+
+        $this->requestStack->push($request);
+
+        $limiter = $this->createMock(PeekableRequestRateLimiterInterface::class);
+        $limiter->expects($this->once())->method('peek')->willReturn(new RateLimit(3, new \DateTimeImmutable(), true, 3));
+        $limiter->expects($this->never())->method('reset');
+
+        $listener = new LoginThrottlingListener($this->requestStack, $limiter);
+        $listener->checkPassport($this->createCheckPassportEvent($passport));
+        $listener->onSuccessfulLogin($this->createLoginSuccessEvent($passport));
+    }
+
+    public function testSuccessfulLoginKeepsTheGlobalLimit()
+    {
+        $this->requestStack->push($this->createRequest());
+
+        // The global limit is 6 and the local one 3, so failing on four
+        // different usernames only brings the global limit close to its
+        // threshold, leaving two attempts.
+        foreach (['a', 'b', 'c', 'd'] as $username) {
+            $passport = $this->createPassport($username);
+            $this->listener->checkPassport($this->createCheckPassportEvent($passport));
+            $this->listener->onFailedLogin($this->createLoginFailedEvent($passport));
+        }
+
+        $passport = $this->createPassport('e');
+        $this->listener->checkPassport($this->createCheckPassportEvent($passport));
+        $this->listener->onSuccessfulLogin($this->createLoginSuccessEvent($passport));
+
+        foreach (['f', 'g'] as $username) {
+            $passport = $this->createPassport($username);
+            $this->listener->checkPassport($this->createCheckPassportEvent($passport));
+            $this->listener->onFailedLogin($this->createLoginFailedEvent($passport));
+        }
+
+        $this->expectException(TooManyLoginAttemptsAuthenticationException::class);
+        $this->listener->checkPassport($this->createCheckPassportEvent($this->createPassport('h')));
+    }
+
     private function createPassport($username)
     {
         return new SelfValidatingPassport(new UserBadge($username));
@@ -108,6 +179,11 @@ class LoginThrottlingListenerTest extends TestCase
     private function createLoginFailedEvent($passport)
     {
         return new LoginFailureEvent(new AuthenticationException(), new DummyAuthenticator(), $this->requestStack->getCurrentRequest(), null, 'main', $passport);
+    }
+
+    private function createLoginSuccessEvent($passport)
+    {
+        return new LoginSuccessEvent(new DummyAuthenticator(), $passport, new NullToken(), $this->requestStack->getCurrentRequest(), null, 'main');
     }
 
     private function createCheckPassportEvent($passport)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65858
| License       | MIT

Failed login attempts made before a successful login stay in the rate limiter when the configured limiter is peekable, which is the case for the default `DefaultLoginRateLimiter`. With a limit of 5, three failures followed by a successful login leave only two attempts instead of a fresh five.

#41137 added the reset on successful login, then #46110 skipped it for peekable limiters, since a token is only consumed on failure there. That holds when the user has no failed attempt in the current window, but not when earlier attempts already consumed tokens. The `peek()` done in `checkPassport()` already tells us which case we are in, so the listener now resets only when something was consumed. Logins with a clean window still hit the backend just once, as #46110 intended.

`DefaultLoginRateLimiter` keeps two limits: one on username+IP, and a higher one on the IP alone, which bounds how many usernames a single client may try. A successful login now clears the username+IP limit only. Before this change `reset()` cleared both, so any successful login gave the client a fresh IP budget, and repeating that pattern removed the IP limit altogether. That also fixes limiters that do not implement `PeekableRequestRateLimiterInterface`, which reached `reset()` on every successful login already.
