### PR TITLE
[Console] Disambiguate the autocompleter callback return type

### DIFF
--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -234,8 +234,8 @@ class QuestionHelper extends Helper
     /**
      * Autocompletes a question.
      *
-     * @param resource                  $inputStream
-     * @param callable(string):string[] $autocomplete
+     * @param resource                       $inputStream
+     * @param callable(string):array<string> $autocomplete
      */
     private function autocomplete(OutputInterface $output, Question $question, $inputStream, callable $autocomplete): string
     {

--- a/src/Symfony/Component/Console/Question/Question.php
+++ b/src/Symfony/Component/Console/Question/Question.php
@@ -192,7 +192,7 @@ class Question
     /**
      * Gets the callback function used for the autocompleter.
      *
-     * @return (callable(string):string[])|null
+     * @return (callable(string):array<string>)|null
      */
     public function getAutocompleterCallback(): ?callable
     {
@@ -204,7 +204,7 @@ class Question
      *
      * The callback is passed the user input as argument and should return an iterable of corresponding suggestions.
      *
-     * @param (callable(string):string[])|null $callback
+     * @param (callable(string):array<string>)|null $callback
      *
      * @return $this
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`QuestionHelper::autocomplete()` and `Question::(get|set)AutocompleterCallback()` annotated the callback as `callable(string):string[]`. Whether that trailing `[]` belongs to the return type or to the whole callable is not settled by any phpdoc standard, and analysers disagree: PHPStan binds it to the return type, Mago binds it to the callable and reads the parameter as an array of callables.

The intent is unambiguous from the code. `autocomplete()` declares `callable $autocomplete` natively, and the body does `$matches = $autocomplete($ret); $numMatches = \count($matches);`, so the callback returns the array. Under Mago's reading the docblock contradicts the native `callable` hint, which turns a correct call into a reported error for anyone analysing a project that depends on this component.

Writing the return type as `array<string>` removes the trailing `[]`, so the precedence question no longer arises for any parser. The type is unchanged: PHPStan reads `string[]` and `array<string>` as the same type, and `array<...>` is already the more common form in this component. The parentheses on the `Question` annotations stay, since they wrap the callable for the `|null` union.

The analyser disagreement is tracked at https://github.com/carthage-software/mago/issues/2310, where the maintainer confirmed neither side can change its precedence without breaking its own users.

These three annotations are the only ones in the monorepo with a callable return type ending in `[]`, and they exist on 7.4 and up.
