### PR TITLE
[Tui] Fix bottom viewport rendering after content shrinks

### DIFF
--- a/src/Symfony/Component/Tui/Render/ScreenWriter.php
+++ b/src/Symfony/Component/Tui/Render/ScreenWriter.php
@@ -186,6 +186,14 @@ final class ScreenWriter
             return;
         }
 
+        // Overflowing content that shrinks moves every visible line up, which
+        // cannot be expressed by erasing the trailing ones.
+        if (!$this->terminal->isVirtual() && \count($this->previousLines) > $rows && $lineCount < \count($this->previousLines)) {
+            $this->redrawViewport($lines, $cursorPos, $rows);
+
+            return;
+        }
+
         if ($firstChanged >= $lineCount) {
             $this->handleDeletedLines($lines, $cursorPos, $rows);
 
@@ -257,6 +265,32 @@ final class ScreenWriter
         }
 
         $this->positionHardwareCursor($cursorPos, \count($newLines));
+        $this->previousLines = $newLines;
+        $this->previousWidth = $this->terminal->getColumns();
+    }
+
+    /**
+     * Redraws the bottom of the content over the whole screen.
+     *
+     * The scrollback is kept, so the lines that scrolled out stay reachable.
+     *
+     * @param string[]                                   $newLines
+     * @param array{row: int, col: int, shape: int}|null $cursorPos
+     */
+    private function redrawViewport(array $newLines, ?array $cursorPos, int $rows): void
+    {
+        $lineCount = \count($newLines);
+
+        $buffer = "\x1b[?2026h\x1b[2J\x1b[H"; // Begin synchronized output, clear screen and home
+        $buffer .= implode("\r\n", \array_slice($newLines, max(0, $lineCount - $rows), $rows));
+        $buffer .= "\x1b[?2026l"; // End synchronized output
+
+        $this->terminal->write($buffer);
+        $this->cursorRow = max(0, $lineCount - 1);
+        $this->hardwareCursorRow = $this->cursorRow;
+        $this->maxLinesRendered = $lineCount;
+
+        $this->positionHardwareCursor($cursorPos, $lineCount);
         $this->previousLines = $newLines;
         $this->previousWidth = $this->terminal->getColumns();
     }

--- a/src/Symfony/Component/Tui/Tests/Render/ScreenWriterTest.php
+++ b/src/Symfony/Component/Tui/Tests/Render/ScreenWriterTest.php
@@ -16,6 +16,8 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Tui\Ansi\AnsiUtils;
 use Symfony\Component\Tui\Exception\RenderException;
 use Symfony\Component\Tui\Render\ScreenWriter;
+use Symfony\Component\Tui\Terminal\ScreenBuffer;
+use Symfony\Component\Tui\Terminal\TerminalInterface;
 use Symfony\Component\Tui\Terminal\VirtualTerminal;
 
 class ScreenWriterTest extends TestCase
@@ -619,5 +621,42 @@ class ScreenWriterTest extends TestCase
         $this->assertStringContainsString('Recovered', $output);
         $this->assertStringContainsString('OK', $output);
         $this->assertStringContainsString("\x1b[2J", $output, 'Screen should be cleared on recovery');
+    }
+
+    #[DataProvider('provideShrinkingOverflowingContent')]
+    public function testShrinkingOverflowingContentKeepsTheViewportAtTheBottom(array $shrunk)
+    {
+        $transcript = [];
+        for ($i = 0; $i < 100; ++$i) {
+            $transcript[] = 'transcript '.$i;
+        }
+
+        $screen = new ScreenBuffer(20, 5);
+        $output = '';
+        $terminal = $this->createStub(TerminalInterface::class);
+        $terminal->method('getColumns')->willReturn(20);
+        $terminal->method('getRows')->willReturn(5);
+        $terminal->method('isVirtual')->willReturn(false);
+        $terminal->method('write')->willReturnCallback(static function (string $data) use ($screen, &$output): void {
+            $screen->write($data);
+            $output .= $data;
+        });
+        $writer = new ScreenWriter($terminal);
+
+        $writer->writeLines([...$transcript, 'A', 'B', 'C', 'D', 'E', 'F', 'G']);
+        $output = '';
+        $writer->writeLines([...$transcript, ...$shrunk]);
+
+        // The terminal shows the last 5 lines of the content, whatever the shrink removed
+        $this->assertSame(\array_slice([...$transcript, ...$shrunk], -5), array_map('rtrim', $screen->getLines()));
+        $this->assertStringNotContainsString("\x1b[3J", $output, 'Scrollback should be preserved');
+    }
+
+    public static function provideShrinkingOverflowingContent(): iterable
+    {
+        yield 'one trailing line removed' => [['A', 'B', 'C', 'D', 'E', 'F']];
+        yield 'three trailing lines removed' => [['A', 'B', 'C', 'D']];
+        yield 'two leading lines removed' => [['C', 'D', 'E', 'F', 'G']];
+        yield 'all but one line removed' => [['A']];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | n/a
| License       | MIT

When the content is taller than the terminal, the visible window is the last `$rows` lines of it. Removing any line therefore moves every visible line up by one, and `handleDeletedLines()` cannot express that: it erases the trailing lines from where the cursor stands, so the top of the screen keeps showing stale lines and blank rows appear at the bottom.

With a 5-row terminal, 107 lines of content, and one trailing line removed:

```
expected  B C D E F        the last 5 lines of the new content
before    C D E F (blank)  the window never moved up
```

Removing three trailing lines gives `C D (blank) (blank) (blank)` where `transcript 99 A B C D` is expected.

`ScreenWriter` now redraws the bottom of the content over the whole screen when the previous frame overflowed and the new one is shorter. The redraw clears the screen but not the scrollback, so the lines that scrolled out stay reachable, and it writes at most `$rows` lines instead of the whole buffer. Virtual terminals keep the previous path, since they model an unbounded screen where nothing scrolls out.

Merge-up to 8.2: the same fix, in the `LineBufferInterface` shape that branch uses. `redrawViewport()` becomes:

```php
    private function redrawViewport(LineBufferInterface $newLines, ?array $cursorPos, int $rows): void
    {
        $lineCount = \count($newLines);
        $visibleLines = $newLines->slice(max(0, $lineCount - $rows), min($lineCount, $rows));
        $buffer = "\x1b[?2026h\x1b[2J\x1b[H";

        foreach ($visibleLines as $i => $line) {
            if ($i > 0) {
                $buffer .= "\r\n";
            }
            $buffer .= $this->prepareLine($line);
        }

        $buffer .= "\x1b[?2026l";

        $this->terminal->write($buffer);
        $this->hardwareCursorRow = max(0, $lineCount - 1);
        $this->maxLinesRendered = $lineCount;

        $this->positionHardwareCursor($cursorPos, $lineCount);
        $this->previousWidth = $this->terminal->getColumns();
    }
```

`previousLines` is assigned by `writeFrame()` on 8.2, so the method must not set it there. The guard reads `\count($this->previousLines)` through the nullable property, and the tests call `writeFrame()` with buffers instead of `writeLines()` with arrays. Slicing the buffer also keeps the transcript unread: with a 100-line prefix the shrink frame reads 0 lines from it, against 100 before. Ran on 8.2: `OK (1981 tests, 5792 assertions)`.
