### PR TITLE
[Security][SecurityBundle] Check the RFC 9068 "at+jwt" type of OIDC access tokens

### DIFF
--- a/UPGRADE-8.2.md
+++ b/UPGRADE-8.2.md
@@ -202,11 +202,17 @@ Security
    The `$allowMultipleAttributes` argument will be removed in 9.0
  * Add argument `$parameters` to `LoginLinkHandlerInterface::createLoginLink()`
  * Add argument `$parameters` to `SignatureHasher::computeSignatureHash()`, `SignatureHasher::acceptSignatureHash()` and `SignatureHasher::verifySignatureHash()`
+ * [BC BREAK] `OidcTokenHandler` now rejects the tokens whose `typ` header is not `at+jwt` or
+   `application/at+jwt`, as RFC 9068 requires from a JWT access token; pass `false` to the new
+   `$enforceAtJwtType` argument to keep accepting them. Configuring the handler through SecurityBundle
+   is not affected until 9.0
 
 SecurityBundle
 --------------
 
  * Deprecate the `remember_me` option of the `form_login`, `json_login`, `login_link`, and `access_token` authenticators, as it has no effect
+ * Deprecate not setting the `enforce_at_jwt_type` option of the `oidc` token handler; it defaults to `false`
+   in 8.2 and will default to `true` in 9.0
  * Deprecate configuring an access control rule with many `roles`, use `allow_if` or role hierarchy instead
  * Deprecate configuring both an access control rule `allow_if` and `roles`, update `allow_if` instead
  * A service used as a firewall `success_handler` or `failure_handler` is now wired as-is, so decorating it

--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -26,6 +26,8 @@ CHANGELOG
  * Add `enable_end_session` and `post_logout_redirect_path` options to the `oidc_login` authenticator for RP-Initiated Logout
  * Allow passing a null user to `Security::isGrantedForUser()` and `Security::getAccessDecisionForUser()` to check guest permissions
  * Show why an authenticator did not support the request in the security profiler panel
+ * Add the `enforce_at_jwt_type` option to the OIDC token handler configuration to reject the tokens whose `typ` header is not the `at+jwt` RFC 9068 requires from an access token
+ * Deprecate not setting the `enforce_at_jwt_type` option of the OIDC token handler, which defaults to `false` in 8.2 and will default to `true` in 9.0
 
 8.1
 ---

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/AccessToken/OidcTokenHandlerFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/AccessToken/OidcTokenHandlerFactory.php
@@ -27,11 +27,18 @@ class OidcTokenHandlerFactory implements TokenHandlerFactoryInterface
 {
     public function create(ContainerBuilder $container, string $id, array|string $config): void
     {
+        if (null === $config['enforce_at_jwt_type']) {
+            trigger_deprecation('symfony/security-bundle', '8.2', 'Not setting the "enforce_at_jwt_type" option of the "oidc" token handler is deprecated, set it explicitly; it will default to true in 9.0.');
+
+            $config['enforce_at_jwt_type'] = false;
+        }
+
         $tokenHandlerDefinition = $container->setDefinition($id, (new ChildDefinition('security.access_token_handler.oidc'))
             ->replaceArgument(2, $config['audience'])
             ->replaceArgument(3, $config['issuers'])
             ->replaceArgument(4, $config['claim'])
             ->replaceArgument(7, $config['allowed_time_drift'])
+            ->replaceArgument(8, $config['enforce_at_jwt_type'])
             ->addTag('container.reversible')
         );
 
@@ -197,6 +204,10 @@ class OidcTokenHandlerFactory implements TokenHandlerFactoryInterface
                         ->info('Allowed time drift in seconds for token validation (iat, nbf, exp claims).')
                         ->defaultValue(0)
                         ->min(0)
+                    ->end()
+                    ->booleanNode('enforce_at_jwt_type')
+                        ->info('When enabled, the "typ" header of the token must be "at+jwt" or "application/at+jwt", as RFC 9068 requires from a JWT access token. This rejects the ID tokens issued for the same audience. Disable it only for providers that do not follow the profile. Defaults to false in 8.2 and to true as of 9.0.')
+                        ->defaultNull()
                     ->end()
                 ->end()
             ->end()

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator_access_token.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator_access_token.php
@@ -92,6 +92,7 @@ return static function (ContainerConfigurator $container) {
                 service('logger')->nullOnInvalid(),
                 service('clock'),
                 0,
+                false,
             ])
 
         ->set('security.access_token_handler.oidc_discovery.http_client', HttpClientInterface::class)

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTestCase.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTestCase.php
@@ -740,6 +740,7 @@ abstract class CompleteConfigurationTestCase extends TestCase
         $this->assertSame('audience', $def->getArgument(2));
         $this->assertSame(['https://www.example.com'], $def->getArgument(3));
         $this->assertSame('sub', $def->getArgument(4));
+        $this->assertTrue($def->getArgument(8));
     }
 
     public function testAccessTokenOidcWithEncryption()

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/access_token_oidc.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/access_token_oidc.php
@@ -16,6 +16,7 @@ $container->loadFromExtension('security', [
                         'issuers' => ['https://www.example.com'],
                         'audience' => 'audience',
                         'keyset' => '{"keys":[{"kty":"RSA","n":"abc","e":"AQAB"}]}',
+                        'enforce_at_jwt_type' => true,
                     ],
                 ],
             ],

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/access_token_oidc_encryption.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/access_token_oidc_encryption.php
@@ -16,6 +16,7 @@ $container->loadFromExtension('security', [
                         'issuers' => ['https://www.example.com'],
                         'audience' => 'audience',
                         'keyset' => '{"keys":[{"kty":"RSA","n":"abc","e":"AQAB"}]}',
+                        'enforce_at_jwt_type' => true,
                         'encryption' => [
                             'enabled' => true,
                             'keyset' => '{"keys":[{"kty":"RSA","n":"abc","e":"AQAB","d":"def"}]}',

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/access_token_oidc.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/access_token_oidc.yml
@@ -13,4 +13,5 @@ security:
                         issuers: ['https://www.example.com']
                         audience: 'audience'
                         keyset: '{"keys":[{"kty":"RSA","n":"abc","e":"AQAB"}]}'
+                        enforce_at_jwt_type: true
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/access_token_oidc_encryption.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/access_token_oidc_encryption.yml
@@ -13,6 +13,7 @@ security:
                         issuers: ['https://www.example.com']
                         audience: 'audience'
                         keyset: '{"keys":[{"kty":"RSA","n":"abc","e":"AQAB"}]}'
+                        enforce_at_jwt_type: true
                         encryption:
                             enabled: true
                             keyset: '{"keys":[{"kty":"RSA","n":"abc","e":"AQAB","d":"def"}]}'

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/AccessTokenFactoryTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/AccessTokenFactoryTest.php
@@ -13,6 +13,8 @@ namespace Symfony\Bundle\SecurityBundle\Tests\DependencyInjection\Security\Facto
 
 use Jose\Component\Core\AlgorithmManager;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\AccessToken\CasTokenHandlerFactory;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\AccessToken\OAuth2TokenHandlerFactory;
@@ -151,6 +153,7 @@ class AccessTokenFactoryTest extends TestCase
         $config = [
             'token_handler' => [
                 'oidc' => [
+                    'enforce_at_jwt_type' => false,
                     'algorithms' => ['RS256', 'ES256'],
                     'issuers' => ['https://www.example.com'],
                     'audience' => 'audience',
@@ -176,6 +179,7 @@ class AccessTokenFactoryTest extends TestCase
             'index_3' => ['https://www.example.com'],
             'index_4' => 'sub',
             'index_7' => 0,
+            'index_8' => false,
         ];
         $this->assertEquals($expected, $container->getDefinition('security.access_token_handler.firewall1')->getArguments());
 
@@ -191,6 +195,7 @@ class AccessTokenFactoryTest extends TestCase
         $config = [
             'token_handler' => [
                 'oidc' => [
+                    'enforce_at_jwt_type' => false,
                     'algorithms' => ['RS256', 'ES256'],
                     'issuers' => ['https://www.example.com'],
                     'audience' => 'audience',
@@ -272,6 +277,7 @@ class AccessTokenFactoryTest extends TestCase
         $config = [
             'token_handler' => [
                 'oidc' => [
+                    'enforce_at_jwt_type' => false,
                     'discovery' => [
                         'base_uri' => 'https://www.example.com/realms/demo/',
                         'cache' => [
@@ -301,6 +307,7 @@ class AccessTokenFactoryTest extends TestCase
             'index_3' => ['https://www.example.com'],
             'index_4' => 'sub',
             'index_7' => 0,
+            'index_8' => false,
         ];
         $expectedCalls = [
             [
@@ -331,6 +338,7 @@ class AccessTokenFactoryTest extends TestCase
         $config = [
             'token_handler' => [
                 'oidc' => [
+                    'enforce_at_jwt_type' => false,
                     'discovery' => [
                         'base_uri' => [
                             'https://www.example.com/realms/demo/',
@@ -363,6 +371,7 @@ class AccessTokenFactoryTest extends TestCase
             'index_3' => ['https://www.example.com'],
             'index_4' => 'sub',
             'index_7' => 0,
+            'index_8' => false,
         ];
         $expectedCalls = [
             [
@@ -403,6 +412,7 @@ class AccessTokenFactoryTest extends TestCase
         $config = [
             'token_handler' => [
                 'oidc' => [
+                    'enforce_at_jwt_type' => false,
                     'discovery' => [
                         'base_uri' => 'https://www.example.com/realms/demo/',
                         'cache' => ['id' => 'oidc_cache'],
@@ -667,6 +677,7 @@ class AccessTokenFactoryTest extends TestCase
         $config = [
             'token_handler' => [
                 'oidc' => [
+                    'enforce_at_jwt_type' => false,
                     'algorithms' => ['RS256', 'ES256'],
                     'issuers' => ['https://www.example.com'],
                     'audience' => 'audience',
@@ -704,6 +715,67 @@ class AccessTokenFactoryTest extends TestCase
         $this->assertFalse($container->hasDefinition('security.access_token_handler.oidc.command.generate'));
     }
 
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
+    public function testNotSettingTheAtJwtTypeEnforcementIsDeprecated()
+    {
+        $container = new ContainerBuilder();
+        $config = [
+            'token_handler' => [
+                'oidc' => [
+                    'algorithms' => ['RS256', 'ES256'],
+                    'issuers' => ['https://www.example.com'],
+                    'audience' => 'audience',
+                    'keyset' => '{"keys":[{"kty":"EC","crv":"P-256","x":"FtgMtrsKDboRO-Zo0XC7tDJTATHVmwuf9GK409kkars","y":"rWDE0ERU2SfwGYCo1DWWdgFEbZ0MiAXLRBBOzBgs_jY","d":"4G7bRIiKih0qrFxc0dtvkHUll19tTyctoCR3eIbOrO0"}]}',
+                ],
+            ],
+        ];
+
+        $factory = new AccessTokenFactory($this->createTokenHandlerFactories());
+        $finalizedConfig = $this->processConfig($config, $factory);
+
+        $this->expectUserDeprecationMessage('Since symfony/security-bundle 8.2: Not setting the "enforce_at_jwt_type" option of the "oidc" token handler is deprecated, set it explicitly; it will default to true in 9.0.');
+
+        $factory->createAuthenticator($container, 'firewall1', $finalizedConfig, 'userprovider');
+
+        $this->assertFalse($container->getDefinition('security.access_token_handler.firewall1')->getArgument(8));
+    }
+
+    public function testOidcTokenHandlerConfigurationWithEnforcedAtJwtType()
+    {
+        $container = new ContainerBuilder();
+        $jwkset = '{"keys":[{"kty":"EC","crv":"P-256","x":"FtgMtrsKDboRO-Zo0XC7tDJTATHVmwuf9GK409kkars","y":"rWDE0ERU2SfwGYCo1DWWdgFEbZ0MiAXLRBBOzBgs_jY","d":"4G7bRIiKih0qrFxc0dtvkHUll19tTyctoCR3eIbOrO0"}]}';
+        $config = [
+            'token_handler' => [
+                'oidc' => [
+                    'algorithms' => ['RS256', 'ES256'],
+                    'issuers' => ['https://www.example.com'],
+                    'audience' => 'audience',
+                    'keyset' => $jwkset,
+                    'enforce_at_jwt_type' => true,
+                ],
+            ],
+        ];
+
+        $factory = new AccessTokenFactory($this->createTokenHandlerFactories());
+        $finalizedConfig = $this->processConfig($config, $factory);
+
+        $factory->createAuthenticator($container, 'firewall1', $finalizedConfig, 'userprovider');
+
+        $expected = [
+            'index_0' => (new ChildDefinition('security.access_token_handler.oidc.signature'))
+                ->replaceArgument(0, ['RS256', 'ES256']),
+            'index_1' => (new ChildDefinition('security.access_token_handler.oidc.jwkset'))
+                ->replaceArgument(0, $jwkset),
+            'index_2' => 'audience',
+            'index_3' => ['https://www.example.com'],
+            'index_4' => 'sub',
+            'index_7' => 0,
+            'index_8' => true,
+        ];
+        $this->assertEquals($expected, $container->getDefinition('security.access_token_handler.firewall1')->getArguments());
+    }
+
     public function testOidcTokenHandlerConfigurationWithAllowedTimeDrift()
     {
         $container = new ContainerBuilder();
@@ -711,6 +783,7 @@ class AccessTokenFactoryTest extends TestCase
         $config = [
             'token_handler' => [
                 'oidc' => [
+                    'enforce_at_jwt_type' => false,
                     'algorithms' => ['RS256', 'ES256'],
                     'issuers' => ['https://www.example.com'],
                     'audience' => 'audience',
@@ -734,6 +807,7 @@ class AccessTokenFactoryTest extends TestCase
             'index_3' => ['https://www.example.com'],
             'index_4' => 'sub',
             'index_7' => 5,
+            'index_8' => false,
         ];
         $this->assertEquals($expected, $container->getDefinition('security.access_token_handler.firewall1')->getArguments());
     }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/AccessTokenTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/AccessTokenTest.php
@@ -466,10 +466,12 @@ class AccessTokenTest extends AbstractWebTestCase
             [static fn () => self::createJws([...$claims, 'username' => 'Invalid Username'])],
             [static fn () => self::createJwe(self::createJws($claims), ['exp' => $time - 3600])],
             [static fn () => self::createJwe(self::createJws($claims), ['cty' => 'x-specific'])],
+            [static fn () => self::createJws($claims, ['typ' => 'JWT'])],
+            [static fn () => self::createJws($claims, [])],
         ];
     }
 
-    private static function createJws(array $claims, array $header = []): string
+    private static function createJws(array $claims, array $header = ['typ' => 'at+jwt']): string
     {
         return (new JwsCompactSerializer())->serialize((new JWSBuilder(new AlgorithmManager([
             new ES256(),

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_oidc.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_oidc.yml
@@ -26,6 +26,7 @@ security:
                         algorithms: [ 'ES256' ]
                         # tip: use https://mkjwk.org/ to generate a JWK
                         keyset: '{"keys":[{"kty":"EC","d":"iA_TV2zvftni_9aFAQwFO_9aypfJFCSpcCyevDvz220","crv":"P-256","x":"0QEAsI1wGI-dmYatdUZoWSRWggLEpyzopuhwk-YUnA4","y":"KYl-qyZ26HobuYwlQh-r0iHX61thfP82qqEku7i0woo"}]}'
+                        enforce_at_jwt_type: true
                         encryption:
                             enabled: true
                             algorithms: ['ECDH-ES', 'A128GCM']

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_oidc_jwe.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_oidc_jwe.yml
@@ -26,6 +26,7 @@ security:
                         algorithms: ['ES256']
                         # tip: use https://mkjwk.org/ to generate a JWK
                         keyset: '{"keys":[{"kty":"EC","d":"iA_TV2zvftni_9aFAQwFO_9aypfJFCSpcCyevDvz220","crv":"P-256","x":"0QEAsI1wGI-dmYatdUZoWSRWggLEpyzopuhwk-YUnA4","y":"KYl-qyZ26HobuYwlQh-r0iHX61thfP82qqEku7i0woo"}]}'
+                        enforce_at_jwt_type: true
                         encryption:
                             enabled: true
                             enforce: true

--- a/src/Symfony/Component/Security/Http/AccessToken/Oidc/OidcTokenGenerator.php
+++ b/src/Symfony/Component/Security/Http/AccessToken/Oidc/OidcTokenGenerator.php
@@ -61,7 +61,7 @@ class OidcTokenGenerator
 
         $jws = $jwsBuilder
             ->withPayload(json_encode($payload, flags: \JSON_THROW_ON_ERROR))
-            ->addSignature($jwk, ['alg' => $algorithm->name()])
+            ->addSignature($jwk, ['alg' => $algorithm->name(), 'typ' => 'at+jwt']) // https://datatracker.ietf.org/doc/html/rfc9068#section-2.1
             ->build();
 
         $serializer = new CompactSerializer();

--- a/src/Symfony/Component/Security/Http/AccessToken/Oidc/OidcTokenHandler.php
+++ b/src/Symfony/Component/Security/Http/AccessToken/Oidc/OidcTokenHandler.php
@@ -45,6 +45,12 @@ use Symfony\Contracts\Service\ResetInterface;
 final class OidcTokenHandler implements AccessTokenHandlerInterface, ResetInterface
 {
     use OidcTrait;
+
+    /**
+     * The "typ" header values RFC 9068 §4 accepts for a JWT access token.
+     */
+    private const AT_JWT_TYPES = ['at+jwt', 'application/at+jwt'];
+
     private ?JWKSet $decryptionKeyset = null;
     private ?AlgorithmManager $decryptionAlgorithms = null;
     private bool $enforceEncryption = false;
@@ -63,6 +69,13 @@ final class OidcTokenHandler implements AccessTokenHandlerInterface, ResetInterf
      */
     private array $discoveries = [];
 
+    /**
+     * @param bool $enforceAtJwtType Whether the "typ" header of the token must be "at+jwt" or "application/at+jwt",
+     *                               which RFC 9068 §4 requires from a JWT access token. This is what tells an access
+     *                               token apart from the ID token the provider issues for the same audience, which
+     *                               would otherwise pass every other check. Turn it off only for providers that do
+     *                               not follow the profile and keep emitting a plain "JWT" type.
+     */
     public function __construct(
         private AlgorithmManager $signatureAlgorithm,
         private ?JWKSet $signatureKeyset,
@@ -72,6 +85,7 @@ final class OidcTokenHandler implements AccessTokenHandlerInterface, ResetInterf
         private ?LoggerInterface $logger = null,
         private ClockInterface $clock = new Clock(),
         private int $allowedTimeDrift = 0,
+        private bool $enforceAtJwtType = true,
     ) {
     }
 
@@ -229,13 +243,18 @@ final class OidcTokenHandler implements AccessTokenHandlerInterface, ResetInterf
             throw new InvalidSignatureException();
         }
 
-        $headerCheckerManager = new Checker\HeaderCheckerManager([
-            new Checker\AlgorithmChecker($this->signatureAlgorithm->list()),
-        ], [
+        $headerCheckers = [new Checker\AlgorithmChecker($this->signatureAlgorithm->list())];
+        $mandatoryHeaders = [];
+        if ($this->enforceAtJwtType) {
+            $headerCheckers[] = new Checker\CallableChecker('typ', static fn ($value) => \is_string($value) && \in_array(strtolower($value), self::AT_JWT_TYPES, true));
+            $mandatoryHeaders[] = 'typ';
+        }
+
+        $headerCheckerManager = new Checker\HeaderCheckerManager($headerCheckers, [
             new JWSTokenSupport(),
         ]);
         // if this check fails, an InvalidHeaderException is thrown
-        $headerCheckerManager->check($jws, 0);
+        $headerCheckerManager->check($jws, 0, $mandatoryHeaders);
 
         return json_decode($jws->getPayload(), true);
     }

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -25,6 +25,8 @@ CHANGELOG
  * Add the `user_data_source` and `user_identifier_claim` options to `OidcLoginAuthenticator` to pick where the user claims are read from and the claim the user identifier is read from
  * Add `OidcEndSessionListener` for RP-Initiated Logout via the OIDC `end_session_endpoint`
  * Add `UnsupportedReasons`, held by the `SecurityRequestAttributes::UNSUPPORTED_REASONS` request attribute while the profiler is enabled, so that `supports()` can tell why an authenticator did not support a request
+ * Make `OidcTokenHandler` reject the tokens whose `typ` header is not the `at+jwt` RFC 9068 requires from an access token, and add the `$enforceAtJwtType` argument to turn the check off
+ * Make `OidcTokenGenerator` emit the `at+jwt` type header RFC 9068 requires from an access token
 
 8.1
 ---

--- a/src/Symfony/Component/Security/Http/Tests/AccessToken/Oidc/OidcTokenGeneratorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/AccessToken/Oidc/OidcTokenGeneratorTest.php
@@ -49,6 +49,22 @@ class OidcTokenGeneratorTest extends TestCase
         ], $badge->getAttributes());
     }
 
+    public function testGeneratesTokensCarryingTheAccessTokenType()
+    {
+        $algorithmManager = new AlgorithmManager([new ES256()]);
+        $audience = 'Symfony OIDC';
+        $issuers = ['https://www.example.com'];
+
+        $generator = new OidcTokenGenerator($algorithmManager, $this->getJWKSet(), $audience, $issuers);
+        $handler = new OidcTokenHandler($algorithmManager, $this->getJWKSet(), $audience, $issuers, 'sub', enforceAtJwtType: true);
+
+        $token = $generator->generate('john_doe', null, null, 3600);
+        $header = json_decode(base64_decode(strtr(explode('.', $token)[0], '-_', '+/')), true);
+
+        $this->assertSame(['alg' => 'ES256', 'typ' => 'at+jwt'], $header);
+        $this->assertSame('john_doe', $handler->getUserBadgeFrom($token)->getUserIdentifier());
+    }
+
     #[DataProvider('provideGenerateWithInvalid')]
     public function testGenerateWithInvalid(?string $algorithm, ?string $issuer, ?int $ttl, ?int $notBefore, string $expectedMessage)
     {

--- a/src/Symfony/Component/Security/Http/Tests/AccessToken/Oidc/OidcTokenHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/AccessToken/Oidc/OidcTokenHandlerTest.php
@@ -14,6 +14,10 @@ namespace Symfony\Component\Security\Http\Tests\AccessToken\Oidc;
 use Jose\Component\Core\AlgorithmManager;
 use Jose\Component\Core\JWK;
 use Jose\Component\Core\JWKSet;
+use Jose\Component\Encryption\Algorithm\ContentEncryption\A128CBCHS256;
+use Jose\Component\Encryption\Algorithm\KeyEncryption\Dir;
+use Jose\Component\Encryption\JWEBuilder;
+use Jose\Component\Encryption\Serializer\CompactSerializer as JweCompactSerializer;
 use Jose\Component\Signature\Algorithm\ES256;
 use Jose\Component\Signature\JWSBuilder;
 use Jose\Component\Signature\Serializer\CompactSerializer;
@@ -191,13 +195,150 @@ class OidcTokenHandlerTest extends TestCase
         ))->getUserBadgeFrom($token);
     }
 
-    private static function buildJWS(string $payload): string
+    #[DataProvider('getAtJwtTypes')]
+    public function testAcceptsTheTokenTypesOfTheAccessTokenProfile(string $type)
+    {
+        $token = self::buildJWS(json_encode(self::getValidClaims()), ['typ' => $type]);
+
+        $loggerMock = $this->createMock(LoggerInterface::class);
+        $loggerMock->expects($this->never())->method('error');
+
+        $userBadge = (new OidcTokenHandler(
+            new AlgorithmManager([new ES256()]),
+            self::getJWKSet(),
+            self::AUDIENCE,
+            ['https://www.example.com'],
+            'sub',
+            $loggerMock,
+        ))->getUserBadgeFrom($token);
+
+        $this->assertSame('e21bf182-1538-406e-8ccb-e25a17aba39f', $userBadge->getUserIdentifier());
+    }
+
+    public static function getAtJwtTypes(): iterable
+    {
+        yield 'short form' => ['at+jwt'];
+        yield 'media type form' => ['application/at+jwt'];
+        yield 'media types are case-insensitive' => ['AT+JWT'];
+    }
+
+    /**
+     * An ID token carries the client identifier in its "aud" claim, so an application whose
+     * configured audience is that same client identifier accepts it as an access token unless
+     * the token type is enforced, which is what RFC 9068 §4 asks the resource server to do.
+     */
+    #[DataProvider('getTokensRejectedByTheAtJwtTypeCheck')]
+    public function testRejectsTheTokensThatDoNotCarryTheAccessTokenType(array $header)
+    {
+        $token = self::buildJWS(json_encode(self::getValidClaims()), $header);
+
+        $loggerMock = $this->createMock(LoggerInterface::class);
+        $loggerMock->expects($this->once())->method('error');
+
+        $this->expectException(BadCredentialsException::class);
+        $this->expectExceptionMessage('Invalid credentials.');
+
+        (new OidcTokenHandler(
+            new AlgorithmManager([new ES256()]),
+            self::getJWKSet(),
+            self::AUDIENCE,
+            ['https://www.example.com'],
+            'sub',
+            $loggerMock,
+        ))->getUserBadgeFrom($token);
+    }
+
+    public static function getTokensRejectedByTheAtJwtTypeCheck(): iterable
+    {
+        yield 'an ID token' => [['typ' => 'JWT']];
+        yield 'no type at all' => [[]];
+        yield 'another profile' => [['typ' => 'logout+jwt']];
+        yield 'a non-string type' => [['typ' => 42]];
+    }
+
+    #[DataProvider('getTokensRejectedByTheAtJwtTypeCheck')]
+    public function testAcceptsAnyTokenTypeWhenTheCheckIsDisabled(array $header)
+    {
+        $token = self::buildJWS(json_encode(self::getValidClaims()), $header);
+
+        $loggerMock = $this->createMock(LoggerInterface::class);
+        $loggerMock->expects($this->never())->method('error');
+
+        $userBadge = (new OidcTokenHandler(
+            new AlgorithmManager([new ES256()]),
+            self::getJWKSet(),
+            self::AUDIENCE,
+            ['https://www.example.com'],
+            'sub',
+            $loggerMock,
+            enforceAtJwtType: false,
+        ))->getUserBadgeFrom($token);
+
+        $this->assertSame('e21bf182-1538-406e-8ccb-e25a17aba39f', $userBadge->getUserIdentifier());
+    }
+
+    /**
+     * The type sits in the signed token, so the check must run after decryption.
+     * Reading it from the outer JWE header rejects every encrypted token instead.
+     */
+    #[DataProvider('getEncryptedTokenTypes')]
+    public function testEnforcesTheAccessTokenTypeInsideAnEncryptedToken(string $type, bool $accepted)
+    {
+        $encryptionKeyset = new JWKSet([new JWK(['kty' => 'oct', 'k' => 'V0hBVCBBIExPVkVMWSBLRVkgT0YgMzIgQllURVMh'])]);
+        $encryptionAlgorithms = new AlgorithmManager([new Dir(), new A128CBCHS256()]);
+
+        $jwe = (new JWEBuilder($encryptionAlgorithms))
+            ->withPayload(self::buildJWS(json_encode(self::getValidClaims()), ['typ' => $type]))
+            ->withSharedProtectedHeader(['alg' => 'dir', 'enc' => 'A128CBC-HS256', 'cty' => 'JWT'])
+            ->addRecipient($encryptionKeyset->get(0))
+            ->build();
+
+        $handler = new OidcTokenHandler(
+            new AlgorithmManager([new ES256()]),
+            self::getJWKSet(),
+            self::AUDIENCE,
+            ['https://www.example.com'],
+            'sub',
+            enforceAtJwtType: true,
+        );
+        $handler->enableJweSupport($encryptionKeyset, $encryptionAlgorithms, true);
+
+        if (!$accepted) {
+            $this->expectException(BadCredentialsException::class);
+        }
+
+        $userBadge = $handler->getUserBadgeFrom((new JweCompactSerializer())->serialize($jwe, 0));
+
+        $this->assertSame('e21bf182-1538-406e-8ccb-e25a17aba39f', $userBadge->getUserIdentifier());
+    }
+
+    public static function getEncryptedTokenTypes(): iterable
+    {
+        yield 'an access token' => ['at+jwt', true];
+        yield 'an ID token' => ['JWT', false];
+    }
+
+    private static function getValidClaims(): array
+    {
+        $time = time();
+
+        return [
+            'iat' => $time,
+            'nbf' => $time,
+            'exp' => $time + 3600,
+            'iss' => 'https://www.example.com',
+            'aud' => self::AUDIENCE,
+            'sub' => 'e21bf182-1538-406e-8ccb-e25a17aba39f',
+        ];
+    }
+
+    private static function buildJWS(string $payload, array $header = ['typ' => 'at+jwt']): string
     {
         return (new CompactSerializer())->serialize((new JWSBuilder(new AlgorithmManager([
             new ES256(),
         ])))
             ->withPayload($payload)
-            ->addSignature(self::getJWK(), ['alg' => 'ES256'])
+            ->addSignature(self::getJWK(), $header + ['alg' => 'ES256'])
             ->build()
         );
     }
@@ -428,7 +569,7 @@ class OidcTokenHandlerTest extends TestCase
             new ES256(),
         ])))
             ->withPayload($payload)
-            ->addSignature($jwk, ['alg' => 'ES256'])
+            ->addSignature($jwk, ['alg' => 'ES256', 'typ' => 'at+jwt'])
             ->build()
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

The `oidc` access token handler never reads the `typ` header of the token it validates: `loadAndVerifyJws()` builds a `HeaderCheckerManager` holding only an `AlgorithmChecker`, and `verifyClaims()` covers `iat`, `nbf`, `exp`, `aud` and `iss`.

RFC 9068 §4 asks a resource server to verify that `typ` is `at+jwt` or `application/at+jwt`, and it asks for it precisely to prevent token substitution. Without that check, an ID token is accepted as an access token: an ID token carries the client identifier in its `aud` claim, so an application whose configured `audience` is that same client identifier sees a correctly signed token, from an allowed issuer, with a matching audience and a valid `sub`. The configuration that gets there is not exotic, it is what you write when the API and the login client are declared as one client on the provider.

This adds the check as the `enforce_at_jwt_type` option, off by default:

```yaml
security:
    firewalls:
        api:
            access_token:
                token_handler:
                    oidc:
                        audience: 'api'
                        issuers: ['https://sso.example.com']
                        algorithms: ['ES256']
                        keyset: '...'
                        enforce_at_jwt_type: true
```

It is opt-in rather than on by default because turning it on unconditionally is a behaviour break in a minor: providers that predate the profile still emit a plain `JWT` type, and their users would lose authentication on upgrade. Making it the default in 9.0 is the natural follow-up.

When the option is on, a missing `typ` is rejected too, since RFC 9068 §2.1 requires the header. The comparison is case-insensitive, media types being case-insensitive.

`OidcTokenGenerator` now emits `typ: at+jwt`, so the tokens `security:oidc:generate-token` mints keep passing the handler that generated them, whatever the option says.

This is the second point of a wider review of Symfony's OAuth 2.0 / OIDC coverage on the resource server side. The other findings, the scopes of RFC 6750 §3.1, the Protected Resource Metadata of RFC 9728 and the state of the `oauth2` introspection handler, will come as separate PRs.
