### PR TITLE
[Console] Type the autocompleter callback as returning a list

### DIFF
--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -234,8 +234,8 @@ class QuestionHelper extends Helper
     /**
      * Autocompletes a question.
      *
-     * @param resource                       $inputStream
-     * @param callable(string):array<string> $autocomplete
+     * @param resource                      $inputStream
+     * @param callable(string):list<string> $autocomplete
      */
     private function autocomplete(OutputInterface $output, Question $question, $inputStream, callable $autocomplete): string
     {

--- a/src/Symfony/Component/Console/Question/Question.php
+++ b/src/Symfony/Component/Console/Question/Question.php
@@ -25,7 +25,7 @@ class Question
     private bool $hidden = false;
     private bool $hiddenFallback = true;
     /**
-     * @var (\Closure(string):string[])|null
+     * @var (\Closure(string):list<string>)|null
      */
     private ?\Closure $autocompleterCallback = null;
     /**
@@ -192,7 +192,7 @@ class Question
     /**
      * Gets the callback function used for the autocompleter.
      *
-     * @return (callable(string):array<string>)|null
+     * @return (callable(string):list<string>)|null
      */
     public function getAutocompleterCallback(): ?callable
     {
@@ -202,9 +202,9 @@ class Question
     /**
      * Sets the callback function used for the autocompleter.
      *
-     * The callback is passed the user input as argument and should return an iterable of corresponding suggestions.
+     * The callback is passed the user input as argument and must return a list of corresponding suggestions.
      *
-     * @param (callable(string):array<string>)|null $callback
+     * @param (callable(string):list<string>)|null $callback
      *
      * @return $this
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Follow-up to #65860 on the same branch. That PR disambiguated these annotations, but left them describing any array. The code is stricter than that.

`QuestionHelper::autocomplete()` indexes the autocompleter callback's result positionally:

```php
$matches = $autocomplete($ret);
$numMatches = \count($matches);
...
$ofs = ($numMatches + $ofs) % $numMatches;
...
substr($matches[$ofs], $charactersEntered)
```

So the callback must return a list, not merely a `string[]`. And `setAutocompleterCallback()` documented something the code cannot take at all: "should return an iterable of corresponding suggestions".

Driving `autocomplete()` with the three shapes, one arrow key each:

```
--- list<string> ---
  answer = 'AsseticBundle'
--- array<string> with string keys ---
  Warning:    Undefined array key 1 at QuestionHelper.php:376
  Deprecated: substr(): Passing null to parameter #1 ($string) at QuestionHelper.php:376
  Warning:    Undefined array key 1 at QuestionHelper.php:319
  answer = ''
--- iterable, as the prose invited ---
  TypeError: count(): Argument #1 ($value) must be of type Countable|array, Generator given
```

This narrows the annotations to `list<string>` and replaces the "iterable" sentence with what the code accepts. Docblocks only, no runtime change:

```diff
-     * @param (callable(string):array<string>)|null $callback
+     * @param (callable(string):list<string>)|null $callback
```

It covers four sites, including the `@var` on the `$autocompleterCallback` property, which #65860 left at `string[]`.

`setAutocompleterValues()` normalises through `array_values()` and `iterator_to_array($values, false)`, so it always produced a list and no in-tree caller changes.

A callback returning a keyed array is now reported by static analysis. It already produces the warnings above at runtime, so this corrects the documented contract rather than constraining code that works.

Checks: PHPStan at level 5 and Psalm at `errorLevel=5` with the repository configs report nothing new on the two files. php-cs-fixer is clean. The `Console` suite gives `Tests: 1480, Failures: 2`, and those two, `testAskTimeout` and `testAskThrowsExceptionOnMissingInputForChoiceQuestion`, fail identically on the unmodified 7.4 tip in my environment.
