### PR TITLE
[Security][SecurityBundle] Serve the RFC 9728 protected resource metadata of an access_token firewall

### DIFF
--- a/UPGRADE-8.2.md
+++ b/UPGRADE-8.2.md
@@ -205,6 +205,10 @@ Security
  * Deprecate not passing the `$enforceAtJwtType` argument to `OidcTokenHandler`; pass `true` to reject
    the tokens whose `typ` header is not `at+jwt` or `application/at+jwt`, as RFC 9068 requires from a
    JWT access token. It defaults to `false` in 8.2 and will default to `true` in 9.0
+ * Add argument `$resourceMetadataUri` to `AccessTokenAuthenticator::__construct()`
+ * `AccessTokenAuthenticator` now implements `FallbackAuthenticationEntryPointInterface`, so it becomes the
+   entry point of a firewall that declares no other one: an unauthenticated request now gets a 401 carrying
+   the RFC 6750 `WWW-Authenticate: Bearer` challenge, where it used to get a 401 with no such header
 
 SecurityBundle
 --------------

--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -28,6 +28,8 @@ CHANGELOG
  * Show why an authenticator did not support the request in the security profiler panel
  * Add the `enforce_at_jwt_type` option to the OIDC token handler configuration to reject the tokens whose `typ` header is not the `at+jwt` RFC 9068 requires from an access token
  * Deprecate not setting the `enforce_at_jwt_type` option of the OIDC token handler, which defaults to `false` in 8.2 and will default to `true` in 9.0
+ * Add the `resource_metadata` option to the `access_token` authenticator to serve the RFC 9728 protected resource metadata document of the firewall and advertise its URL in the `WWW-Authenticate` header
+ * Pick an authenticator implementing `FallbackAuthenticationEntryPointInterface` as the firewall entry point only when no other authenticator provides one
 
 8.1
 ---

--- a/src/Symfony/Bundle/SecurityBundle/Controller/ProtectedResourceMetadataController.php
+++ b/src/Symfony/Bundle/SecurityBundle/Controller/ProtectedResourceMetadataController.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Controller;
+
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * Serves the RFC 9728 protected resource metadata document of an "access_token" firewall,
+ * which tells a client which authorization servers issue the access tokens the firewall
+ * accepts. The route loader declares a route for it at each firewall's well-known path.
+ *
+ * @author Florent Morselli <florent.morselli@spomky-labs.com>
+ *
+ * @see https://datatracker.ietf.org/doc/html/rfc9728
+ */
+final class ProtectedResourceMetadataController
+{
+    /**
+     * @param array<string, array<string, mixed>> $metadata Metadata documents, indexed by firewall name
+     */
+    public function __construct(
+        private readonly array $metadata,
+    ) {
+    }
+
+    public function __invoke(Request $request, string $firewallName): Response
+    {
+        if (!isset($this->metadata[$firewallName])) {
+            throw new NotFoundHttpException(\sprintf('No protected resource metadata is configured for the "%s" firewall.', $firewallName));
+        }
+
+        $metadata = $this->metadata[$firewallName];
+
+        // the "resource" identifier is REQUIRED by RFC 9728, Section 2; when the firewall
+        // does not pin one, the resource is the origin this document is being served from
+        $metadata = ['resource' => $metadata['resource'] ?? $request->getSchemeAndHttpHost()] + $metadata;
+
+        // every other discovery document is served with plain slashes, and RFC 9728,
+        // Section 3.3 has the consumer compare the "resource" value character by character
+        return (new JsonResponse($metadata))->setEncodingOptions(JsonResponse::DEFAULT_ENCODING_OPTIONS | \JSON_UNESCAPED_SLASHES);
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/RegisterEntryPointPass.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/RegisterEntryPointPass.php
@@ -17,6 +17,7 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
+use Symfony\Component\Security\Http\EntryPoint\FallbackAuthenticationEntryPointInterface;
 
 /**
  * @author Wouter de Jong <wouter@wouterj.nl>
@@ -36,6 +37,7 @@ class RegisterEntryPointPass implements CompilerPassInterface
             }
 
             $entryPoints = [];
+            $fallbackEntryPoints = [];
             $indexedAuthenticators = $container->getParameter('security.'.$firewallName.'._indexed_authenticators');
             // this is a compile-only parameter, removing it cleans up space and avoids unintended usage
             $container->getParameterBag()->remove('security.'.$firewallName.'._indexed_authenticators');
@@ -50,12 +52,14 @@ class RegisterEntryPointPass implements CompilerPassInterface
                     $definition = $container->findDefinition($definition->getParent());
                 }
 
-                if (is_a($authenticatorClass, AuthenticationEntryPointInterface::class, true)) {
+                if (is_a($authenticatorClass, FallbackAuthenticationEntryPointInterface::class, true)) {
+                    $fallbackEntryPoints[$key] = $authenticatorId;
+                } elseif (is_a($authenticatorClass, AuthenticationEntryPointInterface::class, true)) {
                     $entryPoints[$key] = $authenticatorId;
                 }
             }
 
-            if (!$entryPoints) {
+            if (!$entryPoints && !$fallbackEntryPoints) {
                 continue;
             }
 
@@ -64,16 +68,22 @@ class RegisterEntryPointPass implements CompilerPassInterface
 
             if (null !== $configuredEntryPoint) {
                 // allow entry points to be configured by authenticator key (e.g. "http_basic")
-                $entryPoint = $entryPoints[$configuredEntryPoint] ?? $configuredEntryPoint;
-            } elseif (1 === \count($entryPoints)) {
-                $entryPoint = array_shift($entryPoints);
+                $entryPoint = $entryPoints[$configuredEntryPoint] ?? $fallbackEntryPoints[$configuredEntryPoint] ?? $configuredEntryPoint;
             } else {
-                $entryPointNames = [];
-                foreach ($entryPoints as $key => $serviceId) {
-                    $entryPointNames[] = is_numeric($key) ? $serviceId : $key;
-                }
+                // a fallback entry point only stands in for a firewall that declares no other
+                // one, so that an authenticator gaining one never makes a firewall ambiguous
+                $entryPoints = $entryPoints ?: $fallbackEntryPoints;
 
-                throw new InvalidConfigurationException(\sprintf('Because you have multiple authenticators in firewall "%s", you need to set the "entry_point" key to one of your authenticators ("%s") or a service ID implementing "%s". The "entry_point" determines what should happen (e.g. redirect to "/login") when an anonymous user tries to access a protected page.', $firewallName, implode('", "', $entryPointNames), AuthenticationEntryPointInterface::class));
+                if (1 === \count($entryPoints)) {
+                    $entryPoint = array_shift($entryPoints);
+                } else {
+                    $entryPointNames = [];
+                    foreach ($entryPoints as $key => $serviceId) {
+                        $entryPointNames[] = is_numeric($key) ? $serviceId : $key;
+                    }
+
+                    throw new InvalidConfigurationException(\sprintf('Because you have multiple authenticators in firewall "%s", you need to set the "entry_point" key to one of your authenticators ("%s") or a service ID implementing "%s". The "entry_point" determines what should happen (e.g. redirect to "/login") when an anonymous user tries to access a protected page.', $firewallName, implode('", "', $entryPointNames), AuthenticationEntryPointInterface::class));
+                }
             }
 
             $config->replaceArgument(7, $entryPoint);

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AccessTokenFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AccessTokenFactory.php
@@ -18,6 +18,7 @@ use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\Security\Http\Oidc\OidcDiscovery;
 
 /**
  * AccessTokenFactory creates services for Access Token authentication.
@@ -29,6 +30,24 @@ use Symfony\Component\DependencyInjection\Reference;
 final class AccessTokenFactory extends AbstractFactory implements StatelessAuthenticatorFactoryInterface
 {
     private const PRIORITY = -40;
+
+    private const WELL_KNOWN_PATH = '/.well-known/oauth-protected-resource';
+
+    private const EXTRACTOR_ALIASES = [
+        'query_string' => 'security.access_token_extractor.query_string',
+        'request_body' => 'security.access_token_extractor.request_body',
+        'header' => 'security.access_token_extractor.header',
+    ];
+
+    /**
+     * The RFC 6750 method each built-in extractor implements, as named by the
+     * "bearer_methods_supported" metadata parameter of RFC 9728, Section 2.
+     */
+    private const BEARER_METHODS = [
+        'security.access_token_extractor.header' => 'header',
+        'security.access_token_extractor.request_body' => 'body',
+        'security.access_token_extractor.query_string' => 'query',
+    ];
 
     /**
      * @param array<TokenHandlerFactoryInterface> $tokenHandlerFactories
@@ -77,6 +96,75 @@ final class AccessTokenFactory extends AbstractFactory implements StatelessAuthe
                     })
                 ->end()
             ->end()
+            ->arrayNode('resource_metadata')
+                ->info('Declaring this node serves the RFC 9728 protected resource metadata document of the firewall at "/.well-known/oauth-protected-resource" and advertises its URL in the "resource_metadata" parameter of the "WWW-Authenticate" header, which is how a client discovers where to get a token this firewall accepts. The route is declared by the "security.authenticator.access_token.route_loader" service, which the application must import as it does for the logout routes; make sure it is reachable without a token.')
+                ->treatNullLike([])
+                ->children()
+                    ->scalarNode('resource')
+                        ->defaultNull()
+                        ->info('The resource identifier of this firewall: an HTTPS URL, without a fragment (e.g. "https://api.example.com" or "https://example.com/api"). Its path component is inserted after the well-known path, as RFC 9728, Section 3.1 prescribes, so that one host can serve the metadata of several protected resources. Defaults to the origin the document is served from, which is what a firewall covering a whole application wants.')
+                        ->validate()
+                            ->ifTrue(static function ($v): bool {
+                                if (false === $parts = parse_url((string) $v)) {
+                                    return true;
+                                }
+
+                                // RFC 9728, Section 3.1 derives the well-known path from the path
+                                // component of this identifier, and the route carrying that path is
+                                // declared at build time, so a value parsing as no URL at all leaves
+                                // the document and the route disagreeing; an environment variable
+                                // interpolated into the URL keeps the path readable and is accepted
+                                if (!isset($parts['scheme'], $parts['host'])) {
+                                    return true;
+                                }
+
+                                // a query component is only a SHOULD NOT, which RFC 8707, Section 2
+                                // relaxes for the cases that need one, so it is accepted here
+                                return isset($parts['fragment']) || !OidcDiscovery::isSecureUrl((string) $v);
+                            })
+                            ->thenInvalid('The protected resource "resource" identifier must be an HTTPS URL without a fragment (got %s), as RFC 9728, Section 1.2 requires. A loopback host (localhost, 127.0.0.1, ::1) or a name reserved for testing (*.localhost, *.test) is accepted over HTTP for local development. It is read when the route is declared, so an environment variable holding the whole value leaves the path unknown: interpolate it into the URL instead, as in "https://%%env(API_HOST)%%/v1".')
+                        ->end()
+                    ->end()
+                    ->arrayNode('authorization_servers', 'authorization_server')
+                        ->acceptAndWrap(['string'])
+                        ->scalarPrototype()->end()
+                        ->defaultValue([])
+                        ->info('The issuer identifiers of the authorization servers issuing the access tokens this firewall accepts (e.g. "https://accounts.example.com"). This is what tells a client holding no token where to go and get one.')
+                    ->end()
+                    ->scalarNode('jwks_uri')
+                        ->defaultNull()
+                        ->info('URL of the JWK Set holding the keys this resource signs its own responses with. Unrelated to the keys the access tokens are verified against, which belong to the authorization server.')
+                    ->end()
+                    ->arrayNode('scopes_supported', 'scope')
+                        ->acceptAndWrap(['string'])
+                        ->scalarPrototype()->end()
+                        ->defaultValue([])
+                        ->info('The scope values this resource uses, one entry per scope.')
+                    ->end()
+                    ->arrayNode('bearer_methods_supported', 'bearer_method')
+                        ->acceptAndWrap(['string'])
+                        ->enumPrototype()->values(['header', 'body', 'query'])->end()
+                        ->defaultValue([])
+                        ->info('The ways this resource accepts to be handed a bearer token, among "header", "body" and "query" (RFC 6750, Sections 2.1 to 2.3). Deduced from "token_extractors" when left empty; set it explicitly when a custom extractor makes that deduction incomplete.')
+                    ->end()
+                    ->scalarNode('resource_name')
+                        ->defaultNull()
+                        ->info('Human-readable name of this resource, meant to be displayed to the end user.')
+                    ->end()
+                    ->scalarNode('resource_documentation')
+                        ->defaultNull()
+                        ->info('URL of the developer documentation of this resource.')
+                    ->end()
+                    ->scalarNode('resource_policy_uri')
+                        ->defaultNull()
+                        ->info('URL of the policy telling how the client may use the data this resource exposes.')
+                    ->end()
+                    ->scalarNode('resource_tos_uri')
+                        ->defaultNull()
+                        ->info('URL of the terms of service of this resource.')
+                    ->end()
+                ->end()
+            ->end()
         ;
     }
 
@@ -106,6 +194,7 @@ final class AccessTokenFactory extends AbstractFactory implements StatelessAuthe
             ->replaceArgument(3, $successHandler)
             ->replaceArgument(4, $failureHandler)
             ->replaceArgument(5, $config['realm'])
+            ->replaceArgument(6, isset($config['resource_metadata']) ? $this->createResourceMetadata($container, $firewallName, $config['resource_metadata'], $config['token_extractors']) : null)
         ;
 
         return $authenticatorId;
@@ -116,12 +205,7 @@ final class AccessTokenFactory extends AbstractFactory implements StatelessAuthe
      */
     private function createExtractor(ContainerBuilder $container, string $firewallName, array $extractors): string
     {
-        $aliases = [
-            'query_string' => 'security.access_token_extractor.query_string',
-            'request_body' => 'security.access_token_extractor.request_body',
-            'header' => 'security.access_token_extractor.header',
-        ];
-        $extractors = array_map(static fn ($extractor) => $aliases[$extractor] ?? $extractor, $extractors);
+        $extractors = array_map(static fn ($extractor) => self::EXTRACTOR_ALIASES[$extractor] ?? $extractor, $extractors);
 
         if (1 === \count($extractors)) {
             return current($extractors);
@@ -133,6 +217,72 @@ final class AccessTokenFactory extends AbstractFactory implements StatelessAuthe
         ;
 
         return $extractorId;
+    }
+
+    /**
+     * Registers the RFC 9728 metadata document of the firewall and the route serving it,
+     * and returns the URL to advertise for it in the "WWW-Authenticate" header.
+     *
+     * @param array<string> $extractors
+     */
+    private function createResourceMetadata(ContainerBuilder $container, string $firewallName, array $config, array $extractors): string
+    {
+        $parts = null === $config['resource'] ? [] : parse_url($config['resource']);
+        $origin = isset($parts['scheme'], $parts['host']) ? $parts['scheme'].'://'.$parts['host'].(isset($parts['port']) ? ':'.$parts['port'] : '') : null;
+
+        if (null === $origin) {
+            // the identifier pins no origin, so the URL can only be resolved against the request
+            $path = $uri = self::WELL_KNOWN_PATH;
+        } else {
+            // RFC 9728, Section 3.1: the well-known path is inserted between the host component
+            // and the path and query components, the terminating slash of the host removed first
+            $path = self::WELL_KNOWN_PATH.rtrim($parts['path'] ?? '', '/');
+            $uri = $origin.$path.(isset($parts['query']) ? '?'.$parts['query'] : '');
+        }
+
+        $paths = $container->hasParameter('security.access_token.resource_metadata_paths') ? (array) $container->getParameter('security.access_token.resource_metadata_paths') : [];
+        $paths[$firewallName] = $path;
+        $container->setParameter('security.access_token.resource_metadata_paths', $paths);
+
+        // every parameter the firewall configuration already carries is derived from it, so
+        // that the document keeps describing what the firewall enforces instead of a copy of
+        // it kept in sync by hand; a protocol feature added later derives its own the same way
+        $metadata = [
+            'resource' => $config['resource'],
+            'authorization_servers' => $config['authorization_servers'],
+            'jwks_uri' => $config['jwks_uri'],
+            'scopes_supported' => $config['scopes_supported'],
+            'bearer_methods_supported' => $config['bearer_methods_supported'] ?: $this->createBearerMethods($extractors),
+            'resource_name' => $config['resource_name'],
+            'resource_documentation' => $config['resource_documentation'],
+            'resource_policy_uri' => $config['resource_policy_uri'],
+            'resource_tos_uri' => $config['resource_tos_uri'],
+        ];
+
+        $controller = $container->getDefinition('security.authenticator.access_token.protected_resource_metadata_controller');
+        // RFC 9728, Section 3.2: a metadata parameter with zero values is omitted
+        $controller->replaceArgument(0, $controller->getArgument(0) + [$firewallName => array_filter($metadata, static fn ($value): bool => null !== $value && [] !== $value)]);
+
+        return $uri;
+    }
+
+    /**
+     * @param array<string> $extractors
+     *
+     * @return array<string>
+     */
+    private function createBearerMethods(array $extractors): array
+    {
+        $methods = [];
+        foreach ($extractors as $extractor) {
+            // a custom extractor implements a method this configuration cannot name, so it
+            // contributes nothing rather than making the document claim something wrong
+            if (null !== $method = self::BEARER_METHODS[self::EXTRACTOR_ALIASES[$extractor] ?? $extractor] ?? null) {
+                $methods[$method] = $method;
+            }
+        }
+
+        return array_values($methods);
     }
 
     private function createTokenHandler(ContainerBuilder $container, string $firewallName, array $config, ?string $userProviderId): string

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -173,6 +173,7 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
         } else {
             $container->removeDefinition('security.route_loader.logout');
             $container->removeDefinition('security.authenticator.oidc_login.route_loader');
+            $container->removeDefinition('security.authenticator.access_token.route_loader');
         }
 
         $this->createAuthorization($config, $container);

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator_access_token.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator_access_token.php
@@ -33,6 +33,8 @@ use Jose\Component\Signature\Algorithm\PS512;
 use Jose\Component\Signature\Algorithm\RS256;
 use Jose\Component\Signature\Algorithm\RS384;
 use Jose\Component\Signature\Algorithm\RS512;
+use Symfony\Bundle\SecurityBundle\Controller\ProtectedResourceMetadataController;
+use Symfony\Bundle\SecurityBundle\Routing\ProtectedResourceMetadataRouteLoader;
 use Symfony\Component\Security\Http\AccessToken\ChainAccessTokenExtractor;
 use Symfony\Component\Security\Http\AccessToken\FormEncodedBodyExtractor;
 use Symfony\Component\Security\Http\AccessToken\HeaderAccessTokenExtractor;
@@ -45,6 +47,12 @@ use Symfony\Component\Security\Http\Authenticator\AccessTokenAuthenticator;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 return static function (ContainerConfigurator $container) {
+    $container->parameters()
+        // the protected resource metadata route loader is wired on this parameter, which the
+        // "access_token" firewall factory fills in; it stays empty when no firewall declares one
+        ->set('security.access_token.resource_metadata_paths', [])
+    ;
+
     $container->services()
         ->set('security.access_token_extractor.header', HeaderAccessTokenExtractor::class)
         ->set('security.access_token_extractor.query_string', QueryAccessTokenExtractor::class)
@@ -59,7 +67,21 @@ return static function (ContainerConfigurator $container) {
                 null,
                 null,
                 null,
+                null,
             ])
+
+        ->set('security.authenticator.access_token.protected_resource_metadata_controller', ProtectedResourceMetadataController::class)
+            ->public()
+            ->args([
+                [],
+            ])
+
+        ->set('security.authenticator.access_token.route_loader', ProtectedResourceMetadataRouteLoader::class)
+            ->args([
+                '%security.access_token.resource_metadata_paths%',
+                'security.access_token.resource_metadata_paths',
+            ])
+            ->tag('routing.route_loader')
 
         ->set('security.authenticator.access_token.chain_extractor', ChainAccessTokenExtractor::class)
             ->abstract()

--- a/src/Symfony/Bundle/SecurityBundle/Routing/ProtectedResourceMetadataRouteLoader.php
+++ b/src/Symfony/Bundle/SecurityBundle/Routing/ProtectedResourceMetadataRouteLoader.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Routing;
+
+use Symfony\Component\DependencyInjection\Config\ContainerParametersResource;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Registers a route serving the RFC 9728 protected resource metadata document of each
+ * "access_token" firewall that configures one, at the well-known path derived from its
+ * resource identifier.
+ *
+ * @author Florent Morselli <florent.morselli@spomky-labs.com>
+ */
+final class ProtectedResourceMetadataRouteLoader
+{
+    /**
+     * @param array<string, string> $paths         Well-known paths indexed by the corresponding firewall name
+     * @param string                $parameterName Name of the container parameter containing {@see $paths} value
+     */
+    public function __construct(
+        private readonly array $paths,
+        private readonly string $parameterName,
+    ) {
+    }
+
+    public function __invoke(): RouteCollection
+    {
+        $collection = new RouteCollection();
+        $collection->addResource(new ContainerParametersResource([$this->parameterName => $this->paths]));
+
+        $firewalls = [];
+        foreach ($this->paths as $firewallName => $path) {
+            // the route carries the firewall name, so two firewalls cannot share a path:
+            // one would serve the metadata document of the other
+            if (isset($firewalls[$path])) {
+                throw new \LogicException(\sprintf('The "%s" and "%s" firewalls both serve their protected resource metadata at "%s"; give each firewall a "resource" with its own path component, as described in RFC 9728, Section 3.1.', $firewalls[$path], $firewallName, $path));
+            }
+
+            $firewalls[$path] = $firewallName;
+            $collection->add('_oauth_protected_resource_metadata_'.$firewallName, (new Route($path, [
+                '_controller' => 'security.authenticator.access_token.protected_resource_metadata_controller',
+                'firewallName' => $firewallName,
+            ]))->setMethods(['GET']));
+        }
+
+        return $collection;
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Controller/ProtectedResourceMetadataControllerTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Controller/ProtectedResourceMetadataControllerTest.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\Controller;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\SecurityBundle\Controller\ProtectedResourceMetadataController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+class ProtectedResourceMetadataControllerTest extends TestCase
+{
+    public function testServesTheMetadataOfTheFirewall()
+    {
+        $controller = new ProtectedResourceMetadataController([
+            'main' => [
+                'resource' => 'https://api.example.com',
+                'authorization_servers' => ['https://accounts.example.com'],
+                'bearer_methods_supported' => ['header'],
+            ],
+            'admin' => [
+                'resource' => 'https://api.example.com/admin',
+            ],
+        ]);
+
+        $response = $controller(Request::create('https://api.example.com/.well-known/oauth-protected-resource'), 'main');
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('application/json', $response->headers->get('Content-Type'));
+        $this->assertSame([
+            'resource' => 'https://api.example.com',
+            'authorization_servers' => ['https://accounts.example.com'],
+            'bearer_methods_supported' => ['header'],
+        ], json_decode($response->getContent(), true));
+    }
+
+    public function testServesPlainSlashes()
+    {
+        $controller = new ProtectedResourceMetadataController([
+            'main' => ['resource' => 'https://api.example.com'],
+        ]);
+
+        $response = $controller(Request::create('https://api.example.com/.well-known/oauth-protected-resource'), 'main');
+
+        $this->assertSame('{"resource":"https://api.example.com"}', $response->getContent());
+    }
+
+    public function testServesThePinnedResourceOfAFirewallCoveringAPath()
+    {
+        $controller = new ProtectedResourceMetadataController([
+            'admin' => ['resource' => 'https://api.example.com/admin'],
+        ]);
+
+        $response = $controller(Request::create('https://api.example.com/.well-known/oauth-protected-resource/admin'), 'admin');
+
+        $this->assertSame(['resource' => 'https://api.example.com/admin'], json_decode($response->getContent(), true));
+    }
+
+    public function testTheResourceDefaultsToTheOriginTheDocumentIsServedFrom()
+    {
+        $controller = new ProtectedResourceMetadataController([
+            'main' => ['authorization_servers' => ['https://accounts.example.com']],
+        ]);
+
+        $response = $controller(Request::create('https://api.example.com:8443/.well-known/oauth-protected-resource'), 'main');
+
+        $this->assertSame([
+            'resource' => 'https://api.example.com:8443',
+            'authorization_servers' => ['https://accounts.example.com'],
+        ], json_decode($response->getContent(), true));
+    }
+
+    public function testThrowsNotFoundForAnUnknownFirewall()
+    {
+        $controller = new ProtectedResourceMetadataController([]);
+
+        $this->expectException(NotFoundHttpException::class);
+        $this->expectExceptionMessage('No protected resource metadata is configured for the "main" firewall.');
+
+        $controller(Request::create('/.well-known/oauth-protected-resource'), 'main');
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/AccessTokenFactoryTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/AccessTokenFactoryTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\SecurityBundle\Controller\ProtectedResourceMetadataController;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\AccessToken\CasTokenHandlerFactory;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\AccessToken\OAuth2TokenHandlerFactory;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\AccessToken\OidcTokenHandlerFactory;
@@ -653,6 +654,186 @@ class AccessTokenFactoryTest extends TestCase
         $normalizedConfig = $node->normalize($config);
 
         return $node->finalize($normalizedConfig);
+    }
+
+    public function testNoResourceMetadataIsServedByDefault()
+    {
+        $container = $this->createContainerBuilder();
+        $factory = new AccessTokenFactory($this->createTokenHandlerFactories());
+        $config = $this->processConfig(['token_handler' => 'in_memory_token_handler_service_id'], $factory);
+
+        $factory->createAuthenticator($container, 'firewall1', $config, 'userprovider');
+
+        $this->assertNull($container->getDefinition('security.authenticator.access_token.firewall1')->getArgument(6));
+        $this->assertSame([], $container->getParameter('security.access_token.resource_metadata_paths'));
+        $this->assertSame([], $container->getDefinition('security.authenticator.access_token.protected_resource_metadata_controller')->getArgument(0));
+    }
+
+    public function testResourceMetadataIsServedAtTheWellKnownPath()
+    {
+        $container = $this->createContainerBuilder();
+        $factory = new AccessTokenFactory($this->createTokenHandlerFactories());
+        $config = $this->processConfig([
+            'token_handler' => 'in_memory_token_handler_service_id',
+            'resource_metadata' => [
+                'authorization_servers' => 'https://accounts.example.com',
+                'scopes_supported' => ['profile', 'email'],
+                'resource_name' => 'My API',
+            ],
+        ], $factory);
+
+        $factory->createAuthenticator($container, 'firewall1', $config, 'userprovider');
+
+        // without a "resource", the URL can only be resolved against the incoming request
+        $this->assertSame('/.well-known/oauth-protected-resource', $container->getDefinition('security.authenticator.access_token.firewall1')->getArgument(6));
+        $this->assertSame(['firewall1' => '/.well-known/oauth-protected-resource'], $container->getParameter('security.access_token.resource_metadata_paths'));
+        $this->assertSame(['firewall1' => [
+            'authorization_servers' => ['https://accounts.example.com'],
+            'scopes_supported' => ['profile', 'email'],
+            'bearer_methods_supported' => ['header'],
+            'resource_name' => 'My API',
+        ]], $container->getDefinition('security.authenticator.access_token.protected_resource_metadata_controller')->getArgument(0));
+    }
+
+    public function testTheResourcePathIsInsertedAfterTheWellKnownPath()
+    {
+        $container = $this->createContainerBuilder();
+        $factory = new AccessTokenFactory($this->createTokenHandlerFactories());
+        $config = $this->processConfig([
+            'token_handler' => 'in_memory_token_handler_service_id',
+            'resource_metadata' => ['resource' => 'https://api.example.com:8443/v1/'],
+        ], $factory);
+
+        $factory->createAuthenticator($container, 'firewall1', $config, 'userprovider');
+
+        $this->assertSame('https://api.example.com:8443/.well-known/oauth-protected-resource/v1', $container->getDefinition('security.authenticator.access_token.firewall1')->getArgument(6));
+        $this->assertSame(['firewall1' => '/.well-known/oauth-protected-resource/v1'], $container->getParameter('security.access_token.resource_metadata_paths'));
+        $this->assertSame(['firewall1' => [
+            'resource' => 'https://api.example.com:8443/v1/',
+            'bearer_methods_supported' => ['header'],
+        ]], $container->getDefinition('security.authenticator.access_token.protected_resource_metadata_controller')->getArgument(0));
+    }
+
+    #[DataProvider('provideBearerMethods')]
+    public function testBearerMethodsAreDeducedFromTheTokenExtractors(array $extractors, array $expected)
+    {
+        $container = $this->createContainerBuilder();
+        $factory = new AccessTokenFactory($this->createTokenHandlerFactories());
+        $config = $this->processConfig([
+            'token_handler' => 'in_memory_token_handler_service_id',
+            'token_extractors' => $extractors,
+            'resource_metadata' => [],
+        ], $factory);
+
+        $factory->createAuthenticator($container, 'firewall1', $config, 'userprovider');
+
+        $metadata = $container->getDefinition('security.authenticator.access_token.protected_resource_metadata_controller')->getArgument(0)['firewall1'];
+        $this->assertSame($expected, $metadata['bearer_methods_supported'] ?? []);
+    }
+
+    public static function provideBearerMethods(): iterable
+    {
+        yield 'aliases' => [['header', 'request_body', 'query_string'], ['header', 'body', 'query']];
+        yield 'service ids' => [['security.access_token_extractor.query_string'], ['query']];
+        yield 'the same method twice' => [['header', 'security.access_token_extractor.header'], ['header']];
+        yield 'a custom extractor names no method' => [['custom_extractor_service_id'], []];
+        yield 'a custom extractor next to a known one' => [['custom_extractor_service_id', 'header'], ['header']];
+    }
+
+    public function testConfiguredBearerMethodsWinOverTheDeducedOnes()
+    {
+        $container = $this->createContainerBuilder();
+        $factory = new AccessTokenFactory($this->createTokenHandlerFactories());
+        $config = $this->processConfig([
+            'token_handler' => 'in_memory_token_handler_service_id',
+            'token_extractors' => ['custom_extractor_service_id'],
+            'resource_metadata' => ['bearer_methods_supported' => 'header'],
+        ], $factory);
+
+        $factory->createAuthenticator($container, 'firewall1', $config, 'userprovider');
+
+        $metadata = $container->getDefinition('security.authenticator.access_token.protected_resource_metadata_controller')->getArgument(0)['firewall1'];
+        $this->assertSame(['header'], $metadata['bearer_methods_supported']);
+    }
+
+    public function testEachFirewallGetsItsOwnMetadata()
+    {
+        $container = $this->createContainerBuilder();
+        $factory = new AccessTokenFactory($this->createTokenHandlerFactories());
+
+        foreach (['firewall1' => 'https://example.com/api', 'firewall2' => 'https://example.com/admin'] as $firewallName => $resource) {
+            $config = $this->processConfig([
+                'token_handler' => 'in_memory_token_handler_service_id',
+                'resource_metadata' => ['resource' => $resource],
+            ], $factory);
+
+            $factory->createAuthenticator($container, $firewallName, $config, 'userprovider');
+        }
+
+        $this->assertSame([
+            'firewall1' => '/.well-known/oauth-protected-resource/api',
+            'firewall2' => '/.well-known/oauth-protected-resource/admin',
+        ], $container->getParameter('security.access_token.resource_metadata_paths'));
+        $this->assertSame(['firewall1', 'firewall2'], array_keys($container->getDefinition('security.authenticator.access_token.protected_resource_metadata_controller')->getArgument(0)));
+    }
+
+    #[DataProvider('provideInvalidResourceIdentifiers')]
+    public function testInvalidResourceIdentifier(string $resource)
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('The protected resource "resource" identifier must be an HTTPS URL without a fragment');
+
+        $this->processConfig([
+            'token_handler' => 'in_memory_token_handler_service_id',
+            'resource_metadata' => ['resource' => $resource],
+        ], new AccessTokenFactory($this->createTokenHandlerFactories()));
+    }
+
+    public static function provideInvalidResourceIdentifiers(): iterable
+    {
+        // the well-known path is derived from the path component of the identifier when the
+        // route is declared, so a value the container cannot parse cannot be served
+        yield 'an environment variable used as the whole value' => ['env_2b0d1a_API_RESOURCE_4f8c'];
+        yield 'not HTTPS' => ['http://api.example.com'];
+        yield 'with a fragment' => ['https://api.example.com/v1#api'];
+        yield 'no URL at all' => ['https://api.example.com:port/v1'];
+    }
+
+    #[DataProvider('provideValidResourceIdentifiers')]
+    public function testValidResourceIdentifier(string $resource, string $expectedPath, string $expectedUri)
+    {
+        $container = $this->createContainerBuilder();
+        $factory = new AccessTokenFactory($this->createTokenHandlerFactories());
+        $config = $this->processConfig([
+            'token_handler' => 'in_memory_token_handler_service_id',
+            'resource_metadata' => ['resource' => $resource],
+        ], $factory);
+
+        $factory->createAuthenticator($container, 'firewall1', $config, 'userprovider');
+
+        $this->assertSame($expectedPath, $container->getParameter('security.access_token.resource_metadata_paths')['firewall1']);
+        $this->assertSame($expectedUri, $container->getDefinition('security.authenticator.access_token.firewall1')->getArgument(6));
+    }
+
+    public static function provideValidResourceIdentifiers(): iterable
+    {
+        yield 'HTTPS' => ['https://api.example.com', '/.well-known/oauth-protected-resource', 'https://api.example.com/.well-known/oauth-protected-resource'];
+        yield 'a loopback host over HTTP' => ['http://127.0.0.1:8000/api', '/.well-known/oauth-protected-resource/api', 'http://127.0.0.1:8000/.well-known/oauth-protected-resource/api'];
+        yield 'a host reserved for testing' => ['http://api.example.test', '/.well-known/oauth-protected-resource', 'http://api.example.test/.well-known/oauth-protected-resource'];
+        // a query is only a SHOULD NOT, and RFC 9728, Section 3.1 keeps it after the path
+        yield 'with a query' => ['https://api.example.com/v1?tenant=acme', '/.well-known/oauth-protected-resource/v1', 'https://api.example.com/.well-known/oauth-protected-resource/v1?tenant=acme'];
+        // an environment variable interpolated into the URL still leaves the path readable
+        yield 'an environment variable inside a URL' => ['https://env_2b0d1a_API_HOST_4f8c/v1', '/.well-known/oauth-protected-resource/v1', 'https://env_2b0d1a_API_HOST_4f8c/.well-known/oauth-protected-resource/v1'];
+    }
+
+    private function createContainerBuilder(): ContainerBuilder
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('security.access_token.resource_metadata_paths', []);
+        $container->register('security.authenticator.access_token.protected_resource_metadata_controller', ProtectedResourceMetadataController::class)
+            ->setArguments([[]]);
+
+        return $container;
     }
 
     private function createTokenHandlerFactories(): array

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
@@ -48,6 +48,7 @@ use Symfony\Component\Security\Http\Authenticator\HttpBasicAuthenticator;
 use Symfony\Component\Security\Http\Authenticator\Oidc\OidcPublicClient;
 use Symfony\Component\Security\Http\Authenticator\Oidc\OidcSignatureVerifier;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
+use Symfony\Component\Security\Http\EntryPoint\FallbackAuthenticationEntryPointInterface;
 
 class SecurityExtensionTest extends TestCase
 {
@@ -1148,6 +1149,38 @@ class SecurityExtensionTest extends TestCase
         $this->assertTrue(true, 'extension throws an InvalidConfigurationException if there is one more more empty access control items');
     }
 
+    #[DataProvider('provideAccessTokenEntryPointFirewalls')]
+    public function testAccessTokenIsAFallbackEntryPoint(array $firewall, string $expectedEntryPoint)
+    {
+        $container = $this->getRawContainer();
+        $container->register('token_handler', \stdClass::class);
+        $container->loadFromExtension('security', [
+            'providers' => [
+                'default' => ['id' => 'foo'],
+            ],
+            'firewalls' => [
+                'main' => $firewall + ['access_token' => ['token_handler' => 'token_handler']],
+            ],
+        ]);
+
+        $container->compile();
+
+        $this->assertSame($expectedEntryPoint, $container->getDefinition('security.firewall.map.config.main')->getArgument(7));
+    }
+
+    public static function provideAccessTokenEntryPointFirewalls(): iterable
+    {
+        // the only entry point of the firewall, so a request carrying no token gets the
+        // RFC 6750 challenge instead of a bare 401
+        yield 'alone' => [[], 'security.authenticator.access_token.main'];
+        // an entry point that starts an actual authentication always wins, so that giving
+        // one to the access token authenticator never changes what an existing firewall does
+        yield 'next to http_basic' => [['http_basic' => true], 'security.authenticator.http_basic.main'];
+        yield 'next to form_login' => [['form_login' => true], 'security.authenticator.form_login.main'];
+        // and it can still be asked for explicitly
+        yield 'explicitly configured' => [['http_basic' => true, 'entry_point' => 'access_token'], 'security.authenticator.access_token.main'];
+    }
+
     public static function provideEntryPointFirewalls(): iterable
     {
         // only one entry point available
@@ -1169,6 +1202,8 @@ class SecurityExtensionTest extends TestCase
     public function testEntryPointRequired(array $firewall, string $messageRegex)
     {
         $container = $this->getRawContainer();
+        $container->register('first_fallback_entry_point', TestFallbackEntryPointAuthenticator::class);
+        $container->register('second_fallback_entry_point', TestFallbackEntryPointAuthenticator::class);
         $container->loadFromExtension('security', [
             'providers' => [
                 'first' => ['id' => 'users'],
@@ -1191,6 +1226,13 @@ class SecurityExtensionTest extends TestCase
         yield [
             ['http_basic' => true, 'form_login' => true],
             '/Because you have multiple authenticators in firewall "main", you need to set the "entry_point" key to one of your authenticators \("form_login", "http_basic"\) or a service ID implementing/',
+        ];
+
+        // a fallback entry point stands in only for a firewall declaring no other one, so two of
+        // them leave the firewall as ambiguous as two entry points that start an authentication
+        yield [
+            ['custom_authenticators' => ['first_fallback_entry_point', 'second_fallback_entry_point']],
+            '/Because you have multiple authenticators in firewall "main", you need to set the "entry_point" key to one of your authenticators \("first_fallback_entry_point", "second_fallback_entry_point"\) or a service ID implementing/',
         ];
     }
 
@@ -1652,6 +1694,14 @@ class TestAuthenticator implements AuthenticatorInterface
 
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception): ?Response
     {
+    }
+}
+
+class TestFallbackEntryPointAuthenticator extends TestAuthenticator implements FallbackAuthenticationEntryPointInterface
+{
+    public function start(Request $request, ?AuthenticationException $authException = null): Response
+    {
+        return new Response('', 401);
     }
 }
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/AccessTokenTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/AccessTokenTest.php
@@ -43,6 +43,48 @@ class AccessTokenTest extends AbstractWebTestCase
         $this->createClient(['test_case' => 'AccessToken', 'root_config' => 'config_no_extractors.yml']);
     }
 
+    public function testProtectedResourceMetadataIsServedAndAdvertised()
+    {
+        $client = $this->createClient(['test_case' => 'AccessToken', 'root_config' => 'config_resource_metadata.yml']);
+
+        $client->request('GET', '/foo', server: ['HTTP_AUTHORIZATION' => 'Bearer INVALID_ACCESS_TOKEN']);
+        $response = $client->getResponse();
+
+        $this->assertSame(401, $response->getStatusCode());
+        $this->assertSame('Bearer realm="My API",error="invalid_token",error_description="Invalid credentials.",resource_metadata="http://localhost/.well-known/oauth-protected-resource"', $response->headers->get('WWW-Authenticate'));
+
+        // the primary RFC 9728 discovery flow: a client holding no token yet is told where
+        // the document is, which the firewall can only answer as its entry point
+        $client->request('GET', '/foo');
+        $response = $client->getResponse();
+
+        $this->assertSame(401, $response->getStatusCode());
+        $this->assertSame('Bearer realm="My API",resource_metadata="http://localhost/.well-known/oauth-protected-resource"', $response->headers->get('WWW-Authenticate'));
+
+        $client->request('GET', '/.well-known/oauth-protected-resource');
+        $response = $client->getResponse();
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('application/json', $response->headers->get('Content-Type'));
+        $this->assertSame([
+            'resource' => 'http://localhost',
+            'authorization_servers' => ['https://accounts.example.com'],
+            'scopes_supported' => ['profile', 'email'],
+            'bearer_methods_supported' => ['header', 'query'],
+            'resource_name' => 'My API',
+            'resource_documentation' => 'https://api.example.com/docs',
+        ], json_decode($response->getContent(), true));
+    }
+
+    public function testNoProtectedResourceMetadataRouteWithoutTheConfiguration()
+    {
+        $client = $this->createClient(['test_case' => 'AccessToken', 'root_config' => 'config_header_default.yml']);
+
+        $client->request('GET', '/.well-known/oauth-protected-resource');
+
+        $this->assertSame(404, $client->getResponse()->getStatusCode());
+    }
+
     public function testAnonymousAccessIsGranted()
     {
         $client = $this->createClient(['test_case' => 'AccessToken', 'root_config' => 'config_anonymous.yml']);

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_resource_metadata.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_resource_metadata.yml
@@ -1,0 +1,35 @@
+imports:
+    - { resource: ./../config/framework.yml }
+
+framework:
+    serializer: ~
+
+security:
+    password_hashers:
+        Symfony\Component\Security\Core\User\InMemoryUser: plaintext
+
+    providers:
+        in_memory:
+            memory:
+                users:
+                    dunglas: { password: foo, roles: [ROLE_USER] }
+
+    firewalls:
+        main:
+            pattern: ^/
+            access_token:
+                token_handler: access_token.access_token_handler
+                token_extractors: ['header', 'query_string']
+                realm: 'My API'
+                resource_metadata:
+                    authorization_servers: ['https://accounts.example.com']
+                    scopes_supported: ['profile', 'email']
+                    resource_name: 'My API'
+                    resource_documentation: 'https://api.example.com/docs'
+
+    access_control:
+        - { path: ^/foo, roles: ROLE_USER }
+
+services:
+    access_token.access_token_handler:
+        class: Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\AccessTokenBundle\Security\Handler\AccessTokenHandler

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/routing.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/routing.yml
@@ -4,3 +4,6 @@ foo_route:
 bar_route:
     path: /bar
     defaults: { _controller: Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\AccessTokenBundle\Controller\BarController::__invoke }
+_security_protected_resource_metadata:
+    resource: security.authenticator.access_token.route_loader
+    type: service

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Routing/ProtectedResourceMetadataRouteLoaderTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Routing/ProtectedResourceMetadataRouteLoaderTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\Routing;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\SecurityBundle\Routing\ProtectedResourceMetadataRouteLoader;
+use Symfony\Component\DependencyInjection\Config\ContainerParametersResource;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+
+class ProtectedResourceMetadataRouteLoaderTest extends TestCase
+{
+    public function testLoad()
+    {
+        $paths = [
+            'main' => '/.well-known/oauth-protected-resource',
+            'admin' => '/.well-known/oauth-protected-resource/admin',
+        ];
+
+        $loader = new ProtectedResourceMetadataRouteLoader($paths, 'parameterName');
+        $collection = $loader();
+
+        self::assertInstanceOf(RouteCollection::class, $collection);
+        self::assertCount(2, $collection);
+
+        $expected = static fn (string $path, string $firewallName): Route => (new Route($path, [
+            '_controller' => 'security.authenticator.access_token.protected_resource_metadata_controller',
+            'firewallName' => $firewallName,
+        ]))->setMethods(['GET']);
+
+        self::assertEquals($expected('/.well-known/oauth-protected-resource', 'main'), $collection->get('_oauth_protected_resource_metadata_main'));
+        self::assertEquals($expected('/.well-known/oauth-protected-resource/admin', 'admin'), $collection->get('_oauth_protected_resource_metadata_admin'));
+
+        $resources = $collection->getResources();
+        self::assertCount(1, $resources);
+
+        $resource = reset($resources);
+        self::assertInstanceOf(ContainerParametersResource::class, $resource);
+        self::assertSame(['parameterName' => $paths], $resource->getParameters());
+    }
+
+    public function testLoadWithoutAnyConfiguredFirewall()
+    {
+        $collection = (new ProtectedResourceMetadataRouteLoader([], 'parameterName'))();
+
+        self::assertCount(0, $collection);
+    }
+
+    public function testRejectsAPathSharedBetweenFirewalls()
+    {
+        $loader = new ProtectedResourceMetadataRouteLoader([
+            'main' => '/.well-known/oauth-protected-resource',
+            'admin' => '/.well-known/oauth-protected-resource',
+        ], 'parameterName');
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('The "main" and "admin" firewalls both serve their protected resource metadata at "/.well-known/oauth-protected-resource"; give each firewall a "resource" with its own path component, as described in RFC 9728, Section 3.1.');
+
+        $loader();
+    }
+}

--- a/src/Symfony/Component/Security/Http/Authenticator/AccessTokenAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/AccessTokenAuthenticator.php
@@ -24,6 +24,7 @@ use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerI
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
 use Symfony\Component\Security\Http\Authenticator\Token\PostAuthenticationToken;
+use Symfony\Component\Security\Http\EntryPoint\FallbackAuthenticationEntryPointInterface;
 use Symfony\Component\Security\Http\SecurityRequestAttributes;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -33,10 +34,14 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  *
  * @author Florent Morselli <florent.morselli@spomky-labs.com>
  */
-class AccessTokenAuthenticator implements AuthenticatorInterface
+class AccessTokenAuthenticator implements AuthenticatorInterface, FallbackAuthenticationEntryPointInterface
 {
     private ?TranslatorInterface $translator = null;
 
+    /**
+     * @param string|null $resourceMetadataUri The URL of the RFC 9728 protected resource metadata document to advertise
+     *                                         in the "WWW-Authenticate" header; a path is resolved against the request
+     */
     public function __construct(
         private readonly AccessTokenHandlerInterface $accessTokenHandler,
         private readonly AccessTokenExtractorInterface $accessTokenExtractor,
@@ -44,6 +49,7 @@ class AccessTokenAuthenticator implements AuthenticatorInterface
         private readonly ?AuthenticationSuccessHandlerInterface $successHandler = null,
         private readonly ?AuthenticationFailureHandlerInterface $failureHandler = null,
         private readonly ?string $realm = null,
+        private readonly ?string $resourceMetadataUri = null,
     ) {
     }
 
@@ -98,7 +104,19 @@ class AccessTokenAuthenticator implements AuthenticatorInterface
         return new Response(
             null,
             Response::HTTP_UNAUTHORIZED,
-            ['WWW-Authenticate' => $this->getAuthenticateHeader($errorMessage)]
+            ['WWW-Authenticate' => $this->getAuthenticateHeader($request, 'invalid_token', $errorMessage)]
+        );
+    }
+
+    public function start(Request $request, ?AuthenticationException $authException = null): Response
+    {
+        // RFC 6750, Section 3: the challenge of a request that carries no access token at all
+        // holds no error code, as an error code describes a token the client did send. This is
+        // the request an RFC 9728 client makes to discover where to get a token from.
+        return new Response(
+            null,
+            Response::HTTP_UNAUTHORIZED,
+            ['WWW-Authenticate' => $this->getAuthenticateHeader($request)]
         );
     }
 
@@ -109,13 +127,19 @@ class AccessTokenAuthenticator implements AuthenticatorInterface
 
     /**
      * @see https://datatracker.ietf.org/doc/html/rfc6750#section-3
+     * @see https://datatracker.ietf.org/doc/html/rfc9728#section-5.1
      */
-    private function getAuthenticateHeader(?string $errorDescription = null): string
+    private function getAuthenticateHeader(Request $request, ?string $error = null, ?string $errorDescription = null): string
     {
         $data = [
             'realm' => $this->realm,
-            'error' => 'invalid_token',
+            'error' => $error,
             'error_description' => $errorDescription,
+            'resource_metadata' => match (true) {
+                null === $this->resourceMetadataUri => null,
+                str_starts_with($this->resourceMetadataUri, '/') => $request->getUriForPath($this->resourceMetadataUri),
+                default => $this->resourceMetadataUri,
+            },
         ];
         $values = [];
         foreach ($data as $k => $v) {
@@ -125,6 +149,6 @@ class AccessTokenAuthenticator implements AuthenticatorInterface
             $values[] = \sprintf('%s="%s"', $k, $v);
         }
 
-        return \sprintf('Bearer %s', implode(',', $values));
+        return $values ? 'Bearer '.implode(',', $values) : 'Bearer';
     }
 }

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -28,6 +28,8 @@ CHANGELOG
  * Add the `$enforceAtJwtType` argument to `OidcTokenHandler` to reject the tokens whose `typ` header is not the `at+jwt` RFC 9068 requires from an access token
  * Deprecate not passing the `$enforceAtJwtType` argument to `OidcTokenHandler`; it defaults to `false` in 8.2 and will default to `true` in 9.0
  * Make `OidcTokenGenerator` emit the `at+jwt` type header RFC 9068 requires from an access token
+ * Add the `$resourceMetadataUri` argument to `AccessTokenAuthenticator`, advertised in the `resource_metadata` parameter of the `WWW-Authenticate` header (RFC 9728)
+ * Add `FallbackAuthenticationEntryPointInterface` for an entry point that only stands in for a firewall declaring no other one, and make `AccessTokenAuthenticator` one, so that a request carrying no access token gets the RFC 6750 challenge instead of a bare 401
 
 8.1
 ---

--- a/src/Symfony/Component/Security/Http/EntryPoint/FallbackAuthenticationEntryPointInterface.php
+++ b/src/Symfony/Component/Security/Http/EntryPoint/FallbackAuthenticationEntryPointInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\EntryPoint;
+
+/**
+ * An entry point that only stands in for a firewall declaring no other one.
+ *
+ * An authenticator implements it when it can answer an unauthenticated request with a
+ * meaningful challenge, but has no authentication to start and must therefore never win
+ * over an entry point that does, e.g. a login form. A firewall that holds one of each
+ * keeps picking the other, so that an authenticator gaining a fallback entry point never
+ * makes an existing firewall ambiguous. Having no authentication to start, it also gets
+ * no target path saved for it, so that answering an unauthenticated request never starts
+ * a session.
+ *
+ * @author Florent Morselli <florent.morselli@spomky-labs.com>
+ */
+interface FallbackAuthenticationEntryPointInterface extends AuthenticationEntryPointInterface
+{
+}

--- a/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
@@ -31,6 +31,7 @@ use Symfony\Component\Security\Core\Exception\LogoutException;
 use Symfony\Component\Security\Http\Authorization\AccessDeniedHandlerInterface;
 use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
 use Symfony\Component\Security\Http\EntryPoint\Exception\NotAnEntryPointException;
+use Symfony\Component\Security\Http\EntryPoint\FallbackAuthenticationEntryPointInterface;
 use Symfony\Component\Security\Http\HttpUtils;
 use Symfony\Component\Security\Http\SecurityRequestAttributes;
 use Symfony\Component\Security\Http\Util\TargetPathTrait;
@@ -181,7 +182,9 @@ class ExceptionListener
 
         $this->logger?->debug('Calling Authentication entry point.', ['entry_point' => $this->authenticationEntryPoint]);
 
-        if (!$this->stateless) {
+        // an entry point that only stands in has no authentication to start, so there is
+        // nothing for the user to come back to and no reason to start a session for it
+        if (!$this->stateless && !$this->authenticationEntryPoint instanceof FallbackAuthenticationEntryPointInterface) {
             $this->setTargetPath($request);
         }
 

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/AccessTokenAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/AccessTokenAuthenticatorTest.php
@@ -194,6 +194,65 @@ class AccessTokenAuthenticatorTest extends TestCase
         ];
     }
 
+    public function testAuthenticateHeaderOfTheFailureResponse()
+    {
+        $authenticator = new AccessTokenAuthenticator(
+            $this->createStub(AccessTokenHandlerInterface::class),
+            new HeaderAccessTokenExtractor(),
+            realm: 'My API',
+        );
+
+        $response = $authenticator->onAuthenticationFailure(Request::create('/test'), new BadCredentialsException());
+
+        $this->assertSame(401, $response->getStatusCode());
+        $this->assertSame('Bearer realm="My API",error="invalid_token",error_description="Invalid credentials."', $response->headers->get('WWW-Authenticate'));
+    }
+
+    #[DataProvider('provideResourceMetadataUris')]
+    public function testAuthenticateHeaderAdvertisesTheResourceMetadata(?string $resourceMetadataUri, string $expected)
+    {
+        $authenticator = new AccessTokenAuthenticator(
+            $this->createStub(AccessTokenHandlerInterface::class),
+            new HeaderAccessTokenExtractor(),
+            resourceMetadataUri: $resourceMetadataUri,
+        );
+
+        $response = $authenticator->onAuthenticationFailure(Request::create('https://api.example.com/test'), new BadCredentialsException());
+
+        $this->assertSame($expected, $response->headers->get('WWW-Authenticate'));
+    }
+
+    public static function provideResourceMetadataUris(): iterable
+    {
+        yield 'none configured' => [null, 'Bearer error="invalid_token",error_description="Invalid credentials."'];
+        yield 'a path is resolved against the request' => ['/.well-known/oauth-protected-resource', 'Bearer error="invalid_token",error_description="Invalid credentials.",resource_metadata="https://api.example.com/.well-known/oauth-protected-resource"'];
+        yield 'an absolute URL is advertised as is' => ['https://other.example.com/.well-known/oauth-protected-resource/api', 'Bearer error="invalid_token",error_description="Invalid credentials.",resource_metadata="https://other.example.com/.well-known/oauth-protected-resource/api"'];
+    }
+
+    public function testTheChallengeOfARequestCarryingNoTokenHoldsNoErrorCode()
+    {
+        $authenticator = new AccessTokenAuthenticator(
+            $this->createStub(AccessTokenHandlerInterface::class),
+            new HeaderAccessTokenExtractor(),
+            realm: 'My API',
+            resourceMetadataUri: '/.well-known/oauth-protected-resource',
+        );
+
+        $response = $authenticator->start(Request::create('https://api.example.com/foo'));
+
+        $this->assertSame(401, $response->getStatusCode());
+        $this->assertSame('Bearer realm="My API",resource_metadata="https://api.example.com/.well-known/oauth-protected-resource"', $response->headers->get('WWW-Authenticate'));
+    }
+
+    public function testTheChallengeOfAFirewallThatPinsNothingIsTheBareScheme()
+    {
+        $authenticator = new AccessTokenAuthenticator($this->createStub(AccessTokenHandlerInterface::class), new HeaderAccessTokenExtractor());
+
+        $response = $authenticator->start(Request::create('https://api.example.com/foo'));
+
+        $this->assertSame('Bearer', $response->headers->get('WWW-Authenticate'));
+    }
+
     public function testUnsupportedReasons()
     {
         $authenticator = new AccessTokenAuthenticator($this->createStub(AccessTokenHandlerInterface::class), new HeaderAccessTokenExtractor());

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/ExceptionListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/ExceptionListenerTest.php
@@ -16,6 +16,8 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
@@ -28,6 +30,7 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Exception\LogoutException;
 use Symfony\Component\Security\Http\Authorization\AccessDeniedHandlerInterface;
 use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
+use Symfony\Component\Security\Http\EntryPoint\FallbackAuthenticationEntryPointInterface;
 use Symfony\Component\Security\Http\Firewall\ExceptionListener;
 use Symfony\Component\Security\Http\HttpUtils;
 
@@ -170,6 +173,28 @@ class ExceptionListenerTest extends TestCase
         ];
     }
 
+    public function testTargetPathIsSavedForAnEntryPointThatStartsAnAuthentication()
+    {
+        $event = $this->createEvent(new AuthenticationException(), null, $session = new Session(new MockArraySessionStorage()));
+
+        $this->createExceptionListener(null, null, null, $this->createEntryPoint())->onKernelException($event);
+
+        $this->assertSame('http://localhost/', $session->get('_security.key.target_path'));
+    }
+
+    public function testNoTargetPathIsSavedForAnEntryPointThatOnlyStandsIn()
+    {
+        $entryPoint = $this->createMock(FallbackAuthenticationEntryPointInterface::class);
+        $entryPoint->expects($this->once())->method('start')->willReturn(new Response(null, 401));
+
+        $event = $this->createEvent(new AuthenticationException(), null, $session = new Session(new MockArraySessionStorage()));
+
+        $this->createExceptionListener(null, null, null, $entryPoint)->onKernelException($event);
+
+        $this->assertFalse($session->isStarted());
+        $this->assertNull($session->get('_security.key.target_path'));
+    }
+
     private function createEntryPoint(?Response $response = null)
     {
         $entryPoint = $this->createMock(AuthenticationEntryPointInterface::class);
@@ -186,11 +211,15 @@ class ExceptionListenerTest extends TestCase
         return $trustResolver;
     }
 
-    private function createEvent(\Exception $exception, $kernel = null)
+    private function createEvent(\Exception $exception, $kernel = null, ?Session $session = null)
     {
         $kernel ??= $this->createStub(HttpKernelInterface::class);
+        $request = Request::create('/');
+        if (null !== $session) {
+            $request->setSession($session);
+        }
 
-        return new ExceptionEvent($kernel, Request::create('/'), HttpKernelInterface::MAIN_REQUEST, $exception);
+        return new ExceptionEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST, $exception);
     }
 
     private function createExceptionListener(?TokenStorageInterface $tokenStorage = null, ?AuthenticationTrustResolverInterface $trustResolver = null, ?HttpUtils $httpUtils = null, ?AuthenticationEntryPointInterface $authenticationEntryPoint = null, $errorPage = null, ?AccessDeniedHandlerInterface $accessDeniedHandler = null)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

RFC 9728 (OAuth 2.0 Protected Resource Metadata) is how a client holding no token discovers which authorization servers issue the tokens a resource accepts: the resource server publishes a JSON document at `/.well-known/oauth-protected-resource`, and points at it from the `WWW-Authenticate` header of its 401 responses. It is what MCP clients expect today, and the `access_token` authenticator had none of it.

This adds a `resource_metadata` node to the `access_token` firewall authenticator. Declaring it serves the document and advertises its URL:

```yaml
security:
    firewalls:
        api:
            pattern: ^/
            access_token:
                realm: 'My API'
                token_extractors: ['header', 'query_string']
                token_handler:
                    oidc: ~
                resource_metadata:
                    authorization_servers: ['https://accounts.example.com']
                    scopes_supported: ['profile', 'email']
                    resource_name: 'My API'
                    resource_documentation: 'https://api.example.com/docs'
```

`GET /.well-known/oauth-protected-resource` then answers:

```json
{
    "resource": "https://api.example.com",
    "authorization_servers": ["https://accounts.example.com"],
    "scopes_supported": ["profile", "email"],
    "bearer_methods_supported": ["header", "query"],
    "resource_name": "My API",
    "resource_documentation": "https://api.example.com/docs"
}
```

and a rejected request carries the pointer to it:

```
WWW-Authenticate: Bearer realm="My API",error="invalid_token",error_description="Invalid credentials.",resource_metadata="https://api.example.com/.well-known/oauth-protected-resource"
```

A few notes on the choices made:

* The route is declared by a `security.authenticator.access_token.route_loader` service, imported the way the logout routes and the `oidc_login` ones already are. Keeping the well-known path reachable without a token is on the application, as for any other public path.
* `resource` is optional. Left out, the resource identifier is the origin the document is served from, resolved on the request, which is what a firewall covering a whole application wants. Carrying a path, the insertion rule of Section 3.1 applies: `https://example.com/api` is served at `/.well-known/oauth-protected-resource/api`, so one host can serve several firewalls. Two firewalls landing on the same path fail with an exception naming both. That path is read when the route is declared, so the identifier cannot be an environment variable used as the whole value: such a value parses as no URL at all, and the route would sit at the bare well-known path while the document published an identifier carrying a path. It is refused, and an environment variable interpolated into the URL, as in `https://%env(API_HOST)%/v1`, keeps the path readable and is accepted.
* `bearer_methods_supported` is deduced from `token_extractors`, since `header`, `request_body` and `query_string` are exactly the three RFC 6750 methods the IANA registry names. A custom extractor contributes nothing rather than making the document claim something wrong, and the key stays available to write the list by hand.
* The document is derived from the firewall configuration instead of being a copy of it kept in sync by hand. The parameters describing features the resource server does not implement yet are deliberately left out: `dpop_signing_alg_values_supported` and `dpop_bound_access_tokens_required` (RFC 9449), `tls_client_certificate_bound_access_tokens` (RFC 8705), and `signed_metadata` belong with the features themselves and will be derived in the same place when they land.

On the component side, `AccessTokenAuthenticator` takes a `$resourceMetadataUri` argument: a path is resolved against the incoming request, an absolute URL is advertised as is, which is what a pinned `resource` produces.

Documentation to follow.

