### PR TITLE
[Security][SecurityBundle] Make the OAuth2 introspection token handler usable

### DIFF
--- a/UPGRADE-8.2.md
+++ b/UPGRADE-8.2.md
@@ -209,10 +209,15 @@ Security
  * `AccessTokenAuthenticator` now implements `FallbackAuthenticationEntryPointInterface`, so it becomes the
    entry point of a firewall that declares no other one: an unauthenticated request now gets a 401 carrying
    the RFC 6750 `WWW-Authenticate: Bearer` challenge, where it used to get a 401 with no such header
+ * [BC BREAK] The `oauth2` access token handler now refuses an introspection response reporting an `exp` in the
+   past, or an `nbf` or an `iat` in the future, and one whose `exp`, `nbf` or `iat` is not a number it can read as
+   a timestamp
 
 SecurityBundle
 --------------
 
+ * The `oauth2` token handler now reads its configuration, where it used to ignore it. Giving it a string names
+   the HTTP client the introspection endpoint is called with, and `oauth2: ~` no longer fails to compile
  * Deprecate the `remember_me` option of the `form_login`, `json_login`, `login_link`, and `access_token` authenticators, as it has no effect
  * Deprecate not setting the `enforce_at_jwt_type` option of the `oidc` token handler; it defaults to `false`
    in 8.2 and will default to `true` in 9.0

--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -8,6 +8,8 @@ CHANGELOG
  * Add the `debug:roles` command to inspect the role hierarchy
  * Add `allowed_time_drift` option to the OIDC token handler configuration
  * Require OAuth2 scopes of the access token with an `OAUTH2_SCOPE(...)` attribute, and answer a denial with the RFC 6750 §3.1 `insufficient_scope` challenge
+ * Add the `http_client`, `issuer`, `audience`, `claim`, `allowed_time_drift` and `cache` options to the `oauth2` token handler, whose configuration used to be ignored. The `audience` option takes a single identifier as a string or several as a list
+ * Fix the `oauth2` token handler, which could not reach any introspection endpoint: `oauth2: ~` made the container fail to compile, and the endpoint was requested with an empty URL
  * Allow disabling the redirection on successful logout by passing `null` to the `target` option
  * Deprecate the `remember_me` option of the `form_login`, `json_login`, `login_link`, and `access_token` authenticators, as it has no effect
  * Add the `ldap_users_only` option to the LDAP authenticators, to bind only `LdapUser` instances against the LDAP server

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/AccessToken/OAuth2TokenHandlerFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/AccessToken/OAuth2TokenHandlerFactory.php
@@ -14,9 +14,21 @@ namespace Symfony\Bundle\SecurityBundle\DependencyInjection\Security\AccessToken
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\LogicException;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Contracts\Cache\CacheInterface;
 
 /**
  * Configures a token handler for an OAuth2 Token Introspection endpoint.
+ *
+ * Where the authorization server lives and how this resource server authenticates there is the
+ * business of the HTTP client the "http_client" option names, not of the firewall: a scoped client
+ * declares the introspection endpoint as its "base_uri" and the credentials RFC 7662 §2.1 requires
+ * the endpoint to demand as its "auth_basic". Those credentials are sent as given, where the
+ * "client_secret_basic" of RFC 6749 §2.3.1 form-urlencodes both halves, so a client id or a secret
+ * holding a colon, a plus, a space or a non-ASCII byte must be encoded before it is passed. What is
+ * configured here is only what the firewall itself needs, namely what the response is confronted
+ * with.
  *
  * @internal
  */
@@ -24,7 +36,28 @@ class OAuth2TokenHandlerFactory implements TokenHandlerFactoryInterface
 {
     public function create(ContainerBuilder $container, string $id, array|string $config): void
     {
-        $container->setDefinition($id, new ChildDefinition('security.access_token_handler.oauth2'));
+        $tokenHandlerDefinition = $container->setDefinition($id, new ChildDefinition('security.access_token_handler.oauth2'))
+            ->replaceArgument(2, $config['audience'])
+            ->replaceArgument(3, $config['issuer'])
+            ->replaceArgument(4, $config['claim'])
+            ->replaceArgument(6, $config['allowed_time_drift'])
+        ;
+
+        if (isset($config['http_client'])) {
+            $tokenHandlerDefinition->replaceArgument(0, new Reference($config['http_client']));
+        }
+
+        if (isset($config['cache'])) {
+            if (!ContainerBuilder::willBeAvailable('symfony/cache', CacheInterface::class, ['symfony/security-bundle'])) {
+                throw new LogicException('You cannot cache the introspection responses of the "oauth2" token handler since the Cache component is not installed. Try running "composer require symfony/cache".');
+            }
+
+            $tokenHandlerDefinition->addMethodCall('enableCache', [
+                new Reference($config['cache']['id']),
+                "$id.introspection.",
+                $config['cache']['ttl'],
+            ]);
+        }
     }
 
     public function getKey(): string
@@ -34,6 +67,54 @@ class OAuth2TokenHandlerFactory implements TokenHandlerFactoryInterface
 
     public function addConfiguration(NodeBuilder $node): void
     {
-        $node->scalarNode($this->getKey())->end();
+        $node
+            ->arrayNode($this->getKey())
+                ->beforeNormalization()
+                    ->ifString()
+                    ->then(static fn ($v) => ['http_client' => $v])
+                ->end()
+                ->children()
+                    ->scalarNode('http_client')
+                        ->info('HttpClient service id the introspection endpoint is called with. Declare it as a scoped client whose "base_uri" is the introspection endpoint of your authorization server and whose "auth_basic" holds the credentials it authenticates with. Those are sent as given, where the "client_secret_basic" of RFC 6749 §2.3.1 form-urlencodes both halves, so encode a client id or a secret holding a colon, a plus or a space yourself.')
+                        ->cannotBeEmpty()
+                    ->end()
+                    ->arrayNode('audience')
+                        ->info('Identifiers of this resource server, one of which the "aud" of the introspection response must name. A single identifier may be given as a string.')
+                        ->acceptAndWrap(['string'])
+                        ->scalarPrototype()->cannotBeEmpty()->end()
+                    ->end()
+                    ->scalarNode('issuer')
+                        ->info('Identifier of the authorization server, checked against the "iss" of the introspection response.')
+                        ->defaultNull()
+                        ->cannotBeEmpty()
+                    ->end()
+                    ->scalarNode('claim')
+                        ->info('Claim which contains the user identifier (e.g.: sub, username, email...). Defaults to "sub", falling back to "username".')
+                        ->defaultNull()
+                        ->cannotBeEmpty()
+                    ->end()
+                    ->integerNode('allowed_time_drift')
+                        ->info('Allowed time drift in seconds when validating the "iat", "nbf" and "exp" of the introspection response.')
+                        ->defaultValue(0)
+                        ->min(0)
+                    ->end()
+                    ->arrayNode('cache')
+                        ->info('Cache the introspection responses of active tokens, never beyond their "exp".')
+                        ->children()
+                            ->scalarNode('id')
+                                ->info('Cache service id to use to cache the introspection responses.')
+                                ->isRequired()
+                                ->cannotBeEmpty()
+                            ->end()
+                            ->integerNode('ttl')
+                                ->info('Maximum lifetime in seconds of a cached introspection response. The shorter it is, the sooner a revoked token stops being accepted.')
+                                ->defaultValue(60)
+                                ->min(1)
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end()
+        ;
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator_access_token.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator_access_token.php
@@ -237,6 +237,11 @@ return static function (ContainerConfigurator $container) {
             ->args([
                 service('http_client'),
                 service('logger')->nullOnInvalid(),
+                abstract_arg('audiences'),
+                abstract_arg('issuer'),
+                abstract_arg('claim'),
+                service('clock'),
+                abstract_arg('allowed time drift'),
             ])
 
         ->set('security.access_token_handler.oidc.generator', OidcTokenGenerator::class)

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/AccessTokenFactoryTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/AccessTokenFactoryTest.php
@@ -603,6 +603,81 @@ class AccessTokenFactoryTest extends TestCase
 
         $this->assertTrue($container->hasDefinition('security.authenticator.access_token.firewall1'));
         $this->assertTrue($container->hasDefinition('security.access_token_handler.firewall1'));
+
+        $this->assertEquals([
+            'index_2' => [],
+            'index_3' => null,
+            'index_4' => null,
+            'index_6' => 0,
+        ], $container->getDefinition('security.access_token_handler.firewall1')->getArguments());
+    }
+
+    public function testOAuth2TokenHandlerConfigurationWithAScopedClient()
+    {
+        $container = new ContainerBuilder();
+        $config = [
+            'token_handler' => [
+                'oauth2' => [
+                    'http_client' => 'oauth2.introspection',
+                    'audience' => 'https://api.example.com',
+                    'issuer' => 'https://www.example.com',
+                    'claim' => 'username',
+                    'allowed_time_drift' => 5,
+                    'cache' => ['id' => 'oauth2_cache'],
+                ],
+            ],
+        ];
+
+        $factory = new AccessTokenFactory($this->createTokenHandlerFactories());
+        $finalizedConfig = $this->processConfig($config, $factory);
+
+        $factory->createAuthenticator($container, 'firewall1', $finalizedConfig, 'userprovider');
+
+        $definition = $container->getDefinition('security.access_token_handler.firewall1');
+        $this->assertEquals([
+            'index_0' => new Reference('oauth2.introspection'),
+            'index_2' => ['https://api.example.com'],
+            'index_3' => 'https://www.example.com',
+            'index_4' => 'username',
+            'index_6' => 5,
+        ], $definition->getArguments());
+        $this->assertEquals([
+            ['enableCache', [new Reference('oauth2_cache'), 'security.access_token_handler.firewall1.introspection.', 60]],
+        ], $definition->getMethodCalls());
+    }
+
+    public function testOAuth2TokenHandlerConfigurationWithSeveralAudiences()
+    {
+        $container = new ContainerBuilder();
+        $config = [
+            'token_handler' => [
+                'oauth2' => [
+                    'audience' => ['https://api.example.com', 'https://admin.example.com'],
+                ],
+            ],
+        ];
+
+        $factory = new AccessTokenFactory($this->createTokenHandlerFactories());
+        $finalizedConfig = $this->processConfig($config, $factory);
+
+        $factory->createAuthenticator($container, 'firewall1', $finalizedConfig, 'userprovider');
+
+        $this->assertSame(['https://api.example.com', 'https://admin.example.com'], $container->getDefinition('security.access_token_handler.firewall1')->getArgument(2));
+    }
+
+    public function testOAuth2TokenHandlerConfigurationWithAClientAsAString()
+    {
+        $container = new ContainerBuilder();
+        $config = [
+            'token_handler' => ['oauth2' => 'oauth2.introspection'],
+        ];
+
+        $factory = new AccessTokenFactory($this->createTokenHandlerFactories());
+        $finalizedConfig = $this->processConfig($config, $factory);
+
+        $factory->createAuthenticator($container, 'firewall1', $finalizedConfig, 'userprovider');
+
+        $this->assertEquals(new Reference('oauth2.introspection'), $container->getDefinition('security.access_token_handler.firewall1')->getArgument(0));
     }
 
     public function testNoTokenHandlerSet()

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/AccessTokenTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/AccessTokenTest.php
@@ -22,6 +22,7 @@ use Jose\Component\Signature\JWSBuilder;
 use Jose\Component\Signature\Serializer\CompactSerializer as JwsCompactSerializer;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+use Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\AccessTokenBundle\Security\Handler\IntrospectionResponseFactory;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
@@ -531,6 +532,53 @@ class AccessTokenTest extends AbstractWebTestCase
             'username' => 'dunglas',
         ]);
         $client->request('GET', '/foo', [], [], ['HTTP_AUTHORIZATION' => \sprintf('Bearer %s', $token)]);
+        $response = $client->getResponse();
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertSame(401, $response->getStatusCode());
+        $this->assertSame('Bearer realm="My API",error="invalid_token",error_description="Invalid credentials."', $response->headers->get('WWW-Authenticate'));
+    }
+
+    public function testOAuth2IntrospectionSuccess()
+    {
+        $client = $this->createClient(['test_case' => 'AccessToken', 'root_config' => 'config_oauth2.yml']);
+        $endpoint = $client->getContainer()->get(IntrospectionResponseFactory::class);
+
+        $client->request('GET', '/foo', [], [], ['HTTP_AUTHORIZATION' => 'Bearer VALID_ACCESS_TOKEN']);
+        $response = $client->getResponse();
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame(['message' => 'Welcome @dunglas!'], json_decode($response->getContent(), true));
+
+        ['method' => $method, 'url' => $url, 'options' => $options] = $endpoint->requests[0];
+        $this->assertSame('POST', $method);
+        $this->assertSame('https://authorization-server.example.com/token/introspect', $url);
+        $this->assertSame(['Authorization: Basic '.base64_encode('client:password')], $options['normalized_headers']['authorization']);
+        $this->assertSame('token=VALID_ACCESS_TOKEN&token_type_hint=access_token', $options['body']);
+    }
+
+    public function testOAuth2IntrospectionFailureOnAnInactiveToken()
+    {
+        $client = $this->createClient(['test_case' => 'AccessToken', 'root_config' => 'config_oauth2.yml']);
+
+        $client->request('GET', '/foo', [], [], ['HTTP_AUTHORIZATION' => 'Bearer INVALID_ACCESS_TOKEN']);
+        $response = $client->getResponse();
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertSame(401, $response->getStatusCode());
+        $this->assertSame('Bearer realm="My API",error="invalid_token",error_description="Invalid credentials."', $response->headers->get('WWW-Authenticate'));
+    }
+
+    /**
+     * The "issuer" the firewall declares reaches the handler, so a token the authorization server
+     * reports as active but attributes to another issuer is still refused.
+     */
+    public function testOAuth2IntrospectionFailureOnAForeignIssuer()
+    {
+        $client = $this->createClient(['test_case' => 'AccessToken', 'root_config' => 'config_oauth2.yml']);
+
+        $client->request('GET', '/foo', [], [], ['HTTP_AUTHORIZATION' => 'Bearer FOREIGN_ISSUER_ACCESS_TOKEN']);
         $response = $client->getResponse();
 
         $this->assertInstanceOf(Response::class, $response);

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/AccessTokenBundle/Security/Handler/IntrospectionResponseFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/AccessTokenBundle/Security/Handler/IntrospectionResponseFactory.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\AccessTokenBundle\Security\Handler;
+
+use Symfony\Component\HttpClient\Response\JsonMockResponse;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+/**
+ * Stands in for the introspection endpoint of an authorization server.
+ *
+ * It is wired as the "mock_response_factory" of a scoped client, so the request still travels
+ * through the real ScopingHttpClient: the URL and the options it records are the ones the scoped
+ * client resolved, which is what the token handler relies on to reach the endpoint at all.
+ */
+final class IntrospectionResponseFactory
+{
+    /**
+     * @var list<array{method: string, url: string, options: array<string, mixed>}>
+     */
+    public array $requests = [];
+
+    public function __invoke(string $method, string $url, array $options): MockResponse
+    {
+        $this->requests[] = ['method' => $method, 'url' => $url, 'options' => $options];
+
+        parse_str($options['body'] ?? '', $body);
+
+        if ('FOREIGN_ISSUER_ACCESS_TOKEN' === ($body['token'] ?? null)) {
+            return new JsonMockResponse([
+                'active' => true,
+                'sub' => 'dunglas',
+                'iss' => 'https://another-authorization-server.example.com/',
+                'aud' => ['https://protected.example.net/resource'],
+                'exp' => time() + 3600,
+            ]);
+        }
+
+        if ('VALID_ACCESS_TOKEN' !== ($body['token'] ?? null)) {
+            return new JsonMockResponse(['active' => false]);
+        }
+
+        return new JsonMockResponse([
+            'active' => true,
+            'sub' => 'dunglas',
+            'iss' => 'https://authorization-server.example.com/',
+            'aud' => ['https://protected.example.net/resource'],
+            'exp' => time() + 3600,
+        ]);
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_oauth2.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_oauth2.yml
@@ -5,10 +5,10 @@ framework:
     serializer: ~
     http_client:
         scoped_clients:
-            oauth2.client:
-                scope: 'https://authorization-server\.example\.com'
-                headers:
-                    Authorization: 'Basic Y2xpZW50OnBhc3N3b3Jk'
+            oauth2.introspection:
+                base_uri: 'https://authorization-server.example.com/token/introspect'
+                auth_basic: 'client:password'
+                mock_response_factory: Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\AccessTokenBundle\Security\Handler\IntrospectionResponseFactory
 
 security:
     password_hashers:
@@ -25,9 +25,18 @@ security:
             pattern: ^/
             access_token:
                 token_handler:
-                    oauth2: ~
+                    oauth2:
+                        http_client: 'oauth2.introspection'
+                        issuer: 'https://authorization-server.example.com/'
+                        audience: 'https://protected.example.net/resource'
                 token_extractors: 'header'
                 realm: 'My API'
 
     access_control:
         - { path: ^/foo, roles: ROLE_USER }
+
+services:
+    _defaults:
+        public: true
+
+    Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\AccessTokenBundle\Security\Handler\IntrospectionResponseFactory: ~

--- a/src/Symfony/Component/Security/Core/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Core/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Deprecate passing more than one Security attribute to `AccessDecisionManager::decide()`, the `$allowMultipleAttributes` argument will be removed in 9.0
+ * Allow a list of identifiers in the `$aud` argument of `OAuth2User`, as RFC 7662 §2.2 defines it
  * Allow using wildcards as placeholders in the keys of the `RoleHierarchy` map
  * Add argument `$parameters` to `SignatureHasher::computeSignatureHash()`, `acceptSignatureHash()` and `verifySignatureHash()`
  * Add `OidcUser::fromClaims()` to build a user from the claims returned by an OIDC provider

--- a/src/Symfony/Component/Security/Core/Tests/User/OAuth2UserTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/User/OAuth2UserTest.php
@@ -24,6 +24,18 @@ class OAuth2UserTest extends TestCase
         new OAuth2User();
     }
 
+    /**
+     * RFC 7662 §2.2 makes "aud" "a service-specific string identifier or list of string
+     * identifiers", so the introspection response of a token minted for several resource servers
+     * has to build a user just as well.
+     */
+    public function testCreateUserWithSeveralAudiences()
+    {
+        $user = new OAuth2User(sub: 'Z5O3upPC88QrAjx00dis', aud: ['https://protected.example.net/resource', 'https://other.example.net']);
+
+        $this->assertSame(['https://protected.example.net/resource', 'https://other.example.net'], $user->aud);
+    }
+
     public function testCreateFullUserWithAdditionalClaimsUsingPositionalParameters()
     {
         $this->assertEquals(new OAuth2User(

--- a/src/Symfony/Component/Security/Core/User/OAuth2User.php
+++ b/src/Symfony/Component/Security/Core/User/OAuth2User.php
@@ -29,7 +29,9 @@ class OAuth2User implements UserInterface
         public readonly ?int $iat = null,
         public readonly ?int $nbf = null,
         public readonly ?string $sub = null,
-        public readonly ?string $aud = null,
+        // RFC 7662 §2.2 makes "aud" "a service-specific string identifier or list of string
+        // identifiers", so an authorization server naming several audiences is not a failure
+        public readonly string|array|null $aud = null,
         public readonly ?string $iss = null,
         public readonly ?string $jti = null,
 

--- a/src/Symfony/Component/Security/Http/AccessToken/OAuth2/Oauth2TokenHandler.php
+++ b/src/Symfony/Component/Security/Http/AccessToken/OAuth2/Oauth2TokenHandler.php
@@ -11,11 +11,15 @@
 
 namespace Symfony\Component\Security\Http\AccessToken\OAuth2;
 
+use Psr\Clock\ClockInterface;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Clock\Clock;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\Security\Core\User\OAuth2User;
 use Symfony\Component\Security\Http\AccessToken\AccessTokenHandlerInterface;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 use function Symfony\Component\String\u;
@@ -23,50 +27,97 @@ use function Symfony\Component\String\u;
 /**
  * The token handler validates the token on the authorization server and the Introspection Endpoint.
  *
- * Anything the introspection request throws is an answer the resource server could not read, so it
- * turns into the bad credentials the firewall reports as a 401: a server that is unreachable, that
- * refuses the caller, or that answers something other than the JSON object RFC 7662 §2.2 defines
- * says nothing about the token, and never that it is usable.
+ * The endpoint is reached by posting to the HTTP client it is given, which carries where the
+ * authorization server lives and how this resource server authenticates there: a scoped client
+ * declaring the introspection endpoint as its "base_uri" and its credentials as "auth_basic" is all
+ * RFC 7662 §2.1 asks for. Nothing of that transport is described here.
  *
- * @see https://tools.ietf.org/html/rfc7662
+ * What is described here is what the resource server expects of the answer. The response is what it
+ * bases its authorization decision on, so the members that qualify the token are confronted with
+ * those expectations before a user badge is built from them: an authorization server that reports a
+ * token as active while dating it in the past or the future, or while naming another issuer or
+ * another audience, has described a token this resource server must not honor.
+ *
+ * @see https://datatracker.ietf.org/doc/html/rfc7662 OAuth 2.0 Token Introspection (RFC 7662)
  *
  * @internal
  */
 final class Oauth2TokenHandler implements AccessTokenHandlerInterface
 {
+    private ?CacheInterface $cache = null;
+    private string $cacheKeyPrefix = '';
+    private int $cacheTtl = 0;
+
+    /**
+     * @param HttpClientInterface $client           The client the introspection endpoint is reached with, whose
+     *                                              base URI is that endpoint and whose options carry the
+     *                                              credentials of this resource server
+     * @param list<string>        $audiences        The identifiers of this resource server, one of which the "aud"
+     *                                              of the introspection response must name, or an empty list to
+     *                                              skip that check
+     * @param string|null         $issuer           The identifier of the authorization server, checked against the
+     *                                              "iss" of the introspection response, or null to skip that check
+     * @param string|null         $claim            The claim holding the user identifier, or null to read "sub" and
+     *                                              fall back to "username"
+     * @param int                 $allowedTimeDrift The tolerance, in seconds, on the "iat", "nbf" and "exp" the
+     *                                              authorization server reports
+     */
     public function __construct(
         private readonly HttpClientInterface $client,
         private readonly ?LoggerInterface $logger = null,
+        private readonly array $audiences = [],
+        private readonly ?string $issuer = null,
+        private readonly ?string $claim = null,
+        private readonly ClockInterface $clock = new Clock(),
+        private readonly int $allowedTimeDrift = 0,
     ) {
     }
 
     /**
-     * RFC 7662 §2.2 defines "active" as a boolean, and the introspection response is JSON, so the
-     * member is compared to true: nothing else states that the token can be used, the string
-     * "false" an authorization server may answer with least of all.
+     * Caches the introspection responses of active tokens, for at most $ttl seconds.
+     *
+     * RFC 7662 §4 leaves the trade-off to the resource server: a longer lifetime spares the
+     * authorization server a round trip per request, at the cost of a window during which a revoked
+     * token is still accepted here. Two bounds are not left to the caller. No entry outlives the
+     * "exp" the authorization server reported, which that section makes a MUST NOT, and the
+     * response of an inactive token is not cached at all, so that arbitrary token values cannot be
+     * used to fill the pool.
+     *
+     * An entry is keyed by the digest of the token rather than by the token itself, so that a pool
+     * an operator, a backup or a neighbouring application can read holds no usable credential.
+     */
+    public function enableCache(CacheInterface $cache, string $cacheKeyPrefix, int $ttl = 60): void
+    {
+        if ($ttl <= 0) {
+            throw new \InvalidArgumentException(\sprintf('The introspection cache lifetime must be a positive number of seconds, %d given.', $ttl));
+        }
+
+        $this->cache = $cache;
+        $this->cacheKeyPrefix = $cacheKeyPrefix;
+        $this->cacheTtl = $ttl;
+    }
+
+    /**
+     * Introspects the token and builds a user badge out of the members of the response.
+     *
+     * RFC 7662 §2.2 guarantees a single member on an inactive token, "active", and makes it a
+     * boolean, so it is the first one read and it is read as one: the string "false" an
+     * authorization server may answer with does not describe an active token. The identifier
+     * claims are only looked up once the server has stated that the token can be used.
      */
     public function getUserBadgeFrom(string $accessToken): UserBadge
     {
         try {
-            // Call the Authorization server to retrieve the resource owner details
-            // If the token is invalid or expired, the Authorization server will return an error
-            $claims = $this->client->request('POST', '', [
-                'body' => [
-                    'token' => $accessToken,
-                    'token_type_hint' => 'access_token',
-                ],
-            ])->toArray();
+            $claims = $this->introspect($accessToken);
 
-            $sub = $claims['sub'] ?? null;
-            $username = $claims['username'] ?? null;
-            if (!$sub && !$username) {
-                throw new BadCredentialsException('"sub" and "username" claims not found on the authorization server response. At least one is required.');
-            }
             if (true !== ($claims['active'] ?? false)) {
                 throw new BadCredentialsException('The claim "active" was not found on the authorization server response or is set to false.');
             }
 
-            return new UserBadge($sub ?? $username, fn () => $this->createUser($claims), $claims);
+            $this->verifyClaims($claims);
+            $identifier = $this->getUserIdentifier($claims);
+
+            return new UserBadge($identifier, fn () => $this->createUser($claims), $claims);
         } catch (\Exception $e) {
             $this->logger?->error('An error occurred on the authorization server.', [
                 'error' => $e->getMessage(),
@@ -76,6 +127,162 @@ final class Oauth2TokenHandler implements AccessTokenHandlerInterface
 
             throw new BadCredentialsException('Invalid credentials.', $e->getCode(), $e);
         }
+    }
+
+    /**
+     * Returns the members of the introspection response, from the cache when one is enabled.
+     *
+     * The lifetime of an entry is the shorter of the configured one and of what the "exp" of the
+     * response leaves, and only the response of an active token is stored: see {@see enableCache()}.
+     *
+     * @return array<string, mixed> The members of the introspection response
+     */
+    private function introspect(string $accessToken): array
+    {
+        if (null === $this->cache) {
+            return $this->requestIntrospection($accessToken);
+        }
+
+        $key = $this->cacheKeyPrefix.hash('sha256', $accessToken);
+
+        return $this->cache->get($key, function (ItemInterface $item, bool &$save) use ($accessToken): array {
+            $claims = $this->requestIntrospection($accessToken);
+
+            $ttl = $this->cacheTtl;
+            if (is_numeric($claims['exp'] ?? null)) {
+                $ttl = min($ttl, (int) $claims['exp'] - $this->clock->now()->getTimestamp());
+            }
+
+            $save = 0 < $ttl && true === ($claims['active'] ?? null);
+            $item->expiresAfter(max(1, $ttl));
+
+            return $claims;
+        });
+    }
+
+    /**
+     * Calls the introspection endpoint, and returns the members it answered with.
+     *
+     * The request carries the token and the "access_token" hint of RFC 7662 §2.1, and is posted to
+     * the base URI of the client, which is where the endpoint and the credentials of this resource
+     * server are configured.
+     *
+     * @return array<string, mixed>
+     */
+    private function requestIntrospection(string $accessToken): array
+    {
+        return $this->client->request('POST', '', [
+            'headers' => ['Accept' => 'application/json'],
+            'body' => [
+                'token' => $accessToken,
+                'token_type_hint' => 'access_token',
+            ],
+        ])->toArray();
+    }
+
+    /**
+     * Confronts the members of the introspection response with what this resource server expects.
+     *
+     * RFC 7662 §2.2 makes all of them optional and §4 puts the checks on the authorization server,
+     * so the dates are only verified when the response carries them: a resource server told the
+     * token is already expired, not valid yet or minted in the future still has no reason to honor
+     * it. The issuer and the audience are checked when this resource server declares which ones it
+     * expects, and the response is then required to carry them, since a token issued by another
+     * authorization server, or for another resource server, must not be honored.
+     *
+     * @param array<string, mixed> $claims
+     */
+    private function verifyClaims(array $claims): void
+    {
+        $now = $this->clock->now()->getTimestamp();
+
+        if (null !== ($exp = $this->readTimestamp($claims, 'exp')) && $exp <= $now - $this->allowedTimeDrift) {
+            throw new BadCredentialsException('The token reported by the authorization server has expired.');
+        }
+
+        if (null !== ($nbf = $this->readTimestamp($claims, 'nbf')) && $nbf > $now + $this->allowedTimeDrift) {
+            throw new BadCredentialsException('The token reported by the authorization server is not valid yet.');
+        }
+
+        if (null !== ($iat = $this->readTimestamp($claims, 'iat')) && $iat > $now + $this->allowedTimeDrift) {
+            throw new BadCredentialsException('The token reported by the authorization server was issued in the future.');
+        }
+
+        if (null !== $this->issuer && $this->issuer !== ($claims['iss'] ?? null)) {
+            throw new BadCredentialsException(\sprintf('The token was issued by "%s", where "%s" was expected.', \is_string($claims['iss'] ?? null) ? $claims['iss'] : '', $this->issuer));
+        }
+
+        if ($this->audiences && !$this->matchesAudience($claims['aud'] ?? null)) {
+            throw new BadCredentialsException(\sprintf('The token is not intended for any of the audiences "%s".', implode('", "', $this->audiences)));
+        }
+    }
+
+    /**
+     * Reads a date member of the introspection response as a timestamp, or null when it is absent.
+     *
+     * RFC 7662 §2.2 types "exp", "nbf" and "iat" as integer timestamps, so a member carrying anything
+     * else describes no instant this resource server can confront its clock with, and the response is
+     * refused rather than honored, as {@see \Symfony\Component\Security\Http\AccessToken\Oidc\OidcTokenHandler}
+     * refuses the same shape. A JSON null is read as an absent member, which §2.2 allows.
+     *
+     * @param array<string, mixed> $claims
+     */
+    private function readTimestamp(array $claims, string $claim): ?int
+    {
+        if (null === $value = $claims[$claim] ?? null) {
+            return null;
+        }
+
+        if (!is_numeric($value) || !is_finite($seconds = (float) $value) || \PHP_INT_MAX <= abs($seconds)) {
+            throw new BadCredentialsException(\sprintf('The "%s" claim reported by the authorization server is not a timestamp.', $claim));
+        }
+
+        return (int) $value;
+    }
+
+    /**
+     * Tells whether an "aud" claim names one of the audiences this resource server answers for.
+     *
+     * RFC 7662 §2.2 makes "aud" "a service-specific string identifier or list of string identifiers",
+     * so both shapes are read, and a single match is enough: an access token minted for several
+     * resource servers is meant for each of them.
+     */
+    private function matchesAudience(mixed $audience): bool
+    {
+        $audiences = array_filter(\is_array($audience) ? $audience : [$audience], \is_string(...));
+
+        return (bool) array_intersect($this->audiences, $audiences);
+    }
+
+    /**
+     * @param array<string, mixed> $claims
+     */
+    private function getUserIdentifier(array $claims): string
+    {
+        if (null !== $this->claim) {
+            if (null === $identifier = self::readIdentifier($claims, $this->claim)) {
+                throw new BadCredentialsException(\sprintf('"%s" claim not found on the authorization server response.', $this->claim));
+            }
+
+            return $identifier;
+        }
+
+        $identifier = self::readIdentifier($claims, 'sub') ?? self::readIdentifier($claims, 'username');
+        if (null === $identifier) {
+            throw new BadCredentialsException('"sub" and "username" claims not found on the authorization server response. At least one is required.');
+        }
+
+        return $identifier;
+    }
+
+    /**
+     * @param array<string, mixed> $claims
+     */
+    private static function readIdentifier(array $claims, string $claim): ?string
+    {
+        $value = $claims[$claim] ?? null;
+
+        return (\is_string($value) || \is_int($value)) && '' !== (string) $value ? (string) $value : null;
     }
 
     private function createUser(array $claims): OAuth2User

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -8,6 +8,8 @@ CHANGELOG
  * Expose the OAuth2 scopes an access token was granted as the `scope` token attribute, read from the `scope` or `scp` claim
  * Add `OAuth2ScopeVoter` to require scopes of the access token, all the ones an `OAUTH2_SCOPE(...)` attribute lists
  * Add `InsufficientScopeAccessDeniedHandler` to answer a denial caused by a missing scope with the RFC 6750 §3.1 challenge
+ * Add the `$audiences`, `$issuer`, `$claim`, `$clock` and `$allowedTimeDrift` arguments to `Oauth2TokenHandler`, which validates the `exp`, `nbf`, `iat`, `iss` and `aud` members of the introspection response against them
+ * Add `Oauth2TokenHandler::enableCache()` to cache the introspection responses of active tokens, never beyond their `exp`
  * Throw a 403 `Symfony\Component\Security\Http\Exception\InvalidCsrfTokenException` instead of the `Security\Core` one when the `#[IsCsrfTokenValid]` attribute fails, so the failure is no longer handled as an authentication failure
  * Add the deauthentication reason and the responsible user providers to `TokenDeauthenticatedEvent`
  * Add `LogoutUrlGenerator::getLogoutForm()` to build a form that logs the user out with a POST

--- a/src/Symfony/Component/Security/Http/Tests/AccessToken/OAuth2/OAuth2TokenHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/AccessToken/OAuth2/OAuth2TokenHandlerTest.php
@@ -13,7 +13,10 @@ namespace Symfony\Component\Security\Http\Tests\AccessToken\OAuth2;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Clock\MockClock;
 use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\JsonMockResponse;
 use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\Security\Core\User\OAuth2User;
@@ -22,13 +25,100 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 
 class OAuth2TokenHandlerTest extends TestCase
 {
+    private const ENDPOINT = 'https://authorization-server.example.com/token/introspect';
+    private const ISSUER = 'https://authorization-server.example.com/';
+    private const AUDIENCE = 'https://protected.example.net/resource';
+
+    public function testGetsUserIdentifierFromOAuth2ServerResponse()
+    {
+        $accessToken = 'a-secret-token';
+        $claims = self::activeClaims([
+            'client_id' => 'l238j323ds-23ij4',
+            'username' => 'jdoe',
+            'scope' => 'read write dolphin',
+            'sub' => 'Z5O3upPC88QrAjx00dis',
+            'extension_field' => 'twenty-seven',
+        ]);
+
+        $client = new MockHttpClient([new JsonMockResponse($claims)]);
+
+        $userBadge = self::createHandler($client)->getUserBadgeFrom($accessToken);
+        $actualUser = $userBadge->getUserLoader()();
+
+        $this->assertInstanceOf(UserBadge::class, $userBadge);
+        $this->assertSame('Z5O3upPC88QrAjx00dis', $userBadge->getUserIdentifier());
+        $this->assertSame($claims, $userBadge->getAttributes());
+        $this->assertInstanceOf(OAuth2User::class, $actualUser);
+        $this->assertSame($claims['sub'], $actualUser->getUserIdentifier());
+    }
+
+    public function testFallsBackToTheUsernameClaim()
+    {
+        $client = new MockHttpClient([new JsonMockResponse(self::activeClaims(['username' => 'jdoe']))]);
+
+        $this->assertSame('jdoe', self::createHandler($client)->getUserBadgeFrom('a-secret-token')->getUserIdentifier());
+    }
+
+    public function testReadsTheConfiguredClaim()
+    {
+        $client = new MockHttpClient([new JsonMockResponse(self::activeClaims(['sub' => 'Z5O3upPC88QrAjx00dis', 'email' => 'jdoe@example.com']))]);
+
+        $handler = self::createHandler($client, claim: 'email');
+
+        $this->assertSame('jdoe@example.com', $handler->getUserBadgeFrom('a-secret-token')->getUserIdentifier());
+    }
+
+    public function testFailsWhenTheConfiguredClaimIsMissing()
+    {
+        $client = new MockHttpClient([new JsonMockResponse(self::activeClaims(['sub' => 'Z5O3upPC88QrAjx00dis']))]);
+
+        $this->assertBadCredentials('"email" claim not found on the authorization server response.', self::createHandler($client, claim: 'email'));
+    }
+
+    public function testFailsWithoutAnyIdentifierClaim()
+    {
+        $client = new MockHttpClient([new JsonMockResponse(self::activeClaims())]);
+
+        $this->assertBadCredentials('"sub" and "username" claims not found on the authorization server response. At least one is required.', self::createHandler($client));
+    }
+
+    /**
+     * The endpoint and the credentials belong to the client, so the request only carries what
+     * RFC 7662 §2.1 asks the resource server for, and is posted relative to its base URI.
+     */
+    public function testPostsTheTokenRelativeToTheBaseUriOfTheClient()
+    {
+        $request = null;
+        $client = new MockHttpClient(static function (string $method, string $url, array $options) use (&$request): MockResponse {
+            $request = [$method, $url, $options];
+
+            return new JsonMockResponse(self::activeClaims(['sub' => 'jdoe']));
+        }, self::ENDPOINT);
+
+        self::createHandler($client)->getUserBadgeFrom('a-secret-token');
+
+        [$method, $url, $options] = $request;
+        $this->assertSame('POST', $method);
+        $this->assertSame(self::ENDPOINT, $url);
+        $this->assertSame(['Accept: application/json'], $options['normalized_headers']['accept']);
+
+        parse_str($options['body'], $body);
+        $this->assertSame(['token' => 'a-secret-token', 'token_type_hint' => 'access_token'], $body);
+    }
+
+    /**
+     * Anything the introspection request throws is an answer this resource server could not read,
+     * so it reports bad credentials rather than letting the exception reach the user as a 500.
+     */
     #[DataProvider('unreadableResponses')]
     public function testTurnsAnErrorOfTheAuthorizationServerIntoBadCredentials(MockResponse $response)
     {
+        $client = new MockHttpClient([$response], self::ENDPOINT);
+
         $this->expectException(BadCredentialsException::class);
         $this->expectExceptionMessage('Invalid credentials.');
 
-        (new Oauth2TokenHandler(new MockHttpClient([$response])))->getUserBadgeFrom('a-secret-token');
+        self::createHandler($client)->getUserBadgeFrom('a-secret-token');
     }
 
     public static function unreadableResponses(): iterable
@@ -42,24 +132,20 @@ class OAuth2TokenHandlerTest extends TestCase
     }
 
     #[DataProvider('inactiveResponses')]
-    public function testRejectsATokenTheServerDoesNotReportAsActive(array $claims)
+    public function testRejectsAnInactiveToken(array $claims)
     {
-        $client = new MockHttpClient([new MockResponse(json_encode($claims, \JSON_THROW_ON_ERROR))]);
+        $client = new MockHttpClient([new JsonMockResponse($claims)]);
 
-        $this->expectException(BadCredentialsException::class);
-        $this->expectExceptionMessage('Invalid credentials.');
-
-        (new Oauth2TokenHandler($client))->getUserBadgeFrom('a-secret-token');
+        $this->assertBadCredentials('The claim "active" was not found on the authorization server response or is set to false.', self::createHandler($client));
     }
 
     /**
-     * Everything but the boolean the specification defines, which is everything the truthy reading
-     * of "active" used to honor, the very "false" of a server not serializing it as a JSON boolean
-     * included.
+     * RFC 7662 §2.2 reports an inactive token with nothing but "active", and makes it a boolean,
+     * so nothing but the boolean true describes a token this resource server may use.
      */
     public static function inactiveResponses(): iterable
     {
-        yield 'inactive' => [['active' => false, 'sub' => 'jdoe']];
+        yield 'inactive' => [['active' => false]];
         yield 'missing' => [['sub' => 'jdoe']];
         yield 'stringly typed false' => [['active' => 'false', 'sub' => 'jdoe']];
         yield 'stringly typed true' => [['active' => 'true', 'sub' => 'jdoe']];
@@ -68,34 +154,217 @@ class OAuth2TokenHandlerTest extends TestCase
         yield 'not a boolean at all' => [['active' => 'bogus', 'sub' => 'jdoe']];
     }
 
-    public function testGetsUserIdentifierFromOAuth2ServerResponse()
+    #[DataProvider('unusableTokens')]
+    public function testRejectsATokenTheServerReportsAsUnusable(array $claims, string $message)
     {
-        $accessToken = 'a-secret-token';
-        $claims = [
-            'active' => true,
-            'client_id' => 'l238j323ds-23ij4',
-            'username' => 'jdoe',
-            'scope' => 'read write dolphin',
-            'sub' => 'Z5O3upPC88QrAjx00dis',
-            'aud' => 'https://protected.example.net/resource',
-            'iss' => 'https://server.example.com/',
-            'exp' => 1419356238,
-            'iat' => 1419350238,
-            'extension_field' => 'twenty-seven',
-        ];
+        $client = new MockHttpClient([new JsonMockResponse(self::activeClaims($claims + ['sub' => 'jdoe']))]);
 
+        $this->assertBadCredentials($message, self::createHandler($client));
+    }
+
+    public static function unusableTokens(): iterable
+    {
+        yield 'expired' => [['exp' => 1719000000 - 1], 'The token reported by the authorization server has expired.'];
+        yield 'not yet valid' => [['nbf' => 1719000000 + 1], 'The token reported by the authorization server is not valid yet.'];
+        yield 'issued in the future' => [['iat' => 1719000000 + 1], 'The token reported by the authorization server was issued in the future.'];
+        yield 'a string "exp"' => [['exp' => 'not-a-number'], 'The "exp" claim reported by the authorization server is not a timestamp.'];
+        yield 'an array "exp"' => [['exp' => []], 'The "exp" claim reported by the authorization server is not a timestamp.'];
+        yield 'a string "nbf"' => [['nbf' => 'soon'], 'The "nbf" claim reported by the authorization server is not a timestamp.'];
+        yield 'a boolean "iat"' => [['iat' => true], 'The "iat" claim reported by the authorization server is not a timestamp.'];
+        yield 'an "exp" no integer can hold' => [['exp' => 1e20], 'The "exp" claim reported by the authorization server is not a timestamp.'];
+        yield 'an "nbf" no integer can hold' => [['nbf' => 1e20], 'The "nbf" claim reported by the authorization server is not a timestamp.'];
+    }
+
+    #[DataProvider('absentDateClaims')]
+    public function testReadsAJsonNullDateClaimAsAbsent(array $claims)
+    {
+        $client = new MockHttpClient([new JsonMockResponse(self::activeClaims($claims + ['sub' => 'jdoe']))]);
+
+        $this->assertSame('jdoe', self::createHandler($client)->getUserBadgeFrom('a-secret-token')->getUserIdentifier());
+    }
+
+    public static function absentDateClaims(): iterable
+    {
+        yield 'exp' => [['exp' => null]];
+        yield 'nbf' => [['nbf' => null]];
+        yield 'iat' => [['iat' => null]];
+    }
+
+    public function testReadsAStringlyTypedDateClaim()
+    {
+        $client = new MockHttpClient([new JsonMockResponse(self::activeClaims(['sub' => 'jdoe', 'exp' => '1719000001']))]);
+
+        $this->assertSame('jdoe', self::createHandler($client)->getUserBadgeFrom('a-secret-token')->getUserIdentifier());
+    }
+
+    public function testAcceptsATokenWithinTheAllowedTimeDrift()
+    {
+        $claims = self::activeClaims(['sub' => 'jdoe', 'exp' => 1719000000 - 5, 'nbf' => 1719000000 + 5]);
+        $client = new MockHttpClient([new JsonMockResponse($claims), new JsonMockResponse($claims)]);
+
+        $this->assertBadCredentials('The token reported by the authorization server has expired.', self::createHandler($client));
+        $this->assertSame('jdoe', self::createHandler($client, allowedTimeDrift: 10)->getUserBadgeFrom('a-secret-token')->getUserIdentifier());
+    }
+
+    public function testChecksTheIssuerOfTheToken()
+    {
+        $claims = self::activeClaims(['sub' => 'jdoe', 'iss' => 'https://evil.example.com/']);
+        $client = new MockHttpClient([new JsonMockResponse($claims), new JsonMockResponse(self::activeClaims(['sub' => 'jdoe', 'iss' => self::ISSUER]))]);
+
+        $this->assertBadCredentials('The token was issued by "https://evil.example.com/", where "'.self::ISSUER.'" was expected.', self::createHandler($client, issuer: self::ISSUER));
+        $this->assertSame('jdoe', self::createHandler($client, issuer: self::ISSUER)->getUserBadgeFrom('a-secret-token')->getUserIdentifier());
+    }
+
+    public function testRequiresTheIssuerWhenOneIsExpected()
+    {
+        $client = new MockHttpClient([new JsonMockResponse(['active' => true, 'sub' => 'jdoe'])]);
+
+        $this->assertBadCredentials('The token was issued by "", where "'.self::ISSUER.'" was expected.', self::createHandler($client, issuer: self::ISSUER));
+    }
+
+    #[DataProvider('audiences')]
+    public function testChecksTheAudienceOfTheToken(mixed $audience, bool $accepted)
+    {
+        $claims = self::activeClaims(['sub' => 'jdoe']);
+        if (null !== $audience) {
+            $claims['aud'] = $audience;
+        }
+        $client = new MockHttpClient([new JsonMockResponse($claims)]);
+        $handler = self::createHandler($client, audiences: [self::AUDIENCE]);
+
+        if ($accepted) {
+            $this->assertSame('jdoe', $handler->getUserBadgeFrom('a-secret-token')->getUserIdentifier());
+        } else {
+            $this->assertBadCredentials('The token is not intended for any of the audiences "'.self::AUDIENCE.'".', $handler);
+        }
+    }
+
+    public static function audiences(): iterable
+    {
+        yield 'string' => [self::AUDIENCE, true];
+        yield 'list' => [['https://other.example.net', self::AUDIENCE], true];
+        yield 'another audience' => ['https://other.example.net', false];
+        yield 'another list' => [['https://other.example.net'], false];
+        yield 'missing' => [null, false];
+    }
+
+    /**
+     * A resource server answering for several identifiers accepts a token minted for any of them.
+     */
+    public function testChecksTheAudienceOfTheTokenAgainstSeveralIdentifiers()
+    {
         $client = new MockHttpClient([
-            new MockResponse(json_encode($claims, \JSON_THROW_ON_ERROR)),
+            new JsonMockResponse(self::activeClaims(['sub' => 'jdoe', 'aud' => 'https://other.example.net'])),
+            new JsonMockResponse(self::activeClaims(['sub' => 'jdoe', 'aud' => ['https://yet-another.example.net']])),
         ]);
+        $audiences = [self::AUDIENCE, 'https://other.example.net'];
 
-        $userBadge = (new Oauth2TokenHandler($client))->getUserBadgeFrom($accessToken);
-        $actualUser = $userBadge->getUserLoader()();
+        $this->assertSame('jdoe', self::createHandler($client, $audiences)->getUserBadgeFrom('a-secret-token')->getUserIdentifier());
+        $this->assertBadCredentials('The token is not intended for any of the audiences "'.implode('", "', $audiences).'".', self::createHandler($client, $audiences));
+    }
 
-        $this->assertInstanceOf(UserBadge::class, $userBadge);
-        $this->assertSame('Z5O3upPC88QrAjx00dis', $userBadge->getUserIdentifier());
-        $this->assertSame($claims, $userBadge->getAttributes());
-        $this->assertInstanceOf(OAuth2User::class, $actualUser);
-        $this->assertSame($claims, $userBadge->getAttributes());
-        $this->assertSame($claims['sub'], $actualUser->getUserIdentifier());
+    /**
+     * RFC 7662 §2.2 types "iss" and "aud" as strings, so a response carrying anything else names
+     * neither an issuer nor an audience this resource server can be compared against: an array
+     * would be juggled into the string "Array", and a number into a string that the audience of a
+     * resource server identified by digits would match.
+     */
+    public function testRefusesANonStringIssuer()
+    {
+        $client = new MockHttpClient([new JsonMockResponse(self::activeClaims(['sub' => 'jdoe', 'iss' => [self::ISSUER]]))], self::ENDPOINT);
+
+        $this->assertBadCredentials('The token was issued by "", where "'.self::ISSUER.'" was expected.', self::createHandler($client, issuer: self::ISSUER));
+    }
+
+    public function testRefusesANonStringAudience()
+    {
+        $client = new MockHttpClient([new JsonMockResponse(self::activeClaims(['sub' => 'jdoe', 'aud' => 123]))], self::ENDPOINT);
+
+        $this->assertBadCredentials('The token is not intended for any of the audiences "123".', self::createHandler($client, audiences: ['123']));
+    }
+
+    /**
+     * The pool is keyed by the digest of the token, so it never holds a usable credential.
+     */
+    public function testCachesTheResponseOfAnActiveToken()
+    {
+        $claims = self::activeClaims(['sub' => 'jdoe', 'exp' => 1719000000 + 3600]);
+        $client = new MockHttpClient([new JsonMockResponse($claims)]);
+        $handler = self::createHandler($client);
+        $handler->enableCache($cache = new ArrayAdapter(), 'introspection.', 60);
+
+        $this->assertSame('jdoe', $handler->getUserBadgeFrom('a-secret-token')->getUserIdentifier());
+        $this->assertSame('jdoe', $handler->getUserBadgeFrom('a-secret-token')->getUserIdentifier());
+        $this->assertSame(1, $client->getRequestsCount());
+        $this->assertTrue($cache->hasItem('introspection.'.hash('sha256', 'a-secret-token')));
+    }
+
+    /**
+     * The two readings of "active" must agree: a response the handler refuses is a response it
+     * must not cache, or arbitrary token values would fill the pool of a resource server whose
+     * authorization server reports "active" as a string.
+     */
+    #[DataProvider('inactiveResponses')]
+    public function testDoesNotCacheTheResponseOfAnInactiveToken(array $claims)
+    {
+        $client = new MockHttpClient([new JsonMockResponse($claims), new JsonMockResponse($claims)]);
+        $handler = self::createHandler($client);
+        $handler->enableCache($cache = new ArrayAdapter(), 'introspection.', 60);
+
+        $this->assertBadCredentials('The claim "active" was not found on the authorization server response or is set to false.', $handler);
+        $this->assertBadCredentials('The claim "active" was not found on the authorization server response or is set to false.', $handler);
+        $this->assertSame(2, $client->getRequestsCount());
+        $this->assertFalse($cache->hasItem('introspection.'.hash('sha256', 'a-secret-token')));
+    }
+
+    /**
+     * RFC 7662 §4 forbids caching a response beyond the "exp" it reports, so the hour asked for
+     * here is cut down to the ten seconds the token still has to live.
+     */
+    public function testDoesNotCacheAResponseBeyondItsExpiration()
+    {
+        $client = new MockHttpClient([new JsonMockResponse(self::activeClaims(['sub' => 'jdoe', 'exp' => 1719000000 + 10]))]);
+        $handler = self::createHandler($client);
+        $handler->enableCache($cache = new ArrayAdapter(), 'introspection.', 3600);
+
+        $this->assertSame('jdoe', $handler->getUserBadgeFrom('a-secret-token')->getUserIdentifier());
+
+        $item = $cache->getItem('introspection.'.hash('sha256', 'a-secret-token'));
+        $this->assertEqualsWithDelta(10, $item->getMetadata()[$item::METADATA_EXPIRY] - microtime(true), 2);
+    }
+
+    public function testRejectsANonPositiveCacheLifetime()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The introspection cache lifetime must be a positive number of seconds, 0 given.');
+
+        self::createHandler(new MockHttpClient())->enableCache(new ArrayAdapter(), 'introspection.', 0);
+    }
+
+    private function assertBadCredentials(string $message, Oauth2TokenHandler $handler): void
+    {
+        try {
+            $handler->getUserBadgeFrom('a-secret-token');
+        } catch (BadCredentialsException $e) {
+            $this->assertSame('Invalid credentials.', $e->getMessage());
+            $this->assertSame($message, $e->getPrevious()?->getMessage());
+
+            return;
+        }
+
+        $this->fail(\sprintf('The handler did not reject the token with "%s".', $message));
+    }
+
+    private static function createHandler(MockHttpClient $client, array $audiences = [], ?string $issuer = null, ?string $claim = null, int $allowedTimeDrift = 0): Oauth2TokenHandler
+    {
+        return new Oauth2TokenHandler($client, null, $audiences, $issuer, $claim, new MockClock('@1719000000'), $allowedTimeDrift);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function activeClaims(array $claims = []): array
+    {
+        return ['active' => true] + $claims;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

The `oauth2` token handler cannot reach any introspection endpoint today, and its factory never read its configuration:

```php
public function create(ContainerBuilder $container, string $id, array|string $config): void
{
    $container->setDefinition($id, new ChildDefinition('security.access_token_handler.oauth2'));
}
```

`$config` is unused and the node it declares is a bare `scalarNode`, so nothing a resource server has to know about the token it is handed could be declared. Worse, neither form of that node works:

| Form | Result on `8.2` |
|---|---|
| `oauth2: ~`, the one shipped in the functional test app | the container fails to compile: `create(): Argument #3 ($config) must be of type array\|string, null given` |
| `oauth2: true` | compiles, but the handler runs `POST ''` on the global `http_client` |
| the request | `InvalidArgumentException: Invalid URL: scheme is missing in ""`, surfacing as a 500 |

`SecurityBundle/Tests/Functional/app/AccessToken/config_oauth2.yml` declares a scoped client next to it, but a scoped client is registered as its own service and does not decorate the default one, so nothing ever connected the two. No test referenced that file.

### Where the transport lives

Where the authorization server lives and how this resource server authenticates there stays **out of the firewall**. It belongs to the HTTP client that `http_client` names: a scoped client whose `base_uri` is the introspection endpoint and whose `auth_basic` holds the credentials covers the `client_secret_basic` of RFC 6749 §2.3.1, which RFC 7662 §2.1 requires the endpoint to demand.

```yaml
framework:
    http_client:
        scoped_clients:
            oauth2.introspection:
                base_uri: 'https://authorization-server.example.com/token/introspect'
                auth_basic: '%env(OAUTH2_CLIENT_ID)%:%env(OAUTH2_CLIENT_SECRET)%'

security:
    firewalls:
        main:
            access_token:
                token_handler:
                    oauth2:
                        http_client: 'oauth2.introspection'
                        issuer: 'https://authorization-server.example.com/'
                        audience: 'https://api.example.com'  # or a list
                        claim: 'sub'
                        allowed_time_drift: 5
                        cache:
                            id: 'cache.app'
                            ttl: 60
```

`oauth2: 'oauth2.introspection'` is accepted as a shorthand for the client alone. What the firewall declares is only what it needs to judge the answer.

### What the handler now does

**Response validation.** RFC 7662 §2.2 makes `exp`, `nbf`, `iat`, `iss` and `aud` optional and §4 puts the checks on the authorization server, so the dates are verified when the response carries them, and the issuer and the audience when the firewall declares which ones it accepts. A resource server told the token is already expired, or that it was issued by another authorization server, has no reason to honor it.

**Audiences.** `aud` is "a service-specific string identifier or list of string identifiers", so both shapes are read. The `audience` option takes a single identifier as a string or several as a list, and a single match is enough: an access token minted for several resource servers is meant for each of them. `OAuth2User` accepts that list too, where a list used to end in a `TypeError` and a 500.

**Caching.** RFC 7662 §4 leaves the trade-off to the resource server, and two bounds are not left to the user: no entry outlives the `exp` the authorization server reported, which that section makes a MUST NOT, and the response of an inactive token is never cached, so arbitrary token values cannot fill the pool. Entries are keyed by the digest of the token, so the pool holds no usable credential.

### Coverage

The functional test exercises the whole path against a scoped client, asserting the resolved URL and the `Authorization` header the client applied, plus a token the authorization server attributes to another issuer, so the `issuer` option is proven to reach the handler.

The `catch` around the HTTP call is not widened here: an error of the authorization server still surfaces as a 500 on this branch. That is a bug of its own and it is fixed on 7.4 by #65870.

