### PR TITLE
[Security][SecurityBundle] Add RFC 9701 signed introspection responses

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -8,7 +8,7 @@ CHANGELOG
  * Add the `debug:roles` command to inspect the role hierarchy
  * Add `allowed_time_drift` option to the OIDC token handler configuration
  * Require OAuth2 scopes of the access token with an `OAUTH2_SCOPE(...)` attribute, and answer a denial with the RFC 6750 §3.1 `insufficient_scope` challenge
- * Add the `http_client`, `issuer`, `audience`, `claim`, `allowed_time_drift` and `cache` options to the `oauth2` token handler, whose configuration used to be ignored. The `audience` option takes a single identifier as a string or several as a list
+ * Add the `http_client`, `issuer`, `audience`, `claim`, `allowed_time_drift`, `cache` and `response_signature` options to the `oauth2` token handler, whose configuration used to be ignored. The `audience` option takes a single identifier as a string or several as a list
  * Fix the `oauth2` token handler, which could not reach any introspection endpoint: `oauth2: ~` made the container fail to compile, and the endpoint was requested with an empty URL
  * Allow disabling the redirection on successful logout by passing `null` to the `target` option
  * Deprecate the `remember_me` option of the `form_login`, `json_login`, `login_link`, and `access_token` authenticators, as it has no effect

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/AccessToken/OAuth2TokenHandlerFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/AccessToken/OAuth2TokenHandlerFactory.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\SecurityBundle\DependencyInjection\Security\AccessToken;
 
+use Jose\Component\Core\Algorithm;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -29,6 +30,11 @@ use Symfony\Contracts\Cache\CacheInterface;
  * holding a colon, a plus, a space or a non-ASCII byte must be encoded before it is passed. What is
  * configured here is only what the firewall itself needs, namely what the response is confronted
  * with.
+ *
+ * The JWKSet and the algorithm manager the "response_signature" option builds are the ones of the
+ * "oidc" token handler: neither is tied to OpenID Connect, they turn a JSON document into a JWKSet
+ * and the algorithms tagged in the bundle into a JWS algorithm manager, which is what RFC 9701 asks
+ * of a resource server verifying a signed introspection response.
  *
  * @internal
  */
@@ -58,6 +64,20 @@ class OAuth2TokenHandlerFactory implements TokenHandlerFactoryInterface
                 $config['cache']['ttl'],
             ]);
         }
+
+        if ($config['response_signature']['enabled']) {
+            if (!ContainerBuilder::willBeAvailable('web-token/jwt-library', Algorithm::class, ['symfony/security-bundle'])) {
+                throw new LogicException('You cannot verify the signature of the introspection responses since "web-token/jwt-library" is not installed. Try running "composer require web-token/jwt-library".');
+            }
+
+            $tokenHandlerDefinition->addMethodCall('enableSignedResponse', [
+                (new ChildDefinition('security.access_token_handler.oidc.signature'))
+                    ->replaceArgument(0, $config['response_signature']['algorithms']),
+                (new ChildDefinition('security.access_token_handler.oidc.jwkset'))
+                    ->replaceArgument(0, $config['response_signature']['keyset']),
+                $config['response_signature']['enforce'],
+            ]);
+        }
     }
 
     public function getKey(): string
@@ -72,6 +92,10 @@ class OAuth2TokenHandlerFactory implements TokenHandlerFactoryInterface
                 ->beforeNormalization()
                     ->ifString()
                     ->then(static fn ($v) => ['http_client' => $v])
+                ->end()
+                ->validate()
+                    ->ifTrue(static fn ($v) => $v['response_signature']['enabled'] && (null === $v['issuer'] || !$v['audience']))
+                    ->thenInvalid('The "issuer" and "audience" options of the "oauth2" token handler are required when "response_signature" is enabled: RFC 9701 §5 makes "iss" and "aud" mandatory claims of the response.')
                 ->end()
                 ->children()
                     ->scalarNode('http_client')
@@ -110,6 +134,28 @@ class OAuth2TokenHandlerFactory implements TokenHandlerFactoryInterface
                                 ->info('Maximum lifetime in seconds of a cached introspection response. The shorter it is, the sooner a revoked token stops being accepted.')
                                 ->defaultValue(60)
                                 ->min(1)
+                            ->end()
+                        ->end()
+                    ->end()
+                    ->arrayNode('response_signature')
+                        ->info('Ask the authorization server for a signed introspection response (RFC 9701) and verify it.')
+                        ->canBeEnabled()
+                        ->validate()
+                            ->ifTrue(static fn ($v) => $v['enabled'] && (!$v['algorithms'] || !$v['keyset']))
+                            ->thenInvalid('The "algorithms" and "keyset" options of the "response_signature" option are required when it is enabled.')
+                        ->end()
+                        ->children()
+                            ->booleanNode('enforce')
+                                ->info('When enabled (default), a plain JSON introspection response is refused.')
+                                ->defaultTrue()
+                            ->end()
+                            ->arrayNode('algorithms', 'algorithm')
+                                ->info('The signature algorithms the introspection response is accepted to be signed with, among "ES256", "ES384", "ES512", "RS256", "RS384", "RS512", "PS256", "PS384" and "PS512"; list the ones your authorization server announces in "introspection_signing_alg_values_supported". Another algorithm is accepted once its service is tagged "security.access_token_handler.oidc.signature_algorithm". No HMAC algorithm is tagged, so that a public key can never be used as a shared secret.')
+                                ->scalarPrototype()->cannotBeEmpty()->end()
+                            ->end()
+                            ->scalarNode('keyset')
+                                ->info('JSON-encoded JWKSet holding the public keys of your authorization server, the ones it announces at its "jwks_uri", which the introspection response is verified against.')
+                                ->defaultNull()
                             ->end()
                         ->end()
                     ->end()

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/AccessToken/OidcTokenHandlerFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/AccessToken/OidcTokenHandlerFactory.php
@@ -174,7 +174,7 @@ class OidcTokenHandlerFactory implements TokenHandlerFactoryInterface
                         ->scalarPrototype()->end()
                     ->end()
                     ->arrayNode('algorithms', 'algorithm')
-                        ->info('Algorithms used to sign the token.')
+                        ->info('The signature algorithms the token is accepted to be signed with, among "ES256", "ES384", "ES512", "RS256", "RS384", "RS512", "PS256", "PS384" and "PS512". Another algorithm is accepted once its service is tagged "security.access_token_handler.oidc.signature_algorithm". No HMAC algorithm is tagged, so that a public key can never be used as a shared secret.')
                         ->isRequired()
                         ->scalarPrototype()->end()
                     ->end()

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/AccessTokenFactoryTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/AccessTokenFactoryTest.php
@@ -143,7 +143,7 @@ class AccessTokenFactoryTest extends TestCase
         $factory = new AccessTokenFactory($this->createTokenHandlerFactories());
 
         $this->expectException(InvalidConfigurationException::class);
-        $this->expectExceptionMessage('The child config "algorithms" under "access_token.token_handler.oidc" must be configured: Algorithms used to sign the token.');
+        $this->expectExceptionMessage('The child config "algorithms" under "access_token.token_handler.oidc" must be configured: The signature algorithms the token is accepted to be signed with');
 
         $this->processConfig($config, $factory);
     }
@@ -663,6 +663,81 @@ class AccessTokenFactoryTest extends TestCase
         $factory->createAuthenticator($container, 'firewall1', $finalizedConfig, 'userprovider');
 
         $this->assertSame(['https://api.example.com', 'https://admin.example.com'], $container->getDefinition('security.access_token_handler.firewall1')->getArgument(2));
+    }
+
+    public function testOAuth2TokenHandlerConfigurationWithASignedResponse()
+    {
+        $container = new ContainerBuilder();
+        $config = [
+            'token_handler' => [
+                'oauth2' => [
+                    'audience' => 'https://api.example.com',
+                    'issuer' => 'https://www.example.com',
+                    'response_signature' => [
+                        'enabled' => true,
+                        'algorithms' => ['RS256'],
+                        'keyset' => '{"keys":[]}',
+                    ],
+                ],
+            ],
+        ];
+
+        $factory = new AccessTokenFactory($this->createTokenHandlerFactories());
+        $finalizedConfig = $this->processConfig($config, $factory);
+
+        $factory->createAuthenticator($container, 'firewall1', $finalizedConfig, 'userprovider');
+
+        $this->assertEquals([
+            [
+                'enableSignedResponse',
+                [
+                    (new ChildDefinition('security.access_token_handler.oidc.signature'))->replaceArgument(0, ['RS256']),
+                    (new ChildDefinition('security.access_token_handler.oidc.jwkset'))->replaceArgument(0, '{"keys":[]}'),
+                    true,
+                ],
+            ],
+        ], $container->getDefinition('security.access_token_handler.firewall1')->getMethodCalls());
+    }
+
+    public function testOAuth2TokenHandlerConfigurationWithASignedResponseDisabled()
+    {
+        $container = new ContainerBuilder();
+        $config = [
+            'token_handler' => [
+                'oauth2' => [
+                    'http_client' => 'oauth2.client',
+                    'response_signature' => false,
+                ],
+            ],
+        ];
+
+        $factory = new AccessTokenFactory($this->createTokenHandlerFactories());
+        $finalizedConfig = $this->processConfig($config, $factory);
+
+        $factory->createAuthenticator($container, 'firewall1', $finalizedConfig, 'userprovider');
+
+        $this->assertSame([], $container->getDefinition('security.access_token_handler.firewall1')->getMethodCalls());
+    }
+
+    public function testOAuth2TokenHandlerConfigurationWithASignedResponseAndNoIssuer()
+    {
+        $config = [
+            'token_handler' => [
+                'oauth2' => [
+                    'audience' => 'https://api.example.com',
+                    'response_signature' => [
+                        'enabled' => true,
+                        'algorithms' => ['RS256'],
+                        'keyset' => '{"keys":[]}',
+                    ],
+                ],
+            ],
+        ];
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('The "issuer" and "audience" options of the "oauth2" token handler are required when "response_signature" is enabled: RFC 9701 §5 makes "iss" and "aud" mandatory claims of the response.');
+
+        $this->processConfig($config, new AccessTokenFactory($this->createTokenHandlerFactories()));
     }
 
     public function testOAuth2TokenHandlerConfigurationWithAClientAsAString()

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/AccessTokenTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/AccessTokenTest.php
@@ -574,6 +574,43 @@ class AccessTokenTest extends AbstractWebTestCase
      * The "issuer" the firewall declares reaches the handler, so a token the authorization server
      * reports as active but attributes to another issuer is still refused.
      */
+    /**
+     * RFC 9701: the endpoint is asked for a signed response, and the RFC 7662 members are read from
+     * the "token_introspection" claim of the JWT it answers with.
+     */
+    #[RequiresPhpExtension('openssl')]
+    public function testOAuth2IntrospectionSuccessWithASignedResponse()
+    {
+        $client = $this->createClient(['test_case' => 'AccessToken', 'root_config' => 'config_oauth2_signed.yml']);
+        $endpoint = $client->getContainer()->get(IntrospectionResponseFactory::class);
+
+        $client->request('GET', '/foo', [], [], ['HTTP_AUTHORIZATION' => 'Bearer SIGNED_ACCESS_TOKEN']);
+        $response = $client->getResponse();
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame(['message' => 'Welcome @dunglas!'], json_decode($response->getContent(), true));
+
+        $this->assertSame(['Accept: application/token-introspection+jwt'], $endpoint->requests[0]['options']['normalized_headers']['accept']);
+    }
+
+    /**
+     * An authorization server answering plain JSON to a request that asked for a JWT has given up
+     * the guarantee the resource server required, so the response is refused.
+     */
+    #[RequiresPhpExtension('openssl')]
+    public function testOAuth2IntrospectionFailureOnAnUnsignedResponse()
+    {
+        $client = $this->createClient(['test_case' => 'AccessToken', 'root_config' => 'config_oauth2_signed.yml']);
+
+        $client->request('GET', '/foo', [], [], ['HTTP_AUTHORIZATION' => 'Bearer VALID_ACCESS_TOKEN']);
+        $response = $client->getResponse();
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertSame(401, $response->getStatusCode());
+        $this->assertSame('Bearer realm="My API",error="invalid_token",error_description="Invalid credentials."', $response->headers->get('WWW-Authenticate'));
+    }
+
     public function testOAuth2IntrospectionFailureOnAForeignIssuer()
     {
         $client = $this->createClient(['test_case' => 'AccessToken', 'root_config' => 'config_oauth2.yml']);

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/AccessTokenBundle/Security/Handler/IntrospectionResponseFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/AccessTokenBundle/Security/Handler/IntrospectionResponseFactory.php
@@ -11,6 +11,11 @@
 
 namespace Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\AccessTokenBundle\Security\Handler;
 
+use Jose\Component\Core\AlgorithmManager;
+use Jose\Component\Core\JWK;
+use Jose\Component\Signature\Algorithm\ES256;
+use Jose\Component\Signature\JWSBuilder;
+use Jose\Component\Signature\Serializer\CompactSerializer;
 use Symfony\Component\HttpClient\Response\JsonMockResponse;
 use Symfony\Component\HttpClient\Response\MockResponse;
 
@@ -34,6 +39,10 @@ final class IntrospectionResponseFactory
 
         parse_str($options['body'] ?? '', $body);
 
+        if ('SIGNED_ACCESS_TOKEN' === ($body['token'] ?? null)) {
+            return self::signedResponse($options['normalized_headers']['accept'] ?? []);
+        }
+
         if ('FOREIGN_ISSUER_ACCESS_TOKEN' === ($body['token'] ?? null)) {
             return new JsonMockResponse([
                 'active' => true,
@@ -55,5 +64,45 @@ final class IntrospectionResponseFactory
             'aud' => ['https://protected.example.net/resource'],
             'exp' => time() + 3600,
         ]);
+    }
+
+    /**
+     * Answers the RFC 9701 signed introspection response, or plain JSON when the request did not
+     * announce that media type, which is what an authorization server unable to sign would do.
+     *
+     * @param list<string> $accept
+     */
+    private static function signedResponse(array $accept): MockResponse
+    {
+        $members = [
+            'active' => true,
+            'sub' => 'dunglas',
+            'iss' => 'https://authorization-server.example.com/',
+            'aud' => ['https://protected.example.net/resource'],
+            'exp' => time() + 3600,
+        ];
+
+        if (!str_contains(implode(',', $accept), 'application/token-introspection+jwt')) {
+            return new JsonMockResponse($members);
+        }
+
+        $jws = (new CompactSerializer())->serialize((new JWSBuilder(new AlgorithmManager([new ES256()])))
+            ->withPayload(json_encode([
+                'iss' => 'https://authorization-server.example.com/',
+                'aud' => 'https://protected.example.net/resource',
+                'iat' => time(),
+                'token_introspection' => $members,
+            ], \JSON_THROW_ON_ERROR))
+            ->addSignature(new JWK([
+                'kty' => 'EC',
+                'crv' => 'P-256',
+                'd' => 'iA_TV2zvftni_9aFAQwFO_9aypfJFCSpcCyevDvz220',
+                'x' => '0QEAsI1wGI-dmYatdUZoWSRWggLEpyzopuhwk-YUnA4',
+                'y' => 'KYl-qyZ26HobuYwlQh-r0iHX61thfP82qqEku7i0woo',
+            ]), ['alg' => 'ES256', 'typ' => 'token-introspection+jwt'])
+            ->build()
+        );
+
+        return new MockResponse($jws, ['response_headers' => ['Content-Type' => 'application/token-introspection+jwt']]);
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_oauth2_signed.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_oauth2_signed.yml
@@ -1,0 +1,45 @@
+imports:
+    - { resource: ./../config/framework.yml }
+
+framework:
+    serializer: ~
+    http_client:
+        scoped_clients:
+            oauth2.introspection:
+                base_uri: 'https://authorization-server.example.com/token/introspect'
+                auth_basic: 'client:password'
+                mock_response_factory: Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\AccessTokenBundle\Security\Handler\IntrospectionResponseFactory
+
+security:
+    password_hashers:
+        Symfony\Component\Security\Core\User\InMemoryUser: plaintext
+
+    providers:
+        in_memory:
+            memory:
+                users:
+                    dunglas: { password: foo, roles: [ROLE_USER] }
+
+    firewalls:
+        main:
+            pattern: ^/
+            access_token:
+                token_handler:
+                    oauth2:
+                        http_client: 'oauth2.introspection'
+                        issuer: 'https://authorization-server.example.com/'
+                        audience: 'https://protected.example.net/resource'
+                        response_signature:
+                            algorithms: ['ES256']
+                            keyset: '{"keys":[{"kty":"EC","crv":"P-256","x":"0QEAsI1wGI-dmYatdUZoWSRWggLEpyzopuhwk-YUnA4","y":"KYl-qyZ26HobuYwlQh-r0iHX61thfP82qqEku7i0woo"}]}'
+                token_extractors: 'header'
+                realm: 'My API'
+
+    access_control:
+        - { path: ^/foo, roles: ROLE_USER }
+
+services:
+    _defaults:
+        public: true
+
+    Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\AccessTokenBundle\Security\Handler\IntrospectionResponseFactory: ~

--- a/src/Symfony/Component/Security/Http/AccessToken/OAuth2/Oauth2TokenHandler.php
+++ b/src/Symfony/Component/Security/Http/AccessToken/OAuth2/Oauth2TokenHandler.php
@@ -11,6 +11,14 @@
 
 namespace Symfony\Component\Security\Http\AccessToken\OAuth2;
 
+use Jose\Component\Checker;
+use Jose\Component\Checker\ClaimCheckerManager;
+use Jose\Component\Core\AlgorithmManager;
+use Jose\Component\Core\JWKSet;
+use Jose\Component\Signature\JWSTokenSupport;
+use Jose\Component\Signature\JWSVerifier;
+use Jose\Component\Signature\Serializer\CompactSerializer;
+use Jose\Component\Signature\Serializer\JWSSerializerManager;
 use Psr\Clock\ClockInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Clock\Clock;
@@ -38,15 +46,37 @@ use function Symfony\Component\String\u;
  * token as active while dating it in the past or the future, or while naming another issuer or
  * another audience, has described a token this resource server must not honor.
  *
+ * The introspection response may also be asked to be a signed JWT, as RFC 9701 defines it: see
+ * {@see enableSignedResponse()}. The endpoint is then requested with the matching "Accept" header,
+ * the JWT is verified against the keys of the authorization server, and the members of RFC 7662 are
+ * read from the "token_introspection" claim it wraps.
+ *
+ * Anything the introspection request throws is an answer the resource server could not read, so it
+ * turns into the bad credentials the firewall reports as a 401: a server that is unreachable, that
+ * refuses the caller, or that answers something other than the JSON object RFC 7662 §2.2 defines
+ * says nothing about the token, and never that it is usable.
+ *
  * @see https://datatracker.ietf.org/doc/html/rfc7662 OAuth 2.0 Token Introspection (RFC 7662)
+ * @see https://datatracker.ietf.org/doc/html/rfc9701 JWT Response for OAuth Token Introspection (RFC 9701)
  *
  * @internal
  */
 final class Oauth2TokenHandler implements AccessTokenHandlerInterface
 {
+    /**
+     * RFC 9701 §5: the media type of a JWT introspection response, also carried by its "typ" header,
+     * where RFC 7515 §4.1.9 lets the "application/" prefix be omitted, so both spellings are read.
+     */
+    private const JWT_RESPONSE_MEDIA_TYPE = 'application/token-introspection+jwt';
+    private const JWT_RESPONSE_TYPES = ['token-introspection+jwt', 'application/token-introspection+jwt'];
+
     private ?CacheInterface $cache = null;
     private string $cacheKeyPrefix = '';
     private int $cacheTtl = 0;
+
+    private ?AlgorithmManager $signatureAlgorithms = null;
+    private ?JWKSet $signatureKeyset = null;
+    private bool $enforceSignedResponse = true;
 
     /**
      * @param HttpClientInterface $client           The client the introspection endpoint is reached with, whose
@@ -98,23 +128,43 @@ final class Oauth2TokenHandler implements AccessTokenHandlerInterface
     }
 
     /**
+     * Requests a JWT introspection response and verifies its signature, as defined by RFC 9701.
+     *
+     * @param bool $enforce Whether a plain JSON response must be refused once the authorization server is expected to sign the introspection response
+     */
+    public function enableSignedResponse(AlgorithmManager $algorithms, JWKSet $keyset, bool $enforce = true): void
+    {
+        $this->signatureAlgorithms = $algorithms;
+        $this->signatureKeyset = $keyset;
+        $this->enforceSignedResponse = $enforce;
+    }
+
+    /**
      * Introspects the token and builds a user badge out of the members of the response.
      *
      * RFC 7662 §2.2 guarantees a single member on an inactive token, "active", and makes it a
-     * boolean, so it is the first one read and it is read as one: the string "false" an
-     * authorization server may answer with does not describe an active token. The identifier
-     * claims are only looked up once the server has stated that the token can be used.
+     * boolean, so it is the first one read and it is compared to true: nothing else states that the
+     * token can be used, the string "false" an authorization server may answer with least of all.
+     * The identifier claims are only looked up once that member has stated it.
+     *
+     * The JOSE checkers a signed response goes through report a refused "typ" header or a missing
+     * mandatory claim with exceptions of their own, which the catch-all around the response covers
+     * as it covers those of the HTTP client.
      */
     public function getUserBadgeFrom(string $accessToken): UserBadge
     {
+        if (null !== $this->signatureKeyset && (!class_exists(JWSVerifier::class) || !class_exists(Checker\HeaderCheckerManager::class))) {
+            throw new \LogicException('You cannot verify signed introspection responses since "web-token/jwt-library" is not installed. Try running "composer require web-token/jwt-library".');
+        }
+
         try {
-            $claims = $this->introspect($accessToken);
+            ['claims' => $claims, 'signed' => $signed] = $this->introspect($accessToken);
 
             if (true !== ($claims['active'] ?? false)) {
                 throw new BadCredentialsException('The claim "active" was not found on the authorization server response or is set to false.');
             }
 
-            $this->verifyClaims($claims);
+            $this->verifyClaims($claims, $signed);
             $identifier = $this->getUserIdentifier($claims);
 
             return new UserBadge($identifier, fn () => $this->createUser($claims), $claims);
@@ -135,7 +185,7 @@ final class Oauth2TokenHandler implements AccessTokenHandlerInterface
      * The lifetime of an entry is the shorter of the configured one and of what the "exp" of the
      * response leaves, and only the response of an active token is stored: see {@see enableCache()}.
      *
-     * @return array<string, mixed> The members of the introspection response
+     * @return array{claims: array<string, mixed>, signed: bool} The members of the introspection response, and whether they were read from a signed one
      */
     private function introspect(string $accessToken): array
     {
@@ -146,17 +196,17 @@ final class Oauth2TokenHandler implements AccessTokenHandlerInterface
         $key = $this->cacheKeyPrefix.hash('sha256', $accessToken);
 
         return $this->cache->get($key, function (ItemInterface $item, bool &$save) use ($accessToken): array {
-            $claims = $this->requestIntrospection($accessToken);
+            $response = $this->requestIntrospection($accessToken);
 
             $ttl = $this->cacheTtl;
-            if (is_numeric($claims['exp'] ?? null)) {
-                $ttl = min($ttl, (int) $claims['exp'] - $this->clock->now()->getTimestamp());
+            if (is_numeric($response['claims']['exp'] ?? null)) {
+                $ttl = min($ttl, (int) $response['claims']['exp'] - $this->clock->now()->getTimestamp());
             }
 
-            $save = 0 < $ttl && true === ($claims['active'] ?? null);
+            $save = 0 < $ttl && true === ($response['claims']['active'] ?? false);
             $item->expiresAfter(max(1, $ttl));
 
-            return $claims;
+            return $response;
         });
     }
 
@@ -165,19 +215,111 @@ final class Oauth2TokenHandler implements AccessTokenHandlerInterface
      *
      * The request carries the token and the "access_token" hint of RFC 7662 §2.1, and is posted to
      * the base URI of the client, which is where the endpoint and the credentials of this resource
-     * server are configured.
+     * server are configured. It asks for the media types it is able to read: a JWT introspection
+     * response is only ever served to a request announcing it, per RFC 9701 §4, and plain JSON is
+     * still offered alongside it when an unsigned response is tolerated, so that an authorization
+     * server that cannot sign answers instead of refusing the media type. The response headers are
+     * read before its body, so that the payload of a 4xx or a 5xx is never mistaken for an
+     * introspection response.
      *
-     * @return array<string, mixed>
+     * @return array{claims: array<string, mixed>, signed: bool}
      */
     private function requestIntrospection(string $accessToken): array
     {
-        return $this->client->request('POST', '', [
-            'headers' => ['Accept' => 'application/json'],
+        if (null === $this->signatureKeyset) {
+            $accept = 'application/json';
+        } else {
+            $accept = $this->enforceSignedResponse ? self::JWT_RESPONSE_MEDIA_TYPE : self::JWT_RESPONSE_MEDIA_TYPE.', application/json';
+        }
+
+        $response = $this->client->request('POST', '', [
+            'headers' => ['Accept' => $accept],
             'body' => [
                 'token' => $accessToken,
                 'token_type_hint' => 'access_token',
             ],
-        ])->toArray();
+        ]);
+        $contentType = strtolower(trim(strtok($response->getHeaders()['content-type'][0] ?? '', ';')));
+
+        if (self::JWT_RESPONSE_MEDIA_TYPE === $contentType) {
+            if (null === $this->signatureKeyset) {
+                throw new BadCredentialsException('The authorization server returned a JWT introspection response, which this resource server is not configured to verify.');
+            }
+
+            return ['claims' => $this->verifySignedResponse($response->getContent()), 'signed' => true];
+        }
+
+        if (null !== $this->signatureKeyset && $this->enforceSignedResponse) {
+            throw new BadCredentialsException(\sprintf('A signed introspection response is required, but the authorization server answered with "%s".', $contentType ?: 'no content type'));
+        }
+
+        return ['claims' => $response->toArray(), 'signed' => false];
+    }
+
+    /**
+     * Verifies a JWT introspection response and returns the members it wraps.
+     *
+     * Beyond the signature, two things are checked because RFC 9701 §8.1 rests on them to keep an
+     * access token or an ID token of the same issuer from being passed off as an introspection
+     * response: the "typ" header, and the nesting of the RFC 7662 members inside the
+     * "token_introspection" claim. The "iss", "aud" and "iat" claims that §5 makes mandatory at the
+     * top level are required as well, and confronted with the issuer and the audiences declared here.
+     *
+     * The library is supported from 3.x, where verify() does not exist yet and verifyWithKeySet()
+     * is not deprecated yet; static analysis only ever sees the newest version, hence the two
+     * ignores around the verification.
+     *
+     * @return array<string, mixed>
+     */
+    private function verifySignedResponse(string $jwt): array
+    {
+        try {
+            $jws = (new JWSSerializerManager([new CompactSerializer()]))->unserialize($jwt);
+        } catch (\InvalidArgumentException $e) {
+            throw new BadCredentialsException('The introspection response is not a valid JWT.', previous: $e);
+        }
+
+        $jwsVerifier = new JWSVerifier($this->signatureAlgorithms);
+
+        if (method_exists($jwsVerifier, 'verify')) { // @phpstan-ignore function.alreadyNarrowedType
+            $verified = $jwsVerifier->verify($jws, $this->signatureKeyset, 0)->isVerified();
+        } else {
+            $verified = $jwsVerifier->verifyWithKeySet($jws, $this->signatureKeyset, 0); // @phpstan-ignore method.deprecated
+        }
+
+        if (!$verified) {
+            throw new BadCredentialsException('The signature of the introspection response is invalid.');
+        }
+
+        (new Checker\HeaderCheckerManager([
+            new Checker\AlgorithmChecker($this->signatureAlgorithms->list()),
+            new Checker\CallableChecker('typ', static fn ($value) => \is_string($value) && \in_array(strtolower($value), self::JWT_RESPONSE_TYPES, true)),
+        ], [new JWSTokenSupport()]))->check($jws, 0, ['alg', 'typ']);
+
+        try {
+            $payload = json_decode($jws->getPayload() ?? '', true, 512, \JSON_THROW_ON_ERROR);
+        } catch (\JsonException $e) {
+            throw new BadCredentialsException('The payload of the introspection response is not valid JSON.', previous: $e);
+        }
+
+        if (!\is_array($payload)) {
+            throw new BadCredentialsException('The payload of the introspection response is not a JSON object.');
+        }
+
+        $checkers = [new Checker\IssuedAtChecker(clock: $this->clock, allowedTimeDrift: $this->allowedTimeDrift)];
+        if (null !== $this->issuer) {
+            $checkers[] = new Checker\IssuerChecker([$this->issuer]);
+        }
+        if ($this->audiences) {
+            $checkers[] = new Checker\CallableChecker('aud', fn ($value) => $this->matchesAudience($value));
+        }
+        (new ClaimCheckerManager($checkers))->check($payload, ['iss', 'aud', 'iat', 'token_introspection']);
+
+        if (!\is_array($payload['token_introspection'])) {
+            throw new BadCredentialsException('The "token_introspection" claim of the introspection response is not a JSON object.');
+        }
+
+        return $payload['token_introspection'];
     }
 
     /**
@@ -188,11 +330,14 @@ final class Oauth2TokenHandler implements AccessTokenHandlerInterface
      * token is already expired, not valid yet or minted in the future still has no reason to honor
      * it. The issuer and the audience are checked when this resource server declares which ones it
      * expects, and the response is then required to carry them, since a token issued by another
-     * authorization server, or for another resource server, must not be honored.
+     * authorization server, or for another resource server, must not be honored. A signed response
+     * is the exception: RFC 9701 §5 already binds it to both at the top level of the JWT, so the
+     * members it wraps are only confronted with them when they repeat them.
      *
      * @param array<string, mixed> $claims
+     * @param bool                 $signed Whether the members come from a JWT introspection response, whose issuer and audience were verified at its top level
      */
-    private function verifyClaims(array $claims): void
+    private function verifyClaims(array $claims, bool $signed): void
     {
         $now = $this->clock->now()->getTimestamp();
 
@@ -208,11 +353,11 @@ final class Oauth2TokenHandler implements AccessTokenHandlerInterface
             throw new BadCredentialsException('The token reported by the authorization server was issued in the future.');
         }
 
-        if (null !== $this->issuer && $this->issuer !== ($claims['iss'] ?? null)) {
+        if (null !== $this->issuer && (!$signed || isset($claims['iss'])) && $this->issuer !== ($claims['iss'] ?? null)) {
             throw new BadCredentialsException(\sprintf('The token was issued by "%s", where "%s" was expected.', \is_string($claims['iss'] ?? null) ? $claims['iss'] : '', $this->issuer));
         }
 
-        if ($this->audiences && !$this->matchesAudience($claims['aud'] ?? null)) {
+        if ($this->audiences && (!$signed || isset($claims['aud'])) && !$this->matchesAudience($claims['aud'] ?? null)) {
             throw new BadCredentialsException(\sprintf('The token is not intended for any of the audiences "%s".', implode('", "', $this->audiences)));
         }
     }

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * Add `InsufficientScopeAccessDeniedHandler` to answer a denial caused by a missing scope with the RFC 6750 §3.1 challenge
  * Add the `$audiences`, `$issuer`, `$claim`, `$clock` and `$allowedTimeDrift` arguments to `Oauth2TokenHandler`, which validates the `exp`, `nbf`, `iat`, `iss` and `aud` members of the introspection response against them
  * Add `Oauth2TokenHandler::enableCache()` to cache the introspection responses of active tokens, never beyond their `exp`
+ * Add `Oauth2TokenHandler::enableSignedResponse()` to request and verify a JWT introspection response (RFC 9701)
  * Throw a 403 `Symfony\Component\Security\Http\Exception\InvalidCsrfTokenException` instead of the `Security\Core` one when the `#[IsCsrfTokenValid]` attribute fails, so the failure is no longer handled as an authentication failure
  * Add the deauthentication reason and the responsible user providers to `TokenDeauthenticatedEvent`
  * Add `LogoutUrlGenerator::getLogoutForm()` to build a form that logs the user out with a POST

--- a/src/Symfony/Component/Security/Http/Tests/AccessToken/OAuth2/OAuth2TokenHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/AccessToken/OAuth2/OAuth2TokenHandlerTest.php
@@ -11,7 +11,16 @@
 
 namespace Symfony\Component\Security\Http\Tests\AccessToken\OAuth2;
 
+use Jose\Component\Core\Algorithm;
+use Jose\Component\Core\AlgorithmManager;
+use Jose\Component\Core\JWK;
+use Jose\Component\Core\JWKSet;
+use Jose\Component\Signature\Algorithm\ES256;
+use Jose\Component\Signature\Algorithm\HS256;
+use Jose\Component\Signature\JWSBuilder;
+use Jose\Component\Signature\Serializer\CompactSerializer;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Clock\MockClock;
@@ -341,6 +350,227 @@ class OAuth2TokenHandlerTest extends TestCase
         self::createHandler(new MockHttpClient())->enableCache(new ArrayAdapter(), 'introspection.', 0);
     }
 
+    /**
+     * RFC 9701 §4: the JWT response is served to a request announcing that media type.
+     *
+     * RFC 9701 §5 spells the "typ" header without the "application/" prefix RFC 7515 §4.1.9 makes
+     * optional, and a media type is case-insensitive, so all three spellings name the same type.
+     */
+    #[DataProvider('provideAcceptedResponseTypes')]
+    #[RequiresPhpExtension('openssl')]
+    public function testVerifiesASignedIntrospectionResponse(string $type)
+    {
+        $request = null;
+        $client = new MockHttpClient(static function (string $method, string $url, array $options) use (&$request, $type): MockResponse {
+            $request = $options;
+
+            return self::jwtResponse(self::signedResponsePayload(self::activeClaims(['sub' => 'jdoe'])), type: $type);
+        }, self::ENDPOINT);
+
+        $userBadge = self::createSignedResponseHandler($client)->getUserBadgeFrom('a-secret-token');
+
+        $this->assertSame(['Accept: application/token-introspection+jwt'], $request['normalized_headers']['accept']);
+        $this->assertSame('jdoe', $userBadge->getUserIdentifier());
+        $this->assertSame(self::activeClaims(['sub' => 'jdoe']), $userBadge->getAttributes());
+    }
+
+    public static function provideAcceptedResponseTypes(): iterable
+    {
+        yield 'the spelling of RFC 9701 §5' => ['token-introspection+jwt'];
+        yield 'the "application/" prefix RFC 7515 §4.1.9 makes optional' => ['application/token-introspection+jwt'];
+        yield 'another case' => ['Token-Introspection+JWT'];
+    }
+
+    /**
+     * RFC 9701 §5 names one media type, so the JWT branch is taken on that type and on nothing that
+     * merely starts with it, while the parameters and the case a "Content-Type" may carry are read.
+     */
+    #[DataProvider('provideResponseContentTypes')]
+    #[RequiresPhpExtension('openssl')]
+    public function testReadsTheMediaTypeOfTheResponseAtItsBoundary(string $contentType, bool $isJwt)
+    {
+        $client = new MockHttpClient([self::jwtResponse(self::signedResponsePayload(self::activeClaims(['sub' => 'jdoe'])), contentType: $contentType)], self::ENDPOINT);
+        $handler = self::createSignedResponseHandler($client);
+
+        if ($isJwt) {
+            $this->assertSame('jdoe', $handler->getUserBadgeFrom('a-secret-token')->getUserIdentifier());
+        } else {
+            $this->assertBadCredentials(\sprintf('A signed introspection response is required, but the authorization server answered with "%s".', strtolower($contentType)), $handler);
+        }
+    }
+
+    public static function provideResponseContentTypes(): iterable
+    {
+        yield 'the media type' => ['application/token-introspection+jwt', true];
+        yield 'with a parameter' => ['application/token-introspection+jwt; charset=utf-8', true];
+        yield 'another case' => ['Application/Token-Introspection+JWT', true];
+        yield 'another media type starting with it' => ['application/token-introspection+jwtfoo', false];
+        yield 'plain JSON' => ['application/json', false];
+    }
+
+    #[RequiresPhpExtension('openssl')]
+    public function testRejectsAnIntrospectionResponseSignedWithAnotherKey()
+    {
+        $client = new MockHttpClient([self::jwtResponse(self::signedResponsePayload(self::activeClaims(['sub' => 'jdoe'])), self::otherJwk())], self::ENDPOINT);
+
+        $this->assertBadCredentials('The signature of the introspection response is invalid.', self::createSignedResponseHandler($client));
+    }
+
+    /**
+     * RFC 9701 §8.1: without the "typ" check, an access token of the same issuer would do.
+     */
+    #[RequiresPhpExtension('openssl')]
+    public function testRejectsAnIntrospectionResponseWithoutTheExpectedType()
+    {
+        $client = new MockHttpClient([self::jwtResponse(self::signedResponsePayload(self::activeClaims(['sub' => 'jdoe'])), type: 'JWT')], self::ENDPOINT);
+
+        $this->assertBadCredentials('The "typ" header is invalid.', self::createSignedResponseHandler($client));
+    }
+
+    /**
+     * RFC 9701 §8.1: the "typ" header is what tells an introspection response from another JWT of
+     * the same issuer, so one carrying none is not an introspection response either.
+     */
+    #[RequiresPhpExtension('openssl')]
+    public function testRejectsAnIntrospectionResponseWithoutAnyType()
+    {
+        $client = new MockHttpClient([self::jwtResponse(self::signedResponsePayload(self::activeClaims(['sub' => 'jdoe'])), type: null)], self::ENDPOINT);
+
+        $this->assertBadCredentials('The following header parameters are mandatory: typ.', self::createSignedResponseHandler($client));
+    }
+
+    /**
+     * RFC 9701 §5 wraps the members in a JSON object, so a payload that is not one carries no claim
+     * to check: it is refused before the checkers, which only ever read an array.
+     */
+    #[RequiresPhpExtension('openssl')]
+    public function testRejectsAnIntrospectionResponseWhosePayloadIsNotAnObject()
+    {
+        $client = new MockHttpClient([self::jwtResponse('"nope"')], self::ENDPOINT);
+
+        $this->assertBadCredentials('The payload of the introspection response is not a JSON object.', self::createSignedResponseHandler($client));
+    }
+
+    /**
+     * RFC 9701 §5: the algorithm is the one the resource server declared, not the one the response names.
+     */
+    #[RequiresPhpExtension('openssl')]
+    public function testRejectsAnIntrospectionResponseSignedWithAnotherAlgorithm()
+    {
+        $client = new MockHttpClient([self::jwtResponse(self::signedResponsePayload(self::activeClaims(['sub' => 'jdoe'])), algorithm: new HS256(), jwk: new JWK(['kty' => 'oct', 'k' => 'MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDE']))], self::ENDPOINT);
+
+        $this->assertBadCredentials('The algorithm "HS256" is not supported.', self::createSignedResponseHandler($client));
+    }
+
+    /**
+     * RFC 9701 §5: "iss", "aud" and "iat" are mandatory at the top level.
+     */
+    #[DataProvider('provideMandatoryTopLevelClaims')]
+    #[RequiresPhpExtension('openssl')]
+    public function testRejectsAnIntrospectionResponseWithoutAMandatoryTopLevelClaim(string $claim)
+    {
+        $payload = self::signedResponsePayload(self::activeClaims(['sub' => 'jdoe']));
+        unset($payload[$claim]);
+        $client = new MockHttpClient([self::jwtResponse($payload)], self::ENDPOINT);
+
+        $this->assertBadCredentials(\sprintf('The following claims are mandatory: %s.', $claim), self::createSignedResponseHandler($client));
+    }
+
+    public static function provideMandatoryTopLevelClaims(): iterable
+    {
+        yield ['iss'];
+        yield ['aud'];
+        yield ['iat'];
+    }
+
+    #[RequiresPhpExtension('openssl')]
+    public function testRejectsAnIntrospectionResponseMintedForAnotherAudience()
+    {
+        $payload = self::signedResponsePayload(self::activeClaims(['sub' => 'jdoe']));
+        $payload['aud'] = 'https://other-api.example.com';
+        $client = new MockHttpClient([self::jwtResponse($payload)], self::ENDPOINT);
+
+        $this->assertBadCredentials('The "aud" claim is invalid.', self::createSignedResponseHandler($client));
+    }
+
+    #[RequiresPhpExtension('openssl')]
+    public function testRejectsAnIntrospectionResponseIssuedInTheFuture()
+    {
+        $payload = self::signedResponsePayload(self::activeClaims(['sub' => 'jdoe']));
+        $payload['iat'] = 1719000001;
+        $client = new MockHttpClient([self::jwtResponse($payload)], self::ENDPOINT);
+
+        $this->assertBadCredentials('The JWT is issued in the future.', self::createSignedResponseHandler($client));
+    }
+
+    #[RequiresPhpExtension('openssl')]
+    public function testRejectsAnIntrospectionResponseWhoseMembersAreNotAnObject()
+    {
+        $payload = self::signedResponsePayload(self::activeClaims(['sub' => 'jdoe']));
+        $payload['token_introspection'] = 'active';
+        $client = new MockHttpClient([self::jwtResponse($payload)], self::ENDPOINT);
+
+        $this->assertBadCredentials('The "token_introspection" claim of the introspection response is not a JSON object.', self::createSignedResponseHandler($client));
+    }
+
+    #[RequiresPhpExtension('openssl')]
+    public function testRejectsAnIntrospectionResponseWithoutTheTokenIntrospectionClaim()
+    {
+        $payload = self::signedResponsePayload(self::activeClaims(['sub' => 'jdoe']));
+        unset($payload['token_introspection']);
+        $client = new MockHttpClient([self::jwtResponse($payload)], self::ENDPOINT);
+
+        $this->assertBadCredentials('The following claims are mandatory: token_introspection.', self::createSignedResponseHandler($client));
+    }
+
+    #[RequiresPhpExtension('openssl')]
+    public function testRejectsAnIntrospectionResponseFromAnotherIssuer()
+    {
+        $payload = self::signedResponsePayload(self::activeClaims(['sub' => 'jdoe']));
+        $payload['iss'] = 'https://evil.example.com/';
+        $client = new MockHttpClient([self::jwtResponse($payload)], self::ENDPOINT);
+
+        $this->assertBadCredentials('Unknown issuer.', self::createSignedResponseHandler($client));
+    }
+
+    #[RequiresPhpExtension('openssl')]
+    public function testChecksTheIssuerRepeatedInASignedResponse()
+    {
+        $client = new MockHttpClient([self::jwtResponse(self::signedResponsePayload(self::activeClaims(['sub' => 'jdoe', 'iss' => 'https://evil.example.com/'])))], self::ENDPOINT);
+
+        $this->assertBadCredentials('The token was issued by "https://evil.example.com/", where "'.self::ISSUER.'" was expected.', self::createSignedResponseHandler($client));
+    }
+
+    #[RequiresPhpExtension('openssl')]
+    public function testRejectsAPlainResponseWhenASignedOneIsEnforced()
+    {
+        $client = new MockHttpClient([new JsonMockResponse(self::activeClaims(['sub' => 'jdoe']))], self::ENDPOINT);
+
+        $this->assertBadCredentials('A signed introspection response is required, but the authorization server answered with "application/json".', self::createSignedResponseHandler($client));
+    }
+
+    #[RequiresPhpExtension('openssl')]
+    public function testAcceptsAPlainResponseWhenASignedOneIsNotEnforced()
+    {
+        $request = null;
+        $client = new MockHttpClient(static function (string $method, string $url, array $options) use (&$request): MockResponse {
+            $request = $options;
+
+            return new JsonMockResponse(self::activeClaims(['sub' => 'jdoe', 'iss' => self::ISSUER, 'aud' => self::AUDIENCE]));
+        }, self::ENDPOINT);
+
+        $this->assertSame('jdoe', self::createSignedResponseHandler($client, enforce: false)->getUserBadgeFrom('a-secret-token')->getUserIdentifier());
+        $this->assertSame(['Accept: application/token-introspection+jwt, application/json'], $request['normalized_headers']['accept']);
+    }
+
+    #[RequiresPhpExtension('openssl')]
+    public function testRejectsASignedResponseWhenNoneIsExpected()
+    {
+        $client = new MockHttpClient([self::jwtResponse(self::signedResponsePayload(self::activeClaims(['sub' => 'jdoe'])))], self::ENDPOINT);
+
+        $this->assertBadCredentials('The authorization server returned a JWT introspection response, which this resource server is not configured to verify.', self::createHandler($client));
+    }
+
     private function assertBadCredentials(string $message, Oauth2TokenHandler $handler): void
     {
         try {
@@ -366,5 +596,76 @@ class OAuth2TokenHandlerTest extends TestCase
     private static function activeClaims(array $claims = []): array
     {
         return ['active' => true] + $claims;
+    }
+
+    private static function createSignedResponseHandler(MockHttpClient $client, bool $enforce = true): Oauth2TokenHandler
+    {
+        $handler = self::createHandler($client, [self::AUDIENCE], self::ISSUER);
+        $handler->enableSignedResponse(new AlgorithmManager([new ES256()]), new JWKSet([self::publicJwk()]), $enforce);
+
+        return $handler;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function signedResponsePayload(array $introspection): array
+    {
+        return [
+            'iss' => self::ISSUER,
+            'aud' => self::AUDIENCE,
+            'iat' => 1719000000,
+            'token_introspection' => $introspection,
+        ];
+    }
+
+    private static function jwtResponse(array|string $payload, ?JWK $jwk = null, ?string $type = 'token-introspection+jwt', ?Algorithm $algorithm = null, string $contentType = 'application/token-introspection+jwt'): MockResponse
+    {
+        $algorithm ??= new ES256();
+        $header = ['alg' => $algorithm->name()];
+        if (null !== $type) {
+            $header['typ'] = $type;
+        }
+
+        $jws = (new CompactSerializer())->serialize((new JWSBuilder(new AlgorithmManager([$algorithm])))
+            ->withPayload(\is_string($payload) ? $payload : json_encode($payload, \JSON_THROW_ON_ERROR))
+            ->addSignature($jwk ?? self::jwk(), $header)
+            ->build()
+        );
+
+        return new MockResponse($jws, ['response_headers' => ['Content-Type' => $contentType]]);
+    }
+
+    /**
+     * Tip: use https://mkjwk.org/ to generate a JWK.
+     */
+    private static function jwk(): JWK
+    {
+        return new JWK([
+            'kty' => 'EC',
+            'crv' => 'P-256',
+            'x' => '0QEAsI1wGI-dmYatdUZoWSRWggLEpyzopuhwk-YUnA4',
+            'y' => 'KYl-qyZ26HobuYwlQh-r0iHX61thfP82qqEku7i0woo',
+            'd' => 'iA_TV2zvftni_9aFAQwFO_9aypfJFCSpcCyevDvz220',
+        ]);
+    }
+
+    private static function publicJwk(): JWK
+    {
+        $key = self::jwk()->all();
+        unset($key['d']);
+
+        return new JWK($key);
+    }
+
+    private static function otherJwk(): JWK
+    {
+        return new JWK([
+            'kty' => 'EC',
+            'crv' => 'P-256',
+            'x' => 'FtgMtrsKDboRO-Zo0XC7tDJTATHVmwuf9GK409kkars',
+            'y' => 'rWDE0ERU2SfwGYCo1DWWdgFEbZ0MiAXLRBBOzBgs_jY',
+            'd' => '4G7bRIiKih0qrFxc0dtvkHUll19tTyctoCR3eIbOrO0',
+        ]);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Depends on #65865, whose commit is included here. Only the second commit belongs to this PR.

RFC 9701 lets a resource server ask the introspection endpoint for a signed response rather than plain JSON. That is what makes the answer usable as evidence: the members of RFC 7662 come with the signature of the authorization server, bound to its issuer and to the resource server the response was minted for.

```yaml
security:
    firewalls:
        main:
            access_token:
                token_handler:
                    oauth2:
                        http_client: 'oauth2.introspection'
                        issuer: 'https://authorization-server.example.com/'
                        audience: 'https://api.example.com'
                        response_signature:
                            enabled: true
                            algorithms: ['RS256']
                            keyset: '%env(AS_JWKS)%'
                            enforce: true  # default
```

The endpoint is then requested with `Accept: application/token-introspection+jwt` (§4), and the JWT is verified against the JWKSet the firewall declares.

### What is checked

Beyond the signature, two things, because §8.1 rests on them to keep an access token or an ID token of the same issuer from being passed off as an introspection response:

- the `typ` header, which must be `token-introspection+jwt`;
- the nesting of the RFC 7662 members inside the `token_introspection` claim, which is where they are read from.

The `iss`, `aud` and `iat` claims that §5 makes mandatory at the top level are required as well, and confronted with the issuer and the audiences the firewall expects. That is why declaring both becomes mandatory when `response_signature` is enabled. Since a signed response already binds those two at the top level of the JWT, the members it wraps are only confronted with them when the authorization server repeats them there.

RFC 9701 §8.1 has two halves, and only one of them is closed here. Its normative sentence is about the other one: a resource server must check the `typ` of the JWT access tokens it receives, so that a signed introspection response cannot be passed off as one. That is what #65862 adds, and it is merged, so the countermeasure is in. The two belong together.

### Downgrade

A plain JSON response is refused by default: an authorization server answering unsigned to a request that asked for a JWT has downgraded the guarantee. `enforce: false` tolerates it, and the request then offers both media types, so a server unable to sign answers rather than refusing the media type.

### Scope

The JWKSet and the algorithm manager reuse the services of the `oidc` token handler: neither is tied to OpenID Connect, they turn a JSON document into a `JWKSet` and the algorithms tagged in the bundle into a JWS algorithm manager.

Resolving the keys from the authorization server metadata is left out on purpose. `introspection_signing_alg_values_supported` and `jwks_uri` come from RFC 8414, which `OidcDiscovery` does not read yet, and adding a bare `jwks_uri` option here would introduce a third configuration idiom next to `keyset` and `discovery`. Encryption of the introspection response (§5, nested JWT) is left out for the same reason: it is optional and driven by resource server policy.

### Merge order

This PR and #65870 overlap: both widen the `catch` around the introspection request to `catch (\Exception)`, and both pass the throwable in the `'exception' =>` log context. Either can land first, since the change is identical on both sides and merges cleanly. What conflicts is `OAuth2TokenHandlerTest`, where the resolution is keep-both: the test #65870 adds passes unmodified on this head.
