### PR TITLE
[Cache] Add support for relay 0.50

### DIFF
--- a/src/Symfony/Component/Cache/Traits/Relay/Relay40Trait.php
+++ b/src/Symfony/Component/Cache/Traits/Relay/Relay40Trait.php
@@ -11,7 +11,33 @@
 
 namespace Symfony\Component\Cache\Traits\Relay;
 
-if (version_compare(phpversion('relay'), '0.40.0', '>=')) {
+if (version_compare(phpversion('relay'), '0.50.0', '>=')) {
+    /**
+     * @internal
+     */
+    trait Relay40Trait
+    {
+        public function blmovem($srckey, $dstkey, $srcpos, $dstpos, $timeout, $options = null): \Relay\Relay|array|false|null
+        {
+            return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->blmovem(...\func_get_args());
+        }
+
+        public function lmovem($srckey, $dstkey, $srcpos, $dstpos, $options = null): \Relay\Relay|array|false|null
+        {
+            return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->lmovem(...\func_get_args());
+        }
+
+        public function sdiffcard($keys, $options = null): \Relay\Relay|false|int
+        {
+            return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sdiffcard(...\func_get_args());
+        }
+
+        public function sunioncard($keys, $options = null): \Relay\Relay|false|int
+        {
+            return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->sunioncard(...\func_get_args());
+        }
+    }
+} elseif (version_compare(phpversion('relay'), '0.40.0', '>=')) {
     /**
      * @internal
      */

--- a/src/Symfony/Component/Cache/Traits/Relay/Relay50Trait.php
+++ b/src/Symfony/Component/Cache/Traits/Relay/Relay50Trait.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Traits\Relay;
+
+if (version_compare(phpversion('relay'), '0.50.0', '>=')) {
+    /**
+     * @internal
+     */
+    trait Relay50Trait
+    {
+        public function himport($op, $hash = null, $fieldset = null, $fields = []): \Relay\Relay|bool|int
+        {
+            return ($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->himport(...\func_get_args());
+        }
+    }
+} else {
+    /**
+     * @internal
+     */
+    trait Relay50Trait
+    {
+    }
+}

--- a/src/Symfony/Component/Cache/Traits/RelayProxy.php
+++ b/src/Symfony/Component/Cache/Traits/RelayProxy.php
@@ -30,6 +30,7 @@ use Symfony\Component\Cache\Traits\Relay\Relay21Trait;
 use Symfony\Component\Cache\Traits\Relay\Relay22Trait;
 use Symfony\Component\Cache\Traits\Relay\Relay30Trait;
 use Symfony\Component\Cache\Traits\Relay\Relay40Trait;
+use Symfony\Component\Cache\Traits\Relay\Relay50Trait;
 use Symfony\Component\Cache\Traits\Relay\SwapdbTrait;
 use Symfony\Component\VarExporter\LazyObjectInterface;
 use Symfony\Component\VarExporter\LazyProxyTrait;
@@ -68,6 +69,7 @@ class RelayProxy extends \Relay\Relay implements ResetInterface, LazyObjectInter
     use Relay22Trait;
     use Relay30Trait;
     use Relay40Trait;
+    use Relay50Trait;
     use SwapdbTrait;
 
     private const LAZY_OBJECT_PROPERTY_SCOPES = [];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The relay extension 0.50.0 was released yesterday and CI installs it on every job. It changes `Relay\Relay` in two ways:

* `blmovem()` and `lmovem()` can now return `null`, so their return type went from `Relay|array|false` to `Relay|array|false|null`;
* a new `himport()` method was added.

`RelayProxy` has to declare the same signatures as the extension, and `RedisProxiesTest::testRelayProxy()` checks that, so the Cache test suite is red on 6.4 and on all higher branches.

`blmovem()` and `lmovem()` keep living in `Relay40Trait`, which now selects between the 0.40 and the 0.50 shapes. The new `himport()` goes to a new `Relay50Trait`.

I ran `RedisProxiesTest` against relay 0.22.0, 0.30.0, 0.40.0 and 0.50.0 (php 8.4, builds from `builds.r2.relay.so`), green on all four. The rest of the Cache suite passes locally except the adapter tests, which my local `cache/integration-tests` clone does not support on this branch.

Merge-up to 7.4: the same change applies, with `$this->initializeLazyObject()->...` bodies instead of `($this->lazyObjectState->realInstance ??= ($this->lazyObjectState->initializer)())->...`. On top of that, 7.4 has `RelayClusterProxy`, which 6.4 does not, and `Relay\Cluster` drifted too: `blmovem()` and `lmovem()` became nullable there as well, and `fcall()`, `fcall_ro()`, `himport()` and `msetex()` were added. That needs a `RelayCluster50Trait` plus the same 0.40/0.50 split in `RelayCluster40Trait`. I prepared and ran that resolution on 7.4, `RedisProxiesTest` is green there with relay 0.30.0, 0.40.0 and 0.50.0.
