### PR TITLE
[Security] Answer 401 instead of 500 when the introspection request fails

### DIFF
--- a/src/Symfony/Component/Security/Http/AccessToken/OAuth2/Oauth2TokenHandler.php
+++ b/src/Symfony/Component/Security/Http/AccessToken/OAuth2/Oauth2TokenHandler.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Security\Http\AccessToken\OAuth2;
 
 use Psr\Log\LoggerInterface;
-use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\Security\Core\User\OAuth2User;
 use Symfony\Component\Security\Http\AccessToken\AccessTokenHandlerInterface;
@@ -23,6 +22,11 @@ use function Symfony\Component\String\u;
 
 /**
  * The token handler validates the token on the authorization server and the Introspection Endpoint.
+ *
+ * Anything the introspection request throws is an answer the resource server could not read, so it
+ * turns into the bad credentials the firewall reports as a 401: a server that is unreachable, that
+ * refuses the caller, or that answers something other than the JSON object RFC 7662 §2.2 defines
+ * says nothing about the token, and never that it is usable.
  *
  * @see https://tools.ietf.org/html/rfc7662
  *
@@ -59,9 +63,10 @@ final class Oauth2TokenHandler implements AccessTokenHandlerInterface
             }
 
             return new UserBadge($sub ?? $username, fn () => $this->createUser($claims), $claims);
-        } catch (AuthenticationException $e) {
+        } catch (\Exception $e) {
             $this->logger?->error('An error occurred on the authorization server.', [
                 'error' => $e->getMessage(),
+                'exception' => $e,
                 'trace' => $e->getTraceAsString(),
             ]);
 

--- a/src/Symfony/Component/Security/Http/Tests/AccessToken/OAuth2/OAuth2TokenHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/AccessToken/OAuth2/OAuth2TokenHandlerTest.php
@@ -11,15 +11,36 @@
 
 namespace Symfony\Component\Security\Http\Tests\AccessToken\OAuth2;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\Security\Core\User\OAuth2User;
 use Symfony\Component\Security\Http\AccessToken\OAuth2\Oauth2TokenHandler;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 
 class OAuth2TokenHandlerTest extends TestCase
 {
+    #[DataProvider('unreadableResponses')]
+    public function testTurnsAnErrorOfTheAuthorizationServerIntoBadCredentials(MockResponse $response)
+    {
+        $this->expectException(BadCredentialsException::class);
+        $this->expectExceptionMessage('Invalid credentials.');
+
+        (new Oauth2TokenHandler(new MockHttpClient([$response])))->getUserBadgeFrom('a-secret-token');
+    }
+
+    public static function unreadableResponses(): iterable
+    {
+        yield 'the caller is refused' => [new MockResponse('{"error":"invalid_client"}', ['http_code' => 401])];
+        yield 'the server is down' => [new MockResponse('', ['http_code' => 503])];
+        yield 'the server is unreachable' => [new MockResponse('', ['error' => 'Could not resolve host: authorization-server.example.com'])];
+        yield 'the body is not JSON' => [new MockResponse('<html>Bad Gateway</html>')];
+        yield 'the body is empty' => [new MockResponse('')];
+        yield 'the body is not an object' => [new MockResponse('"nope"')];
+    }
+
     public function testGetsUserIdentifierFromOAuth2ServerResponse()
     {
         $accessToken = 'a-secret-token';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`Oauth2TokenHandler` only catches `AuthenticationException` around the call to the introspection endpoint:

```php
} catch (AuthenticationException $e) {
    $this->logger?->error('An error occurred on the authorization server.', [...]);

    throw new BadCredentialsException('Invalid credentials.', $e->getCode(), $e);
}
```

Everything the HTTP client throws therefore escapes the handler and reaches the user as a 500, where the firewall should have answered a 401:

| The authorization server… | Thrown | Today |
|---|---|---|
| refuses the caller (401) | `ClientException` | 500 |
| is down (503) | `ServerException` | 500 |
| is unreachable | `TransportException` | 500 |
| answers HTML, or an empty body | `JsonException` | 500 |
| answers a JSON scalar | `JsonException` | 500 |

None of those says the token is usable, so all of them are bad credentials. `catch (\Exception)` is what `OidcTokenHandler` already does with the same reasoning, and the exception is still logged and kept as the previous one, so nothing is swallowed.

On 7.4 the token handler factory ignores its configuration and always injects the `http_client` service, so a
resource server reaches the introspection endpoint by replacing that service with a client carrying the base
URI, for instance through `ScopingHttpClient::forBaseUri()`. There is no `base_uri` under
`framework.http_client.default_options`; it exists only under `scoped_clients`.

Each row above is covered by a data provider, and each fails on the current handler.

Merge-up to 8.2: #65866 already carries this same `catch (\Exception $e)`, so once it has landed take 8.2's
`Oauth2TokenHandler` as is and keep only the test from this branch. When only #65865 has landed, keep its
rewritten body of `getUserBadgeFrom()` but take `catch (\Exception $e)` from here: #65865 still catches
`AuthenticationException` only, and every row of the test added here fails against it. `OAuth2TokenHandlerTest`
conflicts either way and is a plain keep-both.

Spotted by @nicolas-grekas while reviewing #65865, which carries the same change on 8.2 as part of a larger rework.

