### PR TITLE
[Security] Keep the "at+jwt" type check off by default in OidcTokenHandler

### DIFF
--- a/UPGRADE-8.2.md
+++ b/UPGRADE-8.2.md
@@ -202,10 +202,9 @@ Security
    The `$allowMultipleAttributes` argument will be removed in 9.0
  * Add argument `$parameters` to `LoginLinkHandlerInterface::createLoginLink()`
  * Add argument `$parameters` to `SignatureHasher::computeSignatureHash()`, `SignatureHasher::acceptSignatureHash()` and `SignatureHasher::verifySignatureHash()`
- * [BC BREAK] `OidcTokenHandler` now rejects the tokens whose `typ` header is not `at+jwt` or
-   `application/at+jwt`, as RFC 9068 requires from a JWT access token; pass `false` to the new
-   `$enforceAtJwtType` argument to keep accepting them. Configuring the handler through SecurityBundle
-   is not affected until 9.0
+ * Deprecate not passing the `$enforceAtJwtType` argument to `OidcTokenHandler`; pass `true` to reject
+   the tokens whose `typ` header is not `at+jwt` or `application/at+jwt`, as RFC 9068 requires from a
+   JWT access token. It defaults to `false` in 8.2 and will default to `true` in 9.0
 
 SecurityBundle
 --------------

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/AccessTokenFactoryTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/AccessTokenFactoryTest.php
@@ -435,7 +435,7 @@ class AccessTokenFactoryTest extends TestCase
         $reflection = new \ReflectionMethod(OidcTokenHandler::class, 'enableDiscovery');
         $this->assertLessThanOrEqual($reflection->getNumberOfParameters(), \count($methodCalls[0][1]), 'Recorded enableDiscovery call must not pass more arguments than the method accepts.');
 
-        $handler = new OidcTokenHandler(new AlgorithmManager([]), null, 'audience', ['https://www.example.com']);
+        $handler = new OidcTokenHandler(new AlgorithmManager([]), null, 'audience', ['https://www.example.com'], enforceAtJwtType: true);
         $cache = $this->createStub(CacheInterface::class);
         $httpClient = $this->createStub(HttpClientInterface::class);
         $callArgs = $methodCalls[0][1];

--- a/src/Symfony/Component/Security/Http/AccessToken/Oidc/OidcTokenHandler.php
+++ b/src/Symfony/Component/Security/Http/AccessToken/Oidc/OidcTokenHandler.php
@@ -56,6 +56,7 @@ final class OidcTokenHandler implements AccessTokenHandlerInterface, ResetInterf
     private bool $enforceEncryption = false;
 
     private bool $enforceKeyUsageVerification = true;
+    private bool $enforceAtJwtType;
     private ?CacheInterface $discoveryCache = null;
     private ?string $oidcConfigurationCacheKey = null;
 
@@ -70,11 +71,12 @@ final class OidcTokenHandler implements AccessTokenHandlerInterface, ResetInterf
     private array $discoveries = [];
 
     /**
-     * @param bool $enforceAtJwtType Whether the "typ" header of the token must be "at+jwt" or "application/at+jwt",
-     *                               which RFC 9068 §4 requires from a JWT access token. This is what tells an access
-     *                               token apart from the ID token the provider issues for the same audience, which
-     *                               would otherwise pass every other check. Turn it off only for providers that do
-     *                               not follow the profile and keep emitting a plain "JWT" type.
+     * @param bool|null $enforceAtJwtType Whether the "typ" header of the token must be "at+jwt" or "application/at+jwt",
+     *                                    which RFC 9068 §4 requires from a JWT access token. This is what tells an access
+     *                                    token apart from the ID token the provider issues for the same audience, which
+     *                                    would otherwise pass every other check. Turn it off only for providers that do
+     *                                    not follow the profile and keep emitting a plain "JWT" type. Defaults to false
+     *                                    in 8.2 and to true as of 9.0.
      */
     public function __construct(
         private AlgorithmManager $signatureAlgorithm,
@@ -85,8 +87,13 @@ final class OidcTokenHandler implements AccessTokenHandlerInterface, ResetInterf
         private ?LoggerInterface $logger = null,
         private ClockInterface $clock = new Clock(),
         private int $allowedTimeDrift = 0,
-        private bool $enforceAtJwtType = true,
+        ?bool $enforceAtJwtType = null,
     ) {
+        if (null === $enforceAtJwtType) {
+            trigger_deprecation('symfony/security-http', '8.2', 'Not passing a value for the "$enforceAtJwtType" argument of "%s()" is deprecated, pass it explicitly; it will default to true in 9.0.', __METHOD__);
+        }
+
+        $this->enforceAtJwtType = $enforceAtJwtType ?? false;
     }
 
     public function enableJweSupport(JWKSet $decryptionKeyset, AlgorithmManager $decryptionAlgorithms, bool $enforceEncryption): void

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -25,7 +25,8 @@ CHANGELOG
  * Add the `user_data_source` and `user_identifier_claim` options to `OidcLoginAuthenticator` to pick where the user claims are read from and the claim the user identifier is read from
  * Add `OidcEndSessionListener` for RP-Initiated Logout via the OIDC `end_session_endpoint`
  * Add `UnsupportedReasons`, held by the `SecurityRequestAttributes::UNSUPPORTED_REASONS` request attribute while the profiler is enabled, so that `supports()` can tell why an authenticator did not support a request
- * Make `OidcTokenHandler` reject the tokens whose `typ` header is not the `at+jwt` RFC 9068 requires from an access token, and add the `$enforceAtJwtType` argument to turn the check off
+ * Add the `$enforceAtJwtType` argument to `OidcTokenHandler` to reject the tokens whose `typ` header is not the `at+jwt` RFC 9068 requires from an access token
+ * Deprecate not passing the `$enforceAtJwtType` argument to `OidcTokenHandler`; it defaults to `false` in 8.2 and will default to `true` in 9.0
  * Make `OidcTokenGenerator` emit the `at+jwt` type header RFC 9068 requires from an access token
 
 8.1

--- a/src/Symfony/Component/Security/Http/Tests/AccessToken/Oidc/OidcTokenGeneratorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/AccessToken/Oidc/OidcTokenGeneratorTest.php
@@ -34,7 +34,7 @@ class OidcTokenGeneratorTest extends TestCase
         $clock = new MockClock('1998-07-12T22:45:00+02:00');
 
         $generator = new OidcTokenGenerator($algorithmManager, $this->getJWKSet(), $audience, $issuers, 'sub', $clock);
-        $handler = new OidcTokenHandler($algorithmManager, $this->getJWKSet(), $audience, $issuers, 'sub', null, $clock);
+        $handler = new OidcTokenHandler($algorithmManager, $this->getJWKSet(), $audience, $issuers, 'sub', null, $clock, enforceAtJwtType: true);
 
         $token = $generator->generate('john_doe', null, null, 3600);
 

--- a/src/Symfony/Component/Security/Http/Tests/AccessToken/Oidc/OidcTokenHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/AccessToken/Oidc/OidcTokenHandlerTest.php
@@ -22,6 +22,8 @@ use Jose\Component\Signature\Algorithm\ES256;
 use Jose\Component\Signature\JWSBuilder;
 use Jose\Component\Signature\Serializer\CompactSerializer;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -66,6 +68,7 @@ class OidcTokenHandlerTest extends TestCase
             ['https://www.example.com'],
             $claim,
             $loggerMock,
+            enforceAtJwtType: true,
         ))->getUserBadgeFrom($token);
         $actualUser = $userBadge->getUserLoader()();
 
@@ -100,6 +103,7 @@ class OidcTokenHandlerTest extends TestCase
             ['https://www.example.com'],
             'sub',
             $loggerMock,
+            enforceAtJwtType: true,
         ))->getUserBadgeFrom($token);
     }
 
@@ -192,6 +196,7 @@ class OidcTokenHandlerTest extends TestCase
             ['https://www.example.com'],
             'email',
             $loggerMock,
+            enforceAtJwtType: true,
         ))->getUserBadgeFrom($token);
     }
 
@@ -210,6 +215,7 @@ class OidcTokenHandlerTest extends TestCase
             ['https://www.example.com'],
             'sub',
             $loggerMock,
+            enforceAtJwtType: true,
         ))->getUserBadgeFrom($token);
 
         $this->assertSame('e21bf182-1538-406e-8ccb-e25a17aba39f', $userBadge->getUserIdentifier());
@@ -245,6 +251,7 @@ class OidcTokenHandlerTest extends TestCase
             ['https://www.example.com'],
             'sub',
             $loggerMock,
+            enforceAtJwtType: true,
         ))->getUserBadgeFrom($token);
     }
 
@@ -272,6 +279,30 @@ class OidcTokenHandlerTest extends TestCase
             'sub',
             $loggerMock,
             enforceAtJwtType: false,
+        ))->getUserBadgeFrom($token);
+
+        $this->assertSame('e21bf182-1538-406e-8ccb-e25a17aba39f', $userBadge->getUserIdentifier());
+    }
+
+    /**
+     * The check is off unless it is asked for, so that upgrading to 8.2 does not reject the
+     * tokens an application already accepts. It is enforced by default as of 9.0.
+     */
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
+    #[DataProvider('getTokensRejectedByTheAtJwtTypeCheck')]
+    public function testAcceptsAnyTokenTypeWhenTheArgumentIsOmitted(array $header)
+    {
+        $this->expectUserDeprecationMessage('Since symfony/security-http 8.2: Not passing a value for the "$enforceAtJwtType" argument of "Symfony\\Component\\Security\\Http\\AccessToken\\Oidc\\OidcTokenHandler::__construct()" is deprecated, pass it explicitly; it will default to true in 9.0.');
+
+        $token = self::buildJWS(json_encode(self::getValidClaims()), $header);
+
+        $userBadge = (new OidcTokenHandler(
+            new AlgorithmManager([new ES256()]),
+            self::getJWKSet(),
+            self::AUDIENCE,
+            ['https://www.example.com'],
+            'sub',
         ))->getUserBadgeFrom($token);
 
         $this->assertSame('e21bf182-1538-406e-8ccb-e25a17aba39f', $userBadge->getUserIdentifier());
@@ -404,7 +435,8 @@ class OidcTokenHandlerTest extends TestCase
             new AlgorithmManager([new ES256()]),
             null,
             self::AUDIENCE,
-            ['https://www.example.com']
+            ['https://www.example.com'],
+            enforceAtJwtType: true,
         );
         $handler->enableDiscovery($cache, $httpClient, 'oidc_config');
 
@@ -428,7 +460,8 @@ class OidcTokenHandlerTest extends TestCase
             new AlgorithmManager([new ES256()]),
             null,
             self::AUDIENCE,
-            ['https://www.example.com']
+            ['https://www.example.com'],
+            enforceAtJwtType: true,
         );
         $handler->enableDiscovery(new ArrayAdapter(), $httpClient, 'oidc_config');
 
@@ -451,7 +484,8 @@ class OidcTokenHandlerTest extends TestCase
             new AlgorithmManager([new ES256()]),
             null,
             self::AUDIENCE,
-            ['https://www.example.com']
+            ['https://www.example.com'],
+            enforceAtJwtType: true,
         );
         $handler->enableDiscovery(new ArrayAdapter(), $httpClient, 'oidc_config');
 
@@ -487,7 +521,8 @@ class OidcTokenHandlerTest extends TestCase
             new AlgorithmManager([new ES256()]),
             null,
             self::AUDIENCE,
-            ['https://www.example.com']
+            ['https://www.example.com'],
+            enforceAtJwtType: true,
         );
         $handler->enableDiscovery($cache, [$httpClient1, $httpClient2], 'oidc_config');
 
@@ -542,7 +577,7 @@ class OidcTokenHandlerTest extends TestCase
             }, \sprintf('https://provider%d.example.com/', $provider));
         }
 
-        $handler = new OidcTokenHandler(new AlgorithmManager([new ES256()]), null, self::AUDIENCE, ['https://www.example.com']);
+        $handler = new OidcTokenHandler(new AlgorithmManager([new ES256()]), null, self::AUDIENCE, ['https://www.example.com'], enforceAtJwtType: true);
         $handler->enableDiscovery(new ArrayAdapter(), $httpClients, 'oidc_config');
 
         $time = time();
@@ -605,7 +640,8 @@ class OidcTokenHandlerTest extends TestCase
             new AlgorithmManager([new ES256()]),
             null,
             self::AUDIENCE,
-            ['https://www.example.com']
+            ['https://www.example.com'],
+            enforceAtJwtType: true,
         );
         $handler->enableDiscovery($cache, $httpClient, 'oidc_ttl_cc');
         $this->assertSame('user-cache-control', $handler->getUserBadgeFrom($token)->getUserIdentifier());
@@ -641,7 +677,7 @@ class OidcTokenHandlerTest extends TestCase
         ]));
 
         $cache = new ArrayAdapter();
-        $handler = new OidcTokenHandler(new AlgorithmManager([new ES256()]), null, self::AUDIENCE, ['https://www.example.com']);
+        $handler = new OidcTokenHandler(new AlgorithmManager([new ES256()]), null, self::AUDIENCE, ['https://www.example.com'], enforceAtJwtType: true);
         $handler->enableDiscovery($cache, $httpClient, 'oidc_config');
 
         $handler->getUserBadgeFrom($token);
@@ -691,7 +727,8 @@ class OidcTokenHandlerTest extends TestCase
             new AlgorithmManager([new ES256()]),
             null,
             self::AUDIENCE,
-            ['https://www.example.com']
+            ['https://www.example.com'],
+            enforceAtJwtType: true,
         );
         $handler->enableDiscovery($cache, $httpClient, 'oidc_ttl_expires');
         $this->assertSame('user-expires', $handler->getUserBadgeFrom($token)->getUserIdentifier());
@@ -707,7 +744,8 @@ class OidcTokenHandlerTest extends TestCase
             new AlgorithmManager([new ES256()]),
             null,
             self::AUDIENCE,
-            ['https://www.example.com']
+            ['https://www.example.com'],
+            enforceAtJwtType: true,
         );
 
         $handler->enableDiscovery($cache, [], 'oidc_empty_clients');
@@ -733,7 +771,8 @@ class OidcTokenHandlerTest extends TestCase
             new AlgorithmManager([new ES256()]),
             null,
             self::AUDIENCE,
-            ['https://www.example.com']
+            ['https://www.example.com'],
+            enforceAtJwtType: true,
         );
         $handler->enableDiscovery($cache, $httpClient, 'oidc_redirected_discovery');
 
@@ -761,7 +800,8 @@ class OidcTokenHandlerTest extends TestCase
             new AlgorithmManager([new ES256()]),
             null,
             self::AUDIENCE,
-            ['https://www.example.com']
+            ['https://www.example.com'],
+            enforceAtJwtType: true,
         );
         $handler->enableDiscovery($cache, $httpClient, 'oidc_insecure_jwks_uri');
 
@@ -789,7 +829,8 @@ class OidcTokenHandlerTest extends TestCase
             new AlgorithmManager([new ES256()]),
             null,
             self::AUDIENCE,
-            ['http://www.example.com']
+            ['http://www.example.com'],
+            enforceAtJwtType: true,
         );
         $handler->enableDiscovery($cache, $httpClient, 'oidc_http_issuer');
 
@@ -821,7 +862,8 @@ class OidcTokenHandlerTest extends TestCase
             new AlgorithmManager([new ES256()]),
             null,
             self::AUDIENCE,
-            ['https://www.example.com']
+            ['https://www.example.com'],
+            enforceAtJwtType: true,
         );
         $handler->enableDiscovery($cache, $httpClient, 'oidc_missing_jwks_uri');
 
@@ -846,7 +888,8 @@ class OidcTokenHandlerTest extends TestCase
             new AlgorithmManager([new ES256()]),
             null,
             self::AUDIENCE,
-            ['https://www.example.com']
+            ['https://www.example.com'],
+            enforceAtJwtType: true,
         );
         $handler->enableDiscovery($cache, $httpClient, 'oidc_non_sig_keys', enforceKeyUsageVerification: false);
 
@@ -874,7 +917,8 @@ class OidcTokenHandlerTest extends TestCase
             new AlgorithmManager([new ES256()]),
             null,
             self::AUDIENCE,
-            ['https://www.example.com']
+            ['https://www.example.com'],
+            enforceAtJwtType: true,
         );
         $handler->enableDiscovery($cache, $httpClient, 'oidc_enc_key_ops', enforceKeyUsageVerification: false);
 
@@ -910,7 +954,8 @@ class OidcTokenHandlerTest extends TestCase
             new AlgorithmManager([new ES256()]),
             null,
             self::AUDIENCE,
-            ['https://www.example.com']
+            ['https://www.example.com'],
+            enforceAtJwtType: true,
         );
         $handler->enableDiscovery($cache, $httpClient, 'oidc_no_use', enforceKeyUsageVerification: false);
 
@@ -937,7 +982,8 @@ class OidcTokenHandlerTest extends TestCase
             new AlgorithmManager([new ES256()]),
             null,
             self::AUDIENCE,
-            ['https://www.example.com']
+            ['https://www.example.com'],
+            enforceAtJwtType: true,
         );
         $handler->enableDiscovery($cache, $httpClient, 'oidc_enforced', enforceKeyUsageVerification: true);
 
@@ -963,7 +1009,8 @@ class OidcTokenHandlerTest extends TestCase
             new AlgorithmManager([new ES256()]),
             null,
             self::AUDIENCE,
-            ['https://www.example.com']
+            ['https://www.example.com'],
+            enforceAtJwtType: true,
         );
         $handler->enableDiscovery($cache, $httpClient, 'oidc_enforced_ops', enforceKeyUsageVerification: true);
         $item = $this->createStub(ItemInterface::class);
@@ -998,6 +1045,7 @@ class OidcTokenHandlerTest extends TestCase
             ['https://www.example.com'],
             'sub',
             $loggerMock,
+            enforceAtJwtType: true,
         ))->getUserBadgeFrom($token);
     }
 
@@ -1025,6 +1073,7 @@ class OidcTokenHandlerTest extends TestCase
             'sub',
             $loggerMock,
             allowedTimeDrift: 5,
+            enforceAtJwtType: true,
         ))->getUserBadgeFrom($token);
 
         $this->assertInstanceOf(UserBadge::class, $userBadge);
@@ -1058,6 +1107,7 @@ class OidcTokenHandlerTest extends TestCase
             'sub',
             $loggerMock,
             allowedTimeDrift: 5,
+            enforceAtJwtType: true,
         ))->getUserBadgeFrom($token);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | yes
| Issues        | -
| License       | MIT

#65862 added the `$enforceAtJwtType` argument to `OidcTokenHandler` with `true` as its default, so the handler rejects every token whose `typ` header is not `at+jwt`. SecurityBundle opts out until 9.0, which keeps the configured handler on its former behaviour, but an application that builds the handler itself starts rejecting the tokens it used to accept as soon as it upgrades to 8.2. That is a BC break, and `UPGRADE-8.2.md` labelled it as one.

The `Unit Tests (8.4, high-deps)` job is such an application. For the highest branch it builds the local packages, checks 8.1 out, and runs the 8.1 suite against the patched 8.2 components: the 8.1 `OidcTokenHandlerFactory` does not pass the argument, the 8.1 tokens carry no `typ` header, and `AccessTokenTest::testOidcSuccess` answers 401 instead of 200. The job is red on every PR that targets 8.2.

So the argument now defaults to `null`, which keeps the check off and deprecates the omission, the same transition SecurityBundle applies to the `enforce_at_jwt_type` option. The tests pass it explicitly, and a legacy test covers the deprecation and the default.

Reproducing the failure and its fix locally, with the 8.1 SecurityBundle suite run against the 8.2 component:

```
# component as merged
2) Symfony\Bundle\SecurityBundle\Tests\Functional\AccessTokenTest::testOidcSuccess#1
Failed asserting that 401 is identical to 200.
Tests: 39, Assertions: 109, Failures: 2.

# component with this PR
OK, but there were issues!
Tests: 39, Assertions: 111, Deprecations: 1.
```
