### PR TITLE
[Security] Keep the "typ" check of OidcTokenHandler off by default

### DIFF
--- a/UPGRADE-8.2.md
+++ b/UPGRADE-8.2.md
@@ -202,10 +202,9 @@ Security
    The `$allowMultipleAttributes` argument will be removed in 9.0
  * Add argument `$parameters` to `LoginLinkHandlerInterface::createLoginLink()`
  * Add argument `$parameters` to `SignatureHasher::computeSignatureHash()`, `SignatureHasher::acceptSignatureHash()` and `SignatureHasher::verifySignatureHash()`
- * [BC BREAK] `OidcTokenHandler` now rejects the tokens whose `typ` header is not `at+jwt` or
-   `application/at+jwt`, as RFC 9068 requires from a JWT access token; pass `false` to the new
-   `$enforceAtJwtType` argument to keep accepting them. Configuring the handler through SecurityBundle
-   is not affected until 9.0
+ * Add argument `$enforceAtJwtType` to `OidcTokenHandler::__construct()`: pass `true` to reject the tokens
+   whose `typ` header is not `at+jwt` or `application/at+jwt`, as RFC 9068 requires from a JWT access token.
+   It defaults to `false` in 8.2 and will default to `true` in 9.0
 
 SecurityBundle
 --------------

--- a/src/Symfony/Component/Security/Http/AccessToken/Oidc/OidcTokenHandler.php
+++ b/src/Symfony/Component/Security/Http/AccessToken/Oidc/OidcTokenHandler.php
@@ -73,8 +73,9 @@ final class OidcTokenHandler implements AccessTokenHandlerInterface, ResetInterf
      * @param bool $enforceAtJwtType Whether the "typ" header of the token must be "at+jwt" or "application/at+jwt",
      *                               which RFC 9068 §4 requires from a JWT access token. This is what tells an access
      *                               token apart from the ID token the provider issues for the same audience, which
-     *                               would otherwise pass every other check. Turn it off only for providers that do
+     *                               would otherwise pass every other check. Keep it off only for providers that do
      *                               not follow the profile and keep emitting a plain "JWT" type.
+     *                               Defaults to false in 8.2 and will default to true in 9.0.
      */
     public function __construct(
         private AlgorithmManager $signatureAlgorithm,
@@ -85,7 +86,7 @@ final class OidcTokenHandler implements AccessTokenHandlerInterface, ResetInterf
         private ?LoggerInterface $logger = null,
         private ClockInterface $clock = new Clock(),
         private int $allowedTimeDrift = 0,
-        private bool $enforceAtJwtType = true,
+        private bool $enforceAtJwtType = false,
     ) {
     }
 

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -25,7 +25,7 @@ CHANGELOG
  * Add the `user_data_source` and `user_identifier_claim` options to `OidcLoginAuthenticator` to pick where the user claims are read from and the claim the user identifier is read from
  * Add `OidcEndSessionListener` for RP-Initiated Logout via the OIDC `end_session_endpoint`
  * Add `UnsupportedReasons`, held by the `SecurityRequestAttributes::UNSUPPORTED_REASONS` request attribute while the profiler is enabled, so that `supports()` can tell why an authenticator did not support a request
- * Make `OidcTokenHandler` reject the tokens whose `typ` header is not the `at+jwt` RFC 9068 requires from an access token, and add the `$enforceAtJwtType` argument to turn the check off
+ * Add the `$enforceAtJwtType` argument to `OidcTokenHandler` to reject the tokens whose `typ` header is not the `at+jwt` RFC 9068 requires from an access token; it defaults to `false` in 8.2 and will default to `true` in 9.0
  * Make `OidcTokenGenerator` emit the `at+jwt` type header RFC 9068 requires from an access token
 
 8.1

--- a/src/Symfony/Component/Security/Http/Tests/AccessToken/Oidc/OidcTokenHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/AccessToken/Oidc/OidcTokenHandlerTest.php
@@ -210,6 +210,7 @@ class OidcTokenHandlerTest extends TestCase
             ['https://www.example.com'],
             'sub',
             $loggerMock,
+            enforceAtJwtType: true,
         ))->getUserBadgeFrom($token);
 
         $this->assertSame('e21bf182-1538-406e-8ccb-e25a17aba39f', $userBadge->getUserIdentifier());
@@ -245,6 +246,7 @@ class OidcTokenHandlerTest extends TestCase
             ['https://www.example.com'],
             'sub',
             $loggerMock,
+            enforceAtJwtType: true,
         ))->getUserBadgeFrom($token);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

#65862 shipped two opposite defaults for the same switch. `OidcTokenHandler::__construct()` declares `$enforceAtJwtType = true`, while `OidcTokenHandlerFactory` defaults the option to `null`, deprecates leaving it unset, and then sets it to `false`, with the node saying "Defaults to false in 8.2 and to true as of 9.0".

So a service definition that does not pass the argument gets the 9.0 behaviour today, with no deprecation, and every access token whose `typ` header is not `at+jwt` is refused.

That is not hypothetical: it is what a SecurityBundle older than the component does. Its definition of `security.access_token_handler.oidc` stops at the seventh argument, and its own tokens carry no `typ` header. `symfony/security-bundle` 8.1 requires `symfony/security-http: ^8.1`, so anyone pinning the bundle without pinning the component gets 401s on every OIDC access token.

CI shows it on four branches at once. The `high-deps` job installs `symfony/security-http` from the dev branch, which `^7.4|^8.0` and `^8.1` both resolve to `8.2.x-dev`:

```
1) SecurityBundle\Tests\Functional\AccessTokenTest::testOidcSuccess#0
Failed asserting that 401 is identical to 200.
```

The green run before #65862 and the red ones after installed the same `web-token/jwt-library 4.3.x-dev 285bb17`; the only thing that moved is `symfony/security-http`, from `b6d6a09` to `e8456cd`.

Reproduced by putting the 8.2 handler in an 8.1 tree: `Tests: 2, Assertions: 4, Failures: 2` at `AccessTokenTest.php:355`, the line CI names. With this patch, `OK (2 tests, 6 assertions)`.

SecurityBundle needs no change: it already passes `false` explicitly, so its deprecation cycle is untouched and enabling the check through configuration keeps working. The two component tests that exercise the check now pass `enforceAtJwtType: true` themselves.

`Security/Http` `OK (947 tests, 2237 assertions)` and `SecurityBundle` `OK (549 tests, 1591 assertions)`, unchanged before and after.

If we would rather warn direct users of the component than only keep them safe, the follow-up is `?bool $enforceAtJwtType = null` plus a `symfony/security-http` deprecation when it is null, which is what `UriSigner::sign()` does for the same kind of default flip. It would never fire for bundle users.
