### PR TITLE
[TwigBridge] Add `block_export()` support to form attribute blocks

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -468,31 +468,35 @@
 {%- endblock form_rows -%}
 
 {%- block widget_attributes -%}
-    id="{{ id }}" name="{{ full_name }}"
-    {%- if disabled %} disabled="disabled"{% endif -%}
-    {%- if required %} required="required"{% endif -%}
+    {%- set attr = {id: id, name: full_name, disabled: disabled, required: required}|merge(attr) -%}
     {{ block('attributes') }}
 {%- endblock widget_attributes -%}
 
 {%- block widget_container_attributes -%}
-    {%- if id is not empty %}id="{{ id }}"{% endif -%}
+    {%- if id is not empty -%}
+        {%- set attr = {id: id}|merge(attr) -%}
+    {%- endif -%}
     {{ block('attributes') }}
 {%- endblock widget_container_attributes -%}
 
 {%- block button_attributes -%}
-    id="{{ id }}" name="{{ full_name }}"{% if disabled %} disabled="disabled"{% endif -%}
+    {%- set attr = {id: id, name: full_name, disabled: disabled}|merge(attr) -%}
     {{ block('attributes') }}
 {%- endblock button_attributes -%}
 
 {% block attributes -%}
+    {%- set attrs = {} -%}
     {%- for attrname, attrvalue in attr -%}
-        {{- ' ' -}}
         {%- if attrname in ['placeholder', 'title'] -%}
-            {{- attrname }}="{{ translation_domain is same as(false) or attrvalue is null ? attrvalue : attrvalue|trans(attr_translation_parameters, translation_domain) }}"
+            {%- set attrs = attrs|merge({(attrname): translation_domain is same as(false) or attrvalue is null ? attrvalue : attrvalue|trans(attr_translation_parameters, translation_domain)}) -%}
         {%- elseif attrvalue is same as(true) -%}
-            {{- attrname }}="{{ attrname }}"
+            {%- set attrs = attrs|merge({(attrname): attrname}) -%}
         {%- elseif attrvalue is not same as(false) -%}
-            {{- attrname }}="{{ attrvalue }}"
+            {%- set attrs = attrs|merge({(attrname): attrvalue}) -%}
         {%- endif -%}
+    {%- endfor -%}
+    {%- do block_export(attrs) -%}
+    {%- for attrname, attrvalue in attrs -%}
+        {{- ' ' ~ attrname }}="{{ attrvalue }}"
     {%- endfor -%}
 {%- endblock attributes -%}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #65713
| License       | MIT

## Summary

- Refactors `widget_attributes`, `widget_container_attributes`, `button_attributes`, and `attributes` blocks in `form_div_layout.html.twig`
- The `attributes` block now builds a normalized hash (`attrs`), exports it via `block_export(attrs)`, then renders HTML from that hash
- The `widget_attributes`, `widget_container_attributes`, and `button_attributes` blocks set `attr` with proper ordering (standard attributes first, user attributes merged after) before delegating to `attributes`

This allows Twig Component form themes to retrieve the processed attributes as a hash using `block_data()`, enabling the spread syntax (`{{ ...hash }}`) on `<twig:>` components:

```twig
<twig:Input type="{{ type }}" {{ ...block_data('widget_attributes')|merge({value: value|default}) }} />
```

Existing form themes are not affected — `block('widget_attributes')` still returns the rendered HTML string as before.

## Dependencies

This depends on twigphp/Twig#4920 which adds `block_data()` and `block_export()` to Twig core.

Related issue: twigphp/Twig#4919