### PR TITLE
[Security][SecurityBundle] Require OAuth2 scopes on resources protected by an access token

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Add the `security.expression_language_provider` service to evaluate the security functions outside of authorization expressions
  * Add the `debug:roles` command to inspect the role hierarchy
  * Add `allowed_time_drift` option to the OIDC token handler configuration
+ * Require OAuth2 scopes of the access token with an `OAUTH2_SCOPE(...)` attribute, and answer a denial with the RFC 6750 §3.1 `insufficient_scope` challenge
  * Allow disabling the redirection on successful logout by passing `null` to the `target` option
  * Deprecate the `remember_me` option of the `form_login`, `json_login`, `login_link`, and `access_token` authenticators, as it has no effect
  * Add the `ldap_users_only` option to the LDAP authenticators, to bind only `LdapUser` instances against the LDAP server

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AccessTokenFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AccessTokenFactory.php
@@ -194,10 +194,25 @@ final class AccessTokenFactory extends AbstractFactory implements StatelessAuthe
             ->replaceArgument(3, $successHandler)
             ->replaceArgument(4, $failureHandler)
             ->replaceArgument(5, $config['realm'])
-            ->replaceArgument(6, isset($config['resource_metadata']) ? $this->createResourceMetadata($container, $firewallName, $config['resource_metadata'], $config['token_extractors']) : null)
+            ->replaceArgument(6, $resourceMetadataUri = isset($config['resource_metadata']) ? $this->createResourceMetadata($container, $firewallName, $config['resource_metadata'], $config['token_extractors']) : null)
         ;
 
+        $this->createFallbackAccessDeniedHandler($container, $firewallName, $config['realm'], $resourceMetadataUri);
+
         return $authenticatorId;
+    }
+
+    /**
+     * Registers the access denied handler the firewall falls back on, unless it configures one of its own,
+     * so that a denial caused by a missing scope gets the RFC 6750 §3.1 "insufficient_scope" challenge.
+     */
+    private function createFallbackAccessDeniedHandler(ContainerBuilder $container, string $firewallName, ?string $realm, ?string $resourceMetadataUri): void
+    {
+        $container
+            ->setDefinition(\sprintf('security.fallback_access_denied_handler.%s', $firewallName), new ChildDefinition('security.access_token.access_denied_handler'))
+            ->replaceArgument(0, $realm)
+            ->replaceArgument(2, $resourceMetadataUri)
+        ;
     }
 
     /**

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -904,6 +904,13 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
         return 'security.user.provider.concrete.'.strtolower($name);
     }
 
+    /**
+     * When neither the firewall nor the application configures an access denied handler or an access denied URL,
+     * the listener falls back on the "security.fallback_access_denied_handler.<firewall>" handler an authenticator
+     * factory of that firewall may have registered, as AccessTokenFactory does to answer the RFC 6750 §3.1
+     * challenge. That handler hands back every denial no scope took part in, so an application-wide handler keeps
+     * answering those, and an application-wide URL keeps being rendered.
+     */
     private function createExceptionListener(ContainerBuilder $container, array $config, string $id, ?string $defaultEntryPoint, bool $stateless): string
     {
         $exceptionListenerId = 'security.exception_listener.'.$id;
@@ -917,6 +924,10 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
             $listener->replaceArgument(6, new Reference($config['access_denied_handler']));
         } elseif (isset($config['access_denied_url'])) {
             $listener->replaceArgument(5, $config['access_denied_url']);
+        } elseif (!$container->getParameter('security.access.denied_url')
+            && $container->hasDefinition($fallbackHandlerId = 'security.fallback_access_denied_handler.'.$id)
+        ) {
+            $listener->replaceArgument(6, new Reference($fallbackHandlerId));
         }
 
         return $exceptionListenerId;

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator_access_token.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator_access_token.php
@@ -44,6 +44,8 @@ use Symfony\Component\Security\Http\AccessToken\Oidc\OidcTokenHandler;
 use Symfony\Component\Security\Http\AccessToken\Oidc\OidcUserInfoTokenHandler;
 use Symfony\Component\Security\Http\AccessToken\QueryAccessTokenExtractor;
 use Symfony\Component\Security\Http\Authenticator\AccessTokenAuthenticator;
+use Symfony\Component\Security\Http\Authorization\InsufficientScopeAccessDeniedHandler;
+use Symfony\Component\Security\Http\Authorization\OAuth2ScopeVoter;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 return static function (ContainerConfigurator $container) {
@@ -82,6 +84,17 @@ return static function (ContainerConfigurator $container) {
                 'security.access_token.resource_metadata_paths',
             ])
             ->tag('routing.route_loader')
+
+        ->set('security.access.oauth2_scope_voter', OAuth2ScopeVoter::class)
+            ->tag('security.voter', ['priority' => 245])
+
+        ->set('security.access_token.access_denied_handler', InsufficientScopeAccessDeniedHandler::class)
+            ->abstract()
+            ->args([
+                abstract_arg('realm'),
+                service('security.access.denied_handler')->nullOnInvalid(),
+                abstract_arg('resource metadata uri'),
+            ])
 
         ->set('security.authenticator.access_token.chain_extractor', ChainAccessTokenExtractor::class)
             ->abstract()

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/AccessTokenTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/AccessTokenTest.php
@@ -85,6 +85,106 @@ class AccessTokenTest extends AbstractWebTestCase
         $this->assertSame(404, $client->getResponse()->getStatusCode());
     }
 
+    public function testAccessControlGrantedOnTheScopesTheTokenCarries()
+    {
+        $client = $this->createClient(['test_case' => 'AccessToken', 'root_config' => 'config_scope.yml']);
+        $client->request('GET', '/foo', [], [], ['HTTP_AUTHORIZATION' => 'Bearer SCOPED_ACCESS_TOKEN']);
+        $response = $client->getResponse();
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame(['message' => 'Welcome @dunglas!'], json_decode($response->getContent(), true));
+    }
+
+    /**
+     * RFC 9728 §5.1 does not restrict "resource_metadata" to a 401, and a client denied for a missing
+     * scope holds a token from an authorization server it may have to find again.
+     */
+    public function testTheInsufficientScopeChallengeAdvertisesTheResourceMetadata()
+    {
+        $client = $this->createClient(['test_case' => 'AccessToken', 'root_config' => 'config_scope_metadata.yml']);
+        $client->request('GET', '/foo', [], [], ['HTTP_AUTHORIZATION' => 'Bearer VALID_ACCESS_TOKEN']);
+        $response = $client->getResponse();
+
+        $this->assertSame(403, $response->getStatusCode());
+        $this->assertSame('Bearer realm="My API",error="insufficient_scope",error_description="The request requires higher privileges than provided by the access token.",scope="openid profile:read",resource_metadata="http://localhost/.well-known/oauth-protected-resource"', $response->headers->get('WWW-Authenticate'));
+    }
+
+    public function testAccessControlDeniedOnAMissingScope()
+    {
+        $client = $this->createClient(['test_case' => 'AccessToken', 'root_config' => 'config_scope.yml']);
+        $client->request('GET', '/foo', [], [], ['HTTP_AUTHORIZATION' => 'Bearer VALID_ACCESS_TOKEN']);
+        $response = $client->getResponse();
+
+        $this->assertSame(403, $response->getStatusCode());
+        $this->assertSame('Bearer realm="My API",error="insufficient_scope",error_description="The request requires higher privileges than provided by the access token.",scope="openid profile:read"', $response->headers->get('WWW-Authenticate'));
+    }
+
+    /**
+     * The scope challenge stands in only for the denials no handler of the application already
+     * answers, so an application-wide access denied URL keeps being rendered.
+     */
+    public function testTheApplicationWideAccessDeniedUrlStillApplies()
+    {
+        $client = $this->createClient(['test_case' => 'AccessToken', 'root_config' => 'config_scope_denied_url.yml']);
+        $client->request('GET', '/foo', [], [], ['HTTP_AUTHORIZATION' => 'Bearer VALID_ACCESS_TOKEN']);
+        $response = $client->getResponse();
+
+        $this->assertSame(['message' => 'Welcome anonymous!'], json_decode($response->getContent(), true));
+        $this->assertFalse($response->headers->has('WWW-Authenticate'));
+    }
+
+    /**
+     * A denial no scope took part in is handed back to the handler the application registered,
+     * while a denial on a scope still gets the RFC 6750 challenge.
+     */
+    public function testTheApplicationWideAccessDeniedHandlerStillAnswersTheDenialsItUsedTo()
+    {
+        $client = $this->createClient(['test_case' => 'AccessToken', 'root_config' => 'config_scope_app_handler.yml']);
+
+        $client->request('GET', '/bar', [], [], ['HTTP_AUTHORIZATION' => 'Bearer VALID_ACCESS_TOKEN']);
+        $response = $client->getResponse();
+
+        $this->assertSame(403, $response->getStatusCode());
+        $this->assertSame(['message' => 'Denied by the application.'], json_decode($response->getContent(), true));
+        $this->assertFalse($response->headers->has('WWW-Authenticate'));
+
+        $client->request('GET', '/foo', [], [], ['HTTP_AUTHORIZATION' => 'Bearer VALID_ACCESS_TOKEN']);
+        $response = $client->getResponse();
+
+        $this->assertSame(403, $response->getStatusCode());
+        $this->assertSame('Bearer realm="My API",error="insufficient_scope",error_description="The request requires higher privileges than provided by the access token.",scope="openid profile:read"', $response->headers->get('WWW-Authenticate'));
+    }
+
+    public function testIsGrantedDeniedOnAMissingScope()
+    {
+        $client = $this->createClient(['test_case' => 'AccessToken', 'root_config' => 'config_scope.yml']);
+        $client->request('GET', '/scoped', [], [], ['HTTP_AUTHORIZATION' => 'Bearer SCOPED_ACCESS_TOKEN']);
+        $response = $client->getResponse();
+
+        $this->assertSame(403, $response->getStatusCode());
+        $this->assertSame('Bearer realm="My API",error="insufficient_scope",error_description="The request requires higher privileges than provided by the access token.",scope="profile:write"', $response->headers->get('WWW-Authenticate'));
+    }
+
+    public function testIsGrantedDeniedOnOneOfTheScopesAnAttributeRequires()
+    {
+        $client = $this->createClient(['test_case' => 'AccessToken', 'root_config' => 'config_scope.yml']);
+        $client->request('GET', '/all-scopes', [], [], ['HTTP_AUTHORIZATION' => 'Bearer SCOPED_ACCESS_TOKEN']);
+        $response = $client->getResponse();
+
+        $this->assertSame(403, $response->getStatusCode());
+        $this->assertSame('Bearer realm="My API",error="insufficient_scope",error_description="The request requires higher privileges than provided by the access token.",scope="openid profile:write"', $response->headers->get('WWW-Authenticate'));
+    }
+
+    public function testADenialNoScopeTookPartInKeepsThePlainForbiddenResponse()
+    {
+        $client = $this->createClient(['test_case' => 'AccessToken', 'root_config' => 'config_scope.yml']);
+        $client->request('GET', '/bar', [], [], ['HTTP_AUTHORIZATION' => 'Bearer VALID_ACCESS_TOKEN']);
+        $response = $client->getResponse();
+
+        $this->assertSame(403, $response->getStatusCode());
+        $this->assertFalse($response->headers->has('WWW-Authenticate'));
+    }
+
     public function testAnonymousAccessIsGranted()
     {
         $client = $this->createClient(['test_case' => 'AccessToken', 'root_config' => 'config_anonymous.yml']);

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/AccessTokenBundle/Controller/AllScopesController.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/AccessTokenBundle/Controller/AllScopesController.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\AccessTokenBundle\Controller;
+
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+class AllScopesController
+{
+    #[IsGranted('OAUTH2_SCOPE(openid profile:write)')]
+    public function __invoke(UserInterface $user): JsonResponse
+    {
+        return new JsonResponse(['message' => \sprintf('Welcome @%s!', $user->getUserIdentifier())]);
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/AccessTokenBundle/Controller/ScopedController.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/AccessTokenBundle/Controller/ScopedController.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\AccessTokenBundle\Controller;
+
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+class ScopedController
+{
+    #[IsGranted('OAUTH2_SCOPE(profile:write)')]
+    public function __invoke(UserInterface $user): JsonResponse
+    {
+        return new JsonResponse(['message' => \sprintf('Welcome @%s!', $user->getUserIdentifier())]);
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/AccessTokenBundle/Security/AppAccessDeniedHandler.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/AccessTokenBundle/Security/AppAccessDeniedHandler.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\AccessTokenBundle\Security;
+
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Symfony\Component\Security\Http\Authorization\AccessDeniedHandlerInterface;
+
+class AppAccessDeniedHandler implements AccessDeniedHandlerInterface
+{
+    public function handle(Request $request, AccessDeniedException $accessDeniedException): ?Response
+    {
+        return new JsonResponse(['message' => 'Denied by the application.'], Response::HTTP_FORBIDDEN);
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/AccessTokenBundle/Security/Handler/AccessTokenHandler.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/AccessTokenBundle/Security/Handler/AccessTokenHandler.php
@@ -23,6 +23,7 @@ class AccessTokenHandler implements AccessTokenHandlerInterface
         return match ($accessToken) {
             'VALID_ACCESS_TOKEN' => new UserBadge('dunglas'),
             'SELF_CONTAINED_ACCESS_TOKEN' => new UserBadge('dunglas', static fn () => new InMemoryUser('dunglas', null, ['ROLE_USER'])),
+            'SCOPED_ACCESS_TOKEN' => new UserBadge('dunglas', static fn () => new InMemoryUser('dunglas', null, ['ROLE_USER']), ['scope' => 'openid profile:read']),
             default => throw new BadCredentialsException('Invalid credentials.'),
         };
     }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_scope.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_scope.yml
@@ -1,0 +1,31 @@
+imports:
+    - { resource: ./../config/framework.yml }
+
+framework:
+    serializer: ~
+
+security:
+    password_hashers:
+        Symfony\Component\Security\Core\User\InMemoryUser: plaintext
+
+    providers:
+        in_memory:
+            memory:
+                users:
+                    dunglas: { password: foo, roles: [ROLE_USER] }
+
+    firewalls:
+        main:
+            pattern: ^/
+            access_token:
+                token_handler: access_token.access_token_handler
+                token_extractors: 'header'
+                realm: 'My API'
+
+    access_control:
+        - { path: ^/foo, roles: 'OAUTH2_SCOPE(openid profile:read)' }
+        - { path: ^/bar, roles: ROLE_ADMIN }
+
+services:
+    access_token.access_token_handler:
+        class: Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\AccessTokenBundle\Security\Handler\AccessTokenHandler

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_scope_app_handler.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_scope_app_handler.yml
@@ -1,0 +1,33 @@
+imports:
+    - { resource: ./../config/framework.yml }
+
+framework:
+    serializer: ~
+
+security:
+    password_hashers:
+        Symfony\Component\Security\Core\User\InMemoryUser: plaintext
+
+    providers:
+        in_memory:
+            memory:
+                users:
+                    dunglas: { password: foo, roles: [ROLE_USER] }
+
+    firewalls:
+        main:
+            pattern: ^/
+            access_token:
+                token_handler: access_token.access_token_handler
+                token_extractors: 'header'
+                realm: 'My API'
+
+    access_control:
+        - { path: ^/foo, roles: 'OAUTH2_SCOPE(openid profile:read)' }
+        - { path: ^/bar, roles: ROLE_ADMIN }
+
+services:
+    access_token.access_token_handler:
+        class: Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\AccessTokenBundle\Security\Handler\AccessTokenHandler
+    security.access.denied_handler:
+        class: Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\AccessTokenBundle\Security\AppAccessDeniedHandler

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_scope_denied_url.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_scope_denied_url.yml
@@ -1,0 +1,31 @@
+imports:
+    - { resource: ./../config/framework.yml }
+
+framework:
+    serializer: ~
+
+security:
+    access_denied_url: /bar
+    password_hashers:
+        Symfony\Component\Security\Core\User\InMemoryUser: plaintext
+
+    providers:
+        in_memory:
+            memory:
+                users:
+                    dunglas: { password: foo, roles: [ROLE_USER] }
+
+    firewalls:
+        main:
+            pattern: ^/
+            access_token:
+                token_handler: access_token.access_token_handler
+                token_extractors: 'header'
+                realm: 'My API'
+
+    access_control:
+        - { path: ^/foo, roles: 'OAUTH2_SCOPE(openid profile:read)' }
+
+services:
+    access_token.access_token_handler:
+        class: Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\AccessTokenBundle\Security\Handler\AccessTokenHandler

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_scope_metadata.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/config_scope_metadata.yml
@@ -1,0 +1,33 @@
+imports:
+    - { resource: ./../config/framework.yml }
+
+framework:
+    serializer: ~
+
+security:
+    password_hashers:
+        Symfony\Component\Security\Core\User\InMemoryUser: plaintext
+
+    providers:
+        in_memory:
+            memory:
+                users:
+                    dunglas: { password: foo, roles: [ROLE_USER] }
+
+    firewalls:
+        main:
+            pattern: ^/
+            access_token:
+                token_handler: access_token.access_token_handler
+                token_extractors: 'header'
+                realm: 'My API'
+                resource_metadata:
+                    authorization_servers: ['https://accounts.example.com']
+
+    access_control:
+        - { path: ^/foo, roles: 'OAUTH2_SCOPE(openid profile:read)' }
+        - { path: ^/bar, roles: ROLE_ADMIN }
+
+services:
+    access_token.access_token_handler:
+        class: Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\AccessTokenBundle\Security\Handler\AccessTokenHandler

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/routing.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AccessToken/routing.yml
@@ -7,3 +7,9 @@ bar_route:
 _security_protected_resource_metadata:
     resource: security.authenticator.access_token.route_loader
     type: service
+scoped_route:
+    path: /scoped
+    defaults: { _controller: Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\AccessTokenBundle\Controller\ScopedController::__invoke }
+all_scopes_route:
+    path: /all-scopes
+    defaults: { _controller: Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\AccessTokenBundle\Controller\AllScopesController::__invoke }

--- a/src/Symfony/Component/Security/Http/Authenticator/AccessTokenAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/AccessTokenAuthenticator.php
@@ -21,6 +21,7 @@ use Symfony\Component\Security\Http\AccessToken\AccessTokenExtractorInterface;
 use Symfony\Component\Security\Http\AccessToken\AccessTokenHandlerInterface;
 use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface;
 use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
 use Symfony\Component\Security\Http\Authenticator\Token\PostAuthenticationToken;
@@ -36,6 +37,19 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  */
 class AccessTokenAuthenticator implements AuthenticatorInterface, FallbackAuthenticationEntryPointInterface
 {
+    /**
+     * The token attribute holding the scopes the access token was granted, as a list of strings.
+     *
+     * @see https://datatracker.ietf.org/doc/html/rfc6749#section-3.3
+     */
+    public const SCOPE_ATTRIBUTE = 'oauth2_scope';
+
+    /**
+     * The claims a scope is read from, in order of precedence: "scope" is the one RFC 9068 §2.2.3
+     * and RFC 7662 §2.2 define, "scp" is the spelling some providers use instead.
+     */
+    private const SCOPE_CLAIMS = ['scope', 'scp'];
+
     private ?TranslatorInterface $translator = null;
 
     /**
@@ -81,7 +95,10 @@ class AccessTokenAuthenticator implements AuthenticatorInterface, FallbackAuthen
 
     public function createToken(Passport $passport, string $firewallName): TokenInterface
     {
-        return new PostAuthenticationToken($passport->getUser(), $firewallName, $passport->getUser()->getRoles());
+        $token = new PostAuthenticationToken($passport->getUser(), $firewallName, $passport->getUser()->getRoles());
+        $token->setAttribute(self::SCOPE_ATTRIBUTE, self::extractScopes($passport->getBadge(UserBadge::class)?->getAttributes() ?? []));
+
+        return $token;
     }
 
     public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response
@@ -123,6 +140,28 @@ class AccessTokenAuthenticator implements AuthenticatorInterface, FallbackAuthen
     public function setTranslator(?TranslatorInterface $translator): void
     {
         $this->translator = $translator;
+    }
+
+    /**
+     * @return string[]
+     *
+     * @see https://datatracker.ietf.org/doc/html/rfc6749#section-3.3
+     */
+    private static function extractScopes(array $claims): array
+    {
+        foreach (self::SCOPE_CLAIMS as $claim) {
+            $scope = $claims[$claim] ?? null;
+            if (\is_array($scope)) {
+                $scope = implode(' ', array_filter($scope, \is_string(...)));
+            }
+            if (!\is_string($scope) || '' === trim($scope)) {
+                continue;
+            }
+
+            return array_values(array_unique(preg_split('/\s+/', trim($scope))));
+        }
+
+        return [];
     }
 
     /**

--- a/src/Symfony/Component/Security/Http/Authorization/InsufficientScopeAccessDeniedHandler.php
+++ b/src/Symfony/Component/Security/Http/Authorization/InsufficientScopeAccessDeniedHandler.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Authorization;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+
+/**
+ * Answers the RFC 6750 §3.1 "insufficient_scope" challenge when access was denied for a missing OAuth2 scope.
+ *
+ * Access denials that no OAuth2 scope took part in are handed to the handler the application configured,
+ * or left to the regular handling when it configured none, so that a firewall mixing scopes with roles
+ * keeps answering the latter the way the application asked for.
+ *
+ * @see https://datatracker.ietf.org/doc/html/rfc6750#section-3.1
+ *
+ * @author Florent Morselli <florent.morselli@spomky-labs.com>
+ */
+class InsufficientScopeAccessDeniedHandler implements AccessDeniedHandlerInterface
+{
+    /**
+     * The description RFC 6750 §3.1 gives for the "insufficient_scope" error code.
+     */
+    private const ERROR_DESCRIPTION = 'The request requires higher privileges than provided by the access token.';
+
+    public function __construct(
+        private ?string $realm = null,
+        private ?AccessDeniedHandlerInterface $inner = null,
+        private ?string $resourceMetadataUri = null,
+    ) {
+    }
+
+    public function handle(Request $request, AccessDeniedException $accessDeniedException): ?Response
+    {
+        $scopes = [];
+        foreach ($accessDeniedException->getAttributes() as $attribute) {
+            if (\is_string($attribute) && null !== $requiredScopes = OAuth2ScopeVoter::getRequiredScopes($attribute)) {
+                $scopes = array_merge($scopes, $requiredScopes);
+            }
+        }
+
+        if (!$scopes) {
+            return $this->inner?->handle($request, $accessDeniedException);
+        }
+
+        return new Response(
+            null,
+            Response::HTTP_FORBIDDEN,
+            ['WWW-Authenticate' => $this->getAuthenticateHeader($request, $scopes)]
+        );
+    }
+
+    /**
+     * @param string[] $scopes
+     *
+     * RFC 9728 §5.1 does not restrict "resource_metadata" to a 401, and a client denied for a
+     * missing scope is the one that most needs to find the authorization server again.
+     *
+     * @see https://datatracker.ietf.org/doc/html/rfc6750#section-3
+     * @see https://datatracker.ietf.org/doc/html/rfc9728#section-5.1
+     */
+    private function getAuthenticateHeader(Request $request, array $scopes): string
+    {
+        $data = [
+            'realm' => $this->realm,
+            'error' => 'insufficient_scope',
+            'error_description' => self::ERROR_DESCRIPTION,
+            'scope' => implode(' ', array_unique($scopes)),
+            'resource_metadata' => match (true) {
+                null === $this->resourceMetadataUri => null,
+                str_starts_with($this->resourceMetadataUri, '/') => $request->getUriForPath($this->resourceMetadataUri),
+                default => $this->resourceMetadataUri,
+            },
+        ];
+        $values = [];
+        foreach ($data as $k => $v) {
+            if (null === $v || '' === $v) {
+                continue;
+            }
+            $values[] = \sprintf('%s="%s"', $k, $v);
+        }
+
+        return \sprintf('Bearer %s', implode(',', $values));
+    }
+}

--- a/src/Symfony/Component/Security/Http/Authorization/OAuth2ScopeVoter.php
+++ b/src/Symfony/Component/Security/Http/Authorization/OAuth2ScopeVoter.php
@@ -1,0 +1,112 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Authorization;
+
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\CacheableVoterInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Vote;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+use Symfony\Component\Security\Http\Authenticator\AccessTokenAuthenticator;
+
+/**
+ * Grants access when the access token carries the OAuth2 scopes an attribute requires.
+ *
+ * An attribute lists the scopes it requires between parentheses, separated by spaces, which is the
+ * separator RFC 6749 Appendix A leaves out of a scope token: "OAUTH2_SCOPE(profile:read admin:manage)"
+ * requires both of them. Requiring any of several scopes instead is a matter of voting on several
+ * attributes, as an access control rule does.
+ *
+ * The scopes the token was granted are read from the attribute AccessTokenAuthenticator fills in.
+ *
+ * @see https://datatracker.ietf.org/doc/html/rfc6749#section-3.3
+ *
+ * @author Florent Morselli <florent.morselli@spomky-labs.com>
+ */
+class OAuth2ScopeVoter implements CacheableVoterInterface
+{
+    private const ATTRIBUTE_PREFIX = 'OAUTH2_SCOPE(';
+
+    /**
+     * Reads the scopes an attribute requires, all of which are required.
+     *
+     * @return string[]|null the required scopes, or null when the attribute is not one of this voter
+     *                       or lists no scope, so that an attribute of another voter is left alone
+     *                       and a malformed one is abstained on rather than silently honored
+     */
+    public static function getRequiredScopes(string $attribute): ?array
+    {
+        if (!str_starts_with($attribute, self::ATTRIBUTE_PREFIX)) {
+            return null;
+        }
+
+        if (!str_ends_with($attribute, ')')) {
+            return null;
+        }
+
+        $scopes = substr($attribute, \strlen(self::ATTRIBUTE_PREFIX), -1);
+
+        return preg_split('/\s+/', $scopes, flags: \PREG_SPLIT_NO_EMPTY) ?: null;
+    }
+
+    public function vote(TokenInterface $token, mixed $subject, array $attributes, ?Vote $vote = null): int
+    {
+        $result = VoterInterface::ACCESS_ABSTAIN;
+        $grantedScopes = $this->getGrantedScopes($token);
+        $missingScopes = [];
+
+        foreach ($attributes as $attribute) {
+            if (!\is_string($attribute) || null === $requiredScopes = self::getRequiredScopes($attribute)) {
+                continue;
+            }
+
+            $result = VoterInterface::ACCESS_DENIED;
+
+            if (!$missing = array_diff($requiredScopes, $grantedScopes)) {
+                $vote?->addReason(\sprintf('The access token was granted %s.', implode(', ', $requiredScopes)));
+
+                return VoterInterface::ACCESS_GRANTED;
+            }
+
+            $missingScopes[] = $missing;
+        }
+
+        if (VoterInterface::ACCESS_DENIED === $result) {
+            $vote?->addReason(\sprintf('The access token was not granted %s.', implode(', ', array_unique(array_merge(...$missingScopes)))));
+        }
+
+        return $result;
+    }
+
+    public function supportsAttribute(string $attribute): bool
+    {
+        return str_starts_with($attribute, self::ATTRIBUTE_PREFIX);
+    }
+
+    public function supportsType(string $subjectType): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getGrantedScopes(TokenInterface $token): array
+    {
+        if (!$token->hasAttribute(AccessTokenAuthenticator::SCOPE_ATTRIBUTE)) {
+            return [];
+        }
+
+        $scopes = $token->getAttribute(AccessTokenAuthenticator::SCOPE_ATTRIBUTE);
+
+        return \is_array($scopes) ? array_filter($scopes, \is_string(...)) : [];
+    }
+}

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -5,6 +5,9 @@ CHANGELOG
 ---
 
  * Add `allowed_time_drift` option to `OidcTokenHandler` to configure time tolerance for token validation (`iat`, `nbf`, `exp` claims)
+ * Expose the OAuth2 scopes an access token was granted as the `scope` token attribute, read from the `scope` or `scp` claim
+ * Add `OAuth2ScopeVoter` to require scopes of the access token, all the ones an `OAUTH2_SCOPE(...)` attribute lists
+ * Add `InsufficientScopeAccessDeniedHandler` to answer a denial caused by a missing scope with the RFC 6750 §3.1 challenge
  * Throw a 403 `Symfony\Component\Security\Http\Exception\InvalidCsrfTokenException` instead of the `Security\Core` one when the `#[IsCsrfTokenValid]` attribute fails, so the failure is no longer handled as an authentication failure
  * Add the deauthentication reason and the responsible user providers to `TokenDeauthenticatedEvent`
  * Add `LogoutUrlGenerator::getLogoutForm()` to build a form that logs the user out with a POST

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/AccessTokenAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/AccessTokenAuthenticatorTest.php
@@ -253,6 +253,48 @@ class AccessTokenAuthenticatorTest extends TestCase
         $this->assertSame('Bearer', $response->headers->get('WWW-Authenticate'));
     }
 
+    #[DataProvider('provideScopeClaims')]
+    public function testTheGrantedScopesAreExposedAsATokenAttribute(array $claims, array $expectedScopes)
+    {
+        $accessTokenHandler = $this->createStub(AccessTokenHandlerInterface::class);
+        $accessTokenHandler
+            ->method('getUserBadgeFrom')
+            ->willReturn(new UserBadge('john', static fn () => new InMemoryUser('john', null), $claims));
+
+        $authenticator = new AccessTokenAuthenticator($accessTokenHandler, new HeaderAccessTokenExtractor());
+        $passport = $authenticator->authenticate(Request::create('/test', server: ['HTTP_AUTHORIZATION' => 'Bearer VALID_ACCESS_TOKEN']));
+
+        $this->assertSame($expectedScopes, $authenticator->createToken($passport, 'main')->getAttribute(AccessTokenAuthenticator::SCOPE_ATTRIBUTE));
+    }
+
+    public static function provideScopeClaims(): iterable
+    {
+        yield 'the space-delimited "scope" claim of RFC 6749 §3.3' => [['scope' => 'openid profile:read'], ['openid', 'profile:read']];
+        yield 'a single scope' => [['scope' => 'openid'], ['openid']];
+        yield 'scopes separated by more than one space' => [['scope' => " openid \t profile:read "], ['openid', 'profile:read']];
+        yield 'a scope granted twice' => [['scope' => 'openid openid'], ['openid']];
+        yield 'the "scope" claim as a list' => [['scope' => ['openid', 'profile:read']], ['openid', 'profile:read']];
+        yield 'the "scp" claim some providers use instead' => [['scp' => ['openid', 'profile:read']], ['openid', 'profile:read']];
+        yield '"scope" wins over "scp"' => [['scope' => 'openid', 'scp' => ['profile:read']], ['openid']];
+        yield 'an empty "scope" falls back on "scp"' => [['scope' => '', 'scp' => 'profile:read'], ['profile:read']];
+        yield 'no scope claim at all' => [['sub' => 'john'], []];
+        yield 'a scope claim of an unexpected type' => [['scope' => 42], []];
+        yield 'a list holding values that are not scopes' => [['scope' => ['openid', 42, null]], ['openid']];
+    }
+
+    public function testTheScopeAttributeIsSetOnATokenBuiltFromABadgeWithoutAttributes()
+    {
+        $accessTokenHandler = $this->createStub(AccessTokenHandlerInterface::class);
+        $accessTokenHandler
+            ->method('getUserBadgeFrom')
+            ->willReturn(new UserBadge('john', static fn () => new InMemoryUser('john', null)));
+
+        $authenticator = new AccessTokenAuthenticator($accessTokenHandler, new HeaderAccessTokenExtractor());
+        $passport = $authenticator->authenticate(Request::create('/test', server: ['HTTP_AUTHORIZATION' => 'Bearer VALID_ACCESS_TOKEN']));
+
+        $this->assertSame([], $authenticator->createToken($passport, 'main')->getAttribute(AccessTokenAuthenticator::SCOPE_ATTRIBUTE));
+    }
+
     public function testUnsupportedReasons()
     {
         $authenticator = new AccessTokenAuthenticator($this->createStub(AccessTokenHandlerInterface::class), new HeaderAccessTokenExtractor());

--- a/src/Symfony/Component/Security/Http/Tests/Authorization/InsufficientScopeAccessDeniedHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authorization/InsufficientScopeAccessDeniedHandlerTest.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Tests\Authorization;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Symfony\Component\Security\Http\Authorization\InsufficientScopeAccessDeniedHandler;
+
+class InsufficientScopeAccessDeniedHandlerTest extends TestCase
+{
+    public function testMissingScope()
+    {
+        $response = (new InsufficientScopeAccessDeniedHandler('My API'))->handle(Request::create('/test'), $this->createException(['OAUTH2_SCOPE(profile:read)']));
+
+        $this->assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
+        $this->assertSame('Bearer realm="My API",error="insufficient_scope",error_description="The request requires higher privileges than provided by the access token.",scope="profile:read"', $response->headers->get('WWW-Authenticate'));
+    }
+
+    public function testTheRealmIsOptional()
+    {
+        $response = (new InsufficientScopeAccessDeniedHandler())->handle(Request::create('/test'), $this->createException(['OAUTH2_SCOPE(profile:read)']));
+
+        $this->assertSame('Bearer error="insufficient_scope",error_description="The request requires higher privileges than provided by the access token.",scope="profile:read"', $response->headers->get('WWW-Authenticate'));
+    }
+
+    public function testEveryRequiredScopeIsReportedOnce()
+    {
+        $response = (new InsufficientScopeAccessDeniedHandler())->handle(Request::create('/test'), $this->createException(['OAUTH2_SCOPE(openid profile:read)', 'ROLE_USER', 'OAUTH2_SCOPE(openid)']));
+
+        $this->assertStringEndsWith('scope="openid profile:read"', $response->headers->get('WWW-Authenticate'));
+    }
+
+    public function testADenialNoScopeTookPartInIsLeftAlone()
+    {
+        $handler = new InsufficientScopeAccessDeniedHandler();
+
+        $this->assertNull($handler->handle(Request::create('/test'), $this->createException(['ROLE_USER'])));
+        $this->assertNull($handler->handle(Request::create('/test'), $this->createException(['OAUTH2_SCOPE_profile:read'])));
+        $this->assertNull($handler->handle(Request::create('/test'), $this->createException([])));
+        $this->assertNull($handler->handle(Request::create('/test'), $this->createException([new \stdClass()])));
+    }
+
+    public function testTheReportedScopesAreTheOnesTheAttributesRequire()
+    {
+        $handler = new InsufficientScopeAccessDeniedHandler();
+
+        $this->assertStringEndsWith('scope="openid profile:read"', $handler->handle(Request::create('/test'), $this->createException(['OAUTH2_SCOPE(openid profile:read)']))->headers->get('WWW-Authenticate'));
+        $this->assertStringEndsWith('scope="profile:read openid"', $handler->handle(Request::create('/test'), $this->createException(['OAUTH2_SCOPE(profile:read openid)']))->headers->get('WWW-Authenticate'));
+    }
+
+    private function createException(array $attributes): AccessDeniedException
+    {
+        $exception = new AccessDeniedException();
+        $exception->setAttributes($attributes);
+
+        return $exception;
+    }
+}

--- a/src/Symfony/Component/Security/Http/Tests/Authorization/OAuth2ScopeVoterTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authorization/OAuth2ScopeVoterTest.php
@@ -1,0 +1,125 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Tests\Authorization;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Vote;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+use Symfony\Component\Security\Core\User\InMemoryUser;
+use Symfony\Component\Security\Http\Authenticator\AccessTokenAuthenticator;
+use Symfony\Component\Security\Http\Authenticator\Token\PostAuthenticationToken;
+use Symfony\Component\Security\Http\Authorization\OAuth2ScopeVoter;
+
+class OAuth2ScopeVoterTest extends TestCase
+{
+    #[DataProvider('provideVotes')]
+    public function testVote(array $scopes, array $attributes, int $expected)
+    {
+        $this->assertSame($expected, (new OAuth2ScopeVoter())->vote($this->createToken($scopes), null, $attributes));
+    }
+
+    public static function provideVotes(): iterable
+    {
+        yield 'the granted scope is required' => [['profile:read'], ['OAUTH2_SCOPE(profile:read)'], VoterInterface::ACCESS_GRANTED];
+        yield 'one of the granted scopes is required' => [['openid', 'profile:read'], ['OAUTH2_SCOPE(profile:read)'], VoterInterface::ACCESS_GRANTED];
+        yield 'the required scope was not granted' => [['openid'], ['OAUTH2_SCOPE(profile:read)'], VoterInterface::ACCESS_DENIED];
+        yield 'no scope was granted at all' => [[], ['OAUTH2_SCOPE(profile:read)'], VoterInterface::ACCESS_DENIED];
+        yield 'scopes are case-sensitive' => [['profile:read'], ['OAUTH2_SCOPE(PROFILE:READ)'], VoterInterface::ACCESS_DENIED];
+
+        yield 'every scope an attribute lists is required' => [['openid', 'profile:read'], ['OAUTH2_SCOPE(openid profile:read)'], VoterInterface::ACCESS_GRANTED];
+        yield 'one missing scope denies the whole attribute' => [['openid'], ['OAUTH2_SCOPE(openid profile:read)'], VoterInterface::ACCESS_DENIED];
+        yield 'the scopes of an attribute are separated by any run of spaces' => [['openid', 'profile:read'], ["OAUTH2_SCOPE(  openid \t profile:read )"], VoterInterface::ACCESS_GRANTED];
+        yield 'a scope required twice' => [['openid'], ['OAUTH2_SCOPE(openid openid)'], VoterInterface::ACCESS_GRANTED];
+        yield 'the order an attribute lists its scopes in does not matter' => [['openid', 'profile:read'], ['OAUTH2_SCOPE(profile:read openid)'], VoterInterface::ACCESS_GRANTED];
+        yield 'the order the scopes were granted in does not matter' => [['profile:read', 'openid'], ['OAUTH2_SCOPE(openid profile:read)'], VoterInterface::ACCESS_GRANTED];
+        yield 'a missing scope listed first' => [['profile:read'], ['OAUTH2_SCOPE(openid profile:read)'], VoterInterface::ACCESS_DENIED];
+        yield 'a missing scope listed last' => [['profile:read'], ['OAUTH2_SCOPE(profile:read openid)'], VoterInterface::ACCESS_DENIED];
+
+        yield 'any of several attributes is enough' => [['openid'], ['OAUTH2_SCOPE(profile:read)', 'OAUTH2_SCOPE(openid)'], VoterInterface::ACCESS_GRANTED];
+        yield 'none of several attributes is granted' => [['openid'], ['OAUTH2_SCOPE(profile:read)', 'OAUTH2_SCOPE(admin:manage)'], VoterInterface::ACCESS_DENIED];
+
+        yield 'a role attribute is left to the role voter' => [['profile:read'], ['ROLE_USER'], VoterInterface::ACCESS_ABSTAIN];
+        yield 'an attribute merely starting like a scope one' => [['profile:read'], ['OAUTH2_SCOPE_profile:read'], VoterInterface::ACCESS_ABSTAIN];
+        yield 'an attribute that is not a string' => [['profile:read'], [new \stdClass()], VoterInterface::ACCESS_ABSTAIN];
+        yield 'an attribute listing no scope at all' => [['profile:read'], ['OAUTH2_SCOPE()'], VoterInterface::ACCESS_ABSTAIN];
+        yield 'no attribute at all' => [['profile:read'], [], VoterInterface::ACCESS_ABSTAIN];
+    }
+
+    public function testVoteReportsTheScopesItDecidedOn()
+    {
+        $voter = new OAuth2ScopeVoter();
+
+        $voter->vote($this->createToken(['openid']), null, ['OAUTH2_SCOPE(openid)'], $vote = new Vote());
+        $this->assertSame(['The access token was granted openid.'], $vote->reasons);
+
+        $voter->vote($this->createToken(['openid']), null, ['OAUTH2_SCOPE(openid profile:read)', 'OAUTH2_SCOPE(admin:manage)'], $vote = new Vote());
+        $this->assertSame(['The access token was not granted profile:read, admin:manage.'], $vote->reasons);
+    }
+
+    public function testTheReportedScopesFollowTheOrderTheAttributeListsThemIn()
+    {
+        $voter = new OAuth2ScopeVoter();
+
+        $voter->vote($this->createToken(['openid']), null, ['OAUTH2_SCOPE(openid profile:read)'], $vote = new Vote());
+        $this->assertSame(['The access token was not granted profile:read.'], $vote->reasons);
+
+        $voter->vote($this->createToken(['openid', 'profile:read']), null, ['OAUTH2_SCOPE(profile:read openid)'], $vote = new Vote());
+        $this->assertSame(['The access token was granted profile:read, openid.'], $vote->reasons);
+    }
+
+    public function testVoteDeniesATokenCarryingNoScopeAttribute()
+    {
+        $token = new PostAuthenticationToken(new InMemoryUser('john', null), 'main', []);
+
+        $this->assertSame(VoterInterface::ACCESS_DENIED, (new OAuth2ScopeVoter())->vote($token, null, ['OAUTH2_SCOPE(profile:read)']));
+        $this->assertSame(VoterInterface::ACCESS_ABSTAIN, (new OAuth2ScopeVoter())->vote($token, null, ['ROLE_USER']));
+    }
+
+    #[DataProvider('provideRequiredScopes')]
+    public function testGetRequiredScopes(string $attribute, ?array $expected)
+    {
+        $this->assertSame($expected, OAuth2ScopeVoter::getRequiredScopes($attribute));
+    }
+
+    public static function provideRequiredScopes(): iterable
+    {
+        yield 'a single scope' => ['OAUTH2_SCOPE(profile:read)', ['profile:read']];
+        yield 'several scopes' => ['OAUTH2_SCOPE(openid profile:read)', ['openid', 'profile:read']];
+        yield 'an attribute of another voter' => ['ROLE_USER', null];
+        yield 'nothing between the parentheses' => ['OAUTH2_SCOPE()', null];
+        yield 'only spaces between the parentheses' => ['OAUTH2_SCOPE(   )', null];
+        // a malformed attribute is abstained on rather than read as the scopes it seems to list,
+        // so that a typo denies nothing and grants nothing
+        yield 'the closing parenthesis is missing' => ['OAUTH2_SCOPE(profile:read', null];
+        yield 'a doubled closing parenthesis' => ['OAUTH2_SCOPE(profile:read))', ['profile:read)']];
+        yield 'trailing characters' => ['OAUTH2_SCOPE(profile:read)x', null];
+    }
+
+    public function testSupportsAttribute()
+    {
+        $voter = new OAuth2ScopeVoter();
+
+        $this->assertTrue($voter->supportsAttribute('OAUTH2_SCOPE(profile:read)'));
+        $this->assertFalse($voter->supportsAttribute('ROLE_USER'));
+        $this->assertTrue($voter->supportsType('string'));
+    }
+
+    private function createToken(array $scopes): TokenInterface
+    {
+        $token = new PostAuthenticationToken(new InMemoryUser('john', null), 'main', []);
+        $token->setAttribute(AccessTokenAuthenticator::SCOPE_ATTRIBUTE, $scopes);
+
+        return $token;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

OAuth2 scopes are absent from the whole resource server path today: nothing reads the `scope` claim, there is no declarative way to require a scope on an endpoint, and a request that lacks one can only ever be answered with a plain 403, never with the `error="insufficient_scope"` challenge RFC 6750 §3.1 defines. Since scopes are what an authorization server actually delegates, this is the first thing missing from the `access_token` authenticator.

### Reading the scopes

`AccessTokenAuthenticator` now exposes the scopes the token was granted as the `oauth2_scope` token attribute, a list of strings. They are read from the attributes the token handler puts on the `UserBadge`: the `scope` claim first, which is the one RFC 6749 §3.3, RFC 9068 §2.2.3 and RFC 7662 §2.2 define, then `scp`, the spelling some providers use instead. Both the space-delimited string and the list form are accepted.

No token handler is touched: the three handlers shipped in the component already hand their claims to the badge, so `oidc`, `oauth2` and `oidc_user_info` all get this, and so does any custom handler that does the same.

### Requiring a scope

`OAuth2ScopeVoter` compares the scopes of the token against the attributes being voted on. An attribute lists the scopes it requires between parentheses, separated by spaces:

```php
#[IsGranted('OAUTH2_SCOPE(profile:read)')]
public function show(): Response
{
    // ...
}
```

```yaml
security:
    access_control:
        - { path: ^/api/profile, roles: 'OAUTH2_SCOPE(profile:read)' }
```

All the scopes an attribute lists are required, so `OAUTH2_SCOPE(profile:read admin:manage)` demands both; requiring any of several scopes instead is a matter of voting on several attributes, which is what an access control rule already does. The space is the separator here because it is the one RFC 6749 Appendix A leaves out of a scope token, so the list is unambiguous and it maps as is onto the `scope="..."` of the challenge below.

The scopes stay out of `getRoleNames()`: a scope is not a role, role hierarchy must not apply to it, and an application that does want to map one onto the other is free to do so in its user provider.

### Answering with the RFC 6750 §3.1 challenge

`InsufficientScopeAccessDeniedHandler` turns a denial that a scope took part in into the response the RFC asks for:

```
HTTP/1.1 403 Forbidden
WWW-Authenticate: Bearer realm="My API",error="insufficient_scope",error_description="The request requires higher privileges than provided by the access token.",scope="profile:read",resource_metadata="https://api.example.com/.well-known/oauth-protected-resource"
```

It reads the required scopes back from the attributes the `AccessDeniedException` carries. A denial no scope took part in is handed to the handler the application registered as `security.access.denied_handler`, or left to the regular handling when it registered none, so a denial on a plain role keeps being answered the way the application asked for. `resource_metadata` is advertised when the firewall declares a `resource_metadata` node: RFC 9728 §5.1 does not restrict that parameter to a 401, and a client denied for a missing scope holds a token from an authorization server it may have to find again.

Wiring it needed a small addition on the firewall side. `AccessTokenFactory` registers `security.fallback_access_denied_handler.<firewall>`, and `createExceptionListener()` uses it only when neither the firewall nor the application configures a handler or a URL: a firewall `access_denied_handler` or `access_denied_url` wins as before, an application-wide `access_denied_url` is still rendered, and an application-wide `security.access.denied_handler` still answers every denial no scope took part in. The service id is deliberately generic rather than access-token specific: DPoP will need the same hook to answer `WWW-Authenticate: DPoP`.

### Not in this PR

The `roles`, `groups`, `entitlements` and `client_id` claims of RFC 9068 §2.2.3.1 are still unread. They are a separate authorization mechanism from scopes and deserve their own discussion, so they will come in a follow-up built on the same token attributes.

