### PR TITLE
[Security] Renew the OIDC access token with the refresh token grant

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -24,6 +24,7 @@ CHANGELOG
  * Add a `start_path` option to the `oidc_login` authenticator and declare a route there that starts the flow by redirecting to the provider, for login pages linking to it
  * Add `user_data_source` and `user_identifier_claim` options to the `oidc_login` authenticator
  * Add `enable_end_session` and `post_logout_redirect_path` options to the `oidc_login` authenticator for RP-Initiated Logout
+ * Add the `refresh_access_token` option to the `oidc_login` authenticator to renew the access token before it expires
  * Allow passing a null user to `Security::isGrantedForUser()` and `Security::getAccessDecisionForUser()` to check guest permissions
  * Show why an authenticator did not support the request in the security profiler panel
  * Add the `enforce_at_jwt_type` option to the OIDC token handler configuration to reject the tokens whose `typ` header is not the `at+jwt` RFC 9068 requires from an access token

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/OidcLoginFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/OidcLoginFactory.php
@@ -30,7 +30,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  *
  * @internal
  */
-class OidcLoginFactory extends AbstractFactory
+class OidcLoginFactory extends AbstractFactory implements FirewallListenerFactoryInterface
 {
     public const PRIORITY = -25;
 
@@ -159,6 +159,17 @@ class OidcLoginFactory extends AbstractFactory
                     ->thenInvalid('The OIDC "authorization_params" option cannot set "response_type", "client_id", "redirect_uri", "scope", "state", "nonce", "code_challenge", "code_challenge_method" nor "max_age": the authenticator manages these; use the dedicated "scope" and "max_age" options.')
                 ->end()
             ->end()
+            ->arrayNode('refresh_access_token')
+                ->canBeEnabled()
+                ->info('Renew the access token with the refresh token grant of RFC 6749, Section 6, so that it stays usable to call an API on behalf of the logged-in user. The provider only issues a refresh token when it was asked for one, e.g. with the "offline_access" scope, and the renewal needs the "expires_in" it is optional for the provider to report. Whether this is enabled or not, the tokens are held as the "oidc_refresh_token", "oidc_access_token" and "oidc_access_token_expires_at" attributes of the security token, and the "security.authenticator.oidc_login.token_refresher.<firewall>" service renews them on demand. A provider rotating refresh tokens expects the previous one never to be replayed, which a session handler locking the session guarantees, and the default one does.')
+                ->children()
+                    ->integerNode('leeway')
+                        ->defaultValue(30)
+                        ->min(0)
+                        ->info('How many seconds before its expiry the access token is renewed, so that one handed to a call in flight does not expire on the way.')
+                    ->end()
+                ->end()
+            ->end()
             ->booleanNode('enable_end_session')
                 ->defaultFalse()
                 ->info('Enable RP-Initiated Logout via the OIDC end_session_endpoint.')
@@ -278,6 +289,16 @@ class OidcLoginFactory extends AbstractFactory
             $signatureVerifier = new Reference($signatureVerifierId);
         }
 
+        $container
+            ->setDefinition('security.authenticator.oidc_login.token_refresher.'.$firewallName, new ChildDefinition('security.authenticator.oidc_login.token_refresher'))
+            ->replaceArgument(0, new Reference($oidcClientId))
+            ->replaceArgument(1, new Reference($discoveryId))
+            ->replaceArgument(2, new Reference($idTokenId))
+            ->replaceArgument(3, $config['client_id'])
+            ->replaceArgument(4, $signatureVerifier)
+            ->replaceArgument(5, $config['refresh_access_token']['leeway'])
+        ;
+
         $authenticatorId = 'security.authenticator.oidc_login.'.$firewallName;
         $options = array_intersect_key($config, $this->options);
         $options['firewall_name'] = $firewallName;
@@ -332,5 +353,23 @@ class OidcLoginFactory extends AbstractFactory
         $startControllerLocator->setValues([$firewallName => new Reference($authenticatorId)] + $startControllerLocator->getValues());
 
         return $authenticatorId;
+    }
+
+    public function createListeners(ContainerBuilder $container, string $firewallName, array $config): array
+    {
+        if (!$config['refresh_access_token']['enabled']) {
+            return [];
+        }
+
+        // the listener runs once the firewall restored the security token from the
+        // session, so the renewed tokens are the ones this request and the rest of the
+        // session see
+        $listenerId = 'security.authenticator.oidc_login.token_refresh_listener.'.$firewallName;
+        $container
+            ->setDefinition($listenerId, new ChildDefinition('security.authenticator.oidc_login.token_refresh_listener'))
+            ->replaceArgument(1, new Reference('security.authenticator.oidc_login.token_refresher.'.$firewallName))
+        ;
+
+        return [$listenerId];
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator_oidc_login.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator_oidc_login.php
@@ -16,8 +16,10 @@ use Symfony\Component\Security\Http\Authenticator\Oidc\OidcConfidentialClient;
 use Symfony\Component\Security\Http\Authenticator\Oidc\OidcIdToken;
 use Symfony\Component\Security\Http\Authenticator\Oidc\OidcPublicClient;
 use Symfony\Component\Security\Http\Authenticator\Oidc\OidcSignatureVerifier;
+use Symfony\Component\Security\Http\Authenticator\Oidc\OidcTokenRefresher;
 use Symfony\Component\Security\Http\Authenticator\OidcLoginAuthenticator;
 use Symfony\Component\Security\Http\EventListener\OidcEndSessionListener;
+use Symfony\Component\Security\Http\Firewall\OidcTokenRefreshListener;
 use Symfony\Component\Security\Http\Oidc\OidcDiscovery;
 
 return static function (ContainerConfigurator $container) {
@@ -37,6 +39,7 @@ return static function (ContainerConfigurator $container) {
                 abstract_arg('authorization params'),
                 // replaced by the firewall verifier, unless the ID token signature is not verified
                 null,
+                service('clock'),
             ])
 
         ->set('security.authenticator.oidc_login.signature_verifier', OidcSignatureVerifier::class)
@@ -97,6 +100,28 @@ return static function (ContainerConfigurator $container) {
             ->args([
                 service_locator([]),
             ])
+
+        ->set('security.authenticator.oidc_login.token_refresher', OidcTokenRefresher::class)
+            ->abstract()
+            ->args([
+                abstract_arg('OIDC client'),
+                abstract_arg('OIDC discovery'),
+                abstract_arg('ID token'),
+                abstract_arg('client ID'),
+                // replaced by the firewall verifier, unless the ID token signature is not verified
+                null,
+                abstract_arg('leeway'),
+                service('clock'),
+            ])
+
+        ->set('security.authenticator.oidc_login.token_refresh_listener', OidcTokenRefreshListener::class)
+            ->abstract()
+            ->args([
+                service('security.token_storage'),
+                abstract_arg('OIDC token refresher'),
+                service('logger')->nullOnInvalid(),
+            ])
+            ->tag('monolog.logger', ['channel' => 'security'])
 
         ->set('security.authenticator.oidc_login.end_session_listener', OidcEndSessionListener::class)
             ->abstract()

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/OidcLoginFactoryTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/OidcLoginFactoryTest.php
@@ -177,6 +177,8 @@ class OidcLoginFactoryTest extends TestCase
         $this->assertSame('S256', $finalizedConfig['pkce']['method']);
         $this->assertSame(3600, $finalizedConfig['discovery_cache_ttl']);
         $this->assertSame([], $finalizedConfig['authorization_params']);
+        $this->assertFalse($finalizedConfig['refresh_access_token']['enabled']);
+        $this->assertSame(30, $finalizedConfig['refresh_access_token']['leeway']);
         $this->assertArrayNotHasKey('max_age', $finalizedConfig);
     }
 
@@ -877,6 +879,95 @@ class OidcLoginFactoryTest extends TestCase
         $factory->createAuthenticator($container, 'main', $config, 'userprovider');
 
         $this->assertSame(['authorization_endpoint', 'token_endpoint'], $container->getDefinition('security.authenticator.oidc_login.discovery.main')->getArgument(6));
+    }
+
+    public function testTokenRefresherIsAlwaysWired()
+    {
+        // the refresh token is kept on the security token whatever the configuration, so
+        // an application renewing the access token by itself needs no option turned on
+        $container = new ContainerBuilder();
+        $factory = new OidcLoginFactory();
+
+        $config = $this->processConfig([
+            'provider_uri' => 'https://provider.example.com',
+            'client_id' => 'my-client-id',
+            'client_secret' => 'my-client-secret',
+        ], $factory);
+        $factory->createAuthenticator($container, 'main', $config, 'userprovider');
+
+        $refresher = $container->getDefinition('security.authenticator.oidc_login.token_refresher.main');
+        $this->assertEquals(new Reference('security.authenticator.oidc_login.client.main'), $refresher->getArgument(0));
+        $this->assertEquals(new Reference('security.authenticator.oidc_login.discovery.main'), $refresher->getArgument(1));
+        $this->assertEquals(new Reference('security.authenticator.oidc_login.id_token.main'), $refresher->getArgument(2));
+        $this->assertSame('my-client-id', $refresher->getArgument(3));
+        $this->assertEquals(new Reference('security.authenticator.oidc_login.signature_verifier.main'), $refresher->getArgument(4));
+        $this->assertSame(30, $refresher->getArgument(5));
+    }
+
+    public function testTokenRefresherVerifiesNoSignatureWhenTheAuthenticatorDoesNot()
+    {
+        $container = new ContainerBuilder();
+        $factory = new OidcLoginFactory();
+
+        $config = $this->processConfig([
+            'provider_uri' => 'https://provider.example.com',
+            'client_id' => 'my-client-id',
+            'client_secret' => 'my-client-secret',
+            'id_token_signature' => ['required' => false],
+        ], $factory);
+        $factory->createAuthenticator($container, 'main', $config, 'userprovider');
+
+        $this->assertNull($container->getDefinition('security.authenticator.oidc_login.token_refresher.main')->getArgument(4));
+    }
+
+    public function testTokenRefreshListenerIsNotRegisteredByDefault()
+    {
+        $container = new ContainerBuilder();
+        $factory = new OidcLoginFactory();
+
+        $config = $this->processConfig([
+            'provider_uri' => 'https://provider.example.com',
+            'client_id' => 'my-client-id',
+            'client_secret' => 'my-client-secret',
+        ], $factory);
+        $factory->createAuthenticator($container, 'main', $config, 'userprovider');
+
+        $this->assertSame([], $factory->createListeners($container, 'main', $config));
+        $this->assertFalse($container->hasDefinition('security.authenticator.oidc_login.token_refresh_listener.main'));
+    }
+
+    public function testTokenRefreshListenerIsRegisteredWhenEnabled()
+    {
+        $container = new ContainerBuilder();
+        $factory = new OidcLoginFactory();
+
+        $config = $this->processConfig([
+            'provider_uri' => 'https://provider.example.com',
+            'client_id' => 'my-client-id',
+            'client_secret' => 'my-client-secret',
+            'refresh_access_token' => ['enabled' => true, 'leeway' => 60],
+        ], $factory);
+        $factory->createAuthenticator($container, 'main', $config, 'userprovider');
+
+        $this->assertSame(['security.authenticator.oidc_login.token_refresh_listener.main'], $factory->createListeners($container, 'main', $config));
+
+        $listener = $container->getDefinition('security.authenticator.oidc_login.token_refresh_listener.main');
+        $this->assertEquals(new Reference('security.authenticator.oidc_login.token_refresher.main'), $listener->getArgument(1));
+        $this->assertSame(60, $container->getDefinition('security.authenticator.oidc_login.token_refresher.main')->getArgument(5));
+    }
+
+    public function testRejectsANegativeLeeway()
+    {
+        $factory = new OidcLoginFactory();
+
+        $this->expectException(InvalidConfigurationException::class);
+
+        $this->processConfig([
+            'provider_uri' => 'https://provider.example.com',
+            'client_id' => 'my-client-id',
+            'client_secret' => 'my-client-secret',
+            'refresh_access_token' => ['enabled' => true, 'leeway' => -1],
+        ], $factory);
     }
 
     private function processConfig(array $config, OidcLoginFactory $factory): array

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
@@ -1319,6 +1319,63 @@ class SecurityExtensionTest extends TestCase
         $this->assertContains('custom_firewall_listener_id', $firewallListeners);
     }
 
+    public function testOidcLoginRegistersTheTokenRefreshListenerAfterTheContextListener()
+    {
+        // the listener renews the tokens the context listener just restored from the
+        // session, so it is worthless anywhere before it
+        $container = $this->getRawContainer();
+
+        $container->loadFromExtension('security', [
+            'firewalls' => [
+                'main' => [
+                    'oidc_login' => [
+                        'provider_uri' => 'https://provider.example.com',
+                        'client_id' => 'my-client-id',
+                        'client_secret' => 'my-client-secret',
+                        'refresh_access_token' => true,
+                    ],
+                ],
+            ],
+        ]);
+
+        $container->compile();
+
+        /** @var IteratorArgument $listenersIteratorArgument */
+        $listenersIteratorArgument = $container->getDefinition('security.firewall.map.context.main')->getArgument(0);
+        $firewallListeners = array_map('strval', $listenersIteratorArgument->getValues());
+
+        $this->assertContains('security.authenticator.oidc_login.token_refresh_listener.main', $firewallListeners);
+        $this->assertGreaterThan(
+            array_search('security.context_listener.0', $firewallListeners, true),
+            array_search('security.authenticator.oidc_login.token_refresh_listener.main', $firewallListeners, true),
+        );
+    }
+
+    public function testOidcLoginRegistersNoTokenRefreshListenerByDefault()
+    {
+        $container = $this->getRawContainer();
+
+        $container->loadFromExtension('security', [
+            'firewalls' => [
+                'main' => [
+                    'oidc_login' => [
+                        'provider_uri' => 'https://provider.example.com',
+                        'client_id' => 'my-client-id',
+                        'client_secret' => 'my-client-secret',
+                    ],
+                ],
+            ],
+        ]);
+
+        $container->compile();
+
+        /** @var IteratorArgument $listenersIteratorArgument */
+        $listenersIteratorArgument = $container->getDefinition('security.firewall.map.context.main')->getArgument(0);
+        $firewallListeners = array_map('strval', $listenersIteratorArgument->getValues());
+
+        $this->assertNotContains('security.authenticator.oidc_login.token_refresh_listener.main', $firewallListeners);
+    }
+
     public function testDisableLogoutTarget()
     {
         $container = $this->getRawContainer();

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/OidcLoginRouteLoaderTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/OidcLoginRouteLoaderTest.php
@@ -12,7 +12,10 @@
 namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
 
 use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\JsonMockResponse;
 use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\Security\Core\User\InMemoryUser;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 class OidcLoginRouteLoaderTest extends AbstractWebTestCase
 {
@@ -72,5 +75,128 @@ class OidcLoginRouteLoaderTest extends AbstractWebTestCase
         $this->assertNotEmpty($query['state']);
         $this->assertNotEmpty($query['nonce']);
         $this->assertNotEmpty($query['code_challenge']);
+    }
+
+    public function testTheAccessTokenIsRenewedOnTheNextRequest()
+    {
+        $client = $this->createClient(['test_case' => 'OidcLoginRouteLoader', 'root_config' => 'config_oidc_refresh.yml']);
+        $client->loginUser(new InMemoryUser('john', 'test', ['ROLE_USER']), 'oidc', [
+            'oidc_access_token' => 'access-123',
+            'oidc_refresh_token' => 'refresh-123',
+            'oidc_access_token_expires_at' => time() - 1,
+        ]);
+        $client->getContainer()->set(HttpClientInterface::class, new MockHttpClient($this->mockProvider([
+            'access_token' => 'access-456',
+            'refresh_token' => 'refresh-456',
+            'expires_in' => 300,
+        ])));
+        $client->getContainer()->get('security.token_storage')->setToken(null);
+
+        $client->request('GET', '/oidc/start');
+
+        $token = unserialize($client->getRequest()->getSession()->get('_security_oidc'));
+        $this->assertSame('access-456', $token->getAttribute('oidc_access_token'));
+        $this->assertSame('refresh-456', $token->getAttribute('oidc_refresh_token'));
+        $this->assertGreaterThan(time(), $token->getAttribute('oidc_access_token_expires_at'));
+    }
+
+    /**
+     * A lazy firewall, which is what the security recipe configures, asks every listener
+     * whether it supports the request before it restores the security token, so a listener
+     * that answers on the strength of that token is dropped from the chain for good.
+     */
+    public function testTheAccessTokenIsRenewedOnALazyFirewall()
+    {
+        $client = $this->createClient(['test_case' => 'OidcLoginRouteLoader', 'root_config' => 'config_oidc_refresh_lazy.yml']);
+        $client->loginUser(new InMemoryUser('john', 'test', ['ROLE_USER']), 'oidc', [
+            'oidc_access_token' => 'access-123',
+            'oidc_refresh_token' => 'refresh-123',
+            'oidc_access_token_expires_at' => time() - 1,
+        ]);
+        $client->getContainer()->set(HttpClientInterface::class, new MockHttpClient($this->mockProvider([
+            'access_token' => 'access-456',
+            'refresh_token' => 'refresh-456',
+            'expires_in' => 300,
+        ])));
+        $client->getContainer()->get('security.token_storage')->setToken(null);
+
+        $client->request('GET', '/oidc/start');
+
+        $token = unserialize($client->getRequest()->getSession()->get('_security_oidc'));
+        $this->assertSame('access-456', $token->getAttribute('oidc_access_token'));
+        $this->assertSame('refresh-456', $token->getAttribute('oidc_refresh_token'));
+    }
+
+    public function testTheUserIsLoggedOutWhenTheProviderRejectsTheRefreshToken()
+    {
+        $client = $this->createClient(['test_case' => 'OidcLoginRouteLoader', 'root_config' => 'config_oidc_refresh.yml']);
+        $client->loginUser(new InMemoryUser('john', 'test', ['ROLE_USER']), 'oidc', [
+            'oidc_access_token' => 'access-123',
+            'oidc_refresh_token' => 'refresh-123',
+            'oidc_access_token_expires_at' => time() - 1,
+        ]);
+        $client->getContainer()->set(HttpClientInterface::class, new MockHttpClient($this->mockProvider(['error' => 'invalid_grant'], 400)));
+        $client->getContainer()->get('security.token_storage')->setToken(null);
+
+        $client->request('GET', '/oidc/start');
+
+        $this->assertNull($client->getRequest()->getSession()->get('_security_oidc'));
+    }
+
+    public function testTheUserIsLoggedOutOnALazyFirewallWhenTheProviderRejectsTheRefreshToken()
+    {
+        $client = $this->createClient(['test_case' => 'OidcLoginRouteLoader', 'root_config' => 'config_oidc_refresh_lazy.yml']);
+        $client->loginUser(new InMemoryUser('john', 'test', ['ROLE_USER']), 'oidc', [
+            'oidc_access_token' => 'access-123',
+            'oidc_refresh_token' => 'refresh-123',
+            'oidc_access_token_expires_at' => time() - 1,
+        ]);
+        $client->getContainer()->set(HttpClientInterface::class, new MockHttpClient($this->mockProvider(['error' => 'invalid_grant'], 400)));
+        $client->getContainer()->get('security.token_storage')->setToken(null);
+
+        $client->request('GET', '/oidc/start');
+
+        $this->assertNull($client->getRequest()->getSession()->get('_security_oidc'));
+    }
+
+    public function testTheAccessTokenIsNotRenewedWithoutTheOption()
+    {
+        $client = $this->createClient(['test_case' => 'OidcLoginRouteLoader', 'root_config' => 'config_oidc.yml']);
+        $client->loginUser(new InMemoryUser('john', 'test', ['ROLE_USER']), 'oidc', [
+            'oidc_access_token' => 'access-123',
+            'oidc_refresh_token' => 'refresh-123',
+            'oidc_access_token_expires_at' => time() - 1,
+        ]);
+        $client->getContainer()->set(HttpClientInterface::class, new MockHttpClient($this->mockProvider(['access_token' => 'access-456'])));
+        $client->getContainer()->get('security.token_storage')->setToken(null);
+
+        $client->request('GET', '/oidc/start');
+
+        $token = unserialize($client->getRequest()->getSession()->get('_security_oidc'));
+        $this->assertSame('access-123', $token->getAttribute('oidc_access_token'));
+    }
+
+    /**
+     * @param array<string, mixed> $tokenEndpointResponse
+     */
+    private function mockProvider(array $tokenEndpointResponse, int $tokenEndpointStatusCode = 200): \Closure
+    {
+        return static function (string $method, string $url) use ($tokenEndpointResponse, $tokenEndpointStatusCode): MockResponse {
+            if (str_contains($url, '/.well-known/openid-configuration')) {
+                return new JsonMockResponse([
+                    'issuer' => 'https://accounts.example.com',
+                    'authorization_endpoint' => 'https://accounts.example.com/authorize',
+                    'token_endpoint' => 'https://accounts.example.com/token',
+                    'userinfo_endpoint' => 'https://accounts.example.com/userinfo',
+                    'jwks_uri' => 'https://accounts.example.com/jwks',
+                ]);
+            }
+
+            if (str_contains($url, '/token')) {
+                return new JsonMockResponse($tokenEndpointResponse, ['http_code' => $tokenEndpointStatusCode]);
+            }
+
+            throw new \LogicException(\sprintf('Unexpected request to "%s".', $url));
+        };
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/OidcLoginRouteLoader/config_oidc_refresh.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/OidcLoginRouteLoader/config_oidc_refresh.yml
@@ -19,6 +19,7 @@ security:
                 provider_uri: 'https://accounts.example.com'
                 client_id: client_id
                 client_secret: client_secret
+                refresh_access_token: true
         main:
             http_basic: ~
             stateless: true

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/OidcLoginRouteLoader/config_oidc_refresh_lazy.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/OidcLoginRouteLoader/config_oidc_refresh_lazy.yml
@@ -15,10 +15,15 @@ security:
         oidc:
             pattern: ^/oidc
             provider: in_memory
+            lazy: true
             oidc_login:
                 provider_uri: 'https://accounts.example.com'
                 client_id: client_id
                 client_secret: client_secret
+                refresh_access_token: true
         main:
             http_basic: ~
             stateless: true
+
+    access_control:
+        - { path: ^/oidc/start, roles: ROLE_USER }

--- a/src/Symfony/Component/Security/Http/Authenticator/Oidc/OidcClient.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Oidc/OidcClient.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Http\Authenticator\Oidc;
 
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Http\Exception\OidcInvalidGrantException;
 use Symfony\Component\Security\Http\Oidc\OidcDiscovery;
 use Symfony\Contracts\HttpClient\Exception\ExceptionInterface as HttpClientExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -63,6 +64,56 @@ abstract class OidcClient
 
         try {
             return $this->httpClient->request('POST', $tokenEndpoint, $options)->toArray();
+        } catch (HttpClientExceptionInterface $e) {
+            throw new AuthenticationException(\sprintf('The OIDC token endpoint request failed: "%s"', $e->getMessage()), previous: $e);
+        }
+    }
+
+    /**
+     * Renews an access token with the refresh token grant of RFC 6749, Section 6.
+     *
+     * The provider may answer with a new refresh token, which then replaces the one
+     * given here, and with a new ID token, which OIDC Core 1.0, Section 12.2 constrains.
+     *
+     * @param list<string> $scopes The scopes of the new access token, which RFC 6749,
+     *                             Section 6 only allows to narrow the ones the refresh
+     *                             token was issued with; the original scopes are asked
+     *                             for when the list is empty
+     *
+     * @return array<string, mixed>
+     *
+     * @throws OidcInvalidGrantException If the provider no longer honors the refresh token
+     * @throws AuthenticationException   If the token endpoint is missing, cannot be reached or returns an invalid response
+     */
+    public function refreshToken(#[\SensitiveParameter] string $refreshToken, array $scopes = []): array
+    {
+        $tokenEndpoint = $this->discovery->getSecureEndpoint('token_endpoint');
+
+        $body = [
+            'grant_type' => 'refresh_token',
+            'refresh_token' => $refreshToken,
+            'client_id' => $this->clientId,
+        ];
+
+        if ($scopes) {
+            $body['scope'] = implode(' ', $scopes);
+        }
+
+        $options = $this->applyClientAuthentication($body, []);
+
+        try {
+            $response = $this->httpClient->request('POST', $tokenEndpoint, $options);
+
+            // RFC 6749, Section 5.2: "invalid_grant" is the one error saying the refresh
+            // token itself is gone, where every other failure only means the request may
+            // be tried again; the status code is checked first so that a provider error
+            // page is never parsed as a token response
+            $statusCode = $response->getStatusCode();
+            if (400 <= $statusCode && $statusCode < 500 && 'invalid_grant' === ($response->toArray(false)['error'] ?? null)) {
+                throw new OidcInvalidGrantException('The OIDC provider rejected the refresh token: it expired, it was revoked, or it was issued to another client.');
+            }
+
+            return $response->toArray();
         } catch (HttpClientExceptionInterface $e) {
             throw new AuthenticationException(\sprintf('The OIDC token endpoint request failed: "%s"', $e->getMessage()), previous: $e);
         }

--- a/src/Symfony/Component/Security/Http/Authenticator/Oidc/OidcPublicClient.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Oidc/OidcPublicClient.php
@@ -33,7 +33,10 @@ class OidcPublicClient extends OidcClient
 {
     protected function applyClientAuthentication(array $body, array $options): array
     {
-        if ('' === ($body['code_verifier'] ?? '')) {
+        // the refresh token grant of RFC 6749, Section 6 carries neither a code nor a verifier;
+        // every other grant is refused without one, so that a grant added later never reaches the
+        // token endpoint unprotected
+        if ('refresh_token' !== ($body['grant_type'] ?? null) && '' === ($body['code_verifier'] ?? '')) {
             throw new \LogicException('A public OIDC client must exchange the authorization code with PKCE, as it sends no client secret. Pass the code verifier to "exchangeCode()", or use a confidential client.');
         }
 

--- a/src/Symfony/Component/Security/Http/Authenticator/Oidc/OidcSignatureVerifier.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Oidc/OidcSignatureVerifier.php
@@ -71,6 +71,8 @@ final class OidcSignatureVerifier
      */
     private const ROTATION_COOLDOWN = 60;
 
+    private readonly ClockInterface $clock;
+
     /**
      * @param list<string> $algorithms                  The signature algorithms accepted to verify the ID token (e.g. ["RS256"])
      * @param int          $jwksCacheTtl                The JWKS cache lifetime used when the provider advertises none
@@ -84,8 +86,13 @@ final class OidcSignatureVerifier
         private readonly array $algorithms = ['RS256'],
         private readonly int $jwksCacheTtl = 3600,
         private readonly bool $enforceKeyUsageVerification = true,
-        private readonly ClockInterface $clock = new Clock(),
+        ?ClockInterface $clock = null,
     ) {
+        if (null === $clock && !class_exists(Clock::class)) {
+            throw new \LogicException(\sprintf('The "symfony/clock" component is required to build "%s" without a clock. Try running "composer require symfony/clock", or pass any PSR-20 clock to the constructor.', self::class));
+        }
+
+        $this->clock = $clock ?? new Clock();
     }
 
     /**

--- a/src/Symfony/Component/Security/Http/Authenticator/Oidc/OidcTokenRefresher.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Oidc/OidcTokenRefresher.php
@@ -1,0 +1,158 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Authenticator\Oidc;
+
+use Psr\Clock\ClockInterface;
+use Symfony\Component\Clock\Clock;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Http\Exception\OidcInvalidGrantException;
+use Symfony\Component\Security\Http\Oidc\OidcDiscovery;
+
+/**
+ * Renews the OIDC tokens a security token carries, with the refresh token grant
+ * of RFC 6749, Section 6.
+ *
+ * The tokens the "oidc_login" authenticator obtained are held as attributes of the
+ * security token, which the firewall keeps in the session: renewing them in place is
+ * what keeps the access token usable to call an API on behalf of the logged-in user,
+ * long after the short lifetime the provider gave it.
+ *
+ * @see https://datatracker.ietf.org/doc/html/rfc6749#section-6 Refreshing an access token
+ *
+ * @author Florent Morselli <florent.morselli@spomky-labs.com>
+ */
+final class OidcTokenRefresher
+{
+    private readonly ClockInterface $clock;
+
+    /**
+     * @param string                     $clientId          The client the tokens were issued to, checked as the audience of a refreshed ID token
+     * @param OidcSignatureVerifier|null $signatureVerifier Verifies the signature of a refreshed ID token against the
+     *                                                      provider JWKS, or null to decode it without verifying it
+     * @param int                        $leeway            How many seconds before its expiry the access token is renewed,
+     *                                                      so that one handed to a downstream call does not expire in flight
+     * @param ClockInterface|null        $clock             The clock the expiry is read and written against, or null to use
+     *                                                      the clock of the "symfony/clock" component
+     */
+    public function __construct(
+        private readonly OidcClient $client,
+        private readonly OidcDiscovery $discovery,
+        private readonly OidcIdToken $idToken,
+        private readonly string $clientId,
+        private readonly ?OidcSignatureVerifier $signatureVerifier = null,
+        private readonly int $leeway = 30,
+        ?ClockInterface $clock = null,
+    ) {
+        if (null === $clock && !class_exists(Clock::class)) {
+            throw new \LogicException(\sprintf('The "symfony/clock" component is required to build "%s" without a clock. Try running "composer require symfony/clock", or pass any PSR-20 clock to the constructor.', self::class));
+        }
+
+        $this->clock = $clock ?? new Clock();
+    }
+
+    /**
+     * Renews the access token when it is about to expire, and reports whether it did.
+     *
+     * Nothing happens when the security token carries no refresh token, or when the
+     * token endpoint reported no "expires_in", as nothing then says the access token
+     * went stale.
+     *
+     * @throws OidcInvalidGrantException If the provider no longer honors the refresh token
+     * @throws AuthenticationException   If the renewal fails for any other reason
+     */
+    public function refreshIfNeeded(TokenInterface $token): bool
+    {
+        $refreshToken = $token->hasAttribute('oidc_refresh_token') ? $token->getAttribute('oidc_refresh_token') : null;
+        $expiresAt = $token->hasAttribute('oidc_access_token_expires_at') ? $token->getAttribute('oidc_access_token_expires_at') : null;
+
+        if (!\is_string($refreshToken) || '' === $refreshToken || !is_numeric($expiresAt)) {
+            return false;
+        }
+
+        if ($this->clock->now()->getTimestamp() + $this->leeway < (int) $expiresAt) {
+            return false;
+        }
+
+        $this->refresh($token);
+
+        return true;
+    }
+
+    /**
+     * Renews the access token, whatever its expiry, and stores the new tokens on the
+     * security token: the access token and its expiry, the refresh token when the
+     * provider rotated it, and the ID token when it issued a new one.
+     *
+     * @throws OidcInvalidGrantException If the provider no longer honors the refresh token
+     * @throws AuthenticationException   If the renewal fails for any other reason
+     */
+    public function refresh(TokenInterface $token): void
+    {
+        $refreshToken = $token->hasAttribute('oidc_refresh_token') ? $token->getAttribute('oidc_refresh_token') : null;
+        if (!\is_string($refreshToken) || '' === $refreshToken) {
+            throw new AuthenticationException('The security token carries no OIDC refresh token: the access token cannot be renewed.');
+        }
+
+        $tokenData = $this->client->refreshToken($refreshToken);
+
+        if (!\is_string($tokenData['access_token'] ?? null) || '' === $tokenData['access_token']) {
+            throw new AuthenticationException('The token endpoint response does not contain a valid "access_token".');
+        }
+
+        // the whole response is validated before anything is stored, so that a rejected
+        // ID token leaves the security token exactly as it was
+        if (isset($tokenData['id_token'])) {
+            $this->verifyRefreshedIdToken($token, $tokenData['id_token']);
+            $token->setAttribute('oidc_id_token', $tokenData['id_token']);
+        }
+
+        $token->setAttribute('oidc_access_token', $tokenData['access_token']);
+        $token->setAttribute('oidc_access_token_expires_at', is_numeric($tokenData['expires_in'] ?? null) ? $this->clock->now()->getTimestamp() + (int) $tokenData['expires_in'] : null);
+
+        // RFC 6749, Section 6: issuing a new refresh token is a MAY, and the one just
+        // used stays valid until the provider replaces it
+        if (\is_string($tokenData['refresh_token'] ?? null) && '' !== $tokenData['refresh_token']) {
+            $token->setAttribute('oidc_refresh_token', $tokenData['refresh_token']);
+        }
+    }
+
+    /**
+     * Validates an ID token returned by the refresh token grant, per OIDC Core 1.0,
+     * Section 12.2.
+     *
+     * Neither a "nonce" nor a "max_age" is checked here: no authorization request was
+     * made, and the "auth_time" claim still reports the original authentication.
+     *
+     * @throws AuthenticationException If the refreshed ID token does not describe the same authentication
+     */
+    private function verifyRefreshedIdToken(TokenInterface $token, mixed $idToken): void
+    {
+        if (!\is_string($idToken) || '' === $idToken) {
+            throw new AuthenticationException('The token endpoint response does not contain a valid "id_token".');
+        }
+
+        $claims = null !== $this->signatureVerifier ? $this->signatureVerifier->verify($idToken) : $this->idToken->decode($idToken);
+
+        $this->idToken->validateClaims($claims, $this->discovery->getConfiguration()['issuer'] ?? '', $this->clientId);
+
+        $previousIdToken = $token->hasAttribute('oidc_id_token') ? $token->getAttribute('oidc_id_token') : null;
+        if (!\is_string($previousIdToken) || '' === $previousIdToken) {
+            throw new AuthenticationException('The security token carries no OIDC ID token to compare the refreshed one against.');
+        }
+
+        $previousSubject = $this->idToken->decode($previousIdToken)['sub'] ?? null;
+        if (!\is_string($previousSubject) || !\is_string($claims['sub'] ?? null) || !hash_equals($previousSubject, $claims['sub'])) {
+            throw new AuthenticationException('The "sub" claim of the refreshed ID token does not match the one of the ID token issued at authentication.');
+        }
+    }
+}

--- a/src/Symfony/Component/Security/Http/Authenticator/OidcLoginAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/OidcLoginAuthenticator.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Security\Http\Authenticator;
 
+use Psr\Clock\ClockInterface;
+use Symfony\Component\Clock\Clock;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -49,6 +51,7 @@ final class OidcLoginAuthenticator extends AbstractAuthenticator implements Auth
     private const MANAGED_PARAMS = ['response_type', 'client_id', 'redirect_uri', 'scope', 'state', 'nonce', 'code_challenge', 'code_challenge_method', 'max_age'];
 
     private array $options;
+    private readonly ClockInterface $clock;
 
     /**
      * @param array<string, string>      $authorizationParams Additional parameters of the authorization request, e.g.
@@ -58,6 +61,9 @@ final class OidcLoginAuthenticator extends AbstractAuthenticator implements Auth
      *                                                        or null to decode the token without verifying it, which
      *                                                        OIDC Core 1.0, Section 3.1.3.7, item 6 only allows as long
      *                                                        as the token endpoint request verifies TLS
+     * @param ClockInterface|null        $clock               Turns the "expires_in" of the token endpoint response into
+     *                                                        the absolute expiry the security token carries, or null to
+     *                                                        use the clock of the "symfony/clock" component
      */
     public function __construct(
         private readonly HttpUtils $httpUtils,
@@ -71,7 +77,14 @@ final class OidcLoginAuthenticator extends AbstractAuthenticator implements Auth
         array $options,
         private readonly array $authorizationParams = [],
         private readonly ?OidcSignatureVerifier $signatureVerifier = null,
+        ?ClockInterface $clock = null,
     ) {
+        if (null === $clock && !class_exists(Clock::class)) {
+            throw new \LogicException(\sprintf('The "symfony/clock" component is required to build "%s" without a clock. Try running "composer require symfony/clock", or pass any PSR-20 clock to the constructor.', self::class));
+        }
+
+        $this->clock = $clock ?? new Clock();
+
         $this->options = array_merge([
             'check_path' => '/oidc/callback',
             'firewall_name' => 'main',
@@ -273,6 +286,11 @@ final class OidcLoginAuthenticator extends AbstractAuthenticator implements Auth
         if (\is_array($tokenData)) {
             $token->setAttribute('oidc_id_token', $tokenData['id_token'] ?? null);
             $token->setAttribute('oidc_access_token', $tokenData['access_token'] ?? null);
+            // the refresh token of RFC 6749, Section 6 and the expiry of the access token
+            // it renews; both are null unless the provider issued them, as it only issues
+            // a refresh token when it was asked for one, and "expires_in" is optional
+            $token->setAttribute('oidc_refresh_token', $tokenData['refresh_token'] ?? null);
+            $token->setAttribute('oidc_access_token_expires_at', is_numeric($tokenData['expires_in'] ?? null) ? $this->clock->now()->getTimestamp() + (int) $tokenData['expires_in'] : null);
         }
 
         return $token;

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -25,6 +25,8 @@ CHANGELOG
  * Add the `user_data_source` and `user_identifier_claim` options to `OidcLoginAuthenticator` to pick where the user claims are read from and the claim the user identifier is read from
  * Add `OidcEndSessionListener` for RP-Initiated Logout via the OIDC `end_session_endpoint`
  * Add `UnsupportedReasons`, held by the `SecurityRequestAttributes::UNSUPPORTED_REASONS` request attribute while the profiler is enabled, so that `supports()` can tell why an authenticator did not support a request
+ * Add the `oidc_refresh_token` and `oidc_access_token_expires_at` attributes to the token `OidcLoginAuthenticator` creates, and a `$clock` argument to its constructor
+ * Add `OidcClient::refreshToken()`, `OidcTokenRefresher` and `OidcTokenRefreshListener` to renew the OIDC access token with the refresh token grant
  * Add the `$enforceAtJwtType` argument to `OidcTokenHandler` to reject the tokens whose `typ` header is not the `at+jwt` RFC 9068 requires from an access token
  * Deprecate not passing the `$enforceAtJwtType` argument to `OidcTokenHandler`; it defaults to `false` in 8.2 and will default to `true` in 9.0
  * Make `OidcTokenGenerator` emit the `at+jwt` type header RFC 9068 requires from an access token

--- a/src/Symfony/Component/Security/Http/Exception/OidcInvalidGrantException.php
+++ b/src/Symfony/Component/Security/Http/Exception/OidcInvalidGrantException.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Exception;
+
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+
+/**
+ * Thrown when an OIDC provider answers a token request with the "invalid_grant"
+ * error of RFC 6749, Section 5.2.
+ *
+ * It is the one token endpoint error a caller has to tell apart from every other
+ * failure: the grant is gone for good, where an unreachable provider or a server
+ * error only means the request can be tried again.
+ *
+ * @author Florent Morselli <florent.morselli@spomky-labs.com>
+ */
+class OidcInvalidGrantException extends AuthenticationException
+{
+    public function getMessageKey(): string
+    {
+        return 'The OIDC provider rejected the grant.';
+    }
+}

--- a/src/Symfony/Component/Security/Http/Firewall/OidcTokenRefreshListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/OidcTokenRefreshListener.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Firewall;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Http\Authenticator\Oidc\OidcTokenRefresher;
+use Symfony\Component\Security\Http\Exception\OidcInvalidGrantException;
+
+/**
+ * Renews the OIDC access token of the logged-in user before it expires.
+ *
+ * It runs after the firewall restored the security token from the session, so the
+ * renewed tokens are the ones the request and the rest of the session see. Failing
+ * to renew only ends the session when the provider says the refresh token is gone:
+ * a provider that cannot be reached would otherwise log every user out at once.
+ *
+ * @author Florent Morselli <florent.morselli@spomky-labs.com>
+ */
+final class OidcTokenRefreshListener extends AbstractListener
+{
+    public function __construct(
+        private readonly TokenStorageInterface $tokenStorage,
+        private readonly OidcTokenRefresher $refresher,
+        private readonly ?LoggerInterface $logger = null,
+    ) {
+    }
+
+    /**
+     * Always defers to authenticate(), the way ContextListener does.
+     *
+     * A lazy firewall calls supports() on every listener before it installs the token
+     * storage initializer, so the security token is not restored yet: deciding here
+     * whether there is a refresh token to use would evict this listener from the chain
+     * on every lazy firewall, which is what the recipe configures. Returning null keeps
+     * the firewall lazy, and authenticate() is the one that checks the security token.
+     */
+    public function supports(Request $request): ?bool
+    {
+        return null;
+    }
+
+    public function authenticate(RequestEvent $event): void
+    {
+        if (null === $token = $this->tokenStorage->getToken()) {
+            return;
+        }
+
+        try {
+            if ($this->refresher->refreshIfNeeded($token)) {
+                $this->logger?->debug('Renewed the OIDC access token of the logged-in user.');
+            }
+        } catch (OidcInvalidGrantException $e) {
+            $this->logger?->info('The OIDC provider no longer honors the refresh token; logging the user out.', ['exception' => $e]);
+
+            $this->tokenStorage->setToken(null);
+        } catch (AuthenticationException $e) {
+            // the renewal is tried again on the next request, with the tokens left untouched
+            $this->logger?->warning('Could not renew the OIDC access token of the logged-in user.', ['exception' => $e]);
+        }
+    }
+}

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/Oidc/OidcConfidentialClientTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/Oidc/OidcConfidentialClientTest.php
@@ -20,6 +20,7 @@ use Symfony\Component\HttpClient\Response\JsonMockResponse;
 use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\Authenticator\Oidc\OidcConfidentialClient;
+use Symfony\Component\Security\Http\Exception\OidcInvalidGrantException;
 use Symfony\Component\Security\Http\Oidc\OidcDiscovery;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
@@ -257,6 +258,118 @@ class OidcConfidentialClientTest extends TestCase
         $this->expectExceptionMessage('The OIDC userinfo endpoint request failed');
 
         $this->createClient()->fetchUserInfo('access-token');
+    }
+
+    public function testRefreshToken()
+    {
+        $mockResponse = new JsonMockResponse([
+            'access_token' => 'access-456',
+            'refresh_token' => 'refresh-456',
+            'expires_in' => 300,
+        ]);
+
+        $client = new OidcConfidentialClient(new MockHttpClient($mockResponse), $this->discovery, 'test-client-id', 'test-client-secret');
+        $tokens = $client->refreshToken('refresh-123');
+
+        $this->assertSame('https://provider.example.com/token', $mockResponse->getRequestUrl());
+        parse_str($mockResponse->getRequestOptions()['body'], $body);
+        $this->assertSame('refresh_token', $body['grant_type']);
+        $this->assertSame('refresh-123', $body['refresh_token']);
+        $this->assertSame('test-client-id', $body['client_id']);
+        $this->assertSame('test-client-secret', $body['client_secret']);
+        $this->assertArrayNotHasKey('scope', $body);
+        $this->assertSame('access-456', $tokens['access_token']);
+        $this->assertSame('refresh-456', $tokens['refresh_token']);
+    }
+
+    public function testRefreshTokenNarrowsTheScopes()
+    {
+        $mockResponse = new JsonMockResponse(['access_token' => 'access-456']);
+
+        $client = new OidcConfidentialClient(new MockHttpClient($mockResponse), $this->discovery, 'test-client-id', 'test-client-secret');
+        $client->refreshToken('refresh-123', ['openid', 'profile']);
+
+        parse_str($mockResponse->getRequestOptions()['body'], $body);
+        $this->assertSame('openid profile', $body['scope']);
+    }
+
+    public function testRefreshTokenWithClientSecretBasic()
+    {
+        $mockResponse = new JsonMockResponse(['access_token' => 'access-456']);
+
+        $client = new OidcConfidentialClient(new MockHttpClient($mockResponse), $this->discovery, 'test-client-id', 'test-client-secret', 'client_secret_basic');
+        $client->refreshToken('refresh-123');
+
+        $requestOptions = $mockResponse->getRequestOptions();
+        $this->assertSame(['Authorization: Basic '.base64_encode('test-client-id:test-client-secret')], $requestOptions['normalized_headers']['authorization']);
+        $this->assertStringNotContainsString('client_secret', $requestOptions['body']);
+    }
+
+    public function testRefreshTokenReportsAnInvalidGrantOnItsOwn()
+    {
+        // RFC 6749 Section 5.2: only "invalid_grant" says the refresh token is gone for
+        // good, so it is the only failure a caller may act on by ending the session
+        $client = new OidcConfidentialClient(
+            new MockHttpClient(new JsonMockResponse(['error' => 'invalid_grant', 'error_description' => 'Token is not active'], ['http_code' => 400])),
+            $this->discovery,
+            'test-client-id',
+            'test-client-secret',
+        );
+
+        $this->expectException(OidcInvalidGrantException::class);
+        $this->expectExceptionMessage('The OIDC provider rejected the refresh token');
+
+        $client->refreshToken('refresh-123');
+    }
+
+    public function testRefreshTokenReportsAnotherProviderErrorAsAPlainFailure()
+    {
+        $client = new OidcConfidentialClient(
+            new MockHttpClient(new JsonMockResponse(['error' => 'invalid_client'], ['http_code' => 401])),
+            $this->discovery,
+            'test-client-id',
+            'test-client-secret',
+        );
+
+        try {
+            $client->refreshToken('refresh-123');
+            $this->fail(\sprintf('Expected an "%s" to be thrown.', AuthenticationException::class));
+        } catch (AuthenticationException $e) {
+            $this->assertNotInstanceOf(OidcInvalidGrantException::class, $e);
+            $this->assertStringContainsString('The OIDC token endpoint request failed', $e->getMessage());
+        }
+    }
+
+    public function testRefreshTokenReportsAnUnreachableProviderAsAPlainFailure()
+    {
+        $client = new OidcConfidentialClient(
+            new MockHttpClient(new MockResponse('Service Unavailable', ['http_code' => 503])),
+            $this->discovery,
+            'test-client-id',
+            'test-client-secret',
+        );
+
+        try {
+            $client->refreshToken('refresh-123');
+            $this->fail(\sprintf('Expected an "%s" to be thrown.', AuthenticationException::class));
+        } catch (AuthenticationException $e) {
+            $this->assertNotInstanceOf(OidcInvalidGrantException::class, $e);
+            $this->assertStringContainsString('The OIDC token endpoint request failed', $e->getMessage());
+        }
+    }
+
+    public function testRefreshTokenRejectsAnInsecureTokenEndpoint()
+    {
+        $discovery = $this->createDiscovery(['token_endpoint' => 'http://provider.example.com/token']);
+
+        $this->httpClient->expects($this->never())->method('request');
+
+        $client = new OidcConfidentialClient($this->httpClient, $discovery, 'test-client-id', 'test-client-secret');
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('must use HTTPS');
+
+        $client->refreshToken('refresh-123');
     }
 
     private function createClient(string $tokenEndpointAuthMethod = 'client_secret_post'): OidcConfidentialClient

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/Oidc/OidcPublicClientTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/Oidc/OidcPublicClientTest.php
@@ -129,6 +129,23 @@ class OidcPublicClientTest extends TestCase
         $this->assertSame('test@example.com', $claims['email']);
     }
 
+    public function testRefreshTokenNeedsNoCodeVerifier()
+    {
+        // PKCE binds the authorization code to this client; the refresh token grant of
+        // RFC 6749 Section 6 carries neither a code nor a verifier
+        $mockResponse = new JsonMockResponse(['access_token' => 'access-456']);
+
+        $client = new OidcPublicClient(new MockHttpClient($mockResponse), $this->discovery, 'test-client-id');
+        $tokens = $client->refreshToken('refresh-123');
+
+        parse_str($mockResponse->getRequestOptions()['body'], $body);
+        $this->assertSame('refresh_token', $body['grant_type']);
+        $this->assertSame('refresh-123', $body['refresh_token']);
+        $this->assertSame('test-client-id', $body['client_id']);
+        $this->assertArrayNotHasKey('client_secret', $body);
+        $this->assertSame('access-456', $tokens['access_token']);
+    }
+
     private function createClient(): OidcPublicClient
     {
         return new OidcPublicClient(

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/Oidc/OidcTokenRefresherTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/Oidc/OidcTokenRefresherTest.php
@@ -1,0 +1,361 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Tests\Authenticator\Oidc;
+
+use Jose\Component\Core\AlgorithmManager;
+use Jose\Component\Core\JWK;
+use Jose\Component\Signature\Algorithm\ES256;
+use Jose\Component\Signature\JWSBuilder;
+use Jose\Component\Signature\Serializer\CompactSerializer;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Clock\MockClock;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\JsonMockResponse;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\User\InMemoryUser;
+use Symfony\Component\Security\Http\Authenticator\Oidc\OidcConfidentialClient;
+use Symfony\Component\Security\Http\Authenticator\Oidc\OidcIdToken;
+use Symfony\Component\Security\Http\Authenticator\Oidc\OidcSignatureVerifier;
+use Symfony\Component\Security\Http\Authenticator\Oidc\OidcTokenRefresher;
+use Symfony\Component\Security\Http\Authenticator\Token\PostAuthenticationToken;
+use Symfony\Component\Security\Http\Oidc\OidcDiscovery;
+
+class OidcTokenRefresherTest extends TestCase
+{
+    private MockClock $clock;
+    private OidcDiscovery $discovery;
+
+    protected function setUp(): void
+    {
+        $this->clock = new MockClock('2026-09-06 12:00:00');
+        $this->discovery = new OidcDiscovery(
+            new MockHttpClient(static fn (): MockResponse => new JsonMockResponse([
+                'issuer' => 'https://provider.example.com',
+                'token_endpoint' => 'https://provider.example.com/token',
+                'jwks_uri' => 'https://provider.example.com/jwks',
+            ])),
+            new ArrayAdapter(),
+            'https://provider.example.com/.well-known/openid-configuration',
+        );
+    }
+
+    public function testRefreshIfNeededLeavesAValidAccessTokenAlone()
+    {
+        $refresher = $this->createRefresher(new JsonMockResponse(['access_token' => 'access-456']));
+        $token = $this->createToken(['oidc_access_token_expires_at' => $this->clock->now()->getTimestamp() + 300]);
+
+        $this->assertFalse($refresher->refreshIfNeeded($token));
+        $this->assertSame('access-123', $token->getAttribute('oidc_access_token'));
+    }
+
+    public function testRefreshIfNeededDoesNothingWithoutARefreshToken()
+    {
+        $refresher = $this->createRefresher(new JsonMockResponse(['access_token' => 'access-456']));
+        $token = $this->createToken([
+            'oidc_refresh_token' => null,
+            'oidc_access_token_expires_at' => $this->clock->now()->getTimestamp() - 1,
+        ]);
+
+        $this->assertFalse($refresher->refreshIfNeeded($token));
+        $this->assertSame('access-123', $token->getAttribute('oidc_access_token'));
+    }
+
+    public function testRefreshIfNeededDoesNothingWithoutAKnownExpiry()
+    {
+        // RFC 6749 Section 5.1 makes "expires_in" optional: nothing then says the access
+        // token went stale, so renewing it on every request would be the only alternative
+        $refresher = $this->createRefresher(new JsonMockResponse(['access_token' => 'access-456']));
+        $token = $this->createToken(['oidc_access_token_expires_at' => null]);
+
+        $this->assertFalse($refresher->refreshIfNeeded($token));
+        $this->assertSame('access-123', $token->getAttribute('oidc_access_token'));
+    }
+
+    public function testRefreshIfNeededRenewsWithinTheLeeway()
+    {
+        // the access token is handed to a downstream call, which must not receive one
+        // expiring while it is in flight
+        $refresher = $this->createRefresher(new JsonMockResponse(['access_token' => 'access-456', 'expires_in' => 300]), leeway: 30);
+        $token = $this->createToken(['oidc_access_token_expires_at' => $this->clock->now()->getTimestamp() + 29]);
+
+        $this->assertTrue($refresher->refreshIfNeeded($token));
+        $this->assertSame('access-456', $token->getAttribute('oidc_access_token'));
+        $this->assertSame($this->clock->now()->getTimestamp() + 300, $token->getAttribute('oidc_access_token_expires_at'));
+    }
+
+    public function testRefreshStoresARotatedRefreshToken()
+    {
+        $mockResponse = new JsonMockResponse(['access_token' => 'access-456', 'refresh_token' => 'refresh-456', 'expires_in' => 300]);
+        $refresher = $this->createRefresher($mockResponse);
+        $token = $this->createToken();
+
+        $refresher->refresh($token);
+
+        parse_str($mockResponse->getRequestOptions()['body'], $body);
+        $this->assertSame('refresh-123', $body['refresh_token']);
+        $this->assertSame('refresh-456', $token->getAttribute('oidc_refresh_token'));
+    }
+
+    public function testRefreshKeepsThePreviousRefreshTokenWhenTheProviderRotatesNone()
+    {
+        // RFC 6749 Section 6: issuing a new refresh token is a MAY, and the previous one
+        // stays usable until the provider replaces it
+        $refresher = $this->createRefresher(new JsonMockResponse(['access_token' => 'access-456', 'expires_in' => 300]));
+        $token = $this->createToken();
+
+        $refresher->refresh($token);
+
+        $this->assertSame('refresh-123', $token->getAttribute('oidc_refresh_token'));
+    }
+
+    public function testRefreshClearsTheExpiryWhenTheProviderReportsNone()
+    {
+        $refresher = $this->createRefresher(new JsonMockResponse(['access_token' => 'access-456']));
+        $token = $this->createToken(['oidc_access_token_expires_at' => $this->clock->now()->getTimestamp() - 1]);
+
+        $refresher->refresh($token);
+
+        $this->assertSame('access-456', $token->getAttribute('oidc_access_token'));
+        $this->assertNull($token->getAttribute('oidc_access_token_expires_at'));
+    }
+
+    public function testRefreshStoresARefreshedIdToken()
+    {
+        $refreshedIdToken = $this->buildIdToken();
+        $refresher = $this->createRefresher(new JsonMockResponse(['access_token' => 'access-456', 'id_token' => $refreshedIdToken]));
+        $token = $this->createToken();
+
+        $refresher->refresh($token);
+
+        $this->assertSame($refreshedIdToken, $token->getAttribute('oidc_id_token'));
+    }
+
+    public function testRefreshKeepsThePreviousIdTokenWhenTheProviderReturnsNone()
+    {
+        $refresher = $this->createRefresher(new JsonMockResponse(['access_token' => 'access-456']));
+        $token = $this->createToken();
+        $previousIdToken = $token->getAttribute('oidc_id_token');
+
+        $refresher->refresh($token);
+
+        $this->assertSame($previousIdToken, $token->getAttribute('oidc_id_token'));
+    }
+
+    public function testRefreshRejectsARefreshedIdTokenOfAnotherSubject()
+    {
+        // OIDC Core 1.0 Section 12.2: the refreshed ID token describes the very same
+        // authentication, so a different "sub" would silently switch the logged-in user
+        $refresher = $this->createRefresher(new JsonMockResponse([
+            'access_token' => 'access-456',
+            'id_token' => $this->buildIdToken(['sub' => 'user-99']),
+        ]));
+        $token = $this->createToken();
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('The "sub" claim of the refreshed ID token does not match');
+
+        $refresher->refresh($token);
+    }
+
+    /**
+     * Without the ID token of the original authentication there is nothing to bind the refreshed
+     * one to, so nothing says it still describes the user this security token authenticated.
+     */
+    public function testRefreshRejectsARefreshedIdTokenWithNothingToBindItTo()
+    {
+        $refresher = $this->createRefresher(new JsonMockResponse(['access_token' => 'access-456', 'id_token' => $this->buildIdToken()]));
+        $token = $this->createToken(['oidc_id_token' => null]);
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('carries no OIDC ID token to compare the refreshed one against');
+
+        $refresher->refresh($token);
+    }
+
+    public function testRefreshRejectsARefreshedIdTokenOfAnotherIssuer()
+    {
+        $refresher = $this->createRefresher(new JsonMockResponse([
+            'access_token' => 'access-456',
+            'id_token' => $this->buildIdToken(['iss' => 'https://evil.example.com']),
+        ]));
+        $token = $this->createToken();
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('Invalid ID token');
+
+        $refresher->refresh($token);
+    }
+
+    public function testRefreshDoesNotStoreAnythingWhenTheRefreshedIdTokenIsRejected()
+    {
+        $refresher = $this->createRefresher(new JsonMockResponse([
+            'access_token' => 'access-456',
+            'refresh_token' => 'refresh-456',
+            'id_token' => $this->buildIdToken(['sub' => 'user-99']),
+        ]));
+        $token = $this->createToken();
+
+        try {
+            $refresher->refresh($token);
+            $this->fail(\sprintf('Expected an "%s" to be thrown.', AuthenticationException::class));
+        } catch (AuthenticationException) {
+        }
+
+        $this->assertSame('access-123', $token->getAttribute('oidc_access_token'));
+        $this->assertSame('refresh-123', $token->getAttribute('oidc_refresh_token'));
+    }
+
+    public function testRefreshVerifiesTheSignatureOfARefreshedIdToken()
+    {
+        $refresher = $this->createRefresher(
+            new JsonMockResponse(['access_token' => 'access-456', 'id_token' => $this->buildForgedIdToken()]),
+            signatureVerifier: $this->createSignatureVerifier(),
+        );
+        $token = $this->createToken();
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('signature');
+
+        $refresher->refresh($token);
+    }
+
+    public function testRefreshAcceptsASignedRefreshedIdToken()
+    {
+        $refreshedIdToken = $this->buildSignedIdToken();
+        $refresher = $this->createRefresher(
+            new JsonMockResponse(['access_token' => 'access-456', 'id_token' => $refreshedIdToken]),
+            signatureVerifier: $this->createSignatureVerifier(),
+        );
+        $token = $this->createToken();
+
+        $refresher->refresh($token);
+
+        $this->assertSame($refreshedIdToken, $token->getAttribute('oidc_id_token'));
+    }
+
+    public function testRefreshThrowsWithoutARefreshToken()
+    {
+        $refresher = $this->createRefresher(new JsonMockResponse(['access_token' => 'access-456']));
+        $token = $this->createToken(['oidc_refresh_token' => null]);
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('carries no OIDC refresh token');
+
+        $refresher->refresh($token);
+    }
+
+    public function testRefreshRejectsAResponseWithoutAnAccessToken()
+    {
+        $refresher = $this->createRefresher(new JsonMockResponse(['token_type' => 'Bearer']));
+        $token = $this->createToken();
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('does not contain a valid "access_token"');
+
+        $refresher->refresh($token);
+    }
+
+    private function createRefresher(MockResponse $tokenEndpointResponse, ?OidcSignatureVerifier $signatureVerifier = null, int $leeway = 30): OidcTokenRefresher
+    {
+        return new OidcTokenRefresher(
+            new OidcConfidentialClient(new MockHttpClient($tokenEndpointResponse), $this->discovery, 'test-client-id', 'test-client-secret'),
+            $this->discovery,
+            new OidcIdToken($this->clock),
+            'test-client-id',
+            $signatureVerifier,
+            $leeway,
+            $this->clock,
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $attributes
+     */
+    private function createToken(array $attributes = []): TokenInterface
+    {
+        $token = new PostAuthenticationToken(new InMemoryUser('user-42', null), 'main', ['ROLE_USER']);
+        $token->setAttributes(array_merge([
+            'oidc_id_token' => $this->buildIdToken(),
+            'oidc_access_token' => 'access-123',
+            'oidc_refresh_token' => 'refresh-123',
+            'oidc_access_token_expires_at' => $this->clock->now()->getTimestamp() - 1,
+        ], $attributes));
+
+        return $token;
+    }
+
+    /**
+     * @param array<string, mixed> $extraClaims
+     */
+    private function buildIdTokenClaims(array $extraClaims = []): array
+    {
+        return array_merge([
+            'iss' => 'https://provider.example.com',
+            'aud' => 'test-client-id',
+            'sub' => 'user-42',
+            'exp' => $this->clock->now()->getTimestamp() + 3600,
+            'iat' => $this->clock->now()->getTimestamp(),
+        ], $extraClaims);
+    }
+
+    private function buildIdToken(array $extraClaims = []): string
+    {
+        $encode = static fn (array $value): string => rtrim(strtr(base64_encode(json_encode($value)), '+/', '-_'), '=');
+
+        return $encode(['alg' => 'RS256', 'typ' => 'JWT']).'.'.$encode($this->buildIdTokenClaims($extraClaims)).'.'.rtrim(strtr(base64_encode('fake-signature'), '+/', '-_'), '=');
+    }
+
+    private function buildSignedIdToken(array $extraClaims = []): string
+    {
+        return (new CompactSerializer())->serialize(
+            (new JWSBuilder(new AlgorithmManager([new ES256()])))
+                ->withPayload(json_encode($this->buildIdTokenClaims($extraClaims)))
+                ->addSignature(new JWK([
+                    'kty' => 'EC',
+                    'crv' => 'P-256',
+                    'x' => '0QEAsI1wGI-dmYatdUZoWSRWggLEpyzopuhwk-YUnA4',
+                    'y' => 'KYl-qyZ26HobuYwlQh-r0iHX61thfP82qqEku7i0woo',
+                    'd' => 'iA_TV2zvftni_9aFAQwFO_9aypfJFCSpcCyevDvz220',
+                ]), ['alg' => 'ES256', 'kid' => 'signing-key'])
+                ->build()
+        );
+    }
+
+    private function buildForgedIdToken(array $extraClaims = []): string
+    {
+        [$header, $payload] = explode('.', $this->buildSignedIdToken($extraClaims));
+
+        return $header.'.'.$payload.'.'.rtrim(strtr(base64_encode('forged-signature'), '+/', '-_'), '=');
+    }
+
+    private function createSignatureVerifier(): OidcSignatureVerifier
+    {
+        return new OidcSignatureVerifier(
+            $this->discovery,
+            new ArrayAdapter(),
+            new MockHttpClient(new JsonMockResponse(['keys' => [[
+                'kid' => 'signing-key',
+                'kty' => 'EC',
+                'crv' => 'P-256',
+                'x' => '0QEAsI1wGI-dmYatdUZoWSRWggLEpyzopuhwk-YUnA4',
+                'y' => 'KYl-qyZ26HobuYwlQh-r0iHX61thfP82qqEku7i0woo',
+                'use' => 'sig',
+                'alg' => 'ES256',
+            ]]])),
+            ['ES256'],
+            clock: $this->clock,
+        );
+    }
+}

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/OidcLoginAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/OidcLoginAuthenticatorTest.php
@@ -19,8 +19,10 @@ use Jose\Component\Signature\Serializer\CompactSerializer;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Psr\Clock\ClockInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Clock\Clock;
+use Symfony\Component\Clock\MockClock;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\JsonMockResponse;
 use Symfony\Component\HttpClient\Response\MockResponse;
@@ -1063,6 +1065,51 @@ class OidcLoginAuthenticatorTest extends TestCase
         $this->assertSame('access-123', $token->getAttribute('oidc_access_token'));
     }
 
+    public function testCreateTokenStoresTheRefreshTokenAndTheAccessTokenExpiry()
+    {
+        $nonce = bin2hex(random_bytes(16));
+        $state = bin2hex(random_bytes(16));
+
+        $this->oidcClient->method('exchangeCode')->willReturn([
+            'access_token' => 'access-123',
+            'id_token' => $this->buildIdToken(['nonce' => $nonce]),
+            'refresh_token' => 'refresh-123',
+            'expires_in' => 300,
+        ]);
+        $this->oidcClient->method('fetchUserInfo')->willReturn(['sub' => 'user-42']);
+
+        $clock = new MockClock('2026-09-06 12:00:00');
+        $authenticator = $this->createAuthenticator(clock: $clock);
+        $passport = $authenticator->authenticate($this->createCallbackRequest($state, $nonce));
+
+        $token = $authenticator->createToken($passport, 'main');
+
+        $this->assertSame('refresh-123', $token->getAttribute('oidc_refresh_token'));
+        $this->assertSame($clock->now()->getTimestamp() + 300, $token->getAttribute('oidc_access_token_expires_at'));
+    }
+
+    public function testCreateTokenReportsAMissingRefreshTokenAndExpiryAsNull()
+    {
+        // a provider only issues a refresh token when it was asked for one, e.g. with the
+        // "offline_access" scope, and "expires_in" is optional in RFC 6749, Section 5.1
+        $nonce = bin2hex(random_bytes(16));
+        $state = bin2hex(random_bytes(16));
+
+        $this->oidcClient->method('exchangeCode')->willReturn([
+            'access_token' => 'access-123',
+            'id_token' => $this->buildIdToken(['nonce' => $nonce]),
+        ]);
+        $this->oidcClient->method('fetchUserInfo')->willReturn(['sub' => 'user-42']);
+
+        $authenticator = $this->createAuthenticator();
+        $passport = $authenticator->authenticate($this->createCallbackRequest($state, $nonce));
+
+        $token = $authenticator->createToken($passport, 'main');
+
+        $this->assertNull($token->getAttribute('oidc_refresh_token'));
+        $this->assertNull($token->getAttribute('oidc_access_token_expires_at'));
+    }
+
     public function testSessionClearedEvenWhenExchangeCodeFails()
     {
         $state = bin2hex(random_bytes(16));
@@ -1393,7 +1440,7 @@ class OidcLoginAuthenticatorTest extends TestCase
         );
     }
 
-    private function createAuthenticator(array $options = [], ?UserProviderInterface $userProvider = null, array $authorizationParams = [], ?OidcSignatureVerifier $signatureVerifier = null): OidcLoginAuthenticator
+    private function createAuthenticator(array $options = [], ?UserProviderInterface $userProvider = null, array $authorizationParams = [], ?OidcSignatureVerifier $signatureVerifier = null, ?ClockInterface $clock = null): OidcLoginAuthenticator
     {
         return new OidcLoginAuthenticator(
             new HttpUtils(),
@@ -1407,6 +1454,7 @@ class OidcLoginAuthenticatorTest extends TestCase
             $options,
             $authorizationParams,
             $signatureVerifier,
+            $clock ?? new Clock(),
         );
     }
 }

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/OidcTokenRefreshListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/OidcTokenRefreshListenerTest.php
@@ -1,0 +1,155 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Tests\Firewall;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Clock\MockClock;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\JsonMockResponse;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\User\InMemoryUser;
+use Symfony\Component\Security\Http\Authenticator\Oidc\OidcConfidentialClient;
+use Symfony\Component\Security\Http\Authenticator\Oidc\OidcIdToken;
+use Symfony\Component\Security\Http\Authenticator\Oidc\OidcTokenRefresher;
+use Symfony\Component\Security\Http\Authenticator\Token\PostAuthenticationToken;
+use Symfony\Component\Security\Http\Firewall\OidcTokenRefreshListener;
+use Symfony\Component\Security\Http\Oidc\OidcDiscovery;
+
+class OidcTokenRefreshListenerTest extends TestCase
+{
+    private MockClock $clock;
+    private TokenStorage $tokenStorage;
+
+    protected function setUp(): void
+    {
+        $this->clock = new MockClock('2026-09-06 12:00:00');
+        $this->tokenStorage = new TokenStorage();
+    }
+
+    /**
+     * A lazy firewall calls supports() before the security token is restored, and drops
+     * every listener that answers false: anything but null evicts this one for good.
+     */
+    public function testSupportsDefersToAuthenticateSoLazyFirewallsKeepTheListener()
+    {
+        $this->tokenStorage->setToken($this->createToken());
+
+        $this->assertNull($this->createListener(new JsonMockResponse(['access_token' => 'access-456']))->supports(new Request()));
+    }
+
+    public function testDoesNothingWithoutASecurityToken()
+    {
+        $this->createListener(new JsonMockResponse(['access_token' => 'access-456']))->authenticate($this->createRequestEvent());
+
+        $this->assertNull($this->tokenStorage->getToken());
+    }
+
+    public function testDoesNothingWhenTheSecurityTokenCarriesNoRefreshToken()
+    {
+        $this->tokenStorage->setToken($token = $this->createToken(['oidc_refresh_token' => null]));
+
+        $this->createListener(new JsonMockResponse(['access_token' => 'access-456']))->authenticate($this->createRequestEvent());
+
+        $this->assertSame('access-123', $token->getAttribute('oidc_access_token'));
+    }
+
+    public function testRenewsTheExpiredAccessToken()
+    {
+        $this->tokenStorage->setToken($token = $this->createToken());
+
+        $this->createListener(new JsonMockResponse(['access_token' => 'access-456', 'expires_in' => 300]))->authenticate($this->createRequestEvent());
+
+        $this->assertSame($token, $this->tokenStorage->getToken());
+        $this->assertSame('access-456', $token->getAttribute('oidc_access_token'));
+    }
+
+    public function testEndsTheSessionWhenTheProviderRejectsTheRefreshToken()
+    {
+        // the refresh token is gone for good, so the login this application kept can no
+        // longer be backed by the provider session it came from
+        $this->tokenStorage->setToken($this->createToken());
+
+        $this->createListener(new JsonMockResponse(['error' => 'invalid_grant'], ['http_code' => 400]))->authenticate($this->createRequestEvent());
+
+        $this->assertNull($this->tokenStorage->getToken());
+    }
+
+    public function testKeepsTheSessionWhenTheProviderCannotBeReached()
+    {
+        // an unreachable provider says nothing about the refresh token, so logging the
+        // user out here would turn a provider outage into a mass logout
+        $this->tokenStorage->setToken($token = $this->createToken());
+
+        $this->createListener(new MockResponse('Service Unavailable', ['http_code' => 503]))->authenticate($this->createRequestEvent());
+
+        $this->assertSame($token, $this->tokenStorage->getToken());
+        $this->assertSame('access-123', $token->getAttribute('oidc_access_token'));
+    }
+
+    public function testLeavesAValidAccessTokenAlone()
+    {
+        $this->tokenStorage->setToken($token = $this->createToken(['oidc_access_token_expires_at' => $this->clock->now()->getTimestamp() + 300]));
+
+        $this->createListener(new JsonMockResponse(['access_token' => 'access-456']))->authenticate($this->createRequestEvent());
+
+        $this->assertSame('access-123', $token->getAttribute('oidc_access_token'));
+    }
+
+    private function createRequestEvent(): RequestEvent
+    {
+        return new RequestEvent($this->createStub(HttpKernelInterface::class), new Request(), HttpKernelInterface::MAIN_REQUEST);
+    }
+
+    private function createListener(MockResponse $tokenEndpointResponse): OidcTokenRefreshListener
+    {
+        $discovery = new OidcDiscovery(
+            new MockHttpClient(static fn (): MockResponse => new JsonMockResponse([
+                'issuer' => 'https://provider.example.com',
+                'token_endpoint' => 'https://provider.example.com/token',
+            ])),
+            new ArrayAdapter(),
+            'https://provider.example.com/.well-known/openid-configuration',
+        );
+
+        return new OidcTokenRefreshListener(
+            $this->tokenStorage,
+            new OidcTokenRefresher(
+                new OidcConfidentialClient(new MockHttpClient($tokenEndpointResponse), $discovery, 'test-client-id', 'test-client-secret'),
+                $discovery,
+                new OidcIdToken($this->clock),
+                'test-client-id',
+                clock: $this->clock,
+            ),
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $attributes
+     */
+    private function createToken(array $attributes = []): TokenInterface
+    {
+        $token = new PostAuthenticationToken(new InMemoryUser('user-42', null), 'main', ['ROLE_USER']);
+        $token->setAttributes(array_merge([
+            'oidc_access_token' => 'access-123',
+            'oidc_refresh_token' => 'refresh-123',
+            'oidc_access_token_expires_at' => $this->clock->now()->getTimestamp() - 1,
+        ], $attributes));
+
+        return $token;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

The `oidc_login` authenticator threw the refresh token away. `exchangeCode()` received it, but `createToken()` only kept `oidc_id_token` and `oidc_access_token`, and nothing tracked the expiry of the access token. So the access token became useless as soon as the provider expired it, and calling an API on behalf of the logged-in user was over a few minutes after login.

This adds the refresh token grant of RFC 6749, Section 6, and the pieces needed to use it.

## What the security token carries

`createToken()` now sets two more attributes:

| Attribute | Value |
| --- | --- |
| `oidc_refresh_token` | the refresh token, or `null` when the provider issued none |
| `oidc_access_token_expires_at` | the Unix timestamp the access token expires at, or `null` when the token endpoint reported no `expires_in` |

Both are `null` when the provider gave nothing: it only issues a refresh token when it was asked for one, typically with the `offline_access` scope, and `expires_in` is optional in RFC 6749, Section 5.1.

`OidcLoginAuthenticator::__construct()` takes a new last argument, `ClockInterface $clock`, defaulting to `new Clock()`, to turn `expires_in` into that absolute expiry.

## The protocol call

`OidcClient::refreshToken(string $refreshToken, array $scopes = [])` runs the grant at the token endpoint, with the client authentication the client type already implements. An empty `$scopes` asks for the original scopes; a non-empty list narrows them, which is all RFC 6749, Section 6 allows.

`OidcPublicClient` used to refuse any token request without a PKCE verifier. It now only requires one for `grant_type=authorization_code`: the refresh token grant carries neither a code nor a verifier, so a public client can renew its tokens too.

The method throws `OidcInvalidGrantException`, a new `AuthenticationException` subclass, when the provider answers with the `invalid_grant` error of RFC 6749, Section 5.2, and a plain `AuthenticationException` for everything else. That distinction is the whole point of the class: `invalid_grant` means the refresh token is gone for good, while an unreachable provider, a 5xx or a timeout only mean the request can be tried again.

## Renewing the tokens of a logged-in user

`OidcTokenRefresher` renews the tokens a security token holds:

- `refreshIfNeeded(TokenInterface $token): bool` renews when the access token expires within the leeway, and reports whether it did. It does nothing when the token carries no refresh token, or when no expiry is known, since nothing then says the access token went stale.
- `refresh(TokenInterface $token): void` renews whatever the expiry.

An ID token returned by the grant is checked under OIDC Core 1.0, Section 12.2 before anything is stored: signature against the provider JWKS when the firewall verifies signatures, `iss`, `aud`, `exp`, `iat`, `nbf`, and a `sub` equal to the one of the ID token issued at authentication. No `nonce` is checked, since no authorization request was made, and no `max_age`, since `auth_time` still reports the original authentication. A rejected ID token leaves the security token exactly as it was.

A rotated refresh token replaces the previous one. RFC 6749, Section 6 makes that a MAY, so the one just used is kept when the provider returns none.

The service is wired for every `oidc_login` firewall, as `security.authenticator.oidc_login.token_refresher.<firewall>`, whether the option below is on or not. Inject it wherever the application calls a downstream API:

```php
public function __construct(
    private readonly OidcTokenRefresher $refresher,
    private readonly Security $security,
    private readonly HttpClientInterface $client,
) {
}

public function callTheApi(): array
{
    $token = $this->security->getToken();
    $this->refresher->refreshIfNeeded($token);

    return $this->client->request('GET', 'https://api.example.com/me', [
        'auth_bearer' => $token->getAttribute('oidc_access_token'),
    ])->toArray();
}
```

## Renewing it automatically

```yaml
security:
    firewalls:
        main:
            oidc_login:
                provider_uri: 'https://accounts.example.com'
                client_id: '%env(OIDC_CLIENT_ID)%'
                client_secret: '%env(OIDC_CLIENT_SECRET)%'
                scope: ['openid', 'profile', 'offline_access']
                refresh_access_token:
                    enabled: true
                    leeway: 30
```

| Option | Default | What it does |
| --- | --- | --- |
| `refresh_access_token.enabled` | `false` | registers `OidcTokenRefreshListener` on the firewall |
| `refresh_access_token.leeway` | `30` | how many seconds before its expiry the access token is renewed |

The listener runs right after the firewall restored the security token from the session, so the renewed tokens are the ones this request and the rest of the session see, and the firewall writes them back to the session on the response.

Failing to renew only ends the session when the provider answers `invalid_grant`. Any other failure logs a warning and leaves the tokens untouched, to be tried again on the next request: deauthenticating there would turn a provider outage into a mass logout.

The leeway exists so that an access token handed to a call in flight does not expire on the way.

## Traps

- The renewal needs `expires_in`. A provider that reports none gets no automatic renewal at all, since nothing says when the access token went stale. This is silent by design: renewing on every request is the only alternative.
- A provider rotating refresh tokens expects the previous one never to be replayed. Two concurrent requests of the same session are serialized by a session handler that locks the session, which the default one does; a handler that does not lock can replay a rotated refresh token, which such a provider answers by revoking the whole chain.
- `refresh_access_token` is opt-in. It sends a request to the token endpoint from inside the request lifecycle, and it can log a user out, so turning it on is a decision the application makes.

## Checks

- `./phpunit src/Symfony/Component/Security/Http`: OK, 984 tests.
- `./phpunit src/Symfony/Bundle/SecurityBundle`: OK, 559 tests.
- The functional tests drive the whole thing through a real kernel: a session is seeded with an expired access token, a request is made, and the session is read back. One asserts the renewed tokens are there, one asserts an `invalid_grant` cleared the session, one asserts nothing is renewed without the option.
- Every new test was reverted against the unpatched code and fails there.

## Documentation

The documentation must carry: the two new token attributes and their `null` cases; `refresh_access_token` with its two options and their defaults; the `security.authenticator.oidc_login.token_refresher.<firewall>` service and the on-demand snippet above; the need for a scope that makes the provider issue a refresh token, `offline_access` on most of them; the three traps above.
