### PR TITLE
[Validator] Add missing Arabic translation for validation units

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.ar.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.ar.xlf
@@ -572,11 +572,11 @@
             </trans-unit>
             <trans-unit id="147">
                 <source>The referenced entity does not exist.</source>
-                <target state="needs-review-translation">الكيان المشار إليه غير موجود.</target>
+                <target>الكيان المشار إليه غير موجود.</target>
             </trans-unit>
             <trans-unit id="148" resname="This is not a valid ULID.">
                 <source>This value is not a valid ULID.</source>
-                <target state="needs-review-translation">هذه القيمة ليست ULID صالحًا.</target>
+                <target>هذه القيمة ليست ULID صالحًا.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #65549 <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

<!--
🛠️ Replace this text with a concise explanation of your change:
- What it does and why it's needed
- A simple example of how it works (include PHP, YAML, etc.)
- If it modifies existing behavior, include a before/after comparison

Contributor guidelines:
- ✅ Add tests and ensure they pass
- 🐞 Bug fixes must target the **lowest maintained** branch where they apply
  https://symfony.com/releases#maintained-symfony-branches
- ✨ New features and deprecations must target the **feature** branch
  and must add an entry to the changelog file of the patched component:
  https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
- 🔒 Do not break backward compatibility:
  https://symfony.com/bc
-->

Changs has been made:
* Affected file:  [src/Symfony/Component/Validator/Resources/translations/validators.ar.xlf](https://github.com/symfony/symfony/blob/6.4/src/Symfony/Component/Validator/Resources/translations/validators.ar.xlf)

Id | English | Translation | Status
-- | -- | -- | --
147 | The referenced entity does not exist. | الكيان المشار إليه غير موجود. | Reviewed ✅ 
148 | This is not a valid ULID. | هذه القيمة ليست ULID صالحًا. | Reviewed ✅ 

* I have removed state="needs-review-translation" from each. 
