### PR TITLE
[Mailer][Sweego] Add support for CC and BCC recipients

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Sweego/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/Bridge/Sweego/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Add support for CC and BCC recipients
+
 7.3
 ---
 

--- a/src/Symfony/Component/Mailer/Bridge/Sweego/Tests/Transport/SweegoApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sweego/Tests/Transport/SweegoApiTransportTest.php
@@ -135,6 +135,38 @@ class SweegoApiTransportTest extends TestCase
         $this->assertSame('foobar', $message->getMessageId());
     }
 
+    public function testSendWithCcAndBcc()
+    {
+        $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
+            $body = json_decode($options['body'], true);
+
+            $this->assertSame([['email' => 'tony.stark@marvel.com', 'name' => 'Tony Stark']], $body['recipients']);
+            $this->assertSame([['email' => 'pepper@marvel.com', 'name' => 'Pepper']], $body['cc']);
+            $this->assertSame([['email' => 'nick.fury@marvel.com']], $body['bcc']);
+            $this->assertArrayNotHasKey('Cc', $body['headers']);
+            $this->assertArrayNotHasKey('Bcc', $body['headers']);
+
+            return new JsonMockResponse(['transaction_id' => 'foobar'], [
+                'http_code' => 200,
+            ]);
+        });
+
+        $transport = new SweegoApiTransport('ACCESS_KEY', $client);
+
+        $mail = new Email();
+        $mail->subject('Hello!')
+            ->to(new Address('tony.stark@marvel.com', 'Tony Stark'))
+            ->from(new Address('fabpot@symfony.com', 'Fabien'))
+            ->text('Hello here!')
+            ->addCc(new Address('pepper@marvel.com', 'Pepper'))
+            ->addBcc('nick.fury@marvel.com')
+        ;
+
+        $message = $transport->send($mail);
+
+        $this->assertSame('foobar', $message->getMessageId());
+    }
+
     /**
      * IDN (internationalized domain names) like kältetechnik-xyz.de need to be transformed to ACE
      * (ASCII Compatible Encoding) e.g.xn--kltetechnik-xyz-0kb.de, otherwise Sweego api answers with 400 http code.

--- a/src/Symfony/Component/Mailer/Bridge/Sweego/Transport/SweegoApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sweego/Transport/SweegoApiTransport.php
@@ -93,6 +93,14 @@ final class SweegoApiTransport extends AbstractApiTransport
             'channel' => 'email',
         ];
 
+        if ($emails = $email->getCc()) {
+            $payload['cc'] = $this->formatAddresses($emails);
+        }
+
+        if ($emails = $email->getBcc()) {
+            $payload['bcc'] = $this->formatAddresses($emails);
+        }
+
         if ($email->getTextBody()) {
             $payload['message-txt'] = $email->getTextBody();
         }
@@ -145,7 +153,7 @@ final class SweegoApiTransport extends AbstractApiTransport
         $headersPrepared = [];
         foreach ($headers->all() as $header) {
             // Sweego API does not accept those headers.
-            if (\in_array($header->getName(), ['To', 'From', 'Subject'], true)) {
+            if (\in_array($header->getName(), ['To', 'Cc', 'Bcc', 'From', 'Subject'], true)) {
                 continue;
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #65878
| License       | MIT

The Sweego bridge never sent CC and BCC recipients to the API. `getRecipients()` strips them from the envelope, and the payload only carried `recipients`, so anyone added with `$email->cc()` or `$email->bcc()` was silently dropped while their address still leaked through as a custom `Cc`/`Bcc` header.

The API accepts `cc` and `bcc` alongside `recipients`, with the same `{email, name}` shape, so the payload now fills them from the message and the two headers are excluded like `To` already was.

```php
$email->to('tony.stark@marvel.com')
    ->cc('pepper@marvel.com')
    ->bcc('nick.fury@marvel.com');
```
