### PR TITLE
[Security] Call the OIDC token handler through its positional API in tests

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/AccessTokenFactoryTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/AccessTokenFactoryTest.php
@@ -22,6 +22,7 @@ use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\AccessToken\OidcT
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\AccessToken\OidcUserInfoTokenHandlerFactory;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\AccessToken\ServiceTokenHandlerFactory;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\AccessTokenFactory;
+use Symfony\Component\Clock\Clock;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\ChildDefinition;
@@ -435,7 +436,7 @@ class AccessTokenFactoryTest extends TestCase
         $reflection = new \ReflectionMethod(OidcTokenHandler::class, 'enableDiscovery');
         $this->assertLessThanOrEqual($reflection->getNumberOfParameters(), \count($methodCalls[0][1]), 'Recorded enableDiscovery call must not pass more arguments than the method accepts.');
 
-        $handler = new OidcTokenHandler(new AlgorithmManager([]), null, 'audience', ['https://www.example.com'], enforceAtJwtType: true);
+        $handler = new OidcTokenHandler(new AlgorithmManager([]), null, 'audience', ['https://www.example.com'], 'sub', null, new Clock(), 0, true);
         $cache = $this->createStub(CacheInterface::class);
         $httpClient = $this->createStub(HttpClientInterface::class);
         $callArgs = $methodCalls[0][1];

--- a/src/Symfony/Component/Security/Http/Tests/AccessToken/Oidc/OidcTokenGeneratorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/AccessToken/Oidc/OidcTokenGeneratorTest.php
@@ -19,6 +19,7 @@ use Jose\Component\Signature\Algorithm\ES512;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Clock\Clock;
 use Symfony\Component\Clock\MockClock;
 use Symfony\Component\Security\Http\AccessToken\Oidc\OidcTokenGenerator;
 use Symfony\Component\Security\Http\AccessToken\Oidc\OidcTokenHandler;
@@ -34,7 +35,7 @@ class OidcTokenGeneratorTest extends TestCase
         $clock = new MockClock('1998-07-12T22:45:00+02:00');
 
         $generator = new OidcTokenGenerator($algorithmManager, $this->getJWKSet(), $audience, $issuers, 'sub', $clock);
-        $handler = new OidcTokenHandler($algorithmManager, $this->getJWKSet(), $audience, $issuers, 'sub', null, $clock, enforceAtJwtType: true);
+        $handler = new OidcTokenHandler($algorithmManager, $this->getJWKSet(), $audience, $issuers, 'sub', null, $clock, 0, true);
 
         $token = $generator->generate('john_doe', null, null, 3600);
 
@@ -56,7 +57,7 @@ class OidcTokenGeneratorTest extends TestCase
         $issuers = ['https://www.example.com'];
 
         $generator = new OidcTokenGenerator($algorithmManager, $this->getJWKSet(), $audience, $issuers);
-        $handler = new OidcTokenHandler($algorithmManager, $this->getJWKSet(), $audience, $issuers, 'sub', enforceAtJwtType: true);
+        $handler = new OidcTokenHandler($algorithmManager, $this->getJWKSet(), $audience, $issuers, 'sub', null, new Clock(), 0, true);
 
         $token = $generator->generate('john_doe', null, null, 3600);
         $header = json_decode(base64_decode(strtr(explode('.', $token)[0], '-_', '+/')), true);

--- a/src/Symfony/Component/Security/Http/Tests/AccessToken/Oidc/OidcTokenHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/AccessToken/Oidc/OidcTokenHandlerTest.php
@@ -28,6 +28,7 @@ use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Clock\Clock;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\JsonMockResponse;
 use Symfony\Component\HttpClient\Response\MockResponse;
@@ -68,7 +69,9 @@ class OidcTokenHandlerTest extends TestCase
             ['https://www.example.com'],
             $claim,
             $loggerMock,
-            enforceAtJwtType: true,
+            new Clock(),
+            0,
+            true,
         ))->getUserBadgeFrom($token);
         $actualUser = $userBadge->getUserLoader()();
 
@@ -103,7 +106,9 @@ class OidcTokenHandlerTest extends TestCase
             ['https://www.example.com'],
             'sub',
             $loggerMock,
-            enforceAtJwtType: true,
+            new Clock(),
+            0,
+            true,
         ))->getUserBadgeFrom($token);
     }
 
@@ -196,7 +201,9 @@ class OidcTokenHandlerTest extends TestCase
             ['https://www.example.com'],
             'email',
             $loggerMock,
-            enforceAtJwtType: true,
+            new Clock(),
+            0,
+            true,
         ))->getUserBadgeFrom($token);
     }
 
@@ -215,7 +222,9 @@ class OidcTokenHandlerTest extends TestCase
             ['https://www.example.com'],
             'sub',
             $loggerMock,
-            enforceAtJwtType: true,
+            new Clock(),
+            0,
+            true,
         ))->getUserBadgeFrom($token);
 
         $this->assertSame('e21bf182-1538-406e-8ccb-e25a17aba39f', $userBadge->getUserIdentifier());
@@ -251,7 +260,9 @@ class OidcTokenHandlerTest extends TestCase
             ['https://www.example.com'],
             'sub',
             $loggerMock,
-            enforceAtJwtType: true,
+            new Clock(),
+            0,
+            true,
         ))->getUserBadgeFrom($token);
     }
 
@@ -278,7 +289,9 @@ class OidcTokenHandlerTest extends TestCase
             ['https://www.example.com'],
             'sub',
             $loggerMock,
-            enforceAtJwtType: false,
+            new Clock(),
+            0,
+            false,
         ))->getUserBadgeFrom($token);
 
         $this->assertSame('e21bf182-1538-406e-8ccb-e25a17aba39f', $userBadge->getUserIdentifier());
@@ -330,7 +343,10 @@ class OidcTokenHandlerTest extends TestCase
             self::AUDIENCE,
             ['https://www.example.com'],
             'sub',
-            enforceAtJwtType: true,
+            null,
+            new Clock(),
+            0,
+            true,
         );
         $handler->enableJweSupport($encryptionKeyset, $encryptionAlgorithms, true);
 
@@ -436,7 +452,11 @@ class OidcTokenHandlerTest extends TestCase
             null,
             self::AUDIENCE,
             ['https://www.example.com'],
-            enforceAtJwtType: true,
+            'sub',
+            null,
+            new Clock(),
+            0,
+            true,
         );
         $handler->enableDiscovery($cache, $httpClient, 'oidc_config');
 
@@ -461,7 +481,11 @@ class OidcTokenHandlerTest extends TestCase
             null,
             self::AUDIENCE,
             ['https://www.example.com'],
-            enforceAtJwtType: true,
+            'sub',
+            null,
+            new Clock(),
+            0,
+            true,
         );
         $handler->enableDiscovery(new ArrayAdapter(), $httpClient, 'oidc_config');
 
@@ -485,7 +509,11 @@ class OidcTokenHandlerTest extends TestCase
             null,
             self::AUDIENCE,
             ['https://www.example.com'],
-            enforceAtJwtType: true,
+            'sub',
+            null,
+            new Clock(),
+            0,
+            true,
         );
         $handler->enableDiscovery(new ArrayAdapter(), $httpClient, 'oidc_config');
 
@@ -522,7 +550,11 @@ class OidcTokenHandlerTest extends TestCase
             null,
             self::AUDIENCE,
             ['https://www.example.com'],
-            enforceAtJwtType: true,
+            'sub',
+            null,
+            new Clock(),
+            0,
+            true,
         );
         $handler->enableDiscovery($cache, [$httpClient1, $httpClient2], 'oidc_config');
 
@@ -577,7 +609,7 @@ class OidcTokenHandlerTest extends TestCase
             }, \sprintf('https://provider%d.example.com/', $provider));
         }
 
-        $handler = new OidcTokenHandler(new AlgorithmManager([new ES256()]), null, self::AUDIENCE, ['https://www.example.com'], enforceAtJwtType: true);
+        $handler = new OidcTokenHandler(new AlgorithmManager([new ES256()]), null, self::AUDIENCE, ['https://www.example.com'], 'sub', null, new Clock(), 0, true);
         $handler->enableDiscovery(new ArrayAdapter(), $httpClients, 'oidc_config');
 
         $time = time();
@@ -641,7 +673,11 @@ class OidcTokenHandlerTest extends TestCase
             null,
             self::AUDIENCE,
             ['https://www.example.com'],
-            enforceAtJwtType: true,
+            'sub',
+            null,
+            new Clock(),
+            0,
+            true,
         );
         $handler->enableDiscovery($cache, $httpClient, 'oidc_ttl_cc');
         $this->assertSame('user-cache-control', $handler->getUserBadgeFrom($token)->getUserIdentifier());
@@ -677,7 +713,7 @@ class OidcTokenHandlerTest extends TestCase
         ]));
 
         $cache = new ArrayAdapter();
-        $handler = new OidcTokenHandler(new AlgorithmManager([new ES256()]), null, self::AUDIENCE, ['https://www.example.com'], enforceAtJwtType: true);
+        $handler = new OidcTokenHandler(new AlgorithmManager([new ES256()]), null, self::AUDIENCE, ['https://www.example.com'], 'sub', null, new Clock(), 0, true);
         $handler->enableDiscovery($cache, $httpClient, 'oidc_config');
 
         $handler->getUserBadgeFrom($token);
@@ -728,7 +764,11 @@ class OidcTokenHandlerTest extends TestCase
             null,
             self::AUDIENCE,
             ['https://www.example.com'],
-            enforceAtJwtType: true,
+            'sub',
+            null,
+            new Clock(),
+            0,
+            true,
         );
         $handler->enableDiscovery($cache, $httpClient, 'oidc_ttl_expires');
         $this->assertSame('user-expires', $handler->getUserBadgeFrom($token)->getUserIdentifier());
@@ -745,7 +785,11 @@ class OidcTokenHandlerTest extends TestCase
             null,
             self::AUDIENCE,
             ['https://www.example.com'],
-            enforceAtJwtType: true,
+            'sub',
+            null,
+            new Clock(),
+            0,
+            true,
         );
 
         $handler->enableDiscovery($cache, [], 'oidc_empty_clients');
@@ -772,7 +816,11 @@ class OidcTokenHandlerTest extends TestCase
             null,
             self::AUDIENCE,
             ['https://www.example.com'],
-            enforceAtJwtType: true,
+            'sub',
+            null,
+            new Clock(),
+            0,
+            true,
         );
         $handler->enableDiscovery($cache, $httpClient, 'oidc_redirected_discovery');
 
@@ -801,7 +849,11 @@ class OidcTokenHandlerTest extends TestCase
             null,
             self::AUDIENCE,
             ['https://www.example.com'],
-            enforceAtJwtType: true,
+            'sub',
+            null,
+            new Clock(),
+            0,
+            true,
         );
         $handler->enableDiscovery($cache, $httpClient, 'oidc_insecure_jwks_uri');
 
@@ -830,7 +882,11 @@ class OidcTokenHandlerTest extends TestCase
             null,
             self::AUDIENCE,
             ['http://www.example.com'],
-            enforceAtJwtType: true,
+            'sub',
+            null,
+            new Clock(),
+            0,
+            true,
         );
         $handler->enableDiscovery($cache, $httpClient, 'oidc_http_issuer');
 
@@ -863,7 +919,11 @@ class OidcTokenHandlerTest extends TestCase
             null,
             self::AUDIENCE,
             ['https://www.example.com'],
-            enforceAtJwtType: true,
+            'sub',
+            null,
+            new Clock(),
+            0,
+            true,
         );
         $handler->enableDiscovery($cache, $httpClient, 'oidc_missing_jwks_uri');
 
@@ -889,9 +949,13 @@ class OidcTokenHandlerTest extends TestCase
             null,
             self::AUDIENCE,
             ['https://www.example.com'],
-            enforceAtJwtType: true,
+            'sub',
+            null,
+            new Clock(),
+            0,
+            true,
         );
-        $handler->enableDiscovery($cache, $httpClient, 'oidc_non_sig_keys', enforceKeyUsageVerification: false);
+        $handler->enableDiscovery($cache, $httpClient, 'oidc_non_sig_keys', false);
 
         $item = $this->createMock(ItemInterface::class);
         $item->expects($this->never())->method('expiresAfter');
@@ -918,9 +982,13 @@ class OidcTokenHandlerTest extends TestCase
             null,
             self::AUDIENCE,
             ['https://www.example.com'],
-            enforceAtJwtType: true,
+            'sub',
+            null,
+            new Clock(),
+            0,
+            true,
         );
-        $handler->enableDiscovery($cache, $httpClient, 'oidc_enc_key_ops', enforceKeyUsageVerification: false);
+        $handler->enableDiscovery($cache, $httpClient, 'oidc_enc_key_ops', false);
 
         $item = $this->createStub(ItemInterface::class);
         $keys = $handler->computeDiscoveryKeys($item);
@@ -955,9 +1023,13 @@ class OidcTokenHandlerTest extends TestCase
             null,
             self::AUDIENCE,
             ['https://www.example.com'],
-            enforceAtJwtType: true,
+            'sub',
+            null,
+            new Clock(),
+            0,
+            true,
         );
-        $handler->enableDiscovery($cache, $httpClient, 'oidc_no_use', enforceKeyUsageVerification: false);
+        $handler->enableDiscovery($cache, $httpClient, 'oidc_no_use', false);
 
         $userBadge = $handler->getUserBadgeFrom($token);
 
@@ -983,9 +1055,13 @@ class OidcTokenHandlerTest extends TestCase
             null,
             self::AUDIENCE,
             ['https://www.example.com'],
-            enforceAtJwtType: true,
+            'sub',
+            null,
+            new Clock(),
+            0,
+            true,
         );
-        $handler->enableDiscovery($cache, $httpClient, 'oidc_enforced', enforceKeyUsageVerification: true);
+        $handler->enableDiscovery($cache, $httpClient, 'oidc_enforced', true);
 
         $item = $this->createMock(ItemInterface::class);
         $item->expects($this->never())->method('expiresAfter');
@@ -1010,16 +1086,20 @@ class OidcTokenHandlerTest extends TestCase
             null,
             self::AUDIENCE,
             ['https://www.example.com'],
-            enforceAtJwtType: true,
+            'sub',
+            null,
+            new Clock(),
+            0,
+            true,
         );
-        $handler->enableDiscovery($cache, $httpClient, 'oidc_enforced_ops', enforceKeyUsageVerification: true);
+        $handler->enableDiscovery($cache, $httpClient, 'oidc_enforced_ops', true);
         $item = $this->createStub(ItemInterface::class);
         $keys = $handler->computeDiscoveryKeys($item);
         $this->assertCount(1, $keys);
         $this->assertSame(['sign'], $keys[0]['key_ops']);
     }
 
-    public function testTokenWithFutureIatIsRejectedByDefault()
+    public function testTokenWithFutureIatIsRejectedWithoutAllowedTimeDrift()
     {
         $time = time();
         $claims = [
@@ -1045,7 +1125,9 @@ class OidcTokenHandlerTest extends TestCase
             ['https://www.example.com'],
             'sub',
             $loggerMock,
-            enforceAtJwtType: true,
+            new Clock(),
+            0,
+            true,
         ))->getUserBadgeFrom($token);
     }
 
@@ -1072,8 +1154,9 @@ class OidcTokenHandlerTest extends TestCase
             ['https://www.example.com'],
             'sub',
             $loggerMock,
-            allowedTimeDrift: 5,
-            enforceAtJwtType: true,
+            new Clock(),
+            5,
+            true,
         ))->getUserBadgeFrom($token);
 
         $this->assertInstanceOf(UserBadge::class, $userBadge);
@@ -1106,8 +1189,9 @@ class OidcTokenHandlerTest extends TestCase
             ['https://www.example.com'],
             'sub',
             $loggerMock,
-            allowedTimeDrift: 5,
-            enforceAtJwtType: true,
+            new Clock(),
+            5,
+            true,
         ))->getUserBadgeFrom($token);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Follow-up on https://github.com/symfony/symfony/pull/65871#discussion_r3948101126.

The tests added along `$enforceAtJwtType` name that argument. Argument names are not covered by the backward compatibility promise, so a test that names them keeps passing when the signature is reordered, and we lose the signal a positional call would have given us.

So every `OidcTokenHandler` construction in the tests now passes its arguments positionally, and so do the `enableDiscovery()` calls that named `$enforceKeyUsageVerification`. `$enforceAtJwtType` is the ninth parameter, hence the explicit `'sub', null, new Clock(), 0` in front of it. The legacy test that omits the argument to cover the deprecation is left untouched.
