### PR TITLE
[Security] Read the "active" member of an introspection response as a boolean

### DIFF
--- a/src/Symfony/Component/Security/Http/AccessToken/OAuth2/Oauth2TokenHandler.php
+++ b/src/Symfony/Component/Security/Http/AccessToken/OAuth2/Oauth2TokenHandler.php
@@ -40,6 +40,11 @@ final class Oauth2TokenHandler implements AccessTokenHandlerInterface
     ) {
     }
 
+    /**
+     * RFC 7662 §2.2 defines "active" as a boolean, and the introspection response is JSON, so the
+     * member is compared to true: nothing else states that the token can be used, the string
+     * "false" an authorization server may answer with least of all.
+     */
     public function getUserBadgeFrom(string $accessToken): UserBadge
     {
         try {
@@ -57,8 +62,7 @@ final class Oauth2TokenHandler implements AccessTokenHandlerInterface
             if (!$sub && !$username) {
                 throw new BadCredentialsException('"sub" and "username" claims not found on the authorization server response. At least one is required.');
             }
-            $active = $claims['active'] ?? false;
-            if (!$active) {
+            if (true !== ($claims['active'] ?? false)) {
                 throw new BadCredentialsException('The claim "active" was not found on the authorization server response or is set to false.');
             }
 

--- a/src/Symfony/Component/Security/Http/Tests/AccessToken/OAuth2/OAuth2TokenHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/AccessToken/OAuth2/OAuth2TokenHandlerTest.php
@@ -41,6 +41,33 @@ class OAuth2TokenHandlerTest extends TestCase
         yield 'the body is not an object' => [new MockResponse('"nope"')];
     }
 
+    #[DataProvider('inactiveResponses')]
+    public function testRejectsATokenTheServerDoesNotReportAsActive(array $claims)
+    {
+        $client = new MockHttpClient([new MockResponse(json_encode($claims, \JSON_THROW_ON_ERROR))]);
+
+        $this->expectException(BadCredentialsException::class);
+        $this->expectExceptionMessage('Invalid credentials.');
+
+        (new Oauth2TokenHandler($client))->getUserBadgeFrom('a-secret-token');
+    }
+
+    /**
+     * Everything but the boolean the specification defines, which is everything the truthy reading
+     * of "active" used to honor, the very "false" of a server not serializing it as a JSON boolean
+     * included.
+     */
+    public static function inactiveResponses(): iterable
+    {
+        yield 'inactive' => [['active' => false, 'sub' => 'jdoe']];
+        yield 'missing' => [['sub' => 'jdoe']];
+        yield 'stringly typed false' => [['active' => 'false', 'sub' => 'jdoe']];
+        yield 'stringly typed true' => [['active' => 'true', 'sub' => 'jdoe']];
+        yield 'the number one' => [['active' => 1, 'sub' => 'jdoe']];
+        yield 'no' => [['active' => 'no', 'sub' => 'jdoe']];
+        yield 'not a boolean at all' => [['active' => 'bogus', 'sub' => 'jdoe']];
+    }
+
     public function testGetsUserIdentifierFromOAuth2ServerResponse()
     {
         $accessToken = 'a-secret-token';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

RFC 7662 §2.2 defines `active` as a boolean, and makes it the member that states whether a token can be used. `Oauth2TokenHandler` reads it with a truthy test:

```php
$active = $claims['active'] ?? false;
if (!$active) {
    throw new BadCredentialsException('The claim "active" was not found on the authorization server response or is set to false.');
}
```

Every truthy value therefore passes, the string `"false"` among them:

```json
{"active": "false", "sub": "jdoe"}
```

Against an authorization server that does not serialize that boolean as a JSON boolean, this resource server accepts every token the server reports on, revoked and expired ones included. That is not a matter of hardening the check: the control does not do what the specification says it does.

The member is now compared to `true`. The introspection response is JSON, so the value reaches the handler with the type the authorization server gave it, and the boolean the specification defines is the only one that states anything about the token.

Nothing else moves. Reading the member before `sub` and `username` would only change the message, since an inactive response is already rejected in both orders, so it is left to #65865, which reworks the handler on 8.2 and will align on this reading once this one merges up.
