### PR TITLE
[FrameworkBundle] Fix the "framework.remote-event" config node being impossible to set

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -2299,7 +2299,7 @@ class Configuration implements ConfigurationInterface
     {
         $rootNode
             ->children()
-                ->arrayNode('remote-event')
+                ->arrayNode('remote_event')
                     ->info('RemoteEvent configuration')
                     ->{$enableIfStandalone('symfony/remote-event', RemoteEvent::class)}()
                 ->end()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -567,8 +567,8 @@ class FrameworkExtension extends Extension
             }
         }
 
-        if ($this->readConfigEnabled('remote-event', $container, $config['remote-event'])) {
-            $this->registerRemoteEventConfiguration($config['remote-event'], $container, $loader);
+        if ($this->readConfigEnabled('remote_event', $container, $config['remote_event'])) {
+            $this->registerRemoteEventConfiguration($config['remote_event'], $container, $loader);
         }
 
         if ($this->readConfigEnabled('html_sanitizer', $container, $config['html_sanitizer'])) {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -632,6 +632,26 @@ class ConfigurationTest extends TestCase
         $this->assertSame(['foo' => 'bar', JsonDecode::DETAILED_ERROR_MESSAGES => false, 'foobar' => 'baz'], $config['serializer']['default_context'] ?? []);
     }
 
+    public function testRemoteEventCanBeConfigured()
+    {
+        $processor = new Processor();
+
+        foreach (['remote_event', 'remote-event'] as $key) {
+            foreach ([true, false] as $enabled) {
+                $config = $processor->processConfiguration(new Configuration(true), [
+                    [
+                        'http_method_override' => false,
+                        'handle_all_throwables' => true,
+                        'php_errors' => ['log' => true],
+                        $key => ['enabled' => $enabled],
+                    ],
+                ]);
+
+                $this->assertSame(['enabled' => $enabled], $config['remote_event'], $key);
+            }
+        }
+    }
+
     protected static function getBundleDefaultConfig()
     {
         return [
@@ -888,7 +908,7 @@ class ConfigurationTest extends TestCase
                 'routing' => [],
                 'message_bus' => 'messenger.default_bus',
             ],
-            'remote-event' => [
+            'remote_event' => [
                 'enabled' => false,
             ],
         ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`framework.remote-event` cannot be set, in any configuration format, on any maintained branch.

The node is declared as `->arrayNode('remote-event')`, but `ArrayNode::preNormalize()` rewrites any incoming key that contains `-` and no `_` into its underscored form before the child lookup happens. So `remote-event` becomes `remote_event`, which is not a declared child:

```
Unrecognized option "remote_event" under "framework". Did you mean "remote-event"?
```

`remote_event` fails the same way, and the error message suggests the spelling that also fails. The section can therefore only ever take its default. In an application, where `FullStack` does not exist and the section resolves to `canBeDisabled`, that means RemoteEvent is enabled and cannot be turned off.

Nothing in the repository ever set the key, which is why this went unnoticed; the only reference was the expected default in `ConfigurationTest`.

This renames the node to `remote_event`. That is not a backward compatibility break: neither spelling was reachable, so nothing can depend on either. The dashed spelling starts working too, since `preNormalize()` now maps it onto a node that exists, so YAML, XML and PHP config all reach it. The XSD keeps `remote-event`, which is the right XML spelling next to `rate-limiter`, `http-client` and `web-link`.

The two alternatives are worse. Special-casing `preNormalize()` would change normalization for every bundle to unbreak one key. Declaring both spellings as siblings would leave one of them dead by normalization order.

The rename also fixes a second symptom: `ClassBuilder::camelCase()` strips the hyphen, so the generated config builder exposed `remoteevent()` writing the unreachable `remote-event` key. It now generates `remoteEvent()` writing `remote_event`.

## Checks

`./phpunit src/Symfony/Bundle/FrameworkBundle` gives `Tests: 1392, Assertions: 4506, Errors: 15, Failures: 11`, against a pristine baseline on the same tree of `Tests: 1388, Assertions: 4502, Errors: 15, Failures: 11`. The failing test names are identical between the two runs; they are the local `doctrine/annotations` environment failures and `ApiAttributesTest`. The change adds four assertions and no failures. The new test was checked to fail on the base sources with the exact error above. php-cs-fixer is clean.

The cases are asserted inline rather than through a data provider on purpose: this branch runs PHPUnit 9, and a docblock `@dataProvider` carried up to the branches running PHPUnit 13 fails with `ArgumentCountError`.

Merge-up to 7.4, 8.0, 8.1 and 8.2: the defect and the fix are identical on all of them. `Configuration.php` merges clean. `FrameworkExtension.php` conflicts in one block, because those branches call `registerRemoteEventConfiguration($loader)` with one argument; take the `remote_event` rename on the `readConfigEnabled` line and keep the branch's call. `ConfigurationTest.php` conflicts in three blocks: two are insertion-point collisions where both sides added tests, keep both; in `getBundleDefaultConfig()` rename the key only and keep the branch's `enabled` expression and the entries after it.
