### PR TITLE
[Config][DependencyInjection][FrameworkBundle] Allow a configuration node to alias the configuration of another extension

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/JsonSchemaConfigDumpPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/JsonSchemaConfigDumpPass.php
@@ -43,9 +43,7 @@ class JsonSchemaConfigDumpPass implements CompilerPassInterface
             return;
         }
 
-        $generator = new JsonSchemaDumper(parameterSchemas: [['$ref' => '#/$defs/types/param']]);
-
-        $defs = [];
+        $trees = [];
         $allAliases = [];
         $envAliases = [];
 
@@ -74,7 +72,7 @@ class JsonSchemaConfigDumpPass implements CompilerPassInterface
                 continue;
             }
 
-            $defs[$extensionAlias] = $generator->dumpNode($tree);
+            $trees[$extensionAlias] = $tree;
 
             if ($envs['all'] ?? false) {
                 $allAliases[] = $extensionAlias;
@@ -96,8 +94,15 @@ class JsonSchemaConfigDumpPass implements CompilerPassInterface
                 continue;
             }
 
-            $defs[$alias] = $generator->dumpNode($tree);
+            $trees[$alias] = $tree;
             $allAliases[] = $alias;
+        }
+
+        $generator = new JsonSchemaDumper([['$ref' => '#/$defs/types/param']], static fn (string $alias): ?string => isset($trees[$alias]) ? '#/$defs/nodes/'.$alias : null);
+
+        $defs = [];
+        foreach ($trees as $alias => $tree) {
+            $defs[$alias] = $generator->dumpNode($tree);
         }
 
         $allDefs = $generator->getAllDefs();

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/PhpConfigReferenceDumpPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/PhpConfigReferenceDumpPass.php
@@ -102,6 +102,7 @@ class PhpConfigReferenceDumpPass implements CompilerPassInterface
         sort($knownEnvs);
         $extensionsPerEnv = [];
         $appTypes = '';
+        $trees = [];
 
         $anyEnvExtensions = [];
         $registeredExtensions = $container->getExtensions();
@@ -127,8 +128,7 @@ class PhpConfigReferenceDumpPass implements CompilerPassInterface
                 continue;
             }
             $anyEnvExtensions[$extensionAlias] = $extension;
-            $type = $this->camelCase($extensionAlias).'Config';
-            $appTypes .= \sprintf("\n * @psalm-type %s = %s", $type, ArrayShapeGenerator::generate($tree));
+            $trees[$extensionAlias] = $tree;
 
             foreach ($knownEnvs as $env) {
                 if ($envs[$env] ?? $envs['all'] ?? false) {
@@ -147,10 +147,14 @@ class PhpConfigReferenceDumpPass implements CompilerPassInterface
                 continue;
             }
             $anyEnvExtensions[$alias] = $extension;
-            $type = $this->camelCase($alias).'Config';
-            $appTypes .= \sprintf("\n * @psalm-type %s = %s", $type, ArrayShapeGenerator::generate($tree));
+            $trees[$alias] = $tree;
         }
         krsort($extensionsPerEnv);
+
+        $resolveAlias = fn (string $alias): ?string => isset($trees[$alias]) ? $this->camelCase($alias).'Config' : null;
+        foreach ($trees as $alias => $tree) {
+            $appTypes .= \sprintf("\n * @psalm-type %s = %s", $this->camelCase($alias).'Config', ArrayShapeGenerator::generate($tree, $resolveAlias));
+        }
 
         $r = new \ReflectionClass(AppReference::class);
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/JsonSchemaConfigDumpPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/JsonSchemaConfigDumpPassTest.php
@@ -78,6 +78,7 @@ class JsonSchemaConfigDumpPassTest extends TestCase
         $this->assertSame('object', $schema['type']);
         $this->assertArrayHasKey('json_schema_test', $schema['$defs']['nodes']);
         $this->assertSame(['$ref' => '#/$defs/nodes/json_schema_test'], $schema['properties']['json_schema_test']);
+        $this->assertSame(['$ref' => '#/$defs/types/variable'], $schema['$defs']['nodes']['json_schema_test']['properties']['dev']);
         $this->assertArrayNotHasKey('when@all', $schema['properties']);
         // patternProperties allows any when@<custom-env> with 'all' bundles
         $this->assertSame(['$ref' => '#/$defs/nodes/json_schema_test'], $schema['patternProperties']['^when@[a-zA-Z0-9]+$']['properties']['json_schema_test']);
@@ -114,6 +115,8 @@ class JsonSchemaConfigDumpPassTest extends TestCase
         $schema = json_decode(file_get_contents($this->tempDir.'/schema_mixed.json'), true);
         // 'all' bundle in root properties
         $this->assertSame(['$ref' => '#/$defs/nodes/json_schema_test'], $schema['properties']['json_schema_test']);
+        // the alias node references the schema of the aliased extension
+        $this->assertSame(['$ref' => '#/$defs/nodes/json_schema_dev'], $schema['$defs']['nodes']['json_schema_test']['properties']['dev']);
         // dev-only bundle not in root properties
         $this->assertArrayNotHasKey('json_schema_dev', $schema['properties']);
         // when@dev contains both the 'all' bundle and the dev-only bundle, with additionalProperties: false
@@ -232,6 +235,7 @@ class JsonSchemaTestConfiguration implements ConfigurationInterface
             ->children()
                 ->scalarNode('name')->end()
                 ->booleanNode('enabled')->defaultFalse()->end()
+                ->variableNode('dev')->aliasOf('json_schema_dev')->end()
             ->end();
 
         return $treeBuilder;

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/PhpConfigReferenceDumpPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/PhpConfigReferenceDumpPassTest.php
@@ -193,6 +193,8 @@ class TestConfiguration implements ConfigurationInterface
                         ->end()
                     ->end()
                     ->booleanNode('fromBundle')->defaultValue($this->fromBundle)->end()
+                    ->variableNode('app_alias')->aliasOf('app')->setDeprecated('symfony/test', '1.0')->end()
+                    ->variableNode('unknown_alias')->aliasOf('unknown')->end()
                 ->end();
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/reference.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/reference.php
@@ -132,6 +132,8 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         count?: int|Param,
  *     },
  *     fromBundle?: bool|Param, // Default: false
+ *     app_alias?: AppConfig, // Deprecated: The child node "app_alias" at path "test.app_alias" is deprecated.
+ *     unknown_alias?: mixed,
  * }
  * @psalm-type AppConfig = bool|Param
  * @psalm-type PrototypedConfigConfig = array<string, array{ // Default: []

--- a/src/Symfony/Component/Config/CHANGELOG.md
+++ b/src/Symfony/Component/Config/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG
 8.2
 ---
 
+ * Add `NodeDefinition::aliasOf()` to declare that the value of a node belongs to the configuration rooted at another name
+ * Add argument `$resolveAlias` to `ArrayShapeGenerator::generate()` and to the constructor of `JsonSchemaDumper` to dump the nodes declared with `NodeDefinition::aliasOf()` as references
  * Add `JsonSchemaDumper` to dump JSON Schema from configuration node definitions
  * Add `BaseNode::isNullable()` to check if a node accepts null as input
  * Add `BaseNode::hasNormalizationClosures()` to check if closures are used to normalize the value

--- a/src/Symfony/Component/Config/Definition/ArrayShapeGenerator.php
+++ b/src/Symfony/Component/Config/Definition/ArrayShapeGenerator.php
@@ -19,15 +19,22 @@ use Symfony\Component\Config\Loader\ParamConfigurator;
  */
 final class ArrayShapeGenerator
 {
-    public static function generate(NodeInterface $node): string
+    /**
+     * @param (\Closure(string $alias): ?string)|null $resolveAlias Returns the name of the type describing the configuration rooted at the given name, or null when unknown
+     */
+    public static function generate(NodeInterface $node, ?\Closure $resolveAlias = null): string
     {
         // "*/" anywhere in the shape (a comment, an enum value, a node name) would prematurely
         // close the surrounding doc block, so the slash is escaped to keep the value readable
-        return str_replace(['*/', "\n"], ['*\/', "\n * "], self::doGeneratePhpDoc($node));
+        return str_replace(['*/', "\n"], ['*\/', "\n * "], self::doGeneratePhpDoc($node, 1, $resolveAlias));
     }
 
-    private static function doGeneratePhpDoc(NodeInterface $node, int $nestingLevel = 1): string
+    private static function doGeneratePhpDoc(NodeInterface $node, int $nestingLevel = 1, ?\Closure $resolveAlias = null): string
     {
+        if ($node instanceof BaseNode && null !== ($alias = $node->getAttribute('alias_of')) && null !== $type = $resolveAlias?->__invoke($alias)) {
+            return $type;
+        }
+
         if (!$node instanceof ArrayNode) {
             $typeString = match (true) {
                 $node instanceof BooleanNode => $node->hasDefaultValue() && null === $node->getDefaultValue() ? 'bool|null' : 'bool',
@@ -51,7 +58,7 @@ final class ArrayShapeGenerator
 
         if ($node instanceof PrototypedArrayNode) {
             $isHashmap = (bool) $node->getKeyAttribute();
-            $arrayShape = ($isHashmap ? 'array<string, ' : 'list<').self::doGeneratePhpDoc($node->getPrototype(), $nestingLevel).'>';
+            $arrayShape = ($isHashmap ? 'array<string, ' : 'list<').self::doGeneratePhpDoc($node->getPrototype(), $nestingLevel, $resolveAlias).'>';
 
             return implode('|', [...self::getNormalizedTypes($node, ['array', 'any']), $arrayShape]);
         }
@@ -65,7 +72,7 @@ final class ArrayShapeGenerator
         foreach ($children as $child) {
             $arrayShape .= str_repeat('    ', $nestingLevel).self::dumpNodeKey($child, $node).': ';
 
-            $arrayShape .= self::doGeneratePhpDoc($child, 1 + $nestingLevel);
+            $arrayShape .= self::doGeneratePhpDoc($child, 1 + $nestingLevel, $resolveAlias);
 
             $arrayShape .= \sprintf(",%s\n", !$child instanceof ArrayNode ? self::generateInlinePhpDocForNode($child) : '');
         }

--- a/src/Symfony/Component/Config/Definition/Builder/NodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/NodeDefinition.php
@@ -119,6 +119,21 @@ abstract class NodeDefinition implements NodeParentInterface
     }
 
     /**
+     * Declares that the value of this node belongs to the configuration rooted at the given name.
+     *
+     * The value is not processed by this tree, and dumpers reference that
+     * configuration instead of describing the node.
+     *
+     * Only the direct children of a root node can be aliases.
+     *
+     * @return $this
+     */
+    public function aliasOf(string $alias): static
+    {
+        return $this->attribute('alias_of', $alias);
+    }
+
+    /**
      * Sets an attribute on the node.
      *
      * @return $this

--- a/src/Symfony/Component/Config/Definition/Builder/TreeBuilder.php
+++ b/src/Symfony/Component/Config/Definition/Builder/TreeBuilder.php
@@ -11,7 +11,12 @@
 
 namespace Symfony\Component\Config\Definition\Builder;
 
+use Symfony\Component\Config\Definition\ArrayNode;
+use Symfony\Component\Config\Definition\BaseNode;
+use Symfony\Component\Config\Definition\Exception\InvalidDefinitionException;
 use Symfony\Component\Config\Definition\NodeInterface;
+use Symfony\Component\Config\Definition\PrototypedArrayNode;
+use Symfony\Component\Config\Definition\ScalarNode;
 
 /**
  * This is the entry class for building a config tree.
@@ -57,7 +62,13 @@ class TreeBuilder implements NodeParentInterface
 
     public function buildTree(): NodeInterface
     {
-        return $this->tree ??= $this->root->getNode(true);
+        if (null !== $this->tree) {
+            return $this->tree;
+        }
+
+        self::checkAliases($tree = $this->root->getNode(true), 0, $tree->getPath());
+
+        return $this->tree = $tree;
     }
 
     public function setPathSeparator(string $separator): void
@@ -66,5 +77,26 @@ class TreeBuilder implements NodeParentInterface
         $this->tree = null;
 
         $this->root->setPathSeparator($separator);
+    }
+
+    private static function checkAliases(NodeInterface $node, int $depth, string $path): void
+    {
+        if ($node instanceof BaseNode && null !== $node->getAttribute('alias_of')) {
+            if (1 !== $depth) {
+                throw new InvalidDefinitionException(\sprintf('Only the direct children of a root node can declare an "alias_of" attribute, but "%s" does.', $path));
+            }
+
+            if ($node instanceof ScalarNode) {
+                throw new InvalidDefinitionException(\sprintf('The value of a node declaring an "alias_of" attribute is forwarded as the configuration of the aliased extension, so the node must accept arrays, but "%s" does not.', $path));
+            }
+        }
+
+        if ($node instanceof PrototypedArrayNode) {
+            self::checkAliases($node->getPrototype(), 1 + $depth, $path.'[]');
+        } elseif ($node instanceof ArrayNode) {
+            foreach ($node->getChildren() as $child) {
+                self::checkAliases($child, 1 + $depth, $child->getPath());
+            }
+        }
     }
 }

--- a/src/Symfony/Component/Config/Definition/Dumper/JsonSchemaDumper.php
+++ b/src/Symfony/Component/Config/Definition/Dumper/JsonSchemaDumper.php
@@ -54,10 +54,12 @@ final class JsonSchemaDumper
     private array $typeDefs;
 
     /**
-     * @param array<array<string, mixed>> $parameterSchemas additional JSON Schema fragments included as anyOf options for scalar nodes
+     * @param array<array<string, mixed>>             $parameterSchemas additional JSON Schema fragments included as anyOf options for scalar nodes
+     * @param (\Closure(string $alias): ?string)|null $resolveAlias     returns the "$ref" pointer to the schema of the configuration rooted at the given name, or null when unknown
      */
     public function __construct(
         private readonly array $parameterSchemas = [],
+        private readonly ?\Closure $resolveAlias = null,
     ) {
         $this->typeDefs = $this->buildTypeDefs();
     }
@@ -90,7 +92,9 @@ final class JsonSchemaDumper
 
     public function dumpNode(NodeInterface $node): array
     {
-        if ($node instanceof PrototypedArrayNode) {
+        if ($node instanceof BaseNode && null !== ($alias = $node->getAttribute('alias_of')) && null !== $ref = $this->resolveAlias?->__invoke($alias)) {
+            $schema = ['$ref' => $ref];
+        } elseif ($node instanceof PrototypedArrayNode) {
             $prototypeSchema = $this->dumpNode($node->getPrototype());
 
             if ($node->getKeyAttribute()) {

--- a/src/Symfony/Component/Config/Tests/Definition/ArrayShapeGeneratorTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/ArrayShapeGeneratorTest.php
@@ -274,6 +274,41 @@ class ArrayShapeGeneratorTest extends TestCase
             CODE, ArrayShapeGenerator::generate($root->getNode()));
     }
 
+    public function testAliasReferencesTheTypeOfTheAliasedConfiguration()
+    {
+        $root = new ArrayNodeDefinition('root');
+        $root
+            ->children()
+                ->variableNode('foo')->aliasOf('foo_extension')->setDeprecated('symfony/test', '1.0')->end()
+            ->end();
+
+        $resolveAlias = static fn (string $alias): ?string => 'foo_extension' === $alias ? 'FooExtensionConfig' : null;
+
+        $this->assertSame(<<<'CODE'
+            array{
+             *     foo?: FooExtensionConfig, // Deprecated: The child node "foo" at path "root.foo" is deprecated.
+             * }
+            CODE, ArrayShapeGenerator::generate($root->getNode(), $resolveAlias));
+    }
+
+    public function testUnresolvedAliasIsDumpedAsMixed()
+    {
+        $root = new ArrayNodeDefinition('root');
+        $root
+            ->children()
+                ->variableNode('foo')->aliasOf('foo_extension')->end()
+            ->end();
+
+        $expected = <<<'CODE'
+            array{
+             *     foo?: mixed,
+             * }
+            CODE;
+
+        $this->assertSame($expected, ArrayShapeGenerator::generate($root->getNode()));
+        $this->assertSame($expected, ArrayShapeGenerator::generate($root->getNode(), static fn (): ?string => null));
+    }
+
     public function testBeforeNormalizationIfTrueMakesArrayShapeUnsealed()
     {
         $root = new ArrayNodeDefinition('root');

--- a/src/Symfony/Component/Config/Tests/Definition/Builder/NodeDefinitionTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Builder/NodeDefinitionTest.php
@@ -42,6 +42,14 @@ class NodeDefinitionTest extends TestCase
         $parentNode->setPathSeparator('/');
     }
 
+    public function testAliasOf()
+    {
+        $node = new VariableNodeDefinition('foo');
+        $node->aliasOf('bar');
+
+        $this->assertSame('bar', $node->getNode()->getAttribute('alias_of'));
+    }
+
     public function testDocUrl()
     {
         $node = new ArrayNodeDefinition('node');

--- a/src/Symfony/Component/Config/Tests/Definition/Builder/TreeBuilderTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Builder/TreeBuilderTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\Config\Definition\BaseNode;
 use Symfony\Component\Config\Definition\BooleanNode;
 use Symfony\Component\Config\Definition\Builder\BooleanNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\Exception\InvalidDefinitionException;
 use Symfony\Component\Config\Tests\Fixtures\BarNode;
 use Symfony\Component\Config\Tests\Fixtures\Builder\BarNodeDefinition;
 use Symfony\Component\Config\Tests\Fixtures\Builder\NodeBuilder as CustomNodeBuilder;
@@ -193,5 +194,92 @@ class TreeBuilderTest extends TestCase
         $this->assertArrayHasKey('foo', $childChildren);
         $this->assertInstanceOf(BaseNode::class, $childChildren['foo']);
         $this->assertSame('propagation/child/foo', $childChildren['foo']->getPath());
+    }
+
+    public function testAliasesCanBeDeclaredOnTheDirectChildrenOfTheRootNode()
+    {
+        $builder = new TreeBuilder('root');
+
+        $builder->getRootNode()
+            ->children()
+                ->variableNode('alias')->aliasOf('target')->end()
+            ->end();
+
+        $this->assertSame('target', $builder->buildTree()->getChildren()['alias']->getAttribute('alias_of'));
+    }
+
+    public function testAliasesCannotBeDeclaredOnNodesThatCannotHoldAnArray()
+    {
+        $builder = new TreeBuilder('root');
+
+        $builder->getRootNode()
+            ->children()
+                ->booleanNode('alias')->aliasOf('target')->end()
+            ->end();
+
+        $this->expectException(InvalidDefinitionException::class);
+        $this->expectExceptionMessage('The value of a node declaring an "alias_of" attribute is forwarded as the configuration of the aliased extension, so the node must accept arrays, but "root.alias" does not.');
+
+        $builder->buildTree();
+    }
+
+    public function testAliasesCanBeDeclaredOnArrayNodes()
+    {
+        $builder = new TreeBuilder('root');
+
+        $builder->getRootNode()
+            ->children()
+                ->arrayNode('alias')->aliasOf('target')->end()
+            ->end();
+
+        $this->assertSame('target', $builder->buildTree()->getChildren()['alias']->getAttribute('alias_of'));
+    }
+
+    public function testAliasesCannotBeDeclaredOnTheRootNode()
+    {
+        $builder = new TreeBuilder('root');
+
+        $builder->getRootNode()->aliasOf('target');
+
+        $this->expectException(InvalidDefinitionException::class);
+        $this->expectExceptionMessage('Only the direct children of a root node can declare an "alias_of" attribute, but "root" does.');
+
+        $builder->buildTree();
+    }
+
+    public function testAliasesCannotBeDeclaredOnNestedNodes()
+    {
+        $builder = new TreeBuilder('root');
+
+        $builder->getRootNode()
+            ->children()
+                ->arrayNode('nested')
+                    ->children()
+                        ->variableNode('alias')->aliasOf('target')->end()
+                    ->end()
+                ->end()
+            ->end();
+
+        $this->expectException(InvalidDefinitionException::class);
+        $this->expectExceptionMessage('Only the direct children of a root node can declare an "alias_of" attribute, but "root.nested.alias" does.');
+
+        $builder->buildTree();
+    }
+
+    public function testAliasesCannotBeDeclaredOnPrototypes()
+    {
+        $builder = new TreeBuilder('root');
+
+        $builder->getRootNode()
+            ->children()
+                ->arrayNode('nested')
+                    ->prototype('variable')->aliasOf('target')->end()
+                ->end()
+            ->end();
+
+        $this->expectException(InvalidDefinitionException::class);
+        $this->expectExceptionMessage('Only the direct children of a root node can declare an "alias_of" attribute, but "root.nested[]" does.');
+
+        $builder->buildTree();
     }
 }

--- a/src/Symfony/Component/Config/Tests/Definition/Dumper/JsonSchemaDumperTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Dumper/JsonSchemaDumperTest.php
@@ -284,6 +284,26 @@ class JsonSchemaDumperTest extends TestCase
         yield [$node, ['anyOf' => [['enum' => ['a', 'b']], self::param(), ['type' => ['string']]]]];
     }
 
+    public function testAliasReferencesTheSchemaOfTheAliasedConfiguration()
+    {
+        $root = new ArrayNodeDefinition('root');
+        $root
+            ->children()
+                ->variableNode('foo')->aliasOf('foo_extension')->setDeprecated('symfony/test', '1.0')->end()
+                ->variableNode('bar')->aliasOf('unknown')->end()
+            ->end();
+        $node = $root->getNode();
+
+        $properties = (new JsonSchemaDumper())->dumpNode($node)['properties'];
+        $this->assertSame(['$ref' => '#/$defs/types/variable', 'deprecated' => true, 'description' => 'Deprecated since symfony/test 1.0: The child node "foo" at path "root.foo" is deprecated.'], $properties['foo']);
+        $this->assertSame(['$ref' => '#/$defs/types/variable'], $properties['bar']);
+
+        $dumper = new JsonSchemaDumper(resolveAlias: static fn (string $alias): ?string => 'foo_extension' === $alias ? '#/$defs/nodes/foo_extension' : null);
+        $properties = $dumper->dumpNode($node)['properties'];
+        $this->assertSame(['$ref' => '#/$defs/nodes/foo_extension', 'deprecated' => true, 'description' => 'Deprecated since symfony/test 1.0: The child node "foo" at path "root.foo" is deprecated.'], $properties['foo']);
+        $this->assertSame(['$ref' => '#/$defs/types/variable'], $properties['bar']);
+    }
+
     public function testGetAllDefs()
     {
         $allDefs = (new JsonSchemaDumper())->getAllDefs();

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG
 8.2
 ---
 
+ * Add `ContainerBuilder::setExtensionConfig()`
+ * Forward the configuration of the nodes declared with `NodeDefinition::aliasOf()` to the extension with that alias in `MergeExtensionConfigurationPass`
  * Allow computing tag attributes per tagged service when using `#[AutoconfigureTag]`, `#[Autoconfigure]` or `_instanceof`: pass a `\Closure` receiving the concrete class-string (requires PHP 8.5), or a `[class-string, method]` callable resolved against each concrete class (works on PHP 8.4)
  * Call `#[Required]` methods in the order defined by the attribute's `$priority` argument
  * Add support for injecting a service as a lazy proxy on a per-argument basis, using the `!lazy_proxy` YAML tag, the `@~` reference prefix or the `lazy_proxy()` function in the PHP-DSL

--- a/src/Symfony/Component/DependencyInjection/Compiler/MergeExtensionConfigurationPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/MergeExtensionConfigurationPass.php
@@ -11,8 +11,12 @@
 
 namespace Symfony\Component\DependencyInjection\Compiler;
 
+use Symfony\Component\Config\Definition\ArrayNode;
 use Symfony\Component\Config\Definition\BaseNode;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
@@ -58,6 +62,10 @@ class MergeExtensionConfigurationPass implements CompilerPassInterface
             if ($extension instanceof PrependExtensionInterface) {
                 $extension->prepend($container);
             }
+        }
+
+        if ($configAvailable) {
+            $this->forwardExtensionAliases($container);
         }
 
         foreach ($container->getExtensions() as $name => $extension) {
@@ -114,6 +122,106 @@ class MergeExtensionConfigurationPass implements CompilerPassInterface
 
         $container->addDefinitions($definitions);
         $container->addAliases($aliases);
+    }
+
+    /**
+     * Moves the values of the nodes declared with NodeDefinition::aliasOf() to the configuration of the extension with that alias.
+     */
+    private function forwardExtensionAliases(ContainerBuilder $container): void
+    {
+        foreach ($container->getExtensions() as $name => $extension) {
+            if (!$configs = $container->getExtensionConfig($name)) {
+                continue;
+            }
+
+            if ($extension instanceof ConfigurationInterface) {
+                $configuration = $extension;
+            } elseif (!$extension instanceof ConfigurationExtensionInterface || null === $configuration = $extension->getConfiguration($configs, $container)) {
+                continue;
+            }
+
+            $tree = $configuration->getConfigTreeBuilder()->buildTree();
+
+            if (!$tree instanceof ArrayNode) {
+                continue;
+            }
+
+            $aliases = [];
+            foreach ($tree->getChildren() as $key => $child) {
+                if ($child instanceof BaseNode && null !== $child->getAttribute('alias_of')) {
+                    $aliases[$key] = $child;
+                }
+            }
+
+            if (!$aliases) {
+                continue;
+            }
+
+            $forwarded = [];
+            foreach ($configs as $i => $config) {
+                foreach ($tree->getXmlRemappings() as [$singular, $plural]) {
+                    if (isset($aliases[$plural]) && isset($config[$singular])) {
+                        $config[$plural] = Processor::normalizeConfig($config, $singular, $plural);
+                        unset($config[$singular]);
+                    }
+                }
+
+                foreach ($aliases as $key => $node) {
+                    $configKey = $key;
+
+                    if (!\array_key_exists($key, $config)) {
+                        // ArrayNode::preNormalize() turns hyphenated keys into their underscored form
+                        if (!str_contains($key, '_') || !\array_key_exists($configKey = str_replace('_', '-', $key), $config)) {
+                            continue;
+                        }
+                    }
+
+                    $alias = $node->getAttribute('alias_of');
+
+                    if (!$container->hasExtension($alias)) {
+                        throw new LogicException(\sprintf('The "%s.%s" configuration is handled by the "%s" extension, which is not registered.', $name, $key, $alias));
+                    }
+
+                    if ($node->isDeprecated()) {
+                        $deprecation = $node->getDeprecation($key, $node->getPath());
+                        trigger_deprecation($deprecation['package'], $deprecation['version'], $deprecation['message']);
+                    }
+
+                    try {
+                        // the value is merged into another extension's configuration, which is resolved
+                        // before that extension is loaded, so resolve it before normalizing it here
+                        $value = $container->getParameterBag()->resolveValue($config[$configKey]);
+                    } catch (ParameterNotFoundException $e) {
+                        $e->setSourceExtensionName($name);
+
+                        throw $e;
+                    }
+
+                    $value = $node->normalize($value) ?? [];
+
+                    if (!\is_array($value)) {
+                        throw new InvalidArgumentException(\sprintf('The "%s.%s" configuration must be an array or null, "%s" given.', $name, $key, get_debug_type($value)));
+                    }
+
+                    $forwarded[$container->getExtension($alias)->getAlias()][] = $value;
+                    unset($config[$configKey]);
+                }
+
+                $configs[$i] = $config;
+            }
+
+            if (!$forwarded) {
+                continue;
+            }
+
+            $container->setExtensionConfig($name, $configs);
+
+            foreach ($forwarded as $alias => $values) {
+                foreach (array_reverse($values) as $value) {
+                    $container->prependExtensionConfig($alias, $value);
+                }
+            }
+        }
     }
 }
 

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -766,6 +766,16 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
     }
 
     /**
+     * Replaces the configuration arrays of the given extension.
+     *
+     * @param array<array<string, mixed>> $configs
+     */
+    public function setExtensionConfig(string $name, array $configs): void
+    {
+        $this->extensionConfigs[$name] = array_values($configs);
+    }
+
+    /**
      * Deprecates a service container parameter.
      *
      * @throws ParameterNotFoundException if the parameter is not defined

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/MergeExtensionConfigurationPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/MergeExtensionConfigurationPassTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\DependencyInjection\Tests\Compiler;
 
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
@@ -18,6 +20,8 @@ use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\DependencyInjection\Compiler\MergeExtensionConfigurationContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\MergeExtensionConfigurationPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 use Symfony\Component\DependencyInjection\Extension\Extension;
@@ -72,7 +76,7 @@ class MergeExtensionConfigurationPassTest extends TestCase
     public function testExtensionConfigurationIsTrackedByDefault()
     {
         $extension = $this->getMockBuilder(FooExtension::class)->onlyMethods(['getConfiguration'])->getMock();
-        $extension->expects($this->exactly(2))
+        $extension->expects($this->exactly(3))
             ->method('getConfiguration')
             ->willReturn(new FooConfiguration());
 
@@ -158,6 +162,157 @@ class MergeExtensionConfigurationPassTest extends TestCase
         (new MergeExtensionConfigurationPass())->process($container);
 
         $this->addToAssertionCount(1);
+    }
+
+    public function testExtensionAliasesAreForwardedToTheAliasedExtension()
+    {
+        $container = new ContainerBuilder();
+        $container->registerExtension(new AliasingExtension());
+        $container->registerExtension(new TargetExtension());
+        $container->loadFromExtension('aliasing', ['own' => 'first', 'target' => ['value' => 'forwarded first']]);
+        $container->loadFromExtension('aliasing', ['target' => ['value' => 'forwarded second']]);
+        $container->loadFromExtension('target', ['value' => 'explicit']);
+
+        (new MergeExtensionConfigurationPass())->process($container);
+
+        $this->assertSame([['own' => 'first'], []], $container->getParameter('aliasing.configs'));
+        $this->assertSame([['value' => 'forwarded first'], ['value' => 'forwarded second'], ['value' => 'explicit']], $container->getParameter('target.configs'));
+        $this->assertSame([['own' => 'first'], []], $container->getExtensionConfig('aliasing'));
+    }
+
+    public function testExtensionAliasesAreForwardedWhenTheExtensionIsItsOwnConfiguration()
+    {
+        $container = new ContainerBuilder();
+        $container->registerExtension(new SelfConfiguringAliasingExtension());
+        $container->registerExtension(new TargetExtension());
+        $container->loadFromExtension('self_configuring_aliasing', ['target' => ['value' => 'forwarded']]);
+
+        (new MergeExtensionConfigurationPass())->process($container);
+
+        $this->assertSame([['value' => 'forwarded']], $container->getParameter('target.configs'));
+    }
+
+    public function testExtensionAliasesNormalizeTheirValueBeforeForwarding()
+    {
+        $container = new ContainerBuilder();
+        $container->registerExtension(new AliasingExtension());
+        $container->registerExtension(new TargetExtension());
+        $container->loadFromExtension('aliasing', ['target' => null]);
+        $container->loadFromExtension('aliasing', ['target' => false]);
+
+        (new MergeExtensionConfigurationPass())->process($container);
+
+        $this->assertSame([[], ['enabled' => false]], $container->getParameter('target.configs'));
+    }
+
+    public function testExtensionAliasesResolveParametersBeforeNormalizing()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('some_bool', false);
+        $container->setParameter('some_config', ['value' => 'from parameter']);
+        $container->registerExtension(new AliasingExtension());
+        $container->registerExtension(new TargetExtension());
+        $container->loadFromExtension('aliasing', ['target' => '%some_bool%']);
+        $container->loadFromExtension('aliasing', ['target' => '%some_config%']);
+
+        (new MergeExtensionConfigurationPass())->process($container);
+
+        $this->assertSame([['enabled' => false], ['value' => 'from parameter']], $container->getParameter('target.configs'));
+    }
+
+    public function testExtensionAliasesReportTheSourceOfAnUnknownParameter()
+    {
+        $container = new ContainerBuilder();
+        $container->registerExtension(new AliasingExtension());
+        $container->registerExtension(new TargetExtension());
+        $container->loadFromExtension('aliasing', ['target' => '%not_a_parameter%']);
+
+        try {
+            (new MergeExtensionConfigurationPass())->process($container);
+            $this->fail('->process() should throw when an aliased value references an unknown parameter');
+        } catch (ParameterNotFoundException $e) {
+            $this->assertStringContainsString('aliasing', $e->getMessage());
+        }
+    }
+
+    public function testExtensionAliasesCanWrapAScalarShorthand()
+    {
+        $container = new ContainerBuilder();
+        $container->registerExtension(new AliasingExtension());
+        $container->registerExtension(new TargetExtension());
+        $container->loadFromExtension('aliasing', ['shorthand' => 'redis://localhost']);
+        $container->loadFromExtension('aliasing', ['shorthand' => ['value' => 'explicit']]);
+
+        (new MergeExtensionConfigurationPass())->process($container);
+
+        $this->assertSame([['value' => 'redis://localhost'], ['value' => 'explicit']], $container->getParameter('target.configs'));
+    }
+
+    public function testExtensionAliasesAcceptTheHyphenatedSpellingOfTheirKey()
+    {
+        $container = new ContainerBuilder();
+        $container->registerExtension(new AliasingExtension());
+        $container->registerExtension(new TargetExtension());
+        $container->loadFromExtension('aliasing', ['under-scored' => ['value' => 'hyphenated']]);
+
+        (new MergeExtensionConfigurationPass())->process($container);
+
+        $this->assertSame([['value' => 'hyphenated']], $container->getParameter('target.configs'));
+        $this->assertSame([[]], $container->getExtensionConfig('aliasing'));
+    }
+
+    public function testExtensionAliasesUseTheXmlRemappingOfTheirParent()
+    {
+        $container = new ContainerBuilder();
+        $container->registerExtension(new AliasingExtension());
+        $container->registerExtension(new TargetExtension());
+        $container->loadFromExtension('aliasing', ['item' => ['value' => 'single']]);
+        $container->loadFromExtension('aliasing', ['item' => [['value' => 'first'], ['value' => 'second']]]);
+
+        (new MergeExtensionConfigurationPass())->process($container);
+
+        $this->assertSame([[['value' => 'single']], [['value' => 'first'], ['value' => 'second']]], $container->getParameter('target.configs'));
+    }
+
+    public function testExtensionAliasesRejectValuesThatAreNotArrays()
+    {
+        $container = new ContainerBuilder();
+        $container->registerExtension(new AliasingExtension());
+        $container->registerExtension(new TargetExtension());
+        $container->loadFromExtension('aliasing', ['target' => 'not an array']);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "aliasing.target" configuration must be an array or null, "string" given.');
+
+        (new MergeExtensionConfigurationPass())->process($container);
+    }
+
+    public function testExtensionAliasesRequireTheAliasedExtension()
+    {
+        $container = new ContainerBuilder();
+        $container->registerExtension(new AliasingExtension());
+        $container->loadFromExtension('aliasing', ['target' => []]);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('The "aliasing.target" configuration is handled by the "target" extension, which is not registered.');
+
+        (new MergeExtensionConfigurationPass())->process($container);
+    }
+
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
+    public function testDeprecatedExtensionAliasesTriggerTheirDeprecation()
+    {
+        $container = new ContainerBuilder();
+        $container->registerExtension(new AliasingExtension());
+        $container->registerExtension(new TargetExtension());
+        $container->loadFromExtension('aliasing', ['legacy' => ['value' => 'legacy']]);
+
+        $this->expectUserDeprecationMessage('Since symfony/test 1.0: The "aliasing.legacy" configuration is deprecated, use "target" instead.');
+
+        (new MergeExtensionConfigurationPass())->process($container);
+
+        $this->assertSame([['value' => 'legacy']], $container->getParameter('target.configs'));
     }
 }
 
@@ -259,5 +414,79 @@ final class TestCccExtension extends Extension
     {
         $configuration = $this->getConfiguration($configs, $container);
         $this->processConfiguration($configuration, $configs);
+    }
+}
+
+final class AliasingConfiguration implements ConfigurationInterface
+{
+    public function getConfigTreeBuilder(): TreeBuilder
+    {
+        $treeBuilder = new TreeBuilder('aliasing');
+        $treeBuilder->getRootNode()
+            ->fixXmlConfig('item')
+            ->children()
+                ->scalarNode('own')->end()
+                ->variableNode('target')->attribute('alias_of', 'target')->treatFalseLike(['enabled' => false])->end()
+                ->variableNode('items')->attribute('alias_of', 'target')->end()
+                ->variableNode('under_scored')->attribute('alias_of', 'target')->end()
+                ->variableNode('shorthand')->attribute('alias_of', 'target')->beforeNormalization()->ifString()->then(static fn ($v) => ['value' => $v])->end()->end()
+                ->variableNode('legacy')->attribute('alias_of', 'target')->setDeprecated('symfony/test', '1.0', 'The "%path%" configuration is deprecated, use "target" instead.')->end()
+            ->end();
+
+        return $treeBuilder;
+    }
+}
+
+final class AliasingExtension extends Extension
+{
+    public function getAlias(): string
+    {
+        return 'aliasing';
+    }
+
+    public function getConfiguration(array $config, ContainerBuilder $container): ?ConfigurationInterface
+    {
+        return new AliasingConfiguration();
+    }
+
+    public function load(array $configs, ContainerBuilder $container): void
+    {
+        $container->setParameter('aliasing.configs', $configs);
+    }
+}
+
+final class SelfConfiguringAliasingExtension extends Extension implements ConfigurationInterface
+{
+    public function getAlias(): string
+    {
+        return 'self_configuring_aliasing';
+    }
+
+    public function getConfigTreeBuilder(): TreeBuilder
+    {
+        $treeBuilder = new TreeBuilder('self_configuring_aliasing');
+        $treeBuilder->getRootNode()
+            ->children()
+                ->variableNode('target')->attribute('alias_of', 'target')->end()
+            ->end();
+
+        return $treeBuilder;
+    }
+
+    public function load(array $configs, ContainerBuilder $container): void
+    {
+    }
+}
+
+final class TargetExtension extends Extension
+{
+    public function getAlias(): string
+    {
+        return 'target';
+    }
+
+    public function load(array $configs, ContainerBuilder $container): void
+    {
+        $container->setParameter('target.configs', $configs);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

`ServicesBundle` and `ConsoleBundle` showed that a component can carry its own bundle. Moving the sections that own a `framework.*` configuration key is blocked by the configuration namespace: `framework.workflows` has to keep working while the Workflow component owns the `workflow` configuration. This PR adds the missing piece. It changes no behavior on its own.

A node can declare that its value belongs to the configuration rooted at another name:

```php
$rootNode
    ->children()
        ->variableNode('workflows')->aliasOf('workflow')->end()
    ->end();
```

`MergeExtensionConfigurationPass` then moves the value of that node to the configuration of the extension with that alias. This happens after all `prepend()` calls and before any `load()`, so bundles that prepend `framework.workflows` keep working: prepends run in bundle registration order, so doing this inside `FrameworkExtension::prepend()` would miss the bundles registered after it.

The Config component knows nothing about extensions. It carries the name, checks where an alias may appear, and lets a dumper resolve it. Turning that name into an extension is the job of the DependencyInjection component.

Details that the implementation has to get right:

- The value is normalized by the node first, so `treatFalseLike()` and friends apply, and `null` becomes `[]`.
- Forwarded values sort before the configuration written directly under the new key, so the new key wins when both are used.
- The XML remappings of the parent node are honored, so a singular key still normalizes to its plural.
- A key whose node name contains an underscore is also matched in its hyphenated spelling, because `ArrayNode::preNormalize()` accepts that form today. Without this, `framework.web-link` would be silently dropped rather than forwarded: the forwarding reads the raw configuration before normalization, so it would miss the key, and the alias node would then swallow it.
- A missing target extension is an error rather than a silent drop.
- The key is stripped before the tree is processed, so the pass triggers the node deprecation itself when the node is deprecated. Aliases do not have to be deprecated; this PR adds no deprecation.
- Only the direct children of a root node can be aliases. `TreeBuilder::buildTree()` throws when `aliasOf()` sits deeper, because the dumpers would describe such a node as a reference while the pass would never forward it.

Because the node's own normalizers run, an alias can also carry the shorthand of the section it replaces. Sections such as `framework.lock` and `framework.semaphore` accept a bare string, and the forwarded value has to be an array, so those aliases declare the wrapping themselves:

```php
->variableNode('semaphore')->aliasOf('semaphore')
    ->beforeNormalization()->ifString()->then(static fn ($v) => ['resources' => ['default' => $v]])->end()
->end()
```

The dumpers reference the target instead of describing the node. `ArrayShapeGenerator::generate()` takes a `$resolveAlias` closure and emits `workflows?: WorkflowConfig`, and `JsonSchemaDumper` emits `{"$ref": "#/$defs/nodes/workflow"}`. Both FrameworkBundle dumper passes use it, so `config/reference.php` and `config/schema.json` stop inlining an aliased section and describe it once.

Public API added:

- `NodeDefinition::aliasOf(string $alias)`
- `ArrayShapeGenerator::generate(NodeInterface $node, ?\Closure $resolveAlias = null)`
- `JsonSchemaDumper::__construct(array $parameterSchemas = [], ?\Closure $resolveAlias = null)`
- `ContainerBuilder::setExtensionConfig(string $name, array $configs)`

Limits: aliases are not chained.

The next PR uses this to move the workflow configuration into a new `WorkflowBundle`.

## Checks

The Config, DependencyInjection and FrameworkBundle suites pass locally, and php-cs-fixer is clean. Each new test was checked to fail on the base sources. Not run locally: PHPStan and Psalm.

## Documentation

`NodeDefinition::aliasOf()` and the `$resolveAlias` argument of the two dumpers.
