### PR TITLE
[FrameworkBundle] Fix container compilation when a JsonPath function is registered

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/JsonPathPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/JsonPathPass.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\JsonPath\FunctionReturnType;
 
 /**
  * Collects metadata (arity, return type) for custom JsonPath functions
@@ -33,9 +34,11 @@ class JsonPathPass implements CompilerPassInterface
                     continue;
                 }
 
+                $returnType = $attributes['return_type'] ?? null;
+
                 $metadata[$attributes['name']] = [
                     'arity' => $attributes['arity'] ?? null,
-                    'return_type' => $attributes['return_type'] ?? null,
+                    'return_type' => \is_string($returnType) ? FunctionReturnType::from($returnType) : $returnType,
                 ];
             }
         }

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -672,7 +672,7 @@ class FrameworkExtension extends Extension
 
                 $definition->addTag('json_path.function', [
                     'name' => $attribute->name,
-                    'return_type' => $attribute->returnType,
+                    'return_type' => $attribute->returnType->value,
                     'arity' => $reflector->getMethod('__invoke')->getNumberOfRequiredParameters(),
                 ]);
             });

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/JsonPathPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/JsonPathPassTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler;
+
+use PHPUnit\Framework\Attributes\RequiresMethod;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\JsonPathPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\JsonPath\FunctionReturnType;
+use Symfony\Component\JsonPath\JsonPathCrawler;
+use Symfony\Component\JsonPath\JsonPathCrawlerInterface;
+
+#[RequiresMethod(JsonPathCrawlerInterface::class, 'crawl')]
+class JsonPathPassTest extends TestCase
+{
+    public function testReturnTypeIsReadBackFromTheTag()
+    {
+        $container = new ContainerBuilder();
+        $container->register('json_path.crawler', JsonPathCrawler::class)->setArguments([null, []]);
+        $container->register('upper')->addTag('json_path.function', ['name' => 'upper', 'return_type' => 'logical', 'arity' => 1]);
+
+        new JsonPathPass()->process($container);
+
+        $this->assertSame(['upper' => ['arity' => 1, 'return_type' => FunctionReturnType::Logical]], $container->getDefinition('json_path.crawler')->getArgument(1));
+    }
+
+    public function testReturnTypeIsKeptWhenTheTagAlreadyHoldsAnEnum()
+    {
+        $container = new ContainerBuilder();
+        $container->register('json_path.crawler', JsonPathCrawler::class)->setArguments([null, []]);
+        $container->register('upper')->addTag('json_path.function', ['name' => 'upper', 'return_type' => FunctionReturnType::Nodes, 'arity' => 1]);
+
+        new JsonPathPass()->process($container);
+
+        $this->assertSame(['upper' => ['arity' => 1, 'return_type' => FunctionReturnType::Nodes]], $container->getDefinition('json_path.crawler')->getArgument(1));
+    }
+
+    public function testReturnTypeDefaultsToNull()
+    {
+        $container = new ContainerBuilder();
+        $container->register('json_path.crawler', JsonPathCrawler::class)->setArguments([null, []]);
+        $container->register('upper')->addTag('json_path.function', ['name' => 'upper', 'arity' => 1]);
+
+        new JsonPathPass()->process($container);
+
+        $this->assertSame(['upper' => ['arity' => 1, 'return_type' => null]], $container->getDefinition('json_path.crawler')->getArgument(1));
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -18,6 +18,7 @@ use PHPUnit\Framework\Attributes\RequiresMethod;
 use PHPUnit\Framework\Attributes\TestWith;
 use Psr\Cache\CacheItemPoolInterface;
 use Psr\Log\LogLevel;
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\JsonPathPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\FrameworkExtension;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Fixtures\Workflow\Validator\DefinitionValidator;
@@ -41,6 +42,7 @@ use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\AddBehaviorDescribingTagsPass;
+use Symfony\Component\DependencyInjection\Compiler\CheckDefinitionValidityPass;
 use Symfony\Component\DependencyInjection\Compiler\ResolveBindingsPass;
 use Symfony\Component\DependencyInjection\Compiler\ResolveChildDefinitionsPass;
 use Symfony\Component\DependencyInjection\Compiler\ResolveTaggedIteratorArgumentPass;
@@ -3268,13 +3270,29 @@ abstract class FrameworkExtensionTestCase extends TestCase
                 ->setAutoconfigured(true);
         });
 
-        $this->assertEquals([['name' => 'upper', 'return_type' => FunctionReturnType::Value, 'arity' => 1]], $container->getDefinition('json_path.function.upper')->getTag('json_path.function'));
+        $this->assertSame([['name' => 'upper', 'return_type' => 'value', 'arity' => 1]], $container->getDefinition('json_path.function.upper')->getTag('json_path.function'));
 
         $locatorArgument = $container->getDefinition('json_path.crawler')->getArgument(0);
         $this->assertInstanceOf(ServiceLocatorArgument::class, $locatorArgument);
         $this->assertInstanceOf(TaggedIteratorArgument::class, $locatorArgument->getTaggedIteratorArgument());
         $this->assertSame('json_path.function', $locatorArgument->getTaggedIteratorArgument()->getTag());
         $this->assertSame('name', $locatorArgument->getTaggedIteratorArgument()->getIndexAttribute());
+    }
+
+    #[RequiresMethod(JsonPathCrawlerInterface::class, 'crawl')]
+    public function testJsonPathFunctionMetadataIsCollectedOnCompilation()
+    {
+        $container = $this->createContainerFromClosure(static function (ContainerBuilder $container) {
+            $container->loadFromExtension('framework', []);
+            $container->register('json_path.function.upper', UppercaseFunction::class)
+                ->setAutoconfigured(true);
+            $container->addCompilerPass(new JsonPathPass());
+        }, compile: false);
+
+        $container->getCompilerPassConfig()->setOptimizationPasses([new ResolveChildDefinitionsPass(), new CheckDefinitionValidityPass()]);
+        $container->compile();
+
+        $this->assertSame(['upper' => ['arity' => 1, 'return_type' => FunctionReturnType::Value]], $container->getDefinition('json_path.crawler')->getArgument(1));
     }
 
     public function testObjectMapperEnabled()
@@ -3364,7 +3382,7 @@ abstract class FrameworkExtensionTestCase extends TestCase
         return self::$containerCache[$cacheKey] = $container;
     }
 
-    protected function createContainerFromClosure($closure, $data = []): ContainerBuilder
+    protected function createContainerFromClosure($closure, $data = [], bool $compile = true): ContainerBuilder
     {
         $container = $this->createContainer($data);
         $container->registerExtension(new FrameworkExtension());
@@ -3374,7 +3392,10 @@ abstract class FrameworkExtensionTestCase extends TestCase
         $container->getCompilerPassConfig()->setOptimizationPasses([]);
         $container->getCompilerPassConfig()->setRemovingPasses([]);
         $container->getCompilerPassConfig()->setAfterRemovingPasses([]);
-        $container->compile();
+
+        if ($compile) {
+            $container->compile();
+        }
 
         return $container;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Any application that declares a custom JSON Path function fails to compile its container.

`FrameworkExtension` autoconfigures `#[AsJsonPathFunction]` and puts the `FunctionReturnType` enum instance straight into a service tag attribute. `CheckDefinitionValidityPass` rejects non-scalar tag attributes, so compilation dies:

```
A "tags" attribute must be of a scalar-type for service "upper_fn", tag "json_path.function", attribute "return_type".
```

The tag now carries the backed value, and `JsonPathPass` converts it back with `FunctionReturnType::from()`.

Converting back is required rather than cosmetic. `JsonCrawler::validateFunctionReturnType()` compares with `FunctionReturnType::Value === $returnType`, and the crawler documents `functionsMetadata` as `array{arity?: int|null, return_type?: FunctionReturnType|null}`. Leaving a raw string there would compile but silently disable the RFC 9535 return-type checks, which is worse than the crash.

`JsonPathPass` accepts a value that is already an enum and passes it through. No working container can currently hold one, since the validity check kills compilation first, but the guard keeps hand-built `ContainerBuilder` setups that skip that pass working. Hand-tagging with the string `'value'` was silently broken before this change and is correct after it.

The tag is not public API: it appears only in `FrameworkExtension` as the writer, `JsonPathPass` as the reader, the tagged locator in `Resources/config/json_path.php` (which keys on `name` and is unaffected) and `UnusedTagsPass`. It is not documented in `reference/dic_tags.rst`. The advertised surface is the attribute.

## Checks

`./phpunit src/Symfony/Bundle/FrameworkBundle` gives `Tests: 1443, Assertions: 4750, Skipped: 2`, and `./phpunit src/Symfony/Component/JsonPath` gives `OK (1440 tests, 1693 assertions)`.

The regression test is `FrameworkExtensionTestCase::testJsonPathFunctionMetadataIsCollectedOnCompilation`, which compiles with `CheckDefinitionValidityPass` in the pass set and asserts the metadata the crawler receives. That is the point: the existing `testJsonPathFunctionAttributeAutoconfiguration` inspects the tag without compiling, which is exactly why it asserted the broken shape instead of catching it. Its expectation is updated here, but it is not what proves the fix. `JsonPathPassTest` covers the conversion directly. All new tests were checked to fail on the base sources with the production error above.

php-cs-fixer reports two violations in the touched files, both at lines this change does not go near and both present in pristine 8.1: a missing space after a comma in `FrameworkExtension.php` and a non-static closure in `FrameworkExtensionTestCase.php`. They are left alone rather than folded into a bugfix.

Merge-up to 8.2: the defect and the fix are identical there, and the merge is currently clean. If the JsonPathBundle move lands on 8.2 first, take 8.2's version of `Compiler/JsonPathPass.php`, `FrameworkExtension.php` and `FrameworkExtensionTestCase.php`, because that branch already carries the same fix in `JsonPathBundle::loadExtension()` and in the component's own `JsonPathPass`. Re-home `Tests/DependencyInjection/Compiler/JsonPathPassTest.php` under the JsonPath component or drop it, since `JsonPathBundleTest` boots a real kernel and keeps the regression covered. After that move the conversion belongs in the component pass, not in FrameworkBundle, whose class becomes an empty subclass.
