### PR TITLE
[FrameworkBundle] Fix HTTP client request assertion matching

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/HttpClientAssertionsTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/HttpClientAssertionsTrait.php
@@ -31,6 +31,7 @@ trait HttpClientAssertionsTrait
         /** @var HttpClientDataCollector $httpClientDataCollector */
         $httpClientDataCollector = $profile->getCollector('http_client');
         $expectedRequestHasBeenFound = false;
+        $urlAndMethodHaveBeenFound = false;
 
         if (!\array_key_exists($httpClientId, $httpClientDataCollector->getClients())) {
             static::fail(\sprintf('HttpClient "%s" is not registered.', $httpClientId));
@@ -43,6 +44,8 @@ trait HttpClientAssertionsTrait
                 continue;
             }
 
+            $urlAndMethodHaveBeenFound = true;
+
             if (null !== $expectedBody) {
                 $actualBody = null;
 
@@ -54,28 +57,17 @@ trait HttpClientAssertionsTrait
                     $actualBody = $trace['options']['json']->getValue(true);
                 }
 
-                if (!$actualBody) {
+                if ($expectedBody !== $actualBody) {
                     continue;
-                }
-
-                if ($expectedBody === $actualBody) {
-                    $expectedRequestHasBeenFound = true;
-
-                    if (!$expectedHeaders) {
-                        break;
-                    }
                 }
             }
 
             if ($expectedHeaders) {
-                $actualHeaders = $trace['options']['headers'] ?? [];
+                $actualHeaders = ($trace['options']['headers'] ?? null)?->getValue(true) ?? [];
 
-                foreach ($actualHeaders as $headerKey => $actualHeader) {
-                    if (\array_key_exists($headerKey, $expectedHeaders)
-                        && $expectedHeaders[$headerKey] === $actualHeader->getValue(true)
-                    ) {
-                        $expectedRequestHasBeenFound = true;
-                        break 2;
+                foreach ($expectedHeaders as $headerKey => $expectedHeader) {
+                    if (!\array_key_exists($headerKey, $actualHeaders) || $expectedHeader !== $actualHeaders[$headerKey]) {
+                        continue 2;
                     }
                 }
             }
@@ -84,7 +76,9 @@ trait HttpClientAssertionsTrait
             break;
         }
 
-        self::assertTrue($expectedRequestHasBeenFound, 'The expected request has not been called: "'.$expectedMethod.'" - "'.$expectedUrl.'"');
+        self::assertTrue($expectedRequestHasBeenFound, $urlAndMethodHaveBeenFound
+            ? \sprintf('The request "%s" - "%s" has been called, but with a different body or different headers.', $expectedMethod, $expectedUrl)
+            : \sprintf('The expected request has not been called: "%s" - "%s"', $expectedMethod, $expectedUrl));
     }
 
     public function assertNotHttpClientRequest(string $unexpectedUrl, string $expectedMethod = 'GET', string $httpClientId = 'http_client'): void

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Controller/HttpClientController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Controller/HttpClientController.php
@@ -28,6 +28,7 @@ class HttpClientController
             'headers' => ['X-Test-Header' => 'foo'],
             'json' => ['foo' => 'bar'],
         ]);
+        $symfonyHttpClient->request('POST', '/empty-body', ['body' => '']);
         $symfonyHttpClient->request('GET', '/doc/current/index.html');
 
         return new Response();

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/HttpClientTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/HttpClientTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
 
+use PHPUnit\Framework\AssertionFailedError;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -32,7 +33,52 @@ class HttpClientTest extends AbstractWebTestCase
         $this->assertHttpClientRequest('https://symfony.com/doc/current/index.html', httpClientId: 'symfony.http_client');
         $this->assertNotHttpClientRequest('https://laravel.com', httpClientId: 'symfony.http_client');
 
-        $this->assertHttpClientRequestCount(6, 'symfony.http_client');
+        $this->assertHttpClientRequestCount(7, 'symfony.http_client');
+    }
+
+    public function testAssertHttpClientRequestFailsWhenBodyDoesNotMatch()
+    {
+        $client = $this->createClient(['test_case' => 'HttpClient', 'root_config' => 'config.yml', 'debug' => true]);
+        $client->enableProfiler();
+        $client->request('GET', '/http_client_call');
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('The request "POST" - "https://symfony.com/" has been called, but with a different body or different headers.');
+
+        $this->assertHttpClientRequest('https://symfony.com/', 'POST', ['foo' => 'baz'], [], 'symfony.http_client');
+    }
+
+    public function testAssertHttpClientRequestFailsWhenHeadersDoNotMatch()
+    {
+        $client = $this->createClient(['test_case' => 'HttpClient', 'root_config' => 'config.yml', 'debug' => true]);
+        $client->enableProfiler();
+        $client->request('GET', '/http_client_call');
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('The request "POST" - "https://symfony.com/" has been called, but with a different body or different headers.');
+
+        $this->assertHttpClientRequest('https://symfony.com/', 'POST', null, ['X-Test-Header' => 'bar'], 'symfony.http_client');
+    }
+
+    public function testAssertHttpClientRequestFailsWhenTheRequestHasNotBeenCalled()
+    {
+        $client = $this->createClient(['test_case' => 'HttpClient', 'root_config' => 'config.yml', 'debug' => true]);
+        $client->enableProfiler();
+        $client->request('GET', '/http_client_call');
+
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('The expected request has not been called: "POST" - "https://symfony.com/never-called"');
+
+        $this->assertHttpClientRequest('https://symfony.com/never-called', 'POST', null, [], 'symfony.http_client');
+    }
+
+    public function testAssertHttpClientRequestMatchesAnEmptyBody()
+    {
+        $client = $this->createClient(['test_case' => 'HttpClient', 'root_config' => 'config.yml', 'debug' => true]);
+        $client->enableProfiler();
+        $client->request('GET', '/http_client_call');
+
+        $this->assertHttpClientRequest('https://symfony.com/empty-body', 'POST', '', [], 'symfony.http_client');
     }
 
     public function testHttpClientCanBeOverriddenInWebTestCase()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | N/A
| License       | MIT

`HttpClientAssertionsTrait::assertHttpClientRequest()` currently accepts a request after its URL and method match even when a provided non-empty body or provided headers do not match. Unsuccessful checks of those optional criteria fall through to the unconditional successful match, which can produce false-positive test assertions.

The [Symfony 6.4 testing documentation](https://symfony.com/doc/6.4/testing.html#httpclient-assertions) defines the optional method, body, and headers as request-matching criteria. This change brings the implementation in line with that documented behavior.

This fixes the matching flow so that a provided body must strictly equal the recorded body and every provided header must exist with the expected value. A trace that fails either criterion is skipped so another recorded request can still be considered.

Regression tests cover mismatched request bodies and mismatched request headers. The existing functional test continues to cover successful matching, including multiple requests to the same URL.

The failure message now distinguishes the two cases: when no trace matches the URL and the method it still reads `The expected request has not been called`, and when one does but its body or headers differ it reads `The request "POST" - "https://example.com/" has been called, but with a different body or different headers.`

Matching stays case-sensitive on header names. `TraceableHttpClient` decorates at priority 100 while `ScopingHttpClient` sits at 15, so what a trace records is the literal option array passed at the call site, before scope defaults and before the client normalises anything. The assertion compares that array, not the headers that go over the wire, so there is no header name whose case the test author does not control.

Merge-up to 8.1: the only conflict is the overlapping import line, `TransportDecorator` against `AssertionFailedError`. Keep both. 7.4 merges clean.

