### PR TITLE
[FrameworkBundle] Fix referencing "lock.factory" when no default lock resource is configured

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -3491,7 +3491,7 @@ class FrameworkExtension extends Extension
                 ->addTag('rate_limiter', ['name' => $name]);
 
             if ('auto' === $limiterConfig['lock_factory']) {
-                $limiterConfig['lock_factory'] = $this->isInitializedConfigEnabled('lock') ? 'lock.factory' : null;
+                $limiterConfig['lock_factory'] = $container->hasAlias('lock.factory') ? 'lock.factory' : null;
             }
 
             if (null !== $limiterConfig['lock_factory']) {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/PhpFrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/PhpFrameworkExtensionTest.php
@@ -277,6 +277,45 @@ class PhpFrameworkExtensionTest extends FrameworkExtensionTestCase
         $container->getDefinition('limiter.without_lock')->getArgument(2);
     }
 
+    public function testRateLimiterAutoLockFactoryWithoutDefaultLockResource()
+    {
+        $container = $this->createContainerFromClosure(static function (ContainerBuilder $container) {
+            $container->loadFromExtension('framework', [
+                'annotations' => false,
+                'http_method_override' => false,
+                'handle_all_throwables' => true,
+                'php_errors' => ['log' => true],
+                'lock' => ['foo' => 'flock'],
+                'rate_limiter' => [
+                    'without_lock' => ['policy' => 'fixed_window', 'limit' => 10, 'interval' => '1 hour'],
+                ],
+            ]);
+        });
+
+        $this->expectException(OutOfBoundsException::class);
+        $this->expectExceptionMessageMatches('/^The argument "2" doesn\'t exist.*\.$/');
+
+        $container->getDefinition('limiter.without_lock')->getArgument(2);
+    }
+
+    public function testRateLimiterCustomLockFactoryWithoutDefaultLockResource()
+    {
+        $container = $this->createContainerFromClosure(static function (ContainerBuilder $container) {
+            $container->loadFromExtension('framework', [
+                'annotations' => false,
+                'http_method_override' => false,
+                'handle_all_throwables' => true,
+                'php_errors' => ['log' => true],
+                'lock' => ['foo' => 'flock'],
+                'rate_limiter' => [
+                    'with_lock' => ['policy' => 'fixed_window', 'limit' => 10, 'interval' => '1 hour', 'lock_factory' => 'app.lock_factory'],
+                ],
+            ]);
+        });
+
+        $this->assertSame('app.lock_factory', (string) $container->getDefinition('limiter.with_lock')->getArgument(2));
+    }
+
     public function testRateLimiterDisableLockFactory()
     {
         $container = $this->createContainerFromClosure(static function (ContainerBuilder $container) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`framework.rate_limiter.*.lock_factory` defaults to `auto`, which is meant to use the framework's own lock factory when the Lock component is configured. The extension resolved it with `isInitializedConfigEnabled('lock')`, which only answers "is the `framework.lock` section enabled".

But `registerLockConfiguration()` creates the `lock.factory` alias only for a resource named `default`. So a configuration that enables locking under any other resource name gets a reference to a service that was never defined:

```yaml
framework:
    lock:
        foo: 'flock'
    rate_limiter:
        my_limiter:
            policy: 'fixed_window'
            limit: 10
            interval: '1 hour'
```

```
The service "limiter.my_limiter" has a dependency on a non-existent service "lock.factory".
```

The value being chosen is a service id, so the question to ask is whether that service exists:

```php
$limiterConfig['lock_factory'] = $container->hasAlias('lock.factory') ? 'lock.factory' : null;
```

This subsumes the old check, since the alias cannot exist unless the section was enabled and the component installed, and it also covers `resources: {default: [], foo: flock}`, where the `default` key exists but is skipped for having no store.

Only the `auto` path changes. An explicitly named factory keeps being referenced as written, including one that does not exist: naming a missing service is a user error on every branch, and the container reports it precisely. The nearby `LogicException` for a custom factory id stays as it is; making it depend on `hasAlias('lock.factory')` would break configurations that name their own factory and work today.

Messenger already guards the same way at `FrameworkExtension` line 613, checking `$config['lock']['resources']['default']` rather than just the section. `LoginThrottlingFactory` does it by injecting `lock.factory` with `NULL_ON_INVALID_REFERENCE`. The rate limiter was the one place left out.

6.4 is not affected in the same way: it has no `auto` sentinel, so the extension cannot tell a framework default from a user-written `lock.factory`, and no guard can be added there without changing behaviour for people who named that id on purpose.

One behaviour change worth stating: someone who defines their own service literally named `lock.factory` in `services.yaml`, configures `framework.lock` with only named resources, and leaves `lock_factory: auto` used to get a reference to their own service and now gets no lock. Extensions cannot see `services.yaml` definitions, so no check inside `load()` can tell the two apart. Naming the id explicitly keeps working.

Merge-up to 8.0, 8.1 and 8.2: both tests copy their 7.4 neighbours, which still pass `'annotations' => false`, `'http_method_override' => false`, `'handle_all_throwables' => true` and `'php_errors' => ['log' => true]`. Those keys are gone in 8.0, so delete those four lines from both new tests, leaving only `lock` and `rate_limiter`.

Merge-up to 8.2: the `auto` branch appears twice there. The merge fixes the rate limiter site; `RateLimiterBuilder` needs the same guard:

```php
$builderConfig['lock_factory'] = interface_exists(LockInterface::class) && $container->hasAlias('lock.factory') ? 'lock.factory' : null;
```
