### PR TITLE
[Cache] Don't close lock handles that are still in use when evicting a slot

### DIFF
--- a/src/Symfony/Component/Cache/LockRegistry.php
+++ b/src/Symfony/Component/Cache/LockRegistry.php
@@ -94,7 +94,7 @@ final class LockRegistry
 
         $key = self::$files ? abs(crc32($item->getKey())) % \count(self::$files) : -1;
 
-        if ($key < 0 || self::$lockedFiles || !$lock = self::open($key)) {
+        if ($key < 0 || self::$lockedFiles || !$lock = self::open($file = self::$files[$key])) {
             return $callback($item, $save);
         }
 
@@ -108,7 +108,7 @@ final class LockRegistry
 
                 if ($locked || !$wouldBlock) {
                     $logger?->info(\sprintf('Lock %s, now computing item "{key}"', $locked ? 'acquired' : 'not supported'), ['key' => $item->getKey()]);
-                    self::$lockedFiles[$key] = true;
+                    self::$lockedFiles[$file] = true;
 
                     $value = $callback($item, $save);
 
@@ -148,8 +148,12 @@ final class LockRegistry
 
                 if (!$acquired) {
                     $logger?->warning('Lock on item "{key}" timed out, evicting slot', ['key' => $item->getKey()]);
-                    unset(self::$files[$key]);
-                    self::setFiles(self::$files);
+
+                    // don't close the handle: a parent call to compute() might still use it
+                    if (false !== $key = array_search($file, self::$files, true)) {
+                        unset(self::$files[$key]);
+                        self::$files = array_values(self::$files);
+                    }
                     $lock = null;
 
                     return self::compute($callback, $item, $save, $pool, $setMetadata, $logger, $beta);
@@ -163,7 +167,7 @@ final class LockRegistry
                 if ($lock) {
                     flock($lock, \LOCK_UN);
                 }
-                unset(self::$lockedFiles[$key]);
+                unset(self::$lockedFiles[$file]);
             }
 
             try {
@@ -186,18 +190,18 @@ final class LockRegistry
     /**
      * @return resource|false
      */
-    private static function open(int $key)
+    private static function open(string $file)
     {
-        if (null !== $h = self::$openedFiles[$key] ?? null) {
+        if (null !== $h = self::$openedFiles[$file] ?? null) {
             return $h;
         }
         set_error_handler(static fn () => null);
         try {
-            $h = fopen(self::$files[$key], 'r+');
+            $h = fopen($file, 'r+');
         } finally {
             restore_error_handler();
         }
 
-        return self::$openedFiles[$key] = $h ?: @fopen(self::$files[$key], 'r');
+        return self::$openedFiles[$file] = $h ?: @fopen($file, 'r');
     }
 }

--- a/src/Symfony/Component/Cache/Tests/LockRegistryTest.php
+++ b/src/Symfony/Component/Cache/Tests/LockRegistryTest.php
@@ -65,6 +65,99 @@ class LockRegistryTest extends TestCase
     }
 
     /**
+     * Calls LockRegistry::compute() for an item whose slot is read-locked by another process, so
+     * that the wait loop succeeds and the pool is asked for the item. Computing that nested item
+     * evicts its own slot, while the outer call still holds the handle of the first one.
+     */
+    public function testEvictingASlotKeepsTheHandlesOfTheOtherSlotsOpen()
+    {
+        if ('\\' === \DIRECTORY_SEPARATOR) {
+            $this->markTestSkipped('LockRegistry is disabled on Windows');
+        }
+        if (!\function_exists('proc_open')) {
+            $this->markTestSkipped('proc_open() is required');
+        }
+
+        $logger = new class extends AbstractLogger {
+            public array $messages = [];
+
+            public function log($level, $message, array $context = []): void
+            {
+                $this->messages[] = $message;
+            }
+        };
+
+        $files = [tempnam(sys_get_temp_dir(), 'sf_lock'), tempnam(sys_get_temp_dir(), 'sf_lock')];
+        $sharedFile = $files[abs(crc32('foo')) % 2];
+        $wedgedFile = $files[abs(crc32('bar')) % 2];
+
+        $script = 'flock($h = fopen($argv[1], "r+"), (int) $argv[2]) || exit(1); echo "locked\n"; fgets(STDIN);';
+        $descriptors = [['pipe', 'r'], ['pipe', 'w'], ['redirect', 1]];
+        $processes = [];
+
+        foreach (['shared' => [$sharedFile, \LOCK_SH], 'wedged' => [$wedgedFile, \LOCK_EX]] as $name => [$file, $operation]) {
+            $process = proc_open([\PHP_BINARY, '-n', '-r', $script, '--', $file, $operation], $descriptors, $pipes);
+            $this->assertSame("locked\n", fgets($pipes[1]));
+            $processes[$name] = [$process, $pipes];
+        }
+
+        $release = static function (string $name) use (&$processes) {
+            if (null === $process = $processes[$name] ?? null) {
+                return;
+            }
+            unset($processes[$name]);
+            fclose($process[1][0]);
+            fclose($process[1][1]);
+            proc_terminate($process[0]);
+            proc_close($process[0]);
+        };
+
+        $pool = new class extends ArrayAdapter {
+            public \Closure $onGet;
+
+            public function get(string $key, callable $callback, ?float $beta = null, ?array &$metadata = null): mixed
+            {
+                return ($this->onGet)($callback);
+            }
+        };
+        $pool->onGet = static function (callable $callback) use ($pool, $release) {
+            $release('shared');
+            $save = false;
+
+            return LockRegistry::compute($callback, $pool->getItem('bar'), $save, new ArrayAdapter());
+        };
+
+        $item = $pool->getItem('foo');
+        $previousFiles = LockRegistry::setFiles($files);
+        $previousLimit = (int) \ini_get('max_execution_time');
+        $previousRequestTime = $_SERVER['REQUEST_TIME_FLOAT'] ?? null;
+        $save = true;
+
+        try {
+            $_SERVER['REQUEST_TIME_FLOAT'] = microtime(true) - 1.5;
+            set_time_limit(2);
+
+            $this->assertSame('bar', LockRegistry::compute(static fn () => 'bar', $item, $save, $pool, null, $logger));
+            $this->assertSame([
+                'Item "{key}" is locked, waiting for it to be released',
+                'Item "{key}" not found while lock was released, now retrying',
+                'Lock acquired, now computing item "{key}"',
+            ], $logger->messages);
+        } finally {
+            set_time_limit($previousLimit);
+            if (null === $previousRequestTime) {
+                unset($_SERVER['REQUEST_TIME_FLOAT']);
+            } else {
+                $_SERVER['REQUEST_TIME_FLOAT'] = $previousRequestTime;
+            }
+            LockRegistry::setFiles($previousFiles);
+            $release('shared');
+            $release('wedged');
+            array_map('unlink', $files);
+        }
+    }
+
+    /**
      * Calls LockRegistry::compute() while another process holds the lock of the item,
      * with a max_execution_time of 2 seconds of which $requestAge seconds are already spent.
      *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65892
| License       | MIT

`LockRegistry::setFiles()` closes every handle it has opened. Since the slot eviction added in #65659, `compute()` calls it while other frames of the same call stack still hold those handles in their local `$lock` variable, so the next `flock()` gets a closed resource.

The nesting happens on the loser path: a frame that failed the race releases the lock but keeps the handle open, then asks the pool for the item. `ContractsTrait` normally short-circuits that back to the callback, but only when the pool is the adapter itself. `ChainAdapter` passes the inner adapter and `PhpArrayAdapter` passes the wrapped pool, so the nested call goes through `LockRegistry::compute()` again. If it times out on its slot, it evicts it and closes the handles of its callers on the way.

The reported line is misleading: the first `TypeError` is thrown by the race `flock()`, then the `finally` block runs `flock()` on the same closed handle and throws a second one that replaces it. A closed resource is truthy, so the `if ($lock)` guard does not catch it, and replacing that guard with `is_resource()` only moves the error to the race `flock()`.

Eviction now drops the file from the pool without closing anything, and the opened handles are keyed by file name so that shrinking the list keeps them consistent. The handle of an evicted file stays open until `setFiles()` is called or the process ends, which is what already happened for every other slot.
