### PR TITLE
[Security] Name the scope token attribute as it is

### DIFF
--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -5,7 +5,7 @@ CHANGELOG
 ---
 
  * Add `allowed_time_drift` option to `OidcTokenHandler` to configure time tolerance for token validation (`iat`, `nbf`, `exp` claims)
- * Expose the OAuth2 scopes an access token was granted as the `scope` token attribute, read from the `scope` or `scp` claim
+ * Expose the OAuth2 scopes an access token was granted as the `oauth2_scope` token attribute, read from the `scope` or `scp` claim
  * Add `OAuth2ScopeVoter` to require scopes of the access token, all the ones an `OAUTH2_SCOPE(...)` attribute lists
  * Add `InsufficientScopeAccessDeniedHandler` to answer a denial caused by a missing scope with the RFC 6750 §3.1 challenge
  * Throw a 403 `Symfony\Component\Security\Http\Exception\InvalidCsrfTokenException` instead of the `Security\Core` one when the `#[IsCsrfTokenValid]` attribute fails, so the failure is no longer handled as an authentication failure


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`AccessTokenAuthenticator::SCOPE_ATTRIBUTE` is `oauth2_scope`. I renamed it from `scope` while preparing #65874, so that a firewall having nothing to do with access tokens could not satisfy `OAUTH2_SCOPE(...)` through an attribute an application had stored under a name that generic, and I updated the description but missed the changelog entry, which still announces the old name.
