### PR TITLE
[Security][SecurityBundle] Read the introspection signature keys from the authorization server metadata

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * Default the `algorithms` option of the `oidc` token handler and of the `response_signature` option of the `oauth2` one to `RS256`, which OIDC Core 1.0 requires every provider to support
  * Require OAuth2 scopes of the access token with an `OAUTH2_SCOPE(...)` attribute, and answer a denial with the RFC 6750 §3.1 `insufficient_scope` challenge
  * Add the `http_client`, `issuer`, `audience`, `claim`, `allowed_time_drift`, `cache` and `response_signature` options to the `oauth2` token handler, whose configuration used to be ignored. The `audience` option takes a single identifier as a string or several as a list
+ * Add the `discovery` option to the `response_signature` of the `oauth2` token handler, to read its keys from the RFC 8414 authorization server metadata
  * Fix the `oauth2` token handler, which could not reach any introspection endpoint: `oauth2: ~` made the container fail to compile, and the endpoint was requested with an empty URL
  * Allow disabling the redirection on successful logout by passing `null` to the `target` option
  * Deprecate the `remember_me` option of the `form_login`, `json_login`, `login_link`, and `access_token` authenticators, as it has no effect

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/AccessToken/OAuth2TokenHandlerFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/AccessToken/OAuth2TokenHandlerFactory.php
@@ -73,10 +73,19 @@ class OAuth2TokenHandlerFactory implements TokenHandlerFactoryInterface
             $tokenHandlerDefinition->addMethodCall('enableSignedResponse', [
                 (new ChildDefinition('security.access_token_handler.oidc.signature'))
                     ->replaceArgument(0, $config['response_signature']['algorithms']),
-                (new ChildDefinition('security.access_token_handler.oidc.jwkset'))
-                    ->replaceArgument(0, $config['response_signature']['keyset']),
+                $config['response_signature']['keyset']
+                    ? (new ChildDefinition('security.access_token_handler.oidc.jwkset'))->replaceArgument(0, $config['response_signature']['keyset'])
+                    : null,
                 $config['response_signature']['enforce'],
             ]);
+
+            if ($config['response_signature']['discovery']['enabled']) {
+                $tokenHandlerDefinition->addMethodCall('enableSignedResponseDiscovery', [
+                    new Reference($config['response_signature']['discovery']['cache']['id']),
+                    (new ChildDefinition('security.access_token_handler.oidc_discovery.http_client'))->replaceArgument(0, []),
+                    "$id.authorization_server_metadata",
+                ]);
+            }
         }
     }
 
@@ -141,8 +150,12 @@ class OAuth2TokenHandlerFactory implements TokenHandlerFactoryInterface
                         ->info('Ask the authorization server for a signed introspection response (RFC 9701) and verify it.')
                         ->canBeEnabled()
                         ->validate()
-                            ->ifTrue(static fn ($v) => $v['enabled'] && !$v['keyset'])
-                            ->thenInvalid('The "keyset" option of the "response_signature" option is required when it is enabled.')
+                            ->ifTrue(static fn ($v) => $v['enabled'] && !$v['keyset'] && !$v['discovery']['enabled'])
+                            ->thenInvalid('The "response_signature" option needs the keys it verifies the introspection response against: set its "keyset", or enable its "discovery" to read them from the authorization server metadata.')
+                        ->end()
+                        ->validate()
+                            ->ifTrue(static fn ($v) => $v['enabled'] && $v['keyset'] && $v['discovery']['enabled'])
+                            ->thenInvalid('The "keyset" and "discovery" options of the "response_signature" option are exclusive: the keys come either from the configuration or from the authorization server metadata.')
                         ->end()
                         ->children()
                             ->booleanNode('enforce')
@@ -154,6 +167,22 @@ class OAuth2TokenHandlerFactory implements TokenHandlerFactoryInterface
                                 ->defaultValue(['RS256'])
                                 ->requiresAtLeastOneElement()
                                 ->scalarPrototype()->cannotBeEmpty()->end()
+                            ->end()
+                            ->arrayNode('discovery')
+                                ->info('Read the keys the introspection response is verified against from the RFC 8414 metadata of the authorization server, whose URL is derived from the "issuer" this handler already declares. Only the "jwks_uri" is read from it: which algorithms are accepted stays declared here, so that an authorization server cannot widen it by announcing more.')
+                                ->canBeEnabled()
+                                ->children()
+                                    ->arrayNode('cache')
+                                        ->addDefaultsIfNotSet()
+                                        ->children()
+                                            ->scalarNode('id')
+                                                ->info('Cache service id the metadata document and the keys it points at are stored in.')
+                                                ->defaultValue('cache.app')
+                                                ->cannotBeEmpty()
+                                            ->end()
+                                        ->end()
+                                    ->end()
+                                ->end()
                             ->end()
                             ->scalarNode('keyset')
                                 ->info('JSON-encoded JWKSet holding the public keys of your authorization server, the ones it announces at its "jwks_uri", which the introspection response is verified against.')

--- a/src/Symfony/Component/Security/Http/AccessToken/OAuth2/Oauth2TokenHandler.php
+++ b/src/Symfony/Component/Security/Http/AccessToken/OAuth2/Oauth2TokenHandler.php
@@ -25,7 +25,9 @@ use Symfony\Component\Clock\Clock;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\Security\Core\User\OAuth2User;
 use Symfony\Component\Security\Http\AccessToken\AccessTokenHandlerInterface;
+use Symfony\Component\Security\Http\Authenticator\Oidc\OidcJwks;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+use Symfony\Component\Security\Http\Oidc\OidcDiscovery;
 use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Cache\ItemInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -70,6 +72,11 @@ final class Oauth2TokenHandler implements AccessTokenHandlerInterface
     private const JWT_RESPONSE_MEDIA_TYPE = 'application/token-introspection+jwt';
     private const JWT_RESPONSE_TYPES = ['token-introspection+jwt', 'application/token-introspection+jwt'];
 
+    /**
+     * RFC 8414 §3: the well-known path of the OAuth 2.0 authorization server metadata.
+     */
+    private const METADATA_PATH = '/.well-known/oauth-authorization-server';
+
     private ?CacheInterface $cache = null;
     private string $cacheKeyPrefix = '';
     private int $cacheTtl = 0;
@@ -77,6 +84,10 @@ final class Oauth2TokenHandler implements AccessTokenHandlerInterface
     private ?AlgorithmManager $signatureAlgorithms = null;
     private ?JWKSet $signatureKeyset = null;
     private bool $enforceSignedResponse = true;
+    private ?OidcDiscovery $metadata = null;
+    private ?CacheInterface $metadataCache = null;
+    private ?string $metadataCacheKey = null;
+    private ?HttpClientInterface $metadataClient = null;
 
     /**
      * @param HttpClientInterface $client           The client the introspection endpoint is reached with, whose
@@ -132,11 +143,47 @@ final class Oauth2TokenHandler implements AccessTokenHandlerInterface
      *
      * @param bool $enforce Whether a plain JSON response must be refused once the authorization server is expected to sign the introspection response
      */
-    public function enableSignedResponse(AlgorithmManager $algorithms, JWKSet $keyset, bool $enforce = true): void
+    public function enableSignedResponse(AlgorithmManager $algorithms, ?JWKSet $keyset, bool $enforce = true): void
     {
         $this->signatureAlgorithms = $algorithms;
         $this->signatureKeyset = $keyset;
         $this->enforceSignedResponse = $enforce;
+    }
+
+    /**
+     * Reads the keys the introspection response is verified against from the authorization server metadata.
+     *
+     * RFC 8414 §3 builds the metadata URL by inserting the well-known path between the host and the
+     * path of the issuer identifier, where OIDC Discovery 1.0 appends it, so the URL is built here
+     * and handed to {@see OidcDiscovery} already absolute. The document is the authority for the
+     * "jwks_uri" only: which algorithms this resource server accepts stays its own decision, so that
+     * an authorization server cannot widen it by announcing more.
+     */
+    public function enableSignedResponseDiscovery(CacheInterface $cache, HttpClientInterface $client, string $cacheKey): void
+    {
+        if (null === $this->issuer) {
+            throw new \LogicException('The "issuer" of the authorization server is required to read its metadata, since RFC 8414 §3 derives the metadata URL from it.');
+        }
+
+        $this->metadataCache = $cache;
+        $this->metadataClient = $client;
+        $this->metadataCacheKey = $cacheKey;
+        $this->metadata = new OidcDiscovery($client, $cache, self::metadataUrl($this->issuer), $this->issuer, cacheKey: $cacheKey.'.document', checkedEndpoints: ['jwks_uri']);
+    }
+
+    /**
+     * RFC 8414 §3: the well-known path is inserted between the host component and the path of the
+     * issuer identifier, so that one host can serve the metadata of several authorization servers.
+     */
+    private static function metadataUrl(string $issuer): string
+    {
+        $parts = parse_url(rtrim($issuer, '/'));
+
+        if (!isset($parts['scheme'], $parts['host'])) {
+            throw new \LogicException(\sprintf('The "issuer" of the authorization server must be an absolute URL to read its metadata, "%s" given.', $issuer));
+        }
+
+        return $parts['scheme'].'://'.$parts['host'].(isset($parts['port']) ? ':'.$parts['port'] : '').self::METADATA_PATH.($parts['path'] ?? '');
     }
 
     /**
@@ -153,7 +200,7 @@ final class Oauth2TokenHandler implements AccessTokenHandlerInterface
      */
     public function getUserBadgeFrom(string $accessToken): UserBadge
     {
-        if (null !== $this->signatureKeyset && (!class_exists(JWSVerifier::class) || !class_exists(Checker\HeaderCheckerManager::class))) {
+        if ((null !== $this->signatureKeyset || null !== $this->metadata) && (!class_exists(JWSVerifier::class) || !class_exists(Checker\HeaderCheckerManager::class))) {
             throw new \LogicException('You cannot verify signed introspection responses since "web-token/jwt-library" is not installed. Try running "composer require web-token/jwt-library".');
         }
 
@@ -226,7 +273,7 @@ final class Oauth2TokenHandler implements AccessTokenHandlerInterface
      */
     private function requestIntrospection(string $accessToken): array
     {
-        if (null === $this->signatureKeyset) {
+        if (!$this->verifiesSignedResponses()) {
             $accept = 'application/json';
         } else {
             $accept = $this->enforceSignedResponse ? self::JWT_RESPONSE_MEDIA_TYPE : self::JWT_RESPONSE_MEDIA_TYPE.', application/json';
@@ -242,18 +289,50 @@ final class Oauth2TokenHandler implements AccessTokenHandlerInterface
         $contentType = strtolower(trim(strtok($response->getHeaders()['content-type'][0] ?? '', ';')));
 
         if (self::JWT_RESPONSE_MEDIA_TYPE === $contentType) {
-            if (null === $this->signatureKeyset) {
+            if (!$this->verifiesSignedResponses()) {
                 throw new BadCredentialsException('The authorization server returned a JWT introspection response, which this resource server is not configured to verify.');
             }
 
             return ['claims' => $this->verifySignedResponse($response->getContent()), 'signed' => true];
         }
 
-        if (null !== $this->signatureKeyset && $this->enforceSignedResponse) {
+        if ($this->verifiesSignedResponses() && $this->enforceSignedResponse) {
             throw new BadCredentialsException(\sprintf('A signed introspection response is required, but the authorization server answered with "%s".', $contentType ?: 'no content type'));
         }
 
         return ['claims' => $response->toArray(), 'signed' => false];
+    }
+
+    private function verifiesSignedResponses(): bool
+    {
+        return null !== $this->signatureKeyset || null !== $this->metadata;
+    }
+
+    /**
+     * The keys the introspection response is verified against: the configured set, or the one the
+     * authorization server publishes at the "jwks_uri" its metadata announces.
+     */
+    private function resolveSignatureKeyset(): JWKSet
+    {
+        if (null !== $this->signatureKeyset) {
+            return $this->signatureKeyset;
+        }
+
+        return JWKSet::createFromKeyData(['keys' => $this->metadataCache->get($this->metadataCacheKey, $this->computeMetadataKeys(...))]);
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function computeMetadataKeys(ItemInterface $item): array
+    {
+        [$keys, $ttl] = OidcJwks::fromResponse($this->metadataClient->request('GET', $this->metadata->getConfiguration()['jwks_uri']), true);
+
+        if (0 < ($ttl ?? -1)) {
+            $item->expiresAfter(min($ttl, OidcJwks::MAX_TTL));
+        }
+
+        return $keys;
     }
 
     /**
@@ -279,12 +358,13 @@ final class Oauth2TokenHandler implements AccessTokenHandlerInterface
             throw new BadCredentialsException('The introspection response is not a valid JWT.', previous: $e);
         }
 
+        $keyset = $this->resolveSignatureKeyset();
         $jwsVerifier = new JWSVerifier($this->signatureAlgorithms);
 
         if (method_exists($jwsVerifier, 'verify')) { // @phpstan-ignore function.alreadyNarrowedType
-            $verified = $jwsVerifier->verify($jws, $this->signatureKeyset, 0)->isVerified();
+            $verified = $jwsVerifier->verify($jws, $keyset, 0)->isVerified();
         } else {
-            $verified = $jwsVerifier->verifyWithKeySet($jws, $this->signatureKeyset, 0); // @phpstan-ignore method.deprecated
+            $verified = $jwsVerifier->verifyWithKeySet($jws, $keyset, 0); // @phpstan-ignore method.deprecated
         }
 
         if (!$verified) {

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
  * Add the `$audiences`, `$issuer`, `$claim`, `$clock` and `$allowedTimeDrift` arguments to `Oauth2TokenHandler`, which validates the `exp`, `nbf`, `iat`, `iss` and `aud` members of the introspection response against them
  * Add `Oauth2TokenHandler::enableCache()` to cache the introspection responses of active tokens, never beyond their `exp`
  * Add `Oauth2TokenHandler::enableSignedResponse()` to request and verify a JWT introspection response (RFC 9701)
+ * Add `Oauth2TokenHandler::enableSignedResponseDiscovery()` to read the keys that response is verified against from the RFC 8414 metadata of the authorization server
  * Throw a 403 `Symfony\Component\Security\Http\Exception\InvalidCsrfTokenException` instead of the `Security\Core` one when the `#[IsCsrfTokenValid]` attribute fails, so the failure is no longer handled as an authentication failure
  * Add the deauthentication reason and the responsible user providers to `TokenDeauthenticatedEvent`
  * Add `LogoutUrlGenerator::getLogoutForm()` to build a form that logs the user out with a POST

--- a/src/Symfony/Component/Security/Http/Tests/AccessToken/OAuth2/OAuth2TokenHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/AccessToken/OAuth2/OAuth2TokenHandlerTest.php
@@ -408,6 +408,39 @@ class OAuth2TokenHandlerTest extends TestCase
         yield 'plain JSON' => ['application/json', false];
     }
 
+    /**
+     * RFC 8414 §3 inserts the well-known path between the host and the path of the issuer, where
+     * OIDC Discovery 1.0 appends it, so a tenant issuer must still reach the right document.
+     */
+    #[DataProvider('provideIssuersAndMetadataUrls')]
+    #[RequiresPhpExtension('openssl')]
+    public function testReadsTheKeysFromTheAuthorizationServerMetadata(string $issuer, string $metadataUrl)
+    {
+        $requested = [];
+        $client = new MockHttpClient(static function (string $method, string $url) use (&$requested, $issuer): MockResponse {
+            $requested[] = $url;
+
+            return match (true) {
+                str_contains($url, '/.well-known/') => new JsonMockResponse(['issuer' => $issuer, 'jwks_uri' => 'https://as.example.com/jwks']),
+                str_contains($url, '/jwks') => new JsonMockResponse(['keys' => [self::publicJwk()->all() + ['use' => 'sig']]]),
+                default => self::jwtResponse(self::signedResponsePayload(self::activeClaims(['sub' => 'jdoe']), $issuer)),
+            };
+        }, self::ENDPOINT);
+
+        $handler = self::createHandler($client, [self::AUDIENCE], $issuer);
+        $handler->enableSignedResponse(new AlgorithmManager([new ES256()]), null);
+        $handler->enableSignedResponseDiscovery(new ArrayAdapter(), $client, 'metadata.');
+
+        $this->assertSame('jdoe', $handler->getUserBadgeFrom('a-secret-token')->getUserIdentifier());
+        $this->assertContains($metadataUrl, $requested);
+    }
+
+    public static function provideIssuersAndMetadataUrls(): iterable
+    {
+        yield 'a bare origin' => ['https://as.example.com', 'https://as.example.com/.well-known/oauth-authorization-server'];
+        yield 'an issuer carrying a path' => ['https://as.example.com/tenant1', 'https://as.example.com/.well-known/oauth-authorization-server/tenant1'];
+    }
+
     #[RequiresPhpExtension('openssl')]
     public function testRejectsAnIntrospectionResponseSignedWithAnotherKey()
     {
@@ -609,10 +642,10 @@ class OAuth2TokenHandlerTest extends TestCase
     /**
      * @return array<string, mixed>
      */
-    private static function signedResponsePayload(array $introspection): array
+    private static function signedResponsePayload(array $introspection, ?string $issuer = null): array
     {
         return [
-            'iss' => self::ISSUER,
+            'iss' => $issuer ?? self::ISSUER,
             'aud' => self::AUDIENCE,
             'iat' => 1719000000,
             'token_introspection' => $introspection,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Follow-up to #65866. Verifying a signed introspection response needs the keys of the authorization server, and the only way to give them was to paste the JWKSet into the configuration:

```yaml
response_signature:
    enabled: true
    algorithms: ['RS256']
    keyset: '%env(AS_JWKS)%'
```

The `oidc` token handler solved this long ago: its `keyset` is optional because `discovery` reads the keys from the provider. The same is now available here, against the RFC 8414 metadata of the authorization server:

```yaml
response_signature:
    enabled: true
    algorithms: ['RS256']
    discovery: true
```

The `issuer` the handler already declares is what the metadata URL is derived from, so nothing else is configured. `keyset` and `discovery` are exclusive, and one of them is required.

### The URL is not built the way OIDC builds it

RFC 8414, Section 3 inserts the well-known path **between the host and the path** of the issuer, where OIDC Discovery 1.0, Section 4.1 appends it. For an issuer carrying a path the two differ:

| issuer | RFC 8414 | OIDC Discovery |
| --- | --- | --- |
| `https://as.example.com` | `https://as.example.com/.well-known/oauth-authorization-server` | same |
| `https://as.example.com/tenant1` | `https://as.example.com/.well-known/oauth-authorization-server/tenant1` | `https://as.example.com/tenant1/.well-known/...` |

So the URL is built here and handed to `OidcDiscovery` already absolute, which that class passes through untouched. It needs no change, and it still performs the issuer check and refuses a `jwks_uri` that downgrades the transport to plain HTTP. Both issuer shapes are covered by a data provider, and reverting the insertion to an append fails the tenant row.

### What is deliberately not read

Only `jwks_uri`. The document also announces `introspection_signing_alg_values_supported`, and reading it would remove the `algorithms` line too, but that would let the authorization server decide which algorithms this resource server accepts, so it could widen them by announcing more. That stays a local decision. With #65896 defaulting it to `RS256`, the common configuration is already down to two lines.

`Oauth2TokenHandler::enableSignedResponse()` now takes a nullable `JWKSet`, since the keys may come from the metadata. The class is `@internal` and unreleased on 8.2, so this is not a BC event.
