### PR TITLE
[Messenger] Add a transport option to #[AsMessageHandler]

### DIFF
--- a/src/Symfony/Component/Messenger/Attribute/AsMessageHandler.php
+++ b/src/Symfony/Component/Messenger/Attribute/AsMessageHandler.php
@@ -49,6 +49,12 @@ class AsMessageHandler
          * Whether messages should be signed when sent on a transport.
          */
         public bool $sign = false,
+
+        /**
+         * Name of the transport to route the handled messages to.
+         * The handler then only receives messages from that transport, as with $fromTransport.
+         */
+        public ?string $transport = null,
     ) {
     }
 }

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -18,6 +18,7 @@ CHANGELOG
  * Add an optional `LoggingMiddleware` logging the processing time and memory usage of each message
  * Add the `messenger:show` command to list and inspect pending messages of a transport
  * Make the `messenger:consume` and `messenger:failed:retry` commands exit immediately when a second `SIGINT` is received
+ * Add a `transport` option to `#[AsMessageHandler]` and to the `messenger.message_handler` tag to route the handled messages to that transport and bind the handler to it
 
 8.1
 ---

--- a/src/Symfony/Component/Messenger/Command/DebugCommand.php
+++ b/src/Symfony/Component/Messenger/Command/DebugCommand.php
@@ -39,6 +39,7 @@ class DebugCommand extends Command
      * @param array<string, string>                                          $senderAliases
      * @param array<string, list<string>>                                    $attributeMessages Message classes discovered via #[AsMessage] attribute mapped to their transports
      * @param array<string, string>                                          $failureTransports Failure transports mapped by source transport
+     * @param array<string, list<string>>                                    $handlerTransports Transports declared by handlers, mapped by handled message type
      */
     public function __construct(
         private array $mapping,
@@ -46,6 +47,7 @@ class DebugCommand extends Command
         private readonly array $senderAliases = [],
         private readonly array $attributeMessages = [],
         private readonly array $failureTransports = [],
+        private readonly array $handlerTransports = [],
     ) {
         parent::__construct();
     }
@@ -121,6 +123,11 @@ class DebugCommand extends Command
                     if ($handlerDescription = self::getClassDescription($handler[0])) {
                         $tableRows[] = [\sprintf('               <comment>%s</>', $handlerDescription)];
                     }
+
+                    $fromTransport = $handler[1]['from_transport'] ?? null;
+                    if (null !== $fromTransport && $this->senderAliases && !isset($this->senderAliases[$fromTransport]) && !\in_array($fromTransport, $this->senderAliases, true)) {
+                        $tableRows[] = [\sprintf('               <fg=red>transport "%s" is not configured</>', $fromTransport)];
+                    }
                 }
 
                 if (!$handlers) {
@@ -158,7 +165,7 @@ class DebugCommand extends Command
         }
 
         if ($input->mustSuggestOptionValuesFor('message')) {
-            $messages = array_keys($this->sendersMap + $this->attributeMessages);
+            $messages = array_keys($this->sendersMap + $this->attributeMessages + $this->handlerTransports);
             foreach ($this->mapping as $handlersByMessage) {
                 $messages = array_merge($messages, array_keys($handlersByMessage));
             }
@@ -243,7 +250,7 @@ class DebugCommand extends Command
         $serviceToAlias = array_flip($this->senderAliases);
         $transportNames = [];
 
-        foreach (SendersLocator::getSenderAliases($message, $this->sendersMap) as $senderAlias) {
+        foreach ([...SendersLocator::getSenderAliases($message, $this->sendersMap), ...$this->getHandlerTransportsForMessage($message)] as $senderAlias) {
             $transportName = $serviceToAlias[$senderAlias] ?? $senderAlias;
             if (!\in_array($transportName, $transportNames, true)) {
                 $transportNames[] = $transportName;
@@ -276,8 +283,8 @@ class DebugCommand extends Command
             if (!$rules) {
                 $io->writeln('    <comment>No routing rules.</>');
             } else {
-                foreach ($rules as [$rule, $fromAttribute]) {
-                    $io->writeln('    '.$this->formatRoutingRule($rule, $fromAttribute));
+                foreach ($rules as [$rule, $source]) {
+                    $io->writeln('    '.$this->formatRoutingRule($rule, $source));
                 }
             }
             if ($failureTransport = $this->getFailureTransportName($transportName)) {
@@ -288,7 +295,7 @@ class DebugCommand extends Command
     }
 
     /**
-     * @return array<string, list<array{0: string, 1: bool}>>
+     * @return array<string, list<array{0: string, 1: string|null}>>
      */
     private function getRulesByTransport(?string $messageClass): array
     {
@@ -303,7 +310,7 @@ class DebugCommand extends Command
         foreach ($this->sendersMap as $rule => $senders) {
             foreach ($senders as $sender) {
                 $transportName = $serviceToAlias[$sender] ?? $sender;
-                $rulesByTransport[$transportName][] = [$rule, false];
+                $rulesByTransport[$transportName][] = [$rule, null];
             }
         }
 
@@ -314,8 +321,17 @@ class DebugCommand extends Command
 
             foreach ($transports as $transport) {
                 $transportName = $serviceToAlias[$transport] ?? $transport;
-                if (!\in_array([$message, true], $rulesByTransport[$transportName] ?? [], true)) {
-                    $rulesByTransport[$transportName][] = [$message, true];
+                if (!\in_array([$message, 'attribute'], $rulesByTransport[$transportName] ?? [], true)) {
+                    $rulesByTransport[$transportName][] = [$message, 'attribute'];
+                }
+            }
+        }
+
+        foreach ($this->handlerTransports as $rule => $transports) {
+            foreach ($transports as $transport) {
+                $transportName = $serviceToAlias[$transport] ?? $transport;
+                if (!\in_array([$rule, 'handler'], $rulesByTransport[$transportName] ?? [], true)) {
+                    $rulesByTransport[$transportName][] = [$rule, 'handler'];
                 }
             }
         }
@@ -332,7 +348,7 @@ class DebugCommand extends Command
     /**
      * @param array<string, string> $serviceToAlias
      *
-     * @return array<string, list<array{0: string, 1: bool}>>
+     * @return array<string, list<array{0: string, 1: string|null}>>
      */
     private function getRulesByTransportForMessage(string $messageClass, array $serviceToAlias): array
     {
@@ -353,7 +369,7 @@ class DebugCommand extends Command
 
                     $seen[$senderAlias] = true;
                     $transportName = $serviceToAlias[$senderAlias] ?? $senderAlias;
-                    $rulesByTransport[$transportName][] = [$rule, false];
+                    $rulesByTransport[$transportName][] = [$rule, null];
                 }
             }
         } else {
@@ -365,8 +381,20 @@ class DebugCommand extends Command
 
                     $seen[$senderAlias] = true;
                     $transportName = $serviceToAlias[$senderAlias] ?? $senderAlias;
-                    $rulesByTransport[$transportName][] = [$rule, true];
+                    $rulesByTransport[$transportName][] = [$rule, 'attribute'];
                 }
+            }
+        }
+
+        foreach (HandlersLocator::listTypesForClass($messageClass) as $rule) {
+            foreach ($this->handlerTransports[$rule] ?? [] as $senderAlias) {
+                if (isset($seen[$senderAlias])) {
+                    continue;
+                }
+
+                $seen[$senderAlias] = true;
+                $transportName = $serviceToAlias[$senderAlias] ?? $senderAlias;
+                $rulesByTransport[$transportName][] = [$rule, 'handler'];
             }
         }
 
@@ -411,7 +439,24 @@ class DebugCommand extends Command
         return $failureTransport === $transportName ? null : $failureTransport;
     }
 
-    private function formatRoutingRule(string $rule, bool $fromAttribute): string
+    /**
+     * @return list<string>
+     */
+    private function getHandlerTransportsForMessage(string $message): array
+    {
+        $transports = [];
+        foreach (HandlersLocator::listTypesForClass($message) as $type) {
+            foreach ($this->handlerTransports[$type] ?? [] as $transport) {
+                if (!\in_array($transport, $transports, true)) {
+                    $transports[] = $transport;
+                }
+            }
+        }
+
+        return $transports;
+    }
+
+    private function formatRoutingRule(string $rule, ?string $source): string
     {
         $descriptions = [];
         if ('*' === $rule) {
@@ -422,8 +467,10 @@ class DebugCommand extends Command
             $descriptions[] = 'interface, matches implementers';
         }
 
-        if ($fromAttribute) {
+        if ('attribute' === $source) {
             $descriptions[] = 'from #[AsMessage]';
+        } elseif ('handler' === $source) {
+            $descriptions[] = 'from #[AsMessageHandler]';
         }
 
         return $rule.($descriptions ? ' ('.implode(', ', $descriptions).')' : '');

--- a/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
+++ b/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
@@ -24,6 +24,7 @@ use Symfony\Component\Messenger\Handler\HandlerDescriptor;
 use Symfony\Component\Messenger\Handler\HandlersLocator;
 use Symfony\Component\Messenger\TraceableMessageBus;
 use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
+use Symfony\Component\Messenger\Transport\Sender\SendersLocator;
 
 /**
  * @author Samuel Roze <samuel.roze@gmail.com>
@@ -31,6 +32,9 @@ use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
 class MessengerPass implements CompilerPassInterface
 {
     use PriorityTaggedServiceTrait;
+
+    private ?array $configuredSendersMap = null;
+    private array $handlerTransports = [];
 
     public function process(ContainerBuilder $container): void
     {
@@ -63,6 +67,18 @@ class MessengerPass implements CompilerPassInterface
         $handlersByBusAndMessage = [];
         $handlerToOriginalServiceIdMapping = [];
         $signedMessageTypes = [];
+        $handlerTransports = [];
+        $hasSendersLocator = $container->hasDefinition('messenger.senders_locator');
+        $receiverNames = null;
+
+        if ($container->hasDefinition('messenger.receiver_locator')) {
+            $receiverNames = [];
+            foreach ($container->findTaggedServiceIds('messenger.receiver') as $id => $tags) {
+                foreach ($tags as $tag) {
+                    $receiverNames[$tag['alias'] ?? $id] = $id;
+                }
+            }
+        }
 
         foreach ($container->findTaggedServiceIds('messenger.message_handler', true) as $serviceId => $tags) {
             // an option-less tag comes from autoconfiguration; it would defeat the configured ones
@@ -109,6 +125,29 @@ class MessengerPass implements CompilerPassInterface
 
                     $options += array_filter($tag);
                     unset($options['handles']);
+
+                    if (null !== $transport = $options['transport'] ?? null) {
+                        if (isset($options['from_transport']) && $transport !== $options['from_transport']) {
+                            throw new RuntimeException(\sprintf('Invalid handler service "%s": the "transport" and "from_transport" options of the "messenger.message_handler" tag must have the same value, "%s" and "%s" given.', $serviceId, $transport, $options['from_transport']));
+                        }
+
+                        if ('*' === $message) {
+                            throw new RuntimeException(\sprintf('Invalid handler service "%s": the "transport" option cannot be used with "*" as message type.', $serviceId));
+                        }
+
+                        if (null !== $receiverNames && !isset($receiverNames[$transport])) {
+                            throw new RuntimeException(\sprintf('Invalid handler service "%s": the "transport" option refers to "%s", which is not a configured transport (known ones are: "%s").', $serviceId, $transport, implode('", "', array_keys($receiverNames))));
+                        }
+
+                        if (!$hasSendersLocator) {
+                            throw new RuntimeException(\sprintf('Invalid handler service "%s": the "transport" option needs the "messenger.senders_locator" service, which is not defined.', $serviceId));
+                        }
+
+                        unset($options['transport']);
+                        $options['from_transport'] = $transport;
+                        $handlerTransports[$message][] = $transport;
+                    }
+
                     $priority = $options['priority'] ?? 0;
                     $method = $options['method'] ?? '__invoke';
                     $fromTransport = $options['from_transport'] ?? '';
@@ -212,6 +251,35 @@ class MessengerPass implements CompilerPassInterface
             }
         } else {
             $container->removeDefinition('messenger.signing_serializer');
+        }
+
+        if ($handlerTransports) {
+            $sendersLocatorDefinition = $container->getDefinition('messenger.senders_locator');
+            $sendersMap = $sendersLocatorDefinition->getArgument(0);
+            if (!\is_array($sendersMap)) {
+                $sendersMap = [];
+            }
+            // debug:messenger tells the configured routing from the one handlers add
+            $this->configuredSendersMap = $sendersMap;
+            $this->handlerTransports = $handlerTransports;
+
+            foreach ($handlerTransports as $message => $transports) {
+                // a handler transport adds to the routing the message has today, which may come
+                // from a parent, an interface, a wildcard or the #[AsMessage] attribute
+                if (!isset($sendersMap[$message])) {
+                    $container->getReflectionClass($message);
+                    $sendersMap[$message] = SendersLocator::getSenderAliases($message, $sendersMap);
+                }
+
+                foreach ($transports as $transport) {
+                    // the configured routing may name a transport by its service id
+                    if (!\in_array($transport, $sendersMap[$message], true) && !\in_array($receiverNames[$transport] ?? $transport, $sendersMap[$message], true)) {
+                        $sendersMap[$message][] = $transport;
+                    }
+                }
+            }
+
+            $sendersLocatorDefinition->replaceArgument(0, $sendersMap);
         }
 
         foreach ($busIds as $bus) {
@@ -507,7 +575,7 @@ class MessengerPass implements CompilerPassInterface
             return;
         }
 
-        $sendersMap = $container->getDefinition('messenger.senders_locator')->getArgument(0);
+        $sendersMap = $this->configuredSendersMap ?? $container->getDefinition('messenger.senders_locator')->getArgument(0);
         if (!\is_array($sendersMap)) {
             $sendersMap = [];
         }
@@ -544,6 +612,7 @@ class MessengerPass implements CompilerPassInterface
             ->setArgument(2, $senderAliases)
             ->setArgument(3, $attributeMessages)
             ->setArgument(4, $failureTransports)
+            ->setArgument(5, $this->handlerTransports)
         ;
     }
 }

--- a/src/Symfony/Component/Messenger/Tests/Command/DebugCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/DebugCommandTest.php
@@ -378,6 +378,40 @@ class DebugCommandTest extends TestCase
         $this->assertStringNotContainsString('No routing rules apply to this message.', $display);
     }
 
+    public function testOutputKeepsTheAttributeAnnotationWhenAHandlerDeclaresATransport()
+    {
+        $command = new DebugCommand(
+            ['command_bus' => [DummyMessageWithAttribute::class => [[DummyCommandHandler::class, ['from_transport' => 'audit']]]]],
+            [],
+            [
+                'first_sender' => 'messenger.transport.first_sender',
+                'second_sender' => 'messenger.transport.second_sender',
+                'audit' => 'messenger.transport.audit',
+            ],
+            [
+                DummyMessageWithAttribute::class => ['first_sender', 'second_sender'],
+            ],
+            [],
+            [
+                DummyMessageWithAttribute::class => ['audit'],
+            ],
+        );
+
+        $tester = new CommandTester($command);
+        $tester->execute(['--message' => DummyMessageWithAttribute::class], ['decorated' => false]);
+        $display = $tester->getDisplay(true);
+
+        $this->assertSame(2, substr_count($display, DummyMessageWithAttribute::class.' (from #[AsMessage])'));
+        $this->assertSame(1, substr_count($display, DummyMessageWithAttribute::class.' (from #[AsMessageHandler])'));
+        $this->assertStringContainsString('audit', $display);
+
+        $tester->execute([], ['decorated' => false]);
+        $display = $tester->getDisplay(true);
+
+        $this->assertSame(2, substr_count($display, DummyMessageWithAttribute::class.' (from #[AsMessage])'));
+        $this->assertSame(1, substr_count($display, DummyMessageWithAttribute::class.' (from #[AsMessageHandler])'));
+    }
+
     public function testOutputDoesNotListAttributeRuleOverriddenByConfigurationUsingSameTransport()
     {
         $command = new DebugCommand(
@@ -426,6 +460,39 @@ class DebugCommandTest extends TestCase
         $this->assertStringContainsString('not routed', $display);
         $this->assertStringContainsString('No routing rules apply to this message.', $display);
         $this->assertStringNotContainsString('async', $display);
+    }
+
+    public function testOutputWarnsAboutHandlersBoundToAnUnknownTransport()
+    {
+        $command = new DebugCommand(
+            [
+                'command_bus' => [
+                    DummyCommand::class => [
+                        [DummyCommandHandler::class, ['from_transport' => 'ghost']],
+                        [DummyCommandHandler::class, ['from_transport' => 'async']],
+                    ],
+                ],
+            ],
+            [DummyCommand::class => ['messenger.transport.async']],
+            ['async' => 'messenger.transport.async'],
+        );
+
+        $tester = new CommandTester($command);
+        $tester->execute([], ['decorated' => false]);
+        $display = $tester->getDisplay(true);
+
+        $this->assertStringContainsString('transport "ghost" is not configured', $display);
+        $this->assertSame(1, substr_count($display, 'is not configured'));
+    }
+
+    public function testOutputDoesNotWarnAboutBoundHandlersWithoutConfiguredTransports()
+    {
+        $command = new DebugCommand(['command_bus' => [DummyCommand::class => [[DummyCommandHandler::class, ['from_transport' => 'ghost']]]]]);
+
+        $tester = new CommandTester($command);
+        $tester->execute([], ['decorated' => false]);
+
+        $this->assertStringNotContainsString('is not configured', $tester->getDisplay(true));
     }
 
     public function testExceptionOnUnknownBusArgument()

--- a/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerBundleExtensionTest.php
+++ b/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerBundleExtensionTest.php
@@ -27,6 +27,7 @@ use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\DependencyInjection\ParameterBag\EnvPlaceholderParameterBag;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Messenger\Attribute\AsMessage;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\Bridge\AmazonSqs\Transport\AmazonSqsTransportFactory;
 use Symfony\Component\Messenger\Bridge\AmpSql\Transport\AmpSqlTransportFactory;
 use Symfony\Component\Messenger\Bridge\Amqp\Transport\AmqpTransportFactory;
@@ -130,6 +131,20 @@ class MessengerBundleExtensionTest extends TestCase
             [['transport' => null, 'serializedTypeName' => 'my.type', 'serializedTypeNameAliases' => ['my.legacy.type']]],
             $definition->getTag('messenger.message')
         );
+    }
+
+    public function testMessengerAsMessageHandlerTransportIsForwardedToTheTag()
+    {
+        $container = $this->createContainerFromFile('messenger', false);
+        $container->compile();
+
+        $configurators = $container->getAttributeAutoconfigurators()[AsMessageHandler::class] ?? [];
+        $this->assertCount(1, $configurators);
+
+        $definition = new ChildDefinition('');
+        $configurators[0]($definition, new AsMessageHandler(transport: 'async'), new \ReflectionClass(DummyMessage::class));
+
+        $this->assertSame([['bus' => null, 'handles' => null, 'method' => null, 'priority' => 0, 'sign' => false, 'transport' => 'async', 'from_transport' => null]], $definition->getTag('messenger.message_handler'));
     }
 
     public function testMessengerRejectRedeliveredMessagesEnabledByDefault()

--- a/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerPassTest.php
+++ b/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerPassTest.php
@@ -47,6 +47,8 @@ use Symfony\Component\Messenger\Tests\Fixtures\DummyCommand;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyCommandHandler;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyHandlerWithCustomMethods;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyMessageInterface;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyMessageWithAttribute;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyQuery;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyQueryHandler;
 use Symfony\Component\Messenger\Tests\Fixtures\MultipleBusesMessage;
@@ -116,6 +118,210 @@ class MessengerPassTest extends TestCase
         $this->assertCount(1, $handlerDescriptionMapping);
 
         $this->assertHandlerDescriptor($container, $handlerDescriptionMapping, DummyMessage::class, [[DummyHandler::class, '__invoke']], [['from_transport' => 'async']]);
+    }
+
+    public function testTransportViaTagAttributeRoutesTheMessageAndBindsTheHandler()
+    {
+        $container = $this->getContainerBuilder($busId = 'message_bus');
+        $container->register('messenger.senders_locator')->addArgument([]);
+        $container->register('messenger.transport.async', DummyReceiver::class)->addTag('messenger.receiver', ['alias' => 'async']);
+        $container
+            ->register(DummyHandler::class, DummyHandler::class)
+            ->addTag('messenger.message_handler', ['transport' => 'async', 'method' => '__invoke'])
+        ;
+
+        (new MessengerPass())->process($container);
+
+        $handlerDescriptionMapping = $container->getDefinition($busId.'.messenger.handlers_locator')->getArgument(0);
+        $this->assertCount(1, $handlerDescriptionMapping);
+
+        $this->assertHandlerDescriptor($container, $handlerDescriptionMapping, DummyMessage::class, [[DummyHandler::class, '__invoke']], [['from_transport' => 'async']]);
+        $this->assertSame([DummyMessage::class => ['async']], $container->getDefinition('messenger.senders_locator')->getArgument(0));
+    }
+
+    public function testTransportViaTagAttributeIsMergedWithTheConfiguredRouting()
+    {
+        $container = $this->getContainerBuilder();
+        $container->register('messenger.senders_locator')->addArgument([
+            DummyMessage::class => ['sync'],
+            SecondMessage::class => ['audit'],
+        ]);
+        $container->register('messenger.transport.sync', DummyReceiver::class)->addTag('messenger.receiver', ['alias' => 'sync']);
+        $container->register('messenger.transport.async', DummyReceiver::class)->addTag('messenger.receiver', ['alias' => 'async']);
+        $container->register('app.first_handler', DummyHandler::class)->addTag('messenger.message_handler', ['transport' => 'async']);
+        $container->register('app.second_handler', DummyHandler::class)->addTag('messenger.message_handler', ['transport' => 'sync', 'from_transport' => 'sync']);
+        $container->register('app.third_handler', DummyHandler::class)->addTag('messenger.message_handler', ['transport' => 'async']);
+
+        (new MessengerPass())->process($container);
+
+        $this->assertSame([
+            DummyMessage::class => ['sync', 'async'],
+            SecondMessage::class => ['audit'],
+        ], $container->getDefinition('messenger.senders_locator')->getArgument(0));
+    }
+
+    public function testTransportViaTagAttributeIsNotAddedWhenTheTransportIsRoutedByServiceId()
+    {
+        $container = $this->getContainerBuilder($busId = 'message_bus');
+        $container->register('messenger.senders_locator')->addArgument([DummyMessage::class => ['messenger.transport.async']]);
+        $container->register('messenger.transport.async', DummyReceiver::class)->addTag('messenger.receiver', ['alias' => 'async']);
+        $container->register(DummyHandler::class, DummyHandler::class)->addTag('messenger.message_handler', ['transport' => 'async', 'method' => '__invoke']);
+
+        (new MessengerPass())->process($container);
+
+        $handlerDescriptionMapping = $container->getDefinition($busId.'.messenger.handlers_locator')->getArgument(0);
+        $this->assertHandlerDescriptor($container, $handlerDescriptionMapping, DummyMessage::class, [[DummyHandler::class, '__invoke']], [['from_transport' => 'async']]);
+        $this->assertSame([DummyMessage::class => ['messenger.transport.async']], $container->getDefinition('messenger.senders_locator')->getArgument(0));
+    }
+
+    public function testTransportViaTagAttributeIsAddedToTheAttributeRouting()
+    {
+        $container = $this->getContainerBuilder();
+        $container->register('messenger.senders_locator')->addArgument([]);
+        $container->register('messenger.transport.audit', DummyReceiver::class)->addTag('messenger.receiver', ['alias' => 'audit']);
+        $container->register(MissingArgumentTypeHandler::class, MissingArgumentTypeHandler::class)->addTag('messenger.message_handler', ['handles' => DummyMessageWithAttribute::class, 'transport' => 'audit']);
+
+        (new MessengerPass())->process($container);
+
+        $this->assertSame([DummyMessageWithAttribute::class => ['first_sender', 'second_sender', 'audit']], $container->getDefinition('messenger.senders_locator')->getArgument(0));
+    }
+
+    public function testTransportViaTagAttributeIsAddedToTheNamespaceRouting()
+    {
+        $container = $this->getContainerBuilder();
+        $container->register('messenger.senders_locator')->addArgument(['Symfony\Component\Messenger\Tests\Fixtures\*' => ['wild']]);
+        $container->register('messenger.transport.audit', DummyReceiver::class)->addTag('messenger.receiver', ['alias' => 'audit']);
+        $container->register(DummyHandler::class, DummyHandler::class)->addTag('messenger.message_handler', ['transport' => 'audit']);
+
+        (new MessengerPass())->process($container);
+
+        $this->assertSame([
+            'Symfony\Component\Messenger\Tests\Fixtures\*' => ['wild'],
+            DummyMessage::class => ['wild', 'audit'],
+        ], $container->getDefinition('messenger.senders_locator')->getArgument(0));
+    }
+
+    public function testTransportViaTagAttributeIsAddedToTheInterfaceRouting()
+    {
+        $container = $this->getContainerBuilder();
+        $container->register('messenger.senders_locator')->addArgument([DummyMessageInterface::class => ['async']]);
+        $container->register('messenger.transport.audit', DummyReceiver::class)->addTag('messenger.receiver', ['alias' => 'audit']);
+        $container->register(DummyHandler::class, DummyHandler::class)->addTag('messenger.message_handler', ['transport' => 'audit']);
+
+        (new MessengerPass())->process($container);
+
+        $this->assertSame([
+            DummyMessageInterface::class => ['async'],
+            DummyMessage::class => ['async', 'audit'],
+        ], $container->getDefinition('messenger.senders_locator')->getArgument(0));
+    }
+
+    public function testTransportViaTagAttributeIsAddedToTheFallbackRouting()
+    {
+        $container = $this->getContainerBuilder();
+        $container->register('messenger.senders_locator')->addArgument(['*' => ['fallback']]);
+        $container->register('messenger.transport.audit', DummyReceiver::class)->addTag('messenger.receiver', ['alias' => 'audit']);
+        $container->register(DummyHandler::class, DummyHandler::class)->addTag('messenger.message_handler', ['transport' => 'audit']);
+
+        (new MessengerPass())->process($container);
+
+        $this->assertSame([
+            '*' => ['fallback'],
+            DummyMessage::class => ['fallback', 'audit'],
+        ], $container->getDefinition('messenger.senders_locator')->getArgument(0));
+    }
+
+    public function testTransportViaTagAttributeIsNotAddedWhenAWildcardRoutesToTheTransportServiceId()
+    {
+        $container = $this->getContainerBuilder();
+        $container->register('messenger.senders_locator')->addArgument(['Symfony\Component\Messenger\Tests\Fixtures\*' => ['messenger.transport.audit']]);
+        $container->register('messenger.transport.audit', DummyReceiver::class)->addTag('messenger.receiver', ['alias' => 'audit']);
+        $container->register(DummyHandler::class, DummyHandler::class)->addTag('messenger.message_handler', ['transport' => 'audit']);
+
+        (new MessengerPass())->process($container);
+
+        $this->assertSame([
+            'Symfony\Component\Messenger\Tests\Fixtures\*' => ['messenger.transport.audit'],
+            DummyMessage::class => ['messenger.transport.audit'],
+        ], $container->getDefinition('messenger.senders_locator')->getArgument(0));
+    }
+
+    public function testTransportViaTagAttributeIsNotCheckedWithoutReceiverLocator()
+    {
+        $container = $this->getContainerBuilder();
+        $container->removeDefinition('messenger.receiver_locator');
+        $container->register('messenger.senders_locator')->addArgument([]);
+        $container->register(DummyHandler::class, DummyHandler::class)->addTag('messenger.message_handler', ['transport' => 'async']);
+
+        (new MessengerPass())->process($container);
+
+        $this->assertSame([DummyMessage::class => ['async']], $container->getDefinition('messenger.senders_locator')->getArgument(0));
+    }
+
+    public function testTransportViaTagAttributeIsAddedToTheDebugCommandRouting()
+    {
+        $container = $this->getContainerBuilder();
+        $container->register('messenger.senders_locator')->addArgument([DummyMessage::class => ['sync']]);
+        $container->register('messenger.transport.sync', DummyReceiver::class)->addTag('messenger.receiver', ['alias' => 'sync']);
+        $container->register('messenger.transport.async', DummyReceiver::class)->addTag('messenger.receiver', ['alias' => 'async']);
+        $container->register(DummyHandler::class, DummyHandler::class)->addTag('messenger.message_handler', ['transport' => 'async']);
+        $container->register('console.command.messenger_debug', DebugCommand::class)->addArgument([]);
+
+        (new MessengerPass())->process($container);
+
+        $this->assertSame([DummyMessage::class => ['sync']], $container->getDefinition('console.command.messenger_debug')->getArgument(1));
+        $this->assertSame([DummyMessage::class => ['async']], $container->getDefinition('console.command.messenger_debug')->getArgument(5));
+    }
+
+    public function testTransportViaTagAttributeConflictingWithFromTransport()
+    {
+        $container = $this->getContainerBuilder();
+        $container->register('messenger.senders_locator')->addArgument([]);
+        $container->register(DummyHandler::class, DummyHandler::class)->addTag('messenger.message_handler', ['transport' => 'async', 'from_transport' => 'sync']);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Invalid handler service "Symfony\Component\Messenger\Tests\DependencyInjection\DummyHandler": the "transport" and "from_transport" options of the "messenger.message_handler" tag must have the same value, "async" and "sync" given.');
+
+        (new MessengerPass())->process($container);
+    }
+
+    public function testTransportViaTagAttributeMustBeAConfiguredTransport()
+    {
+        $container = $this->getContainerBuilder();
+        $container->register('messenger.senders_locator')->addArgument([]);
+        $container->register('messenger.transport.async', DummyReceiver::class)->addTag('messenger.receiver', ['alias' => 'async']);
+        $container->register('messenger.transport.audit', DummyReceiver::class)->addTag('messenger.receiver', ['alias' => 'audit']);
+        $container->register(DummyHandler::class, DummyHandler::class)->addTag('messenger.message_handler', ['transport' => 'unknown']);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Invalid handler service "Symfony\Component\Messenger\Tests\DependencyInjection\DummyHandler": the "transport" option refers to "unknown", which is not a configured transport (known ones are: "async", "audit").');
+
+        (new MessengerPass())->process($container);
+    }
+
+    public function testTransportViaTagAttributeCannotRouteEveryMessage()
+    {
+        $container = $this->getContainerBuilder();
+        $container->register('messenger.senders_locator')->addArgument([]);
+        $container->register('messenger.transport.async', DummyReceiver::class)->addTag('messenger.receiver', ['alias' => 'async']);
+        $container->register(MissingArgumentTypeHandler::class, MissingArgumentTypeHandler::class)->addTag('messenger.message_handler', ['handles' => '*', 'transport' => 'async']);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Invalid handler service "Symfony\Component\Messenger\Tests\DependencyInjection\MissingArgumentTypeHandler": the "transport" option cannot be used with "*" as message type.');
+
+        (new MessengerPass())->process($container);
+    }
+
+    public function testTransportViaTagAttributeNeedsTheSendersLocator()
+    {
+        $container = $this->getContainerBuilder();
+        $container->register('messenger.transport.async', DummyReceiver::class)->addTag('messenger.receiver', ['alias' => 'async']);
+        $container->register(DummyHandler::class, DummyHandler::class)->addTag('messenger.message_handler', ['transport' => 'async']);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Invalid handler service "Symfony\Component\Messenger\Tests\DependencyInjection\DummyHandler": the "transport" option needs the "messenger.senders_locator" service, which is not defined.');
+
+        (new MessengerPass())->process($container);
     }
 
     public function testHandledMessageTypeResolvedWithMethodAndNoHandlesViaTagAttributes()

--- a/src/Symfony/Component/Messenger/Tests/HandlerTransportIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Tests/HandlerTransportIntegrationTest.php
@@ -1,0 +1,118 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\LogicException;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\ServiceLocator;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Messenger\DependencyInjection\MessengerPass;
+use Symfony\Component\Messenger\EventListener\StopWorkerOnMessageLimitListener;
+use Symfony\Component\Messenger\MessageBus;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Middleware\HandleMessageMiddleware;
+use Symfony\Component\Messenger\Middleware\SendMessageMiddleware;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport;
+use Symfony\Component\Messenger\Transport\Sender\SendersLocator;
+use Symfony\Component\Messenger\Transport\TransportInterface;
+use Symfony\Component\Messenger\Worker;
+
+class HandlerTransportIntegrationTest extends TestCase
+{
+    public function testHandlersReceiveMessagesFromTheirDeclaredTransportOnly()
+    {
+        $container = new ContainerBuilder();
+        $container->register('message_bus', MessageBus::class)->setPublic(true)->addTag('messenger.bus')->setArgument(0, []);
+        $container->setParameter('message_bus.middleware', [['id' => 'send_message'], ['id' => 'handle_message']]);
+        $container->register('messenger.middleware.send_message', SendMessageMiddleware::class)->setAbstract(true)->setArgument(0, new Reference('messenger.senders_locator'));
+        $container->register('messenger.middleware.handle_message', HandleMessageMiddleware::class)->setAbstract(true)->setArgument(0, null);
+        $container->register('messenger.transport.a', InMemoryTransport::class)->setPublic(true)->addTag('messenger.receiver', ['alias' => 'a']);
+        $container->register('messenger.transport.b', InMemoryTransport::class)->setPublic(true)->addTag('messenger.receiver', ['alias' => 'b']);
+        $container->register('messenger.receiver_locator', ServiceLocator::class)->setArgument(0, [])->addTag('container.service_locator');
+        $container->register('messenger.senders_locator', SendersLocator::class)->setArguments([[], ServiceLocatorTagPass::register($container, ['a' => new Reference('messenger.transport.a'), 'b' => new Reference('messenger.transport.b')])]);
+        $container->registerAttributeForAutoconfiguration(AsMessageHandler::class, static function (ChildDefinition $definition, AsMessageHandler $attribute, \ReflectionClass|\ReflectionMethod $reflector): void {
+            $tagAttributes = get_object_vars($attribute);
+            $tagAttributes['from_transport'] = $tagAttributes['fromTransport'];
+            unset($tagAttributes['fromTransport']);
+            if ($reflector instanceof \ReflectionMethod) {
+                if (isset($tagAttributes['method'])) {
+                    throw new LogicException(\sprintf('AsMessageHandler attribute cannot declare a method on "%s::%s()".', $reflector->class, $reflector->name));
+                }
+                $tagAttributes['method'] = $reflector->getName();
+            }
+            $definition->addTag('messenger.message_handler', $tagAttributes);
+        });
+        foreach ([HandlerBoundToTransportA::class, HandlerBoundToTransportB::class, UnboundHandler::class] as $handlerClass) {
+            $container->register($handlerClass, $handlerClass)->setAutoconfigured(true);
+        }
+        $container->addCompilerPass(new MessengerPass());
+        $container->compile();
+
+        RecordingHandler::$calls = [];
+        $bus = $container->get('message_bus');
+        $transportA = $container->get('messenger.transport.a');
+        $transportB = $container->get('messenger.transport.b');
+
+        $bus->dispatch(new DummyMessage('Hello'));
+
+        $this->assertCount(1, $transportA->getSent());
+        $this->assertCount(1, $transportB->getSent());
+        $this->assertSame([], RecordingHandler::$calls);
+
+        $this->consume('a', $transportA, $bus);
+
+        $this->assertSame([HandlerBoundToTransportA::class, UnboundHandler::class], RecordingHandler::$calls);
+
+        $this->consume('b', $transportB, $bus);
+
+        $this->assertSame([HandlerBoundToTransportA::class, UnboundHandler::class, HandlerBoundToTransportB::class, UnboundHandler::class], RecordingHandler::$calls);
+    }
+
+    private function consume(string $transportName, TransportInterface $transport, MessageBusInterface $bus): void
+    {
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addSubscriber(new StopWorkerOnMessageLimitListener(1));
+
+        (new Worker([$transportName => $transport], $bus, $dispatcher))->run();
+    }
+}
+
+abstract class RecordingHandler
+{
+    public static array $calls = [];
+
+    public function __invoke(DummyMessage $message): void
+    {
+        self::$calls[] = static::class;
+    }
+}
+
+#[AsMessageHandler(transport: 'a')]
+class HandlerBoundToTransportA extends RecordingHandler
+{
+}
+
+#[AsMessageHandler(transport: 'b')]
+class HandlerBoundToTransportB extends RecordingHandler
+{
+}
+
+#[AsMessageHandler]
+class UnboundHandler extends RecordingHandler
+{
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #30634
| License       | MIT

This is a proposal, open for discussion. It started from Dariusz Gafka's article [Symfony Messenger vs Ecotone: The Real Difference](https://blog.ecotone.tech/ecotone-vs-symfony-messenger-the-real-difference/), which describes how Ecotone approaches this. What is proposed here is a free interpretation for Symfony, built on Messenger's own model rather than ported from Ecotone, so it departs from the article where the two models differ. The examples in this description are the article's.

To have two handlers of the same message run on two different transports, each with its own retries, dead letter and consumers, a message has to be routed to both transports in `framework.messenger.routing` and each handler has to declare `fromTransport`; the two declarations must agree by hand, and a typo in `fromTransport` compiles silently and the handler never runs. This PR lets the handler declare it in one place:

```php
#[AsMessageHandler(transport: 'notifications')]
final class NotifyCustomer
{
    public function __invoke(OrderWasPlaced $event): void { /* ... */ }
}

#[AsMessageHandler(transport: 'projections')]
final class UpdateOrdersList
{
    public function __invoke(OrderWasPlaced $event): void { /* ... */ }
}
```

`OrderWasPlaced` is sent to both transports, each handler receives its own copy from its own transport, and nothing has to be added to the routing configuration.

## Behaviour

- `transport` routes every message type the handler handles to that transport and binds the handler to it (`fromTransport` is implied; giving both with different values is an error).
- The transport is added to the message's effective routing: a `routing` entry, a `#[AsMessage(transport:)]` attribute or a namespace wildcard for that message keeps sending it where it did, the handler transport is appended. Routing by service id is recognized, so a transport is never sent to twice.
- Handlers that declare neither `transport` nor `fromTransport` keep running on every transport the message is received from (unchanged rule). To keep one handler synchronous next to asynchronous siblings, bind it to a `sync://` transport.
- Compile-time errors: unknown transport name (the configured ones are listed), `handles: '*'` with a transport, conflicting `fromTransport`, and outside FrameworkBundle a missing `messenger.senders_locator` service.
- `debug:messenger` shows the merged routing with its source: configured routes as before, attribute routes as `(from #[AsMessage])`, handler routes as `(from #[AsMessageHandler])`, both in the per-message view and in the transports section. It also prints `transport "x" is not configured` under a handler whose `from_transport` names a transport that does not exist.

## Public API

- `AsMessageHandler::$transport` (`?string`, last constructor parameter) and the `transport` attribute of the `messenger.message_handler` tag.

## Checks

- `./phpunit src/Symfony/Component/Messenger/Tests` and `./phpunit src/Symfony/Bundle/FrameworkBundle/Tests`: green (usual missing-server skips).
- Revert-verified: the pass tests fail without the pass changes, the end-to-end test fails with `Unknown named parameter $transport` without the attribute change, the bundle mapping test is skipped when the attribute has no `transport` property (low-deps job).
- The end-to-end test compiles a container with two bound handlers and one unbound handler and consumes both in-memory transports.

## Documentation

- The attribute option, the implied `fromTransport`, and the union with existing routing.
- The unchanged rule for unbound handlers and the `sync://` trick for a synchronous sibling.
- The compile-time errors and the `debug:messenger` warning.


