### PR TITLE
[Messenger] Let a flow carry its context in stamps: propagation, handler arguments and identity

### DIFF
--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -21,6 +21,13 @@ CHANGELOG
  * Add a `transport` option to `#[AsMessageHandler]` and to the `messenger.message_handler` tag to route the handled messages to that transport and bind the handler to it
  * Add `OutboxStamp` and `OutboxSender` to store messages in an outbox transport and forward them to their target transport when the outbox is consumed
  * Add the `outbox` option to transports
+ * Add `PropagatedStampInterface` to mark stamps that are copied onto the messages dispatched while handling the message carrying them
+ * Add `PropagateStampsMiddleware` to copy the propagated stamps of the message being handled onto nested dispatches
+ * Allow handler methods to declare arguments typed with `Envelope` or with a stamp class after the message argument
+ * Add `CorrelationStamp` to tie together the messages of one flow
+ * Add `MessageIdStamp` and `CausationStamp` to identify a message and the message whose handling caused it
+ * Add `AddIdentityStampsMiddleware` to add these identity stamps to the dispatched messages
+ * Add the `messenger.identity_stamps` option to enable `AddIdentityStampsMiddleware` on every bus
 
 8.1
 ---

--- a/src/Symfony/Component/Messenger/Handler/HandlerDescriptor.php
+++ b/src/Symfony/Component/Messenger/Handler/HandlerDescriptor.php
@@ -11,6 +11,9 @@
 
 namespace Symfony\Component\Messenger\Handler;
 
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Stamp\StampInterface;
+
 /**
  * Describes a handler and the possible associated options, such as `from_transport`, `bus`, etc.
  *
@@ -21,6 +24,11 @@ final class HandlerDescriptor
     private \Closure $handler;
     private string $name;
     private ?BatchHandlerInterface $batchHandler = null;
+
+    /**
+     * @var array<string, array{class-string<Envelope|StampInterface>, bool, bool}>
+     */
+    private array $stampParameters = [];
 
     public function __construct(
         callable $handler,
@@ -44,6 +52,19 @@ final class HandlerDescriptor
             }
 
             $this->name = $handler::class.'::'.$r->name;
+        }
+
+        foreach (\array_slice($r->getParameters(), 1) as $parameter) {
+            $type = $parameter->getType();
+
+            if (!$type instanceof \ReflectionNamedType || $type->isBuiltin()) {
+                continue;
+            }
+            $class = $type->getName();
+
+            if (Envelope::class === $class || is_subclass_of($class, StampInterface::class)) {
+                $this->stampParameters[$parameter->name] = [$class, $type->allowsNull(), $parameter->isDefaultValueAvailable()];
+            }
         }
     }
 
@@ -77,5 +98,20 @@ final class HandlerDescriptor
     public function getOptions(): array
     {
         return $this->options;
+    }
+
+    /**
+     * Returns the parameters of the handler typed with Envelope or with a stamp class, keyed by name.
+     *
+     * The first parameter, which receives the message, is never listed. Each entry holds
+     * the class, whether the parameter accepts null and whether it has a default value.
+     *
+     * @internal
+     *
+     * @return array<string, array{class-string<Envelope|StampInterface>, bool, bool}>
+     */
+    public function getStampParameters(): array
+    {
+        return $this->stampParameters;
     }
 }

--- a/src/Symfony/Component/Messenger/MessengerBundle.php
+++ b/src/Symfony/Component/Messenger/MessengerBundle.php
@@ -40,6 +40,7 @@ use Symfony\Component\Messenger\Transport\TransportInterface;
 use Symfony\Component\RateLimiter\LimiterInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Stopwatch\Stopwatch;
+use Symfony\Component\Uid\Uuid;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 /**
@@ -212,6 +213,10 @@ class MessengerBundle extends AbstractBundle
                     ->defaultTrue()
                     ->info('Whether redeliveries should be rejected and retried through a new message instead of being handled directly. This mostly makes sense for AMQP, which redelivers messages that were neither acknowledged nor rejected. Disabling it avoids losing a message when the retry or the failure transport is unreachable, at the risk of a redelivery loop that blocks the queue.')
                 ->end()
+                ->booleanNode('identity_stamps')
+                    ->defaultFalse()
+                    ->info('Adds a message id and a causation id to dispatched messages, and a correlation id at the start of each flow.')
+                ->end()
                 ->scalarNode('default_bus')->defaultNull()->end()
                 ->arrayNode('buses', 'bus')
                     ->defaultValue(['messenger.bus.default' => ['default_middleware' => ['enabled' => true, 'allow_no_handlers' => false, 'allow_no_senders' => true], 'middleware' => []]])
@@ -363,6 +368,8 @@ class MessengerBundle extends AbstractBundle
             'before' => [
                 ['id' => 'add_default_stamps_middleware'],
                 ['id' => 'add_bus_name_stamp_middleware'],
+                ...($config['identity_stamps'] ? [['id' => 'add_identity_stamps']] : []),
+                ['id' => 'propagate_stamps'],
                 ...($config['reject_redelivered_messages'] ? [['id' => 'reject_redelivered_message_middleware']] : []),
                 ['id' => 'dispatch_after_current_bus'],
                 ['id' => 'decode_failed_message_middleware'],
@@ -377,6 +384,14 @@ class MessengerBundle extends AbstractBundle
         // RemoveMissingDependenciesPass drops the middleware again when no default lock factory is registered
         if (class_exists(LockFactory::class)) {
             $defaultMiddleware['before'][] = ['id' => 'deduplicate_middleware'];
+        }
+
+        if (!$config['identity_stamps']) {
+            $container->removeDefinition('messenger.middleware.add_identity_stamps');
+            $container->removeDefinition('messenger.message_id_generator');
+        } elseif (!ContainerBuilder::willBeAvailable('symfony/uid', Uuid::class, ['symfony/messenger'])) {
+            $container->removeDefinition('messenger.message_id_generator');
+            $container->getDefinition('messenger.middleware.add_identity_stamps')->replaceArgument(0, null);
         }
 
         foreach ($config['buses'] as $busId => $bus) {

--- a/src/Symfony/Component/Messenger/Middleware/AddIdentityStampsMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/AddIdentityStampsMiddleware.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Middleware;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Stamp\CausationStamp;
+use Symfony\Component\Messenger\Stamp\CorrelationStamp;
+use Symfony\Component\Messenger\Stamp\MessageIdStamp;
+
+/**
+ * Identifies the dispatched messages and the flow they belong to.
+ *
+ * Each message gets a MessageIdStamp. A message that opens a flow also gets a CorrelationStamp
+ * built from that id, and a message dispatched while another one is handled gets a CausationStamp
+ * holding the id of that other message. Stamps already carried by the message are kept as they are.
+ *
+ * This middleware must run before PropagateStampsMiddleware: the latter copies the correlation of
+ * the message being handled onto the messages dispatched while handling it, which requires the id
+ * to be on the envelope it pushes.
+ *
+ * @see PropagateStampsMiddleware
+ */
+final class AddIdentityStampsMiddleware implements MiddlewareInterface
+{
+    private \Closure $generateId;
+
+    /**
+     * @var list<Envelope>
+     */
+    private array $stack = [];
+
+    /**
+     * @param \Closure(): (string|\Stringable) $generateId
+     */
+    public function __construct(?\Closure $generateId = null)
+    {
+        $this->generateId = $generateId ?? static fn (): string => bin2hex(random_bytes(16));
+    }
+
+    public function handle(Envelope $envelope, StackInterface $stack): Envelope
+    {
+        if (null === $messageId = $envelope->last(MessageIdStamp::class)) {
+            $envelope = $envelope->with($messageId = new MessageIdStamp(($this->generateId)()));
+        }
+
+        if (!$this->stack) {
+            if (null === $envelope->last(CorrelationStamp::class)) {
+                $envelope = $envelope->with(new CorrelationStamp($messageId->getId()));
+            }
+        } elseif (null === $envelope->last(CausationStamp::class) && null !== $causedBy = end($this->stack)->last(MessageIdStamp::class)) {
+            $envelope = $envelope->with(new CausationStamp($causedBy->getId()));
+        }
+
+        $this->stack[] = $envelope;
+
+        try {
+            return $stack->next()->handle($envelope, $stack);
+        } finally {
+            array_pop($this->stack);
+        }
+    }
+}

--- a/src/Symfony/Component/Messenger/Middleware/HandleMessageMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/HandleMessageMiddleware.php
@@ -89,7 +89,7 @@ class HandleMessageMiddleware implements MiddlewareInterface
                         $ackStamp->ack($envelope, $e);
                     }, $this->clock);
 
-                    $result = $this->callHandler($handler, $message, $ack, $envelope->last(HandlerArgumentsStamp::class));
+                    $result = $this->callHandler($handlerDescriptor, $envelope, $ack);
 
                     if (!\is_int($result) || 0 > $result) {
                         throw new LogicException(\sprintf('A handler implementing BatchHandlerInterface must return the size of the current batch as a positive integer, "%s" returned from "%s".', \is_int($result) ? $result : get_debug_type($result), get_debug_type($batchHandler)));
@@ -104,7 +104,7 @@ class HandleMessageMiddleware implements MiddlewareInterface
                         $result = $ack->getResult();
                     }
                 } else {
-                    $result = $this->callHandler($handler, $message, null, $envelope->last(HandlerArgumentsStamp::class));
+                    $result = $this->callHandler($handlerDescriptor, $envelope, null);
                 }
 
                 $handledStamp = HandledStamp::fromDescriptor($handlerDescriptor, $result);
@@ -162,18 +162,28 @@ class HandleMessageMiddleware implements MiddlewareInterface
         return false;
     }
 
-    /**
-     * @param-immediately-invoked-callable $handler
-     */
-    private function callHandler(\Closure $handler, object $message, ?Acknowledger $ack, ?HandlerArgumentsStamp $handlerArgumentsStamp): mixed
+    private function callHandler(HandlerDescriptor $handlerDescriptor, Envelope $envelope, ?Acknowledger $ack): mixed
     {
-        $arguments = [$message];
+        $arguments = [$envelope->getMessage()];
         if (null !== $ack) {
             $arguments[] = $ack;
         }
-        if (null !== $handlerArgumentsStamp) {
+        if (null !== $handlerArgumentsStamp = $envelope->last(HandlerArgumentsStamp::class)) {
             $arguments = [...$arguments, ...$handlerArgumentsStamp->getAdditionalArguments()];
         }
+        foreach ($handlerDescriptor->getStampParameters() as $name => [$class, $allowsNull, $hasDefault]) {
+            if (Envelope::class === $class) {
+                $arguments[$name] = $envelope;
+            } elseif (null !== $stamp = $envelope->last($class)) {
+                $arguments[$name] = $stamp;
+            } elseif (!$hasDefault) {
+                if (!$allowsNull) {
+                    throw new LogicException(\sprintf('Handler "%s" requires a "%s" stamp for argument "$%s", but the envelope carries none.', $handlerDescriptor->getName(), $class, $name));
+                }
+                $arguments[$name] = null;
+            }
+        }
+        $handler = $handlerDescriptor->getHandler();
 
         return $handler(...$arguments);
     }

--- a/src/Symfony/Component/Messenger/Middleware/PropagateStampsMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/PropagateStampsMiddleware.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Middleware;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Stamp\PropagatedStampInterface;
+use Symfony\Component\Messenger\Stamp\ReceivedStamp;
+
+/**
+ * Copies the propagated stamps of the message being handled onto the messages dispatched while handling it.
+ *
+ * A nested dispatch inherits the PropagatedStampInterface stamps of the message on top of the
+ * handling stack, except for the stamp classes it already carries. A received message is never
+ * enriched, but the messages its handler dispatches inherit its propagated stamps. One instance
+ * shared by several buses propagates across them.
+ */
+final class PropagateStampsMiddleware implements MiddlewareInterface
+{
+    /**
+     * @var list<Envelope>
+     */
+    private array $stack = [];
+
+    public function handle(Envelope $envelope, StackInterface $stack): Envelope
+    {
+        if ($this->stack && null === $envelope->last(ReceivedStamp::class)) {
+            foreach (end($this->stack)->all() as $class => $stamps) {
+                if (is_subclass_of($class, PropagatedStampInterface::class) && null === $envelope->last($class)) {
+                    $envelope = $envelope->with(...$stamps);
+                }
+            }
+        }
+
+        $this->stack[] = $envelope;
+
+        try {
+            return $stack->next()->handle($envelope, $stack);
+        } finally {
+            array_pop($this->stack);
+        }
+    }
+}

--- a/src/Symfony/Component/Messenger/Resources/config/messenger.php
+++ b/src/Symfony/Component/Messenger/Resources/config/messenger.php
@@ -31,12 +31,14 @@ use Symfony\Component\Messenger\EventListener\StopWorkerOnRestartSignalListener;
 use Symfony\Component\Messenger\Handler\RedispatchMessageHandler;
 use Symfony\Component\Messenger\Middleware\AddBusNameStampMiddleware;
 use Symfony\Component\Messenger\Middleware\AddDefaultStampsMiddleware;
+use Symfony\Component\Messenger\Middleware\AddIdentityStampsMiddleware;
 use Symfony\Component\Messenger\Middleware\DecodeFailedMessageMiddleware;
 use Symfony\Component\Messenger\Middleware\DeduplicateMiddleware;
 use Symfony\Component\Messenger\Middleware\DispatchAfterCurrentBusMiddleware;
 use Symfony\Component\Messenger\Middleware\FailedMessageProcessingMiddleware;
 use Symfony\Component\Messenger\Middleware\HandleMessageMiddleware;
 use Symfony\Component\Messenger\Middleware\LoggingMiddleware;
+use Symfony\Component\Messenger\Middleware\PropagateStampsMiddleware;
 use Symfony\Component\Messenger\Middleware\RejectRedeliveredMessageMiddleware;
 use Symfony\Component\Messenger\Middleware\RouterContextMiddleware;
 use Symfony\Component\Messenger\Middleware\SendMessageMiddleware;
@@ -54,6 +56,7 @@ use Symfony\Component\Messenger\Transport\Serialization\SigningSerializer;
 use Symfony\Component\Messenger\Transport\Sync\SyncTransportFactory;
 use Symfony\Component\Messenger\Transport\TransportFactory;
 use Symfony\Component\String\LazyString;
+use Symfony\Component\Uid\Uuid;
 
 return static function (ContainerConfigurator $container) {
     $container->services()
@@ -128,6 +131,17 @@ return static function (ContainerConfigurator $container) {
 
         ->set('messenger.middleware.add_bus_name_stamp_middleware', AddBusNameStampMiddleware::class)
             ->abstract()
+
+        ->set('messenger.message_id_generator', \Closure::class)
+            ->factory([\Closure::class, 'fromCallable'])
+            ->args([[Uuid::class, 'v7']])
+
+        ->set('messenger.middleware.add_identity_stamps', AddIdentityStampsMiddleware::class)
+            ->args([
+                service('messenger.message_id_generator'),
+            ])
+
+        ->set('messenger.middleware.propagate_stamps', PropagateStampsMiddleware::class)
 
         ->set('messenger.middleware.dispatch_after_current_bus', DispatchAfterCurrentBusMiddleware::class)
 

--- a/src/Symfony/Component/Messenger/Stamp/CausationStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/CausationStamp.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Stamp;
+
+/**
+ * Holds the id of the message whose handling caused this one to be dispatched.
+ *
+ * @see MessageIdStamp
+ */
+final class CausationStamp implements StampInterface
+{
+    public function __construct(
+        private string $id,
+    ) {
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+}

--- a/src/Symfony/Component/Messenger/Stamp/CorrelationStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/CorrelationStamp.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Stamp;
+
+/**
+ * Ties together the messages of one flow, whatever the buses and transports they travel through.
+ *
+ * Add it to the message that opens the flow, with the identifier of the request or of the
+ * process it belongs to. Every message dispatched while that one is handled inherits it.
+ */
+final class CorrelationStamp implements PropagatedStampInterface
+{
+    public function __construct(
+        private string $id,
+    ) {
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+}

--- a/src/Symfony/Component/Messenger/Stamp/MessageIdStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/MessageIdStamp.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Stamp;
+
+/**
+ * Identifies the message itself, as opposed to TransportMessageIdStamp which identifies one delivery in one transport.
+ *
+ * The same message keeps the same id across retries, through the failure transport and when it is replayed.
+ *
+ * @see TransportMessageIdStamp
+ */
+final class MessageIdStamp implements StampInterface
+{
+    public function __construct(
+        private string $id,
+    ) {
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+}

--- a/src/Symfony/Component/Messenger/Stamp/PropagatedStampInterface.php
+++ b/src/Symfony/Component/Messenger/Stamp/PropagatedStampInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Stamp;
+
+use Symfony\Component\Messenger\Middleware\PropagateStampsMiddleware;
+
+/**
+ * A stamp that is copied onto every message dispatched while the message carrying it is being handled.
+ *
+ * @see PropagateStampsMiddleware
+ */
+interface PropagatedStampInterface extends StampInterface
+{
+}

--- a/src/Symfony/Component/Messenger/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Component/Messenger/Tests/DependencyInjection/ConfigurationTest.php
@@ -35,6 +35,7 @@ class ConfigurationTest extends TestCase
             'failure_transport' => null,
             'stop_worker_on_signals' => [],
             'reject_redelivered_messages' => true,
+            'identity_stamps' => false,
             'default_bus' => null,
             'buses' => ['messenger.bus.default' => ['default_middleware' => ['enabled' => true, 'allow_no_handlers' => false, 'allow_no_senders' => true], 'middleware' => []]],
         ], $this->process([]));

--- a/src/Symfony/Component/Messenger/Tests/DependencyInjection/Fixtures/messenger_identity_stamps.php
+++ b/src/Symfony/Component/Messenger/Tests/DependencyInjection/Fixtures/messenger_identity_stamps.php
@@ -1,0 +1,5 @@
+<?php
+
+$container->loadFromExtension('messenger', [
+    'identity_stamps' => true,
+]);

--- a/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerBundleExtensionTest.php
+++ b/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerBundleExtensionTest.php
@@ -35,12 +35,19 @@ use Symfony\Component\Messenger\Bridge\Beanstalkd\Transport\BeanstalkdTransportF
 use Symfony\Component\Messenger\Bridge\MongoDb\Transport\MongoDbTransportFactory;
 use Symfony\Component\Messenger\Bridge\Redis\Transport\RedisTransportFactory;
 use Symfony\Component\Messenger\DependencyInjection\MessengerPass;
+use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Messenger\MessengerBundle;
+use Symfony\Component\Messenger\Middleware\AddIdentityStampsMiddleware;
+use Symfony\Component\Messenger\Middleware\PropagateStampsMiddleware;
+use Symfony\Component\Messenger\Middleware\StackMiddleware;
+use Symfony\Component\Messenger\Stamp\MessageIdStamp;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Messenger\Transport\Sender\OutboxSender;
 use Symfony\Component\Messenger\Transport\Serialization\ClaimCheckSerializer;
 use Symfony\Component\Messenger\Transport\TransportFactory;
+use Symfony\Component\Uid\Uuid;
+use Symfony\Component\Uid\UuidV7;
 
 class MessengerBundleExtensionTest extends TestCase
 {
@@ -179,6 +186,57 @@ class MessengerBundleExtensionTest extends TestCase
 
         $this->assertNotContains('messenger.middleware.reject_redelivered_message_middleware', $this->getBusMiddlewareIds($container, 'messenger.bus.default'));
         $this->assertContains('messenger.middleware.reject_redelivered_message_middleware', $this->getBusMiddlewareIds($container, 'messenger.bus.commands'));
+    }
+
+    public function testMessengerIdentityStampsAreDisabledByDefault()
+    {
+        $container = $this->createContainerFromFile('messenger', false);
+        $container->compile();
+
+        $this->assertNotContains(['id' => 'add_identity_stamps'], $container->getParameter('messenger.bus.default.middleware'));
+        $this->assertFalse($container->hasDefinition('messenger.middleware.add_identity_stamps'));
+        $this->assertFalse($container->hasDefinition('messenger.message_id_generator'));
+    }
+
+    public function testMessengerIdentityStampsMiddlewareRunsBeforePropagateStamps()
+    {
+        $container = $this->createContainerFromFile('messenger_identity_stamps', false);
+        $container->compile();
+
+        $middleware = array_values($container->getParameter('messenger.bus.default.middleware'));
+        $position = array_search(['id' => 'add_identity_stamps'], $middleware, true);
+
+        $this->assertNotFalse($position, 'The add_identity_stamps middleware is listed.');
+        $this->assertSame(['id' => 'propagate_stamps'], $middleware[$position + 1]);
+        $this->assertSame(AddIdentityStampsMiddleware::class, $container->getDefinition('messenger.middleware.add_identity_stamps')->getClass());
+    }
+
+    public function testMessengerIdentityStampsUseUuidV7WhenTheUidComponentIsInstalled()
+    {
+        if (!class_exists(Uuid::class)) {
+            $this->markTestSkipped('The Uid component is not installed.');
+        }
+
+        $container = $this->createContainerFromFile('messenger_identity_stamps', false);
+        $container->register('foo', \stdClass::class)
+            ->setPublic(true)
+            ->setProperty('middleware', new Reference('messenger.middleware.add_identity_stamps'));
+        $container->compile();
+
+        $envelope = $container->get('foo')->middleware->handle(new Envelope(new \stdClass()), new StackMiddleware());
+
+        $this->assertInstanceOf(UuidV7::class, Uuid::fromString($envelope->last(MessageIdStamp::class)->getId()));
+    }
+
+    public function testMessengerPropagateStampsMiddlewareIsSharedByAllBuses()
+    {
+        $container = $this->createContainerFromFile('messenger_reject_redelivered_messages_disabled_explicit_bus', false);
+        $container->addCompilerPass(new MessengerPass());
+        $container->compile();
+
+        $this->assertSame(PropagateStampsMiddleware::class, $container->getDefinition('messenger.middleware.propagate_stamps')->getClass());
+        $this->assertContains('messenger.middleware.propagate_stamps', $this->getBusMiddlewareIds($container, 'messenger.bus.default'));
+        $this->assertContains('messenger.middleware.propagate_stamps', $this->getBusMiddlewareIds($container, 'messenger.bus.commands'));
     }
 
     public function testMessengerMultipleFailureTransports()
@@ -525,6 +583,7 @@ class MessengerBundleExtensionTest extends TestCase
         $this->assertEquals([
             ['id' => 'add_default_stamps_middleware'],
             ['id' => 'add_bus_name_stamp_middleware', 'arguments' => ['messenger.bus.events']],
+            ['id' => 'propagate_stamps'],
             ['id' => 'reject_redelivered_message_middleware'],
             ['id' => 'dispatch_after_current_bus'],
             ['id' => 'decode_failed_message_middleware'],
@@ -544,6 +603,7 @@ class MessengerBundleExtensionTest extends TestCase
         $this->assertEquals([
             ['id' => 'add_default_stamps_middleware'],
             ['id' => 'add_bus_name_stamp_middleware', 'arguments' => ['messenger.bus.commands']],
+            ['id' => 'propagate_stamps'],
             ['id' => 'reject_redelivered_message_middleware'],
             ['id' => 'dispatch_after_current_bus'],
             ['id' => 'decode_failed_message_middleware'],
@@ -557,6 +617,7 @@ class MessengerBundleExtensionTest extends TestCase
         $this->assertEquals([
             ['id' => 'add_default_stamps_middleware'],
             ['id' => 'add_bus_name_stamp_middleware', 'arguments' => ['messenger.bus.events']],
+            ['id' => 'propagate_stamps'],
             ['id' => 'reject_redelivered_message_middleware'],
             ['id' => 'dispatch_after_current_bus'],
             ['id' => 'decode_failed_message_middleware'],

--- a/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerPassTest.php
+++ b/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerPassTest.php
@@ -46,6 +46,7 @@ use Symfony\Component\Messenger\Tests\Fixtures\ChildDummyMessage;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyCommand;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyCommandHandler;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyHandlerWithCustomMethods;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyHandlerWithStampArgument;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessageInterface;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessageWithAttribute;
@@ -430,6 +431,24 @@ class MessengerPassTest extends TestCase
             UnionTypeTwoMessage::class,
             [[TaggedDummyHandlerWithUnionTypes::class, 'handleUnionTypeMessage']]
         );
+    }
+
+    public function testTaggedMessageHandlerWithStampArgument()
+    {
+        $container = $this->getContainerBuilder($busId = 'message_bus');
+        $container
+            ->register(DummyHandlerWithStampArgument::class, DummyHandlerWithStampArgument::class)
+            ->setAutoconfigured(true)
+        ;
+
+        (new AttributeAutoconfigurationPass())->process($container);
+        (new ResolveInstanceofConditionalsPass())->process($container);
+        (new MessengerPass())->process($container);
+
+        $handlerDescriptionMapping = $container->getDefinition($busId.'.messenger.handlers_locator')->getArgument(0);
+
+        $this->assertCount(1, $handlerDescriptionMapping);
+        $this->assertHandlerDescriptor($container, $handlerDescriptionMapping, DummyMessage::class, [DummyHandlerWithStampArgument::class], [[]]);
     }
 
     public function testTaggedBatchMessageHandlerIsRegisteredOnce()

--- a/src/Symfony/Component/Messenger/Tests/Fixtures/DummyHandlerWithStampArgument.php
+++ b/src/Symfony/Component/Messenger/Tests/Fixtures/DummyHandlerWithStampArgument.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Fixtures;
+
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+#[AsMessageHandler]
+class DummyHandlerWithStampArgument
+{
+    public function __invoke(DummyMessage $message, AnEnvelopeStamp $stamp): void
+    {
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/Handler/HandlerDescriptorTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Handler/HandlerDescriptorTest.php
@@ -13,8 +13,13 @@ namespace Symfony\Component\Messenger\Tests\Handler;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Handler\Acknowledger;
 use Symfony\Component\Messenger\Handler\HandlerDescriptor;
+use Symfony\Component\Messenger\Tests\Fixtures\AnEnvelopeStamp;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyCommandHandler;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyHandlerWithStampArgument;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
 
 class HandlerDescriptorTest extends TestCase
 {
@@ -58,6 +63,40 @@ class HandlerDescriptorTest extends TestCase
         $descriptor = new HandlerDescriptor(static function () {}, $options);
 
         $this->assertSame($options, $descriptor->getOptions());
+    }
+
+    public function testStampParameters()
+    {
+        $descriptor = new HandlerDescriptor(static function (DummyMessage $message, Envelope $envelope, AnEnvelopeStamp $stamp, ?AnEnvelopeStamp $nullable, ?AnEnvelopeStamp $optional = null, AnEnvelopeStamp $withDefault = new AnEnvelopeStamp(), ?Acknowledger $ack = null, string $other = '') {});
+
+        $this->assertSame([
+            'envelope' => [Envelope::class, false, false],
+            'stamp' => [AnEnvelopeStamp::class, false, false],
+            'nullable' => [AnEnvelopeStamp::class, true, false],
+            'optional' => [AnEnvelopeStamp::class, true, true],
+            'withDefault' => [AnEnvelopeStamp::class, false, true],
+        ], $descriptor->getStampParameters());
+    }
+
+    public function testStampParametersOfAnInvokableHandler()
+    {
+        $descriptor = new HandlerDescriptor(new DummyHandlerWithStampArgument());
+
+        $this->assertSame(['stamp' => [AnEnvelopeStamp::class, false, false]], $descriptor->getStampParameters());
+    }
+
+    public function testTheMessageParameterIsNotAStampParameter()
+    {
+        $descriptor = new HandlerDescriptor(static function (AnEnvelopeStamp $message, AnEnvelopeStamp $stamp) {});
+
+        $this->assertSame(['stamp' => [AnEnvelopeStamp::class, false, false]], $descriptor->getStampParameters());
+    }
+
+    public function testHandlersWithoutStampParameters()
+    {
+        $this->assertSame([], (new HandlerDescriptor(new DummyCommandHandler()))->getStampParameters());
+        $this->assertSame([], (new HandlerDescriptor('var_dump'))->getStampParameters());
+        $this->assertSame([], (new HandlerDescriptor(static function (DummyMessage $message, ?Acknowledger $ack = null) {}))->getStampParameters());
     }
 }
 

--- a/src/Symfony/Component/Messenger/Tests/Middleware/AddIdentityStampsMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/AddIdentityStampsMiddlewareTest.php
@@ -1,0 +1,236 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Middleware;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Handler\HandlersLocator;
+use Symfony\Component\Messenger\MessageBus;
+use Symfony\Component\Messenger\Middleware\AddIdentityStampsMiddleware;
+use Symfony\Component\Messenger\Middleware\HandleMessageMiddleware;
+use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
+use Symfony\Component\Messenger\Middleware\PropagateStampsMiddleware;
+use Symfony\Component\Messenger\Middleware\StackInterface;
+use Symfony\Component\Messenger\Middleware\StackMiddleware;
+use Symfony\Component\Messenger\Stamp\CausationStamp;
+use Symfony\Component\Messenger\Stamp\CorrelationStamp;
+use Symfony\Component\Messenger\Stamp\MessageIdStamp;
+use Symfony\Component\Messenger\Stamp\ReceivedStamp;
+use Symfony\Component\Messenger\Test\Middleware\MiddlewareTestCase;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Messenger\Tests\Fixtures\SecondMessage;
+use Symfony\Component\Messenger\Tests\Fixtures\ThirdMessage;
+
+class AddIdentityStampsMiddlewareTest extends MiddlewareTestCase
+{
+    public function testARootDispatchOpensAFlow()
+    {
+        $middleware = new AddIdentityStampsMiddleware();
+
+        $envelope = $middleware->handle(new Envelope(new DummyMessage('Hey')), $this->getStackMock());
+
+        $id = $envelope->last(MessageIdStamp::class)->getId();
+        $this->assertNotSame('', $id);
+        $this->assertSame($id, $envelope->last(CorrelationStamp::class)->getId());
+        $this->assertNull($envelope->last(CausationStamp::class));
+    }
+
+    public function testANestedDispatchIsCausedByTheMessageBeingHandled()
+    {
+        $middleware = new AddIdentityStampsMiddleware();
+        $parent = null;
+
+        $child = $this->handleNested($middleware, new Envelope(new DummyMessage('Hey')), new Envelope(new SecondMessage()), $parent);
+
+        $this->assertNotSame($parent->last(MessageIdStamp::class)->getId(), $child->last(MessageIdStamp::class)->getId());
+        $this->assertSame($parent->last(MessageIdStamp::class)->getId(), $child->last(CausationStamp::class)->getId());
+        $this->assertNull($child->last(CorrelationStamp::class));
+    }
+
+    public function testAGrandchildIsCausedByItsParent()
+    {
+        $middleware = new AddIdentityStampsMiddleware();
+        $child = null;
+        $grandchild = null;
+
+        $middleware->handle(new Envelope(new DummyMessage('Hey')), $this->getNestingStackMock(function () use ($middleware, &$child, &$grandchild) {
+            $child = $middleware->handle(new Envelope(new SecondMessage()), $this->getNestingStackMock(function () use ($middleware, &$grandchild) {
+                $grandchild = $middleware->handle(new Envelope(new ThirdMessage()), $this->getStackMock());
+            }));
+        }));
+
+        $this->assertSame($child->last(MessageIdStamp::class)->getId(), $grandchild->last(CausationStamp::class)->getId());
+    }
+
+    public function testAnExistingMessageIdIsKept()
+    {
+        $middleware = new AddIdentityStampsMiddleware();
+        $id = new MessageIdStamp('the-message-id');
+
+        $envelope = $middleware->handle(new Envelope(new DummyMessage('Hey'), [$id]), $this->getStackMock());
+
+        $this->assertSame([$id], $envelope->all(MessageIdStamp::class));
+        $this->assertSame('the-message-id', $envelope->last(CorrelationStamp::class)->getId());
+    }
+
+    public function testAnExistingCorrelationIsKept()
+    {
+        $middleware = new AddIdentityStampsMiddleware();
+        $correlation = new CorrelationStamp('the-request-id');
+
+        $envelope = $middleware->handle(new Envelope(new DummyMessage('Hey'), [$correlation]), $this->getStackMock());
+
+        $this->assertSame([$correlation], $envelope->all(CorrelationStamp::class));
+        $this->assertNotNull($envelope->last(MessageIdStamp::class));
+    }
+
+    public function testAnExistingCausationIsKept()
+    {
+        $middleware = new AddIdentityStampsMiddleware();
+        $causation = new CausationStamp('the-causing-id');
+        $parent = null;
+
+        $child = $this->handleNested($middleware, new Envelope(new DummyMessage('Hey')), new Envelope(new SecondMessage(), [$causation]), $parent);
+
+        $this->assertSame([$causation], $child->all(CausationStamp::class));
+    }
+
+    public function testAReceivedMessageKeepsItsIdentity()
+    {
+        $middleware = new AddIdentityStampsMiddleware();
+        $id = new MessageIdStamp('the-message-id');
+        $correlation = new CorrelationStamp('the-request-id');
+        $causation = new CausationStamp('the-causing-id');
+
+        $envelope = $middleware->handle(new Envelope(new DummyMessage('Hey'), [new ReceivedStamp('async'), $id, $correlation, $causation]), $this->getStackMock());
+
+        $this->assertSame([$id], $envelope->all(MessageIdStamp::class));
+        $this->assertSame([$correlation], $envelope->all(CorrelationStamp::class));
+        $this->assertSame([$causation], $envelope->all(CausationStamp::class));
+    }
+
+    public function testTheStackUnwindsWhenHandlingThrows()
+    {
+        $middleware = new AddIdentityStampsMiddleware();
+
+        try {
+            $middleware->handle(new Envelope(new DummyMessage('Hey')), $this->getThrowingStackMock());
+            $this->fail('The exception of the next middleware should bubble up.');
+        } catch (\RuntimeException $e) {
+            $this->assertSame('Thrown from next middleware.', $e->getMessage());
+        }
+
+        $envelope = $middleware->handle(new Envelope(new SecondMessage()), $this->getStackMock());
+
+        $this->assertNull($envelope->last(CausationStamp::class));
+        $this->assertNotNull($envelope->last(CorrelationStamp::class));
+    }
+
+    public function testTheGivenGeneratorIsUsed()
+    {
+        $middleware = new AddIdentityStampsMiddleware(static fn (): string => 'the-generated-id');
+
+        $envelope = $middleware->handle(new Envelope(new DummyMessage('Hey')), $this->getStackMock());
+
+        $this->assertSame('the-generated-id', $envelope->last(MessageIdStamp::class)->getId());
+    }
+
+    public function testAGeneratorReturningAStringableIsCastToString()
+    {
+        $middleware = new AddIdentityStampsMiddleware(static fn (): \Stringable => new class implements \Stringable {
+            public function __toString(): string
+            {
+                return 'the-generated-id';
+            }
+        });
+
+        $envelope = $middleware->handle(new Envelope(new DummyMessage('Hey')), $this->getStackMock());
+
+        $this->assertSame('the-generated-id', $envelope->last(MessageIdStamp::class)->getId());
+    }
+
+    public function testTheDefaultGeneratorProducesDistinctIds()
+    {
+        $middleware = new AddIdentityStampsMiddleware();
+
+        $first = $middleware->handle(new Envelope(new DummyMessage('Hey')), $this->getStackMock());
+        $second = $middleware->handle(new Envelope(new SecondMessage()), $this->getStackMock());
+
+        $this->assertNotSame($first->last(MessageIdStamp::class)->getId(), $second->last(MessageIdStamp::class)->getId());
+    }
+
+    public function testAFlowIsIdentifiedThroughARealBus()
+    {
+        $recorder = new IdentityRecordingMiddleware();
+        $bus = new MessageBus([
+            new AddIdentityStampsMiddleware(),
+            new PropagateStampsMiddleware(),
+            $recorder,
+            new HandleMessageMiddleware(new HandlersLocator([
+                DummyMessage::class => [static function () use (&$bus) { $bus->dispatch(new SecondMessage()); }],
+                SecondMessage::class => [static function () use (&$bus) { $bus->dispatch(new ThirdMessage()); }],
+                ThirdMessage::class => [static function () {}],
+            ])),
+        ]);
+
+        $bus->dispatch(new DummyMessage('Hey'));
+
+        $this->assertCount(3, $recorder->envelopes);
+        [$root, $child, $grandchild] = $recorder->envelopes;
+
+        $correlation = $root->last(CorrelationStamp::class)->getId();
+        $this->assertSame($root->last(MessageIdStamp::class)->getId(), $correlation);
+        $this->assertSame($correlation, $child->last(CorrelationStamp::class)->getId());
+        $this->assertSame($correlation, $grandchild->last(CorrelationStamp::class)->getId());
+
+        $this->assertNull($root->last(CausationStamp::class));
+        $this->assertSame($root->last(MessageIdStamp::class)->getId(), $child->last(CausationStamp::class)->getId());
+        $this->assertSame($child->last(MessageIdStamp::class)->getId(), $grandchild->last(CausationStamp::class)->getId());
+
+        $ids = array_map(static fn (Envelope $envelope): string => $envelope->last(MessageIdStamp::class)->getId(), $recorder->envelopes);
+        $this->assertSame($ids, array_unique($ids));
+    }
+
+    private function handleNested(AddIdentityStampsMiddleware $middleware, Envelope $parent, Envelope $child, ?Envelope &$handledParent): Envelope
+    {
+        $nested = null;
+        $handledParent = $middleware->handle($parent, $this->getNestingStackMock(function () use ($middleware, $child, &$nested) {
+            $nested = $middleware->handle($child, $this->getStackMock());
+        }));
+
+        return $nested;
+    }
+
+    private function getNestingStackMock(\Closure $nested): StackInterface
+    {
+        $next = $this->createMock(MiddlewareInterface::class);
+        $next->expects($this->once())->method('handle')->willReturnCallback(static function (Envelope $envelope) use ($nested): Envelope {
+            $nested();
+
+            return $envelope;
+        });
+
+        return new StackMiddleware($next);
+    }
+}
+
+class IdentityRecordingMiddleware implements MiddlewareInterface
+{
+    /** @var list<Envelope> */
+    public array $envelopes = [];
+
+    public function handle(Envelope $envelope, StackInterface $stack): Envelope
+    {
+        $this->envelopes[] = $envelope;
+
+        return $stack->next()->handle($envelope, $stack);
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/Middleware/HandleMessageMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/HandleMessageMiddlewareTest.php
@@ -32,6 +32,7 @@ use Symfony\Component\Messenger\Stamp\HandledStamp;
 use Symfony\Component\Messenger\Stamp\HandlerArgumentsStamp;
 use Symfony\Component\Messenger\Stamp\NoAutoAckStamp;
 use Symfony\Component\Messenger\Test\Middleware\MiddlewareTestCase;
+use Symfony\Component\Messenger\Tests\Fixtures\AnEnvelopeStamp;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
 
 class HandleMessageMiddlewareTest extends MiddlewareTestCase
@@ -441,6 +442,141 @@ class HandleMessageMiddlewareTest extends MiddlewareTestCase
         $handler->expects($this->once())->method('__invoke')->with($message, 'additional named argument');
 
         $middleware->handle($envelope, $this->getStackMock());
+    }
+
+    public function testEnvelopeArgument()
+    {
+        $envelope = new Envelope(new DummyMessage('Hey'));
+        $received = null;
+
+        $middleware = new HandleMessageMiddleware(new HandlersLocator([
+            DummyMessage::class => [static function (DummyMessage $message, Envelope $envelope) use (&$received) {
+                $received = $envelope;
+            }],
+        ]));
+
+        $middleware->handle($envelope, $this->getStackMock());
+
+        $this->assertSame($envelope, $received);
+    }
+
+    public function testStampArgument()
+    {
+        $stamp = new AnEnvelopeStamp();
+        $received = null;
+
+        $middleware = new HandleMessageMiddleware(new HandlersLocator([
+            DummyMessage::class => [static function (DummyMessage $message, AnEnvelopeStamp $stamp) use (&$received) {
+                $received = $stamp;
+            }],
+        ]));
+
+        $middleware->handle(new Envelope(new DummyMessage('Hey'), [new AnEnvelopeStamp(), $stamp]), $this->getStackMock());
+
+        $this->assertSame($stamp, $received);
+    }
+
+    public function testNullableStampArgumentIsNullWhenTheStampIsMissing()
+    {
+        $received = false;
+
+        $middleware = new HandleMessageMiddleware(new HandlersLocator([
+            DummyMessage::class => [static function (DummyMessage $message, ?AnEnvelopeStamp $stamp) use (&$received) {
+                $received = $stamp;
+            }],
+        ]));
+
+        $middleware->handle(new Envelope(new DummyMessage('Hey')), $this->getStackMock());
+
+        $this->assertNull($received);
+    }
+
+    public function testTheDefaultValueOfAStampArgumentAppliesWhenTheStampIsMissing()
+    {
+        $received = null;
+
+        $middleware = new HandleMessageMiddleware(new HandlersLocator([
+            DummyMessage::class => [static function (DummyMessage $message, AnEnvelopeStamp $stamp = new AnEnvelopeStamp()) use (&$received) {
+                $received = $stamp;
+            }],
+        ]));
+
+        $middleware->handle(new Envelope(new DummyMessage('Hey')), $this->getStackMock());
+
+        $this->assertInstanceOf(AnEnvelopeStamp::class, $received);
+    }
+
+    public function testAMissingRequiredStampArgumentThrows()
+    {
+        $middleware = new HandleMessageMiddleware(new HandlersLocator([
+            DummyMessage::class => [static function (DummyMessage $message, AnEnvelopeStamp $stamp) {}],
+        ]));
+
+        try {
+            $middleware->handle(new Envelope(new DummyMessage('Hey')), $this->getStackMock(false));
+        } catch (HandlerFailedException $e) {
+            $this->assertCount(1, $e->getWrappedExceptions());
+            $this->assertInstanceOf(LogicException::class, $e->getWrappedExceptions()['Closure']);
+            $this->assertSame('Handler "Closure" requires a "Symfony\Component\Messenger\Tests\Fixtures\AnEnvelopeStamp" stamp for argument "$stamp", but the envelope carries none.', $e->getWrappedExceptions()['Closure']->getMessage());
+
+            return;
+        }
+
+        $this->fail('Exception not thrown.');
+    }
+
+    public function testBatchHandlerStampArgument()
+    {
+        $handler = new class implements BatchHandlerInterface {
+            use BatchHandlerTrait;
+
+            public array $stamps = [];
+
+            public function __invoke(DummyMessage $message, ?Acknowledger $ack = null, ?AnEnvelopeStamp $stamp = null)
+            {
+                $this->stamps[] = $stamp;
+
+                return $this->handle($message, $ack);
+            }
+
+            private function shouldFlush()
+            {
+                return true;
+            }
+
+            private function process(array $jobs): void
+            {
+                foreach ($jobs as [$job, $ack]) {
+                    $ack->ack($job);
+                }
+            }
+        };
+
+        $middleware = new HandleMessageMiddleware(new HandlersLocator([
+            DummyMessage::class => [new HandlerDescriptor($handler)],
+        ]));
+
+        $stamp = new AnEnvelopeStamp();
+        $middleware->handle(new Envelope(new DummyMessage('Hey'), [new AckStamp(static function () {}), $stamp]), new StackMiddleware());
+        $middleware->handle(new Envelope(new DummyMessage('Bob')), new StackMiddleware());
+
+        $this->assertSame([$stamp, null], $handler->stamps);
+    }
+
+    public function testHandlerArgumentsStampCombinesWithStampArguments()
+    {
+        $stamp = new AnEnvelopeStamp();
+        $received = null;
+
+        $middleware = new HandleMessageMiddleware(new HandlersLocator([
+            DummyMessage::class => [static function (DummyMessage $message, string $additional, AnEnvelopeStamp $stamp) use (&$received) {
+                $received = [$additional, $stamp];
+            }],
+        ]));
+
+        $middleware->handle(new Envelope(new DummyMessage('Hey'), [new HandlerArgumentsStamp(['additional argument']), $stamp]), $this->getStackMock());
+
+        $this->assertSame(['additional argument', $stamp], $received);
     }
 
     public function testDispatchHandlerEvents()

--- a/src/Symfony/Component/Messenger/Tests/Middleware/PropagateStampsMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/PropagateStampsMiddlewareTest.php
@@ -1,0 +1,240 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Middleware;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Handler\HandlersLocator;
+use Symfony\Component\Messenger\MessageBus;
+use Symfony\Component\Messenger\Middleware\HandleMessageMiddleware;
+use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
+use Symfony\Component\Messenger\Middleware\PropagateStampsMiddleware;
+use Symfony\Component\Messenger\Middleware\StackInterface;
+use Symfony\Component\Messenger\Middleware\StackMiddleware;
+use Symfony\Component\Messenger\Stamp\CorrelationStamp;
+use Symfony\Component\Messenger\Stamp\PropagatedStampInterface;
+use Symfony\Component\Messenger\Stamp\ReceivedStamp;
+use Symfony\Component\Messenger\Test\Middleware\MiddlewareTestCase;
+use Symfony\Component\Messenger\Tests\Fixtures\AnEnvelopeStamp;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Messenger\Tests\Fixtures\SecondMessage;
+use Symfony\Component\Messenger\Tests\Fixtures\ThirdMessage;
+
+class PropagateStampsMiddlewareTest extends MiddlewareTestCase
+{
+    public function testNothingIsCopiedOnRootDispatches()
+    {
+        $middleware = new PropagateStampsMiddleware();
+        $middleware->handle(new Envelope(new DummyMessage('Hey'), [new TraceStamp('abc')]), $this->getStackMock());
+
+        $envelope = new Envelope(new SecondMessage());
+
+        $this->assertSame($envelope, $middleware->handle($envelope, $this->getStackMock()));
+    }
+
+    public function testPropagatedStampsAreCopiedOnNestedDispatches()
+    {
+        $middleware = new PropagateStampsMiddleware();
+        $trace = new TraceStamp('abc');
+
+        $nested = $this->handleNested($middleware, new Envelope(new DummyMessage('Hey'), [$trace, new AnEnvelopeStamp()]), new Envelope(new SecondMessage()));
+
+        $this->assertSame([$trace], $nested->all(TraceStamp::class));
+        $this->assertSame([], $nested->all(AnEnvelopeStamp::class));
+    }
+
+    public function testAllStampsOfAPropagatedClassAreCopiedInOrder()
+    {
+        $middleware = new PropagateStampsMiddleware();
+        $first = new TraceStamp('first');
+        $second = new TraceStamp('second');
+
+        $nested = $this->handleNested($middleware, new Envelope(new DummyMessage('Hey'), [$first, $second]), new Envelope(new SecondMessage()));
+
+        $this->assertSame([$first, $second], $nested->all(TraceStamp::class));
+    }
+
+    public function testAnExplicitStampOnTheNestedEnvelopeWins()
+    {
+        $middleware = new PropagateStampsMiddleware();
+        $tenant = new TenantStamp('acme');
+        $childTrace = new TraceStamp('child');
+
+        $nested = $this->handleNested($middleware, new Envelope(new DummyMessage('Hey'), [new TraceStamp('parent'), $tenant]), new Envelope(new SecondMessage(), [$childTrace]));
+
+        $this->assertSame([$childTrace], $nested->all(TraceStamp::class));
+        $this->assertSame([$tenant], $nested->all(TenantStamp::class));
+    }
+
+    public function testAReceivedEnvelopePropagatesToNestedDispatches()
+    {
+        $middleware = new PropagateStampsMiddleware();
+        $trace = new TraceStamp('abc');
+
+        $nested = $this->handleNested($middleware, new Envelope(new DummyMessage('Hey'), [new ReceivedStamp('async'), $trace]), new Envelope(new SecondMessage()));
+
+        $this->assertSame([$trace], $nested->all(TraceStamp::class));
+    }
+
+    public function testAReceivedEnvelopeIsNeverEnriched()
+    {
+        $middleware = new PropagateStampsMiddleware();
+        $received = new Envelope(new SecondMessage(), [new ReceivedStamp('sync')]);
+
+        $this->assertSame($received, $this->handleNested($middleware, new Envelope(new DummyMessage('Hey'), [new TraceStamp('abc')]), $received));
+    }
+
+    public function testStampsPropagateAcrossSeveralLevels()
+    {
+        $middleware = new PropagateStampsMiddleware();
+        $trace = new TraceStamp('abc');
+        $tenant = new TenantStamp('acme');
+        $grandchild = null;
+
+        $middleware->handle(new Envelope(new DummyMessage('Hey'), [$trace]), $this->getNestingStackMock(function () use ($middleware, $tenant, &$grandchild) {
+            $middleware->handle(new Envelope(new SecondMessage(), [$tenant]), $this->getNestingStackMock(function () use ($middleware, &$grandchild) {
+                $grandchild = $middleware->handle(new Envelope(new ThirdMessage()), $this->getStackMock());
+            }));
+        }));
+
+        $this->assertSame([$trace], $grandchild->all(TraceStamp::class));
+        $this->assertSame([$tenant], $grandchild->all(TenantStamp::class));
+    }
+
+    public function testTheStackUnwindsWhenHandlingThrows()
+    {
+        $middleware = new PropagateStampsMiddleware();
+
+        try {
+            $middleware->handle(new Envelope(new DummyMessage('Hey'), [new TraceStamp('abc')]), $this->getThrowingStackMock());
+            $this->fail('The exception of the next middleware should bubble up.');
+        } catch (\RuntimeException $e) {
+            $this->assertSame('Thrown from next middleware.', $e->getMessage());
+        }
+
+        $envelope = new Envelope(new SecondMessage());
+
+        $this->assertSame($envelope, $middleware->handle($envelope, $this->getStackMock()));
+    }
+
+    public function testStampsPropagateThroughARealBus()
+    {
+        $trace = new TraceStamp('abc');
+        $recorder = new EnvelopeRecordingMiddleware();
+        $bus = new MessageBus([
+            new PropagateStampsMiddleware(),
+            $recorder,
+            new HandleMessageMiddleware(new HandlersLocator([
+                DummyMessage::class => [static function () use (&$bus) { $bus->dispatch(new SecondMessage()); }],
+                SecondMessage::class => [static function () {}],
+            ])),
+        ]);
+
+        $bus->dispatch(new DummyMessage('Hey'), [$trace]);
+
+        $this->assertCount(2, $recorder->envelopes);
+        $this->assertInstanceOf(SecondMessage::class, $recorder->envelopes[1]->getMessage());
+        $this->assertSame([$trace], $recorder->envelopes[1]->all(TraceStamp::class));
+    }
+
+    public function testAnInstanceSharedByTwoBusesPropagatesAcrossBuses()
+    {
+        $middleware = new PropagateStampsMiddleware();
+        $trace = new TraceStamp('abc');
+        $recorder = new EnvelopeRecordingMiddleware();
+
+        $eventBus = new MessageBus([$middleware, $recorder]);
+        $commandBus = new MessageBus([$middleware, new HandleMessageMiddleware(new HandlersLocator([
+            DummyMessage::class => [static function () use ($eventBus) { $eventBus->dispatch(new SecondMessage()); }],
+        ]))]);
+
+        $commandBus->dispatch(new DummyMessage('Hey'), [$trace]);
+
+        $this->assertCount(1, $recorder->envelopes);
+        $this->assertSame([$trace], $recorder->envelopes[0]->all(TraceStamp::class));
+    }
+
+    public function testSeparateInstancesDoNotPropagateAcrossBuses()
+    {
+        $recorder = new EnvelopeRecordingMiddleware();
+
+        $eventBus = new MessageBus([new PropagateStampsMiddleware(), $recorder]);
+        $commandBus = new MessageBus([new PropagateStampsMiddleware(), new HandleMessageMiddleware(new HandlersLocator([
+            DummyMessage::class => [static function () use ($eventBus) { $eventBus->dispatch(new SecondMessage()); }],
+        ]))]);
+
+        $commandBus->dispatch(new DummyMessage('Hey'), [new TraceStamp('abc')]);
+
+        $this->assertCount(1, $recorder->envelopes);
+        $this->assertSame([], $recorder->envelopes[0]->all(TraceStamp::class));
+    }
+
+    public function testTheCorrelationStampIsPropagated()
+    {
+        $middleware = new PropagateStampsMiddleware();
+        $correlation = new CorrelationStamp('the-request-id');
+
+        $nested = $this->handleNested($middleware, new Envelope(new DummyMessage('Hey'), [$correlation]), new Envelope(new SecondMessage()));
+
+        $this->assertSame([$correlation], $nested->all(CorrelationStamp::class));
+    }
+
+    private function handleNested(PropagateStampsMiddleware $middleware, Envelope $parent, Envelope $child): Envelope
+    {
+        $nested = null;
+        $middleware->handle($parent, $this->getNestingStackMock(function () use ($middleware, $child, &$nested) {
+            $nested = $middleware->handle($child, $this->getStackMock());
+        }));
+
+        return $nested;
+    }
+
+    private function getNestingStackMock(\Closure $nested): StackInterface
+    {
+        $next = $this->createMock(MiddlewareInterface::class);
+        $next->expects($this->once())->method('handle')->willReturnCallback(static function (Envelope $envelope) use ($nested): Envelope {
+            $nested();
+
+            return $envelope;
+        });
+
+        return new StackMiddleware($next);
+    }
+}
+
+class TraceStamp implements PropagatedStampInterface
+{
+    public function __construct(
+        public readonly string $id,
+    ) {
+    }
+}
+
+class TenantStamp implements PropagatedStampInterface
+{
+    public function __construct(
+        public readonly string $name,
+    ) {
+    }
+}
+
+class EnvelopeRecordingMiddleware implements MiddlewareInterface
+{
+    /** @var list<Envelope> */
+    public array $envelopes = [];
+
+    public function handle(Envelope $envelope, StackInterface $stack): Envelope
+    {
+        $this->envelopes[] = $envelope;
+
+        return $stack->next()->handle($envelope, $stack);
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/Stamp/CausationStampTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Stamp/CausationStampTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Stamp;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Stamp\CausationStamp;
+use Symfony\Component\Messenger\Stamp\NonSendableStampInterface;
+use Symfony\Component\Messenger\Stamp\PropagatedStampInterface;
+
+class CausationStampTest extends TestCase
+{
+    public function testItHoldsTheIdOfTheCausingMessage()
+    {
+        $this->assertSame('the-message-id', (new CausationStamp('the-message-id'))->getId());
+    }
+
+    public function testItIsSentButNotPropagated()
+    {
+        $stamp = new CausationStamp('the-message-id');
+
+        $this->assertNotInstanceOf(PropagatedStampInterface::class, $stamp);
+        $this->assertNotInstanceOf(NonSendableStampInterface::class, $stamp);
+    }
+
+    public function testItIsSerializable()
+    {
+        $stamp = new CausationStamp('the-message-id');
+
+        $this->assertEquals($stamp, unserialize(serialize($stamp)));
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/Stamp/CorrelationStampTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Stamp/CorrelationStampTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Stamp;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Stamp\CorrelationStamp;
+use Symfony\Component\Messenger\Stamp\PropagatedStampInterface;
+
+class CorrelationStampTest extends TestCase
+{
+    public function testTheGivenIdIsKept()
+    {
+        $this->assertSame('the-request-id', (new CorrelationStamp('the-request-id'))->getId());
+    }
+
+    public function testItIsPropagated()
+    {
+        $this->assertInstanceOf(PropagatedStampInterface::class, new CorrelationStamp('the-request-id'));
+    }
+
+    public function testItIsSerializable()
+    {
+        $stamp = new CorrelationStamp('the-request-id');
+
+        $this->assertEquals($stamp, unserialize(serialize($stamp)));
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/Stamp/MessageIdStampTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Stamp/MessageIdStampTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Stamp;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Stamp\MessageIdStamp;
+use Symfony\Component\Messenger\Stamp\NonSendableStampInterface;
+use Symfony\Component\Messenger\Stamp\PropagatedStampInterface;
+
+class MessageIdStampTest extends TestCase
+{
+    public function testItHoldsTheIdOfTheMessage()
+    {
+        $this->assertSame('the-message-id', (new MessageIdStamp('the-message-id'))->getId());
+    }
+
+    public function testItIsSentButNotPropagated()
+    {
+        $stamp = new MessageIdStamp('the-message-id');
+
+        $this->assertNotInstanceOf(PropagatedStampInterface::class, $stamp);
+        $this->assertNotInstanceOf(NonSendableStampInterface::class, $stamp);
+    }
+
+    public function testItIsSerializable()
+    {
+        $stamp = new MessageIdStamp('the-message-id');
+
+        $this->assertEquals($stamp, unserialize(serialize($stamp)));
+    }
+}

--- a/src/Symfony/Component/Messenger/composer.json
+++ b/src/Symfony/Component/Messenger/composer.json
@@ -37,6 +37,7 @@
         "symfony/serializer": "^7.4.4|^8.0.4",
         "symfony/service-contracts": "^3.7.1",
         "symfony/stopwatch": "^7.4|^8.0",
+        "symfony/uid": "^7.4|^8.0",
         "symfony/validator": "^7.4|^8.0",
         "symfony/var-dumper": "^7.4|^8.0"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

This is a proposal, open for discussion. It started from Dariusz Gafka's article [Symfony Messenger vs Ecotone: The Real Difference](https://blog.ecotone.tech/ecotone-vs-symfony-messenger-the-real-difference/), which describes how Ecotone approaches this. What is proposed here is a free interpretation for Symfony, built on Messenger's own model rather than ported from Ecotone, so it departs from the article where the two models differ.

Stamps are the place for what a flow knows about a message but the message itself is not: a trace id, the tenant, who asked, which import run this row belongs to. Two things stop them from being used that way today:

1. a handler that dispatches a follow-up message starts from an empty envelope, so a stamp attached at the entry point is gone at the next hop;
2. a handler receives the message only, so it cannot read a stamp at all without a custom middleware feeding `HandlerArgumentsStamp`.

Either gap alone forces the same workaround, and it is the interesting part of this PR: the value gets added as a field to the message class, then to the next message class, and so on down the flow. Messages end up carrying data they do not use, only to pass it along. This PR closes both gaps, so a value can be attached once and read where it is needed.

## The two halves together

```php
final class TenantStamp implements PropagatedStampInterface
{
    public function __construct(public readonly string $tenantId) {}
}

// Entry point: attached once.
$bus->dispatch(new ImportCatalog($path), [new TenantStamp($tenant->id)]);

// First handler: splits the file. It knows nothing about tenants and does not have to.
#[AsMessageHandler]
final class ImportCatalogHandler
{
    public function __construct(private MessageBusInterface $bus) {}

    public function __invoke(ImportCatalog $import): void
    {
        foreach ($this->reader->rows($import->path) as $row) {
            $this->bus->dispatch(new ImportRow($row)); // the TenantStamp is copied onto it
        }
    }
}

// Second handler: reads the tenant, although ImportRow never carried it.
#[AsMessageHandler]
final class ImportRowHandler
{
    public function __invoke(ImportRow $row, TenantStamp $tenant): void
    {
        $this->catalogs->for($tenant->tenantId)->add($row);
    }
}
```

Without the first half, `ImportCatalogHandler` has to re-attach the stamp on every dispatch, and forgetting once loses it silently. Without the second half, `ImportRow` has to carry a `$tenantId` field, and so does every other message of the flow, which is what the stamp was meant to avoid.

## Propagated stamps

A stamp implementing the new `PropagatedStampInterface` is copied onto every message dispatched while the message carrying it is being handled, at any nesting depth and across buses. The copy is done by the new `PropagateStampsMiddleware`, which keeps a stack of the envelopes being handled. Rules:

- an explicit stamp of the same class on the nested message wins, nothing is copied for that class;
- all stamps of a propagated class are copied, in order;
- a received message (consumed by a worker) is never modified, but what its handler dispatches inherits its propagated stamps, so a stamp must be sendable for the propagation to continue past a transport;
- messages dispatched with `DispatchAfterCurrentBusStamp` inherit at dispatch time; what their own handlers dispatch later inherits from the root message being handled.

`CorrelationStamp` is what the component ships on top of the interface. Give it the identifier of the request or of the process the flow belongs to, and every message of the flow carries it:

```php
$bus->dispatch(new ImportCatalog($path), [new CorrelationStamp($request->headers->get('X-Request-Id'))]);
```

Nothing attaches it on its own, so an application that does not use it sees no change. The identity middleware below adds one when it is enabled.

FrameworkBundle enables the middleware by default as `propagate_stamps`, right after `add_bus_name_stamp_middleware` and before `dispatch_after_current_bus` (that order is required, since queued messages are executed once the stack has unwound). It is one shared service for all buses, so that a command handler dispatching an event propagates to the event bus. Buses configured with `default_middleware: false` have to add it themselves.

## Stamp and envelope arguments for handlers

A handler method can declare, after the message, parameters typed with `Envelope` or with a stamp class. This half is also useful on its own, for stamps the system puts on the envelope:

```php
#[AsMessageHandler]
final class SendInvoiceHandler
{
    public function __invoke(SendInvoice $invoice, ?RedeliveryStamp $redelivery = null): void
    {
        if (2 < $redelivery?->getRetryCount()) {
            // last attempts, fall back to the plain text invoice
        }
    }
}
```

A missing stamp gives `null` to a nullable parameter, keeps the default value of a parameter that has one, and throws a `LogicException` for a required one:

> Handler "App\Import\ImportRowHandler" requires a "App\Import\TenantStamp" stamp for argument "$tenant", but the envelope carries none.

## Message identity

Correlation says which flow a message belongs to. Two more stamps say which message this is and what caused it:

- `MessageIdStamp` identifies the message itself, where `TransportMessageIdStamp` identifies one delivery in one transport. It is kept across a retry, the failure transport and a replay, so it stays the same identifier from one end of a flow to the other.
- `CausationStamp` holds the id of the message whose handling dispatched this one.

`AddIdentityStampsMiddleware` assigns them. A message that opens a flow gets an id and a correlation built from it. A message dispatched while another one is handled gets its own id and the id of that one as its cause. Anything the envelope already carries is left untouched, which is what lets an incoming message keep its place in the flow. It keeps its own frame of the messages in flight, so causation needs no interface of its own, and it has to run before `propagate_stamps`: the frame it pushes is what the children read, and the correlation of a nested dispatch has to come from the parent.

Stamping every dispatch changes serialized envelopes, so it is opt-in:

```yaml
framework:
    messenger:
        identity_stamps: true
```

Identifiers are UUIDv7 when the Uid component is installed, which keeps them ordered by creation and friendly to a database index, and 32 random hexadecimal characters otherwise. The generator is a closure, so decorating `messenger.message_id_generator` replaces it.

The option is global rather than per bus on purpose, because the middleware has to see every hop. A bus that skips it leaves its messages without an id, and the messages their handlers dispatch then take their cause from the nearest ancestor that did run, which is not the message that dispatched them. Enabling it on a command bus but not on the event bus it dispatches to gives this:

| message | bus | id | caused by |
| --- | --- | --- | --- |
| `PlaceOrder` | command, on | 875c608c | none |
| `OrderWasPlaced` | event, off | none | none |
| `NotifyWarehouse` | command, on | b2303dd1 | 875c608c |

`NotifyWarehouse` was dispatched by the handler of `OrderWasPlaced`, yet it names `PlaceOrder` as its cause. So a bus configured with `default_middleware: false` has to list `add_identity_stamps` itself, immediately before `propagate_stamps`, or stay out of flows that are identified elsewhere.

The stamp is looked up by exact class (`Envelope::last()`), so a parameter typed with an interface or a parent class never matches. Stamp parameters are passed as named arguments, while the extra arguments of `HandlerArgumentsStamp` stay positional, so the two must not overlap. Batch handlers keep their `Acknowledger` parameter.

## Public API

- `Symfony\Component\Messenger\Stamp\PropagatedStampInterface` (marker interface)
- `Symfony\Component\Messenger\Middleware\PropagateStampsMiddleware`
- `Symfony\Component\Messenger\Stamp\CorrelationStamp`, the stamp of the component using that interface
- `Symfony\Component\Messenger\Stamp\MessageIdStamp` and `Symfony\Component\Messenger\Stamp\CausationStamp`
- `Symfony\Component\Messenger\Middleware\AddIdentityStampsMiddleware`, and `framework.messenger.identity_stamps` to enable it
- Handler methods may declare `Envelope` or stamp-typed parameters after the message. `HandlerDescriptor::getStampParameters()` carries the reflection result and is `@internal` (the class is final).

The two halves are independently mergeable and touch disjoint files. They are one PR because either one alone leaves the workaround above in place. Identity is a third part, built on the first: it is the flow context the framework itself puts on a message. Say the word and I will split them.

## Checks

- `./phpunit src/Symfony/Component/Messenger/Tests` and `./phpunit src/Symfony/Bundle/FrameworkBundle/Tests`: green (usual missing-server skips).
- The three snippets above were run against this branch, including the exception message.
- Revert-verified: the middleware tests fail without the middleware and the interface; the handler-argument tests fail with `ArgumentCountError` on the base branch; the bundle tests fail without the wiring.
- The bundle wiring is guarded with `class_exists()` for the low-deps job (Messenger 7.4/8.0/8.1), and the identity middleware falls back to its own generator when the Uid component is absent.
- The identity tests cover a flow two levels deep: one correlation shared by the three messages, three distinct ids, no cause on the root, and a causation chain that follows the dispatch tree.

## Documentation

- Stamps as flow context: the marker interface, the copy rules, the received-message rule, and the worked example above.
- `CorrelationStamp`: what to put in it, and that it follows a flow through transports and retries as long as it is attached at the entry point.
- Message identity: the `identity_stamps` option and why it is opt-in, the three stamps and how they relate, `MessageIdStamp` against `TransportMessageIdStamp`, the UUIDv7 generator and how to replace it, and why a bus that lists its middleware by hand has to include `add_identity_stamps` immediately before `propagate_stamps`, with the broken causation chain above as the reason.
- The default middleware position and the shared-instance requirement for custom middleware lists.
- Stamp and envelope parameters: nullable, default, required, exact class match, no overlap with `HandlerArgumentsStamp`.




