### PR TITLE
[FrameworkBundle][Messenger] Add MessengerAssertionsTrait to test in-memory transports

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -60,6 +60,7 @@ CHANGELOG
  * Add `framework.profiler.excluded_paths` and `framework.profiler.excluded_http_codes` to skip profiling requests matching a path or answered with a given HTTP status code
  * Add `framework.property_access.wildcard_reads` option to read every element of a collection through a `[*]` path
  * Instantiate on the console only the bundles that override the deprecated `Bundle::registerCommands()` method
+ * Add `MessengerAssertionsTrait` to `KernelTestCase`, with `assertQueuedMessageCount()`, `getQueuedMessages()`, `getMessengerTransport()` and `consumeQueuedMessages()` for in-memory Messenger transports
 
 8.1
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
@@ -29,6 +29,7 @@ abstract class KernelTestCase extends TestCase
 {
     use ConsoleCommandAssertionsTrait;
     use MailerAssertionsTrait;
+    use MessengerAssertionsTrait;
     use NotificationAssertionsTrait;
 
     protected static ?string $class = null;

--- a/src/Symfony/Bundle/FrameworkBundle/Test/MessengerAssertionsTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/MessengerAssertionsTrait.php
@@ -1,0 +1,192 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Test;
+
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
+use Symfony\Component\Messenger\Event\WorkerMessageHandledEvent;
+use Symfony\Component\Messenger\EventListener\StopWorkerOnIdleListener;
+use Symfony\Component\Messenger\EventListener\StopWorkerOnMessageLimitListener;
+use Symfony\Component\Messenger\Stamp\RedeliveryStamp;
+use Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport;
+use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
+use Symfony\Component\Messenger\Worker;
+
+/**
+ * Assertions and helpers for the messages queued on in-memory Messenger transports.
+ */
+trait MessengerAssertionsTrait
+{
+    /**
+     * Asserts the number of messages queued on an in-memory transport.
+     *
+     * @param string|null $messageClass Counts only the messages that are instances of this class
+     */
+    public static function assertQueuedMessageCount(int $count, string $transport, ?string $messageClass = null, string $message = ''): void
+    {
+        $envelopes = self::getQueuedMessages($transport);
+
+        if (null !== $messageClass) {
+            if (!class_exists($messageClass) && !interface_exists($messageClass)) {
+                throw new \InvalidArgumentException(\sprintf('The message class "%s" given to assertQueuedMessageCount() does not exist.', $messageClass));
+            }
+
+            $envelopes = array_filter($envelopes, static fn (Envelope $envelope) => $envelope->getMessage() instanceof $messageClass);
+        }
+
+        self::assertCount($count, $envelopes, $message ?: \sprintf('Failed asserting that the "%s" transport has %d queued message(s)%s.', $transport, $count, null === $messageClass ? '' : ' of class "'.$messageClass.'"'));
+    }
+
+    /**
+     * Returns the envelopes queued on an in-memory transport, delayed ones included.
+     *
+     * @return Envelope[]
+     */
+    public static function getQueuedMessages(string $transport): array
+    {
+        return self::getMessengerTransport($transport)->all();
+    }
+
+    /**
+     * Handles the messages queued on an in-memory transport with the message bus of the application.
+     *
+     * The worker listeners of the application run as in production: a failing message is sent for
+     * retry or to the failure transport as configured. A message sent for retry is consumed again
+     * without waiting for its delay, so that the retries of a test play out within the call, and
+     * the failure that exhausts them is rethrown. A message the application delayed itself is left
+     * in the transport until it is due.
+     *
+     * @param int|null $limit Stops after this number of messages, instead of draining the queue
+     *
+     * @return int The number of messages that were handled
+     */
+    public static function consumeQueuedMessages(string $transport, ?int $limit = null): int
+    {
+        $container = static::getContainer();
+        $receiver = self::createRetryAwareReceiver(self::getMessengerTransport($transport));
+        $bus = $container->get('messenger.routable_message_bus');
+        /** @var EventDispatcherInterface $dispatcher */
+        $dispatcher = $container->get('event_dispatcher');
+
+        $handled = 0;
+        $failures = [];
+        $countHandled = static function () use (&$handled): void {
+            ++$handled;
+        };
+        $recordFailure = static function (WorkerMessageFailedEvent $event) use (&$failures): void {
+            // a failure the retry strategy replays is not the outcome of this run
+            if (!$event->willRetry()) {
+                $failures[] = $event->getThrowable();
+            }
+        };
+        $subscribers = [new StopWorkerOnIdleListener()];
+
+        if (null !== $limit) {
+            $subscribers[] = new StopWorkerOnMessageLimitListener($limit);
+        }
+
+        foreach ($subscribers as $subscriber) {
+            $dispatcher->addSubscriber($subscriber);
+        }
+        $dispatcher->addListener(WorkerMessageHandledEvent::class, $countHandled);
+        $dispatcher->addListener(WorkerMessageFailedEvent::class, $recordFailure);
+
+        try {
+            (new Worker([$transport => $receiver], $bus, $dispatcher))->run(['sleep' => 0]);
+        } finally {
+            foreach ($subscribers as $subscriber) {
+                $dispatcher->removeSubscriber($subscriber);
+            }
+            $dispatcher->removeListener(WorkerMessageHandledEvent::class, $countHandled);
+            $dispatcher->removeListener(WorkerMessageFailedEvent::class, $recordFailure);
+        }
+
+        if ($failures) {
+            throw $failures[0];
+        }
+
+        return $handled;
+    }
+
+    /**
+     * Returns the in-memory transport registered under the given name.
+     */
+    public static function getMessengerTransport(string $transport): InMemoryTransport
+    {
+        $container = static::getContainer();
+
+        if (!$container->has($id = 'messenger.transport.'.$transport)) {
+            static::fail(\sprintf('The "%s" Messenger transport is not registered. Did you forget to configure it under "framework.messenger.transports"?', $transport));
+        }
+
+        if (!($service = $container->get($id)) instanceof InMemoryTransport) {
+            static::fail(\sprintf('The "%s" Messenger transport is not an in-memory transport. Configure "in-memory://" as its DSN in the test environment to make queued message assertions.', $transport));
+        }
+
+        return $service;
+    }
+
+    /**
+     * Reads the messages sent for retry without waiting for their delay, so that a test does not have to.
+     */
+    private static function createRetryAwareReceiver(InMemoryTransport $transport): ReceiverInterface
+    {
+        return new class($transport) implements ReceiverInterface {
+            public function __construct(
+                private InMemoryTransport $transport,
+            ) {
+            }
+
+            /**
+             * @return list<Envelope>
+             */
+            public function get(): iterable
+            {
+                $fetchSize = \func_num_args() > 0 ? max(1, func_get_arg(0)) : 1;
+                $envelopes = [];
+
+                foreach ($this->transport->get($fetchSize) as $envelope) {
+                    $envelopes[] = $envelope;
+                }
+
+                if ($envelopes) {
+                    return $envelopes;
+                }
+
+                foreach ($this->transport->all() as $envelope) {
+                    if (!$envelope->last(RedeliveryStamp::class)) {
+                        continue;
+                    }
+
+                    $envelopes[] = $envelope;
+
+                    if (\count($envelopes) >= $fetchSize) {
+                        break;
+                    }
+                }
+
+                return $envelopes;
+            }
+
+            public function ack(Envelope $envelope): void
+            {
+                $this->transport->ack($envelope);
+            }
+
+            public function reject(Envelope $envelope): void
+            {
+                $this->transport->reject($envelope);
+            }
+        };
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Messenger/RecordingMessageHandler.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Messenger/RecordingMessageHandler.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger;
+
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+#[AsMessageHandler]
+class RecordingMessageHandler
+{
+    public static array $handled = [];
+    public static int $attempts = 0;
+    public static int $failures = 0;
+
+    public function __invoke(FooMessage|BarMessage $message): void
+    {
+        ++self::$attempts;
+
+        if (0 < self::$failures--) {
+            throw new \RuntimeException('Handling failed.');
+        }
+
+        self::$handled[] = $message;
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/MessengerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/MessengerTest.php
@@ -1,0 +1,146 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
+
+use PHPUnit\Framework\AssertionFailedError;
+use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\BarMessage;
+use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\FooMessage;
+use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\RecordingMessageHandler;
+use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\SecondMessage;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\HandlerFailedException;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\DelayStamp;
+use Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport;
+
+class MessengerTest extends AbstractWebTestCase
+{
+    protected function setUp(): void
+    {
+        RecordingMessageHandler::$handled = [];
+        RecordingMessageHandler::$attempts = 0;
+        RecordingMessageHandler::$failures = 0;
+    }
+
+    public function testQueuedMessagesAreConsumedThroughTheBus()
+    {
+        $bus = self::getContainer()->get(MessageBusInterface::class);
+        $bus->dispatch($foo = new FooMessage());
+        $bus->dispatch($bar = new BarMessage());
+
+        $this->assertInstanceOf(InMemoryTransport::class, $this->getMessengerTransport('async'));
+        $this->assertQueuedMessageCount(2, 'async');
+        $this->assertQueuedMessageCount(1, 'async', FooMessage::class);
+        $this->assertQueuedMessageCount(0, 'async', SecondMessage::class);
+        $this->assertSame([$foo, $bar], array_map(static fn (Envelope $envelope) => $envelope->getMessage(), $this->getQueuedMessages('async')));
+        $this->assertSame([], RecordingMessageHandler::$handled);
+
+        $this->assertSame(2, $this->consumeQueuedMessages('async'));
+
+        $this->assertQueuedMessageCount(0, 'async');
+        $this->assertSame([], $this->getQueuedMessages('async'));
+        $this->assertSame([$foo, $bar], RecordingMessageHandler::$handled);
+
+        $this->assertSame(0, $this->consumeQueuedMessages('async'));
+
+        $this->assertSame([$foo, $bar], RecordingMessageHandler::$handled, 'Consuming an empty queue returns without handling anything');
+    }
+
+    public function testConsumeQueuedMessagesWithLimit()
+    {
+        $bus = self::getContainer()->get(MessageBusInterface::class);
+        $bus->dispatch($foo1 = new FooMessage());
+        $bus->dispatch($foo2 = new FooMessage());
+        $bus->dispatch($foo3 = new FooMessage());
+
+        $this->consumeQueuedMessages('async', 2);
+
+        $this->assertQueuedMessageCount(1, 'async');
+        $this->assertSame([$foo1, $foo2], RecordingMessageHandler::$handled);
+
+        $this->consumeQueuedMessages('async', 2);
+
+        $this->assertQueuedMessageCount(0, 'async');
+        $this->assertSame([$foo1, $foo2, $foo3], RecordingMessageHandler::$handled);
+    }
+
+    public function testConsumeQueuedMessagesReplaysARetryUntilItSucceeds()
+    {
+        RecordingMessageHandler::$failures = 1;
+        self::getContainer()->get(MessageBusInterface::class)->dispatch($foo = new FooMessage());
+
+        $this->assertSame(1, $this->consumeQueuedMessages('async'));
+
+        // the retry was consumed without waiting for the 10 seconds of the retry strategy
+        $this->assertSame(2, RecordingMessageHandler::$attempts);
+        $this->assertSame([$foo], RecordingMessageHandler::$handled);
+        $this->assertQueuedMessageCount(0, 'async');
+    }
+
+    public function testConsumeQueuedMessagesRethrowsTheFailureThatExhaustsTheRetries()
+    {
+        RecordingMessageHandler::$failures = \PHP_INT_MAX;
+        self::getContainer()->get(MessageBusInterface::class)->dispatch(new FooMessage());
+
+        try {
+            $this->consumeQueuedMessages('async');
+            $this->fail('The failure that exhausts the retries should have been rethrown.');
+        } catch (HandlerFailedException $e) {
+            $this->assertSame('Handling failed.', array_values($e->getWrappedExceptions())[0]->getMessage());
+        }
+
+        // the default strategy allows three retries, and none of them waited
+        $this->assertSame(4, RecordingMessageHandler::$attempts);
+        $this->assertQueuedMessageCount(0, 'async');
+        $this->assertSame([], RecordingMessageHandler::$handled);
+    }
+
+    public function testConsumeQueuedMessagesLeavesAMessageDelayedByTheApplication()
+    {
+        self::getContainer()->get(MessageBusInterface::class)->dispatch(new FooMessage(), [new DelayStamp(3600000)]);
+
+        $this->assertSame(0, $this->consumeQueuedMessages('async'));
+
+        $this->assertQueuedMessageCount(1, 'async');
+        $this->assertSame(0, RecordingMessageHandler::$attempts);
+    }
+
+    public function testAssertQueuedMessageCountRejectsAnUnknownMessageClass()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The message class "App\Message\Unknown" given to assertQueuedMessageCount() does not exist.');
+
+        $this->assertQueuedMessageCount(0, 'async', 'App\Message\Unknown');
+    }
+
+    public function testGetMessengerTransportRequiresAnInMemoryTransport()
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('The "sync" Messenger transport is not an in-memory transport. Configure "in-memory://" as its DSN in the test environment to make queued message assertions.');
+
+        $this->getMessengerTransport('sync');
+    }
+
+    public function testGetMessengerTransportRequiresAConfiguredTransport()
+    {
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('The "unknown" Messenger transport is not registered. Did you forget to configure it under "framework.messenger.transports"?');
+
+        $this->getMessengerTransport('unknown');
+    }
+
+    protected static function createKernel(array $options = []): KernelInterface
+    {
+        return parent::createKernel(['test_case' => 'Messenger'] + $options);
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Messenger/bundles.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Messenger/bundles.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+
+return [
+    new FrameworkBundle(),
+];

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Messenger/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Messenger/config.yml
@@ -1,0 +1,18 @@
+imports:
+    - { resource: ../config/default.yml }
+
+framework:
+    messenger:
+        transports:
+            async:
+                dsn: 'in-memory://'
+                retry_strategy:
+                    delay: 10000
+            sync: 'sync://'
+        routing:
+            Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\FooMessage: async
+            Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\BarMessage: async
+
+services:
+    Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\RecordingMessageHandler:
+        autoconfigure: true

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -21,6 +21,8 @@ CHANGELOG
  * Add a `transport` option to `#[AsMessageHandler]` and to the `messenger.message_handler` tag to route the handled messages to that transport and bind the handler to it
  * Add `OutboxStamp` and `OutboxSender` to store messages in an outbox transport and forward them to their target transport when the outbox is consumed
  * Add the `outbox` option to transports
+ * Add `StopWorkerOnIdleListener` to stop the worker as soon as no message is available
+ * Make `InMemoryTransport` implement `ListableReceiverInterface` and `MessageCountAwareInterface`
 
 8.1
 ---

--- a/src/Symfony/Component/Messenger/EventListener/StopWorkerOnIdleListener.php
+++ b/src/Symfony/Component/Messenger/EventListener/StopWorkerOnIdleListener.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\EventListener;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Messenger\Event\WorkerRunningEvent;
+
+/**
+ * Stops the worker as soon as its receivers return no message.
+ *
+ * The worker handles every message that is available and exits without sleeping.
+ */
+class StopWorkerOnIdleListener implements EventSubscriberInterface
+{
+    public function __construct(
+        private ?LoggerInterface $logger = null,
+    ) {
+    }
+
+    public function onWorkerRunning(WorkerRunningEvent $event): void
+    {
+        if ($event->isWorkerIdle()) {
+            $event->getWorker()->stop();
+
+            $this->logger?->info('Worker stopped because no message was available');
+        }
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            WorkerRunningEvent::class => 'onWorkerRunning',
+        ];
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/EventListener/StopWorkerOnIdleListenerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/EventListener/StopWorkerOnIdleListenerTest.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\EventListener;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Clock\MockClock;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Event\WorkerRunningEvent;
+use Symfony\Component\Messenger\EventListener\StopWorkerOnIdleListener;
+use Symfony\Component\Messenger\MessageBus;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyReceiver;
+use Symfony\Component\Messenger\Worker;
+
+class StopWorkerOnIdleListenerTest extends TestCase
+{
+    public function testWorkerStopsWhenIdle()
+    {
+        $worker = $this->createMock(Worker::class);
+        $worker->expects($this->once())->method('stop');
+
+        $listener = new StopWorkerOnIdleListener();
+        $listener->onWorkerRunning(new WorkerRunningEvent($worker, true));
+    }
+
+    public function testWorkerKeepsRunningWhileMessagesAreReceived()
+    {
+        $worker = $this->createMock(Worker::class);
+        $worker->expects($this->never())->method('stop');
+
+        $listener = new StopWorkerOnIdleListener();
+        $listener->onWorkerRunning(new WorkerRunningEvent($worker, false));
+    }
+
+    public function testWorkerLogsWhenStoppedOnIdle()
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())->method('info')->with('Worker stopped because no message was available');
+
+        $listener = new StopWorkerOnIdleListener($logger);
+        $listener->onWorkerRunning(new WorkerRunningEvent(new Worker([], new MessageBus()), true));
+    }
+
+    public function testWorkerDrainsTheReceiverAndStopsWithoutSleeping()
+    {
+        $receiver = new DummyReceiver([
+            [new Envelope(new DummyMessage('API'))],
+            [new Envelope(new DummyMessage('IPA'))],
+            [],
+        ]);
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addSubscriber(new StopWorkerOnIdleListener());
+
+        $clock = new MockClock();
+        $startedAt = $clock->now();
+
+        $worker = new Worker(['transport' => $receiver], new MessageBus(), $dispatcher, clock: $clock);
+        $worker->run();
+
+        $this->assertSame(2, $receiver->getAcknowledgeCount());
+        $this->assertEquals($startedAt, $clock->now());
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/Transport/InMemory/InMemoryTransportTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/InMemory/InMemoryTransportTest.php
@@ -223,4 +223,78 @@ class InMemoryTransportTest extends TestCase
         $this->assertSame([], $this->transport->getRejected(), 'Should be empty after reset');
         $this->assertSame([], $this->transport->getSent(), 'Should be empty after reset');
     }
+
+    public function testGetMessageCount()
+    {
+        $this->assertSame(0, $this->transport->getMessageCount());
+
+        $envelope1 = $this->transport->send(new Envelope(new \stdClass()));
+        $envelope2 = $this->transport->send((new Envelope(new \stdClass()))->with(new DelayStamp(10_000)));
+        $this->assertSame(2, $this->transport->getMessageCount());
+
+        $this->transport->ack($envelope1);
+        $this->assertSame(1, $this->transport->getMessageCount());
+
+        $this->transport->reject($envelope2);
+        $this->assertSame(0, $this->transport->getMessageCount());
+    }
+
+    public function testAll()
+    {
+        $this->assertSame([], $this->transport->all());
+
+        $envelope1 = $this->transport->send(new Envelope(new \stdClass()));
+        $envelope2 = $this->transport->send((new Envelope(new \stdClass()))->with(new DelayStamp(10_000)));
+        $envelope3 = $this->transport->send(new Envelope(new \stdClass()));
+        $this->assertSame([$envelope1, $envelope2, $envelope3], $this->transport->all());
+        $this->assertSame([$envelope1, $envelope2], $this->transport->all(2));
+
+        $this->transport->ack($envelope1);
+        $this->transport->reject($envelope3);
+        $this->assertSame([$envelope2], $this->transport->all());
+        $this->assertSame([], $this->transport->get(), 'Delayed messages are listed but not received');
+    }
+
+    public function testAllWithSerialization()
+    {
+        $envelope = new Envelope(new \stdClass());
+        $envelopeDecoded = Envelope::wrap(new DummyMessage('Hello.'));
+        $serializer = $this->createStub(SerializerInterface::class);
+        $serializer
+            ->method('encode')
+            ->willReturnCallback(function (Envelope $encodedEnvelope) use ($envelope) {
+                $this->assertEquals($envelope->with(new TransportMessageIdStamp(1)), $encodedEnvelope);
+
+                return ['foo' => 'ba'];
+            })
+        ;
+        $serializer
+            ->method('decode')
+            ->willReturnMap([
+                [['foo' => 'ba'], $envelopeDecoded],
+            ])
+        ;
+        $serializeTransport = new InMemoryTransport($serializer);
+        $serializeTransport->send($envelope);
+        $this->assertSame([$envelopeDecoded], $serializeTransport->all());
+        $this->assertSame($envelopeDecoded, $serializeTransport->find(1));
+    }
+
+    public function testFind()
+    {
+        $this->assertNull($this->transport->find(1));
+
+        $envelope1 = $this->transport->send(new Envelope(new \stdClass()));
+        $envelope2 = $this->transport->send(new Envelope(new \stdClass()));
+        $this->assertSame($envelope1, $this->transport->find(1));
+        $this->assertSame($envelope2, $this->transport->find('2'));
+        $this->assertNull($this->transport->find(3));
+        $this->assertNull($this->transport->find('foo'));
+        $this->assertNull($this->transport->find([]));
+
+        $this->transport->ack($envelope1);
+        $this->assertNull($this->transport->find(1));
+        $this->transport->reject($envelope2);
+        $this->assertNull($this->transport->find(2));
+    }
 }

--- a/src/Symfony/Component/Messenger/Transport/InMemory/InMemoryTransport.php
+++ b/src/Symfony/Component/Messenger/Transport/InMemory/InMemoryTransport.php
@@ -16,6 +16,8 @@ use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\LogicException;
 use Symfony\Component\Messenger\Stamp\DelayStamp;
 use Symfony\Component\Messenger\Stamp\TransportMessageIdStamp;
+use Symfony\Component\Messenger\Transport\Receiver\ListableReceiverInterface;
+use Symfony\Component\Messenger\Transport\Receiver\MessageCountAwareInterface;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 use Symfony\Component\Messenger\Transport\TransportInterface;
 use Symfony\Contracts\Service\ResetInterface;
@@ -25,7 +27,7 @@ use Symfony\Contracts\Service\ResetInterface;
  *
  * @author Gary PEGEOT <garypegeot@gmail.com>
  */
-class InMemoryTransport implements TransportInterface, ResetInterface
+class InMemoryTransport implements TransportInterface, ListableReceiverInterface, MessageCountAwareInterface, ResetInterface
 {
     /**
      * @var Envelope[]
@@ -96,6 +98,30 @@ class InMemoryTransport implements TransportInterface, ResetInterface
         }
 
         unset($this->queue[$id = $transportMessageIdStamp->getId()], $this->availableAt[$id]);
+    }
+
+    public function getMessageCount(): int
+    {
+        return \count($this->queue);
+    }
+
+    /**
+     * Returns the queued envelopes in order, delayed ones included.
+     *
+     * @return Envelope[]
+     */
+    public function all(?int $limit = null): array
+    {
+        return array_values($this->decode(null === $limit ? $this->queue : \array_slice($this->queue, 0, $limit, true)));
+    }
+
+    public function find(mixed $id): ?Envelope
+    {
+        if (!\is_int($id) && !\is_string($id) || !isset($this->queue[$id])) {
+            return null;
+        }
+
+        return $this->decode([$this->queue[$id]])[0];
     }
 
     public function send(Envelope $envelope): Envelope


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

This is a proposal, open for discussion. It started from Dariusz Gafka's article [Symfony Messenger vs Ecotone: The Real Difference](https://blog.ecotone.tech/ecotone-vs-symfony-messenger-the-real-difference/), which describes how Ecotone approaches this. What is proposed here is a free interpretation for Symfony, built on Messenger's own model rather than ported from Ecotone, so it departs from the article where the two models differ. The examples in this description are the article's.

Testing a flow whose second step is asynchronous currently means building a `Worker` by hand in the test, with an `EventDispatcher` and a `StopWorkerOnMessageLimitListener`, and handler failures never surface because the worker turns them into events. FrameworkBundle ships assertion traits for Mailer, Notifier, HttpClient and Console, but nothing for Messenger. This PR adds `MessengerAssertionsTrait` to `KernelTestCase`:

```php
$bus->dispatch(new LoanApplication('123', 25000));

$this->assertQueuedMessageCount(1, 'async');
$this->assertQueuedMessageCount(1, 'async', ScoreLoanApplication::class);

$this->consumeQueuedMessages('async');   // runs the queued messages through the real bus
// assert on what the handlers did
```

The transport must be configured as `in-memory://` in the test environment; the helpers fail with an explicit message otherwise.

## Public API

FrameworkBundle, `Symfony\Bundle\FrameworkBundle\Test\MessengerAssertionsTrait` (used by `KernelTestCase`, so also by `WebTestCase`):
- `assertQueuedMessageCount(int $count, string $transport, ?string $messageClass = null, string $message = '')`: number of envelopes queued on the transport, delayed ones included, optionally only the messages that are instances of the given class. A class name that does not exist is rejected, so a filter cannot silently match nothing after a rename.
- `getQueuedMessages(string $transport): Envelope[]`
- `getMessengerTransport(string $transport): InMemoryTransport`: the transport service, with a clear failure when the transport is not registered or not in-memory.
- `consumeQueuedMessages(string $transport, ?int $limit = null): int`: runs a real `Worker` on the transport with the application's routable bus and event dispatcher, stops when the transport is empty or after `$limit` messages, and returns the number of messages handled.

The application's worker listeners run as in production, with one difference that a test needs: a message sent for retry is consumed again without waiting for its delay, so the retries play out inside the call instead of leaving the message parked for `retry_strategy.delay` seconds. What that gives:

- a handler that throws once and succeeds on its retry lets the call return normally;
- a handler that keeps failing exhausts its retries in the same call, and the failure that exhausts them is rethrown, so a broken handler still fails the test;
- a failure that the strategy will replay is not rethrown, since it is not the outcome of the run;
- a message the application itself delayed is left in the transport until it is due, and the returned count shows that nothing was handled.

Messenger:
- `StopWorkerOnIdleListener`: stops the worker as soon as its receivers return no message (drain and exit).
- `InMemoryTransport` implements `ListableReceiverInterface` (`all()`, `find()`) and `MessageCountAwareInterface` (`getMessageCount()`), which also makes `messenger:show` and `messenger:stats` accept in-memory transports.

## Checks

- `./phpunit src/Symfony/Component/Messenger/Tests` and `./phpunit src/Symfony/Bundle/FrameworkBundle/Tests`: green (usual missing-server skips). The new functional test app (`Tests/Functional/app/Messenger`) covers counting, the class filter, the limit, the rethrow and both failure messages of `getMessengerTransport()`.
- Revert-verified, each behaviour against its own test: without the retry-aware reading, the two retry tests fail; without the gate on `willRetry()`, a handler that recovers on its retry still aborts the call; without the class check, the unknown-class test passes silently.

The functional test app keeps `retry_strategy.delay: 10000` on purpose: the retry tests prove that a ten second delay does not make the test wait.

## Documentation

- Configure `in-memory://` in `when@test`; the four methods and their semantics (delayed messages are counted and listed; envelopes, not messages, are returned).
- `consumeQueuedMessages()` runs the real bus and listeners; that retries are replayed without their delay while application delays are honoured; which failure is rethrown and which is not; and how to inspect the failure transport afterwards.
- `StopWorkerOnIdleListener` for hand-built workers.


