### PR TITLE
[Messenger] Add an outbox option to transports

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrineOutboxIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrineOutboxIntegrationTest.php
@@ -1,0 +1,109 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Bridge\Doctrine\Tests\Transport;
+
+use Doctrine\DBAL\Configuration;
+use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Schema\DefaultSchemaManagerFactory;
+use Doctrine\DBAL\Tools\DsnParser;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\Messenger\Bridge\Doctrine\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Messenger\Bridge\Doctrine\Transport\Connection;
+use Symfony\Component\Messenger\Bridge\Doctrine\Transport\DoctrineTransport;
+use Symfony\Component\Messenger\MessageBus;
+use Symfony\Component\Messenger\Middleware\SendMessageMiddleware;
+use Symfony\Component\Messenger\Stamp\OutboxStamp;
+use Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport;
+use Symfony\Component\Messenger\Transport\Sender\OutboxSender;
+use Symfony\Component\Messenger\Transport\Sender\SendersLocator;
+use Symfony\Component\Messenger\Transport\Serialization\PhpSerializer;
+
+#[RequiresPhpExtension('pdo_sqlite')]
+class DoctrineOutboxIntegrationTest extends TestCase
+{
+    private \Doctrine\DBAL\Connection $driverConnection;
+    private DoctrineTransport $outbox;
+    private InMemoryTransport $target;
+    private MessageBus $bus;
+
+    protected function setUp(): void
+    {
+        if (!class_exists(OutboxSender::class)) {
+            $this->markTestSkipped('This test requires symfony/messenger 8.2 or higher.');
+        }
+
+        $dsn = getenv('MESSENGER_DOCTRINE_DSN') ?: 'pdo-sqlite://:memory:';
+        $params = (new DsnParser())->parse($dsn);
+        $config = new Configuration();
+        $config->setSchemaManagerFactory(new DefaultSchemaManagerFactory());
+
+        $this->driverConnection = DriverManager::getConnection($params, $config);
+        $this->outbox = new DoctrineTransport(new Connection([], $this->driverConnection), new PhpSerializer());
+        $this->outbox->setup();
+        $this->target = new InMemoryTransport();
+
+        $senders = new class(['orders' => new OutboxSender($this->target, $this->outbox, 'orders')]) implements ContainerInterface {
+            public function __construct(private array $senders)
+            {
+            }
+
+            public function get(string $id): mixed
+            {
+                return $this->senders[$id];
+            }
+
+            public function has(string $id): bool
+            {
+                return isset($this->senders[$id]);
+            }
+        };
+
+        $this->bus = new MessageBus([new SendMessageMiddleware(new SendersLocator([DummyMessage::class => ['orders']], $senders))]);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->driverConnection->close();
+    }
+
+    public function testTheStoredMessageIsRolledBackWithTheBusinessTransaction()
+    {
+        $this->driverConnection->beginTransaction();
+        $this->bus->dispatch(new DummyMessage('Hey'));
+        $this->driverConnection->rollBack();
+
+        $this->assertSame(0, $this->countStoredMessages());
+        $this->assertSame([], $this->target->getSent());
+    }
+
+    public function testTheStoredMessageIsCommittedWithTheBusinessTransaction()
+    {
+        $this->driverConnection->beginTransaction();
+        $this->bus->dispatch(new DummyMessage('Hey'));
+        $this->driverConnection->commit();
+
+        $this->assertSame(1, $this->countStoredMessages());
+        $this->assertSame([], $this->target->getSent(), 'the target gets the message when the outbox is consumed, not when it is stored');
+
+        $stored = $this->outbox->get();
+
+        $this->assertCount(1, $stored);
+        $this->assertSame('orders', $stored[0]->last(OutboxStamp::class)?->getTransportName());
+    }
+
+    private function countStoredMessages(): int
+    {
+        return (int) $this->driverConnection->fetchOne('SELECT COUNT(*) FROM messenger_messages');
+    }
+}

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -19,6 +19,8 @@ CHANGELOG
  * Add the `messenger:show` command to list and inspect pending messages of a transport
  * Make the `messenger:consume` and `messenger:failed:retry` commands exit immediately when a second `SIGINT` is received
  * Add a `transport` option to `#[AsMessageHandler]` and to the `messenger.message_handler` tag to route the handled messages to that transport and bind the handler to it
+ * Add `OutboxStamp` and `OutboxSender` to store messages in an outbox transport and forward them to their target transport when the outbox is consumed
+ * Add the `outbox` option to transports
 
 8.1
 ---

--- a/src/Symfony/Component/Messenger/MessengerBundle.php
+++ b/src/Symfony/Component/Messenger/MessengerBundle.php
@@ -32,6 +32,7 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\DependencyInjection\MessengerPass;
 use Symfony\Component\Messenger\DependencyInjection\RemoveMissingDependenciesPass;
 use Symfony\Component\Messenger\Handler\BatchHandlerInterface;
+use Symfony\Component\Messenger\Transport\Sender\OutboxSender;
 use Symfony\Component\Messenger\Transport\Serialization\ClaimCheckSerializer;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 use Symfony\Component\Messenger\Transport\TransportFactoryInterface;
@@ -143,6 +144,10 @@ class MessengerBundle extends AbstractBundle
                             ->scalarNode('failure_transport')
                                 ->defaultNull()
                                 ->info('Transport name to send failed messages to (after all retries have failed).')
+                            ->end()
+                            ->scalarNode('outbox')
+                                ->defaultNull()
+                                ->info('Name of the transport that stores the messages inside the current database transaction; consume that transport to forward them to this one.')
                             ->end()
                             ->arrayNode('retry_strategy')
                                 ->addDefaultsIfNotSet()
@@ -525,6 +530,19 @@ class MessengerBundle extends AbstractBundle
                 if (!isset($senderReferences[$transport['failure_transport']])) {
                     throw new LogicException(\sprintf('Invalid Messenger configuration: the failure transport "%s" is not a valid transport or service id.', $transport['failure_transport']));
                 }
+            }
+
+            if ($transport['outbox']) {
+                if (!isset($config['transports'][$transport['outbox']])) {
+                    throw new LogicException(\sprintf('Invalid Messenger configuration: the outbox "%s" of the "%s" transport is not a configured transport.', $transport['outbox'], $name));
+                }
+                if ($transport['outbox'] === $name) {
+                    throw new LogicException(\sprintf('Invalid Messenger configuration: the "%s" transport cannot be its own outbox.', $name));
+                }
+
+                $container->setDefinition($outboxSenderId = '.messenger.transport.'.$name.'.outbox_sender', (new Definition(OutboxSender::class))
+                    ->setArguments([new Reference($senderAliases[$name]), new Reference($senderAliases[$transport['outbox']]), $name]));
+                $senderReferences[$name] = $senderReferences[$senderAliases[$name]] = new Reference($outboxSenderId);
             }
         }
 

--- a/src/Symfony/Component/Messenger/Middleware/SendMessageMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/SendMessageMiddleware.php
@@ -18,8 +18,10 @@ use Symfony\Component\Messenger\Event\MessageSentToTransportsEvent;
 use Symfony\Component\Messenger\Event\SendMessageToTransportsEvent;
 use Symfony\Component\Messenger\Exception\NoSenderForMessageException;
 use Symfony\Component\Messenger\Stamp\FlushBatchHandlersStamp;
+use Symfony\Component\Messenger\Stamp\OutboxStamp;
 use Symfony\Component\Messenger\Stamp\ReceivedStamp;
 use Symfony\Component\Messenger\Stamp\SentStamp;
+use Symfony\Component\Messenger\Stamp\TransportNamesStamp;
 use Symfony\Component\Messenger\Transport\Sender\SendersLocatorInterface;
 
 /**
@@ -43,40 +45,49 @@ class SendMessageMiddleware implements MiddlewareInterface
             'class' => $envelope->getMessage()::class,
         ];
 
-        $sender = null;
+        $relayStamp = null;
 
-        if ($envelope->all(ReceivedStamp::class)) {
+        if (!$receivedStamp = $envelope->last(ReceivedStamp::class)) {
+            $senders = $this->sendersLocator->getSenders($envelope);
+        } elseif (($relayStamp = $envelope->last(OutboxStamp::class)) && $relayStamp->getTransportName() !== $receivedStamp->getTransportName()) {
+            $this->logger?->info('Forwarding message {class} from the outbox to {alias}', $context + ['alias' => $relayStamp->getTransportName()]);
+            $senders = $this->sendersLocator->getSenders($envelope->with(new TransportNamesStamp($relayStamp->getTransportName())));
+        } else {
             // it's a received message, do not send it back
             if (!$envelope->all(FlushBatchHandlersStamp::class)) {
                 $this->logger?->info('Received message {class}', $context);
             }
-        } else {
-            $senders = $this->sendersLocator->getSenders($envelope);
-            $senders = \is_array($senders) ? $senders : iterator_to_array($senders);
 
-            if (null !== $this->eventDispatcher && $senders) {
-                $event = new SendMessageToTransportsEvent($envelope, $senders);
-                $this->eventDispatcher->dispatch($event);
-                $envelope = $event->getEnvelope();
-            }
-
-            foreach ($senders as $alias => $sender) {
-                $this->logger?->info('Sending message {class} with {alias} sender using {sender}', $context + ['alias' => $alias, 'sender' => $sender::class]);
-                $envelope = $sender->send($envelope->with(new SentStamp($sender::class, \is_string($alias) ? $alias : null)));
-            }
-
-            if (null !== $this->eventDispatcher && $senders) {
-                $this->eventDispatcher->dispatch(new MessageSentToTransportsEvent($envelope, $senders));
-            }
-
-            if (!$this->allowNoSenders && !$sender) {
-                throw new NoSenderForMessageException(\sprintf('No sender for message "%s".', $context['class']));
-            }
-        }
-
-        if (null === $sender) {
             return $stack->next()->handle($envelope, $stack);
         }
+
+        $senders = \is_array($senders) ? $senders : iterator_to_array($senders);
+
+        if (!$senders) {
+            if (!$this->allowNoSenders) {
+                throw new NoSenderForMessageException(\sprintf('No sender for message "%s".', $context['class']));
+            }
+
+            return $stack->next()->handle($envelope, $stack);
+        }
+
+        if (null !== $this->eventDispatcher) {
+            $event = new SendMessageToTransportsEvent($envelope, $senders);
+            $this->eventDispatcher->dispatch($event);
+            $envelope = $event->getEnvelope();
+
+            // the sender tells a relayed message from a new one by this stamp
+            if ($relayStamp && $relayStamp !== $envelope->last(OutboxStamp::class)) {
+                $envelope = $envelope->withoutAll(OutboxStamp::class)->with($relayStamp);
+            }
+        }
+
+        foreach ($senders as $alias => $sender) {
+            $this->logger?->info('Sending message {class} with {alias} sender using {sender}', $context + ['alias' => $alias, 'sender' => $sender::class]);
+            $envelope = $sender->send($envelope->with(new SentStamp($sender::class, \is_string($alias) ? $alias : null)));
+        }
+
+        $this->eventDispatcher?->dispatch(new MessageSentToTransportsEvent($envelope, $senders));
 
         // message should only be sent and not be handled by the next middleware
         return $envelope;

--- a/src/Symfony/Component/Messenger/Stamp/OutboxStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/OutboxStamp.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Stamp;
+
+/**
+ * Marks a message stored in an outbox transport with the name of the transport it must be forwarded to.
+ */
+final class OutboxStamp implements StampInterface
+{
+    public function __construct(
+        private string $transportName,
+    ) {
+    }
+
+    public function getTransportName(): string
+    {
+        return $this->transportName;
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Component/Messenger/Tests/DependencyInjection/ConfigurationTest.php
@@ -88,6 +88,22 @@ class ConfigurationTest extends TestCase
         ], $config['transports']['async']['claim_check']);
     }
 
+    public function testOutboxConfiguration()
+    {
+        $config = $this->process([
+            'transports' => [
+                'orders' => [
+                    'dsn' => 'amqp://localhost/%2f/orders',
+                    'outbox' => 'outbox',
+                ],
+                'outbox' => 'doctrine://default?queue_name=outbox',
+            ],
+        ]);
+
+        $this->assertSame('outbox', $config['transports']['orders']['outbox']);
+        $this->assertNull($config['transports']['outbox']['outbox']);
+    }
+
     public function testBusMiddlewareDontMerge()
     {
         $config = new Processor()->processConfiguration($this->configuration(), [

--- a/src/Symfony/Component/Messenger/Tests/DependencyInjection/Fixtures/messenger_outbox.php
+++ b/src/Symfony/Component/Messenger/Tests/DependencyInjection/Fixtures/messenger_outbox.php
@@ -1,0 +1,11 @@
+<?php
+
+$container->loadFromExtension('messenger', [
+    'transports' => [
+        'orders' => [
+            'dsn' => 'amqp://localhost/%2f/orders',
+            'outbox' => 'outbox',
+        ],
+        'outbox' => 'doctrine://default?queue_name=outbox',
+    ],
+]);

--- a/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerBundleExtensionTest.php
+++ b/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerBundleExtensionTest.php
@@ -38,6 +38,7 @@ use Symfony\Component\Messenger\DependencyInjection\MessengerPass;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Messenger\MessengerBundle;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Messenger\Transport\Sender\OutboxSender;
 use Symfony\Component\Messenger\Transport\Serialization\ClaimCheckSerializer;
 use Symfony\Component\Messenger\Transport\TransportFactory;
 
@@ -391,6 +392,56 @@ class MessengerBundleExtensionTest extends TestCase
         $eligible = $container->getDefinition('messenger.signing_serializer')->getArgument(2)['*'];
         $this->assertContains('messenger.default_serializer', $eligible);
         $this->assertNotContains('.messenger.transport.async.claim_check_serializer', $eligible);
+    }
+
+    public function testMessengerOutbox()
+    {
+        $container = $this->createContainerFromFile('messenger_outbox');
+
+        $outboxSender = $container->getDefinition('.messenger.transport.orders.outbox_sender');
+        $this->assertSame(OutboxSender::class, $outboxSender->getClass());
+        $this->assertEquals([new Reference('messenger.transport.orders'), new Reference('messenger.transport.outbox'), 'orders'], $outboxSender->getArguments());
+
+        $sendersLocatorId = (string) $container->getDefinition('messenger.senders_locator')->getArgument(1);
+        $senders = $container->getDefinition($sendersLocatorId)->getArgument(0);
+        $this->assertEquals(new Reference('.messenger.transport.orders.outbox_sender'), $senders['orders']->getValues()[0]);
+        $this->assertEquals(new Reference('.messenger.transport.orders.outbox_sender'), $senders['messenger.transport.orders']->getValues()[0]);
+        $this->assertEquals(new Reference('messenger.transport.outbox'), $senders['outbox']->getValues()[0]);
+        $this->assertSame($sendersLocatorId, (string) $container->getDefinition('messenger.retry.send_failed_message_for_retry_listener')->getArgument(0));
+
+        $transport = $container->getDefinition('messenger.transport.orders');
+        $this->assertEquals([new Reference('messenger.transport_factory'), 'createTransport'], $transport->getFactory());
+        $this->assertSame('amqp://localhost/%2f/orders', $transport->getArgument(0));
+        $this->assertSame(['transport_name' => 'orders'], $transport->getArgument(1));
+        $this->assertEquals([['alias' => 'orders', 'is_failure_transport' => false, 'priority' => 0]], $transport->getTag('messenger.receiver'));
+    }
+
+    public function testMessengerOutboxMustBeAConfiguredTransport()
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Invalid Messenger configuration: the outbox "missing" of the "orders" transport is not a configured transport.');
+
+        $this->createContainerFromClosure(static function (ContainerBuilder $container) {
+            $container->loadFromExtension('messenger', [
+                'transports' => [
+                    'orders' => ['dsn' => 'in-memory:///', 'outbox' => 'missing'],
+                ],
+            ]);
+        });
+    }
+
+    public function testMessengerOutboxCannotBeTheTransportItself()
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Invalid Messenger configuration: the "orders" transport cannot be its own outbox.');
+
+        $this->createContainerFromClosure(static function (ContainerBuilder $container) {
+            $container->loadFromExtension('messenger', [
+                'transports' => [
+                    'orders' => ['dsn' => 'in-memory:///', 'outbox' => 'orders'],
+                ],
+            ]);
+        });
     }
 
     #[Group('legacy')]

--- a/src/Symfony/Component/Messenger/Tests/Middleware/SendMessageMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/SendMessageMiddlewareTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\Messenger\Event\MessageSentToTransportsEvent;
 use Symfony\Component\Messenger\Event\SendMessageToTransportsEvent;
 use Symfony\Component\Messenger\Exception\NoSenderForMessageException;
 use Symfony\Component\Messenger\Middleware\SendMessageMiddleware;
+use Symfony\Component\Messenger\Stamp\OutboxStamp;
 use Symfony\Component\Messenger\Stamp\ReceivedStamp;
 use Symfony\Component\Messenger\Stamp\SentStamp;
 use Symfony\Component\Messenger\Test\Middleware\MiddlewareTestCase;
@@ -161,6 +162,83 @@ class SendMessageMiddlewareTest extends MiddlewareTestCase
         $envelope = $middleware->handle($envelope, $this->getStackMock());
 
         $this->assertNull($envelope->last(SentStamp::class), 'it does not add sent stamp for received messages');
+    }
+
+    public function testItForwardsAReceivedMessageCarryingAnOutboxStamp()
+    {
+        $envelope = (new Envelope(new DummyMessage('Hey')))->with(new ReceivedStamp('outbox'), new OutboxStamp('orders'));
+        $target = $this->createMock(SenderInterface::class);
+        $routed = $this->createMock(SenderInterface::class);
+
+        $sendersLocator = $this->createSendersLocator([DummyMessage::class => ['routed']], ['orders' => $target, 'routed' => $routed]);
+        $middleware = new SendMessageMiddleware($sendersLocator);
+
+        $target->expects($this->once())->method('send')->with($envelope->with(new SentStamp($target::class, 'orders')))->willReturnArgument(0);
+        $routed->expects($this->never())->method('send');
+
+        $envelope = $middleware->handle($envelope, $this->getStackMock(false));
+
+        $this->assertSame('orders', $envelope->last(SentStamp::class)?->getSenderAlias());
+    }
+
+    public function testItDispatchesTheEventsWhenForwardingFromTheOutbox()
+    {
+        $envelope = (new Envelope(new DummyMessage('Hey')))->with(new ReceivedStamp('outbox'), new OutboxStamp('orders'));
+        $target = $this->createMock(SenderInterface::class);
+        $target->expects($this->once())->method('send')->willReturnArgument(0);
+
+        $dispatcher = $this->createMock(EventDispatcherInterface::class);
+        $expectedEvents = [
+            new SendMessageToTransportsEvent($envelope, $senders = ['orders' => $target]),
+            new MessageSentToTransportsEvent($envelope->with(new SentStamp($target::class, 'orders')), $senders),
+        ];
+        $dispatcher->expects($this->exactly(2))
+            ->method('dispatch')
+            ->willReturnCallback(function (object $event) use (&$expectedEvents) {
+                $expectedEvent = array_shift($expectedEvents);
+
+                $this->assertEquals($expectedEvent, $event);
+            });
+
+        $middleware = new SendMessageMiddleware($this->createSendersLocator([], ['orders' => $target]), $dispatcher);
+
+        $middleware->handle($envelope, $this->getStackMock(false));
+    }
+
+    public function testTheOutboxStampIsRestoredWhenAListenerRemovesIt()
+    {
+        $envelope = (new Envelope(new DummyMessage('Hey')))->with(new ReceivedStamp('outbox'), $outboxStamp = new OutboxStamp('orders'));
+        $target = $this->createMock(SenderInterface::class);
+        $target->expects($this->once())
+            ->method('send')
+            ->with($this->callback(function (Envelope $envelope) use ($outboxStamp) {
+                $this->assertSame([$outboxStamp], $envelope->all(OutboxStamp::class));
+
+                return true;
+            }))
+            ->willReturnArgument(0);
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener(SendMessageToTransportsEvent::class, static function (SendMessageToTransportsEvent $event) {
+            $event->setEnvelope($event->getEnvelope()->withoutAll(OutboxStamp::class));
+        });
+
+        $middleware = new SendMessageMiddleware($this->createSendersLocator([], ['orders' => $target]), $dispatcher);
+
+        $middleware->handle($envelope, $this->getStackMock(false));
+    }
+
+    public function testItHandlesAMessageReceivedFromTheTargetOfItsOutboxStamp()
+    {
+        $envelope = (new Envelope(new DummyMessage('Hey')))->with(new ReceivedStamp('orders'), new OutboxStamp('orders'));
+        $target = $this->createMock(SenderInterface::class);
+        $target->expects($this->never())->method('send');
+
+        $middleware = new SendMessageMiddleware($this->createSendersLocator([], ['orders' => $target]));
+
+        $envelope = $middleware->handle($envelope, $this->getStackMock());
+
+        $this->assertNull($envelope->last(SentStamp::class));
     }
 
     public function testItDispatchesTheEventOneTime()

--- a/src/Symfony/Component/Messenger/Tests/OutboxIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Tests/OutboxIntegrationTest.php
@@ -1,0 +1,235 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Clock\MockClock;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\ServiceLocator;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
+use Symfony\Component\Messenger\EventListener\AddErrorDetailsStampListener;
+use Symfony\Component\Messenger\EventListener\SendFailedMessageForRetryListener;
+use Symfony\Component\Messenger\EventListener\SendFailedMessageToFailureTransportListener;
+use Symfony\Component\Messenger\EventListener\StopWorkerOnMessageLimitListener;
+use Symfony\Component\Messenger\Exception\HandlerFailedException;
+use Symfony\Component\Messenger\Exception\TransportException;
+use Symfony\Component\Messenger\Handler\HandlerDescriptor;
+use Symfony\Component\Messenger\Handler\HandlersLocator;
+use Symfony\Component\Messenger\MessageBus;
+use Symfony\Component\Messenger\Middleware\FailedMessageProcessingMiddleware;
+use Symfony\Component\Messenger\Middleware\HandleMessageMiddleware;
+use Symfony\Component\Messenger\Middleware\SendMessageMiddleware;
+use Symfony\Component\Messenger\Retry\MultiplierRetryStrategy;
+use Symfony\Component\Messenger\Stamp\DelayStamp;
+use Symfony\Component\Messenger\Stamp\ErrorDetailsStamp;
+use Symfony\Component\Messenger\Stamp\OutboxStamp;
+use Symfony\Component\Messenger\Stamp\RedeliveryStamp;
+use Symfony\Component\Messenger\Stamp\SentToFailureTransportStamp;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport;
+use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
+use Symfony\Component\Messenger\Transport\Sender\OutboxSender;
+use Symfony\Component\Messenger\Transport\Sender\SenderInterface;
+use Symfony\Component\Messenger\Transport\Sender\SendersLocator;
+use Symfony\Component\Messenger\Worker;
+
+class OutboxIntegrationTest extends TestCase
+{
+    private MockClock $clock;
+    private InMemoryTransport $target;
+    private InMemoryTransport $outbox;
+    private InMemoryTransport $failed;
+    private OutboxTestTargetSender $targetSender;
+    private OutboxTestHandler $handler;
+    private MessageBus $bus;
+    private EventDispatcher $dispatcher;
+
+    protected function setUp(): void
+    {
+        $this->clock = new MockClock();
+        $this->target = new InMemoryTransport(clock: $this->clock);
+        $this->outbox = new InMemoryTransport(clock: $this->clock);
+        $this->failed = new InMemoryTransport(clock: $this->clock);
+        $this->targetSender = new OutboxTestTargetSender($this->target);
+        $this->handler = new OutboxTestHandler();
+
+        $senders = new Container();
+        $senders->set('orders', new OutboxSender($this->targetSender, $this->outbox, 'orders'));
+        $senders->set('outbox', $this->outbox);
+        $senders->set('failed', $this->failed);
+
+        $retryStrategies = new Container();
+        $retryStrategies->set('orders', new MultiplierRetryStrategy(1, 1000, 1, 0, 0));
+        $retryStrategies->set('outbox', new MultiplierRetryStrategy(1, 1000, 1, 0, 0));
+
+        $this->bus = new MessageBus([
+            new FailedMessageProcessingMiddleware(),
+            new SendMessageMiddleware(new SendersLocator([DummyMessage::class => ['orders']], $senders)),
+            new HandleMessageMiddleware(new HandlersLocator([DummyMessage::class => [new HandlerDescriptor($this->handler, ['from_transport' => 'orders'])]])),
+        ]);
+
+        $this->dispatcher = new EventDispatcher();
+        $this->dispatcher->addSubscriber(new AddErrorDetailsStampListener());
+        $this->dispatcher->addSubscriber(new SendFailedMessageForRetryListener($senders, $retryStrategies));
+        $this->dispatcher->addSubscriber(new SendFailedMessageToFailureTransportListener(new ServiceLocator(['orders' => fn () => $this->failed, 'outbox' => fn () => $this->failed])));
+        $this->dispatcher->addSubscriber(new StopWorkerOnMessageLimitListener(1));
+    }
+
+    public function testMessagesAreStoredInTheOutboxThenForwardedToTheTarget()
+    {
+        // make the message ids of the outbox differ from the ones of the target
+        $this->outbox->reject($this->outbox->send(new Envelope(new DummyMessage('warm-up'))));
+
+        $this->bus->dispatch(new DummyMessage('Hey'));
+
+        $this->assertCount(1, $stored = $this->outbox->get());
+        $this->assertSame('orders', $stored[0]->last(OutboxStamp::class)?->getTransportName());
+        $this->assertSame([], $this->target->get());
+        $this->assertSame(0, $this->handler->calls);
+
+        $this->assertNull($this->runWorker('outbox', $this->outbox));
+
+        $this->assertSame([], $this->outbox->get(), 'the outbox acknowledged the forwarded message');
+        $this->assertCount(1, $forwarded = $this->target->get());
+        $this->assertNull($forwarded[0]->last(OutboxStamp::class));
+        $this->assertSame(0, $this->handler->calls, 'the relay does not handle the message');
+
+        $this->assertNull($this->runWorker('orders', $this->target));
+
+        $this->assertSame(1, $this->handler->calls);
+        $this->assertSame([], $this->target->get());
+    }
+
+    public function testTheDelayIsAppliedByTheOutboxOnly()
+    {
+        $this->bus->dispatch(new DummyMessage('Hey'), [new DelayStamp(5000)]);
+
+        $this->assertSame([], $this->outbox->get());
+        $this->clock->sleep(6);
+        $this->assertCount(1, $this->outbox->get());
+
+        $this->assertNull($this->runWorker('outbox', $this->outbox));
+
+        $this->assertCount(1, $forwarded = $this->target->get(), 'the target delivers the message without delaying it again');
+        $this->assertNull($forwarded[0]->last(DelayStamp::class));
+    }
+
+    public function testARelayFailureIsRetriedThenSentToTheFailureTransportThenRetriedFromThere()
+    {
+        $this->targetSender->failures = 2;
+        $this->bus->dispatch(new DummyMessage('Hey'));
+
+        $this->assertInstanceOf(TransportException::class, $this->runWorker('outbox', $this->outbox));
+
+        $this->assertSame([], $this->target->get());
+        $this->assertSame([], $this->failed->get());
+        $this->clock->sleep(2);
+        $this->assertCount(1, $retried = $this->outbox->get(), 'the retry strategy of the outbox applies to the relay');
+        $this->assertSame(1, $retried[0]->last(RedeliveryStamp::class)?->getRetryCount());
+
+        $this->assertInstanceOf(TransportException::class, $this->runWorker('outbox', $this->outbox));
+
+        $this->assertSame([], $this->outbox->get());
+        $this->assertSame([], $this->target->get());
+        $this->clock->sleep(1);
+        $this->assertCount(1, $failed = $this->failed->get(), 'the failure transport of the outbox receives the message');
+        $this->assertSame('outbox', $failed[0]->last(SentToFailureTransportStamp::class)?->getOriginalReceiverName());
+        $this->assertSame('orders', $failed[0]->last(OutboxStamp::class)?->getTransportName());
+
+        // messenger:failed:retry consumes the failure transport: the message re-enters the relay
+        $this->assertNull($this->runWorker('failed', $this->failed));
+
+        $this->assertSame([], $this->failed->get());
+        $this->assertSame([], $this->outbox->get());
+        $this->assertCount(1, $forwarded = $this->target->get());
+        foreach ([OutboxStamp::class, RedeliveryStamp::class, SentToFailureTransportStamp::class, ErrorDetailsStamp::class, DelayStamp::class] as $stampFqcn) {
+            $this->assertNull($forwarded[0]->last($stampFqcn), $stampFqcn.' must not reach the target');
+        }
+
+        $this->assertNull($this->runWorker('orders', $this->target));
+
+        $this->assertSame(1, $this->handler->calls);
+    }
+
+    public function testARetryFromTheTargetDoesNotGoThroughTheOutbox()
+    {
+        $this->handler->shouldFail = true;
+        $this->bus->dispatch(new DummyMessage('Hey'));
+        $this->assertNull($this->runWorker('outbox', $this->outbox));
+
+        $this->assertInstanceOf(HandlerFailedException::class, $this->runWorker('orders', $this->target));
+
+        $this->assertSame(1, $this->handler->calls);
+        $this->assertCount(1, $this->outbox->getSent(), 'the retry is sent to the target directly');
+        $this->clock->sleep(2);
+        $this->assertCount(1, $retried = $this->target->get());
+        $this->assertSame(1, $retried[0]->last(RedeliveryStamp::class)?->getRetryCount());
+        $this->assertNull($retried[0]->last(OutboxStamp::class));
+
+        $this->handler->shouldFail = false;
+        $this->assertNull($this->runWorker('orders', $this->target));
+
+        $this->assertSame(2, $this->handler->calls);
+        $this->assertSame([], $this->target->get());
+    }
+
+    private function runWorker(string $transportName, ReceiverInterface $receiver): ?\Throwable
+    {
+        $throwable = null;
+        $listener = static function (WorkerMessageFailedEvent $event) use (&$throwable) {
+            $throwable = $event->getThrowable();
+        };
+        $this->dispatcher->addListener(WorkerMessageFailedEvent::class, $listener);
+
+        (new Worker([$transportName => $receiver], $this->bus, $this->dispatcher, clock: $this->clock))->run();
+
+        $this->dispatcher->removeListener(WorkerMessageFailedEvent::class, $listener);
+
+        return $throwable;
+    }
+}
+
+class OutboxTestTargetSender implements SenderInterface
+{
+    public int $failures = 0;
+
+    public function __construct(
+        private SenderInterface $target,
+    ) {
+    }
+
+    public function send(Envelope $envelope): Envelope
+    {
+        if (0 < $this->failures--) {
+            throw new TransportException('The target is unreachable.');
+        }
+
+        return $this->target->send($envelope);
+    }
+}
+
+class OutboxTestHandler
+{
+    public int $calls = 0;
+    public bool $shouldFail = false;
+
+    public function __invoke(DummyMessage $message): void
+    {
+        ++$this->calls;
+
+        if ($this->shouldFail) {
+            throw new \RuntimeException('Handling failed.');
+        }
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/Transport/Sender/OutboxSenderTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Sender/OutboxSenderTest.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Transport\Sender;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Stamp\DelayStamp;
+use Symfony\Component\Messenger\Stamp\ErrorDetailsStamp;
+use Symfony\Component\Messenger\Stamp\OutboxStamp;
+use Symfony\Component\Messenger\Stamp\ReceivedStamp;
+use Symfony\Component\Messenger\Stamp\RedeliveryStamp;
+use Symfony\Component\Messenger\Stamp\SentToFailureTransportStamp;
+use Symfony\Component\Messenger\Stamp\TransportMessageIdStamp;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport;
+use Symfony\Component\Messenger\Transport\Sender\OutboxSender;
+use Symfony\Component\Messenger\Transport\Sender\SenderInterface;
+
+class OutboxSenderTest extends TestCase
+{
+    public function testItStoresANewMessageInTheOutbox()
+    {
+        $target = $this->createMock(SenderInterface::class);
+        $target->expects($this->never())->method('send');
+        $outbox = new InMemoryTransport();
+
+        $envelope = (new OutboxSender($target, $outbox, 'orders'))->send(new Envelope(new DummyMessage('Hey')));
+
+        $this->assertCount(1, $stored = $outbox->getSent());
+        $this->assertSame('orders', $stored[0]->last(OutboxStamp::class)?->getTransportName());
+        $this->assertNull($envelope->last(OutboxStamp::class));
+        $this->assertSame(1, $envelope->last(TransportMessageIdStamp::class)?->getId());
+    }
+
+    public function testItForwardsAMessageReceivedFromTheOutboxToTheTarget()
+    {
+        $target = new InMemoryTransport();
+        $outbox = $this->createMock(SenderInterface::class);
+        $outbox->expects($this->never())->method('send');
+        $received = (new Envelope(new DummyMessage('Hey')))->with(new OutboxStamp('orders'), new TransportMessageIdStamp(42), new ReceivedStamp('outbox'));
+
+        $envelope = (new OutboxSender($target, $outbox, 'orders'))->send($received);
+
+        $this->assertCount(1, $forwarded = $target->getSent());
+        $this->assertNull($forwarded[0]->last(OutboxStamp::class));
+        $this->assertSame($received->getMessage(), $forwarded[0]->getMessage());
+        $this->assertNull($envelope->last(OutboxStamp::class));
+        $this->assertSame(42, $envelope->last(TransportMessageIdStamp::class)?->getId(), 'the relay worker acks the returned envelope on the outbox transport');
+    }
+
+    public function testItForwardsWithoutTheStampsAddedWhileInTheOutbox()
+    {
+        $target = new InMemoryTransport();
+        $outbox = $this->createMock(SenderInterface::class);
+        $outbox->expects($this->never())->method('send');
+        $stamps = [new OutboxStamp('orders'), new DelayStamp(1000), new RedeliveryStamp(2), new ErrorDetailsStamp('Exception', 0, 'relay failed'), new SentToFailureTransportStamp('outbox'), new ReceivedStamp('outbox')];
+        $received = (new Envelope(new DummyMessage('Hey')))->with(...$stamps);
+
+        $envelope = (new OutboxSender($target, $outbox, 'orders'))->send($received);
+
+        foreach ([OutboxStamp::class, DelayStamp::class, RedeliveryStamp::class, ErrorDetailsStamp::class, SentToFailureTransportStamp::class] as $stampFqcn) {
+            $this->assertNull($target->getSent()[0]->last($stampFqcn), $stampFqcn.' must not reach the target');
+            $this->assertNull($envelope->last($stampFqcn));
+        }
+    }
+
+    public function testItSendsARedeliveredMessageToTheTargetDirectly()
+    {
+        $target = new InMemoryTransport();
+        $outbox = $this->createMock(SenderInterface::class);
+        $outbox->expects($this->never())->method('send');
+        $redelivered = (new Envelope(new DummyMessage('Hey')))->with(new RedeliveryStamp(1), new DelayStamp(1000));
+
+        $envelope = (new OutboxSender($target, $outbox, 'orders'))->send($redelivered);
+
+        $this->assertCount(1, $target->getSent());
+        $this->assertSame(1, $target->getSent()[0]->last(RedeliveryStamp::class)?->getRetryCount());
+        $this->assertSame(1000, $target->getSent()[0]->last(DelayStamp::class)?->getDelay());
+        $this->assertNull($envelope->last(OutboxStamp::class));
+        $this->assertSame(1, $envelope->last(TransportMessageIdStamp::class)?->getId());
+    }
+}

--- a/src/Symfony/Component/Messenger/Transport/Sender/OutboxSender.php
+++ b/src/Symfony/Component/Messenger/Transport/Sender/OutboxSender.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Transport\Sender;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Stamp\DelayStamp;
+use Symfony\Component\Messenger\Stamp\ErrorDetailsStamp;
+use Symfony\Component\Messenger\Stamp\OutboxStamp;
+use Symfony\Component\Messenger\Stamp\RedeliveryStamp;
+use Symfony\Component\Messenger\Stamp\SentToFailureTransportStamp;
+
+/**
+ * Stores new messages in an outbox transport instead of sending them to their target transport.
+ *
+ * Consuming the outbox transport forwards the stored messages to the target transport.
+ * Redelivered messages went through the outbox already and are sent to the target directly.
+ */
+final class OutboxSender implements SenderInterface
+{
+    public function __construct(
+        private SenderInterface $target,
+        private SenderInterface $outbox,
+        private string $targetName,
+    ) {
+    }
+
+    public function send(Envelope $envelope): Envelope
+    {
+        if ($envelope->last(OutboxStamp::class)) {
+            // the outbox served the delay and the retry history belongs to the relay
+            foreach ([OutboxStamp::class, DelayStamp::class, RedeliveryStamp::class, ErrorDetailsStamp::class, SentToFailureTransportStamp::class] as $stampFqcn) {
+                $envelope = $envelope->withoutAll($stampFqcn);
+            }
+
+            // the relay worker acks the returned envelope on the outbox transport,
+            // so the message id given by the target must not shadow the outbox one
+            $this->target->send($envelope);
+
+            return $envelope;
+        }
+
+        if ($envelope->last(RedeliveryStamp::class)) {
+            return $this->target->send($envelope);
+        }
+
+        return $this->outbox->send($envelope->with(new OutboxStamp($this->targetName)))->withoutAll(OutboxStamp::class);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #34147
| License       | MIT

This is a proposal, open for discussion. It started from Dariusz Gafka's article [Symfony Messenger vs Ecotone: The Real Difference](https://blog.ecotone.tech/ecotone-vs-symfony-messenger-the-real-difference/), which describes how Ecotone approaches this. What is proposed here is a free interpretation for Symfony, built on Messenger's own model rather than ported from Ecotone, so it departs from the article where the two models differ.

The documented way to make a message survive the business transaction is to route it to the Doctrine transport: the insert joins the transaction, but the database then becomes the queue every worker polls. The outbox pattern stores the message in the database inside the transaction and has a relay forward it to the real broker, so consumers scale against the broker. This PR makes that a transport option:

```yaml
framework:
    messenger:
        transports:
            orders:
                dsn: '%env(MESSENGER_TRANSPORT_DSN)%'   # amqp, sqs, ...
                outbox: outbox
            outbox: 'doctrine://default?queue_name=outbox'
```

- Sending to `orders` stores the message in `outbox` instead, inside the current database transaction (`DoctrineTransactionMiddleware`, or an explicit transaction on the same DBAL connection).
- `messenger:consume outbox` is the relay: each stored message is forwarded to `orders`, the relay never runs handlers.
- `messenger:consume orders` handles the messages as usual.

## How it works

- `OutboxSender` decorates the sender registered under the transport name. A new message is stored in the outbox transport with an `OutboxStamp` naming the target. A message carrying a `RedeliveryStamp` (a retry, or a message sent to a failure transport) goes to the target directly: it already went through the outbox once.
- `SendMessageMiddleware` gains one branch: a received message that carries an `OutboxStamp` naming another transport is forwarded to that transport and not handled. The `OutboxSender` strips the `OutboxStamp`, and the `DelayStamp`, `RedeliveryStamp`, `ErrorDetailsStamp` and `SentToFailureTransportStamp` that belong to the stay in the outbox, so the target receives a clean message: the delay was served by the outbox, and the relay's retry history must not shrink the target's retry budget.
- Relay failures (broker down) follow the outbox transport's `retry_strategy` and `failure_transport`; `messenger:failed:retry` on that failure transport forwards the message again.
- A message that reaches its target while still carrying an outbox stamp (the option was removed while messages were pending) is handled normally.

## Public API

- `Symfony\Component\Messenger\Stamp\OutboxStamp` (`getTransportName()`)
- `Symfony\Component\Messenger\Transport\Sender\OutboxSender` (`__construct(SenderInterface $target, SenderInterface $outbox, string $targetName)`)
- `framework.messenger.transports.<name>.outbox` (default `null`): must name another configured transport. The service `.messenger.transport.<name>.outbox_sender` is private.

## Checks

- `./phpunit src/Symfony/Component/Messenger/Tests` and `./phpunit src/Symfony/Bundle/FrameworkBundle/Tests`: green (usual missing-server skips).
- Revert-verified: the sender, middleware and integration tests fail without the new classes; the bundle tests fail with `Unrecognized option "outbox"`.
- The integration test covers the store-then-forward flow with diverging message ids, the delay served once, a relay failure retried then dead-lettered then retried from the failure transport, and a handler retry on the target bypassing the outbox.
- A Doctrine integration test on SQLite proves the transactional claim: with the business transaction rolled back neither the outbox row nor a direct publication remains, and with it committed the row is there while the target is still empty.
- The bundle wiring is guarded for Messenger < 8.2 (`Outbox transports require symfony/messenger 8.2 or higher.`).

## Documentation

- The configuration above, and that the outbox transport must be a database transport on the same connection as the business writes.
- Dispatch from inside the handler without `DispatchAfterCurrentBusStamp`, otherwise the insert runs after the commit.
- The relay command and the failure/retry behaviour of the relay.
- Redeliveries bypass the outbox; the delay is served by the outbox.
- Publication order is not guaranteed: rows with the same availability date and several relay workers can publish out of order.
- The relay decodes the stored message, so the workers consuming the outbox need the message and stamp classes of the version that stored them.
- The Doctrine transport waits an hour before redelivering a claimed message, which is worth lowering for an outbox so that a relay crash recovers sooner.


