### PR TITLE
[Messenger] Add ChainStamp to dispatch messages one after another

### DIFF
--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -21,6 +21,8 @@ CHANGELOG
  * Add a `transport` option to `#[AsMessageHandler]` and to the `messenger.message_handler` tag to route the handled messages to that transport and bind the handler to it
  * Add `OutboxStamp` and `OutboxSender` to store messages in an outbox transport and forward them to their target transport when the outbox is consumed
  * Add the `outbox` option to transports
+ * Add `ChainStamp` and `ChainMiddleware` to dispatch a sequence of messages one after another, each one once the previous one is handled
+ * Add `chain` to the default bus middleware, between `send_message` and `handle_message`
 
 8.1
 ---

--- a/src/Symfony/Component/Messenger/MessengerBundle.php
+++ b/src/Symfony/Component/Messenger/MessengerBundle.php
@@ -370,6 +370,7 @@ class MessengerBundle extends AbstractBundle
             ],
             'after' => [
                 ['id' => 'send_message'],
+                ['id' => 'chain'],
                 ['id' => 'handle_message'],
             ],
         ];
@@ -384,7 +385,7 @@ class MessengerBundle extends AbstractBundle
 
             if ($bus['default_middleware']['enabled']) {
                 $defaultMiddleware['after'][0]['arguments'] = [$bus['default_middleware']['allow_no_senders']];
-                $defaultMiddleware['after'][1]['arguments'] = ['index_1' => $bus['default_middleware']['allow_no_handlers']];
+                $defaultMiddleware['after'][2]['arguments'] = ['index_1' => $bus['default_middleware']['allow_no_handlers']];
 
                 $middleware = array_merge($defaultMiddleware['before'], $middleware, $defaultMiddleware['after']);
             }

--- a/src/Symfony/Component/Messenger/Middleware/ChainMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/ChainMiddleware.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Middleware;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\LogicException;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\BusNameStamp;
+use Symfony\Component\Messenger\Stamp\ChainStamp;
+use Symfony\Component\Messenger\Stamp\DispatchAfterCurrentBusStamp;
+use Symfony\Component\Messenger\Stamp\NoAutoAckStamp;
+use Symfony\Component\Messenger\Stamp\ReceivedStamp;
+use Symfony\Component\Messenger\Stamp\SentStamp;
+
+/**
+ * Dispatches the next message of a ChainStamp once the current message is handled.
+ *
+ * The next message is dispatched with a DispatchAfterCurrentBusStamp: it is
+ * handled after the current message, outside a transaction opened for it,
+ * and in a worker, after the handlers of the current message returned.
+ * The remaining messages travel with it in a new ChainStamp, so a chain
+ * continues from where it stopped when a failed step is retried.
+ *
+ * When an envelope carries several ChainStamps, their messages form one
+ * sequence, in stamp order.
+ *
+ * A message sent to a transport starts its next step where it is handled,
+ * whatever the position of this middleware in the stack.
+ *
+ * The chain stamps leave the returned envelope once the next step is dispatched,
+ * so a stack that reaches this middleware twice for the same message, as a
+ * synchronous transport does, starts that step once.
+ *
+ * A message handled by a batch handler cannot open a chain: the batch decides
+ * when it processes the message, which is after the handler returned.
+ */
+final class ChainMiddleware implements MiddlewareInterface
+{
+    public function __construct(
+        private MessageBusInterface $bus,
+    ) {
+    }
+
+    public function handle(Envelope $envelope, StackInterface $stack): Envelope
+    {
+        $envelope = $stack->next()->handle($envelope, $stack);
+
+        $messages = [];
+        foreach ($envelope->all(ChainStamp::class) as $stamp) {
+            $messages = [...$messages, ...$stamp->getMessages()];
+        }
+
+        if (!$messages) {
+            return $envelope;
+        }
+
+        if ($envelope->last(SentStamp::class) && !$envelope->last(ReceivedStamp::class)) {
+            return $envelope;
+        }
+
+        if ($noAutoAckStamp = $envelope->last(NoAutoAckStamp::class)) {
+            throw new LogicException(\sprintf('A message handled by the batch handler "%s" cannot carry a "%s".', $noAutoAckStamp->getHandlerDescriptor()->getName(), ChainStamp::class));
+        }
+
+        $next = Envelope::wrap(array_shift($messages), [new DispatchAfterCurrentBusStamp()]);
+
+        if ($messages) {
+            $next = $next->with(new ChainStamp(...$messages));
+        }
+
+        if (null === $next->last(BusNameStamp::class) && null !== $busNameStamp = $envelope->last(BusNameStamp::class)) {
+            $next = $next->with($busNameStamp);
+        }
+
+        $this->bus->dispatch($next);
+
+        return $envelope->withoutAll(ChainStamp::class);
+    }
+}

--- a/src/Symfony/Component/Messenger/Resources/config/messenger.php
+++ b/src/Symfony/Component/Messenger/Resources/config/messenger.php
@@ -31,6 +31,7 @@ use Symfony\Component\Messenger\EventListener\StopWorkerOnRestartSignalListener;
 use Symfony\Component\Messenger\Handler\RedispatchMessageHandler;
 use Symfony\Component\Messenger\Middleware\AddBusNameStampMiddleware;
 use Symfony\Component\Messenger\Middleware\AddDefaultStampsMiddleware;
+use Symfony\Component\Messenger\Middleware\ChainMiddleware;
 use Symfony\Component\Messenger\Middleware\DecodeFailedMessageMiddleware;
 use Symfony\Component\Messenger\Middleware\DeduplicateMiddleware;
 use Symfony\Component\Messenger\Middleware\DispatchAfterCurrentBusMiddleware;
@@ -130,6 +131,11 @@ return static function (ContainerConfigurator $container) {
             ->abstract()
 
         ->set('messenger.middleware.dispatch_after_current_bus', DispatchAfterCurrentBusMiddleware::class)
+
+        ->set('messenger.middleware.chain', ChainMiddleware::class)
+            ->args([
+                service('messenger.routable_message_bus'),
+            ])
 
         ->set('messenger.middleware.validation', ValidationMiddleware::class)
             ->args([

--- a/src/Symfony/Component/Messenger/Stamp/ChainStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/ChainStamp.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Stamp;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\InvalidArgumentException;
+use Symfony\Component\Messenger\Middleware\ChainMiddleware;
+
+/**
+ * Lists the messages to dispatch one after another once the current message is handled.
+ *
+ * @see ChainMiddleware
+ */
+final class ChainStamp implements StampInterface
+{
+    /**
+     * @var list<object|Envelope>
+     */
+    private array $messages = [];
+
+    /**
+     * @param object|Envelope ...$messages The messages, or messages pre-wrapped in envelopes, in handling order
+     */
+    public function __construct(object ...$messages)
+    {
+        if (!$messages) {
+            throw new InvalidArgumentException('A chain needs at least one message.');
+        }
+
+        foreach ($messages as $message) {
+            // the chain travels inside another envelope, which does not strip these stamps for it
+            $this->messages[] = $message instanceof Envelope ? $message->withoutStampsOfType(NonSendableStampInterface::class) : $message;
+        }
+    }
+
+    /**
+     * @return list<object|Envelope>
+     */
+    public function getMessages(): array
+    {
+        return $this->messages;
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/ChainIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Tests/ChainIntegrationTest.php
@@ -1,0 +1,158 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Messenger\EventListener\StopWorkerOnMessageLimitListener;
+use Symfony\Component\Messenger\Exception\DelayedMessageHandlingException;
+use Symfony\Component\Messenger\Exception\HandlerFailedException;
+use Symfony\Component\Messenger\Handler\HandlersLocator;
+use Symfony\Component\Messenger\MessageBus;
+use Symfony\Component\Messenger\Middleware\AddBusNameStampMiddleware;
+use Symfony\Component\Messenger\Middleware\ChainMiddleware;
+use Symfony\Component\Messenger\Middleware\DispatchAfterCurrentBusMiddleware;
+use Symfony\Component\Messenger\Middleware\HandleMessageMiddleware;
+use Symfony\Component\Messenger\Middleware\SendMessageMiddleware;
+use Symfony\Component\Messenger\RoutableMessageBus;
+use Symfony\Component\Messenger\Stamp\ChainStamp;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Messenger\Tests\Fixtures\SecondMessage;
+use Symfony\Component\Messenger\Tests\Fixtures\ThirdMessage;
+use Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport;
+use Symfony\Component\Messenger\Transport\Sender\SendersLocator;
+use Symfony\Component\Messenger\Worker;
+
+class ChainIntegrationTest extends TestCase
+{
+    private array $handled = [];
+    private InMemoryTransport $transport;
+
+    protected function setUp(): void
+    {
+        $this->handled = [];
+        $this->transport = new InMemoryTransport();
+    }
+
+    public function testSynchronousChainIsHandledInOrderWithinTheDispatchCall()
+    {
+        $bus = $this->createBus();
+
+        $bus->dispatch($first = new DummyMessage('first'), [new ChainStamp($second = new SecondMessage(), $third = new ThirdMessage())]);
+
+        $this->assertSame([$first, $second, $third], $this->handled);
+        $this->assertSame([], $this->transport->getSent());
+    }
+
+    public function testChainContinuesAfterAnAsynchronousStep()
+    {
+        $bus = $this->createBus(routing: [SecondMessage::class => ['async']]);
+
+        $bus->dispatch($first = new DummyMessage('first'), [new ChainStamp($second = new SecondMessage(), $third = new ThirdMessage())]);
+
+        $this->assertSame([$first], $this->handled);
+        $this->assertCount(1, $sent = $this->transport->getSent());
+        $this->assertSame($second, $sent[0]->getMessage());
+        $this->assertSame([$third], $sent[0]->last(ChainStamp::class)->getMessages());
+
+        $this->runWorker($bus);
+
+        $this->assertSame([$first, $second, $third], $this->handled);
+        $this->assertCount(1, $this->transport->getAcknowledged());
+        $this->assertSame([], $this->transport->get());
+    }
+
+    public function testNothingIsDispatchedWhenTheFirstStepFails()
+    {
+        $bus = $this->createBus([DummyMessage::class], [SecondMessage::class => ['async']]);
+
+        try {
+            $bus->dispatch(new DummyMessage('first'), [new ChainStamp(new SecondMessage(), new ThirdMessage())]);
+            $this->fail('The failure of the first step should have been reported.');
+        } catch (HandlerFailedException) {
+        }
+
+        $this->assertSame([], $this->handled);
+        $this->assertSame([], $this->transport->getSent());
+    }
+
+    public function testChainStopsWhenASynchronousStepFails()
+    {
+        $bus = $this->createBus([SecondMessage::class]);
+
+        try {
+            $bus->dispatch($first = new DummyMessage('first'), [new ChainStamp(new SecondMessage(), new ThirdMessage())]);
+            $this->fail('The failure of the second step should have been reported.');
+        } catch (DelayedMessageHandlingException $e) {
+            $this->assertInstanceOf(HandlerFailedException::class, $e->getPrevious());
+        }
+
+        $this->assertSame([$first], $this->handled);
+    }
+
+    public function testAsynchronousStepFailsWhenTheNextSynchronousStepFails()
+    {
+        $bus = $this->createBus([ThirdMessage::class], [SecondMessage::class => ['async']]);
+
+        $bus->dispatch($first = new DummyMessage('first'), [new ChainStamp($second = new SecondMessage(), new ThirdMessage())]);
+        $this->runWorker($bus);
+
+        $this->assertSame([$first, $second], $this->handled);
+        $this->assertSame([], $this->transport->getAcknowledged());
+        $this->assertCount(1, $rejected = $this->transport->getRejected());
+        $this->assertSame($second, $rejected[0]->getMessage());
+    }
+
+    /**
+     * @param class-string[]                    $failing The messages whose handler throws
+     * @param array<class-string, list<string>> $routing The messages sent to the "async" transport
+     */
+    private function createBus(array $failing = [], array $routing = []): MessageBus
+    {
+        $handler = function (object $message) use ($failing): void {
+            if (\in_array($message::class, $failing, true)) {
+                throw new \RuntimeException(\sprintf('Handling "%s" failed.', $message::class));
+            }
+
+            $this->handled[] = $message;
+        };
+        $handlersLocator = new HandlersLocator([
+            DummyMessage::class => [$handler],
+            SecondMessage::class => [$handler],
+            ThirdMessage::class => [$handler],
+        ]);
+
+        $senders = new Container();
+        $senders->set('async', $this->transport);
+
+        $buses = new Container();
+        $bus = new MessageBus([
+            new AddBusNameStampMiddleware('the_bus'),
+            new DispatchAfterCurrentBusMiddleware(),
+            new SendMessageMiddleware(new SendersLocator($routing, $senders)),
+            new ChainMiddleware(new RoutableMessageBus($buses)),
+            new HandleMessageMiddleware($handlersLocator),
+        ]);
+        $buses->set('the_bus', $bus);
+
+        return $bus;
+    }
+
+    private function runWorker(MessageBus $bus): void
+    {
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addSubscriber(new StopWorkerOnMessageLimitListener(1));
+
+        (new Worker(['async' => $this->transport], $bus, $dispatcher))->run();
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerBundleExtensionTest.php
+++ b/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerBundleExtensionTest.php
@@ -148,6 +148,16 @@ class MessengerBundleExtensionTest extends TestCase
         $this->assertSame([['bus' => null, 'handles' => null, 'method' => null, 'priority' => 0, 'sign' => false, 'transport' => 'async', 'from_transport' => null]], $definition->getTag('messenger.message_handler'));
     }
 
+    public function testMessengerChainMiddleware()
+    {
+        $container = $this->createContainerFromFile('messenger', false);
+        $container->addCompilerPass(new MessengerPass());
+        $container->compile();
+
+        $this->assertSame('messenger.routable_message_bus', (string) $container->getDefinition('messenger.middleware.chain')->getArgument(0));
+        $this->assertContains('messenger.middleware.chain', $this->getBusMiddlewareIds($container, 'messenger.bus.default'));
+    }
+
     public function testMessengerRejectRedeliveredMessagesEnabledByDefault()
     {
         $container = $this->createContainerFromFile('messenger', false);
@@ -531,6 +541,7 @@ class MessengerBundleExtensionTest extends TestCase
             ['id' => 'failed_message_processing_middleware'],
             ['id' => 'deduplicate_middleware'],
             ['id' => 'send_message', 'arguments' => [true]],
+            ['id' => 'chain'],
             ['id' => 'handle_message', 'arguments' => ['index_1' => false]],
         ], $container->getParameter('messenger.bus.events.middleware'));
     }
@@ -550,6 +561,7 @@ class MessengerBundleExtensionTest extends TestCase
             ['id' => 'failed_message_processing_middleware'],
             ['id' => 'deduplicate_middleware'],
             ['id' => 'send_message', 'arguments' => [true]],
+            ['id' => 'chain'],
             ['id' => 'handle_message', 'arguments' => ['index_1' => false]],
         ], $container->getParameter('messenger.bus.commands.middleware'));
         $this->assertTrue($container->has('messenger.bus.events'));
@@ -564,6 +576,7 @@ class MessengerBundleExtensionTest extends TestCase
             ['id' => 'deduplicate_middleware'],
             ['id' => 'with_factory', 'arguments' => ['foo', true, ['bar' => 'baz']]],
             ['id' => 'send_message', 'arguments' => [true]],
+            ['id' => 'chain'],
             ['id' => 'handle_message', 'arguments' => ['index_1' => false]],
         ], $container->getParameter('messenger.bus.events.middleware'));
         $this->assertTrue($container->has('messenger.bus.queries'));

--- a/src/Symfony/Component/Messenger/Tests/Middleware/ChainMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/ChainMiddlewareTest.php
@@ -1,0 +1,220 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Middleware;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\LogicException;
+use Symfony\Component\Messenger\Handler\HandlerDescriptor;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Middleware\ChainMiddleware;
+use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
+use Symfony\Component\Messenger\Middleware\StackInterface;
+use Symfony\Component\Messenger\Middleware\StackMiddleware;
+use Symfony\Component\Messenger\Stamp\BusNameStamp;
+use Symfony\Component\Messenger\Stamp\ChainStamp;
+use Symfony\Component\Messenger\Stamp\DelayStamp;
+use Symfony\Component\Messenger\Stamp\DispatchAfterCurrentBusStamp;
+use Symfony\Component\Messenger\Stamp\NoAutoAckStamp;
+use Symfony\Component\Messenger\Stamp\ReceivedStamp;
+use Symfony\Component\Messenger\Stamp\SentStamp;
+use Symfony\Component\Messenger\Stamp\StampInterface;
+use Symfony\Component\Messenger\Test\Middleware\MiddlewareTestCase;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Messenger\Tests\Fixtures\SecondMessage;
+use Symfony\Component\Messenger\Tests\Fixtures\ThirdMessage;
+
+class ChainMiddlewareTest extends MiddlewareTestCase
+{
+    public function testNextMessageIsDispatchedOnceTheCurrentOneIsHandled()
+    {
+        $second = new SecondMessage();
+        $third = new ThirdMessage();
+        $envelope = new Envelope(new DummyMessage('first'), [new BusNameStamp('the_bus'), new ChainStamp($second, $third)]);
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects($this->once())
+            ->method('dispatch')
+            ->with($this->callback(function (Envelope $next) use ($second, $third) {
+                $this->assertSame($second, $next->getMessage());
+                $this->assertCount(1, $next->all(DispatchAfterCurrentBusStamp::class));
+                $this->assertSame([$third], $next->last(ChainStamp::class)->getMessages());
+                $this->assertSame('the_bus', $next->last(BusNameStamp::class)->getBusName());
+
+                return true;
+            }))
+            ->willReturnArgument(0);
+
+        $middleware = new ChainMiddleware($bus);
+
+        $handled = $middleware->handle($envelope, $this->getStackMock());
+
+        $this->assertSame($envelope->getMessage(), $handled->getMessage());
+        $this->assertSame([], $handled->all(ChainStamp::class));
+    }
+
+    public function testTheChainStampsAreConsumed()
+    {
+        $envelope = new Envelope(new DummyMessage('first'), [new ChainStamp(new SecondMessage())]);
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects($this->once())->method('dispatch')->willReturnArgument(0);
+
+        $middleware = new ChainMiddleware($bus);
+
+        // a synchronous transport dispatches the message again, so the middleware
+        // sees the same envelope twice and must start the step only once
+        $handled = $middleware->handle($envelope, $this->getStackMock());
+        $middleware->handle($handled, $this->getStackMock());
+    }
+
+    public function testLastMessageIsDispatchedWithoutChain()
+    {
+        $second = new SecondMessage();
+        $envelope = new Envelope(new DummyMessage('first'), [new ChainStamp($second)]);
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects($this->once())
+            ->method('dispatch')
+            ->with($this->callback(function (Envelope $next) use ($second) {
+                $this->assertSame($second, $next->getMessage());
+                $this->assertCount(1, $next->all(DispatchAfterCurrentBusStamp::class));
+                $this->assertSame([], $next->all(ChainStamp::class));
+                $this->assertNull($next->last(BusNameStamp::class));
+
+                return true;
+            }))
+            ->willReturnArgument(0);
+
+        $middleware = new ChainMiddleware($bus);
+        $middleware->handle($envelope, $this->getStackMock());
+    }
+
+    public function testEnvelopeWithoutChainIsPassedThrough()
+    {
+        $envelope = new Envelope(new DummyMessage('first'));
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects($this->never())->method('dispatch');
+
+        $middleware = new ChainMiddleware($bus);
+
+        $this->assertSame($envelope, $middleware->handle($envelope, $this->getStackMock()));
+    }
+
+    public function testEnvelopeInChainKeepsItsStamps()
+    {
+        $second = new SecondMessage();
+        $third = new ThirdMessage();
+        $delayStamp = new DelayStamp(1000);
+        $envelope = new Envelope(new DummyMessage('first'), [new BusNameStamp('the_bus'), new ChainStamp(new Envelope($second, [$delayStamp, new BusNameStamp('other_bus')]), $third)]);
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects($this->once())
+            ->method('dispatch')
+            ->with($this->callback(function (Envelope $next) use ($second, $third, $delayStamp) {
+                $this->assertSame($second, $next->getMessage());
+                $this->assertSame([$delayStamp], $next->all(DelayStamp::class));
+                $this->assertSame('other_bus', $next->last(BusNameStamp::class)->getBusName());
+                $this->assertCount(1, $next->all(BusNameStamp::class));
+                $this->assertCount(1, $next->all(DispatchAfterCurrentBusStamp::class));
+                $this->assertSame([$third], $next->last(ChainStamp::class)->getMessages());
+
+                return true;
+            }))
+            ->willReturnArgument(0);
+
+        $middleware = new ChainMiddleware($bus);
+        $middleware->handle($envelope, $this->getStackMock());
+    }
+
+    public function testChainStampsOfAnEnvelopeFormOneSequence()
+    {
+        $second = new SecondMessage();
+        $third = new ThirdMessage();
+        $fourth = new DummyMessage('fourth');
+        $envelope = new Envelope(new DummyMessage('first'), [new ChainStamp(new Envelope($second, [new ChainStamp($third)])), new ChainStamp($fourth)]);
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects($this->once())
+            ->method('dispatch')
+            ->with($this->callback(function (Envelope $next) use ($second, $third, $fourth) {
+                $this->assertSame($second, $next->getMessage());
+                $this->assertSame([[$third], [$fourth]], array_map(static fn (ChainStamp $stamp) => $stamp->getMessages(), $next->all(ChainStamp::class)));
+
+                return true;
+            }))
+            ->willReturnArgument(0);
+
+        $middleware = new ChainMiddleware($bus);
+        $middleware->handle($envelope, $this->getStackMock());
+    }
+
+    public function testNothingIsDispatchedWhenTheMessageWasSentToATransport()
+    {
+        $envelope = new Envelope(new DummyMessage('first'), [new ChainStamp(new SecondMessage())]);
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects($this->never())->method('dispatch');
+
+        $middleware = new ChainMiddleware($bus);
+        $middleware->handle($envelope, $this->getStackAdding(new SentStamp('Some\\Sender', 'async')));
+    }
+
+    public function testTheChainContinuesWhenTheMessageWasSentToASynchronousTransport()
+    {
+        $envelope = new Envelope(new DummyMessage('first'), [new ChainStamp(new SecondMessage())]);
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects($this->once())->method('dispatch')->willReturnArgument(0);
+
+        $middleware = new ChainMiddleware($bus);
+        $middleware->handle($envelope, $this->getStackAdding(new SentStamp('Some\\Sender', 'sync'), new ReceivedStamp('sync')));
+    }
+
+    public function testAMessageHandledByABatchHandlerCannotOpenAChain()
+    {
+        $envelope = new Envelope(new DummyMessage('first'), [new ChainStamp(new SecondMessage())]);
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects($this->never())->method('dispatch');
+
+        $middleware = new ChainMiddleware($bus);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('A message handled by the batch handler "Closure" cannot carry a "Symfony\\Component\\Messenger\\Stamp\\ChainStamp".');
+
+        $middleware->handle($envelope, $this->getStackAdding(new NoAutoAckStamp(new HandlerDescriptor(static function () {}))));
+    }
+
+    public function testNothingIsDispatchedWhenHandlingFails()
+    {
+        $envelope = new Envelope(new DummyMessage('first'), [new ChainStamp(new SecondMessage())]);
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects($this->never())->method('dispatch');
+
+        $middleware = new ChainMiddleware($bus);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Thrown from next middleware.');
+
+        $middleware->handle($envelope, $this->getThrowingStackMock());
+    }
+
+    private function getStackAdding(StampInterface ...$stamps): StackInterface
+    {
+        $next = $this->createMock(MiddlewareInterface::class);
+        $next->expects($this->once())->method('handle')->willReturnCallback(static fn (Envelope $envelope): Envelope => $envelope->with(...$stamps));
+
+        return new StackMiddleware($next);
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/Stamp/ChainStampTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Stamp/ChainStampTest.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Stamp;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\InvalidArgumentException;
+use Symfony\Component\Messenger\Stamp\ChainStamp;
+use Symfony\Component\Messenger\Stamp\DelayStamp;
+use Symfony\Component\Messenger\Stamp\ReceivedStamp;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Messenger\Tests\Fixtures\SecondMessage;
+
+class ChainStampTest extends TestCase
+{
+    public function testMessagesAreKeptInOrder()
+    {
+        $first = new DummyMessage('first');
+        $second = new SecondMessage();
+
+        $stamp = new ChainStamp($first, $second);
+
+        $this->assertSame([$first, $second], $stamp->getMessages());
+    }
+
+    public function testEnvelopesAreAccepted()
+    {
+        $envelope = new Envelope(new DummyMessage('first'), [$delay = new DelayStamp(1000)]);
+
+        $stamp = new ChainStamp($envelope, new SecondMessage());
+
+        $this->assertSame($envelope->getMessage(), $stamp->getMessages()[0]->getMessage());
+        $this->assertSame([$delay], $stamp->getMessages()[0]->all(DelayStamp::class));
+    }
+
+    public function testTheStampsAnEnvelopeCannotCarryToATransportAreDropped()
+    {
+        $envelope = new Envelope(new SecondMessage(), [$delay = new DelayStamp(1000), new ReceivedStamp('async')]);
+
+        $stamp = new ChainStamp($envelope);
+
+        $this->assertSame([], $stamp->getMessages()[0]->all(ReceivedStamp::class));
+        $this->assertSame([$delay], $stamp->getMessages()[0]->all(DelayStamp::class));
+    }
+
+    public function testEmptyChainIsRejected()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('A chain needs at least one message.');
+
+        new ChainStamp();
+    }
+
+    public function testSerializable()
+    {
+        $stamp = new ChainStamp(new DummyMessage('first'), new Envelope(new SecondMessage(), [new DelayStamp(1000)]));
+
+        $this->assertEquals($stamp, unserialize(serialize($stamp)));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #50462
| License       | MIT

This is a proposal, open for discussion. It started from Dariusz Gafka's article [Symfony Messenger vs Ecotone: The Real Difference](https://blog.ecotone.tech/ecotone-vs-symfony-messenger-the-real-difference/), which describes how Ecotone approaches this. What is proposed here is a free interpretation for Symfony, built on Messenger's own model rather than ported from Ecotone, so it departs from the article where the two models differ.

A multi-step flow is usually built by having each handler dispatch the next message class. The sequence is then implied by dispatch calls scattered across handlers, and nothing survives a retry. This PR lets the sequence be declared once, at dispatch time:

```php
$bus->dispatch(new ProcessPodcast($id), [new ChainStamp(new OptimizePodcast($id), new ReleasePodcast($id))]);
```

Each message of the chain is dispatched once the previous one was handled by all its handlers. A failing step stops the chain. The remaining steps travel in the stamp, so a step that is retried (retry strategy or `messenger:failed:retry`) resumes the chain from where it stopped.

## Public API

- `Symfony\Component\Messenger\Stamp\ChainStamp`: `__construct(object ...$messages)` (messages or `Envelope` instances, in handling order; an empty chain throws), `getMessages(): array`.
- `Symfony\Component\Messenger\Middleware\ChainMiddleware`: dispatches the next message once the current one is handled. It runs between `send_message` and `handle_message`, so a message sent to a transport starts its next step in the worker that handles it, not at send time.
- FrameworkBundle registers `messenger.middleware.chain` (shared by all buses, bound to the routable bus) and adds `chain` to the default middleware stack between `send_message` and `handle_message`. Buses configured with `default_middleware: false` have to list it themselves.

## Behavior

- The next step is dispatched with a `DispatchAfterCurrentBusStamp`: it runs after the current message completed, after the commit of a `doctrine_transaction` middleware, and in a worker after the current handlers returned.
- A step routed to a transport is sent instead of handled; the chain continues in the worker consuming it. A step handled synchronously runs inside the same `dispatch()` call.
- An item can be an `Envelope`, to give that step its own stamps (`DelayStamp`, `TransportNamesStamp`, `BusNameStamp`, ...). An `Envelope` item carrying its own `ChainStamp` runs that inner chain before the remaining outer steps. Its non-sendable stamps are dropped, since the chain travels inside another envelope, which would otherwise carry an `AckStamp` closure or a `ReceivedStamp` of its own into the next send.
- A step runs on the bus of the previous step unless it carries its own `BusNameStamp`.
- Errors: a failing first step surfaces as `HandlerFailedException` from `dispatch()`; a failing later synchronous step surfaces as `DelayedMessageHandlingException`. In a worker, a synchronous step failing right after an asynchronous one fails that asynchronous message as a whole, so steps that follow an asynchronous one should be idempotent, or be routed to a transport so that each step is retried on its own.
- A message sent to a transport starts its next step where it is handled, wherever `chain` sits in the middleware stack.
- A message handled by a batch handler cannot open a chain: the batch decides when it processes the message, which is after the handler returned, so the combination throws instead of starting the step early and twice.
- No data flows between steps: handler results are not passed along.
- The stamp carries message objects. The default `PhpSerializer` handles it; transports using the Symfony serializer need normalizers for the chained messages, as they do for `RedispatchMessage`.

## Checks

- `./phpunit src/Symfony/Component/Messenger/Tests` and `./phpunit src/Symfony/Bundle/FrameworkBundle/Tests`: green (skips are the usual missing-server ones).
- The new tests fail on the base branch without the two new classes and without the bundle wiring (revert-verified).
- The wiring now lives in `MessengerBundle` rather than FrameworkBundle, following the split upstream, so the version guards the branch carried are gone.

## Documentation

- Dispatching a chain, what "handled" means, and that a failing step stops the chain.
- Envelope items for per-step stamps, bus selection, and the timing given by `DispatchAfterCurrentBusStamp`.
- The worker caveat for a synchronous step following an asynchronous one.
- That a batch handler cannot open a chain, and that a sent message continues where it is handled.
- The serializer note for the Symfony serializer.


