### PR TITLE
[Messenger] Fix sub-second delays being ignored by the in-memory transport

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/Transport/InMemory/InMemoryTransportTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/InMemory/InMemoryTransportTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Messenger\Tests\Transport\InMemory;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Clock\MockClock;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Stamp\DelayStamp;
 use Symfony\Component\Messenger\Stamp\TransportMessageIdStamp;
@@ -87,6 +88,19 @@ class InMemoryTransportTest extends TestCase
         $envelope2 = (new Envelope(new \stdClass()))->with(new DelayStamp(10_000));
         $envelope2 = $this->transport->send($envelope2);
         $this->assertSame([$envelope1], $this->transport->get());
+    }
+
+    public function testQueueWithSubSecondDelay()
+    {
+        $clock = new MockClock('2020-01-01 00:00:00');
+        $transport = new InMemoryTransport(clock: $clock);
+        $envelope = $transport->send((new Envelope(new \stdClass()))->with(new DelayStamp(500)));
+
+        $clock->sleep(0.1);
+        $this->assertSame([], $transport->get());
+
+        $clock->sleep(0.5);
+        $this->assertSame([$envelope], $transport->get());
     }
 
     public function testQueueWithSerialization()

--- a/src/Symfony/Component/Messenger/Transport/InMemory/InMemoryTransport.php
+++ b/src/Symfony/Component/Messenger/Transport/InMemory/InMemoryTransport.php
@@ -102,7 +102,7 @@ class InMemoryTransport implements TransportInterface, ResetInterface
         /** @var DelayStamp|null $delayStamp */
         if ($delayStamp = $envelope->last(DelayStamp::class)) {
             $now = $this->clock?->now() ?? new \DateTimeImmutable();
-            $this->availableAt[$id] = $now->modify(\sprintf('+%d seconds', $delayStamp->getDelay() / 1000));
+            $this->availableAt[$id] = $now->modify(\sprintf('+%d milliseconds', $delayStamp->getDelay()));
         }
 
         return $envelope;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`InMemoryTransport::send()` computes when a delayed message becomes available with `'+%d seconds'` applied to `getDelay() / 1000`, so `%d` truncates the fraction: a 500 ms delay becomes no delay at all, and 1500 ms becomes one second. With the default retry strategy (1000 ms with 10% jitter) a message sent for retry can be received again right away, which makes tests on in-memory transports flaky. The fix uses PHP's millisecond relative format.

## Checks

- The new `testQueueWithSubSecondDelay` fails on the current code (the message is available 100 ms after being sent with a 500 ms delay) and passes with the fix.
- `./phpunit src/Symfony/Component/Messenger/Tests` on 6.4: 424 tests, green.
- The same line exists unchanged on every higher branch, so the merge up is conflict free.
