### PR TITLE
[FrameworkBundle] Fix configuring the S/MIME encrypter cipher

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -2443,16 +2443,18 @@ class Configuration implements ConfigurationInterface
                                     ->defaultNull()
                                     ->beforeNormalization()
                                         ->ifString()
-                                        ->then(static function ($v): ?int {
-                                            if (\defined('OPENSSL_CIPHER_'.$v)) {
-                                                return \constant('OPENSSL_CIPHER_'.$v);
+                                        ->then(static function ($v): int {
+                                            $ciphers = self::getOpensslCiphers();
+
+                                            if (!isset($ciphers[$v])) {
+                                                throw new \InvalidArgumentException(\sprintf('"%s" is not a valid OPENSSL cipher.', $v));
                                             }
 
-                                            throw new \InvalidArgumentException(\sprintf('"%s" is not a valid OPENSSL cipher.', $v));
+                                            return $ciphers[$v];
                                         })
                                     ->end()
                                     ->validate()
-                                        ->ifTrue(static fn ($v) => \extension_loaded('openssl') && null !== $v && !\defined('OPENSSL_CIPHER_'.$v))
+                                        ->ifTrue(static fn ($v) => null !== $v && ($ciphers = self::getOpensslCiphers()) && !\in_array($v, $ciphers, true))
                                         ->thenInvalid('You must provide a valid cipher.')
                                     ->end()
                                 ->end()
@@ -2796,5 +2798,21 @@ class Configuration implements ConfigurationInterface
                 ->end()
             ->end()
         ;
+    }
+
+    /**
+     * @return array<string, int> The values of the OPENSSL_CIPHER_* constants, keyed by their unprefixed name
+     */
+    private static function getOpensslCiphers(): array
+    {
+        $ciphers = [];
+
+        foreach (get_defined_constants(true)['openssl'] ?? [] as $name => $value) {
+            if (str_starts_with($name, 'OPENSSL_CIPHER_')) {
+                $ciphers[substr($name, \strlen('OPENSSL_CIPHER_'))] = $value;
+            }
+        }
+
+        return $ciphers;
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -898,7 +898,7 @@
 
     <xsd:complexType name="mailer_smime_encrypter">
         <xsd:attribute name="repository" type="xsd:string" />
-        <xsd:attribute name="cipher" type="xsd:integer" />
+        <xsd:attribute name="cipher" type="xsd:string" />
     </xsd:complexType>
 
     <xsd:complexType name="http_cache">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection;
 
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Configuration;
@@ -795,6 +796,78 @@ class ConfigurationTest extends TestCase
                 $this->assertSame(['enabled' => $enabled], $config['remote_event'], $key);
             }
         }
+    }
+
+    #[RequiresPhpExtension('openssl')]
+    public function testMailerSmimeEncrypterCipherAsConstantName()
+    {
+        $config = self::processSmimeEncrypterConfig(['cipher' => 'AES_256_CBC']);
+        $this->assertSame(\OPENSSL_CIPHER_AES_256_CBC, $config['mailer']['smime_encrypter']['cipher']);
+
+        $config = self::processSmimeEncrypterConfig(['cipher' => 'RC2_40']);
+        $this->assertSame(\OPENSSL_CIPHER_RC2_40, $config['mailer']['smime_encrypter']['cipher']);
+    }
+
+    #[RequiresPhpExtension('openssl')]
+    public function testMailerSmimeEncrypterCipherAsConstantValue()
+    {
+        $config = self::processSmimeEncrypterConfig(['cipher' => \OPENSSL_CIPHER_AES_256_CBC]);
+        $this->assertSame(\OPENSSL_CIPHER_AES_256_CBC, $config['mailer']['smime_encrypter']['cipher']);
+
+        $config = self::processSmimeEncrypterConfig(['cipher' => \OPENSSL_CIPHER_RC2_40]);
+        $this->assertSame(\OPENSSL_CIPHER_RC2_40, $config['mailer']['smime_encrypter']['cipher']);
+    }
+
+    public function testMailerSmimeEncrypterCipherDefaultsToNull()
+    {
+        $config = self::processSmimeEncrypterConfig([]);
+
+        $this->assertNull($config['mailer']['smime_encrypter']['cipher']);
+    }
+
+    public function testMailerSmimeEncrypterCipherAsInvalidConstantName()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('"NOT_A_CIPHER" is not a valid OPENSSL cipher.');
+
+        self::processSmimeEncrypterConfig(['cipher' => 'NOT_A_CIPHER']);
+    }
+
+    #[RequiresPhpExtension('openssl')]
+    public function testMailerSmimeEncrypterCipherAsInvalidConstantValue()
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('Invalid configuration for path "framework.mailer.smime_encrypter.cipher": You must provide a valid cipher.');
+
+        self::processSmimeEncrypterConfig(['cipher' => 123456]);
+    }
+
+    public function testMailerSmimeEncrypterCipherIsNotValidatedWithoutOpenssl()
+    {
+        if (\extension_loaded('openssl')) {
+            $this->markTestSkipped('The "openssl" extension is loaded.');
+        }
+
+        $config = self::processSmimeEncrypterConfig(['cipher' => 123456]);
+        $this->assertSame(123456, $config['mailer']['smime_encrypter']['cipher']);
+
+        $config = self::processSmimeEncrypterConfig([]);
+        $this->assertNull($config['mailer']['smime_encrypter']['cipher']);
+    }
+
+    private static function processSmimeEncrypterConfig(array $smimeEncrypter): array
+    {
+        return (new Processor())->processConfiguration(new Configuration(true), [
+            [
+                'http_method_override' => false,
+                'handle_all_throwables' => true,
+                'php_errors' => ['log' => true],
+                'mailer' => [
+                    'dsn' => 'null://null',
+                    'smime_encrypter' => $smimeEncrypter + ['repository' => 'my_certificate_repository'],
+                ],
+            ],
+        ]);
     }
 
     protected static function getBundleDefaultConfig()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/mailer_with_smime_encrypter.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/mailer_with_smime_encrypter.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:framework="http://symfony.com/schema/dic/symfony"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+
+    <framework:config http-method-override="false" handle-all-throwables="true">
+        <framework:php-errors log="true" />
+        <framework:mailer dsn="null://null">
+            <framework:smime-encrypter repository="my_certificate_repository" cipher="AES_256_CBC" />
+        </framework:mailer>
+    </framework:config>
+</container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/XmlFrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/XmlFrameworkExtensionTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection;
 
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
@@ -62,6 +63,14 @@ class XmlFrameworkExtensionTest extends FrameworkExtensionTestCase
 
         $definition = $container->getDefinition('asset_mapper.compiler.css_asset_url_compiler');
         $this->assertSame('strict', $definition->getArgument(0));
+    }
+
+    #[RequiresPhpExtension('openssl')]
+    public function testMailerSmimeEncrypterCipherAsConstantName()
+    {
+        $container = $this->createContainerFromFile('mailer_with_smime_encrypter');
+
+        $this->assertSame(\OPENSSL_CIPHER_AES_256_CBC, $container->getParameter('mailer.smime_encrypter.cipher'));
     }
 
     public function testWorkflowEnumPlaces()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`framework.mailer.smime_encrypter.cipher` cannot be set to any value at all today. Both spellings are rejected:

```yaml
framework:
    mailer:
        smime_encrypter:
            repository: '%kernel.project_dir%/certs'
            cipher: 'AES_256_CBC'   # Invalid configuration ... You must provide a valid cipher.
            cipher: 7               # Invalid configuration ... You must provide a valid cipher.
```

The node had two disagreeing notions of what a valid cipher is. `beforeNormalization` maps the name to a constant with `defined('OPENSSL_CIPHER_'.$v)`, so `'AES_256_CBC'` becomes `7`. Then `validate()` re-checks `defined('OPENSSL_CIPHER_'.$v)` on the already-normalized value, which asks whether a constant named `OPENSSL_CIPHER_7` exists. It does not, so everything fails, including a raw constant passed straight in.

Both now read the same source of truth, a private helper returning the actual `OPENSSL_CIPHER_*` constants keyed by unprefixed name. After the fix:

```
'AES_256_CBC'  accepted as 7
'RC2_40'       accepted as 0
7              accepted as 7
0              accepted as 0
123456         rejected: You must provide a valid cipher.
'NOT_A_CIPHER' rejected: "NOT_A_CIPHER" is not a valid OPENSSL cipher.
```

`RC2_40` is worth a look in review: its value is `0`, so any truthiness-based check would silently reject it.

The `validate()` is kept rather than dropped, because it is what stops an out-of-range int reaching `openssl_pkcs7_encrypt()` and failing there with an opaque error. Its openssl guard changed from `extension_loaded('openssl')` to "we know the set of ciphers", which is equivalent on every real build but cannot reintroduce this same bug class if the extension is ever present without the constants. Downstream is unaffected: the parameter feeds `SmimeEncryptedMessageListener::__construct(..., ?int $cipher)` and then `SMimeEncrypter`, and both spellings now land as `int(7)`.

The XSD is fixed in the same commit for a second, independent reason: `cipher` was declared `xsd:integer`, so the documented string form was rejected by schema validation before normalization ever ran, with `'AES_256_CBC' is not a valid value of the atomic type 'xs:integer'`. It is now `xsd:string`, and `XmlUtils::phpize` still turns `cipher="7"` into an int. `framework.php-errors log` is the precedent for a node accepting several scalar types under `xsd:string`.

Two related problems are left alone as out of scope, both pre-existing and both in the Config component rather than here: `cipher: '%env(int:MAILER_CIPHER)%'` fails because `BaseNode::normalize()` runs normalization closures before `resolvePlaceholderValue()`, so the placeholder string reaches the `ifString()` closure; and an explicit `cipher: null` is rejected by every `integerNode()->defaultNull()`, not just this one, while omitting the key correctly yields null.

Merge-up to 8.0, 8.1 and 8.2: XML configuration support was removed in 8.0 by `af1f0305c6b`, so the XSD half of this fix is 7.4 only. Take the deletion for `Resources/config/schema/symfony-1.0.xsd` and `XmlFrameworkExtensionTest.php`, and note that `Fixtures/xml/mailer_with_smime_encrypter.xml` is a new file, so git raises no conflict and will silently re-add it into a directory that no longer exists; it has to be removed by hand. `Configuration.php` itself auto-merges on all three. `ConfigurationTest.php` conflicts on 8.0 because that branch removed `testRemoteEventCanBeConfigured` (keep only the new tests, do not re-add it), and on 8.1 and 8.2 only in the `use` block.
