### PR TITLE
[Serializer] Don't reuse list items with deep_object_to_populate

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/ArrayDenormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ArrayDenormalizer.php
@@ -73,6 +73,11 @@ class ArrayDenormalizer implements ContextAwareDenormalizerInterface, Denormaliz
 
         if (\is_array($objectsToPopulate = $context[AbstractNormalizer::OBJECT_TO_POPULATE] ?? null)) {
             unset($context[AbstractNormalizer::OBJECT_TO_POPULATE]);
+
+            if (array_is_list($objectsToPopulate)) {
+                // positions are not identities, the payload can list different items
+                $objectsToPopulate = [];
+            }
         } else {
             $objectsToPopulate = [];
         }

--- a/src/Symfony/Component/Serializer/Tests/DeserializeNestedArrayOfObjectsTest.php
+++ b/src/Symfony/Component/Serializer/Tests/DeserializeNestedArrayOfObjectsTest.php
@@ -54,7 +54,7 @@ class DeserializeNestedArrayOfObjectsTest extends TestCase
         self::assertInstanceOf(Animal::class, $zoo->getAnimals()[0]);
     }
 
-    public function testPropertyPhpDocWithDeepObjectToPopulate()
+    public function testDeepObjectToPopulateRebuildsTheItemsOfAList()
     {
         $json = <<<EOF
             {
@@ -69,7 +69,9 @@ class DeserializeNestedArrayOfObjectsTest extends TestCase
         ], ['json' => new JsonEncoder()]);
 
         $zoo = new Zoo();
-        $zoo->setAnimals([$animal = new Animal()]);
+        $zoo->setAnimals([$cat = new Animal(), $dog = new Animal()]);
+        $cat->setName('Cat');
+        $dog->setName('Dog');
 
         $serializer->deserialize($json, Zoo::class, 'json', [
             'object_to_populate' => $zoo,
@@ -77,7 +79,36 @@ class DeserializeNestedArrayOfObjectsTest extends TestCase
         ]);
 
         self::assertCount(1, $zoo->getAnimals());
-        self::assertSame($animal, $zoo->getAnimals()[0]);
+        self::assertNotSame($cat, $zoo->getAnimals()[0]);
+        self::assertSame('Bug', $zoo->getAnimals()[0]->getName());
+        self::assertSame('Cat', $cat->getName());
+        self::assertSame('Dog', $dog->getName());
+    }
+
+    public function testDeepObjectToPopulateReusesTheItemsOfAKeyedCollection()
+    {
+        $json = <<<EOF
+            {
+                "animalsString": {
+                    "animal1": {"name": "Bug"}
+                }
+            }
+            EOF;
+        $serializer = new Serializer([
+            new ObjectNormalizer(null, null, null, new PhpDocExtractor()),
+            new ArrayDenormalizer(),
+        ], ['json' => new JsonEncoder()]);
+
+        $zoo = new ZooWithKeyTypes();
+        $zoo->animalsString = ['animal1' => $animal = new Animal()];
+
+        $serializer->deserialize($json, ZooWithKeyTypes::class, 'json', [
+            'object_to_populate' => $zoo,
+            'deep_object_to_populate' => true,
+        ]);
+
+        self::assertCount(1, $zoo->animalsString);
+        self::assertSame($animal, $zoo->animalsString['animal1']);
         self::assertSame('Bug', $animal->getName());
     }
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ArrayDenormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ArrayDenormalizerTest.php
@@ -85,6 +85,33 @@ class ArrayDenormalizerTest extends TestCase
         $this->assertArrayNotHasKey('object_to_populate', $contexts[3]);
     }
 
+    public function testDenormalizeKeepsObjectToPopulateOutOfListItems()
+    {
+        $contexts = [];
+
+        $nestedDenormalizer = $this->createMock(DenormalizerInterface::class);
+        $nestedDenormalizer->expects($this->exactly(2))
+            ->method('denormalize')
+            ->willReturnCallback(static function ($data, $type, $format, $context) use (&$contexts) {
+                $contexts[] = $context;
+
+                return $data;
+            })
+        ;
+
+        $denormalizer = new ArrayDenormalizer();
+        $denormalizer->setDenormalizer($nestedDenormalizer);
+        $denormalizer->denormalize(
+            [[], []],
+            __NAMESPACE__.'\ArrayDummy[]',
+            null,
+            ['object_to_populate' => [new ArrayDummy('one', 'two'), new ArrayDummy('three', 'four')]]
+        );
+
+        $this->assertArrayNotHasKey('object_to_populate', $contexts[0]);
+        $this->assertArrayNotHasKey('object_to_populate', $contexts[1]);
+    }
+
     public function testSupportsValidArray()
     {
         $nestedDenormalizer = $this->createMock(DenormalizerInterface::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65905
| License       | MIT

#65670 gives each item of a collection the existing entry at the same key as `object_to_populate`, so that items keep their identity and the properties the payload does not mention.

In a keyed collection the key identifies the item, so the reuse is right. In a list the index is only a position, and the payload can list other items. Since 6.4.45, 7.4.18 and 8.1.6, removing an item from a list therefore copies what the payload omits from the removed item into its successor:

```php
class Cost
{
    public ?string $department = null;
    public ?float $amount = null;
    public ?string $comments = null;
}

class Project
{
    /** @var Cost[] */
    public array $costs = [];
}

// stored: ['ENG', 10.0, 'about ENG'] and ['OPS', 20.0, 'about OPS']
// the client drops the ENG line and keeps the OPS one
$serializer->denormalize(
    ['costs' => [['department' => 'OPS', 'amount' => 20.0]]],
    Project::class,
    context: [
        AbstractNormalizer::OBJECT_TO_POPULATE => $project,
        AbstractObjectNormalizer::DEEP_OBJECT_TO_POPULATE => true,
    ],
);

// before: $project->costs[0] is the ENG instance, its comments are 'about ENG'
// after:  $project->costs[0] is a new Cost, its comments are null
```

Reusing the instances has a second effect, the one reported in #65905. `Doctrine\ORM\UnitOfWork::computeChangeSet()` skips a field when `$orgValue === $actualValue`, and two arrays holding the same instances in the same order are identical. A `json_document` column holding a collection of objects then stops producing an UPDATE, and the request returns 200 with nothing written.

This limits the reuse to keyed collections, where the key carries an identity. Lists build fresh items again, as they did before 6.4.45.

Out of scope: `deep_object_to_populate` populates a nested object in place, and has done so since 4.4. A `json_document` column holding a single object has never produced an UPDATE either. That is what the option asks for, so this pull request leaves it alone.

Checks: the Serializer suite on 6.4 (1174 tests, the only 19 errors are the local absence of `doctrine/annotations`, present on the base too), and on 8.2 after a cherry-pick (1608 tests, green). Both new tests were run against the unpatched normalizer first: the list one fails with "Failed asserting that two variables don't reference the same object", the unit one with "Failed asserting that an array does not have the key 'object_to_populate'". `testDeepObjectToPopulateReusesTheItemsOfAKeyedCollection` passes in both states, it protects what #65670 fixed.
