### PR TITLE
[Security] Harden the oidc_login authenticator against malformed provider data and mix-up attacks

### DIFF
--- a/src/Symfony/Component/Security/Core/Tests/User/OidcUserTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/User/OidcUserTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Security\Core\Tests\User;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\User\OidcUser;
 
@@ -44,6 +45,27 @@ class OidcUserTest extends TestCase
         $this->assertNull($user->getNickname());
         $this->assertSame(['customId' => 12345], $user->getAdditionalClaims());
         $this->assertSame(['ROLE_USER'], $user->getRoles());
+    }
+
+    #[DataProvider('getVerifiedFlags')]
+    public function testFromClaimsOnlyKeepsARecognizableVerifiedFlag(mixed $value, ?bool $expected)
+    {
+        $user = OidcUser::fromClaims(['sub' => 'e21bf182-1538-406e-8ccb-e25a17aba39f', 'email_verified' => $value, 'phone_number_verified' => $value]);
+
+        $this->assertSame($expected, $user->getEmailVerified());
+        $this->assertSame($expected, $user->getPhoneNumberVerified());
+    }
+
+    public static function getVerifiedFlags(): iterable
+    {
+        yield 'true' => [true, true];
+        yield 'false' => [false, false];
+        yield '"true"' => ['true', true];
+        // a plain (bool) cast would turn this one into true
+        yield '"false"' => ['false', false];
+        yield '"0"' => ['0', false];
+        yield '1' => [1, true];
+        yield '"maybe"' => ['maybe', null];
     }
 
     public function testFromClaimsGrantsTheRolesItIsGiven()

--- a/src/Symfony/Component/Security/Http/Authenticator/Oidc/OidcJwks.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Oidc/OidcJwks.php
@@ -111,6 +111,19 @@ final class OidcJwks
     private static function filterSignatureKeys(array $keys, bool $enforceKeyUsageVerification): array
     {
         return array_values(array_filter($keys, static function (array $jwk) use ($enforceKeyUsageVerification): bool {
+            // RFC 7517 makes "kty" mandatory and both it and "kid" strings. An entry
+            // breaking that is unusable, and worse than useless: an entry without a
+            // "kty" makes JWKSet::createFromKeyData() throw, and a "kid" that is not
+            // a string makes it throw too on web-token/jwt-library 3.x, which uses it
+            // as an array offset. Either way a single odd entry failed every login
+            // with a 500 instead of an authentication failure.
+            if (!isset($jwk['kty']) || !\is_string($jwk['kty']) || '' === $jwk['kty']) {
+                return false;
+            }
+            if (isset($jwk['kid']) && !\is_string($jwk['kid'])) {
+                return false;
+            }
+
             if ($enforceKeyUsageVerification) {
                 if (isset($jwk['use']) && 'sig' === $jwk['use']) {
                     return true;

--- a/src/Symfony/Component/Security/Http/Authenticator/Oidc/OidcSignatureVerifier.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Oidc/OidcSignatureVerifier.php
@@ -129,7 +129,12 @@ final class OidcSignatureVerifier
             throw new AuthenticationException(\sprintf('The ID token is not signed with any of the expected algorithms ("%s").', implode('", "', $algorithms->list())), previous: $e);
         }
 
-        $keys = $this->getKeys($jws->getSignature(0)->hasProtectedHeaderParameter('kid') ? $jws->getSignature(0)->getProtectedHeaderParameter('kid') : null);
+        $kid = $jws->getSignature(0)->hasProtectedHeaderParameter('kid') ? $jws->getSignature(0)->getProtectedHeaderParameter('kid') : null;
+        if (null !== $kid && !\is_string($kid)) {
+            throw new AuthenticationException('The ID token "kid" header must be a string.');
+        }
+
+        $keys = $this->getKeys($kid);
         if (!$keys) {
             throw new AuthenticationException('The OIDC provider published no signing key usable to verify the ID token signature.');
         }
@@ -199,7 +204,10 @@ final class OidcSignatureVerifier
         // document downgrading its transport to plain HTTP must not be honored
         $jwksUri = $this->discovery->getSecureEndpoint('jwks_uri');
 
-        $cacheKey = 'oidc_jwks.'.hash('xxh128', $jwksUri);
+        // strict and lax filters yield different key sets, so each gets its own entry;
+        // the strictness is kept out of the hash, where a "jwks_uri" ending with the
+        // marker would collide with the other strictness of the same endpoint
+        $cacheKey = 'oidc_jwks.'.($this->enforceKeyUsageVerification ? '' : 'lax.').hash('xxh128', $jwksUri);
         $compute = fn (ItemInterface $item): array => [
             'keys' => OidcJwks::fetchKeys($this->httpClient, $jwksUri, $item, $this->jwksCacheTtl, $this->enforceKeyUsageVerification),
             // the JWKS is stored with the time it was fetched, so that the rotation

--- a/src/Symfony/Component/Security/Http/Authenticator/OidcLoginAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/OidcLoginAuthenticator.php
@@ -233,6 +233,7 @@ final class OidcLoginAuthenticator extends AbstractAuthenticator implements Auth
         $codeVerifier = \is_array($attempt) ? $attempt['code_verifier'] ?? null : null;
         $redirectUri = \is_array($attempt) ? $attempt['redirect_uri'] ?? null : null;
 
+        $this->checkIssuerParameter($request);
         $this->checkForProviderError($request);
 
         $code = $request->query->get('code');
@@ -343,6 +344,35 @@ final class OidcLoginAuthenticator extends AbstractAuthenticator implements Auth
             // only the matched attempt was consumed: a provider error for one tab
             // must not cancel the logins pending in the others
             throw new AuthenticationException(\sprintf('OIDC provider returned an error: "%s"', $description));
+        }
+    }
+
+    /**
+     * Checks the "iss" authorization response parameter of RFC 9207, which ties the
+     * callback to the provider that issued it: without it, a client registered with
+     * several providers can be led to send the code of an honest one to the token
+     * endpoint of a malicious one (the mix-up attack of the OAuth 2.0 Security BCP).
+     * It is checked before the "error" parameter, which RFC 9207, Section 2 requires
+     * it to accompany too.
+     */
+    private function checkIssuerParameter(Request $request): void
+    {
+        $configuration = $this->discovery->getConfiguration();
+        $iss = $request->query->get('iss');
+
+        if (null === $iss) {
+            // a provider announcing support for the parameter sends it on every
+            // authorization response, so a callback without it did not come from it
+            if (true === ($configuration['authorization_response_iss_parameter_supported'] ?? null)) {
+                throw new AuthenticationException('The OIDC provider announces support for the "iss" authorization response parameter, but the callback does not carry it.');
+            }
+
+            return;
+        }
+
+        $expectedIssuer = $configuration['issuer'] ?? null;
+        if (!\is_string($iss) || '' === $iss || !\is_string($expectedIssuer) || !hash_equals($expectedIssuer, $iss)) {
+            throw new AuthenticationException('The OIDC callback "iss" parameter does not match the expected issuer.');
         }
     }
 

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/Oidc/OidcJwksTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/Oidc/OidcJwksTest.php
@@ -45,13 +45,42 @@ class OidcJwksTest extends TestCase
      */
     public static function getKeyUsages(): iterable
     {
-        yield 'use=sig' => [['kid' => 'k', 'use' => 'sig'], true, true];
-        yield 'use=enc' => [['kid' => 'k', 'use' => 'enc'], false, false];
-        yield 'no usage at all' => [['kid' => 'k'], false, true];
-        yield 'key_ops=verify' => [['kid' => 'k', 'key_ops' => ['verify']], true, true];
-        yield 'key_ops=sign' => [['kid' => 'k', 'key_ops' => ['sign']], true, true];
-        yield 'key_ops=encrypt' => [['kid' => 'k', 'key_ops' => ['encrypt']], false, false];
-        yield 'key_ops=encrypt+verify' => [['kid' => 'k', 'key_ops' => ['encrypt', 'verify']], true, true];
+        yield 'use=sig' => [['kid' => 'k', 'kty' => 'EC', 'use' => 'sig'], true, true];
+        yield 'use=enc' => [['kid' => 'k', 'kty' => 'EC', 'use' => 'enc'], false, false];
+        yield 'no usage at all' => [['kid' => 'k', 'kty' => 'EC'], false, true];
+        yield 'key_ops=verify' => [['kid' => 'k', 'kty' => 'EC', 'key_ops' => ['verify']], true, true];
+        yield 'key_ops=sign' => [['kid' => 'k', 'kty' => 'EC', 'key_ops' => ['sign']], true, true];
+        yield 'key_ops=encrypt' => [['kid' => 'k', 'kty' => 'EC', 'key_ops' => ['encrypt']], false, false];
+        yield 'key_ops=encrypt+verify' => [['kid' => 'k', 'kty' => 'EC', 'key_ops' => ['encrypt', 'verify']], true, true];
+    }
+
+    #[DataProvider('getMalformedKeys')]
+    public function testFromResponseDropsTheKeysJwkSetCannotLoad(array $malformedKey, bool $strict)
+    {
+        // a valid key sits next to the malformed one, and is the only one kept
+        $validKey = ['kid' => 'k', 'kty' => 'EC', 'use' => 'sig'];
+        $response = (new MockHttpClient(new JsonMockResponse(['keys' => [$malformedKey, $validKey]])))
+            ->request('GET', 'https://provider.example.com/jwks');
+
+        [$keys] = OidcJwks::fromResponse($response, $strict);
+
+        $this->assertSame([$validKey], $keys);
+    }
+
+    /**
+     * Entries that make JWKSet::createFromKeyData() throw: no "kty", a "kty" that is
+     * not a non-empty string, or a "kid" that is not a string.
+     */
+    public static function getMalformedKeys(): iterable
+    {
+        foreach ([true, false] as $strict) {
+            $mode = $strict ? 'strict' : 'lax';
+
+            yield "no kty ($mode)" => [['kid' => 'k', 'use' => 'sig'], $strict];
+            yield "non-string kty ($mode)" => [['kid' => 'k', 'kty' => 123, 'use' => 'sig'], $strict];
+            yield "empty kty ($mode)" => [['kid' => 'k', 'kty' => '', 'use' => 'sig'], $strict];
+            yield "array kid ($mode)" => [['kid' => ['not', 'a', 'string'], 'kty' => 'EC', 'use' => 'sig'], $strict];
+        }
     }
 
     public function testFromResponseRejectsAnOversizedJwks()
@@ -67,24 +96,24 @@ class OidcJwksTest extends TestCase
 
     public function testFromResponseIgnoresKeysThatAreNotObjects()
     {
-        $response = (new MockHttpClient(new JsonMockResponse(['keys' => ['garbage', ['kid' => 'k', 'use' => 'sig']]])))
+        $response = (new MockHttpClient(new JsonMockResponse(['keys' => ['garbage', ['kid' => 'k', 'kty' => 'EC', 'use' => 'sig']]])))
             ->request('GET', 'https://provider.example.com/jwks');
 
         [$keys] = OidcJwks::fromResponse($response);
 
-        $this->assertSame([['kid' => 'k', 'use' => 'sig']], $keys);
+        $this->assertSame([['kid' => 'k', 'kty' => 'EC', 'use' => 'sig']], $keys);
     }
 
     public function testFromResponseReadsTheProviderMaxAge()
     {
         $response = (new MockHttpClient(new JsonMockResponse(
-            ['keys' => [['kid' => 'sig-key', 'use' => 'sig']]],
+            ['keys' => [['kid' => 'sig-key', 'kty' => 'EC', 'use' => 'sig']]],
             ['response_headers' => ['cache-control' => 'public, max-age=600']],
         )))->request('GET', 'https://provider.example.com/jwks');
 
         [$keys, $ttl] = OidcJwks::fromResponse($response);
 
-        $this->assertSame([['kid' => 'sig-key', 'use' => 'sig']], $keys);
+        $this->assertSame([['kid' => 'sig-key', 'kty' => 'EC', 'use' => 'sig']], $keys);
         $this->assertSame(600, $ttl);
     }
 
@@ -102,7 +131,7 @@ class OidcJwksTest extends TestCase
     public function testFetchKeysAppliesProviderTtlToCacheItem()
     {
         $httpClient = new MockHttpClient(new JsonMockResponse(
-            ['keys' => [['kid' => 'sig-key', 'use' => 'sig']]],
+            ['keys' => [['kid' => 'sig-key', 'kty' => 'EC', 'use' => 'sig']]],
             ['response_headers' => ['cache-control' => 'max-age=120']],
         ));
 
@@ -111,7 +140,7 @@ class OidcJwksTest extends TestCase
 
         $keys = OidcJwks::fetchKeys($httpClient, 'https://provider.example.com/jwks', $item);
 
-        $this->assertSame([['kid' => 'sig-key', 'use' => 'sig']], $keys);
+        $this->assertSame([['kid' => 'sig-key', 'kty' => 'EC', 'use' => 'sig']], $keys);
     }
 
     public function testFetchKeysCapsTheProviderTtl()
@@ -140,11 +169,11 @@ class OidcJwksTest extends TestCase
 
     public function testFetchKeysIsUsableAsACacheCallback()
     {
-        $httpClient = new MockHttpClient(new JsonMockResponse(['keys' => [['kid' => 'sig-key', 'use' => 'sig']]]));
+        $httpClient = new MockHttpClient(new JsonMockResponse(['keys' => [['kid' => 'sig-key', 'kty' => 'EC', 'use' => 'sig']]]));
         $cache = new ArrayAdapter();
 
         $keys = $cache->get('jwks', static fn (ItemInterface $item) => OidcJwks::fetchKeys($httpClient, 'https://provider.example.com/jwks', $item));
 
-        $this->assertSame([['kid' => 'sig-key', 'use' => 'sig']], $keys);
+        $this->assertSame([['kid' => 'sig-key', 'kty' => 'EC', 'use' => 'sig']], $keys);
     }
 }

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/Oidc/OidcSignatureVerifierTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/Oidc/OidcSignatureVerifierTest.php
@@ -26,6 +26,7 @@ use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\Authenticator\Oidc\OidcSignatureVerifier;
 use Symfony\Component\Security\Http\Oidc\OidcDiscovery;
+use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 #[RequiresPhpExtension('openssl')]
@@ -155,6 +156,58 @@ class OidcSignatureVerifierTest extends TestCase
         $verifier->verify($this->buildJws(json_encode(['sub' => 'user-42'])));
     }
 
+    public function testVerifyIgnoresAMalformedJwksEntryNextToTheSigningKey()
+    {
+        // an entry without "kty" would make JWKSet::createFromKeyData() throw
+        $verifier = $this->createVerifier(jwks: [['keys' => [['kid' => 'malformed', 'use' => 'sig'], self::PUBLIC_JWK]]]);
+
+        $this->assertSame(['sub' => 'user-42'], $verifier->verify($this->buildJws(json_encode(['sub' => 'user-42']))));
+    }
+
+    public function testVerifyDoesNotShareTheKeysCachedByALaxVerifier()
+    {
+        // the provider publishes its key without any usage designation, which only the
+        // lax filter keeps: the strict verifier must not find it in the cache entry the
+        // lax one warmed, or the strictness of one firewall would depend on another
+        $cache = new ArrayAdapter();
+        $jwks = [['keys' => [array_diff_key(self::PUBLIC_JWK, ['use' => true])]]];
+        $token = $this->buildJws(json_encode(['sub' => 'user-42']));
+
+        $this->assertSame(['sub' => 'user-42'], $this->createVerifier(jwks: $jwks, jwksCache: $cache, enforceKeyUsageVerification: false)->verify($token));
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('The OIDC provider published no signing key usable to verify the ID token signature.');
+
+        $this->createVerifier(jwks: $jwks, jwksCache: $cache)->verify($token);
+    }
+
+    public function testVerifyKeepsTheStrictnessOutOfTheHashedCacheKey()
+    {
+        // the strictness marker must not be hashed together with the "jwks_uri": a lax
+        // verifier on ".../jwks" would otherwise land on the same entry as a strict one
+        // on ".../jwks#lax", and the strict firewall would read the lax key set
+        $cache = new ArrayAdapter();
+        $jwks = [['keys' => [array_diff_key(self::PUBLIC_JWK, ['use' => true])]]];
+        $token = $this->buildJws(json_encode(['sub' => 'user-42']));
+        $lax = ['issuer' => 'https://provider.example.com', 'jwks_uri' => 'https://provider.example.com/jwks'];
+        $strict = ['issuer' => 'https://provider.example.com', 'jwks_uri' => 'https://provider.example.com/jwks#lax'];
+
+        $this->assertSame(['sub' => 'user-42'], $this->createVerifier(jwks: $jwks, configuration: $lax, jwksCache: $cache, enforceKeyUsageVerification: false)->verify($token));
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('The OIDC provider published no signing key usable to verify the ID token signature.');
+
+        $this->createVerifier(jwks: $jwks, configuration: $strict, jwksCache: $cache)->verify($token);
+    }
+
+    public function testVerifyRejectsATokenWhoseKidIsNotAString()
+    {
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('The ID token "kid" header must be a string.');
+
+        $this->createVerifier()->verify($this->buildJws(json_encode(['sub' => 'user-42']), ['not', 'a', 'string']));
+    }
+
     public function testVerifyRejectsAPlainHttpJwksUri()
     {
         $httpClient = $this->createMock(HttpClientInterface::class);
@@ -278,7 +331,7 @@ class OidcSignatureVerifierTest extends TestCase
      * @param list<array<string, mixed>> $jwks
      * @param list<string>               $algorithms
      */
-    private function createVerifier(?array $jwks = null, array $algorithms = ['ES256'], ?array $configuration = null, ?HttpClientInterface $httpClient = null, ?MockClock $clock = null): OidcSignatureVerifier
+    private function createVerifier(?array $jwks = null, array $algorithms = ['ES256'], ?array $configuration = null, ?HttpClientInterface $httpClient = null, ?MockClock $clock = null, ?CacheInterface $jwksCache = null, bool $enforceKeyUsageVerification = true): OidcSignatureVerifier
     {
         $configuration ??= [
             'issuer' => 'https://provider.example.com',
@@ -294,14 +347,16 @@ class OidcSignatureVerifierTest extends TestCase
 
         return new OidcSignatureVerifier(
             $discovery,
-            new ArrayAdapter(),
+            $jwksCache ?? new ArrayAdapter(),
             $httpClient ?? new MockHttpClient(array_map(static fn (array $jwkSet): JsonMockResponse => new JsonMockResponse($jwkSet), $jwks)),
             $algorithms,
+            3600,
+            $enforceKeyUsageVerification,
             clock: $clock ?? new MockClock(),
         );
     }
 
-    private function buildJws(string $payload, string $kid = 'signing-key'): string
+    private function buildJws(string $payload, string|array $kid = 'signing-key'): string
     {
         // tip: use https://mkjwk.org/ to generate a JWK
         $jwk = new JWK([

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/OidcLoginAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/OidcLoginAuthenticatorTest.php
@@ -501,6 +501,67 @@ class OidcLoginAuthenticatorTest extends TestCase
         $authenticator->authenticate($request);
     }
 
+    public function testAuthenticateAcceptsTheIssParameterOfTheExpectedIssuer()
+    {
+        // RFC 9207: the "iss" authorization response parameter names the provider that
+        // issued the response, and must be the expected one
+        $nonce = bin2hex(random_bytes(16));
+        $state = bin2hex(random_bytes(16));
+
+        $this->oidcClient->expects($this->once())
+            ->method('exchangeCode')
+            ->willReturn(['access_token' => 'access-123', 'id_token' => $this->buildIdToken(['nonce' => $nonce])]);
+        $this->oidcClient->expects($this->once())
+            ->method('fetchUserInfo')
+            ->willReturn(['sub' => 'user-42']);
+
+        $passport = $this->createAuthenticator()->authenticate($this->createCallbackRequest($state, $nonce, query: ['iss' => 'https://provider.example.com']));
+
+        $this->assertSame('user-42', $passport->getBadge(UserBadge::class)->getUserIdentifier());
+    }
+
+    public function testAuthenticateRejectsTheIssParameterOfAnotherIssuer()
+    {
+        // the response of another provider is rejected before any request is sent
+        // to the token endpoint (mix-up attack), and the attempt is consumed anyway
+        $nonce = bin2hex(random_bytes(16));
+        $state = bin2hex(random_bytes(16));
+
+        $this->oidcClient->expects($this->never())->method('exchangeCode');
+
+        $request = $this->createCallbackRequest($state, $nonce, query: ['iss' => 'https://evil.example.com']);
+
+        try {
+            $this->createAuthenticator()->authenticate($request);
+            $this->fail('An AuthenticationException should have been thrown.');
+        } catch (AuthenticationException $e) {
+            $this->assertSame('The OIDC callback "iss" parameter does not match the expected issuer.', $e->getMessage());
+        }
+
+        $this->assertFalse($request->getSession()->has('_security.oidc_login.main.attempt.'.$state));
+    }
+
+    public function testAuthenticateRequiresTheIssParameterWhenTheProviderSupportsIt()
+    {
+        // a provider announcing support sends the parameter on every response, so a
+        // callback without it did not come from it
+        $this->discovery = $this->createDiscovery([
+            'issuer' => 'https://provider.example.com',
+            'authorization_endpoint' => 'https://provider.example.com/authorize',
+            'token_endpoint' => 'https://provider.example.com/token',
+            'userinfo_endpoint' => 'https://provider.example.com/userinfo',
+            'jwks_uri' => 'https://provider.example.com/jwks',
+            'authorization_response_iss_parameter_supported' => true,
+        ]);
+        $nonce = bin2hex(random_bytes(16));
+        $state = bin2hex(random_bytes(16));
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('The OIDC provider announces support for the "iss" authorization response parameter, but the callback does not carry it.');
+
+        $this->createAuthenticator()->authenticate($this->createCallbackRequest($state, $nonce));
+    }
+
     public function testAuthenticateWithProviderError()
     {
         // the provider echoes the "state" back on an error response too (RFC 6749,
@@ -1346,9 +1407,9 @@ class OidcLoginAuthenticatorTest extends TestCase
         $authenticator->authenticate($request);
     }
 
-    private function createCallbackRequest(string $state, string $nonce, ?string $codeVerifier = null): Request
+    private function createCallbackRequest(string $state, string $nonce, ?string $codeVerifier = null, array $query = []): Request
     {
-        $request = Request::create('/oidc/callback?code=auth-code&state='.$state);
+        $request = Request::create('/oidc/callback?'.http_build_query(['code' => 'auth-code', 'state' => $state] + $query));
         $session = new Session(new MockArraySessionStorage());
         $request->setSession($session);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Follow-up of the `oidc_login` series (#64954, #65798, #65799, #65812, #65813, #65814, #65817), from a security review of the whole surface before 8.2 is released. Nothing exploitable by a network attacker or an end user came out of it; these are robustness fixes against malformed provider data, and one hardening the OAuth 2.0 Security BCP (RFC 9700) recommends. Since none of this is released yet, there is no changelog entry.

**Malformed JWKS entries (`OidcJwks`).** `JWKSet::createFromKeyData()` throws on an entry without `kty`, and uses `kid` as an array offset. Both the `oidc_login` signature verifier and the `oidc` access token handler call it outside any `try`, so a single odd entry in a provider JWKS turned every login into a 500 instead of an authentication failure. The shared filter now drops the entries the library cannot load, and only those.

**Non-string `kid` header (`OidcSignatureVerifier`).** The protected `kid` header went straight into a `?string` parameter; an array raised a `TypeError`. It is now rejected as an `AuthenticationException`.

**JWKS cache entries per strictness (`OidcSignatureVerifier`).** The cache key was derived from `jwks_uri` alone, so two firewalls on the same provider with different `enforce_key_usage_verification` settings shared whichever entry was warmed first, and a strict firewall could verify against keys the lax one kept. The strictness is now part of the key.

**RFC 9207 `iss` parameter (`OidcLoginAuthenticator`).** The authorization response `iss` parameter is checked once the `state` has been matched, and before the `error` parameter, as RFC 9207 requires it on error responses too: when present it must be the discovered issuer, and it is required from a provider whose discovery document announces `authorization_response_iss_parameter_supported`. This is the mix-up defense of RFC 9700, Section 4.4.1, relevant as soon as two `oidc_login` firewalls point to different providers. Providers that do not announce support are unaffected.

**Boolean claims (`OidcUser::fromClaims()`).** `email_verified` and `phone_number_verified` were cast with `(bool)`, so a provider emitting the claim as the string `"false"` produced a user reported as verified (the class of CVE-2026-55076). That one turned out to reach 6.4, so it was fixed there by #65912 and came up with the merge-up; what is left here is the regression test covering `fromClaims()` itself.

Each change comes with its regression test.

