### PR TITLE
[Mailer][Brevo] Note template deprecation in readme

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Brevo/README.md
+++ b/src/Symfony/Component/Mailer/Bridge/Brevo/README.md
@@ -45,8 +45,8 @@ $email
 
 This example allow you to set:
 
- * templateId
- * params
+ * templateId (deprecated, use RemoteTemplateEmail instead)
+ * params (deprecated, use RemoteTemplateEmail instead)
  * tags
  * headers
      * sender.ip


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2 for features
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

#64782 introduced a new deprecation in Brevo Bridge in 8.2
Bridge are mainly documented directly in code readme, I think this is the best place to note the deprecation even though it will also be mentioned in the documentation.
