### PR TITLE
[SecurityBundle] Add an "http_client" option to the "oidc_login" authenticator

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -36,6 +36,7 @@ CHANGELOG
  * Deprecate not setting the `enforce_at_jwt_type` option of the OIDC token handler, which defaults to `false` in 8.2 and will default to `true` in 9.0
  * Add the `resource_metadata` option to the `access_token` authenticator to serve the RFC 9728 protected resource metadata document of the firewall and advertise its URL in the `WWW-Authenticate` header
  * Pick an authenticator implementing `FallbackAuthenticationEntryPointInterface` as the firewall entry point only when no other authenticator provides one
+ * Add the `http_client` option to the `oidc_login` authenticator, naming the HTTP client its calls to the provider are made with
 
 8.1
 ---

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/OidcLoginFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/OidcLoginFactory.php
@@ -62,6 +62,11 @@ class OidcLoginFactory extends AbstractFactory implements FirewallListenerFactor
                 ->end()
                 ->info('The OIDC Issuer URL (e.g. "https://accounts.example.com"). Used for .well-known/openid-configuration discovery.')
             ->end()
+            ->scalarNode('http_client')
+                ->defaultNull()
+                ->cannotBeEmpty()
+                ->info('The id of the HttpClient service every call to the provider is made with: discovery, JWKS, token and UserInfo endpoints. Defaults to "http_client". A scoped client must scope every host the provider announces, not only the issuer.')
+            ->end()
             ->scalarNode('client_id')
                 ->isRequired()
                 ->cannotBeEmpty()
@@ -289,9 +294,12 @@ class OidcLoginFactory extends AbstractFactory implements FirewallListenerFactor
             $checkedEndpoints[] = 'userinfo_endpoint';
         }
 
+        $httpClient = new Reference($config['http_client'] ?? 'http_client');
+
         $discoveryId = 'security.authenticator.oidc_login.discovery.'.$firewallName;
         $container
             ->setDefinition($discoveryId, new ChildDefinition('security.authenticator.oidc_login.discovery'))
+            ->replaceArgument(0, $httpClient)
             // the discovery URL is built from the issuer by OidcDiscovery, which is the only
             // place a "provider_uri" coming from an environment variable can be normalized
             ->replaceArgument(3, $config['provider_uri'])
@@ -310,6 +318,7 @@ class OidcLoginFactory extends AbstractFactory implements FirewallListenerFactor
         $oidcClientId = 'security.authenticator.oidc_login.client.'.$firewallName;
         $container
             ->setDefinition($oidcClientId, new ChildDefinition('security.authenticator.oidc_login.client'))
+            ->replaceArgument(0, $httpClient)
             ->replaceArgument(1, new Reference($discoveryId))
             ->replaceArgument(2, $config['client_id'])
             ->replaceArgument(3, new Reference($this->createClientAuthentication($container, $firewallName, $config['client_authentication'])))
@@ -321,6 +330,7 @@ class OidcLoginFactory extends AbstractFactory implements FirewallListenerFactor
             $container
                 ->setDefinition($signatureVerifierId, new ChildDefinition('security.authenticator.oidc_login.signature_verifier'))
                 ->replaceArgument(0, new Reference($discoveryId))
+                ->replaceArgument(2, $httpClient)
                 ->replaceArgument(3, $config['id_token_signature']['algorithms'])
                 ->replaceArgument(4, $config['discovery_cache_ttl'])
                 ->replaceArgument(5, $config['id_token_signature']['enforce_key_usage_verification'])

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/OidcLoginFactoryTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/OidcLoginFactoryTest.php
@@ -1101,6 +1101,70 @@ class OidcLoginFactoryTest extends TestCase
         ], $factory);
     }
 
+    public function testTheConfiguredHttpClientIsUsedForEveryCallToTheProvider()
+    {
+        $container = new ContainerBuilder();
+        $factory = new OidcLoginFactory();
+
+        $config = $this->processConfig([
+            'provider_uri' => 'https://provider.example.com',
+            'client_id' => 'my-client-id',
+            'client_authentication' => 'app.client_authentication',
+            'http_client' => 'oidc.client',
+        ], $factory);
+        $factory->createAuthenticator($container, 'main', $config, 'userprovider');
+
+        $this->assertEquals(new Reference('oidc.client'), $container->getDefinition('security.authenticator.oidc_login.discovery.main')->getArgument(0));
+        $this->assertEquals(new Reference('oidc.client'), $container->getDefinition('security.authenticator.oidc_login.client.main')->getArgument(0));
+        $this->assertEquals(new Reference('oidc.client'), $container->getDefinition('security.authenticator.oidc_login.signature_verifier.main')->getArgument(2));
+    }
+
+    public function testTheConfiguredHttpClientIsUsedWhenTheIdTokenSignatureIsNotVerified()
+    {
+        $container = new ContainerBuilder();
+        $factory = new OidcLoginFactory();
+
+        $config = $this->processConfig([
+            'provider_uri' => 'https://provider.example.com',
+            'client_id' => 'my-client-id',
+            'client_authentication' => 'app.client_authentication',
+            'id_token_signature' => ['required' => false],
+            'http_client' => 'oidc.client',
+        ], $factory);
+        $factory->createAuthenticator($container, 'main', $config, 'userprovider');
+
+        $this->assertFalse($container->hasDefinition('security.authenticator.oidc_login.signature_verifier.main'));
+        $this->assertEquals(new Reference('oidc.client'), $container->getDefinition('security.authenticator.oidc_login.discovery.main')->getArgument(0));
+        $this->assertEquals(new Reference('oidc.client'), $container->getDefinition('security.authenticator.oidc_login.client.main')->getArgument(0));
+    }
+
+    public function testTheHttpClientDefaultsToNull()
+    {
+        $factory = new OidcLoginFactory();
+
+        $config = $this->processConfig([
+            'provider_uri' => 'https://provider.example.com',
+            'client_id' => 'my-client-id',
+            'client_authentication' => 'app.client_authentication',
+        ], $factory);
+
+        $this->assertNull($config['http_client']);
+    }
+
+    public function testRejectsAnEmptyHttpClient()
+    {
+        $factory = new OidcLoginFactory();
+
+        $this->expectException(InvalidConfigurationException::class);
+
+        $this->processConfig([
+            'provider_uri' => 'https://provider.example.com',
+            'client_id' => 'my-client-id',
+            'client_authentication' => 'app.client_authentication',
+            'http_client' => '',
+        ], $factory);
+    }
+
     private function processConfig(array $config, OidcLoginFactory $factory): array
     {
         $nodeDefinition = new ArrayNodeDefinition('oidc-login');

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
@@ -31,6 +31,7 @@ use Symfony\Component\DependencyInjection\Compiler\ValidateEnvPlaceholdersPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\ExpressionLanguage\Expression;
+use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestMatcher\PathRequestMatcher;
 use Symfony\Component\HttpFoundation\Response;
@@ -1704,6 +1705,54 @@ class SecurityExtensionTest extends TestCase
         $this->assertArrayHasKey('routing.route_loader', $loader->getTags());
         // it declares no route as long as no firewall configures the OIDC authenticator
         $this->assertCount(0, (new OidcLoginRouteLoader($container->getParameter('security.oidc_login.callback_uris'), 'security.oidc_login.callback_uris', $container->getParameter('security.oidc_login.start_paths'), 'security.oidc_login.start_paths'))());
+    }
+
+    public function testOidcLoginCallsTheProviderWithTheDefaultHttpClient()
+    {
+        $container = $this->getRawContainer();
+        $container->loadFromExtension('security', [
+            'providers' => ['oidc' => ['oidc' => null]],
+            'firewalls' => [
+                'main' => [
+                    'oidc_login' => [
+                        'provider_uri' => 'https://provider.example.com',
+                        'client_id' => 'my-client-id',
+                        'client_authentication' => ['client_secret_post' => 'my-client-secret'],
+                    ],
+                ],
+            ],
+        ]);
+
+        $container->compile();
+
+        $this->assertSame('http_client', (string) $container->getDefinition('security.authenticator.oidc_login.discovery.main')->getArgument(0));
+        $this->assertSame('http_client', (string) $container->getDefinition('security.authenticator.oidc_login.client.main')->getArgument(0));
+        $this->assertSame('http_client', (string) $container->getDefinition('security.authenticator.oidc_login.signature_verifier.main')->getArgument(2));
+    }
+
+    public function testOidcLoginCallsTheProviderWithTheConfiguredHttpClient()
+    {
+        $container = $this->getRawContainer();
+        $container->register('oidc.http_client', MockHttpClient::class);
+        $container->loadFromExtension('security', [
+            'providers' => ['oidc' => ['oidc' => null]],
+            'firewalls' => [
+                'main' => [
+                    'oidc_login' => [
+                        'provider_uri' => 'https://provider.example.com',
+                        'client_id' => 'my-client-id',
+                        'client_authentication' => ['client_secret_post' => 'my-client-secret'],
+                        'http_client' => 'oidc.http_client',
+                    ],
+                ],
+            ],
+        ]);
+
+        $container->compile();
+
+        $this->assertSame('oidc.http_client', (string) $container->getDefinition('security.authenticator.oidc_login.discovery.main')->getArgument(0));
+        $this->assertSame('oidc.http_client', (string) $container->getDefinition('security.authenticator.oidc_login.client.main')->getArgument(0));
+        $this->assertSame('oidc.http_client', (string) $container->getDefinition('security.authenticator.oidc_login.signature_verifier.main')->getArgument(2));
     }
 
     protected function getRawContainer()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

The three services the `oidc_login` firewall builds to talk to the provider are wired on `service('http_client')`, so an application has no way to give them anything else: no `User-Agent` identifying it, which some providers require and on which they base their quotas and their diagnostics, no `timeout`, no `retry_failed`. This adds an `http_client` option taking a service id, on the model of the `oauth2` and `cas` token handlers.

```yaml
framework:
    http_client:
        scoped_clients:
            oidc.client:
                scope: 'https://accounts\.example\.com'
                headers: { 'User-Agent': 'AcmeApp/1.0 (+https://acme.example.com)' }
                timeout: 5
                retry_failed: { max_retries: 2 }

security:
    firewalls:
        main:
            oidc_login:
                provider_uri: 'https://accounts.example.com'
                client_id: '%env(OIDC_CLIENT_ID)%'
                client_authentication:
                    client_secret_basic: '%env(OIDC_CLIENT_SECRET)%'
                http_client: oidc.client
```

The one client covers the whole exchange: the discovery document, the JWKS, the token endpoint and the UserInfo endpoint. Left unset, nothing changes, the definitions keeping the `http_client` service their abstract parents are wired on.

Two things worth stating, both of which the `info()` of the option carries.

The scope of a scoped client has to match every endpoint, not only the issuer. The endpoints requested are the absolute URLs the provider announces in its discovery document, and those often live on other hosts: Google announces `oauth2.googleapis.com` for its token endpoint, `www.googleapis.com` for its JWKS and `openidconnect.googleapis.com` for its UserInfo, while its issuer is `accounts.google.com`. The options of a scoped client apply to the URLs its scope matches and to nothing else, without saying so, so a client scoped on the issuer alone reaches the discovery request and leaves the three others with the defaults.

And the client credentials do not belong on this client, which is what `client_authentication` is for. It is not that they would not work: `HttpClientTrait::mergeDefaultOptions()` really merges `headers`, `extra` and `resolve`, every other option being a `$options += $defaultOptions` where the request wins, so an `auth_basic` set on the client and a `client_authentication: none` do reach the token endpoint. They reach the discovery, JWKS and UserInfo requests too, which have no business seeing them, and `auth_basic` base64s both halves verbatim where `client_secret_basic` form-urlencodes them first (RFC 6749, Section 2.3.1). `client_authentication` sends them to the token endpoint alone, in the form the RFC asks for.

Nothing of the `oidc_login` firewall is released yet, so the option costs nothing now and could not be added after 8.2 freezes.

Documentation points:

 * the option takes a service id and defaults to `http_client`; it covers the discovery document, the JWKS, the token endpoint and the UserInfo endpoint;
 * a scoped client needs a `scope` matching every host the provider announces, not just the issuer, and its options silently apply to nothing else;
 * a client built with `withOptions()` on top of `http_client` applies its options to every request whatever the host, which is the simpler answer when the provider spreads its endpoints;
 * the client credentials belong to `client_authentication`, never to the HTTP client.
