### PR TITLE
[Security] Read the OIDC verified claims as booleans

### DIFF
--- a/src/Symfony/Component/Security/Http/AccessToken/Oidc/OidcTrait.php
+++ b/src/Symfony/Component/Security/Http/AccessToken/Oidc/OidcTrait.php
@@ -40,12 +40,12 @@ trait OidcTrait
             $claims['updatedAt'] = (new \DateTimeImmutable())->setTimestamp($claims['updatedAt']);
         }
 
-        if (\array_key_exists('emailVerified', $claims) && null !== $claims['emailVerified'] && '' !== $claims['emailVerified']) {
-            $claims['emailVerified'] = (bool) $claims['emailVerified'];
-        }
-
-        if (\array_key_exists('phoneNumberVerified', $claims) && null !== $claims['phoneNumberVerified'] && '' !== $claims['phoneNumberVerified']) {
-            $claims['phoneNumberVerified'] = (bool) $claims['phoneNumberVerified'];
+        // a string "false" would cast to true, so only a recognizable boolean is kept,
+        // and any other value is dropped rather than turned into a verified flag
+        foreach (['emailVerified', 'phoneNumberVerified'] as $flag) {
+            if (isset($claims[$flag]) && '' !== $claims[$flag] && null === $claims[$flag] = filter_var($claims[$flag], \FILTER_VALIDATE_BOOL, \FILTER_NULL_ON_FAILURE)) {
+                unset($claims[$flag]);
+            }
         }
 
         return new OidcUser(...$claims);

--- a/src/Symfony/Component/Security/Http/Tests/AccessToken/Oidc/OidcUserInfoTokenHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/AccessToken/Oidc/OidcUserInfoTokenHandlerTest.php
@@ -24,6 +24,42 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 class OidcUserInfoTokenHandlerTest extends TestCase
 {
     /**
+     * @dataProvider getVerifiedClaims
+     */
+    public function testOnlyKeepsARecognizableBooleanForTheVerifiedClaims(mixed $value, ?bool $expected)
+    {
+        $claims = ['sub' => 'e21bf182-1538-406e-8ccb-e25a17aba39f', 'email_verified' => $value];
+
+        $responseMock = $this->createMock(ResponseInterface::class);
+        $responseMock->expects($this->once())->method('toArray')->willReturn($claims);
+
+        $clientMock = $this->createMock(HttpClientInterface::class);
+        $clientMock->expects($this->once())->method('request')->willReturn($responseMock);
+
+        $user = (new OidcUserInfoTokenHandler($clientMock))->getUserBadgeFrom('a-secret-token')->getUserLoader()();
+
+        $this->assertSame($expected, $user->getEmailVerified());
+    }
+
+    /**
+     * A provider that does not serialize the claim as a JSON boolean must not end up
+     * reporting a verified email: "false" cast to true, which is the reverse of what
+     * the claim says, and anything unrecognizable leaves the flag unknown.
+     */
+    public static function getVerifiedClaims(): iterable
+    {
+        yield 'a boolean true' => [true, true];
+        yield 'a boolean false' => [false, false];
+        yield 'a stringly typed true' => ['true', true];
+        yield 'a stringly typed false' => ['false', false];
+        yield 'no' => ['no', false];
+        yield 'off' => ['off', false];
+        yield 'the number one' => [1, true];
+        yield 'the number zero' => [0, false];
+        yield 'anything else' => ['maybe', null];
+    }
+
+    /**
      * @dataProvider getClaims
      */
     public function testGetsUserIdentifierFromOidcServerResponse(string $claim, string $expected)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`OidcTrait::createUser()` casts the `email_verified` and `phone_number_verified` claims with `(bool)`:

```php
if (\array_key_exists('emailVerified', $claims) && null !== $claims['emailVerified'] && '' !== $claims['emailVerified']) {
    $claims['emailVerified'] = (bool) $claims['emailVerified'];
}
```

A provider that does not serialize those claims as JSON booleans therefore makes the user report the opposite of what the claim says, because `(bool) "false"` is `true`, and so are `"no"` and `"off"`. Run against this branch:

```
"false"  emailVerified=true  phoneNumberVerified=true
"no"     emailVerified=true
"off"    emailVerified=true
```

The value reaches `OidcUser::getEmailVerified()`, a typed `?bool` accessor, through both the `oidc` and the `oidc_user_info` access token handlers, so an application gating on a verified email trusts it. Stringly typed booleans are common enough in this corner of the ecosystem for the same defect to have its own advisory elsewhere ([GHSA-75vm-6w67-gwvp](https://github.com/coder/coder/security/advisories/GHSA-75vm-6w67-gwvp), which describes the fix as coercing across bool, string and numeric types, fail-closed).

The claims are now read with `filter_var()`, which recognizes the shapes a boolean is serialized with and only those. A value that describes no boolean leaves the flag unknown rather than true, which is what `OidcUser` already reports for an absent claim.

Regression test in `OidcUserInfoTokenHandlerTest`, since that handler exercises the same trait without needing `web-token/jwt-library`. Four of its nine rows fail on this branch: `"false"`, `"no"`, `"off"` and an unrecognizable value.

`Oauth2TokenHandler::createUser()` carries the same defect on 7.4 and up, where its value lands in a variadic claims bag rather than a typed accessor; #65913 fixes it there.

Merge-up: `OidcTrait::createUser()` is identical on 7.4, 8.0 and 8.1, so the fix applies unchanged. It conflicts on 8.2, where the trait is `return OidcUser::fromClaims($claims);`. Keep 8.2's version there: #65908 applies the same fix inside `fromClaims()`. The regression test merges up cleanly and passes once that one is in, so it is the one to merge first.


