### PR TITLE
[Security] Read the OAuth2 verified claims as booleans

### DIFF
--- a/src/Symfony/Component/Security/Http/AccessToken/OAuth2/Oauth2TokenHandler.php
+++ b/src/Symfony/Component/Security/Http/AccessToken/OAuth2/Oauth2TokenHandler.php
@@ -96,12 +96,12 @@ final class Oauth2TokenHandler implements AccessTokenHandlerInterface
             $claims['updatedAt'] = (new \DateTimeImmutable())->setTimestamp($claims['updatedAt']);
         }
 
-        if ('' !== ($claims['emailVerified'] ?? '')) {
-            $claims['emailVerified'] = (bool) $claims['emailVerified'];
-        }
-
-        if ('' !== ($claims['phoneNumberVerified'] ?? '')) {
-            $claims['phoneNumberVerified'] = (bool) $claims['phoneNumberVerified'];
+        // a string "false" would cast to true, so only a recognizable boolean is kept,
+        // and any other value is dropped rather than turned into a verified flag
+        foreach (['emailVerified', 'phoneNumberVerified'] as $flag) {
+            if (isset($claims[$flag]) && '' !== $claims[$flag] && null === $claims[$flag] = filter_var($claims[$flag], \FILTER_VALIDATE_BOOL, \FILTER_NULL_ON_FAILURE)) {
+                unset($claims[$flag]);
+            }
         }
 
         return new OAuth2User(...$claims);

--- a/src/Symfony/Component/Security/Http/Tests/AccessToken/OAuth2/OAuth2TokenHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/AccessToken/OAuth2/OAuth2TokenHandlerTest.php
@@ -68,6 +68,32 @@ class OAuth2TokenHandlerTest extends TestCase
         yield 'not a boolean at all' => [['active' => 'bogus', 'sub' => 'jdoe']];
     }
 
+    /**
+     * A provider that does not serialize the verified claims as JSON booleans must not make
+     * the user report the opposite of what the claim says: (bool) "false" is true.
+     */
+    #[DataProvider('verifiedClaims')]
+    public function testOnlyKeepsARecognizableBooleanForTheVerifiedClaims(mixed $value, ?bool $expected)
+    {
+        $claims = ['active' => true, 'sub' => 'jdoe', 'email_verified' => $value];
+        $client = new MockHttpClient([new MockResponse(json_encode($claims, \JSON_THROW_ON_ERROR))]);
+
+        $user = (new Oauth2TokenHandler($client))->getUserBadgeFrom('a-secret-token')->getUserLoader()();
+
+        $this->assertSame($expected, $user->additionalClaims['emailVerified'] ?? null);
+    }
+
+    public static function verifiedClaims(): iterable
+    {
+        yield 'a boolean true' => [true, true];
+        yield 'a boolean false' => [false, false];
+        yield 'a stringly typed true' => ['true', true];
+        yield 'a stringly typed false' => ['false', false];
+        yield 'no' => ['no', false];
+        yield 'off' => ['off', false];
+        yield 'anything else' => ['maybe', null];
+    }
+
     public function testGetsUserIdentifierFromOAuth2ServerResponse()
     {
         $accessToken = 'a-secret-token';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The OAuth2 twin of #65912. `Oauth2TokenHandler::createUser()` casts the `email_verified` and `phone_number_verified` claims with `(bool)`:

```php
if ('' !== ($claims['emailVerified'] ?? '')) {
    $claims['emailVerified'] = (bool) $claims['emailVerified'];
}
```

An authorization server that does not serialize those claims of its introspection response as JSON booleans therefore makes the user report the opposite of what the claim says, because `(bool) "false"` is `true`, and so are `"no"` and `"off"`. Run against this branch:

```
"false"  emailVerified=true  phoneNumberVerified=true
"no"     emailVerified=true
"off"    emailVerified=true
```

The reach is narrower than in #65912: `OAuth2User` has no `emailVerified` constructor argument on any branch, so the value lands in the variadic `$additionalClaims` bag rather than behind a typed accessor. It is still what an application reads to decide whether an email is verified, and it is still handed the opposite of what the server sent.

The claims are now read with `filter_var()`, which recognizes the shapes a boolean is serialized with and only those. A value that describes no boolean is dropped rather than turned into a verified flag, leaving the claim absent, which is what the user already reports when the server does not send it.

Four of the seven rows of the regression test fail on this branch: `"false"`, `"no"`, `"off"` and an unrecognizable value.

The `createUser()` method is byte-identical on 8.0, 8.1 and 8.2, so the fix merges up unchanged.
