### PR TITLE
[HttpClient] Suppress warnings from failed DNS lookups

### DIFF
--- a/src/Symfony/Component/HttpClient/NoPrivateNetworkHttpClient.php
+++ b/src/Symfony/Component/HttpClient/NoPrivateNetworkHttpClient.php
@@ -198,7 +198,7 @@ final class NoPrivateNetworkHttpClient implements HttpClientInterface, LoggerAwa
             return $host;
         }
 
-        if ($ip = dns_get_record($host, \DNS_AAAA)) {
+        if ($ip = @dns_get_record($host, \DNS_AAAA)) {
             $ip = $ip[0]['ipv6'];
         } elseif (\extension_loaded('sockets')) {
             if (!$info = socket_addrinfo_lookup($host, 0, ['ai_socktype' => \SOCK_STREAM, 'ai_family' => \AF_INET6])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | 
| License       | MIT

`dns_get_record()` returns`false` on failure, which the existing fallback already handles, but it also emits warnings for transient DNS errors. Application error handlers may convert those to exceptions and your logs get flooded 😊 