### PR TITLE
[Security][SecurityBundle] Let the oidc token handler answer for several audiences

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -37,6 +37,7 @@ CHANGELOG
  * Add the `resource_metadata` option to the `access_token` authenticator to serve the RFC 9728 protected resource metadata document of the firewall and advertise its URL in the `WWW-Authenticate` header
  * Pick an authenticator implementing `FallbackAuthenticationEntryPointInterface` as the firewall entry point only when no other authenticator provides one
  * Add the `http_client` option to the `oidc_login` authenticator, naming the HTTP client its calls to the provider are made with
+ * Allow the `audience` option of the `oidc` token handler to name several identifiers as a list, as the `oauth2` one does
 
 8.1
 ---

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/AccessToken/OAuth2TokenHandlerFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/AccessToken/OAuth2TokenHandlerFactory.php
@@ -42,8 +42,12 @@ class OAuth2TokenHandlerFactory implements TokenHandlerFactoryInterface
 {
     public function create(ContainerBuilder $container, string $id, array|string $config): void
     {
+        // a lone identifier is passed as it was given, so that an environment variable holding the
+        // whole list, as "%env(json:AUDIENCES)%" does, reaches the handler as the list it resolves to
+        $audience = [0] === array_keys($config['audience']) ? $config['audience'][0] : $config['audience'];
+
         $tokenHandlerDefinition = $container->setDefinition($id, new ChildDefinition('security.access_token_handler.oauth2'))
-            ->replaceArgument(2, $config['audience'])
+            ->replaceArgument(2, $audience)
             ->replaceArgument(3, $config['issuer'])
             ->replaceArgument(4, $config['claim'])
             ->replaceArgument(6, $config['allowed_time_drift'])

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/AccessToken/OidcTokenHandlerFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/AccessToken/OidcTokenHandlerFactory.php
@@ -33,8 +33,12 @@ class OidcTokenHandlerFactory implements TokenHandlerFactoryInterface
             $config['enforce_at_jwt_type'] = false;
         }
 
+        // a lone identifier is passed as it was given, so that an environment variable holding the
+        // whole list, as "%env(json:AUDIENCES)%" does, reaches the handler as the list it resolves to
+        $audience = [0] === array_keys($config['audience']) ? $config['audience'][0] : $config['audience'];
+
         $tokenHandlerDefinition = $container->setDefinition($id, (new ChildDefinition('security.access_token_handler.oidc'))
-            ->replaceArgument(2, $config['audience'])
+            ->replaceArgument(2, $audience)
             ->replaceArgument(3, $config['issuers'])
             ->replaceArgument(4, $config['claim'])
             ->replaceArgument(7, $config['allowed_time_drift'])
@@ -113,7 +117,7 @@ class OidcTokenHandlerFactory implements TokenHandlerFactoryInterface
                 (new ChildDefinition('security.access_token_handler.oidc.generator'))
                     ->replaceArgument(0, (new ChildDefinition('security.access_token_handler.oidc.signature'))->replaceArgument(0, $config['algorithms']))
                     ->replaceArgument(1, (new ChildDefinition('security.access_token_handler.oidc.jwkset'))->replaceArgument(0, $config['keyset']))
-                    ->replaceArgument(2, $config['audience'])
+                    ->replaceArgument(2, $audience)
                     ->replaceArgument(3, $config['issuers'])
                     ->replaceArgument(4, $config['claim']),
                 $config['algorithms'],
@@ -164,9 +168,12 @@ class OidcTokenHandlerFactory implements TokenHandlerFactoryInterface
                         ->info('Claim which contains the user identifier (e.g.: sub, email..).')
                         ->defaultValue('sub')
                     ->end()
-                    ->scalarNode('audience')
-                        ->info('Audience set in the token, for validation purpose.')
+                    ->arrayNode('audience')
+                        ->info('Identifiers of this resource server, one of which the "aud" of the token must name. A single identifier may be given as a string.')
                         ->isRequired()
+                        ->requiresAtLeastOneElement()
+                        ->acceptAndWrap(['string'])
+                        ->scalarPrototype()->cannotBeEmpty()->end()
                     ->end()
                     ->arrayNode('issuers', 'issuer')
                         ->info('Issuers allowed to generate the token, for validation purpose.')

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/AccessTokenFactoryTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/AccessTokenFactoryTest.php
@@ -188,6 +188,28 @@ class AccessTokenFactoryTest extends TestCase
         $this->assertArrayNotHasKey('kernel.reset', $tags);
     }
 
+    public function testOidcTokenHandlerConfigurationWithSeveralAudiences()
+    {
+        $container = new ContainerBuilder();
+        $config = [
+            'token_handler' => [
+                'oidc' => [
+                    'enforce_at_jwt_type' => true,
+                    'issuers' => ['https://www.example.com'],
+                    'audience' => ['https://api.example.com', 'https://admin.example.com'],
+                    'keyset' => '{"keys":[]}',
+                ],
+            ],
+        ];
+
+        $factory = new AccessTokenFactory($this->createTokenHandlerFactories());
+        $finalizedConfig = $this->processConfig($config, $factory);
+
+        $factory->createAuthenticator($container, 'firewall1', $finalizedConfig, 'userprovider');
+
+        $this->assertSame(['https://api.example.com', 'https://admin.example.com'], $container->getDefinition('security.access_token_handler.firewall1')->getArgument(2));
+    }
+
     public function testOidcTokenHandlerConfigurationWithEncryption()
     {
         $container = new ContainerBuilder();
@@ -634,7 +656,7 @@ class AccessTokenFactoryTest extends TestCase
         $definition = $container->getDefinition('security.access_token_handler.firewall1');
         $this->assertEquals([
             'index_0' => new Reference('oauth2.introspection'),
-            'index_2' => ['https://api.example.com'],
+            'index_2' => 'https://api.example.com',
             'index_3' => 'https://www.example.com',
             'index_4' => 'username',
             'index_6' => 5,

--- a/src/Symfony/Component/Security/Http/AccessToken/OAuth2/Oauth2TokenHandler.php
+++ b/src/Symfony/Component/Security/Http/AccessToken/OAuth2/Oauth2TokenHandler.php
@@ -90,10 +90,15 @@ final class Oauth2TokenHandler implements AccessTokenHandlerInterface
     private ?HttpClientInterface $metadataClient = null;
 
     /**
+     * @var list<string>
+     */
+    private readonly array $audiences;
+
+    /**
      * @param HttpClientInterface $client           The client the introspection endpoint is reached with, whose
      *                                              base URI is that endpoint and whose options carry the
      *                                              credentials of this resource server
-     * @param list<string>        $audiences        The identifiers of this resource server, one of which the "aud"
+     * @param string|list<string> $audiences        The identifiers of this resource server, one of which the "aud"
      *                                              of the introspection response must name, or an empty list to
      *                                              skip that check
      * @param string|null         $issuer           The identifier of the authorization server, checked against the
@@ -106,12 +111,19 @@ final class Oauth2TokenHandler implements AccessTokenHandlerInterface
     public function __construct(
         private readonly HttpClientInterface $client,
         private readonly ?LoggerInterface $logger = null,
-        private readonly array $audiences = [],
+        string|array $audiences = [],
         private readonly ?string $issuer = null,
         private readonly ?string $claim = null,
         private readonly ClockInterface $clock = new Clock(),
         private readonly int $allowedTimeDrift = 0,
     ) {
+        $this->audiences = \is_array($audiences) ? array_values($audiences) : [$audiences];
+
+        foreach ($this->audiences as $value) {
+            if (!\is_string($value) || '' === $value) {
+                throw new \InvalidArgumentException(\sprintf('The "$audiences" argument of "%s()" must be a non-empty string or a list of non-empty strings.', __METHOD__));
+            }
+        }
     }
 
     /**

--- a/src/Symfony/Component/Security/Http/AccessToken/Oidc/OidcTokenGenerator.php
+++ b/src/Symfony/Component/Security/Http/AccessToken/Oidc/OidcTokenGenerator.php
@@ -21,14 +21,39 @@ use Symfony\Component\Clock\Clock;
 
 class OidcTokenGenerator
 {
+    /**
+     * @var string|list<string>
+     */
+    private readonly string|array $audience;
+
+    /**
+     * RFC 7519 §4.1.3 allows "aud" to hold a single string or a list: the token names every
+     * identifier declared here, and keeps the single-string form when only one is declared,
+     * which is the form providers emit.
+     *
+     * @param string|list<string> $audience The identifiers of the resource server the token is minted for
+     */
     public function __construct(
         private readonly AlgorithmManager $algorithmManager,
         private readonly JWKSet $jwkset,
-        private readonly string $audience,
+        string|array $audience,
         private readonly array $issuers,
         private readonly string $claim = 'sub',
         private readonly ClockInterface $clock = new Clock(),
     ) {
+        $audiences = \is_array($audience) ? array_values($audience) : [$audience];
+
+        if (!$audiences) {
+            throw new \InvalidArgumentException(\sprintf('The "$audience" argument of "%s()" cannot be an empty list.', __METHOD__));
+        }
+
+        foreach ($audiences as $value) {
+            if (!\is_string($value) || '' === $value) {
+                throw new \InvalidArgumentException(\sprintf('The "$audience" argument of "%s()" must be a non-empty string or a list of non-empty strings.', __METHOD__));
+            }
+        }
+
+        $this->audience = 1 === \count($audiences) ? $audiences[0] : $audiences;
     }
 
     public function generate(string $userIdentifier, ?string $algorithmAlias = null, ?string $issuer = null, ?int $ttl = null, ?\DateTimeImmutable $notBefore = null): string

--- a/src/Symfony/Component/Security/Http/AccessToken/Oidc/OidcTokenHandler.php
+++ b/src/Symfony/Component/Security/Http/AccessToken/Oidc/OidcTokenHandler.php
@@ -57,6 +57,12 @@ final class OidcTokenHandler implements AccessTokenHandlerInterface, ResetInterf
 
     private bool $enforceKeyUsageVerification = true;
     private bool $enforceAtJwtType;
+
+    /**
+     * @var list<string>
+     */
+    private array $audiences;
+
     private ?CacheInterface $discoveryCache = null;
     private ?string $oidcConfigurationCacheKey = null;
 
@@ -71,17 +77,21 @@ final class OidcTokenHandler implements AccessTokenHandlerInterface, ResetInterf
     private array $discoveries = [];
 
     /**
-     * @param bool|null $enforceAtJwtType Whether the "typ" header of the token must be "at+jwt" or "application/at+jwt",
-     *                                    which RFC 9068 §4 requires from a JWT access token. This is what tells an access
-     *                                    token apart from the ID token the provider issues for the same audience, which
-     *                                    would otherwise pass every other check. Turn it off only for providers that do
-     *                                    not follow the profile and keep emitting a plain "JWT" type. Defaults to false
-     *                                    in 8.2 and to true as of 9.0.
+     * @param string|list<string> $audience         The identifiers of this resource server, one of which the "aud" of
+     *                                              the token must name. A resource server answering for several
+     *                                              identifiers, as one deployed behind more than one API base URL is,
+     *                                              declares them all.
+     * @param bool|null           $enforceAtJwtType Whether the "typ" header of the token must be "at+jwt" or "application/at+jwt",
+     *                                              which RFC 9068 §4 requires from a JWT access token. This is what tells an access
+     *                                              token apart from the ID token the provider issues for the same audience, which
+     *                                              would otherwise pass every other check. Turn it off only for providers that do
+     *                                              not follow the profile and keep emitting a plain "JWT" type. Defaults to false
+     *                                              in 8.2 and to true as of 9.0.
      */
     public function __construct(
         private AlgorithmManager $signatureAlgorithm,
         private ?JWKSet $signatureKeyset,
-        private string $audience,
+        string|array $audience,
         private array $issuers,
         private string $claim = 'sub',
         private ?LoggerInterface $logger = null,
@@ -89,6 +99,20 @@ final class OidcTokenHandler implements AccessTokenHandlerInterface, ResetInterf
         private int $allowedTimeDrift = 0,
         ?bool $enforceAtJwtType = null,
     ) {
+        $audiences = \is_array($audience) ? array_values($audience) : [$audience];
+
+        if (!$audiences) {
+            throw new \InvalidArgumentException(\sprintf('The "$audience" argument of "%s()" cannot be an empty list: a resource server that answers for no identifier can accept no token.', __METHOD__));
+        }
+
+        foreach ($audiences as $value) {
+            if (!\is_string($value) || '' === $value) {
+                throw new \InvalidArgumentException(\sprintf('The "$audience" argument of "%s()" must be a non-empty string or a list of non-empty strings.', __METHOD__));
+            }
+        }
+
+        $this->audiences = $audiences;
+
         if (null === $enforceAtJwtType) {
             trigger_deprecation('symfony/security-http', '8.2', 'Not passing a value for the "$enforceAtJwtType" argument of "%s()" is deprecated, pass it explicitly; it will default to true in 9.0.', __METHOD__);
         }
@@ -273,13 +297,27 @@ final class OidcTokenHandler implements AccessTokenHandlerInterface, ResetInterf
             new Checker\IssuedAtChecker(clock: $this->clock, allowedTimeDrift: $this->allowedTimeDrift),
             new Checker\NotBeforeChecker(clock: $this->clock, allowedTimeDrift: $this->allowedTimeDrift),
             new Checker\ExpirationTimeChecker(clock: $this->clock, allowedTimeDrift: $this->allowedTimeDrift),
-            new Checker\AudienceChecker($this->audience),
+            new Checker\CallableChecker('aud', fn ($value) => $this->matchesAudience($value)),
             new Checker\IssuerChecker($this->issuers),
         ];
         $claimCheckerManager = new ClaimCheckerManager($checkers);
 
         // if this check fails, an InvalidClaimException is thrown
         return $claimCheckerManager->check($claims, ['iat', 'exp', 'aud', 'iss']);
+    }
+
+    /**
+     * Tells whether an "aud" claim names one of the audiences this resource server answers for.
+     *
+     * RFC 9068 §2.2 leaves "aud" to RFC 7519, where it is a string or a list of strings, so both
+     * shapes are read, and a single match is enough: an access token minted for several resource
+     * servers is meant for each of them.
+     */
+    private function matchesAudience(mixed $audience): bool
+    {
+        $audiences = array_filter(\is_array($audience) ? $audience : [$audience], \is_string(...));
+
+        return (bool) array_intersect($this->audiences, $audiences);
     }
 
     private function decryptIfNeeded(string $accessToken): string

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -38,6 +38,7 @@ CHANGELOG
  * Deprecate not passing the `$enforceAtJwtType` argument to `OidcTokenHandler`; it defaults to `false` in 8.2 and will default to `true` in 9.0
  * Make `OidcTokenGenerator` emit the `at+jwt` type header RFC 9068 requires from an access token
  * Add the `$resourceMetadataUri` argument to `AccessTokenAuthenticator`, advertised in the `resource_metadata` parameter of the `WWW-Authenticate` header (RFC 9728)
+ * Widen the `$audience` argument of `OidcTokenHandler` and `OidcTokenGenerator` and the `$audiences` argument of `Oauth2TokenHandler` to take one identifier as a string or several as a list, one of which the `aud` claim must name
  * Add `FallbackAuthenticationEntryPointInterface` for an entry point that only stands in for a firewall declaring no other one, and make `AccessTokenAuthenticator` one, so that a request carrying no access token gets the RFC 6750 challenge instead of a bare 401
 
 8.1

--- a/src/Symfony/Component/Security/Http/Tests/AccessToken/OAuth2/OAuth2TokenHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/AccessToken/OAuth2/OAuth2TokenHandlerTest.php
@@ -299,6 +299,37 @@ class OAuth2TokenHandlerTest extends TestCase
     }
 
     /**
+     * A lone identifier is taken as a string, which is the shape the bundle passes when one is
+     * configured, so that an environment variable can carry the whole list instead.
+     */
+    public function testTakesALoneAudienceAsAString()
+    {
+        $client = new MockHttpClient([
+            new JsonMockResponse(self::activeClaims(['sub' => 'jdoe', 'aud' => self::AUDIENCE])),
+            new JsonMockResponse(self::activeClaims(['sub' => 'jdoe', 'aud' => 'https://other.example.net'])),
+        ]);
+
+        $this->assertSame('jdoe', self::createHandler($client, self::AUDIENCE)->getUserBadgeFrom('a-secret-token')->getUserIdentifier());
+        $this->assertBadCredentials('The token is not intended for any of the audiences "'.self::AUDIENCE.'".', self::createHandler($client, self::AUDIENCE));
+    }
+
+    #[DataProvider('audiencesNamingNothing')]
+    public function testRejectsAnAudienceNamingNothing(string|array $audiences)
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('must be a non-empty string or a list of non-empty strings');
+
+        new Oauth2TokenHandler(new MockHttpClient(), null, $audiences);
+    }
+
+    public static function audiencesNamingNothing(): iterable
+    {
+        yield 'an empty string' => [''];
+        yield 'an empty string among others' => [[self::AUDIENCE, '']];
+        yield 'a non-string' => [[42]];
+    }
+
+    /**
      * RFC 7662 §2.2 types "iss" and "aud" as strings, so a response carrying anything else names
      * neither an issuer nor an audience this resource server can be compared against: an array
      * would be juggled into the string "Array", and a number into a string that the audience of a
@@ -644,7 +675,7 @@ class OAuth2TokenHandlerTest extends TestCase
         $this->fail(\sprintf('The handler did not reject the token with "%s".', $message));
     }
 
-    private static function createHandler(MockHttpClient $client, array $audiences = [], ?string $issuer = null, ?string $claim = null, int $allowedTimeDrift = 0): Oauth2TokenHandler
+    private static function createHandler(MockHttpClient $client, string|array $audiences = [], ?string $issuer = null, ?string $claim = null, int $allowedTimeDrift = 0): Oauth2TokenHandler
     {
         return new Oauth2TokenHandler($client, null, $audiences, $issuer, $claim, new MockClock('@1719000000'), $allowedTimeDrift);
     }

--- a/src/Symfony/Component/Security/Http/Tests/AccessToken/Oidc/OidcTokenGeneratorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/AccessToken/Oidc/OidcTokenGeneratorTest.php
@@ -66,6 +66,48 @@ class OidcTokenGeneratorTest extends TestCase
         $this->assertSame('john_doe', $handler->getUserBadgeFrom($token)->getUserIdentifier());
     }
 
+    /**
+     * The "aud" claim keeps the single-string form of RFC 7519 §4.1.3 when the resource server
+     * answers for one identifier, and names them all when it answers for several.
+     */
+    #[DataProvider('getAudiences')]
+    public function testGeneratesTokensNamingEveryDeclaredAudience(string|array $audience, string|array $expected)
+    {
+        $algorithmManager = new AlgorithmManager([new ES256()]);
+        $issuers = ['https://www.example.com'];
+
+        $generator = new OidcTokenGenerator($algorithmManager, $this->getJWKSet(), $audience, $issuers);
+        $handler = new OidcTokenHandler($algorithmManager, $this->getJWKSet(), $audience, $issuers, 'sub', null, new Clock(), 0, true);
+
+        $token = $generator->generate('john_doe', null, null, 3600);
+
+        $this->assertSame($expected, $handler->getUserBadgeFrom($token)->getAttributes()['aud']);
+    }
+
+    public static function getAudiences(): iterable
+    {
+        yield 'a string' => ['Symfony OIDC', 'Symfony OIDC'];
+        yield 'a list of one' => [['Symfony OIDC'], 'Symfony OIDC'];
+        yield 'a list of several' => [['Symfony OIDC', 'https://api.example.com'], ['Symfony OIDC', 'https://api.example.com']];
+    }
+
+    #[DataProvider('getAudiencesNamingNothing')]
+    public function testRejectsAnAudienceNamingNothing(string|array $audience, string $expectedMessage)
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage($expectedMessage);
+
+        new OidcTokenGenerator(new AlgorithmManager([new ES256()]), $this->getJWKSet(), $audience, ['https://www.example.com']);
+    }
+
+    public static function getAudiencesNamingNothing(): iterable
+    {
+        yield 'an empty list' => [[], 'cannot be an empty list'];
+        yield 'an empty string' => ['', 'must be a non-empty string or a list of non-empty strings'];
+        yield 'an empty string among others' => [['https://api.example.com', ''], 'must be a non-empty string or a list of non-empty strings'];
+        yield 'a non-string' => [[42], 'must be a non-empty string or a list of non-empty strings'];
+    }
+
     #[DataProvider('provideGenerateWithInvalid')]
     public function testGenerateWithInvalid(?string $algorithm, ?string $issuer, ?int $ttl, ?int $notBefore, string $expectedMessage)
     {

--- a/src/Symfony/Component/Security/Http/Tests/AccessToken/Oidc/OidcTokenHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/AccessToken/Oidc/OidcTokenHandlerTest.php
@@ -1194,4 +1194,100 @@ class OidcTokenHandlerTest extends TestCase
             true,
         ))->getUserBadgeFrom($token);
     }
+
+    /**
+     * A resource server answering for several identifiers, as one deployed behind more than one
+     * API base URL is, declares them all, and RFC 7519 §4.1.3 lets the provider name the ones a
+     * token is minted for as a string or as a list.
+     */
+    #[DataProvider('getAudiencesNamingADeclaredOne')]
+    public function testAcceptsATokenIssuedForAnyOfTheDeclaredAudiences(string|array $tokenAudience)
+    {
+        $token = self::buildJWS(json_encode(['aud' => $tokenAudience] + self::getValidClaims()));
+
+        $loggerMock = $this->createMock(LoggerInterface::class);
+        $loggerMock->expects($this->never())->method('error');
+
+        $userBadge = (new OidcTokenHandler(
+            new AlgorithmManager([new ES256()]),
+            self::getJWKSet(),
+            ['https://api.example.com', self::AUDIENCE],
+            ['https://www.example.com'],
+            'sub',
+            $loggerMock,
+            new Clock(),
+            0,
+            true,
+        ))->getUserBadgeFrom($token);
+
+        $this->assertSame('e21bf182-1538-406e-8ccb-e25a17aba39f', $userBadge->getUserIdentifier());
+    }
+
+    public static function getAudiencesNamingADeclaredOne(): iterable
+    {
+        yield 'a string naming the first one' => ['https://api.example.com'];
+        yield 'a string naming the last one' => [self::AUDIENCE];
+        yield 'a list naming one of them' => [['https://elsewhere.example.com', self::AUDIENCE]];
+        yield 'a list naming them all' => [['https://api.example.com', self::AUDIENCE]];
+    }
+
+    #[DataProvider('getAudiencesNamingNoDeclaredOne')]
+    public function testRejectsATokenIssuedForNoneOfTheDeclaredAudiences(mixed $tokenAudience)
+    {
+        $token = self::buildJWS(json_encode(['aud' => $tokenAudience] + self::getValidClaims()));
+
+        $loggerMock = $this->createMock(LoggerInterface::class);
+        $loggerMock->expects($this->once())->method('error');
+
+        $this->expectException(BadCredentialsException::class);
+        $this->expectExceptionMessage('Invalid credentials.');
+
+        (new OidcTokenHandler(
+            new AlgorithmManager([new ES256()]),
+            self::getJWKSet(),
+            ['https://api.example.com', self::AUDIENCE],
+            ['https://www.example.com'],
+            'sub',
+            $loggerMock,
+            new Clock(),
+            0,
+            true,
+        ))->getUserBadgeFrom($token);
+    }
+
+    public static function getAudiencesNamingNoDeclaredOne(): iterable
+    {
+        yield 'a string naming another audience' => ['https://elsewhere.example.com'];
+        yield 'a list naming another audience' => [['https://elsewhere.example.com']];
+        yield 'an empty list' => [[]];
+        yield 'a non-string' => [42];
+        yield 'a list of non-strings' => [[42]];
+    }
+
+    #[DataProvider('getAudiencesNamingNothing')]
+    public function testRejectsAnAudienceNamingNothing(string|array $audience, string $expectedMessage)
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage($expectedMessage);
+
+        new OidcTokenHandler(
+            new AlgorithmManager([new ES256()]),
+            self::getJWKSet(),
+            $audience,
+            ['https://www.example.com'],
+            'sub',
+            null,
+            new Clock(),
+            0,
+            true,
+        );
+    }
+
+    public static function getAudiencesNamingNothing(): iterable
+    {
+        yield 'an empty list' => [[], 'cannot be an empty list'];
+        yield 'an empty string' => ['', 'must be a non-empty string or a list of non-empty strings'];
+        yield 'an empty string among others' => [['https://api.example.com', ''], 'must be a non-empty string or a list of non-empty strings'];
+        yield 'a non-string' => [[42], 'must be a non-empty string or a list of non-empty strings'];
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

The `oauth2` token handler answers for several resource identifiers since #65865: its `audience` option takes one as a string or several as a list, and the `aud` of the introspection response has to name one of them. The `oidc` handler kept a single `scalarNode`, so a resource server reachable under more than one identifier, as one deployed behind several API base URLs is, could not accept the tokens minted for the other ones. This aligns the two.

```yaml
security:
    firewalls:
        api:
            access_token:
                token_handler:
                    oidc:
                        audience: ['https://api.example.com', 'https://admin.example.com']
                        issuers: ['https://sso.example.com']
                        keyset: '%env(OIDC_KEYSET)%'
```

A single identifier is still given as a string, and the option is still required. On the token side, RFC 7519 §4.1.3 makes `aud` a string or a list of strings, so both shapes are read and a single match is enough: an access token minted for several resource servers is meant for each of them. That is the rule the `oauth2` handler already applies, and the `AudienceChecker` of the JWT library is replaced by the same `CallableChecker` it uses.

`OidcTokenHandler` and `OidcTokenGenerator` take `string|list<string>` in their `$audience` argument, a widening that breaks nothing. The generator gets the same value from the bundle, so it follows: it keeps the single-string `aud` form when one identifier is declared, which is what providers emit and what it emitted before, and names them all when several are.

An empty list, an empty string or a non-string entry now throws from the constructor, where it used to build a handler that rejected every token in silence.

The bundle passes a lone identifier on as the string it was given rather than as a one-element list, which is what `FrameworkExtension` does for `trusted_hosts` and `trusted_proxies`. A prototyped list refuses a whole `%env()%` value, so the option is written as a string and wrapped during normalization; unwrapping it again lets the placeholder reach the handler untouched, and the environment variable decides the shape:

```yaml
audience: '%env(json:AUDIENCES)%'   # ["https://api.example.com","https://admin.example.com"]
audience: '%env(API_AUDIENCE)%'     # https://api.example.com
```

`Oauth2TokenHandler` takes the same `string|list<string>` argument so that its own `audience` option reads an environment variable the same way. Whatever the variable resolves to is checked when the handler is built.

This is the resource server half of RFC 8707. The `resource` request parameter, which is the client half, is not part of this PR.

Documentation points:

- the `audience` option of the `oidc` token handler takes one identifier as a string or several as a list, and at least one is required
- a token is accepted when its `aud` claim names any one of them, whether the claim holds a string or a list, which is the two shapes RFC 7519 §4.1.3 allows
- the case for several identifiers is a resource server reachable under more than one of them, such as one deployed behind several API base URLs
- the `audience` option of the `oauth2` token handler reads the same way
- one environment variable can carry the whole list, as `audience: '%env(json:AUDIENCES)%'`, or a single identifier, as `audience: '%env(API_AUDIENCE)%'`


