### PR TITLE
[Security][SecurityBundle] Add the private_key_jwt and client_secret_jwt client authentication methods

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -38,6 +38,7 @@ CHANGELOG
  * Pick an authenticator implementing `FallbackAuthenticationEntryPointInterface` as the firewall entry point only when no other authenticator provides one
  * Add the `http_client` option to the `oidc_login` authenticator, naming the HTTP client its calls to the provider are made with
  * Allow the `audience` option of the `oidc` token handler to name several identifiers as a list, as the `oauth2` one does
+ * Add the `client_secret_jwt` and `private_key_jwt` client authentication methods to the `oidc_login` authenticator, which authenticate the client at the token endpoint with a JWT assertion it signs itself (RFC 7523, OIDC Core 1.0 §9)
 
 8.1
 ---

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/OidcLoginFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/OidcLoginFactory.php
@@ -86,7 +86,7 @@ class OidcLoginFactory extends AbstractFactory implements FirewallListenerFactor
                 // "isRequired" must be set otherwise the following custom validation is not called
                 ->validate()
                     ->ifTrue(static fn (array $v): bool => 1 !== \count($v))
-                    ->thenInvalid('Exactly one OIDC "client_authentication" method must be configured, got %s. Set "client_secret_basic", "client_secret_post" or "none", or the "id" of your own implementation.')
+                    ->thenInvalid('Exactly one OIDC "client_authentication" method must be configured, got %s. Set "client_secret_basic", "client_secret_post", "client_secret_jwt", "private_key_jwt" or "none", or the "id" of your own implementation.')
                 ->end()
                 ->validate()
                     ->ifTrue(static fn (array $v): bool => false === ($v['none'] ?? null))
@@ -105,9 +105,59 @@ class OidcLoginFactory extends AbstractFactory implements FirewallListenerFactor
                         ->treatNullLike(true)
                         ->info('Declare a public client (a SPA, a mobile or a native application), which holds no secret and relies on PKCE to protect the code exchange. It can disable neither PKCE nor the ID token signature check.')
                     ->end()
+                    ->arrayNode('client_secret_jwt')
+                        ->info('Authenticate with a JWT assertion keyed with the client secret, the "client_secret_jwt" method of OIDC Core 1.0, Section 9. The secret keys an HMAC and is never sent, but the provider holds it too and could sign an assertion in the name of the client: prefer "private_key_jwt", which nobody but the client can sign. Takes the client secret, or a mapping to also set "algorithm" and "lifetime".')
+                        ->example(['secret' => '%env(OIDC_CLIENT_SECRET)%', 'algorithm' => 'HS256'])
+                        ->beforeNormalization()
+                            ->ifString()
+                            ->then(static fn (string $v): array => ['secret' => $v])
+                        ->end()
+                        ->children()
+                            ->scalarNode('secret')
+                                ->isRequired()
+                                ->cannotBeEmpty()
+                                ->info('The client secret, whose octets key the HMAC. It must be at least as long as the digest the algorithm produces, which RFC 7518, Section 3.2 requires and the algorithm itself checks: 32 bytes for "HS256", 48 for "HS384", 64 for "HS512".')
+                            ->end()
+                            ->enumNode('algorithm')
+                                ->values(['HS256', 'HS384', 'HS512'])
+                                ->defaultValue('HS256')
+                                ->info('The MAC algorithm the assertion is signed with, which must be one your provider announces in "token_endpoint_auth_signing_alg_values_supported".')
+                            ->end()
+                            ->integerNode('lifetime')
+                                ->min(1)
+                                ->defaultValue(60)
+                                ->info('How long an assertion is valid, in seconds. It is built for one request and sent right away, so keep it short: it is the window a provider that does not track the "jti" would accept a captured assertion in.')
+                            ->end()
+                        ->end()
+                    ->end()
+                    ->arrayNode('private_key_jwt')
+                        ->info('Authenticate with a JWT assertion signed with the private key of the client, the "private_key_jwt" method of OIDC Core 1.0, Section 9, and the one FAPI 2.0 asks for. The provider only holds the public half, registered as the client "jwks" or fetched from its "jwks_uri", so it learns nothing it could authenticate as the client with.')
+                        ->example(['key' => '%env(OIDC_CLIENT_SIGNING_KEY)%', 'algorithm' => 'ES256'])
+                        ->beforeNormalization()
+                            ->ifString()
+                            ->then(static fn (string $v): array => ['key' => $v])
+                        ->end()
+                        ->children()
+                            ->scalarNode('key')
+                                ->isRequired()
+                                ->cannotBeEmpty()
+                                ->info('JSON-encoded JWK of the private key the assertion is signed with. Give it a "kid" when the client publishes several keys, so that the provider knows which one verifies the signature without trying them all.')
+                            ->end()
+                            ->enumNode('algorithm')
+                                ->values(['RS256', 'RS384', 'RS512', 'ES256', 'ES384', 'ES512', 'PS256', 'PS384', 'PS512'])
+                                ->defaultValue('RS256')
+                                ->info('The signature algorithm the assertion is signed with, which must be one your provider announces in "token_endpoint_auth_signing_alg_values_supported". FAPI 2.0 asks for "PS256" or "ES256".')
+                            ->end()
+                            ->integerNode('lifetime')
+                                ->min(1)
+                                ->defaultValue(60)
+                                ->info('How long an assertion is valid, in seconds. It is built for one request and sent right away, so keep it short: it is the window a provider that does not track the "jti" would accept a captured assertion in.')
+                            ->end()
+                        ->end()
+                    ->end()
                     ->scalarNode('id')
                         ->cannotBeEmpty()
-                        ->info('The id of a service implementing "ClientAuthenticationInterface", for a scheme Symfony does not ship, such as the "private_key_jwt" of OIDC Core 1.0, Section 9. The method it reports is only known once it is built, so the rules a public client cannot bend are then checked on the first request to this firewall instead of while the container compiles.')
+                        ->info('The id of a service implementing "ClientAuthenticationInterface", for a scheme Symfony does not ship, such as the "tls_client_auth" of RFC 8705, Section 2. The method it reports is only known once it is built, so the rules a public client cannot bend are then checked on the first request to this firewall instead of while the container compiles.')
                     ->end()
                 ->end()
             ->end()
@@ -251,11 +301,21 @@ class OidcLoginFactory extends AbstractFactory implements FirewallListenerFactor
         }
 
         $method = array_key_first($config);
+        $arguments = match ($method) {
+            'client_secret_jwt' => [$config[$method]['secret'], $config[$method]['algorithm'], $config[$method]['lifetime']],
+            'private_key_jwt' => [
+                (new ChildDefinition('security.oauth2.client_authentication.private_key_jwt.signing_key'))->replaceArgument(0, $config[$method]['key']),
+                $config[$method]['algorithm'],
+                $config[$method]['lifetime'],
+            ],
+            default => [$config[$method]],
+        };
+
         $clientAuthenticationId = 'security.authenticator.oidc_login.client_authentication.'.$firewallName;
-        $container
-            ->setDefinition($clientAuthenticationId, new ChildDefinition('security.oauth2.client_authentication.'.$method))
-            ->replaceArgument(0, $config[$method])
-        ;
+        $definition = $container->setDefinition($clientAuthenticationId, new ChildDefinition('security.oauth2.client_authentication.'.$method));
+        foreach ($arguments as $index => $argument) {
+            $definition->replaceArgument($index, $argument);
+        }
 
         return $clientAuthenticationId;
     }

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator_oidc_login.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator_oidc_login.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
+use Jose\Component\Core\JWK;
 use Symfony\Bundle\SecurityBundle\Controller\OidcLoginStartController;
 use Symfony\Component\Security\Http\Authenticator\Oidc\OidcClient;
 use Symfony\Component\Security\Http\Authenticator\Oidc\OidcIdToken;
@@ -20,8 +21,10 @@ use Symfony\Component\Security\Http\Authenticator\OidcLoginAuthenticator;
 use Symfony\Component\Security\Http\EventListener\OidcEndSessionListener;
 use Symfony\Component\Security\Http\Firewall\OidcTokenRefreshListener;
 use Symfony\Component\Security\Http\OAuth2\ClientAuthentication\ClientSecretBasic;
+use Symfony\Component\Security\Http\OAuth2\ClientAuthentication\ClientSecretJwt;
 use Symfony\Component\Security\Http\OAuth2\ClientAuthentication\ClientSecretPost;
 use Symfony\Component\Security\Http\OAuth2\ClientAuthentication\NoClientAuthentication;
+use Symfony\Component\Security\Http\OAuth2\ClientAuthentication\PrivateKeyJwt;
 use Symfony\Component\Security\Http\Oidc\OidcDiscovery;
 
 return static function (ContainerConfigurator $container) {
@@ -100,6 +103,33 @@ return static function (ContainerConfigurator $container) {
             ->abstract()
             ->args([
                 abstract_arg('client secret'),
+            ])
+
+        ->set('security.oauth2.client_authentication.client_secret_jwt', ClientSecretJwt::class)
+            ->abstract()
+            ->args([
+                abstract_arg('client secret'),
+                abstract_arg('signature algorithm'),
+                abstract_arg('assertion lifetime'),
+                service('clock'),
+            ])
+
+        ->set('security.oauth2.client_authentication.private_key_jwt', PrivateKeyJwt::class)
+            ->abstract()
+            ->args([
+                abstract_arg('client signing key'),
+                abstract_arg('signature algorithm'),
+                abstract_arg('assertion lifetime'),
+                service('clock'),
+            ])
+
+        // the private key of the "private_key_jwt" method, parsed from the JSON-encoded JWK
+        // the firewall configures, as the "oidc" access token handler parses its own keyset
+        ->set('security.oauth2.client_authentication.private_key_jwt.signing_key', JWK::class)
+            ->abstract()
+            ->factory([JWK::class, 'createFromJson'])
+            ->args([
+                abstract_arg('JSON-encoded JWK'),
             ])
 
         // the target of the routes declared for the "start_path" of each oidc_login

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/OidcLoginFactoryTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/OidcLoginFactoryTest.php
@@ -23,6 +23,11 @@ use Symfony\Component\Security\Http\OAuth2\ClientAuthentication\NoClientAuthenti
 
 class OidcLoginFactoryTest extends TestCase
 {
+    /**
+     * A JSON-encoded private JWK, the shape the "private_key_jwt" method takes its key in.
+     */
+    private const SIGNING_KEY = '{"kty":"EC","crv":"P-256","x":"0QEAsI1wGI-dmYatdUZoWSRWggLEpyzopuhwk-YUnA4","y":"KYl-qyZ26HobuYwlQh-r0iHX61thfP82qqEku7i0woo","d":"iA_TV2zvftni_9aFAQwFO_9aypfJFCSpcCyevDvz220"}';
+
     public function testBasicServiceConfiguration()
     {
         $container = new ContainerBuilder();
@@ -706,6 +711,138 @@ class OidcLoginFactoryTest extends TestCase
         $this->assertSame('my-client-secret', $clientAuthentication->getArgument(0));
     }
 
+    public function testTheClientSecretJwtMethodIsBuiltFromTheConfiguration()
+    {
+        $container = new ContainerBuilder();
+
+        $config = [
+            'provider_uri' => 'https://provider.example.com',
+            'client_id' => 'my-client-id',
+            'client_authentication' => ['client_secret_jwt' => ['secret' => 'my-client-secret', 'algorithm' => 'HS512', 'lifetime' => 30]],
+        ];
+
+        $factory = new OidcLoginFactory();
+        $factory->createAuthenticator($container, 'main', $this->processConfig($config, $factory), 'userprovider');
+
+        $clientAuthentication = $container->getDefinition('security.authenticator.oidc_login.client_authentication.main');
+        $this->assertSame('security.oauth2.client_authentication.client_secret_jwt', $clientAuthentication->getParent());
+        $this->assertSame('my-client-secret', $clientAuthentication->getArgument(0));
+        $this->assertSame('HS512', $clientAuthentication->getArgument(1));
+        $this->assertSame(30, $clientAuthentication->getArgument(2));
+    }
+
+    public function testTheClientSecretJwtMethodTakesTheSecretAlone()
+    {
+        $container = new ContainerBuilder();
+
+        $config = [
+            'provider_uri' => 'https://provider.example.com',
+            'client_id' => 'my-client-id',
+            'client_authentication' => ['client_secret_jwt' => 'my-client-secret'],
+        ];
+
+        $factory = new OidcLoginFactory();
+        $factory->createAuthenticator($container, 'main', $this->processConfig($config, $factory), 'userprovider');
+
+        $clientAuthentication = $container->getDefinition('security.authenticator.oidc_login.client_authentication.main');
+        $this->assertSame('my-client-secret', $clientAuthentication->getArgument(0));
+        $this->assertSame('HS256', $clientAuthentication->getArgument(1));
+        $this->assertSame(60, $clientAuthentication->getArgument(2));
+    }
+
+    /**
+     * The key is configured as a JSON-encoded JWK, which an environment variable can carry,
+     * and parsed by a definition of its own so that it stays a string until runtime.
+     */
+    public function testThePrivateKeyJwtMethodIsBuiltFromTheConfiguration()
+    {
+        $container = new ContainerBuilder();
+
+        $config = [
+            'provider_uri' => 'https://provider.example.com',
+            'client_id' => 'my-client-id',
+            'client_authentication' => ['private_key_jwt' => ['key' => self::SIGNING_KEY, 'algorithm' => 'ES256', 'lifetime' => 30]],
+        ];
+
+        $factory = new OidcLoginFactory();
+        $factory->createAuthenticator($container, 'main', $this->processConfig($config, $factory), 'userprovider');
+
+        $clientAuthentication = $container->getDefinition('security.authenticator.oidc_login.client_authentication.main');
+        $this->assertSame('security.oauth2.client_authentication.private_key_jwt', $clientAuthentication->getParent());
+        $this->assertSame('ES256', $clientAuthentication->getArgument(1));
+        $this->assertSame(30, $clientAuthentication->getArgument(2));
+
+        $signingKey = $clientAuthentication->getArgument(0);
+        $this->assertInstanceOf(ChildDefinition::class, $signingKey);
+        $this->assertSame('security.oauth2.client_authentication.private_key_jwt.signing_key', $signingKey->getParent());
+        $this->assertSame(self::SIGNING_KEY, $signingKey->getArgument(0));
+    }
+
+    public function testThePrivateKeyJwtMethodTakesTheKeyAlone()
+    {
+        $container = new ContainerBuilder();
+
+        $config = [
+            'provider_uri' => 'https://provider.example.com',
+            'client_id' => 'my-client-id',
+            'client_authentication' => ['private_key_jwt' => self::SIGNING_KEY],
+        ];
+
+        $factory = new OidcLoginFactory();
+        $factory->createAuthenticator($container, 'main', $this->processConfig($config, $factory), 'userprovider');
+
+        $clientAuthentication = $container->getDefinition('security.authenticator.oidc_login.client_authentication.main');
+        $this->assertSame(self::SIGNING_KEY, $clientAuthentication->getArgument(0)->getArgument(0));
+        $this->assertSame('RS256', $clientAuthentication->getArgument(1));
+        $this->assertSame(60, $clientAuthentication->getArgument(2));
+    }
+
+    /**
+     * Each assertion method takes the algorithms it can be signed with and no other, so that
+     * a shared secret never keys an asymmetric signature nor a private key a MAC.
+     */
+    #[DataProvider('provideAlgorithmsTheMethodDoesNotAllow')]
+    public function testRejectsAnAlgorithmTheAssertionMethodDoesNotAllow(array $clientAuthentication, string $message)
+    {
+        $factory = new OidcLoginFactory();
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage($message);
+
+        $this->processConfig([
+            'provider_uri' => 'https://provider.example.com',
+            'client_id' => 'my-client-id',
+            'client_authentication' => $clientAuthentication,
+        ], $factory);
+    }
+
+    public static function provideAlgorithmsTheMethodDoesNotAllow(): iterable
+    {
+        yield 'an asymmetric algorithm for client_secret_jwt' => [['client_secret_jwt' => ['secret' => 'my-client-secret', 'algorithm' => 'RS256']], 'The value "RS256" is not allowed for path "oidc-login.client_authentication.client_secret_jwt.algorithm". Permissible values: "HS256", "HS384", "HS512".'];
+        yield 'a MAC algorithm for private_key_jwt' => [['private_key_jwt' => ['key' => self::SIGNING_KEY, 'algorithm' => 'HS256']], 'The value "HS256" is not allowed for path "oidc-login.client_authentication.private_key_jwt.algorithm". Permissible values: "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512".'];
+    }
+
+    #[DataProvider('provideAssertionMethodsWithoutALifetime')]
+    public function testRejectsAnAssertionLifetimeThatIsNotPositive(array $clientAuthentication, string $message)
+    {
+        $factory = new OidcLoginFactory();
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage($message);
+
+        $this->processConfig([
+            'provider_uri' => 'https://provider.example.com',
+            'client_id' => 'my-client-id',
+            'client_authentication' => $clientAuthentication,
+        ], $factory);
+    }
+
+    public static function provideAssertionMethodsWithoutALifetime(): iterable
+    {
+        yield 'client_secret_jwt' => [['client_secret_jwt' => ['secret' => 'my-client-secret', 'lifetime' => 0]], 'The value 0 is too small for path "oidc-login.client_authentication.client_secret_jwt.lifetime". Should be greater than or equal to 1'];
+        yield 'private_key_jwt' => [['private_key_jwt' => ['key' => self::SIGNING_KEY, 'lifetime' => 0]], 'The value 0 is too small for path "oidc-login.client_authentication.private_key_jwt.lifetime". Should be greater than or equal to 1'];
+    }
+
     /**
      * Each firewall gets its own client authentication, as two of them authenticate at two
      * providers with two secrets.
@@ -803,6 +940,10 @@ class OidcLoginFactoryTest extends TestCase
 
         yield 'client_secret_basic' => [['client_secret_basic' => 'my-client-secret'], $perFirewall];
         yield 'client_secret_post' => [['client_secret_post' => 'my-client-secret'], $perFirewall];
+        yield 'client_secret_jwt' => [['client_secret_jwt' => 'my-client-secret'], $perFirewall];
+        yield 'client_secret_jwt as a mapping' => [['client_secret_jwt' => ['secret' => 'my-client-secret', 'algorithm' => 'HS384']], $perFirewall];
+        yield 'private_key_jwt' => [['private_key_jwt' => self::SIGNING_KEY], $perFirewall];
+        yield 'private_key_jwt as a mapping' => [['private_key_jwt' => ['key' => self::SIGNING_KEY, 'algorithm' => 'ES256']], $perFirewall];
         yield 'none as a mapping' => [['none' => true], 'security.oauth2.client_authentication.none'];
         yield 'none as a null mapping' => [['none' => null], 'security.oauth2.client_authentication.none'];
         yield 'none as a string' => ['none', 'security.oauth2.client_authentication.none'];

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\SecurityBundle\Tests\DependencyInjection;
 
+use Jose\Component\Core\JWK;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\AuthenticatorFactoryInterface;
@@ -50,11 +51,19 @@ use Symfony\Component\Security\Http\Authenticator\Oidc\OidcClient;
 use Symfony\Component\Security\Http\Authenticator\Oidc\OidcSignatureVerifier;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\EntryPoint\FallbackAuthenticationEntryPointInterface;
+use Symfony\Component\Security\Http\OAuth2\ClientAuthentication\ClientSecretJwt;
 use Symfony\Component\Security\Http\OAuth2\ClientAuthentication\ClientSecretPost;
 use Symfony\Component\Security\Http\OAuth2\ClientAuthentication\NoClientAuthentication;
+use Symfony\Component\Security\Http\OAuth2\ClientAuthentication\PrivateKeyJwt;
 
 class SecurityExtensionTest extends TestCase
 {
+    /**
+     * A JSON-encoded private JWK, the shape the "private_key_jwt" client authentication takes
+     * its key in.
+     */
+    private const OIDC_SIGNING_KEY = '{"kty":"EC","crv":"P-256","x":"0QEAsI1wGI-dmYatdUZoWSRWggLEpyzopuhwk-YUnA4","y":"KYl-qyZ26HobuYwlQh-r0iHX61thfP82qqEku7i0woo","d":"iA_TV2zvftni_9aFAQwFO_9aypfJFCSpcCyevDvz220"}';
+
     public function testLdapAndNonLdapVariantsOfTheSameAuthenticatorCanShareAFirewall()
     {
         $container = $this->getRawContainer();
@@ -1682,6 +1691,64 @@ class SecurityExtensionTest extends TestCase
         $client = $container->getDefinition('security.authenticator.oidc_login.client.main');
         $this->assertSame(OidcClient::class, $client->getClass());
         $this->assertSame(NoClientAuthentication::class, $container->getDefinition('security.oauth2.client_authentication.none')->getClass());
+    }
+
+    /**
+     * The assertion methods are wired end to end: the JSON-encoded key becomes a JWK built by
+     * a definition of its own, which the client authentication takes as its first argument.
+     */
+    public function testOidcLoginBuildsThePrivateKeyJwtClientAuthentication()
+    {
+        $container = $this->getRawContainer();
+        $container->loadFromExtension('security', [
+            'providers' => ['oidc' => ['oidc' => null]],
+            'firewalls' => [
+                'main' => [
+                    'oidc_login' => [
+                        'provider_uri' => 'https://provider.example.com',
+                        'client_id' => 'my-client-id',
+                        'client_authentication' => ['private_key_jwt' => ['key' => self::OIDC_SIGNING_KEY, 'algorithm' => 'ES256']],
+                    ],
+                ],
+            ],
+        ]);
+
+        $container->compile();
+
+        $clientAuthentication = $container->getDefinition('security.authenticator.oidc_login.client_authentication.main');
+        $this->assertSame(PrivateKeyJwt::class, $clientAuthentication->getClass());
+        $this->assertSame('ES256', $clientAuthentication->getArgument(1));
+        $this->assertSame(60, $clientAuthentication->getArgument(2));
+        $this->assertEquals(new Reference('clock'), $clientAuthentication->getArgument(3));
+
+        $signingKey = $clientAuthentication->getArgument(0);
+        $this->assertSame([JWK::class, 'createFromJson'], $signingKey->getFactory());
+        $this->assertSame(self::OIDC_SIGNING_KEY, $signingKey->getArgument(0));
+    }
+
+    public function testOidcLoginBuildsTheClientSecretJwtClientAuthentication()
+    {
+        $container = $this->getRawContainer();
+        $container->loadFromExtension('security', [
+            'providers' => ['oidc' => ['oidc' => null]],
+            'firewalls' => [
+                'main' => [
+                    'oidc_login' => [
+                        'provider_uri' => 'https://provider.example.com',
+                        'client_id' => 'my-client-id',
+                        'client_authentication' => ['client_secret_jwt' => 'a-client-secret-of-thirty-two-by'],
+                    ],
+                ],
+            ],
+        ]);
+
+        $container->compile();
+
+        $clientAuthentication = $container->getDefinition('security.authenticator.oidc_login.client_authentication.main');
+        $this->assertSame(ClientSecretJwt::class, $clientAuthentication->getClass());
+        $this->assertSame('a-client-secret-of-thirty-two-by', $clientAuthentication->getArgument(0));
+        $this->assertSame('HS256', $clientAuthentication->getArgument(1));
+        $this->assertSame(60, $clientAuthentication->getArgument(2));
     }
 
     public function testOidcLoginCallbackRouteLoaderIsAlwaysRegistered()

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -40,6 +40,7 @@ CHANGELOG
  * Add the `$resourceMetadataUri` argument to `AccessTokenAuthenticator`, advertised in the `resource_metadata` parameter of the `WWW-Authenticate` header (RFC 9728)
  * Widen the `$audience` argument of `OidcTokenHandler` and `OidcTokenGenerator` and the `$audiences` argument of `Oauth2TokenHandler` to take one identifier as a string or several as a list, one of which the `aud` claim must name
  * Add `FallbackAuthenticationEntryPointInterface` for an entry point that only stands in for a firewall declaring no other one, and make `AccessTokenAuthenticator` one, so that a request carrying no access token gets the RFC 6750 challenge instead of a bare 401
+ * Add `PrivateKeyJwt` and `ClientSecretJwt`, which authenticate the OAuth2 client at the token endpoint with a JWT assertion it signs itself, respectively with its private key and with its secret (RFC 7523, OIDC Core 1.0 §9)
 
 8.1
 ---

--- a/src/Symfony/Component/Security/Http/OAuth2/ClientAuthentication/AbstractClientAssertion.php
+++ b/src/Symfony/Component/Security/Http/OAuth2/ClientAuthentication/AbstractClientAssertion.php
@@ -1,0 +1,151 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\OAuth2\ClientAuthentication;
+
+use Jose\Component\Core\Algorithm;
+use Jose\Component\Core\AlgorithmManager;
+use Jose\Component\Core\JWK;
+use Jose\Component\Signature\JWSBuilder;
+use Jose\Component\Signature\Serializer\CompactSerializer;
+use Psr\Clock\ClockInterface;
+use Symfony\Component\Clock\Clock;
+
+/**
+ * Authenticates the client with a JWT it signs itself, the assertion of RFC 7523, Section 2.2.
+ *
+ * Nothing secret is then sent to the provider: the request carries a short-lived assertion
+ * naming the client as both its issuer and its subject, and the token endpoint as its
+ * audience, so that an assertion captured at one provider cannot be replayed at another.
+ * What signs it is what tells the two methods built on this apart, {@see PrivateKeyJwt}
+ * holding a key the provider only knows the public half of, {@see ClientSecretJwt} the
+ * shared secret itself.
+ *
+ * The assertion is single use: it carries a "jti" and a lifetime of a minute by default,
+ * which is what RFC 7523, Section 3, item 7 lets the provider reject a replay against.
+ *
+ * @see https://datatracker.ietf.org/doc/html/rfc7523#section-2.2                    JWT client authentication
+ * @see https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication   OIDC Core 1.0, Section 9
+ *
+ * @author Florent Morselli <florent.morselli@spomky-labs.com>
+ *
+ * @internal
+ */
+abstract class AbstractClientAssertion implements ClientAuthenticationInterface
+{
+    /**
+     * The assertion format RFC 7523, Section 2.2 registers, and the only value the
+     * "client_assertion_type" parameter takes when the assertion is a JWT.
+     */
+    public const ASSERTION_TYPE = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer';
+
+    private readonly ClockInterface $clock;
+
+    /**
+     * @param JWK       $signingKey The key the assertion is signed with
+     * @param Algorithm $algorithm  The algorithm it is signed with, which the subclass picked from
+     *                              the ones its method allows, see {@see createAlgorithm()}
+     * @param int       $lifetime   How long the assertion is valid, in seconds; it is built for one
+     *                              request and sent right away, so it is short by design
+     */
+    protected function __construct(
+        private readonly JWK $signingKey,
+        private readonly Algorithm $algorithm,
+        private readonly int $lifetime,
+        ?ClockInterface $clock,
+    ) {
+        if (0 >= $lifetime) {
+            throw new \InvalidArgumentException(\sprintf('The lifetime of an OAuth2 client assertion must be a positive number of seconds, got %d.', $lifetime));
+        }
+
+        if (null === $clock && !class_exists(Clock::class)) {
+            throw new \LogicException(\sprintf('The "symfony/clock" component is required to build "%s" without a clock. Try running "composer require symfony/clock", or pass any PSR-20 clock to the constructor.', static::class));
+        }
+
+        $this->clock = $clock ?? new Clock();
+    }
+
+    /**
+     * RFC 7523, Section 2.2: the assertion is added to the token request body next to the
+     * "client_assertion_type" naming its format, and nothing else the request already
+     * carries is touched, the "client_id" of RFC 7521, Section 4.2 among it.
+     */
+    final public function authenticate(string $clientId, string $tokenEndpoint, array $options): array
+    {
+        $options['body']['client_assertion_type'] = self::ASSERTION_TYPE;
+        $options['body']['client_assertion'] = $this->createAssertion($clientId, $tokenEndpoint);
+
+        return $options;
+    }
+
+    /**
+     * Resolves an algorithm name to the implementation of it, refusing the ones the method
+     * does not allow.
+     *
+     * The algorithm decides what the key may be, so this allowlist is what keeps a shared
+     * secret out of "private_key_jwt" and an asymmetric key out of "client_secret_jwt":
+     * either confusion turns a value one party holds into a signature the other party is
+     * supposed to be the only one able to make.
+     *
+     * @template T of Algorithm
+     *
+     * @param array<string, class-string<T>> $allowedAlgorithms The algorithms the method allows, indexed by their JWA name
+     * @param string                         $method            The RFC 7591, Section 2 name of the method, quoted in the error messages
+     *
+     * @return T
+     */
+    protected static function createAlgorithm(string $algorithm, array $allowedAlgorithms, string $method): Algorithm
+    {
+        if (!isset($allowedAlgorithms[$algorithm])) {
+            throw new \InvalidArgumentException(\sprintf('The "%s" algorithm cannot sign a "%s" client assertion. Use one of "%s".', $algorithm, $method, implode('", "', array_keys($allowedAlgorithms))));
+        }
+
+        return new $allowedAlgorithms[$algorithm]();
+    }
+
+    /**
+     * Builds the assertion of RFC 7523, Section 3.
+     *
+     * The client is both the issuer and the subject, as Section 3, items 1 and 2 require
+     * from a client authenticating itself, and the audience is the token endpoint the
+     * request is about to be made to, which OIDC Core 1.0, Section 9 recommends over the
+     * other identifier of the provider Section 3, item 3 allows.
+     *
+     * The "kid" header is set whenever the key carries one, so that a provider holding
+     * several public keys for the client knows which one verifies the signature without
+     * trying them all, as OIDC Core 1.0, Section 10.1 asks of a rotating client.
+     */
+    private function createAssertion(string $clientId, string $tokenEndpoint): string
+    {
+        $now = $this->clock->now()->getTimestamp();
+
+        $claims = [
+            'iss' => $clientId,
+            'sub' => $clientId,
+            'aud' => $tokenEndpoint,
+            'jti' => bin2hex(random_bytes(16)),
+            'iat' => $now,
+            'exp' => $now + $this->lifetime,
+        ];
+
+        $header = ['alg' => $this->algorithm->name()];
+        if ($this->signingKey->has('kid') && \is_string($kid = $this->signingKey->get('kid'))) {
+            $header['kid'] = $kid;
+        }
+
+        $jws = (new JWSBuilder(new AlgorithmManager([$this->algorithm])))
+            ->withPayload(json_encode($claims, flags: \JSON_THROW_ON_ERROR))
+            ->addSignature($this->signingKey, $header)
+            ->build();
+
+        return (new CompactSerializer())->serialize($jws, 0);
+    }
+}

--- a/src/Symfony/Component/Security/Http/OAuth2/ClientAuthentication/ClientSecretJwt.php
+++ b/src/Symfony/Component/Security/Http/OAuth2/ClientAuthentication/ClientSecretJwt.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\OAuth2\ClientAuthentication;
+
+use Jose\Component\Core\JWK;
+use Jose\Component\Signature\Algorithm\HS256;
+use Jose\Component\Signature\Algorithm\HS384;
+use Jose\Component\Signature\Algorithm\HS512;
+use Jose\Component\Signature\Algorithm\MacAlgorithm;
+use Jose\Component\Signature\JWSBuilder;
+use Psr\Clock\ClockInterface;
+
+/**
+ * Authenticates the client with an assertion signed with its secret.
+ *
+ * This is the "client_secret_jwt" method of OIDC Core 1.0, Section 9, which the same
+ * section defines as an HMAC keyed with "the octets of the UTF-8 representation of the
+ * client_secret". The secret itself never leaves the client, unlike in "client_secret_post"
+ * and "client_secret_basic", but the provider still holds it and could sign an assertion in
+ * the name of the client: prefer {@see PrivateKeyJwt}, which nobody but the client can sign.
+ *
+ * @see https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication
+ *
+ * @author Florent Morselli <florent.morselli@spomky-labs.com>
+ */
+final class ClientSecretJwt extends AbstractClientAssertion
+{
+    /**
+     * @var array<string, class-string<MacAlgorithm>>
+     */
+    private const MAC_ALGORITHMS = [
+        'HS256' => HS256::class,
+        'HS384' => HS384::class,
+        'HS512' => HS512::class,
+    ];
+
+    /**
+     * The secret is not measured here: how long a key an algorithm needs is the business of
+     * that algorithm, which RFC 7518, Section 3.2 gives at least as many bytes as the digest
+     * it produces. The algorithm is exercised once on the key instead, so that a secret it
+     * refuses fails on the service rather than on the first token request made with it.
+     *
+     * @param string          $clientSecret The secret shared with the provider, used as the HMAC key
+     * @param string          $algorithm    The JWA name of the MAC algorithm, which must be one the provider lists
+     *                                      in the "token_endpoint_auth_signing_alg_values_supported" of its metadata
+     * @param int             $lifetime     How long the assertion is valid, in seconds
+     * @param ?ClockInterface $clock        The clock the assertion is dated with
+     */
+    public function __construct(
+        #[\SensitiveParameter] string $clientSecret,
+        string $algorithm = 'HS256',
+        int $lifetime = 60,
+        ?ClockInterface $clock = null,
+    ) {
+        if (!class_exists(JWSBuilder::class)) {
+            throw new \LogicException('You cannot authenticate an OAuth2 client with the "client_secret_jwt" method since the "web-token/jwt-library" package is not installed. Try running "composer require web-token/jwt-library".');
+        }
+
+        $macAlgorithm = self::createAlgorithm($algorithm, self::MAC_ALGORITHMS, 'client_secret_jwt');
+        $signingKey = new JWK(['kty' => 'oct', 'k' => rtrim(strtr(base64_encode($clientSecret), '+/', '-_'), '=')]);
+
+        try {
+            $macAlgorithm->hash($signingKey, '');
+        } catch (\Throwable $e) {
+            throw new \InvalidArgumentException(\sprintf('The OAuth2 client secret cannot key a "client_secret_jwt" assertion signed with "%s", which rejected it: "%s" Ask the provider for a longer secret, or authenticate the client with "PrivateKeyJwt".', $algorithm, $e->getMessage()), previous: $e);
+        }
+
+        parent::__construct($signingKey, $macAlgorithm, $lifetime, $clock);
+    }
+
+    public function getMethod(): string
+    {
+        return 'client_secret_jwt';
+    }
+}

--- a/src/Symfony/Component/Security/Http/OAuth2/ClientAuthentication/PrivateKeyJwt.php
+++ b/src/Symfony/Component/Security/Http/OAuth2/ClientAuthentication/PrivateKeyJwt.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\OAuth2\ClientAuthentication;
+
+use Jose\Component\Core\JWK;
+use Jose\Component\Signature\Algorithm\ES256;
+use Jose\Component\Signature\Algorithm\ES384;
+use Jose\Component\Signature\Algorithm\ES512;
+use Jose\Component\Signature\Algorithm\PS256;
+use Jose\Component\Signature\Algorithm\PS384;
+use Jose\Component\Signature\Algorithm\PS512;
+use Jose\Component\Signature\Algorithm\RS256;
+use Jose\Component\Signature\Algorithm\RS384;
+use Jose\Component\Signature\Algorithm\RS512;
+use Jose\Component\Signature\Algorithm\SignatureAlgorithm;
+use Jose\Component\Signature\JWSBuilder;
+use Psr\Clock\ClockInterface;
+
+/**
+ * Authenticates the client with an assertion signed by its private key.
+ *
+ * This is the "private_key_jwt" method of OIDC Core 1.0, Section 9, the one FAPI 2.0 asks
+ * for: the provider only ever holds the public half of the key, registered as the client
+ * "jwks" or fetched from its "jwks_uri", so a provider that is compromised, or one the
+ * client was tricked into talking to, learns nothing it could authenticate as the client with.
+ *
+ * @see https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication
+ *
+ * @author Florent Morselli <florent.morselli@spomky-labs.com>
+ */
+final class PrivateKeyJwt extends AbstractClientAssertion
+{
+    /**
+     * The asymmetric signature algorithms {@see \Symfony\Component\Security\Http\Authenticator\Oidc\OidcSignatureVerifier}
+     * accepts on the way in. No MAC algorithm is among them, so a client secret can never be
+     * passed off as the private key this method is built on.
+     *
+     * @var array<string, class-string<SignatureAlgorithm>>
+     */
+    private const SIGNATURE_ALGORITHMS = [
+        'RS256' => RS256::class,
+        'RS384' => RS384::class,
+        'RS512' => RS512::class,
+        'ES256' => ES256::class,
+        'ES384' => ES384::class,
+        'ES512' => ES512::class,
+        'PS256' => PS256::class,
+        'PS384' => PS384::class,
+        'PS512' => PS512::class,
+    ];
+
+    /**
+     * @param JWK             $signingKey The private key of the client, whose public half is registered at the provider
+     * @param string          $algorithm  The JWA name of the signature algorithm, which must be one the provider lists
+     *                                    in the "token_endpoint_auth_signing_alg_values_supported" of its metadata
+     * @param int             $lifetime   How long the assertion is valid, in seconds
+     * @param ?ClockInterface $clock      The clock the assertion is dated with
+     */
+    public function __construct(
+        JWK $signingKey,
+        string $algorithm = 'RS256',
+        int $lifetime = 60,
+        ?ClockInterface $clock = null,
+    ) {
+        if (!class_exists(JWSBuilder::class)) {
+            throw new \LogicException('You cannot authenticate an OAuth2 client with the "private_key_jwt" method since the "web-token/jwt-library" package is not installed. Try running "composer require web-token/jwt-library".');
+        }
+
+        $signatureAlgorithm = self::createAlgorithm($algorithm, self::SIGNATURE_ALGORITHMS, 'private_key_jwt');
+
+        if (!$signingKey->has('d')) {
+            throw new \InvalidArgumentException('The "private_key_jwt" client assertion must be signed with the private key of the client, and the given JWK has no "d" parameter: it is the public key. Register that public key at the provider, and sign with the private one.');
+        }
+
+        parent::__construct($signingKey, $signatureAlgorithm, $lifetime, $clock);
+    }
+
+    public function getMethod(): string
+    {
+        return 'private_key_jwt';
+    }
+}

--- a/src/Symfony/Component/Security/Http/Tests/OAuth2/ClientAuthentication/ClientSecretJwtTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/OAuth2/ClientAuthentication/ClientSecretJwtTest.php
@@ -1,0 +1,145 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Tests\OAuth2\ClientAuthentication;
+
+use Jose\Component\Core\JWK;
+use Jose\Component\Signature\Algorithm\HS256;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Clock\MockClock;
+use Symfony\Component\Security\Http\OAuth2\ClientAuthentication\AbstractClientAssertion;
+use Symfony\Component\Security\Http\OAuth2\ClientAuthentication\ClientSecretJwt;
+
+class ClientSecretJwtTest extends TestCase
+{
+    /**
+     * 32 bytes, the shortest secret RFC 7518, Section 3.2 allows "HS256" to be keyed with.
+     */
+    private const CLIENT_SECRET = 'a-client-secret-of-thirty-two-by';
+
+    public function testSendsTheAssertionInTheBodyAndNeverTheSecretItself()
+    {
+        $options = $this->createClientAuthentication()->authenticate('test-client-id', 'https://provider.example.com/token', ['body' => [
+            'grant_type' => 'refresh_token',
+            'client_id' => 'test-client-id',
+        ]]);
+
+        $this->assertSame(AbstractClientAssertion::ASSERTION_TYPE, $options['body']['client_assertion_type']);
+        $this->assertSame('refresh_token', $options['body']['grant_type']);
+        $this->assertArrayNotHasKey('client_secret', $options['body']);
+        $this->assertArrayNotHasKey('auth_basic', $options);
+        $this->assertStringNotContainsString(self::CLIENT_SECRET, $options['body']['client_assertion']);
+    }
+
+    public function testNamesTheClientAsIssuerAndSubjectAndTheTokenEndpointAsAudience()
+    {
+        $options = $this->createClientAuthentication()->authenticate('test-client-id', 'https://provider.example.com/token', ['body' => []]);
+
+        $claims = json_decode(self::decodeBase64Url(explode('.', $options['body']['client_assertion'])[1]), true, flags: \JSON_THROW_ON_ERROR);
+
+        $this->assertSame('test-client-id', $claims['iss']);
+        $this->assertSame('test-client-id', $claims['sub']);
+        $this->assertSame('https://provider.example.com/token', $claims['aud']);
+        $this->assertNotEmpty($claims['jti']);
+        $this->assertSame(strtotime('2026-09-08 10:00:00 UTC'), $claims['iat']);
+        $this->assertSame(strtotime('2026-09-08 10:01:00 UTC'), $claims['exp']);
+    }
+
+    /**
+     * OIDC Core 1.0, Section 9: the HMAC key is the octets of the UTF-8 representation of the
+     * client secret, so the provider verifies the assertion with the secret it already holds
+     * and nothing has to be registered for this method.
+     */
+    public function testKeysTheHmacWithTheOctetsOfTheSecret()
+    {
+        $options = $this->createClientAuthentication()->authenticate('test-client-id', 'https://provider.example.com/token', ['body' => []]);
+
+        [$header, $payload, $signature] = explode('.', $options['body']['client_assertion']);
+        $key = new JWK(['kty' => 'oct', 'k' => rtrim(strtr(base64_encode(self::CLIENT_SECRET), '+/', '-_'), '=')]);
+
+        $this->assertTrue((new HS256())->verify($key, $header.'.'.$payload, self::decodeBase64Url($signature)));
+        $this->assertSame(['alg' => 'HS256'], json_decode(self::decodeBase64Url($header), true, flags: \JSON_THROW_ON_ERROR));
+    }
+
+    /**
+     * An asymmetric algorithm would make the client sign with a secret the provider also
+     * holds, which no key of that kind is meant to be.
+     */
+    public function testRejectsASignatureAlgorithm()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "RS256" algorithm cannot sign a "client_secret_jwt" client assertion. Use one of "HS256", "HS384", "HS512".');
+
+        new ClientSecretJwt(self::CLIENT_SECRET, 'RS256');
+    }
+
+    /**
+     * RFC 7518, Section 3.2: the key of an HMAC must be at least as long as the digest it
+     * produces, or the secret and not the algorithm sets the strength of the signature. The
+     * rule belongs to the algorithm, which is asked about the key when the service is built
+     * so that the secret is refused there and not on the first token request.
+     */
+    #[DataProvider('provideSecretsShorterThanTheDigest')]
+    public function testRejectsASecretTheAlgorithmRefusesToBeKeyedWith(string $algorithm, int $length)
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(\sprintf('The OAuth2 client secret cannot key a "client_secret_jwt" assertion signed with "%s", which rejected it', $algorithm));
+
+        new ClientSecretJwt(str_repeat('s', $length), $algorithm);
+    }
+
+    public static function provideSecretsShorterThanTheDigest(): iterable
+    {
+        yield 'empty' => ['HS256', 0];
+        yield 'HS256' => ['HS256', 31];
+        yield 'HS384' => ['HS384', 47];
+        yield 'HS512' => ['HS512', 63];
+    }
+
+    #[DataProvider('provideSecretsAsLongAsTheDigest')]
+    public function testAcceptsASecretAsLongAsTheDigest(string $algorithm, int $length)
+    {
+        $options = (new ClientSecretJwt(str_repeat('s', $length), $algorithm))->authenticate('test-client-id', 'https://provider.example.com/token', ['body' => []]);
+
+        $this->assertSame(['alg' => $algorithm], json_decode(self::decodeBase64Url(explode('.', $options['body']['client_assertion'])[0]), true, flags: \JSON_THROW_ON_ERROR));
+    }
+
+    public static function provideSecretsAsLongAsTheDigest(): iterable
+    {
+        yield 'HS256' => ['HS256', 32];
+        yield 'HS384' => ['HS384', 48];
+        yield 'HS512' => ['HS512', 64];
+    }
+
+    public function testRejectsALifetimeThatIsNotPositive()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The lifetime of an OAuth2 client assertion must be a positive number of seconds, got -1.');
+
+        new ClientSecretJwt(self::CLIENT_SECRET, 'HS256', -1);
+    }
+
+    public function testReportsItsMethod()
+    {
+        $this->assertSame('client_secret_jwt', $this->createClientAuthentication()->getMethod());
+    }
+
+    private function createClientAuthentication(): ClientSecretJwt
+    {
+        return new ClientSecretJwt(self::CLIENT_SECRET, 'HS256', 60, new MockClock('2026-09-08 10:00:00'));
+    }
+
+    private static function decodeBase64Url(string $value): string
+    {
+        return base64_decode(strtr($value, '-_', '+/'));
+    }
+}

--- a/src/Symfony/Component/Security/Http/Tests/OAuth2/ClientAuthentication/PrivateKeyJwtTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/OAuth2/ClientAuthentication/PrivateKeyJwtTest.php
@@ -1,0 +1,187 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Tests\OAuth2\ClientAuthentication;
+
+use Jose\Component\Core\JWK;
+use Jose\Component\Signature\Algorithm\ES256;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Clock\MockClock;
+use Symfony\Component\Security\Http\OAuth2\ClientAuthentication\AbstractClientAssertion;
+use Symfony\Component\Security\Http\OAuth2\ClientAuthentication\PrivateKeyJwt;
+
+#[RequiresPhpExtension('openssl')]
+class PrivateKeyJwtTest extends TestCase
+{
+    private const PRIVATE_JWK = [
+        'kty' => 'EC',
+        'crv' => 'P-256',
+        'x' => '0QEAsI1wGI-dmYatdUZoWSRWggLEpyzopuhwk-YUnA4',
+        'y' => 'KYl-qyZ26HobuYwlQh-r0iHX61thfP82qqEku7i0woo',
+        'd' => 'iA_TV2zvftni_9aFAQwFO_9aypfJFCSpcCyevDvz220',
+    ];
+
+    /**
+     * Another key pair entirely: an assertion signed with the key above does not verify against it.
+     */
+    private const FOREIGN_PUBLIC_JWK = [
+        'kty' => 'EC',
+        'crv' => 'P-256',
+        'x' => 'N1aUu8Pd2WdClkpCQ4QCPnGjYe_bTmDgEaSoxy5LhTw',
+        'y' => 'Yr1v-tCNxE8QgAGlartrJAi343bI8VlAaNvgCOp8Azs',
+    ];
+
+    public function testSendsTheAssertionInTheBodyAndLeavesTheRestOfItAlone()
+    {
+        $options = $this->createClientAuthentication()->authenticate('test-client-id', 'https://provider.example.com/token', ['body' => [
+            'grant_type' => 'authorization_code',
+            'client_id' => 'test-client-id',
+        ]]);
+
+        $this->assertSame('urn:ietf:params:oauth:client-assertion-type:jwt-bearer', $options['body']['client_assertion_type']);
+        $this->assertSame(AbstractClientAssertion::ASSERTION_TYPE, $options['body']['client_assertion_type']);
+        $this->assertSame('authorization_code', $options['body']['grant_type']);
+        $this->assertSame('test-client-id', $options['body']['client_id']);
+        $this->assertArrayNotHasKey('auth_basic', $options);
+    }
+
+    /**
+     * RFC 7523, Section 3: the client is both the issuer and the subject of the assertion it
+     * authenticates itself with, and the token endpoint the request goes to is the audience,
+     * so that the provider it is sent to is the only one that can use it.
+     */
+    public function testNamesTheClientAsIssuerAndSubjectAndTheTokenEndpointAsAudience()
+    {
+        $options = $this->createClientAuthentication()->authenticate('test-client-id', 'https://provider.example.com/token', ['body' => []]);
+
+        $claims = self::decodePayload($options['body']['client_assertion']);
+
+        $this->assertSame('test-client-id', $claims['iss']);
+        $this->assertSame('test-client-id', $claims['sub']);
+        $this->assertSame('https://provider.example.com/token', $claims['aud']);
+    }
+
+    public function testSignsTheAssertionWithThePrivateKeyOfTheClient()
+    {
+        $options = $this->createClientAuthentication()->authenticate('test-client-id', 'https://provider.example.com/token', ['body' => []]);
+
+        [$header, $payload, $signature] = explode('.', $options['body']['client_assertion']);
+
+        $this->assertTrue((new ES256())->verify(new JWK(self::PRIVATE_JWK), $header.'.'.$payload, self::decodeBase64Url($signature)));
+        $this->assertFalse((new ES256())->verify(new JWK(self::FOREIGN_PUBLIC_JWK), $header.'.'.$payload, self::decodeBase64Url($signature)));
+        $this->assertSame(['alg' => 'ES256'], self::decodeHeader($options['body']['client_assertion']));
+    }
+
+    /**
+     * OIDC Core 1.0, Section 10.1: a client that publishes several keys makes the provider
+     * pick the right one by naming it, and one that publishes a single unnamed key sends
+     * no "kid" at all rather than an empty one.
+     */
+    public function testSetsTheKeyIdentifierHeaderOnlyWhenTheKeyCarriesOne()
+    {
+        $named = new PrivateKeyJwt(new JWK(self::PRIVATE_JWK + ['kid' => 'client-signing-key']), 'ES256');
+        $options = $named->authenticate('test-client-id', 'https://provider.example.com/token', ['body' => []]);
+
+        $this->assertSame('client-signing-key', self::decodeHeader($options['body']['client_assertion'])['kid']);
+
+        $options = $this->createClientAuthentication()->authenticate('test-client-id', 'https://provider.example.com/token', ['body' => []]);
+
+        $this->assertArrayNotHasKey('kid', self::decodeHeader($options['body']['client_assertion']));
+    }
+
+    public function testDatesTheAssertionWithTheClockAndExpiresItAfterTheGivenLifetime()
+    {
+        $clientAuthentication = new PrivateKeyJwt(new JWK(self::PRIVATE_JWK), 'ES256', 30, new MockClock('2026-09-08 10:00:00'));
+
+        $claims = self::decodePayload($clientAuthentication->authenticate('test-client-id', 'https://provider.example.com/token', ['body' => []])['body']['client_assertion']);
+
+        $this->assertSame(strtotime('2026-09-08 10:00:00 UTC'), $claims['iat']);
+        $this->assertSame(strtotime('2026-09-08 10:00:30 UTC'), $claims['exp']);
+    }
+
+    /**
+     * RFC 7523, Section 3, item 7: the "jti" is what a provider rejects a replayed assertion
+     * on, so two assertions must never share one, not even when they are built in the same
+     * second for the same request.
+     */
+    public function testGivesEveryAssertionAnIdentifierOfItsOwn()
+    {
+        $clientAuthentication = new PrivateKeyJwt(new JWK(self::PRIVATE_JWK), 'ES256', 60, new MockClock('2026-09-08 10:00:00'));
+
+        $first = self::decodePayload($clientAuthentication->authenticate('test-client-id', 'https://provider.example.com/token', ['body' => []])['body']['client_assertion']);
+        $second = self::decodePayload($clientAuthentication->authenticate('test-client-id', 'https://provider.example.com/token', ['body' => []])['body']['client_assertion']);
+
+        $this->assertNotEmpty($first['jti']);
+        $this->assertNotSame($first['jti'], $second['jti']);
+    }
+
+    /**
+     * A MAC algorithm would turn the shared secret of the provider into a signature only the
+     * client is supposed to be able to make, which is the whole point of this method.
+     */
+    public function testRejectsAMacAlgorithm()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "HS256" algorithm cannot sign a "private_key_jwt" client assertion. Use one of "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512".');
+
+        new PrivateKeyJwt(new JWK(self::PRIVATE_JWK), 'HS256');
+    }
+
+    public function testRejectsAnUnknownAlgorithm()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "none" algorithm cannot sign a "private_key_jwt" client assertion.');
+
+        new PrivateKeyJwt(new JWK(self::PRIVATE_JWK), 'none');
+    }
+
+    public function testRejectsAPublicKey()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('the given JWK has no "d" parameter: it is the public key');
+
+        new PrivateKeyJwt(new JWK(self::FOREIGN_PUBLIC_JWK), 'ES256');
+    }
+
+    public function testRejectsALifetimeThatIsNotPositive()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The lifetime of an OAuth2 client assertion must be a positive number of seconds, got 0.');
+
+        new PrivateKeyJwt(new JWK(self::PRIVATE_JWK), 'ES256', 0);
+    }
+
+    public function testReportsItsMethod()
+    {
+        $this->assertSame('private_key_jwt', $this->createClientAuthentication()->getMethod());
+    }
+
+    private function createClientAuthentication(): PrivateKeyJwt
+    {
+        return new PrivateKeyJwt(new JWK(self::PRIVATE_JWK), 'ES256');
+    }
+
+    private static function decodeHeader(string $assertion): array
+    {
+        return json_decode(self::decodeBase64Url(explode('.', $assertion)[0]), true, flags: \JSON_THROW_ON_ERROR);
+    }
+
+    private static function decodePayload(string $assertion): array
+    {
+        return json_decode(self::decodeBase64Url(explode('.', $assertion)[1]), true, flags: \JSON_THROW_ON_ERROR);
+    }
+
+    private static function decodeBase64Url(string $value): string
+    {
+        return base64_decode(strtr($value, '-_', '+/'));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

RFC 7523, Section 2.2 and OIDC Core 1.0, Section 9 let a client authenticate at the token endpoint with a JWT it signs itself, instead of sending a secret. Symfony ships `client_secret_post`, `client_secret_basic` and `none`; the two assertion-based methods were missing, and `private_key_jwt` is what FAPI 2.0 asks for.

Since #65895 the authentication method is a dependency of `OidcClient` rather than a property of its class, so this adds two implementations of `ClientAuthenticationInterface` and configuration to reach them.

### Configuration

The `client_authentication` node gains two methods, each taking its parameter alone or a mapping:

```yaml
security:
    firewalls:
        main:
            oidc_login:
                provider_uri: 'https://provider.example.com'
                client_id: '%env(OIDC_CLIENT_ID)%'

                # the secret alone, "HS256" and 60 seconds by default
                client_authentication: { client_secret_jwt: '%env(OIDC_CLIENT_SECRET)%' }

                # or every parameter of the assertion
                client_authentication:
                    client_secret_jwt:
                        secret: '%env(OIDC_CLIENT_SECRET)%'
                        algorithm: HS256
                        lifetime: 60

                # the key alone, "RS256" and 60 seconds by default
                client_authentication: { private_key_jwt: '%env(OIDC_CLIENT_SIGNING_KEY)%' }

                # or every parameter of the assertion
                client_authentication:
                    private_key_jwt:
                        key: '%env(OIDC_CLIENT_SIGNING_KEY)%'
                        algorithm: ES256
                        lifetime: 60
```

`key` is a JSON-encoded JWK, the shape the `oidc` access token handler already takes its `keyset` in, so an environment variable carries it and a definition of its own parses it. Give it a `kid` when the client publishes several keys: the assertion then names the one that verifies its signature.

### What the assertion looks like

`AbstractClientAssertion` builds it, and the two final classes only say what signs it. Per RFC 7523, Section 3, the client is both `iss` and `sub`, and the `aud` is the token endpoint the request is about to be made to, which Section 9 recommends over the other provider identifier the RFC allows. Each assertion carries its own `jti` and expires after a minute by default, which is what Section 3, item 7 lets the provider reject a replay against.

No `typ` header is emitted. `draft-ietf-oauth-rfc7523bis` wants `client-authentication+jwt` there, but it is a draft and an unexpected `typ` gets rejected by deployed servers today.

### Which algorithms

Each method takes its own algorithms and no other, and that list is the security boundary rather than a convenience:

- `private_key_jwt` takes `RS256`/`384`/`512`, `ES256`/`384`/`512` and `PS256`/`384`/`512`, the asymmetric algorithms `OidcSignatureVerifier` accepts on the way in. No MAC algorithm is among them, so a client secret cannot be passed off as the private key the method is built on. It also refuses a JWK carrying no `d`, which is a public key.
- `client_secret_jwt` takes `HS256`/`384`/`512` and nothing else, so an asymmetric key cannot end up where a shared secret belongs.

How long a key an algorithm needs is left to the algorithm: `HS256` and its siblings refuse a key shorter than the digest they produce, on both major versions of `web-token/jwt-library` the component supports. The key is submitted to the algorithm once in the constructor, so a secret it refuses fails when the service is built rather than on the first token request.

### Documentation points

- `client_authentication` gains `client_secret_jwt` and `private_key_jwt`, each taking its parameter alone or a mapping that also sets `algorithm` and `lifetime`
- `client_secret_jwt` takes the client secret and signs with `HS256` (the default), `HS384` or `HS512`; `private_key_jwt` takes a JSON-encoded JWK of the private key and signs with `RS256` (the default), `RS384`, `RS512`, `ES256`, `ES384`, `ES512`, `PS256`, `PS384` or `PS512`
- the algorithm must be one the provider announces in `token_endpoint_auth_signing_alg_values_supported`, and the method one it announces in `token_endpoint_auth_methods_supported`
- give the JWK a `kid` when the client publishes several keys: the assertion then names the one that verifies its signature
- `lifetime` defaults to 60 seconds, and is the window in which a provider that does not track the `jti` would accept a captured assertion
- prefer `private_key_jwt`: with `client_secret_jwt` the provider holds the secret too and could sign an assertion in the name of the client
- a secret shorter than the digest is refused when the service is built, and a JWK carrying no `d` is refused as a public key

