### PR TITLE
[Messenger] Add DispatchOnFailureStamp to dispatch a message when another one fails

### DIFF
--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -20,6 +20,8 @@ CHANGELOG
  * Make the `messenger:consume` and `messenger:failed:retry` commands exit immediately when a second `SIGINT` is received
  * Add `ChainStamp` and `ChainMiddleware` to dispatch a sequence of messages one after another, each one once the previous one is handled
  * Add `chain` to the default bus middleware, between `send_message` and `handle_message`
+ * Add `DispatchOnFailureStamp`, `FailedMessageStamp`, `DispatchOnFailureMiddleware` and `DispatchOnFailureListener` to dispatch a message when another one fails for good
+ * Add `dispatch_on_failure` to the default bus middleware, after `failed_message_processing_middleware`
 
 8.1
 ---

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -18,6 +18,8 @@ CHANGELOG
  * Add an optional `LoggingMiddleware` logging the processing time and memory usage of each message
  * Add the `messenger:show` command to list and inspect pending messages of a transport
  * Make the `messenger:consume` and `messenger:failed:retry` commands exit immediately when a second `SIGINT` is received
+ * Add `ChainStamp` and `ChainMiddleware` to dispatch a sequence of messages one after another, each one once the previous one is handled
+ * Add `chain` to the default bus middleware, between `send_message` and `handle_message`
 
 8.1
 ---

--- a/src/Symfony/Component/Messenger/DispatchOnFailureTrait.php
+++ b/src/Symfony/Component/Messenger/DispatchOnFailureTrait.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Messenger\Stamp\BusNameStamp;
+use Symfony\Component\Messenger\Stamp\DispatchOnFailureStamp;
+use Symfony\Component\Messenger\Stamp\ErrorDetailsStamp;
+use Symfony\Component\Messenger\Stamp\FailedMessageStamp;
+
+/**
+ * @internal
+ */
+trait DispatchOnFailureTrait
+{
+    private MessageBusInterface $bus;
+    private ?LoggerInterface $logger;
+
+    /**
+     * Dispatches the message named by the DispatchOnFailureStamp of a failed envelope.
+     *
+     * The failure message gets the message that failed, the error details recorded
+     * on the failed envelope, or created from the throwable when there are none,
+     * and the bus name of the failed envelope unless it names its own bus.
+     *
+     * A failure to dispatch it is logged and swallowed: it must not replace the
+     * original failure, nor stop what the caller does next about it.
+     */
+    private function dispatchFailureMessage(Envelope $failedEnvelope, ?\Throwable $throwable): void
+    {
+        $envelope = Envelope::wrap($failedEnvelope->last(DispatchOnFailureStamp::class)->getMessage(), [new FailedMessageStamp($failedEnvelope->getMessage())]);
+
+        if (null !== $errorDetailsStamp = $failedEnvelope->last(ErrorDetailsStamp::class)) {
+            $envelope = $envelope->with($errorDetailsStamp);
+        } elseif (null !== $throwable) {
+            $envelope = $envelope->with(ErrorDetailsStamp::create($throwable));
+        }
+
+        if (null === $envelope->last(BusNameStamp::class) && null !== $busNameStamp = $failedEnvelope->last(BusNameStamp::class)) {
+            $envelope = $envelope->with($busNameStamp);
+        }
+
+        try {
+            $this->bus->dispatch($envelope);
+        } catch (\Throwable $e) {
+            $this->logger?->error('Failed dispatching {failure_class} after message {class} failed.', [
+                'class' => $failedEnvelope->getMessage()::class,
+                'failure_class' => $envelope->getMessage()::class,
+                'exception' => $e,
+            ]);
+        }
+    }
+}

--- a/src/Symfony/Component/Messenger/EventListener/DispatchOnFailureListener.php
+++ b/src/Symfony/Component/Messenger/EventListener/DispatchOnFailureListener.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\EventListener;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Messenger\DispatchOnFailureTrait;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\DispatchOnFailureStamp;
+
+/**
+ * Dispatches the failure message of a message that a worker gives up on.
+ *
+ * It runs after the retry listener decided whether the message is retried,
+ * and before the message is sent to a failure transport.
+ */
+final class DispatchOnFailureListener implements EventSubscriberInterface
+{
+    use DispatchOnFailureTrait;
+
+    public function __construct(
+        private MessageBusInterface $bus,
+        private ?LoggerInterface $logger = null,
+    ) {
+    }
+
+    public function onMessageFailed(WorkerMessageFailedEvent $event): void
+    {
+        if ($event->willRetry()) {
+            return;
+        }
+
+        $envelope = $event->getEnvelope();
+
+        if (null === $stamp = $envelope->last(DispatchOnFailureStamp::class)) {
+            return;
+        }
+
+        $this->logger?->info('Dispatching {failure_class} because message {class} failed.', [
+            'class' => $envelope->getMessage()::class,
+            'failure_class' => Envelope::wrap($stamp->getMessage())->getMessage()::class,
+        ]);
+
+        $this->dispatchFailureMessage($envelope, $event->getThrowable());
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            WorkerMessageFailedEvent::class => ['onMessageFailed', 0],
+        ];
+    }
+}

--- a/src/Symfony/Component/Messenger/MessengerBundle.php
+++ b/src/Symfony/Component/Messenger/MessengerBundle.php
@@ -362,6 +362,7 @@ class MessengerBundle extends AbstractBundle
                 ['id' => 'dispatch_after_current_bus'],
                 ['id' => 'decode_failed_message_middleware'],
                 ['id' => 'failed_message_processing_middleware'],
+                ['id' => 'dispatch_on_failure'],
             ],
             'after' => [
                 ['id' => 'send_message'],

--- a/src/Symfony/Component/Messenger/MessengerBundle.php
+++ b/src/Symfony/Component/Messenger/MessengerBundle.php
@@ -365,6 +365,7 @@ class MessengerBundle extends AbstractBundle
             ],
             'after' => [
                 ['id' => 'send_message'],
+                ['id' => 'chain'],
                 ['id' => 'handle_message'],
             ],
         ];
@@ -379,7 +380,7 @@ class MessengerBundle extends AbstractBundle
 
             if ($bus['default_middleware']['enabled']) {
                 $defaultMiddleware['after'][0]['arguments'] = [$bus['default_middleware']['allow_no_senders']];
-                $defaultMiddleware['after'][1]['arguments'] = ['index_1' => $bus['default_middleware']['allow_no_handlers']];
+                $defaultMiddleware['after'][2]['arguments'] = ['index_1' => $bus['default_middleware']['allow_no_handlers']];
 
                 $middleware = array_merge($defaultMiddleware['before'], $middleware, $defaultMiddleware['after']);
             }

--- a/src/Symfony/Component/Messenger/Middleware/ChainMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/ChainMiddleware.php
@@ -17,6 +17,7 @@ use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Messenger\Stamp\BusNameStamp;
 use Symfony\Component\Messenger\Stamp\ChainStamp;
 use Symfony\Component\Messenger\Stamp\DispatchAfterCurrentBusStamp;
+use Symfony\Component\Messenger\Stamp\DispatchOnFailureStamp;
 use Symfony\Component\Messenger\Stamp\NoAutoAckStamp;
 use Symfony\Component\Messenger\Stamp\ReceivedStamp;
 use Symfony\Component\Messenger\Stamp\SentStamp;
@@ -79,6 +80,10 @@ final class ChainMiddleware implements MiddlewareInterface
 
         if (null === $next->last(BusNameStamp::class) && null !== $busNameStamp = $envelope->last(BusNameStamp::class)) {
             $next = $next->with($busNameStamp);
+        }
+
+        if (null === $next->last(DispatchOnFailureStamp::class) && null !== $failureStamp = $envelope->last(DispatchOnFailureStamp::class)) {
+            $next = $next->with($failureStamp);
         }
 
         $this->bus->dispatch($next);

--- a/src/Symfony/Component/Messenger/Middleware/ChainMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/ChainMiddleware.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Middleware;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\LogicException;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\BusNameStamp;
+use Symfony\Component\Messenger\Stamp\ChainStamp;
+use Symfony\Component\Messenger\Stamp\DispatchAfterCurrentBusStamp;
+use Symfony\Component\Messenger\Stamp\NoAutoAckStamp;
+use Symfony\Component\Messenger\Stamp\ReceivedStamp;
+use Symfony\Component\Messenger\Stamp\SentStamp;
+
+/**
+ * Dispatches the next message of a ChainStamp once the current message is handled.
+ *
+ * The next message is dispatched with a DispatchAfterCurrentBusStamp: it is
+ * handled after the current message, outside a transaction opened for it,
+ * and in a worker, after the handlers of the current message returned.
+ * The remaining messages travel with it in a new ChainStamp, so a chain
+ * continues from where it stopped when a failed step is retried.
+ *
+ * When an envelope carries several ChainStamps, their messages form one
+ * sequence, in stamp order.
+ *
+ * A message sent to a transport starts its next step where it is handled,
+ * whatever the position of this middleware in the stack.
+ *
+ * The chain stamps leave the returned envelope once the next step is dispatched,
+ * so a stack that reaches this middleware twice for the same message, as a
+ * synchronous transport does, starts that step once.
+ *
+ * A message handled by a batch handler cannot open a chain: the batch decides
+ * when it processes the message, which is after the handler returned.
+ */
+final class ChainMiddleware implements MiddlewareInterface
+{
+    public function __construct(
+        private MessageBusInterface $bus,
+    ) {
+    }
+
+    public function handle(Envelope $envelope, StackInterface $stack): Envelope
+    {
+        $envelope = $stack->next()->handle($envelope, $stack);
+
+        $messages = [];
+        foreach ($envelope->all(ChainStamp::class) as $stamp) {
+            $messages = [...$messages, ...$stamp->getMessages()];
+        }
+
+        if (!$messages) {
+            return $envelope;
+        }
+
+        if ($envelope->last(SentStamp::class) && !$envelope->last(ReceivedStamp::class)) {
+            return $envelope;
+        }
+
+        if ($noAutoAckStamp = $envelope->last(NoAutoAckStamp::class)) {
+            throw new LogicException(\sprintf('A message handled by the batch handler "%s" cannot carry a "%s".', $noAutoAckStamp->getHandlerDescriptor()->getName(), ChainStamp::class));
+        }
+
+        $next = Envelope::wrap(array_shift($messages), [new DispatchAfterCurrentBusStamp()]);
+
+        if ($messages) {
+            $next = $next->with(new ChainStamp(...$messages));
+        }
+
+        if (null === $next->last(BusNameStamp::class) && null !== $busNameStamp = $envelope->last(BusNameStamp::class)) {
+            $next = $next->with($busNameStamp);
+        }
+
+        $this->bus->dispatch($next);
+
+        return $envelope->withoutAll(ChainStamp::class);
+    }
+}

--- a/src/Symfony/Component/Messenger/Middleware/DispatchOnFailureMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/DispatchOnFailureMiddleware.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Middleware;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Messenger\DispatchOnFailureTrait;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\DispatchOnFailureStamp;
+use Symfony\Component\Messenger\Stamp\ReceivedStamp;
+use Symfony\Component\Messenger\Stamp\SentToFailureTransportStamp;
+
+/**
+ * Dispatches the failure message of a message that fails while it is handled synchronously.
+ *
+ * A message received from a transport is skipped: the worker decides when it
+ * fails for good, and the DispatchOnFailureListener dispatches the failure
+ * message then. A message that a synchronous transport sent to a failure
+ * transport instead of throwing comes back with a SentToFailureTransportStamp,
+ * which counts as a failure too.
+ *
+ * This middleware should run before the middleware that opens a transaction,
+ * so that the failure message is dispatched once the transaction was rolled back.
+ */
+final class DispatchOnFailureMiddleware implements MiddlewareInterface
+{
+    use DispatchOnFailureTrait;
+
+    public function __construct(
+        private MessageBusInterface $bus,
+        private ?LoggerInterface $logger = null,
+    ) {
+    }
+
+    public function handle(Envelope $envelope, StackInterface $stack): Envelope
+    {
+        if (null !== $envelope->last(ReceivedStamp::class) || null === $envelope->last(DispatchOnFailureStamp::class)) {
+            return $stack->next()->handle($envelope, $stack);
+        }
+
+        try {
+            $result = $stack->next()->handle($envelope, $stack);
+        } catch (\Throwable $e) {
+            $this->dispatchFailureMessage($envelope, $e);
+
+            throw $e;
+        }
+
+        if (null !== ($stamp = $result->last(SentToFailureTransportStamp::class)) && $stamp !== $envelope->last(SentToFailureTransportStamp::class)) {
+            $this->dispatchFailureMessage($result, null);
+        }
+
+        return $result;
+    }
+}

--- a/src/Symfony/Component/Messenger/Resources/config/messenger.php
+++ b/src/Symfony/Component/Messenger/Resources/config/messenger.php
@@ -31,6 +31,7 @@ use Symfony\Component\Messenger\EventListener\StopWorkerOnRestartSignalListener;
 use Symfony\Component\Messenger\Handler\RedispatchMessageHandler;
 use Symfony\Component\Messenger\Middleware\AddBusNameStampMiddleware;
 use Symfony\Component\Messenger\Middleware\AddDefaultStampsMiddleware;
+use Symfony\Component\Messenger\Middleware\ChainMiddleware;
 use Symfony\Component\Messenger\Middleware\DecodeFailedMessageMiddleware;
 use Symfony\Component\Messenger\Middleware\DeduplicateMiddleware;
 use Symfony\Component\Messenger\Middleware\DispatchAfterCurrentBusMiddleware;
@@ -130,6 +131,11 @@ return static function (ContainerConfigurator $container) {
             ->abstract()
 
         ->set('messenger.middleware.dispatch_after_current_bus', DispatchAfterCurrentBusMiddleware::class)
+
+        ->set('messenger.middleware.chain', ChainMiddleware::class)
+            ->args([
+                service('messenger.routable_message_bus'),
+            ])
 
         ->set('messenger.middleware.validation', ValidationMiddleware::class)
             ->args([

--- a/src/Symfony/Component/Messenger/Resources/config/messenger.php
+++ b/src/Symfony/Component/Messenger/Resources/config/messenger.php
@@ -20,6 +20,7 @@ use Symfony\Component\Messenger\Bridge\Beanstalkd\Transport\BeanstalkdTransportF
 use Symfony\Component\Messenger\Bridge\MongoDb\Transport\MongoDbTransportFactory;
 use Symfony\Component\Messenger\Bridge\Redis\Transport\RedisTransportFactory;
 use Symfony\Component\Messenger\EventListener\AddErrorDetailsStampListener;
+use Symfony\Component\Messenger\EventListener\DispatchOnFailureListener;
 use Symfony\Component\Messenger\EventListener\DispatchPcntlSignalListener;
 use Symfony\Component\Messenger\EventListener\ReleaseDeduplicationLockOnFailureListener;
 use Symfony\Component\Messenger\EventListener\ResetMemoryUsageListener;
@@ -35,6 +36,7 @@ use Symfony\Component\Messenger\Middleware\ChainMiddleware;
 use Symfony\Component\Messenger\Middleware\DecodeFailedMessageMiddleware;
 use Symfony\Component\Messenger\Middleware\DeduplicateMiddleware;
 use Symfony\Component\Messenger\Middleware\DispatchAfterCurrentBusMiddleware;
+use Symfony\Component\Messenger\Middleware\DispatchOnFailureMiddleware;
 use Symfony\Component\Messenger\Middleware\FailedMessageProcessingMiddleware;
 use Symfony\Component\Messenger\Middleware\HandleMessageMiddleware;
 use Symfony\Component\Messenger\Middleware\LoggingMiddleware;
@@ -136,6 +138,13 @@ return static function (ContainerConfigurator $container) {
             ->args([
                 service('messenger.routable_message_bus'),
             ])
+
+        ->set('messenger.middleware.dispatch_on_failure', DispatchOnFailureMiddleware::class)
+            ->args([
+                service('messenger.routable_message_bus'),
+                service('logger')->ignoreOnInvalid(),
+            ])
+            ->tag('monolog.logger', ['channel' => 'messenger'])
 
         ->set('messenger.middleware.validation', ValidationMiddleware::class)
             ->args([
@@ -264,6 +273,14 @@ return static function (ContainerConfigurator $container) {
                 abstract_arg('failure transports'),
                 service('logger')->ignoreOnInvalid(),
                 abstract_arg('failure transports by name'),
+            ])
+            ->tag('kernel.event_subscriber')
+            ->tag('monolog.logger', ['channel' => 'messenger'])
+
+        ->set('messenger.failure.dispatch_on_failure_listener', DispatchOnFailureListener::class)
+            ->args([
+                service('messenger.routable_message_bus'),
+                service('logger')->ignoreOnInvalid(),
             ])
             ->tag('kernel.event_subscriber')
             ->tag('monolog.logger', ['channel' => 'messenger'])

--- a/src/Symfony/Component/Messenger/Stamp/ChainStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/ChainStamp.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Stamp;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\InvalidArgumentException;
+use Symfony\Component\Messenger\Middleware\ChainMiddleware;
+
+/**
+ * Lists the messages to dispatch one after another once the current message is handled.
+ *
+ * @see ChainMiddleware
+ */
+final class ChainStamp implements StampInterface
+{
+    /**
+     * @var list<object|Envelope>
+     */
+    private array $messages = [];
+
+    /**
+     * @param object|Envelope ...$messages The messages, or messages pre-wrapped in envelopes, in handling order
+     */
+    public function __construct(object ...$messages)
+    {
+        if (!$messages) {
+            throw new InvalidArgumentException('A chain needs at least one message.');
+        }
+
+        foreach ($messages as $message) {
+            // the chain travels inside another envelope, which does not strip these stamps for it
+            $this->messages[] = $message instanceof Envelope ? $message->withoutStampsOfType(NonSendableStampInterface::class) : $message;
+        }
+    }
+
+    /**
+     * @return list<object|Envelope>
+     */
+    public function getMessages(): array
+    {
+        return $this->messages;
+    }
+}

--- a/src/Symfony/Component/Messenger/Stamp/DispatchOnFailureStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/DispatchOnFailureStamp.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Stamp;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\EventListener\DispatchOnFailureListener;
+use Symfony\Component\Messenger\Middleware\DispatchOnFailureMiddleware;
+
+/**
+ * Names the message to dispatch when the current message fails for good.
+ *
+ * The failure message is dispatched with a FailedMessageStamp holding the
+ * message that failed, and an ErrorDetailsStamp describing the error.
+ *
+ * @see DispatchOnFailureListener
+ * @see DispatchOnFailureMiddleware
+ */
+final class DispatchOnFailureStamp implements StampInterface
+{
+    /**
+     * @param object|Envelope $message The message, or a message pre-wrapped in an envelope
+     */
+    public function __construct(
+        private object $message,
+    ) {
+    }
+
+    /**
+     * @return object|Envelope
+     */
+    public function getMessage(): object
+    {
+        return $this->message;
+    }
+}

--- a/src/Symfony/Component/Messenger/Stamp/FailedMessageStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/FailedMessageStamp.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Stamp;
+
+/**
+ * Holds the message whose failure caused the current message to be dispatched.
+ *
+ * @see DispatchOnFailureStamp
+ */
+final class FailedMessageStamp implements StampInterface
+{
+    public function __construct(
+        private object $message,
+    ) {
+    }
+
+    public function getMessage(): object
+    {
+        return $this->message;
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/ChainIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Tests/ChainIntegrationTest.php
@@ -1,0 +1,158 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Messenger\EventListener\StopWorkerOnMessageLimitListener;
+use Symfony\Component\Messenger\Exception\DelayedMessageHandlingException;
+use Symfony\Component\Messenger\Exception\HandlerFailedException;
+use Symfony\Component\Messenger\Handler\HandlersLocator;
+use Symfony\Component\Messenger\MessageBus;
+use Symfony\Component\Messenger\Middleware\AddBusNameStampMiddleware;
+use Symfony\Component\Messenger\Middleware\ChainMiddleware;
+use Symfony\Component\Messenger\Middleware\DispatchAfterCurrentBusMiddleware;
+use Symfony\Component\Messenger\Middleware\HandleMessageMiddleware;
+use Symfony\Component\Messenger\Middleware\SendMessageMiddleware;
+use Symfony\Component\Messenger\RoutableMessageBus;
+use Symfony\Component\Messenger\Stamp\ChainStamp;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Messenger\Tests\Fixtures\SecondMessage;
+use Symfony\Component\Messenger\Tests\Fixtures\ThirdMessage;
+use Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport;
+use Symfony\Component\Messenger\Transport\Sender\SendersLocator;
+use Symfony\Component\Messenger\Worker;
+
+class ChainIntegrationTest extends TestCase
+{
+    private array $handled = [];
+    private InMemoryTransport $transport;
+
+    protected function setUp(): void
+    {
+        $this->handled = [];
+        $this->transport = new InMemoryTransport();
+    }
+
+    public function testSynchronousChainIsHandledInOrderWithinTheDispatchCall()
+    {
+        $bus = $this->createBus();
+
+        $bus->dispatch($first = new DummyMessage('first'), [new ChainStamp($second = new SecondMessage(), $third = new ThirdMessage())]);
+
+        $this->assertSame([$first, $second, $third], $this->handled);
+        $this->assertSame([], $this->transport->getSent());
+    }
+
+    public function testChainContinuesAfterAnAsynchronousStep()
+    {
+        $bus = $this->createBus(routing: [SecondMessage::class => ['async']]);
+
+        $bus->dispatch($first = new DummyMessage('first'), [new ChainStamp($second = new SecondMessage(), $third = new ThirdMessage())]);
+
+        $this->assertSame([$first], $this->handled);
+        $this->assertCount(1, $sent = $this->transport->getSent());
+        $this->assertSame($second, $sent[0]->getMessage());
+        $this->assertSame([$third], $sent[0]->last(ChainStamp::class)->getMessages());
+
+        $this->runWorker($bus);
+
+        $this->assertSame([$first, $second, $third], $this->handled);
+        $this->assertCount(1, $this->transport->getAcknowledged());
+        $this->assertSame([], $this->transport->get());
+    }
+
+    public function testNothingIsDispatchedWhenTheFirstStepFails()
+    {
+        $bus = $this->createBus([DummyMessage::class], [SecondMessage::class => ['async']]);
+
+        try {
+            $bus->dispatch(new DummyMessage('first'), [new ChainStamp(new SecondMessage(), new ThirdMessage())]);
+            $this->fail('The failure of the first step should have been reported.');
+        } catch (HandlerFailedException) {
+        }
+
+        $this->assertSame([], $this->handled);
+        $this->assertSame([], $this->transport->getSent());
+    }
+
+    public function testChainStopsWhenASynchronousStepFails()
+    {
+        $bus = $this->createBus([SecondMessage::class]);
+
+        try {
+            $bus->dispatch($first = new DummyMessage('first'), [new ChainStamp(new SecondMessage(), new ThirdMessage())]);
+            $this->fail('The failure of the second step should have been reported.');
+        } catch (DelayedMessageHandlingException $e) {
+            $this->assertInstanceOf(HandlerFailedException::class, $e->getPrevious());
+        }
+
+        $this->assertSame([$first], $this->handled);
+    }
+
+    public function testAsynchronousStepFailsWhenTheNextSynchronousStepFails()
+    {
+        $bus = $this->createBus([ThirdMessage::class], [SecondMessage::class => ['async']]);
+
+        $bus->dispatch($first = new DummyMessage('first'), [new ChainStamp($second = new SecondMessage(), new ThirdMessage())]);
+        $this->runWorker($bus);
+
+        $this->assertSame([$first, $second], $this->handled);
+        $this->assertSame([], $this->transport->getAcknowledged());
+        $this->assertCount(1, $rejected = $this->transport->getRejected());
+        $this->assertSame($second, $rejected[0]->getMessage());
+    }
+
+    /**
+     * @param class-string[]                    $failing The messages whose handler throws
+     * @param array<class-string, list<string>> $routing The messages sent to the "async" transport
+     */
+    private function createBus(array $failing = [], array $routing = []): MessageBus
+    {
+        $handler = function (object $message) use ($failing): void {
+            if (\in_array($message::class, $failing, true)) {
+                throw new \RuntimeException(\sprintf('Handling "%s" failed.', $message::class));
+            }
+
+            $this->handled[] = $message;
+        };
+        $handlersLocator = new HandlersLocator([
+            DummyMessage::class => [$handler],
+            SecondMessage::class => [$handler],
+            ThirdMessage::class => [$handler],
+        ]);
+
+        $senders = new Container();
+        $senders->set('async', $this->transport);
+
+        $buses = new Container();
+        $bus = new MessageBus([
+            new AddBusNameStampMiddleware('the_bus'),
+            new DispatchAfterCurrentBusMiddleware(),
+            new SendMessageMiddleware(new SendersLocator($routing, $senders)),
+            new ChainMiddleware(new RoutableMessageBus($buses)),
+            new HandleMessageMiddleware($handlersLocator),
+        ]);
+        $buses->set('the_bus', $bus);
+
+        return $bus;
+    }
+
+    private function runWorker(MessageBus $bus): void
+    {
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addSubscriber(new StopWorkerOnMessageLimitListener(1));
+
+        (new Worker(['async' => $this->transport], $bus, $dispatcher))->run();
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerBundleExtensionTest.php
+++ b/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerBundleExtensionTest.php
@@ -132,6 +132,16 @@ class MessengerBundleExtensionTest extends TestCase
         );
     }
 
+    public function testMessengerChainMiddleware()
+    {
+        $container = $this->createContainerFromFile('messenger', false);
+        $container->addCompilerPass(new MessengerPass());
+        $container->compile();
+
+        $this->assertSame('messenger.routable_message_bus', (string) $container->getDefinition('messenger.middleware.chain')->getArgument(0));
+        $this->assertContains('messenger.middleware.chain', $this->getBusMiddlewareIds($container, 'messenger.bus.default'));
+    }
+
     public function testMessengerRejectRedeliveredMessagesEnabledByDefault()
     {
         $container = $this->createContainerFromFile('messenger', false);
@@ -465,6 +475,7 @@ class MessengerBundleExtensionTest extends TestCase
             ['id' => 'failed_message_processing_middleware'],
             ['id' => 'deduplicate_middleware'],
             ['id' => 'send_message', 'arguments' => [true]],
+            ['id' => 'chain'],
             ['id' => 'handle_message', 'arguments' => ['index_1' => false]],
         ], $container->getParameter('messenger.bus.events.middleware'));
     }
@@ -484,6 +495,7 @@ class MessengerBundleExtensionTest extends TestCase
             ['id' => 'failed_message_processing_middleware'],
             ['id' => 'deduplicate_middleware'],
             ['id' => 'send_message', 'arguments' => [true]],
+            ['id' => 'chain'],
             ['id' => 'handle_message', 'arguments' => ['index_1' => false]],
         ], $container->getParameter('messenger.bus.commands.middleware'));
         $this->assertTrue($container->has('messenger.bus.events'));
@@ -498,6 +510,7 @@ class MessengerBundleExtensionTest extends TestCase
             ['id' => 'deduplicate_middleware'],
             ['id' => 'with_factory', 'arguments' => ['foo', true, ['bar' => 'baz']]],
             ['id' => 'send_message', 'arguments' => [true]],
+            ['id' => 'chain'],
             ['id' => 'handle_message', 'arguments' => ['index_1' => false]],
         ], $container->getParameter('messenger.bus.events.middleware'));
         $this->assertTrue($container->has('messenger.bus.queries'));

--- a/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerBundleExtensionTest.php
+++ b/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerBundleExtensionTest.php
@@ -22,6 +22,7 @@ use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\ResolveChildDefinitionsPass;
 use Symfony\Component\DependencyInjection\Compiler\ResolveTaggedIteratorArgumentPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Loader\ClosureLoader;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\DependencyInjection\ParameterBag\EnvPlaceholderParameterBag;
@@ -140,6 +141,23 @@ class MessengerBundleExtensionTest extends TestCase
 
         $this->assertSame('messenger.routable_message_bus', (string) $container->getDefinition('messenger.middleware.chain')->getArgument(0));
         $this->assertContains('messenger.middleware.chain', $this->getBusMiddlewareIds($container, 'messenger.bus.default'));
+    }
+
+    public function testMessengerDispatchOnFailure()
+    {
+        $container = $this->createContainerFromFile('messenger', false);
+        $container->addCompilerPass(new MessengerPass());
+        $container->compile();
+
+        $middleware = $container->getDefinition('messenger.middleware.dispatch_on_failure');
+        $this->assertSame('messenger.routable_message_bus', (string) $middleware->getArgument(0));
+        $this->assertEquals(new Reference('logger', ContainerInterface::IGNORE_ON_INVALID_REFERENCE), $middleware->getArgument(1));
+        $this->assertContains('messenger.middleware.dispatch_on_failure', $this->getBusMiddlewareIds($container, 'messenger.bus.default'));
+
+        $listener = $container->getDefinition('messenger.failure.dispatch_on_failure_listener');
+        $this->assertEquals(new Reference('messenger.routable_message_bus'), $listener->getArgument(0));
+        $this->assertEquals(new Reference('logger', ContainerInterface::IGNORE_ON_INVALID_REFERENCE), $listener->getArgument(1));
+        $this->assertTrue($listener->hasTag('kernel.event_subscriber'));
     }
 
     public function testMessengerRejectRedeliveredMessagesEnabledByDefault()
@@ -473,6 +491,7 @@ class MessengerBundleExtensionTest extends TestCase
             ['id' => 'dispatch_after_current_bus'],
             ['id' => 'decode_failed_message_middleware'],
             ['id' => 'failed_message_processing_middleware'],
+            ['id' => 'dispatch_on_failure'],
             ['id' => 'deduplicate_middleware'],
             ['id' => 'send_message', 'arguments' => [true]],
             ['id' => 'chain'],
@@ -493,6 +512,7 @@ class MessengerBundleExtensionTest extends TestCase
             ['id' => 'dispatch_after_current_bus'],
             ['id' => 'decode_failed_message_middleware'],
             ['id' => 'failed_message_processing_middleware'],
+            ['id' => 'dispatch_on_failure'],
             ['id' => 'deduplicate_middleware'],
             ['id' => 'send_message', 'arguments' => [true]],
             ['id' => 'chain'],
@@ -507,6 +527,7 @@ class MessengerBundleExtensionTest extends TestCase
             ['id' => 'dispatch_after_current_bus'],
             ['id' => 'decode_failed_message_middleware'],
             ['id' => 'failed_message_processing_middleware'],
+            ['id' => 'dispatch_on_failure'],
             ['id' => 'deduplicate_middleware'],
             ['id' => 'with_factory', 'arguments' => ['foo', true, ['bar' => 'baz']]],
             ['id' => 'send_message', 'arguments' => [true]],

--- a/src/Symfony/Component/Messenger/Tests/DispatchOnFailureIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Tests/DispatchOnFailureIntegrationTest.php
@@ -1,0 +1,199 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\EventListener\DispatchOnFailureListener;
+use Symfony\Component\Messenger\EventListener\StopWorkerOnMessageLimitListener;
+use Symfony\Component\Messenger\Exception\DelayedMessageHandlingException;
+use Symfony\Component\Messenger\Exception\HandlerFailedException;
+use Symfony\Component\Messenger\Handler\HandlersLocator;
+use Symfony\Component\Messenger\MessageBus;
+use Symfony\Component\Messenger\Middleware\AddBusNameStampMiddleware;
+use Symfony\Component\Messenger\Middleware\ChainMiddleware;
+use Symfony\Component\Messenger\Middleware\DispatchAfterCurrentBusMiddleware;
+use Symfony\Component\Messenger\Middleware\DispatchOnFailureMiddleware;
+use Symfony\Component\Messenger\Middleware\HandleMessageMiddleware;
+use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
+use Symfony\Component\Messenger\Middleware\SendMessageMiddleware;
+use Symfony\Component\Messenger\Middleware\StackInterface;
+use Symfony\Component\Messenger\RoutableMessageBus;
+use Symfony\Component\Messenger\Stamp\ChainStamp;
+use Symfony\Component\Messenger\Stamp\DispatchOnFailureStamp;
+use Symfony\Component\Messenger\Stamp\ErrorDetailsStamp;
+use Symfony\Component\Messenger\Stamp\FailedMessageStamp;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Messenger\Tests\Fixtures\SecondMessage;
+use Symfony\Component\Messenger\Tests\Fixtures\ThirdMessage;
+use Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport;
+use Symfony\Component\Messenger\Transport\Sender\SendersLocator;
+use Symfony\Component\Messenger\Worker;
+
+class DispatchOnFailureIntegrationTest extends TestCase
+{
+    private array $handled = [];
+    private array $attempted = [];
+    private array $failureEnvelopes = [];
+    private InMemoryTransport $transport;
+
+    protected function setUp(): void
+    {
+        $this->handled = [];
+        $this->attempted = [];
+        $this->failureEnvelopes = [];
+        $this->transport = new InMemoryTransport();
+    }
+
+    public function testFailureMessageIsDispatchedWhenASingleMessageFailsSynchronously()
+    {
+        $bus = $this->createBus([DummyMessage::class]);
+
+        try {
+            $bus->dispatch($first = new DummyMessage('first'), [new DispatchOnFailureStamp($failure = new ThirdMessage())]);
+            $this->fail('The failure of the message should have been reported.');
+        } catch (HandlerFailedException) {
+        }
+
+        $this->assertSame([$failure], $this->handled);
+        $this->assertCount(1, $this->failureEnvelopes);
+        $this->assertSame($first, $this->failureEnvelopes[0]->last(FailedMessageStamp::class)->getMessage());
+        $this->assertSame(\RuntimeException::class, $this->failureEnvelopes[0]->last(ErrorDetailsStamp::class)->getExceptionClass());
+    }
+
+    public function testFailureMessageIsDispatchedOnceWhenASynchronousStepOfAChainFails()
+    {
+        $bus = $this->createBus([SecondMessage::class]);
+
+        try {
+            $bus->dispatch($first = new DummyMessage('first'), [new ChainStamp($second = new SecondMessage(), new ThirdMessage()), new DispatchOnFailureStamp($failure = new DummyMessage('failure'))]);
+            $this->fail('The failure of the second step should have been reported.');
+        } catch (DelayedMessageHandlingException) {
+        }
+
+        $this->assertSame([$first, $failure], $this->handled);
+        $this->assertCount(1, $this->failureEnvelopes);
+        $this->assertSame($second, $this->failureEnvelopes[0]->last(FailedMessageStamp::class)->getMessage());
+    }
+
+    public function testFailureMessageIsDispatchedOnceWhenAnAsynchronousStepOfAChainFailsInAWorker()
+    {
+        $bus = $this->createBus([SecondMessage::class], [SecondMessage::class => ['async']]);
+
+        $bus->dispatch($first = new DummyMessage('first'), [new ChainStamp($second = new SecondMessage(), new ThirdMessage()), new DispatchOnFailureStamp($failure = new DummyMessage('failure'))]);
+
+        $this->assertSame([$first], $this->handled);
+        $this->assertSame([], $this->failureEnvelopes);
+
+        $this->runWorker($bus);
+
+        $this->assertSame([$first, $failure], $this->handled);
+        $this->assertCount(1, $this->failureEnvelopes);
+        $this->assertSame($second, $this->failureEnvelopes[0]->last(FailedMessageStamp::class)->getMessage());
+        $this->assertSame(\RuntimeException::class, $this->failureEnvelopes[0]->last(ErrorDetailsStamp::class)->getExceptionClass());
+        $this->assertCount(1, $this->transport->getRejected());
+    }
+
+    public function testNothingIsDispatchedWhenTheChainSucceeds()
+    {
+        $bus = $this->createBus(routing: [SecondMessage::class => ['async']]);
+
+        $bus->dispatch($first = new DummyMessage('first'), [new ChainStamp($second = new SecondMessage(), $third = new ThirdMessage()), new DispatchOnFailureStamp(new DummyMessage('failure'))]);
+        $this->runWorker($bus);
+
+        $this->assertSame([$first, $second, $third], $this->handled);
+        $this->assertSame([], $this->failureEnvelopes);
+    }
+
+    public function testAFailingFailureMessageDoesNotLoopAndDoesNotHideTheOriginalFailure()
+    {
+        $bus = $this->createBus([DummyMessage::class, SecondMessage::class]);
+
+        try {
+            $bus->dispatch($first = new DummyMessage('first'), [new DispatchOnFailureStamp($failure = new SecondMessage())]);
+            $this->fail('The failure of the first message should have been reported.');
+        } catch (HandlerFailedException $e) {
+            $this->assertSame($first, $e->getEnvelope()->getMessage());
+            $this->assertSame(\sprintf('Handling "%s" failed.', DummyMessage::class), $e->getPrevious()->getMessage());
+        }
+
+        $this->assertSame([$first, $failure], $this->attempted);
+        $this->assertSame([], $this->handled);
+        $this->assertCount(1, $this->failureEnvelopes);
+    }
+
+    /**
+     * @param class-string[]                    $failing The messages whose handler throws
+     * @param array<class-string, list<string>> $routing The messages sent to the "async" transport
+     */
+    private function createBus(array $failing = [], array $routing = []): MessageBus
+    {
+        $handler = function (object $message) use ($failing): void {
+            $this->attempted[] = $message;
+
+            if (\in_array($message::class, $failing, true)) {
+                throw new \RuntimeException(\sprintf('Handling "%s" failed.', $message::class));
+            }
+
+            $this->handled[] = $message;
+        };
+        $handlersLocator = new HandlersLocator([
+            DummyMessage::class => [$handler],
+            SecondMessage::class => [$handler],
+            ThirdMessage::class => [$handler],
+        ]);
+
+        $senders = new Container();
+        $senders->set('async', $this->transport);
+
+        $recorder = new class($this->failureEnvelopes) implements MiddlewareInterface {
+            public function __construct(private array &$failureEnvelopes)
+            {
+            }
+
+            public function handle(Envelope $envelope, StackInterface $stack): Envelope
+            {
+                if (null !== $envelope->last(FailedMessageStamp::class)) {
+                    $this->failureEnvelopes[] = $envelope;
+                }
+
+                return $stack->next()->handle($envelope, $stack);
+            }
+        };
+
+        $buses = new Container();
+        $routableBus = new RoutableMessageBus($buses);
+        $bus = new MessageBus([
+            new AddBusNameStampMiddleware('the_bus'),
+            $recorder,
+            new DispatchAfterCurrentBusMiddleware(),
+            new DispatchOnFailureMiddleware($routableBus),
+            new SendMessageMiddleware(new SendersLocator($routing, $senders)),
+            new ChainMiddleware($routableBus),
+            new HandleMessageMiddleware($handlersLocator),
+        ]);
+        $buses->set('the_bus', $bus);
+
+        return $bus;
+    }
+
+    private function runWorker(MessageBus $bus): void
+    {
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addSubscriber(new StopWorkerOnMessageLimitListener(1));
+        $dispatcher->addSubscriber(new DispatchOnFailureListener($bus));
+
+        (new Worker(['async' => $this->transport], $bus, $dispatcher))->run();
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/EventListener/DispatchOnFailureListenerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/EventListener/DispatchOnFailureListenerTest.php
@@ -1,0 +1,182 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\EventListener;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\ServiceLocator;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
+use Symfony\Component\Messenger\EventListener\DispatchOnFailureListener;
+use Symfony\Component\Messenger\EventListener\SendFailedMessageToFailureTransportListener;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\BusNameStamp;
+use Symfony\Component\Messenger\Stamp\DelayStamp;
+use Symfony\Component\Messenger\Stamp\DispatchOnFailureStamp;
+use Symfony\Component\Messenger\Stamp\ErrorDetailsStamp;
+use Symfony\Component\Messenger\Stamp\FailedMessageStamp;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Messenger\Tests\Fixtures\SecondMessage;
+use Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport;
+
+class DispatchOnFailureListenerTest extends TestCase
+{
+    public function testNothingIsDispatchedWhenTheMessageWillBeRetried()
+    {
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects($this->never())->method('dispatch');
+
+        $event = new WorkerMessageFailedEvent(new Envelope(new DummyMessage('failed'), [new DispatchOnFailureStamp(new SecondMessage())]), 'my_receiver', new \RuntimeException('It failed.'));
+        $event->setForRetry();
+
+        (new DispatchOnFailureListener($bus))->onMessageFailed($event);
+    }
+
+    public function testNothingIsDispatchedWithoutTheStamp()
+    {
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects($this->never())->method('dispatch');
+
+        $event = new WorkerMessageFailedEvent(new Envelope(new DummyMessage('failed')), 'my_receiver', new \RuntimeException('It failed.'));
+
+        (new DispatchOnFailureListener($bus))->onMessageFailed($event);
+    }
+
+    public function testFailureMessageIsDispatchedWithTheErrorDetailsOfTheFailedEnvelope()
+    {
+        $failed = new DummyMessage('failed');
+        $failure = new SecondMessage();
+        $errorDetailsStamp = ErrorDetailsStamp::create(new \RuntimeException('Recorded by the worker.'));
+        $envelope = new Envelope($failed, [new BusNameStamp('the_bus'), new DispatchOnFailureStamp($failure), $errorDetailsStamp]);
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects($this->once())
+            ->method('dispatch')
+            ->with($this->callback(function (Envelope $dispatched) use ($failed, $failure, $errorDetailsStamp) {
+                $this->assertSame($failure, $dispatched->getMessage());
+                $this->assertSame($failed, $dispatched->last(FailedMessageStamp::class)->getMessage());
+                $this->assertSame([$errorDetailsStamp], $dispatched->all(ErrorDetailsStamp::class));
+                $this->assertSame('the_bus', $dispatched->last(BusNameStamp::class)->getBusName());
+                $this->assertSame([], $dispatched->all(DispatchOnFailureStamp::class));
+
+                return true;
+            }))
+            ->willReturnArgument(0);
+
+        $event = new WorkerMessageFailedEvent($envelope, 'my_receiver', new \RuntimeException('It failed.'));
+
+        (new DispatchOnFailureListener($bus))->onMessageFailed($event);
+    }
+
+    public function testErrorDetailsAreCreatedFromTheThrowableWhenTheFailedEnvelopeHasNone()
+    {
+        $exception = new \RuntimeException('It failed.');
+        $envelope = new Envelope(new DummyMessage('failed'), [new DispatchOnFailureStamp(new SecondMessage())]);
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects($this->once())
+            ->method('dispatch')
+            ->with($this->callback(function (Envelope $dispatched) use ($exception) {
+                $this->assertEquals(ErrorDetailsStamp::create($exception), $dispatched->last(ErrorDetailsStamp::class));
+                $this->assertNull($dispatched->last(BusNameStamp::class));
+
+                return true;
+            }))
+            ->willReturnArgument(0);
+
+        $event = new WorkerMessageFailedEvent($envelope, 'my_receiver', $exception);
+
+        (new DispatchOnFailureListener($bus))->onMessageFailed($event);
+    }
+
+    public function testEnvelopeItemKeepsItsStamps()
+    {
+        $failure = new SecondMessage();
+        $delayStamp = new DelayStamp(1000);
+        $ownFailureStamp = new DispatchOnFailureStamp(new DummyMessage('nested'));
+        $envelope = new Envelope(new DummyMessage('failed'), [new BusNameStamp('the_bus'), new DispatchOnFailureStamp(new Envelope($failure, [$delayStamp, new BusNameStamp('other_bus'), $ownFailureStamp]))]);
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects($this->once())
+            ->method('dispatch')
+            ->with($this->callback(function (Envelope $dispatched) use ($failure, $delayStamp, $ownFailureStamp) {
+                $this->assertSame($failure, $dispatched->getMessage());
+                $this->assertSame([$delayStamp], $dispatched->all(DelayStamp::class));
+                $this->assertSame('other_bus', $dispatched->last(BusNameStamp::class)->getBusName());
+                $this->assertCount(1, $dispatched->all(BusNameStamp::class));
+                $this->assertSame([$ownFailureStamp], $dispatched->all(DispatchOnFailureStamp::class));
+
+                return true;
+            }))
+            ->willReturnArgument(0);
+
+        $event = new WorkerMessageFailedEvent($envelope, 'my_receiver', new \RuntimeException('It failed.'));
+
+        (new DispatchOnFailureListener($bus))->onMessageFailed($event);
+    }
+
+    public function testTheFailureToDispatchTheFailureMessageIsLogged()
+    {
+        $dispatchException = new \LogicException('No handler for the failure message.');
+        $envelope = new Envelope(new DummyMessage('failed'), [new DispatchOnFailureStamp(new SecondMessage())]);
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects($this->once())->method('dispatch')->willThrowException($dispatchException);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
+            ->method('error')
+            ->with($this->callback(function (string $message) {
+                $this->assertStringContainsString('{failure_class}', $message);
+                $this->assertStringContainsString('{class}', $message);
+
+                return true;
+            }), $this->callback(function (array $context) use ($dispatchException) {
+                $this->assertSame(DummyMessage::class, $context['class']);
+                $this->assertSame(SecondMessage::class, $context['failure_class']);
+                $this->assertSame($dispatchException, $context['exception']);
+
+                return true;
+            }));
+
+        $event = new WorkerMessageFailedEvent($envelope, 'my_receiver', new \RuntimeException('It failed.'));
+
+        (new DispatchOnFailureListener($bus, $logger))->onMessageFailed($event);
+    }
+
+    public function testTheFailedMessageStillReachesTheFailureTransportWhenTheFailureMessageCannotBeDispatched()
+    {
+        $failed = new DummyMessage('failed');
+        $envelope = new Envelope($failed, [new DispatchOnFailureStamp(new SecondMessage())]);
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects($this->once())->method('dispatch')->willThrowException(new \LogicException('No handler for the failure message.'));
+
+        $failureTransport = new InMemoryTransport();
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addSubscriber(new DispatchOnFailureListener($bus));
+        $dispatcher->addSubscriber(new SendFailedMessageToFailureTransportListener(new ServiceLocator(['my_receiver' => static fn () => $failureTransport])));
+
+        $dispatcher->dispatch(new WorkerMessageFailedEvent($envelope, 'my_receiver', new \RuntimeException('It failed.')));
+
+        $sent = $failureTransport->getSent();
+        $this->assertCount(1, $sent);
+        $this->assertSame($failed, $sent[0]->getMessage());
+    }
+
+    public function testSubscribedEvents()
+    {
+        $this->assertSame([WorkerMessageFailedEvent::class => ['onMessageFailed', 0]], DispatchOnFailureListener::getSubscribedEvents());
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/Middleware/ChainMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/ChainMiddlewareTest.php
@@ -23,6 +23,7 @@ use Symfony\Component\Messenger\Stamp\BusNameStamp;
 use Symfony\Component\Messenger\Stamp\ChainStamp;
 use Symfony\Component\Messenger\Stamp\DelayStamp;
 use Symfony\Component\Messenger\Stamp\DispatchAfterCurrentBusStamp;
+use Symfony\Component\Messenger\Stamp\DispatchOnFailureStamp;
 use Symfony\Component\Messenger\Stamp\NoAutoAckStamp;
 use Symfony\Component\Messenger\Stamp\ReceivedStamp;
 use Symfony\Component\Messenger\Stamp\SentStamp;
@@ -193,6 +194,48 @@ class ChainMiddlewareTest extends MiddlewareTestCase
         $this->expectExceptionMessage('A message handled by the batch handler "Closure" cannot carry a "Symfony\\Component\\Messenger\\Stamp\\ChainStamp".');
 
         $middleware->handle($envelope, $this->getStackAdding(new NoAutoAckStamp(new HandlerDescriptor(static function () {}))));
+    }
+
+    public function testDispatchOnFailureStampIsCopiedToTheNextMessage()
+    {
+        $second = new SecondMessage();
+        $failureStamp = new DispatchOnFailureStamp(new ThirdMessage());
+        $envelope = new Envelope(new DummyMessage('first'), [$failureStamp, new ChainStamp($second)]);
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects($this->once())
+            ->method('dispatch')
+            ->with($this->callback(function (Envelope $next) use ($second, $failureStamp) {
+                $this->assertSame($second, $next->getMessage());
+                $this->assertSame([$failureStamp], $next->all(DispatchOnFailureStamp::class));
+
+                return true;
+            }))
+            ->willReturnArgument(0);
+
+        $middleware = new ChainMiddleware($bus);
+        $middleware->handle($envelope, $this->getStackMock());
+    }
+
+    public function testEnvelopeInChainKeepsItsOwnDispatchOnFailureStamp()
+    {
+        $second = new SecondMessage();
+        $ownFailureStamp = new DispatchOnFailureStamp(new ThirdMessage());
+        $envelope = new Envelope(new DummyMessage('first'), [new DispatchOnFailureStamp(new DummyMessage('failure')), new ChainStamp(new Envelope($second, [$ownFailureStamp]))]);
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects($this->once())
+            ->method('dispatch')
+            ->with($this->callback(function (Envelope $next) use ($second, $ownFailureStamp) {
+                $this->assertSame($second, $next->getMessage());
+                $this->assertSame([$ownFailureStamp], $next->all(DispatchOnFailureStamp::class));
+
+                return true;
+            }))
+            ->willReturnArgument(0);
+
+        $middleware = new ChainMiddleware($bus);
+        $middleware->handle($envelope, $this->getStackMock());
     }
 
     public function testNothingIsDispatchedWhenHandlingFails()

--- a/src/Symfony/Component/Messenger/Tests/Middleware/ChainMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/ChainMiddlewareTest.php
@@ -1,0 +1,220 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Middleware;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\LogicException;
+use Symfony\Component\Messenger\Handler\HandlerDescriptor;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Middleware\ChainMiddleware;
+use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
+use Symfony\Component\Messenger\Middleware\StackInterface;
+use Symfony\Component\Messenger\Middleware\StackMiddleware;
+use Symfony\Component\Messenger\Stamp\BusNameStamp;
+use Symfony\Component\Messenger\Stamp\ChainStamp;
+use Symfony\Component\Messenger\Stamp\DelayStamp;
+use Symfony\Component\Messenger\Stamp\DispatchAfterCurrentBusStamp;
+use Symfony\Component\Messenger\Stamp\NoAutoAckStamp;
+use Symfony\Component\Messenger\Stamp\ReceivedStamp;
+use Symfony\Component\Messenger\Stamp\SentStamp;
+use Symfony\Component\Messenger\Stamp\StampInterface;
+use Symfony\Component\Messenger\Test\Middleware\MiddlewareTestCase;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Messenger\Tests\Fixtures\SecondMessage;
+use Symfony\Component\Messenger\Tests\Fixtures\ThirdMessage;
+
+class ChainMiddlewareTest extends MiddlewareTestCase
+{
+    public function testNextMessageIsDispatchedOnceTheCurrentOneIsHandled()
+    {
+        $second = new SecondMessage();
+        $third = new ThirdMessage();
+        $envelope = new Envelope(new DummyMessage('first'), [new BusNameStamp('the_bus'), new ChainStamp($second, $third)]);
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects($this->once())
+            ->method('dispatch')
+            ->with($this->callback(function (Envelope $next) use ($second, $third) {
+                $this->assertSame($second, $next->getMessage());
+                $this->assertCount(1, $next->all(DispatchAfterCurrentBusStamp::class));
+                $this->assertSame([$third], $next->last(ChainStamp::class)->getMessages());
+                $this->assertSame('the_bus', $next->last(BusNameStamp::class)->getBusName());
+
+                return true;
+            }))
+            ->willReturnArgument(0);
+
+        $middleware = new ChainMiddleware($bus);
+
+        $handled = $middleware->handle($envelope, $this->getStackMock());
+
+        $this->assertSame($envelope->getMessage(), $handled->getMessage());
+        $this->assertSame([], $handled->all(ChainStamp::class));
+    }
+
+    public function testTheChainStampsAreConsumed()
+    {
+        $envelope = new Envelope(new DummyMessage('first'), [new ChainStamp(new SecondMessage())]);
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects($this->once())->method('dispatch')->willReturnArgument(0);
+
+        $middleware = new ChainMiddleware($bus);
+
+        // a synchronous transport dispatches the message again, so the middleware
+        // sees the same envelope twice and must start the step only once
+        $handled = $middleware->handle($envelope, $this->getStackMock());
+        $middleware->handle($handled, $this->getStackMock());
+    }
+
+    public function testLastMessageIsDispatchedWithoutChain()
+    {
+        $second = new SecondMessage();
+        $envelope = new Envelope(new DummyMessage('first'), [new ChainStamp($second)]);
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects($this->once())
+            ->method('dispatch')
+            ->with($this->callback(function (Envelope $next) use ($second) {
+                $this->assertSame($second, $next->getMessage());
+                $this->assertCount(1, $next->all(DispatchAfterCurrentBusStamp::class));
+                $this->assertSame([], $next->all(ChainStamp::class));
+                $this->assertNull($next->last(BusNameStamp::class));
+
+                return true;
+            }))
+            ->willReturnArgument(0);
+
+        $middleware = new ChainMiddleware($bus);
+        $middleware->handle($envelope, $this->getStackMock());
+    }
+
+    public function testEnvelopeWithoutChainIsPassedThrough()
+    {
+        $envelope = new Envelope(new DummyMessage('first'));
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects($this->never())->method('dispatch');
+
+        $middleware = new ChainMiddleware($bus);
+
+        $this->assertSame($envelope, $middleware->handle($envelope, $this->getStackMock()));
+    }
+
+    public function testEnvelopeInChainKeepsItsStamps()
+    {
+        $second = new SecondMessage();
+        $third = new ThirdMessage();
+        $delayStamp = new DelayStamp(1000);
+        $envelope = new Envelope(new DummyMessage('first'), [new BusNameStamp('the_bus'), new ChainStamp(new Envelope($second, [$delayStamp, new BusNameStamp('other_bus')]), $third)]);
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects($this->once())
+            ->method('dispatch')
+            ->with($this->callback(function (Envelope $next) use ($second, $third, $delayStamp) {
+                $this->assertSame($second, $next->getMessage());
+                $this->assertSame([$delayStamp], $next->all(DelayStamp::class));
+                $this->assertSame('other_bus', $next->last(BusNameStamp::class)->getBusName());
+                $this->assertCount(1, $next->all(BusNameStamp::class));
+                $this->assertCount(1, $next->all(DispatchAfterCurrentBusStamp::class));
+                $this->assertSame([$third], $next->last(ChainStamp::class)->getMessages());
+
+                return true;
+            }))
+            ->willReturnArgument(0);
+
+        $middleware = new ChainMiddleware($bus);
+        $middleware->handle($envelope, $this->getStackMock());
+    }
+
+    public function testChainStampsOfAnEnvelopeFormOneSequence()
+    {
+        $second = new SecondMessage();
+        $third = new ThirdMessage();
+        $fourth = new DummyMessage('fourth');
+        $envelope = new Envelope(new DummyMessage('first'), [new ChainStamp(new Envelope($second, [new ChainStamp($third)])), new ChainStamp($fourth)]);
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects($this->once())
+            ->method('dispatch')
+            ->with($this->callback(function (Envelope $next) use ($second, $third, $fourth) {
+                $this->assertSame($second, $next->getMessage());
+                $this->assertSame([[$third], [$fourth]], array_map(static fn (ChainStamp $stamp) => $stamp->getMessages(), $next->all(ChainStamp::class)));
+
+                return true;
+            }))
+            ->willReturnArgument(0);
+
+        $middleware = new ChainMiddleware($bus);
+        $middleware->handle($envelope, $this->getStackMock());
+    }
+
+    public function testNothingIsDispatchedWhenTheMessageWasSentToATransport()
+    {
+        $envelope = new Envelope(new DummyMessage('first'), [new ChainStamp(new SecondMessage())]);
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects($this->never())->method('dispatch');
+
+        $middleware = new ChainMiddleware($bus);
+        $middleware->handle($envelope, $this->getStackAdding(new SentStamp('Some\\Sender', 'async')));
+    }
+
+    public function testTheChainContinuesWhenTheMessageWasSentToASynchronousTransport()
+    {
+        $envelope = new Envelope(new DummyMessage('first'), [new ChainStamp(new SecondMessage())]);
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects($this->once())->method('dispatch')->willReturnArgument(0);
+
+        $middleware = new ChainMiddleware($bus);
+        $middleware->handle($envelope, $this->getStackAdding(new SentStamp('Some\\Sender', 'sync'), new ReceivedStamp('sync')));
+    }
+
+    public function testAMessageHandledByABatchHandlerCannotOpenAChain()
+    {
+        $envelope = new Envelope(new DummyMessage('first'), [new ChainStamp(new SecondMessage())]);
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects($this->never())->method('dispatch');
+
+        $middleware = new ChainMiddleware($bus);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('A message handled by the batch handler "Closure" cannot carry a "Symfony\\Component\\Messenger\\Stamp\\ChainStamp".');
+
+        $middleware->handle($envelope, $this->getStackAdding(new NoAutoAckStamp(new HandlerDescriptor(static function () {}))));
+    }
+
+    public function testNothingIsDispatchedWhenHandlingFails()
+    {
+        $envelope = new Envelope(new DummyMessage('first'), [new ChainStamp(new SecondMessage())]);
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects($this->never())->method('dispatch');
+
+        $middleware = new ChainMiddleware($bus);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Thrown from next middleware.');
+
+        $middleware->handle($envelope, $this->getThrowingStackMock());
+    }
+
+    private function getStackAdding(StampInterface ...$stamps): StackInterface
+    {
+        $next = $this->createMock(MiddlewareInterface::class);
+        $next->expects($this->once())->method('handle')->willReturnCallback(static fn (Envelope $envelope): Envelope => $envelope->with(...$stamps));
+
+        return new StackMiddleware($next);
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/Middleware/DispatchOnFailureMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/DispatchOnFailureMiddlewareTest.php
@@ -1,0 +1,200 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Middleware;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Middleware\DispatchOnFailureMiddleware;
+use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
+use Symfony\Component\Messenger\Middleware\StackInterface;
+use Symfony\Component\Messenger\Middleware\StackMiddleware;
+use Symfony\Component\Messenger\Stamp\BusNameStamp;
+use Symfony\Component\Messenger\Stamp\DispatchOnFailureStamp;
+use Symfony\Component\Messenger\Stamp\ErrorDetailsStamp;
+use Symfony\Component\Messenger\Stamp\FailedMessageStamp;
+use Symfony\Component\Messenger\Stamp\ReceivedStamp;
+use Symfony\Component\Messenger\Stamp\SentToFailureTransportStamp;
+use Symfony\Component\Messenger\Test\Middleware\MiddlewareTestCase;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Messenger\Tests\Fixtures\SecondMessage;
+
+class DispatchOnFailureMiddlewareTest extends MiddlewareTestCase
+{
+    public function testReceivedEnvelopeIsPassedThrough()
+    {
+        $envelope = new Envelope(new DummyMessage('failed'), [new ReceivedStamp('async'), new DispatchOnFailureStamp(new SecondMessage())]);
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects($this->never())->method('dispatch');
+
+        $middleware = new DispatchOnFailureMiddleware($bus);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Thrown from next middleware.');
+
+        $middleware->handle($envelope, $this->getThrowingStackMock());
+    }
+
+    public function testEnvelopeWithoutTheStampIsPassedThrough()
+    {
+        $envelope = new Envelope(new DummyMessage('failed'));
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects($this->never())->method('dispatch');
+
+        $middleware = new DispatchOnFailureMiddleware($bus);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Thrown from next middleware.');
+
+        $middleware->handle($envelope, $this->getThrowingStackMock());
+    }
+
+    public function testFailureMessageIsDispatchedWhenHandlingThrows()
+    {
+        $failed = new DummyMessage('failed');
+        $failure = new SecondMessage();
+        $exception = new \RuntimeException('It failed.');
+        $envelope = new Envelope($failed, [new BusNameStamp('the_bus'), new DispatchOnFailureStamp($failure)]);
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects($this->once())
+            ->method('dispatch')
+            ->with($this->callback(function (Envelope $dispatched) use ($failed, $failure, $exception) {
+                $this->assertSame($failure, $dispatched->getMessage());
+                $this->assertSame($failed, $dispatched->last(FailedMessageStamp::class)->getMessage());
+                $this->assertEquals(ErrorDetailsStamp::create($exception), $dispatched->last(ErrorDetailsStamp::class));
+                $this->assertSame('the_bus', $dispatched->last(BusNameStamp::class)->getBusName());
+                $this->assertSame([], $dispatched->all(DispatchOnFailureStamp::class));
+
+                return true;
+            }))
+            ->willReturnArgument(0);
+
+        $middleware = new DispatchOnFailureMiddleware($bus);
+
+        try {
+            $middleware->handle($envelope, $this->getThrowingStackMock($exception));
+            $this->fail('The exception should have been rethrown.');
+        } catch (\RuntimeException $e) {
+            $this->assertSame($exception, $e);
+        }
+    }
+
+    public function testTheOriginalExceptionIsRethrownWhenTheFailureMessageCannotBeDispatched()
+    {
+        $exception = new \RuntimeException('It failed.');
+        $dispatchException = new \LogicException('No handler for the failure message.');
+        $envelope = new Envelope(new DummyMessage('failed'), [new DispatchOnFailureStamp(new SecondMessage())]);
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects($this->once())->method('dispatch')->willThrowException($dispatchException);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
+            ->method('error')
+            ->with($this->callback(function (string $message) {
+                $this->assertStringContainsString('{failure_class}', $message);
+                $this->assertStringContainsString('{class}', $message);
+
+                return true;
+            }), $this->callback(function (array $context) use ($dispatchException) {
+                $this->assertSame(DummyMessage::class, $context['class']);
+                $this->assertSame(SecondMessage::class, $context['failure_class']);
+                $this->assertSame($dispatchException, $context['exception']);
+
+                return true;
+            }));
+
+        $middleware = new DispatchOnFailureMiddleware($bus, $logger);
+
+        try {
+            $middleware->handle($envelope, $this->getThrowingStackMock($exception));
+            $this->fail('The exception should have been rethrown.');
+        } catch (\Throwable $e) {
+            $this->assertSame($exception, $e);
+        }
+    }
+
+    public function testFailureMessageIsDispatchedWhenTheMessageWasSentToAFailureTransport()
+    {
+        $failed = new DummyMessage('failed');
+        $failure = new SecondMessage();
+        $errorDetailsStamp = ErrorDetailsStamp::create(new \RuntimeException('Recorded by the transport.'));
+        $envelope = new Envelope($failed, [new DispatchOnFailureStamp($failure)]);
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects($this->once())
+            ->method('dispatch')
+            ->with($this->callback(function (Envelope $dispatched) use ($failed, $failure, $errorDetailsStamp) {
+                $this->assertSame($failure, $dispatched->getMessage());
+                $this->assertSame($failed, $dispatched->last(FailedMessageStamp::class)->getMessage());
+                $this->assertSame([$errorDetailsStamp], $dispatched->all(ErrorDetailsStamp::class));
+
+                return true;
+            }))
+            ->willReturnArgument(0);
+
+        $middleware = new DispatchOnFailureMiddleware($bus);
+        $result = $middleware->handle($envelope, $this->getStackReturning(static fn (Envelope $envelope) => $envelope->with(new SentToFailureTransportStamp('sync'), $errorDetailsStamp)));
+
+        $this->assertNotNull($result->last(SentToFailureTransportStamp::class));
+    }
+
+    public function testNothingIsDispatchedWhenHandlingSucceeds()
+    {
+        $envelope = new Envelope(new DummyMessage('handled'), [new DispatchOnFailureStamp(new SecondMessage())]);
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects($this->never())->method('dispatch');
+
+        $middleware = new DispatchOnFailureMiddleware($bus);
+
+        $this->assertSame($envelope, $middleware->handle($envelope, $this->getStackMock()));
+    }
+
+    public function testOnlyANewSentToFailureTransportStampCounts()
+    {
+        $envelope = new Envelope(new DummyMessage('failed before'), [new SentToFailureTransportStamp('sync'), new DispatchOnFailureStamp(new SecondMessage())]);
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects($this->never())->method('dispatch');
+
+        $middleware = new DispatchOnFailureMiddleware($bus);
+
+        $this->assertSame($envelope, $middleware->handle($envelope, $this->getStackMock()));
+    }
+
+    public function testAnotherSentToFailureTransportStampCounts()
+    {
+        $envelope = new Envelope(new DummyMessage('failed before'), [new SentToFailureTransportStamp('sync'), new DispatchOnFailureStamp(new SecondMessage())]);
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects($this->once())->method('dispatch')->willReturnArgument(0);
+
+        $middleware = new DispatchOnFailureMiddleware($bus);
+        $middleware->handle($envelope, $this->getStackReturning(static fn (Envelope $envelope) => $envelope->with(new SentToFailureTransportStamp('sync'))));
+    }
+
+    private function getStackReturning(callable $callback): StackMiddleware
+    {
+        $nextMiddleware = $this->createMock(MiddlewareInterface::class);
+        $nextMiddleware
+            ->expects($this->once())
+            ->method('handle')
+            ->willReturnCallback(static fn (Envelope $envelope, StackInterface $stack): Envelope => $callback($envelope))
+        ;
+
+        return new StackMiddleware($nextMiddleware);
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/Stamp/ChainStampTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Stamp/ChainStampTest.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Stamp;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\InvalidArgumentException;
+use Symfony\Component\Messenger\Stamp\ChainStamp;
+use Symfony\Component\Messenger\Stamp\DelayStamp;
+use Symfony\Component\Messenger\Stamp\ReceivedStamp;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Messenger\Tests\Fixtures\SecondMessage;
+
+class ChainStampTest extends TestCase
+{
+    public function testMessagesAreKeptInOrder()
+    {
+        $first = new DummyMessage('first');
+        $second = new SecondMessage();
+
+        $stamp = new ChainStamp($first, $second);
+
+        $this->assertSame([$first, $second], $stamp->getMessages());
+    }
+
+    public function testEnvelopesAreAccepted()
+    {
+        $envelope = new Envelope(new DummyMessage('first'), [$delay = new DelayStamp(1000)]);
+
+        $stamp = new ChainStamp($envelope, new SecondMessage());
+
+        $this->assertSame($envelope->getMessage(), $stamp->getMessages()[0]->getMessage());
+        $this->assertSame([$delay], $stamp->getMessages()[0]->all(DelayStamp::class));
+    }
+
+    public function testTheStampsAnEnvelopeCannotCarryToATransportAreDropped()
+    {
+        $envelope = new Envelope(new SecondMessage(), [$delay = new DelayStamp(1000), new ReceivedStamp('async')]);
+
+        $stamp = new ChainStamp($envelope);
+
+        $this->assertSame([], $stamp->getMessages()[0]->all(ReceivedStamp::class));
+        $this->assertSame([$delay], $stamp->getMessages()[0]->all(DelayStamp::class));
+    }
+
+    public function testEmptyChainIsRejected()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('A chain needs at least one message.');
+
+        new ChainStamp();
+    }
+
+    public function testSerializable()
+    {
+        $stamp = new ChainStamp(new DummyMessage('first'), new Envelope(new SecondMessage(), [new DelayStamp(1000)]));
+
+        $this->assertEquals($stamp, unserialize(serialize($stamp)));
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/Stamp/DispatchOnFailureStampTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Stamp/DispatchOnFailureStampTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Stamp;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Stamp\DelayStamp;
+use Symfony\Component\Messenger\Stamp\DispatchOnFailureStamp;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
+
+class DispatchOnFailureStampTest extends TestCase
+{
+    public function testMessageIsKept()
+    {
+        $message = new DummyMessage('failed');
+
+        $stamp = new DispatchOnFailureStamp($message);
+
+        $this->assertSame($message, $stamp->getMessage());
+    }
+
+    public function testEnvelopeIsAccepted()
+    {
+        $envelope = new Envelope(new DummyMessage('failed'), [new DelayStamp(1000)]);
+
+        $stamp = new DispatchOnFailureStamp($envelope);
+
+        $this->assertSame($envelope, $stamp->getMessage());
+    }
+
+    public function testSerializable()
+    {
+        $stamp = new DispatchOnFailureStamp(new Envelope(new DummyMessage('failed'), [new DelayStamp(1000)]));
+
+        $this->assertEquals($stamp, unserialize(serialize($stamp)));
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/Stamp/FailedMessageStampTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Stamp/FailedMessageStampTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Stamp;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Stamp\DelayStamp;
+use Symfony\Component\Messenger\Stamp\FailedMessageStamp;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
+
+class FailedMessageStampTest extends TestCase
+{
+    public function testMessageIsKept()
+    {
+        $message = new DummyMessage('failed');
+
+        $stamp = new FailedMessageStamp($message);
+
+        $this->assertSame($message, $stamp->getMessage());
+    }
+
+    public function testEnvelopeIsAccepted()
+    {
+        $envelope = new Envelope(new DummyMessage('failed'), [new DelayStamp(1000)]);
+
+        $stamp = new FailedMessageStamp($envelope);
+
+        $this->assertSame($envelope, $stamp->getMessage());
+    }
+
+    public function testSerializable()
+    {
+        $stamp = new FailedMessageStamp(new Envelope(new DummyMessage('failed'), [new DelayStamp(1000)]));
+
+        $this->assertEquals($stamp, unserialize(serialize($stamp)));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Stacked on #65903, which has to be merged first: the diff shows both until then.

A message can now declare what to dispatch when it fails for good:

```php
$bus->dispatch(new ProcessPodcast($id), [
    new ChainStamp(new OptimizePodcast($id), new ReleasePodcast($id)),
    new DispatchOnFailureStamp(new PodcastFailed($id)),
]);
```

This is the "catch" that #50462 asked for, without serializing a closure: the failure hook is a message, and the failed message plus the error travel with it. The hook belongs to the message that can fail, not to the chain, so it is just as useful on a single message ("notify when this import fails"); `ChainMiddleware` copies it onto each next step, so whichever step breaks fires it once.

## When it fires

"For good" means after the retries:

- In a worker, when `WorkerMessageFailedEvent` reports that the message will not be retried (`DispatchOnFailureListener`, priority 0, between the retry listener and the failure-transport listener).
- In a synchronous dispatch, when handling throws (`DispatchOnFailureMiddleware`, at the end of the default `before` middleware so that it wraps `doctrine_transaction`: the failure message is dispatched after the rollback). The same middleware fires when a `sync://` transport with a failure transport (#65902) sends the message there instead of throwing, which it detects from the `SentToFailureTransportStamp` on the returned envelope.
- A message that is only sent to a transport does not fire anything at send time.

A nested synchronous dispatch inside a worker handler has no retries of its own, so its failure fires on every attempt of the outer message.

## What is dispatched

`Envelope::wrap($failureMessage)` with a `FailedMessageStamp` holding the message that failed, the `ErrorDetailsStamp` of the failure, and the `BusNameStamp` of the failed message so that the same bus handles it. With #65899, a handler reads both by type-hinting them:

```php
public function __invoke(PodcastFailed $message, FailedMessageStamp $failed, ErrorDetailsStamp $error): void
```

The failure message carries no `DispatchOnFailureStamp` of its own, so a failing failure message does not loop.

## Public API

- `Symfony\Component\Messenger\Stamp\DispatchOnFailureStamp(object $message)`
- `Symfony\Component\Messenger\Stamp\FailedMessageStamp(object $message)`
- `Symfony\Component\Messenger\EventListener\DispatchOnFailureListener`
- `Symfony\Component\Messenger\Middleware\DispatchOnFailureMiddleware`
- FrameworkBundle registers both, with `dispatch_on_failure` in the default middleware stack (guarded for older Messenger versions).

## Checks

- `./phpunit src/Symfony/Component/Messenger/Tests` and `./phpunit src/Symfony/Bundle/FrameworkBundle/Tests`: green (usual missing-server skips).
- Revert-verified: the new tests fail without the stamps, listener and middleware; the bundle tests fail without the wiring.

## Documentation

- The stamp, the three firing points and the "after retries" rule.
- What the failure message receives, and the stamp arguments example.
- The nested-synchronous-dispatch caveat.
- Serializer note: the stamps carry message objects, so transports using the Symfony serializer need normalizers for them, as with `ChainStamp` and `RedispatchMessage`.
