### PR TITLE
[Messenger] Fix Beanstalkd reconnect mechanism

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Beanstalkd/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Beanstalkd/Tests/Transport/ConnectionTest.php
@@ -18,6 +18,7 @@ use Pheanstalk\Exception;
 use Pheanstalk\Exception\ClientException;
 use Pheanstalk\Exception\ConnectionException;
 use Pheanstalk\Exception\DeadlineSoonException;
+use Pheanstalk\Exception\JobNotFoundException;
 use Pheanstalk\Exception\ServerException;
 use Pheanstalk\Pheanstalk;
 use Pheanstalk\Values\Job;
@@ -267,6 +268,47 @@ final class ConnectionTest extends TestCase
         $connection->ack($id);
     }
 
+    public function testAckOnReconnect()
+    {
+        $id = '123456';
+
+        $tube = 'xyz';
+
+        $calls = 0;
+
+        $client = $this->createMock(PheanstalkInterface::class);
+        $client->expects($this->exactly(2))->method('useTube')->with(new TubeName($tube));
+        $client->expects($this->once())->method('reserveJob')->with($this->callback(static fn (JobId $jobId): bool => $jobId->getId() === $id))->willReturn(new Job(new JobId($id), 'foobar'));
+        $client->expects($this->exactly(2))->method('delete')->with($this->callback(static fn (JobId $jobId): bool => $jobId->getId() === $id))->willReturnCallback(static function () use (&$calls): void {
+            if (1 === ++$calls) {
+                throw new ConnectionException('123', 'foobar');
+            }
+        });
+
+        $connection = new Connection(['tube_name' => $tube], $client);
+
+        $connection->ack($id);
+    }
+
+    public function testAckOnReconnectWhenTheJobHasBeenReservedByAnotherConsumer()
+    {
+        $id = '123456';
+
+        $tube = 'xyz';
+
+        $exception = new JobNotFoundException();
+
+        $client = $this->createMock(PheanstalkInterface::class);
+        $client->expects($this->once())->method('useTube')->with(new TubeName($tube));
+        $client->expects($this->once())->method('delete')->with($this->callback(static fn (JobId $jobId): bool => $jobId->getId() === $id))->willThrowException(new ConnectionException('123', 'foobar'));
+        $client->expects($this->once())->method('reserveJob')->with($this->callback(static fn (JobId $jobId): bool => $jobId->getId() === $id))->willThrowException($exception);
+
+        $connection = new Connection(['tube_name' => $tube], $client);
+
+        $this->expectExceptionObject(new TransportException(\sprintf('Failed to reacquire the reservation for the Beanstalkd job "%s": the job no longer exists or was reserved by another consumer.', $id), 0, $exception));
+        $connection->ack($id);
+    }
+
     #[TestWith([false, false])]
     #[TestWith([false, true])]
     #[TestWith([true, true])]
@@ -314,6 +356,69 @@ final class ConnectionTest extends TestCase
         $connection = new Connection(['tube_name' => $tube, 'bury_on_reject' => true], $client);
 
         $connection->reject($id, $priority);
+    }
+
+    public function testRejectOnReconnect()
+    {
+        $id = '123456';
+
+        $tube = 'baz';
+
+        $calls = 0;
+
+        $client = $this->createMock(PheanstalkInterface::class);
+        $client->expects($this->exactly(2))->method('useTube')->with(new TubeName($tube));
+        $client->expects($this->once())->method('reserveJob')->with($this->callback(static fn (JobId $jobId): bool => $jobId->getId() === $id))->willReturn(new Job(new JobId($id), 'foobar'));
+        $client->expects($this->exactly(2))->method('delete')->with($this->callback(static fn (JobId $jobId): bool => $jobId->getId() === $id))->willReturnCallback(static function () use (&$calls): void {
+            if (1 === ++$calls) {
+                throw new ConnectionException('123', 'foobar');
+            }
+        });
+
+        $connection = new Connection(['tube_name' => $tube, 'bury_on_reject' => true], $client);
+
+        $connection->reject($id, null, true);
+    }
+
+    public function testRejectWithBuryOnReconnect()
+    {
+        $id = '123456';
+
+        $tube = 'baz';
+
+        $calls = 0;
+
+        $client = $this->createMock(PheanstalkInterface::class);
+        $client->expects($this->exactly(2))->method('useTube')->with(new TubeName($tube));
+        $client->expects($this->once())->method('reserveJob')->with($this->callback(static fn (JobId $jobId): bool => $jobId->getId() === $id))->willReturn(new Job(new JobId($id), 'foobar'));
+        $client->expects($this->exactly(2))->method('bury')->with($this->callback(static fn (JobId $jobId): bool => $jobId->getId() === $id), 1024)->willReturnCallback(static function () use (&$calls): void {
+            if (1 === ++$calls) {
+                throw new ConnectionException('123', 'foobar');
+            }
+        });
+
+        $connection = new Connection(['tube_name' => $tube, 'bury_on_reject' => true], $client);
+
+        $connection->reject($id);
+    }
+
+    public function testRejectWithBuryOnReconnectWhenTheJobHasBeenReservedByAnotherConsumer()
+    {
+        $id = '123456';
+
+        $tube = 'baz';
+
+        $exception = new JobNotFoundException();
+
+        $client = $this->createMock(PheanstalkInterface::class);
+        $client->expects($this->once())->method('useTube')->with(new TubeName($tube));
+        $client->expects($this->once())->method('bury')->with($this->callback(static fn (JobId $jobId): bool => $jobId->getId() === $id), 1024)->willThrowException(new ConnectionException('123', 'foobar'));
+        $client->expects($this->once())->method('reserveJob')->with($this->callback(static fn (JobId $jobId): bool => $jobId->getId() === $id))->willThrowException($exception);
+
+        $connection = new Connection(['tube_name' => $tube, 'bury_on_reject' => true], $client);
+
+        $this->expectExceptionObject(new TransportException(\sprintf('Failed to reacquire the reservation for the Beanstalkd job "%s": the job no longer exists or was reserved by another consumer.', $id), 0, $exception));
+        $connection->reject($id);
     }
 
     public function testRejectWhenABeanstalkdExceptionOccurs()
@@ -578,6 +683,47 @@ final class ConnectionTest extends TestCase
         $connection = new Connection(['tube_name' => $tube], $client);
 
         $this->expectExceptionObject(new TransportException($exception->getMessage(), 0, $exception));
+        $connection->keepalive($id);
+    }
+
+    public function testKeepaliveOnReconnect()
+    {
+        $id = '123456';
+
+        $tube = 'baz';
+
+        $calls = 0;
+
+        $client = $this->createMock(PheanstalkInterface::class);
+        $client->expects($this->exactly(2))->method('useTube')->with(new TubeName($tube));
+        $client->expects($this->once())->method('reserveJob')->with($this->callback(static fn (JobId $jobId): bool => $jobId->getId() === $id))->willReturn(new Job(new JobId($id), 'foobar'));
+        $client->expects($this->exactly(2))->method('touch')->with($this->callback(static fn (JobId $jobId): bool => $jobId->getId() === $id))->willReturnCallback(static function () use (&$calls): void {
+            if (1 === ++$calls) {
+                throw new ConnectionException('123', 'foobar');
+            }
+        });
+
+        $connection = new Connection(['tube_name' => $tube], $client);
+
+        $connection->keepalive($id);
+    }
+
+    public function testKeepaliveOnReconnectWhenTheJobHasBeenReservedByAnotherConsumer()
+    {
+        $id = '123456';
+
+        $tube = 'baz';
+
+        $exception = new JobNotFoundException();
+
+        $client = $this->createMock(PheanstalkInterface::class);
+        $client->expects($this->once())->method('useTube')->with(new TubeName($tube));
+        $client->expects($this->once())->method('touch')->with($this->callback(static fn (JobId $jobId): bool => $jobId->getId() === $id))->willThrowException(new ConnectionException('123', 'foobar'));
+        $client->expects($this->once())->method('reserveJob')->with($this->callback(static fn (JobId $jobId): bool => $jobId->getId() === $id))->willThrowException($exception);
+
+        $connection = new Connection(['tube_name' => $tube], $client);
+
+        $this->expectExceptionObject(new TransportException(\sprintf('Failed to reacquire the reservation for the Beanstalkd job "%s": the job no longer exists or was reserved by another consumer.', $id), 0, $exception));
         $connection->keepalive($id);
     }
 

--- a/src/Symfony/Component/Messenger/Bridge/Beanstalkd/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Beanstalkd/Transport/Connection.php
@@ -17,6 +17,7 @@ use Pheanstalk\Contract\PheanstalkSubscriberInterface;
 use Pheanstalk\Contract\SocketFactoryInterface;
 use Pheanstalk\Exception;
 use Pheanstalk\Exception\ConnectionException;
+use Pheanstalk\Exception\JobNotFoundException;
 use Pheanstalk\Pheanstalk;
 use Pheanstalk\Values\JobId;
 use Pheanstalk\Values\TubeName;
@@ -182,31 +183,37 @@ class Connection
 
     public function ack(string $id): void
     {
-        $this->withReconnect(function () use ($id) {
+        $jobId = new JobId($id);
+
+        $this->withReconnect(function () use ($jobId) {
             $this->useTube();
-            $this->client->delete(new JobId($id));
-        });
+            $this->client->delete($jobId);
+        }, $jobId);
     }
 
     public function reject(string $id, ?int $priority = null, bool $forceDelete = false): void
     {
-        $this->withReconnect(function () use ($id, $priority, $forceDelete) {
+        $jobId = new JobId($id);
+
+        $this->withReconnect(function () use ($jobId, $priority, $forceDelete) {
             $this->useTube();
 
             if (!$forceDelete && $this->buryOnReject) {
-                $this->client->bury(new JobId($id), $priority ?? PheanstalkPublisherInterface::DEFAULT_PRIORITY);
+                $this->client->bury($jobId, $priority ?? PheanstalkPublisherInterface::DEFAULT_PRIORITY);
             } else {
-                $this->client->delete(new JobId($id));
+                $this->client->delete($jobId);
             }
-        });
+        }, $jobId);
     }
 
     public function keepalive(string $id): void
     {
-        $this->withReconnect(function () use ($id) {
+        $jobId = new JobId($id);
+
+        $this->withReconnect(function () use ($jobId) {
             $this->useTube();
-            $this->client->touch(new JobId($id));
-        });
+            $this->client->touch($jobId);
+        }, $jobId);
     }
 
     public function getMessageCount(): int
@@ -255,7 +262,12 @@ class Connection
         $this->watchingTube = true;
     }
 
-    private function withReconnect(callable $command): mixed
+    /**
+     * @param ?JobId $reservedJobId The id of a job the command may only run on while holding its
+     *                              reservation, which then has to be reacquired after a reconnect
+     *                              before the command can be retried
+     */
+    private function withReconnect(callable $command, ?JobId $reservedJobId = null): mixed
     {
         try {
             try {
@@ -265,6 +277,14 @@ class Connection
 
                 $this->usingTube = false;
                 $this->watchingTube = false;
+
+                if (null !== $reservedJobId) {
+                    try {
+                        $this->client->reserveJob($reservedJobId);
+                    } catch (JobNotFoundException $exception) {
+                        throw new TransportException(\sprintf('Failed to reacquire the reservation for the Beanstalkd job "%s": the job no longer exists or was reserved by another consumer.', $reservedJobId->getId()), 0, $exception);
+                    }
+                }
 
                 return $command();
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Since the upgrade to Pheanstalk v5 (#60040), `Connection::withReconnect()` retries the failed command on a fresh connection after a `ConnectionException`.

One thing I didn't take into account is that certain commands, such as `delete`, `bury` & `touch`, need the job to be reserved for them to work.

Since beanstalkd releases every job reserved by a connection the moment that connection goes away, the retried `bury`/`touch` can never succeed, and the retried `delete` fails whenever another consumer picked the job up in the meantime. The failure surfaces as a `TransportException` wrapping a message-less `JobNotFoundException`.

With this change, the reconnect handler first reacquires the reservation with the `reserve-job` command, then retries. When the reservation cannot be reacquired, because the job was finished or reserved by another consumer in the meantime, a descriptive exception is thrown instead of the empty one.
