### PR TITLE
[Messenger] Fix Beanstalkd keepalive when triggered during another command

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Beanstalkd/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Beanstalkd/Tests/Transport/ConnectionTest.php
@@ -727,6 +727,48 @@ final class ConnectionTest extends TestCase
         $connection->keepalive($id);
     }
 
+    public function testKeepaliveIsSkippedWhileAnotherCommandIsInFlight()
+    {
+        $id = '123456';
+
+        $tube = 'baz';
+
+        $connection = null;
+
+        $client = $this->createMock(PheanstalkInterface::class);
+        $client->expects($this->once())->method('useTube')->with(new TubeName($tube));
+        $client->expects($this->never())->method('touch');
+        $client->expects($this->once())->method('delete')->with($this->callback(static fn (JobId $jobId): bool => $jobId->getId() === $id))->willReturnCallback(static function () use (&$connection, $id): void {
+            $connection->keepalive($id);
+        });
+
+        $connection = new Connection(['tube_name' => $tube], $client);
+
+        $connection->ack($id);
+    }
+
+    public function testKeepaliveAfterAFailedCommand()
+    {
+        $id = '123456';
+
+        $tube = 'baz';
+
+        $client = $this->createMock(PheanstalkInterface::class);
+        $client->expects($this->once())->method('useTube')->with(new TubeName($tube));
+        $client->expects($this->once())->method('delete')->with($this->callback(static fn (JobId $jobId): bool => $jobId->getId() === $id))->willThrowException(new ServerException('baz error'));
+        $client->expects($this->once())->method('touch')->with($this->callback(static fn (JobId $jobId): bool => $jobId->getId() === $id));
+
+        $connection = new Connection(['tube_name' => $tube], $client);
+
+        try {
+            $connection->ack($id);
+            $this->fail(TransportException::class.' should have been thrown.');
+        } catch (TransportException) {
+        }
+
+        $connection->keepalive($id);
+    }
+
     public function testSendWithRoundedDelay()
     {
         $tube = 'xyz';

--- a/src/Symfony/Component/Messenger/Bridge/Beanstalkd/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Beanstalkd/Transport/Connection.php
@@ -47,6 +47,7 @@ class Connection
 
     private bool $usingTube = false;
     private bool $watchingTube = false;
+    private bool $busy = false;
 
     /**
      * Constructor.
@@ -208,6 +209,12 @@ class Connection
 
     public function keepalive(string $id): void
     {
+        // keepalive can be triggered by a signal while another command awaits its
+        // response; a touch sent now would cross replies with it on the shared socket
+        if ($this->busy) {
+            return;
+        }
+
         $jobId = new JobId($id);
 
         $this->withReconnect(function () use ($jobId) {
@@ -269,6 +276,8 @@ class Connection
      */
     private function withReconnect(callable $command, ?JobId $reservedJobId = null): mixed
     {
+        $this->busy = true;
+
         try {
             try {
                 return $command();
@@ -290,6 +299,8 @@ class Connection
             }
         } catch (Exception $exception) {
             throw new TransportException($exception->getMessage(), 0, $exception);
+        } finally {
+            $this->busy = false;
         }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`messenger:consume --keepalive` uses a recurring async `SIGALRM`, so the consumer runs `Worker::keepalive()` in the middle of whatever the worker was doing when the alarm fired.

When the alarm lands while a command on the Beanstalkd connection is between its write and its read, for example a blocking `reserve-with-timeout` while batched messages are still unacked, or the `put` of a retry, the `touch` gets interspersed on the same socket. Beanstalkd answers commands on a connection strictly in order, so the `touch` reads the reply belonging to the interrupted command and blows up inside the signal handler, killing the worker:

```
Response type Reserved is not supported for this command
```

With this change, the connection tracks when a command is awaiting its response and skips the keepalive during that window.