### PR TITLE
[DependencyInjection][HttpKernel] Instantiate on demand the bundles that have nothing to do at boot time

### DIFF
--- a/UPGRADE-8.2.md
+++ b/UPGRADE-8.2.md
@@ -32,6 +32,13 @@ Crowdin Translation Provider
 
  * Add `$projectId` constructor parameter to `CrowdinProvider`
 
+DependencyInjection
+-------------------
+
+ * Bundles that declare no constructor and inherit `boot()`, `shutdown()` and `setContainer()` from
+   `AbstractBundle` are now instantiated on demand instead of on every boot. The `$bundles` property of
+   the kernel holds only the bundles that have been instantiated, call `getBundles()` to get them all
+
 DoctrineBridge
 --------------
 
@@ -87,6 +94,9 @@ FrameworkBundle
  * Deprecate the `framework.ide` config option, use the `SYMFONY_IDE` env var instead
  * BrowserKit assertions are no longer verbose by default. Failed response assertions no longer include the response body unless `setBrowserKitAssertionsAsVerbose(true)` is called or `verbose: true` is passed to the assertion.
  * Deprecate the `framework.fragments.hinclude_default_template` config option and the `fragment.renderer.hinclude.global_template` parameter; use the `esi` or `inline` fragment renderer, or [Symfony UX Turbo](https://ux.symfony.com/turbo), instead
+ * `Console\Application` does not instantiate every bundle anymore, only the ones that override the deprecated
+   `Bundle::registerCommands()` method, listed in the new `console.command.bundles` container parameter; that
+   parameter exists only to support the deprecated method and goes away with it in 9.0
 
 HttpClient
 ----------
@@ -106,6 +116,8 @@ HttpKernel
 ----------
 
  * Deprecate the `HIncludeFragmentRenderer` class, use the `EsiFragmentRenderer` or `InlineFragmentRenderer`, or [Symfony UX Turbo](https://ux.symfony.com/turbo), instead
+ * `Kernel::boot()` now iterates over the `$bundles` property instead of calling `getBundles()`, so that the
+   bundles that have nothing to do at boot time are not instantiated
 
 Lock
 ----

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -43,6 +43,7 @@ CHANGELOG
  * Register the security functions `is_granted()`, `is_authenticated()`, `is_fully_authenticated()`, `is_remember_me()` and `current_user()` in the validator expression language
  * Add `framework.profiler.excluded_paths` and `framework.profiler.excluded_http_codes` to skip profiling requests matching a path or answered with a given HTTP status code
  * Add `framework.property_access.wildcard_reads` option to read every element of a collection through a `[*]` path
+ * Instantiate on the console only the bundles that override the deprecated `Bundle::registerCommands()` method
 
 8.1
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
@@ -173,7 +173,11 @@ class Application extends BaseApplication implements ContainerProviderInterface
 
         $container = $this->kernel->getContainer();
 
-        foreach ($this->kernel->getBundles() as $bundle) {
+        $commandBundles = $container->hasParameter('console.command.bundles')
+            ? array_map($this->kernel->getBundle(...), $container->getParameter('console.command.bundles'))
+            : $this->kernel->getBundles();
+
+        foreach ($commandBundles as $bundle) {
             if ($bundle instanceof Bundle
                 && method_exists($bundle, 'registerCommands')
                 && Bundle::class !== new \ReflectionMethod($bundle, 'registerCommands')->getDeclaringClass()->getName()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/FindCommandBundlesPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/FindCommandBundlesPass.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+/**
+ * Lists the bundles that override the deprecated Bundle::registerCommands() method,
+ * so that the console instantiates only those instead of all of them.
+ *
+ * @internal to be removed in Symfony 9.0
+ */
+class FindCommandBundlesPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        $bundles = [];
+
+        foreach ($container->getParameter('kernel.bundles') as $name => $class) {
+            if (is_subclass_of($class, Bundle::class) && Bundle::class !== new \ReflectionMethod($class, 'registerCommands')->getDeclaringClass()->getName()) {
+                $bundles[] = $name;
+            }
+        }
+
+        $container->setParameter('console.command.bundles', $bundles);
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -18,6 +18,7 @@ use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AssetsContextPas
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ContainerBuilderDebugDumpPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\DeprecateJsonStreamerValueTransformerTagPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ErrorLoggerCompilerPass;
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\FindCommandBundlesPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\JsonPathPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\JsonSchemaConfigDumpPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\PhpConfigReferenceDumpPass;
@@ -168,6 +169,7 @@ class FrameworkBundle extends Bundle
 
         $container->addCompilerPass(new AddBehaviorDescribingTagsPass(['kernel.locale_aware']), PassConfig::TYPE_BEFORE_OPTIMIZATION, 200);
         $container->addCompilerPass(new AssetsContextPass());
+        $container->addCompilerPass(new FindCommandBundlesPass());
         $container->addCompilerPass(new LoggerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, -32);
         $container->addCompilerPass(new RegisterControllerArgumentLocatorsPass());
         $container->addCompilerPass(new RemoveEmptyControllerArgumentLocatorsPass(), PassConfig::TYPE_BEFORE_REMOVING);

--- a/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
@@ -149,7 +149,7 @@ trait MicroKernelTrait
         $parameters = $this->doGetKernelParameters();
         $parameters['kernel.charset'] = $this->getCharset();
 
-        foreach ($this->bundles as $name => $bundle) {
+        foreach ($this->getBundles() as $name => $bundle) {
             $parameters['kernel.bundles_metadata'][$name]['namespace'] = $bundle->getNamespace();
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/ApplicationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/ApplicationTest.php
@@ -55,6 +55,31 @@ class ApplicationTest extends TestCase
         $application->doRun(new ArrayInput(['list']), new NullOutput());
     }
 
+    public function testNoBundleIsInstantiatedWhenNoneRegistersCommands()
+    {
+        $kernel = $this->getKernelWithCommandBundles([]);
+
+        $application = new Application($kernel);
+
+        $this->assertArrayNotHasKey('example', $application->all());
+    }
+
+    #[Group('legacy')]
+    #[IgnoreDeprecations]
+    public function testOnlyTheBundlesRegisteringCommandsAreInstantiated()
+    {
+        $command = new Command('example');
+        $bundle = $this->createBundleMock([$command]);
+
+        $kernel = $this->getKernelWithCommandBundles(['CommandBundle' => $bundle]);
+
+        $application = new Application($kernel);
+
+        $this->expectUserDeprecationMessage(\sprintf('Since symfony/framework-bundle 8.1: Overriding the "Symfony\Component\HttpKernel\Bundle\Bundle::registerCommands()" method in "%s" is deprecated, use the "#[AsCommand]" attribute or the "console.command" service tag instead.', get_debug_type($bundle)));
+
+        $this->assertSame($command, $application->get('example'));
+    }
+
     #[Group('legacy')]
     #[IgnoreDeprecations]
     public function testBundleCommandsAreRegistered()
@@ -323,6 +348,32 @@ class ApplicationTest extends TestCase
         $kernel
             ->method('getBundles')
             ->willReturn($bundles)
+        ;
+        $kernel
+            ->method('getContainer')
+            ->willReturn($container)
+        ;
+
+        return $kernel;
+    }
+
+    /**
+     * @param array<string, BundleInterface> $bundles
+     */
+    private function getKernelWithCommandBundles(array $bundles): KernelInterface&MockObject
+    {
+        $container = new Container(new ParameterBag([
+            'console.command.ids' => [],
+            'console.lazy_command.ids' => [],
+            'console.command.bundles' => array_keys($bundles),
+        ]));
+
+        $kernel = $this->createMock(KernelInterface::class);
+        $kernel->expects($this->once())->method('boot');
+        $kernel->expects($this->never())->method('getBundles');
+        $kernel
+            ->method('getBundle')
+            ->willReturnCallback(static fn (string $name) => $bundles[$name])
         ;
         $kernel
             ->method('getContainer')

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/FindCommandBundlesPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/FindCommandBundlesPassTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\FindCommandBundlesPass;
+use Symfony\Component\Console\Application;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Kernel\AbstractBundle;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class FindCommandBundlesPassTest extends TestCase
+{
+    public function testOnlyBundlesOverridingRegisterCommandsAreListed()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('kernel.bundles', [
+            'InertBundle' => InertBundle::class,
+            'CommandRegisteringBundle' => CommandRegisteringBundle::class,
+            'DiBundle' => DiBundle::class,
+            'MissingBundle' => 'Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler\MissingBundle',
+        ]);
+
+        (new FindCommandBundlesPass())->process($container);
+
+        $this->assertSame(['CommandRegisteringBundle'], $container->getParameter('console.command.bundles'));
+    }
+
+    public function testParameterIsSetWhenNoBundleOverridesRegisterCommands()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('kernel.bundles', ['InertBundle' => InertBundle::class]);
+
+        (new FindCommandBundlesPass())->process($container);
+
+        $this->assertSame([], $container->getParameter('console.command.bundles'));
+    }
+}
+
+class InertBundle extends Bundle
+{
+}
+
+class CommandRegisteringBundle extends Bundle
+{
+    public function registerCommands(Application $application): void
+    {
+    }
+}
+
+class DiBundle extends AbstractBundle
+{
+}

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -12,6 +12,7 @@ CHANGELOG
  * Add `Preloader::ignore()` to exclude classes or namespace prefixes from preloading
  * Allow computing resource tag attributes per tagged class when using `#[AutoconfigureResourceTag]`, `#[Autoconfigure]` or `_instanceof`, like for regular tags
  * Add `#[AutowireClassMap]` attribute, `TaggedClassMapArgument`, the `!tagged_class_map` YAML tag and the `tagged_class_map()` PHP-DSL function to inject a map of classes found by resource tag name
+ * Instantiate on demand the bundles that have nothing to do when the kernel boots, and add `AbstractKernel::instantiateBundle()` to control how they are created
 
 8.1
 ---

--- a/src/Symfony/Component/DependencyInjection/Kernel/AbstractKernel.php
+++ b/src/Symfony/Component/DependencyInjection/Kernel/AbstractKernel.php
@@ -26,6 +26,19 @@ abstract class AbstractKernel implements KernelInterface
 {
     /** @var array<string, BundleInterface> */
     protected array $bundles = [];
+
+    private array $bundleClassMap = [];
+
+    /**
+     * The class of every registered bundle in registration order; those missing from $bundles are instantiated on demand.
+     *
+     * @var array<string, class-string<BundleInterface>>
+     */
+    protected array $bundleClasses {
+        get => $this->bundleClassMap;
+        set (array $bundleClasses) { $this->bundleClassMap = $bundleClasses; }
+    }
+
     protected ?ContainerInterface $container = null;
     protected bool $booted = false;
     protected ?float $startTime = null;
@@ -104,16 +117,30 @@ abstract class AbstractKernel implements KernelInterface
      */
     public function getBundles(): array
     {
+        if (\count($this->bundles) < \count($this->bundleClasses)) {
+            foreach ($this->bundleClasses as $name => $class) {
+                if (!isset($this->bundles[$name])) {
+                    $this->loadBundle($name);
+                }
+            }
+
+            $this->bundles = array_replace($this->bundleClasses, $this->bundles);
+        }
+
         return $this->bundles;
     }
 
     public function getBundle(string $name): BundleInterface
     {
-        if (!isset($this->bundles[$name])) {
+        if (isset($this->bundles[$name])) {
+            return $this->bundles[$name];
+        }
+
+        if (!isset($this->bundleClasses[$name])) {
             throw new \InvalidArgumentException(\sprintf('Bundle "%s" does not exist or it is not enabled. Maybe you forgot to add it in the "registerBundles()" method of your "%s.php" file?', $name, get_debug_type($this)));
         }
 
-        return $this->bundles[$name];
+        return $this->loadBundle($name);
     }
 
     public function locateResource(string $name): string
@@ -224,5 +251,26 @@ abstract class AbstractKernel implements KernelInterface
      */
     protected function build(ContainerBuilder $container): void
     {
+    }
+
+    /**
+     * Creates a bundle that has not been instantiated when booting the kernel.
+     *
+     * @param class-string<BundleInterface> $class
+     */
+    protected function instantiateBundle(string $class): BundleInterface
+    {
+        return new $class();
+    }
+
+    private function loadBundle(string $name): BundleInterface
+    {
+        $bundle = $this->instantiateBundle($this->bundleClasses[$name]);
+
+        if ($this->container) {
+            $bundle->setContainer($this->container);
+        }
+
+        return $this->bundles[$name] = $bundle;
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Kernel/KernelTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Kernel/KernelTrait.php
@@ -47,8 +47,6 @@ class_exists(ConfigCache::class);
  */
 trait KernelTrait
 {
-    private array $bundleClasses = [];
-
     public function getCacheDir(): string
     {
         if (null !== $dir = $_SERVER['APP_CACHE_DIR'] ?? null) {
@@ -102,10 +100,14 @@ trait KernelTrait
             is_file($cachePath)
             && (!$this->debug || is_file($bundlesPath = $this->getBundlesPath()) && filemtime($cachePath) > filemtime($bundlesPath))
         ) {
-            $this->bundles = require $cachePath;
-            $this->bundleClasses = array_map('get_class', $this->bundles);
+            $cached = require $cachePath;
 
-            return;
+            // ignore files dumped by an older version of this trait
+            if (\is_array($cached[1] ?? null)) {
+                [$this->bundleClasses, $this->bundles] = $cached;
+
+                return;
+            }
         }
 
         $this->bundles = [];
@@ -318,7 +320,7 @@ trait KernelTrait
      */
     protected function prepareContainer(ContainerBuilder $container): void
     {
-        foreach ($this->bundles as $bundle) {
+        foreach ($this->getBundles() as $bundle) {
             if ($extension = $bundle->getContainerExtension()) {
                 $container->registerExtension($extension);
             }
@@ -330,7 +332,7 @@ trait KernelTrait
             }
         }
 
-        foreach ($this->bundles as $bundle) {
+        foreach ($this->getBundles() as $bundle) {
             $bundle->build($container);
         }
 
@@ -403,12 +405,18 @@ trait KernelTrait
 
         $cache->write($rootCode, $container->getResources());
 
-        // Dump resolved bundle list so initializeBundles() can skip reflection on next boot
-        $code = "<?php\n\nreturn [\n";
+        // Dump resolved bundle list so initializeBundles() can skip reflection on next boot,
+        // instantiating only the bundles that have something to do at runtime
+        $code = "<?php\n\nreturn [[\n";
+        $runtimeBundles = '';
         foreach ($this->bundleClasses as $name => $bundleClass) {
-            $code .= \sprintf("    %s => new \\%s(),\n", var_export($name, true), $bundleClass);
+            $code .= \sprintf("    %s => %s,\n", var_export($name, true), var_export($bundleClass, true));
+
+            if (!$this->isLazyBundle($bundleClass)) {
+                $runtimeBundles .= \sprintf("    %s => new \\%s(),\n", var_export($name, true), $bundleClass);
+            }
         }
-        $code .= "];\n";
+        $code .= "], [\n".$runtimeBundles."]];\n";
         $fs->dumpFile($this->getEffectiveBuildDir().'/'.$class.'.bundles.php', $code);
     }
 
@@ -577,7 +585,7 @@ trait KernelTrait
         $bundles = [];
         $bundlesMetadata = [];
 
-        foreach ($this->bundles as $name => $bundle) {
+        foreach ($this->getBundles() as $name => $bundle) {
             $bundles[$name] = $bundle::class;
             $bundlesMetadata[$name] = [
                 'path' => $bundle->getPath(),
@@ -682,5 +690,27 @@ trait KernelTrait
             throw new \LogicException(\sprintf('Trying to register two bundles with the same name "%s".', $name));
         }
         $this->bundles[$name] = $bundle;
+    }
+
+    /**
+     * Tells whether a bundle can be instantiated on demand because nothing it declares runs when booting the kernel.
+     *
+     * @param class-string<BundleInterface> $class
+     */
+    private function isLazyBundle(string $class): bool
+    {
+        $r = new \ReflectionClass($class);
+
+        if ($r->hasMethod('__construct') || $r->hasMethod('__destruct')) {
+            return false;
+        }
+
+        foreach (['boot', 'shutdown', 'setContainer'] as $method) {
+            if (AbstractBundle::class !== $r->getMethod($method)->getDeclaringClass()->name) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/AbstractKernelTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/AbstractKernelTest.php
@@ -184,7 +184,7 @@ class AbstractKernelTest extends TestCase
         $bundle = $this->createMock(BundleInterface::class);
         $bundle->method('getName')->willReturn('TestBundle');
         $bundle->expects($this->once())->method('shutdown');
-        $bundle->expects($this->atLeast(2))
+        $bundle->expects($this->exactly(2))
             ->method('setContainer')
             ->willReturnCallback(function ($container) {
                 if (null !== $container) {
@@ -358,7 +358,7 @@ class AbstractKernelTest extends TestCase
 
         $kernel = $this->createKernel();
         @mkdir($kernel->getBuildDir(), 0o777, true);
-        file_put_contents($kernel->getBuildDir().'/'.$kernel->getTestContainerClass().'.bundles.php', '<?php return [\'TestAbstractBundle\' => new \Symfony\Component\DependencyInjection\Tests\TestAbstractBundle()];');
+        file_put_contents($kernel->getBuildDir().'/'.$kernel->getTestContainerClass().'.bundles.php', '<?php return [[\'TestAbstractBundle\' => \'Symfony\\\\Component\\\\DependencyInjection\\\\Tests\\\\TestAbstractBundle\'], []];');
 
         $kernel->boot();
 
@@ -369,6 +369,98 @@ class AbstractKernelTest extends TestCase
         $kernel->boot();
 
         $this->assertCount(1, $kernel->getBundles());
+        $this->assertSame([TestAbstractBundle::class], array_values($kernel->getContainer()->getParameter('kernel.bundles')));
+    }
+
+    public function testBundlesCacheDumpedByAnOlderVersionIsIgnored()
+    {
+        $dir = $this->varDir;
+        @mkdir($dir.'/config', 0o777, true);
+        file_put_contents($dir.'/config/bundles.php', '<?php return ['.TestAbstractBundle::class.'::class => [\'all\' => true]];');
+        touch($dir.'/config/bundles.php', time() - 10);
+
+        $kernel = $this->createKernel();
+        @mkdir($kernel->getBuildDir(), 0o777, true);
+        file_put_contents($kernel->getBuildDir().'/'.$kernel->getTestContainerClass().'.bundles.php', '<?php return [\'TestAbstractBundle\' => new \\'.TestAbstractBundle::class.'()];');
+
+        $kernel->boot();
+
+        $this->assertSame(['TestAbstractBundle'], array_keys($kernel->getBundles()));
+    }
+
+    public function testBundlesWithNothingToDoAtRuntimeAreInstantiatedOnDemand()
+    {
+        $this->writeBundlesFile([LazyBundle::class, BootingBundle::class]);
+
+        $kernel = $this->createKernel('test', false);
+        $kernel->boot();
+        $kernel->shutdown();
+
+        $kernel = $this->createKernel('test', false);
+        $kernel->boot();
+
+        $this->assertSame(['BootingBundle'], array_keys($kernel->getInstantiatedBundles()));
+        $this->assertSame(['LazyBundle', 'BootingBundle'], array_keys($kernel->getBundles()));
+        $this->assertInstanceOf(LazyBundle::class, $kernel->getBundles()['LazyBundle']);
+    }
+
+    public function testBundlesWithSomethingToDoAtRuntimeAreInstantiatedOnBoot()
+    {
+        $this->writeBundlesFile([LazyBundle::class, BootingBundle::class, ShuttingDownBundle::class, ContainerAwareBundle::class, ConstructedBundle::class]);
+
+        $kernel = $this->createKernel('test', false);
+        $kernel->boot();
+        $kernel->shutdown();
+
+        $kernel = $this->createKernel('test', false);
+        $kernel->boot();
+
+        $this->assertSame(['BootingBundle', 'ShuttingDownBundle', 'ContainerAwareBundle', 'ConstructedBundle'], array_keys($kernel->getInstantiatedBundles()));
+    }
+
+    public function testCachedBundlesFileOnlyInstantiatesWhatIsNeededAtRuntime()
+    {
+        $this->writeBundlesFile([LazyBundle::class, BootingBundle::class]);
+
+        $kernel = $this->createKernel('test', false);
+        $kernel->boot();
+
+        $code = file_get_contents($kernel->getBuildDir().'/'.$kernel->getTestContainerClass().'.bundles.php');
+
+        $this->assertStringContainsString(\sprintf("'BootingBundle' => new \\%s(),", BootingBundle::class), $code);
+        $this->assertStringNotContainsString('new \\'.LazyBundle::class, $code);
+        $this->assertStringContainsString(var_export(LazyBundle::class, true), $code);
+    }
+
+    public function testLazyBundleIsGivenTheContainerAndKeptAround()
+    {
+        $this->writeBundlesFile([LazyBundle::class]);
+
+        $kernel = $this->createKernel('test', false);
+        $kernel->boot();
+        $kernel->shutdown();
+
+        $kernel = $this->createKernel('test', false);
+        $kernel->boot();
+
+        $bundle = $kernel->getBundle('LazyBundle');
+
+        $this->assertSame($kernel->getContainer(), $bundle->getBoundContainer());
+        $this->assertSame($bundle, $kernel->getBundle('LazyBundle'));
+        $this->assertSame($bundle, $kernel->getBundles()['LazyBundle']);
+    }
+
+    public function testLazyBundleIsRegisteredInTheContainerParameters()
+    {
+        $this->writeBundlesFile([LazyBundle::class]);
+
+        $kernel = $this->createKernel('test', false);
+        $kernel->boot();
+
+        $container = $kernel->getContainer();
+
+        $this->assertSame(['LazyBundle' => LazyBundle::class], $container->getParameter('kernel.bundles'));
+        $this->assertArrayHasKey('path', $container->getParameter('kernel.bundles_metadata')['LazyBundle']);
     }
 
     public function testConfigureContainerHook()
@@ -478,6 +570,13 @@ class AbstractKernelTest extends TestCase
         $this->assertSame(['IgnoreOnInvalidBundle'], array_keys($kernel->getBundles()));
     }
 
+    private function writeBundlesFile(array $classes): void
+    {
+        @mkdir($this->varDir.'/config', 0o777, true);
+        $code = array_map(static fn ($class) => var_export($class, true)." => ['all' => true]", $classes);
+        file_put_contents($this->varDir.'/config/bundles.php', '<?php return ['.implode(', ', $code).'];');
+    }
+
     private function createKernel(string $env = 'test', bool $debug = true): TestKernel
     {
         return new TestKernel($env, $debug, $this->varDir);
@@ -513,6 +612,11 @@ class TestKernel extends AbstractKernel
     public function getTestContainerClass(): string
     {
         return $this->getContainerClass();
+    }
+
+    public function getInstantiatedBundles(): array
+    {
+        return $this->bundles;
     }
 }
 
@@ -561,6 +665,43 @@ class BundleTestKernel extends AbstractKernel
 
 class TestAbstractBundle extends AbstractBundle
 {
+}
+
+class LazyBundle extends AbstractBundle
+{
+    public function getBoundContainer(): ?ContainerInterface
+    {
+        return $this->container ?? null;
+    }
+}
+
+class BootingBundle extends AbstractBundle
+{
+    public function boot(): void
+    {
+    }
+}
+
+class ShuttingDownBundle extends AbstractBundle
+{
+    public function shutdown(): void
+    {
+    }
+}
+
+class ContainerAwareBundle extends AbstractBundle
+{
+    public function setContainer(?ContainerInterface $container): void
+    {
+        $this->container = $container;
+    }
+}
+
+class ConstructedBundle extends AbstractBundle
+{
+    public function __construct()
+    {
+    }
 }
 
 class ExtensionBundle extends AbstractBundle

--- a/src/Symfony/Component/DependencyInjection/composer.json
+++ b/src/Symfony/Component/DependencyInjection/composer.json
@@ -28,7 +28,8 @@
         "symfony/yaml": "^7.4|^8.0"
     },
     "conflict": {
-        "ext-psr": "<1.1|>=2"
+        "ext-psr": "<1.1|>=2",
+        "symfony/http-kernel": "<8.2"
     },
     "provide": {
         "psr/container-implementation": "1.1|2.0",

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -18,6 +18,7 @@ CHANGELOG
  * Add the `$excludedPaths` and `$excludedHttpCodes` arguments to `ProfilerListener::__construct()` to skip profiling some requests
  * Make `#[MapRequestPayload]` deserialize any media type carrying a structured syntax suffix with the encoder of the suffix format, e.g. `application/vnd.api+json` with the `json` encoder
  * Add the `$exposeHeaders` argument to `#[RateLimit]`
+ * Instantiate on demand the bundles that have nothing to do when the kernel boots
 
 8.1
 ---

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\HttpKernel;
 
 use Symfony\Component\DependencyInjection\Dumper\Preloader;
 use Symfony\Component\DependencyInjection\Kernel\AbstractKernel;
+use Symfony\Component\DependencyInjection\Kernel\BundleInterface as BaseBundleInterface;
 use Symfony\Component\DependencyInjection\Kernel\KernelTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -83,7 +84,7 @@ abstract class Kernel extends AbstractKernel implements KernelInterface, Reboota
             $this->preBoot();
         }
 
-        foreach ($this->getBundles() as $bundle) {
+        foreach ($this->bundles as $bundle) {
             $bundle->setContainer($this->container);
             $bundle->boot();
         }
@@ -153,11 +154,7 @@ abstract class Kernel extends AbstractKernel implements KernelInterface, Reboota
 
     public function getBundle(string $name): BundleInterface
     {
-        if (!isset($this->bundles[$name])) {
-            throw new \InvalidArgumentException(\sprintf('Bundle "%s" does not exist or it is not enabled. Maybe you forgot to add it in the "registerBundles()" method of your "%s.php" file?', $name, get_debug_type($this)));
-        }
-
-        return $this->bundles[$name];
+        return parent::getBundle($name);
     }
 
     public function getCacheDir(): string
@@ -230,7 +227,7 @@ abstract class Kernel extends AbstractKernel implements KernelInterface, Reboota
             'kernel.charset' => $this->getCharset(),
         ];
 
-        foreach ($this->bundles as $name => $bundle) {
+        foreach ($this->getBundles() as $name => $bundle) {
             if ($bundle instanceof BundleAdapter) {
                 $parameters['kernel.bundles'][$name] = $bundle->getInnerBundle()::class;
             }
@@ -238,6 +235,16 @@ abstract class Kernel extends AbstractKernel implements KernelInterface, Reboota
         }
 
         return $parameters;
+    }
+
+    /**
+     * @param class-string<BaseBundleInterface> $class
+     */
+    protected function instantiateBundle(string $class): BundleInterface
+    {
+        $bundle = new $class();
+
+        return $bundle instanceof BundleInterface ? $bundle : new BundleAdapter($bundle);
     }
 
     private function preBoot(): void

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\DependencyInjection\Compiler\ResettableServicePass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
+use Symfony\Component\DependencyInjection\Kernel\AbstractBundle;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\ServicesResetter;
 use Symfony\Component\Filesystem\Exception\IOException;
@@ -26,6 +27,7 @@ use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Symfony\Component\HttpKernel\Bundle\BundleAdapter;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 use Symfony\Component\HttpKernel\CacheWarmer\WarmableInterface;
 use Symfony\Component\HttpKernel\HttpKernel;
@@ -131,12 +133,26 @@ class KernelTest extends TestCase
         $bundle->expects($this->once())
             ->method('setContainer');
 
-        $kernel = $this->getKernel(['initializeBundles', 'getBundles']);
-        $kernel->expects($this->once())
-            ->method('getBundles')
-            ->willReturn([$bundle]);
-
+        $kernel = new KernelForTest('test', false, true, [$bundle]);
         $kernel->boot();
+    }
+
+    public function testBundlesWithNothingToDoAtRuntimeAreInstantiatedOnDemand()
+    {
+        $kernel = new LazyBundleKernel();
+        $kernel->boot();
+        $kernel->shutdown();
+
+        $kernel = new LazyBundleKernel();
+        $kernel->boot();
+
+        $this->assertSame([], $kernel->getInstantiatedBundles());
+
+        $bundle = $kernel->getBundle('LazyDiBundle');
+
+        $this->assertInstanceOf(BundleAdapter::class, $bundle);
+        $this->assertInstanceOf(LazyDiBundle::class, $bundle->getInnerBundle());
+        $this->assertSame(['LazyDiBundle' => $bundle], $kernel->getBundles());
     }
 
     public function testDebugBootSetsShellVerbosity()
@@ -904,6 +920,37 @@ class KernelForTest extends Kernel
             parent::initializeContainer();
         }
     }
+}
+
+class LazyBundleKernel extends Kernel
+{
+    public function __construct()
+    {
+        parent::__construct('lazybundle', false);
+    }
+
+    public function registerBundles(): iterable
+    {
+        return [new LazyDiBundle()];
+    }
+
+    public function registerContainerConfiguration(LoaderInterface $loader): void
+    {
+    }
+
+    public function getProjectDir(): string
+    {
+        return __DIR__.'/Fixtures';
+    }
+
+    public function getInstantiatedBundles(): array
+    {
+        return $this->bundles;
+    }
+}
+
+class LazyDiBundle extends AbstractBundle
+{
 }
 
 class KernelForTestWithLoadClassCache extends KernelForTest


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`initializeBundles()` caches the resolved bundle list next to the container, and that dumped file
instantiates every bundle on every boot. Instantiating them links their classes, and most bundles have
nothing to link them for: a bundle that only declares `getPath()`, `build()`, `configure()` and
`loadExtension()` does nothing once the container is built, `boot()` and `shutdown()` being the inherited
no-ops of `AbstractBundle`. The component bundles that come with the bundle split are all of that shape.

The dumped file now stores class names, plus instances for the bundles that actually have something to do
at runtime:

```php
return [[
    'CacheBundle' => 'Symfony\\Component\\Cache\\CacheBundle',
    // ... one line per bundle, in registration order
    'FrameworkBundle' => 'Symfony\\Bundle\\FrameworkBundle\\FrameworkBundle',
], [
    'FrameworkBundle' => new \Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
]];
```

A bundle goes in the second list when it declares a constructor or a destructor, or when `boot()`,
`shutdown()` or `setContainer()` is not the one it inherits from `AbstractBundle`. That is decided when the
container is dumped, where the instances already exist, so nothing is reflected at runtime. Anything that
cannot be proven inert stays in the second list, in particular a bundle that implements `BundleInterface`
without extending `AbstractBundle`.

`$bundles` then holds only the bundles that have been instantiated. `getBundle()` and `getBundles()`
instantiate the missing ones on demand, in registration order, and hand them the container when the kernel
holds one, so `locateResource()` and `getKernelParameters()` see the same thing as before. `getBundles()`
still returns `BundleInterface` instances. `AbstractKernel::instantiateBundle()` is the seam where
`Kernel` wraps a bundle in a `BundleAdapter`, the same way `initializeBundles()` does for the eager ones.

The dumped `kernel.bundles` and `kernel.bundles_metadata` parameters are unchanged, and so is the rest of
the dumped container.

## The console

`FrameworkBundle`'s `Application::registerCommands()` walked `getBundles()` on every command, which
instantiated every bundle again. It did so only to find the bundles that override
`Bundle::registerCommands()`, deprecated since 8.1. In an app where none does, which is the normal case,
the whole walk is wasted.

That list is now computed when the container is compiled, by `FindCommandBundlesPass`, which reflects over
the classes named in `kernel.bundles` and stores the matching bundle names in the new
`console.command.bundles` parameter. The console then asks `getBundle()` for those names only, so an app
where no bundle overrides the method instantiates no bundle at all to build its command list. The
deprecation, the order of the calls and the `\RuntimeException` wrapping a failing `registerCommands()`
are unchanged. A container that carries no such parameter, one dumped before this change for instance,
still makes `Application` walk `getBundles()` as it used to.

`$bundleClasses` is a hooked property backed by a private array, so the class map cannot be replaced wholesale
from a child class: every write goes through the setter, including one made by a subclass. It has to stay
assignable rather than `private(set)`, because `AbstractKernel` does not use `KernelTrait`, so the parent reads
it while the trait that writes it is used by `Kernel`.

This is not limited to bundles extending the new `AbstractBundle`. `HttpKernel\Bundle\Bundle` extends it and
does not redeclare `boot()`, `shutdown()` or `setContainer()`, so ordinary bundles qualify too: in a stock app
`TwigBundle` and `SecurityBundle` are created on demand, while `FrameworkBundle`, `WebProfilerBundle` and
`DebugBundle` stay eager because they really do override `boot()`.

## Numbers

Two apps with the same features enabled, one with 22 bundles (the bundle-split branch) and one with 3.

Web, booted with an opcache file cache, 36 processes per variant, 200 fresh kernels each, medians of the
per-process medians:

| | first boot | steady boot | classes named `*Bundle` linked |
| --- | --- | --- | --- |
| 3 bundles, before | 4.515 ms | 0.0711 ms | 6 |
| 3 bundles, after | 4.406 ms | 0.0704 ms | 4 |
| 22 bundles, before | 6.028 ms | 0.0881 ms | 25 |
| 22 bundles, after | 4.577 ms | 0.0709 ms | 4 |

Going from 3 to 22 bundles costs 1.513 ms on the first boot and 0.0170 ms per boot afterwards. This
recovers 1.451 ms of the first (96%) and all of the second, leaving a 22-bundle app 0.06 ms away from a
3-bundle one. Preloading already hid this cost, this makes it disappear without preloading too.

The console pays more, because opcache is usually off there: each bundle file is parsed, not merely
linked. `bin/console list` against a warm build directory, opcache off, 62 processes per variant, medians:

| | time | files included | classes named `*Bundle` linked |
| --- | --- | --- | --- |
| 3 bundles, before | 60.28 ms | 257 | 5 |
| 3 bundles, after | 58.35 ms | 254 | 3 |
| 22 bundles, before | 69.82 ms | 294 | 24 |
| 22 bundles, after | 61.03 ms | 272 | 3 |

The 22 files that stop being included are the 21 bundle classes that are not instantiated anymore, plus
the `BundleAdapter` that wrapped them. `FrameworkBundle` stays, because it overrides `boot()`. That is
8.79 ms of the 9.54 ms the 19 extra bundles used to cost per command, and what remains is not bundle
instantiation: a 22-bundle app now runs a command within 2.68 ms of a 3-bundle one.

## Things to weigh

 * `Kernel::boot()` iterates `$bundles` instead of calling `getBundles()`, like `AbstractKernel::boot()`
   already did. Overriding `getBundles()` no longer changes what gets booted.
 * The constructor of an inert bundle no longer runs on every boot. Only bundles that declare no
   constructor at all are made lazy, so what stops running is the implicit one.
 * A bundle class is not autoloaded anymore until something asks for the bundle, so statements at the top
   level of its file, such as the `class_exists()` calls `FrameworkBundle.php` makes for `opcache.preload`,
   no longer run at boot. Bundles that do this are the ones that also override `boot()`, hence eager.
 * The dumped file changed shape, so one dumped by 8.1 is ignored: the kernel falls back to resolving the
   bundle list itself until the container is dumped again. That keeps `cache:clear` working on a build
   directory carried over from 8.1 instead of failing on it.
 * Overriding `registerCommands()` does not make a bundle eager, because that method runs on the console
   only. Such a bundle stays out of the boot list and is instantiated by name when a command is looked up,
   so a web request keeps paying nothing for it.
 * `console.command.bundles` is a public parameter, so it shows up in `debug:container --parameters`. A
   parameter whose name starts with a dot cannot be read from a dumped container, and `Application` needs
   to read this one at runtime.
