### PR TITLE
[Form][Validator] Review Romanian (ro) translations

### DIFF
--- a/src/Symfony/Component/Form/Resources/translations/validators.ro.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.ro.xlf
@@ -136,7 +136,7 @@
             </trans-unit>
             <trans-unit id="129">
                 <source>Please enter a valid UUID.</source>
-                <target state="needs-review-translation">Vă rugăm să introduceți un UUID valid.</target>
+                <target>Vă rugăm să introduceți un UUID valid.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.ro.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.ro.xlf
@@ -556,27 +556,27 @@
             </trans-unit>
             <trans-unit id="143">
                 <source>This value is not valid XML.</source>
-                <target state="needs-review-translation">Această valoare nu este un XML valid.</target>
+                <target>Această valoare nu este un XML valid.</target>
             </trans-unit>
             <trans-unit id="144">
                 <source>This value does not conform to the expected XSD schema.</source>
-                <target state="needs-review-translation">Această valoare nu este conformă cu schema XSD așteptată.</target>
+                <target>Această valoare nu corespunde schemei XSD așteptate.</target>
             </trans-unit>
             <trans-unit id="145">
                 <source>This XML payload is too large ({{ size }} bytes): it exceeds the limit of {{ limit }} bytes.</source>
-                <target state="needs-review-translation">Această încărcătură utilă XML este prea mare ({{ size }} octeți): depășește limita de {{ limit }} octeți.</target>
+                <target>Acest payload XML este prea mare ({{ size }} bytes): depășește limita de {{ limit }} bytes.</target>
             </trans-unit>
             <trans-unit id="146">
                 <source>This value is not a valid cron expression.</source>
-                <target state="needs-review-translation">Această valoare nu este o expresie cron validă.</target>
+                <target>Această valoare nu este o expresie cron validă.</target>
             </trans-unit>
             <trans-unit id="147">
                 <source>The referenced entity does not exist.</source>
-                <target state="needs-review-translation">Entitatea referențiată nu există.</target>
+                <target>Entitatea la care se face referire nu există.</target>
             </trans-unit>
             <trans-unit id="148" resname="This is not a valid ULID.">
                 <source>This value is not a valid ULID.</source>
-                <target state="needs-review-translation">Această valoare nu este un ULID valid.</target>
+                <target>Această valoare nu este un ULID valid.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #64511
| License       | MIT

Reviewed the 7 Romanian strings flagged with `state="needs-review-translation"` and removed the markers. I am a native Romanian speaker.

Four were already correct and are kept verbatim — they follow the catalog's established patterns (`#148` is identical in shape to the already-reviewed UUID entry `#83`). Three were reworded:

| Id | English | Before | After | Why |
| -- | -- | -- | -- | -- |
| V144 | This value does not conform to the expected XSD schema. | Această valoare nu este conformă cu schema XSD așteptată. | Această valoare nu corespunde schemei XSD așteptate. | Aligns with the existing `nu corespunde ... așteptat` phrasing used in `#310` and `#554`. |
| V145 | This XML payload is too large (`{{ size }}` bytes)... | Această încărcătură utilă XML este prea mare (`{{ size }}` octeți)... | Acest payload XML este prea mare (`{{ size }}` bytes): depășește limita de `{{ limit }}` bytes. | "încărcătură utilă" is a calque that carries the aerospace/military sense of *payload*. Romanian developers use "payload" and "bytes" untranslated, consistent with the catalog already keeping "hostname" untranslated in `#370`. |
| V147 | The referenced entity does not exist. | Entitatea referențiată nu există. | Entitatea la care se face referire nu există. | **"referențiat" is not a Romanian word** — neither `a referenția` nor `referențiat` appears in any dictionary (DEX '09, DEX '16, MDA2, DOOM 3). It is a calque of English *referenced*. Unlike Italian/Spanish/French/Portuguese, which legitimately use a participle here because `referenziare`/`referenciar`/`référencer` are attested verbs, Romanian has no such verb. The two obvious alternatives are also wrong: `referită` (from `a referi`, transitive) means "reported", and `de referință` means "authoritative, benchmark" (as in *lucrare de referință*). The relative clause `la care se face referire` is the standard correct construction. |

Both files still validate against `xliff-core-1.2-transitional.xsd` and keep trans-unit parity with English (34 / 144). Indentation is untouched, and the comma-below diacritics (`ș` U+0219, `ț` U+021B) used throughout the file are preserved.
