### PR TITLE
[Tui] Measure malformed UTF-8 instead of throwing

### DIFF
--- a/src/Symfony/Component/Tui/Ansi/AnsiUtils.php
+++ b/src/Symfony/Component/Tui/Ansi/AnsiUtils.php
@@ -518,11 +518,25 @@ final class AnsiUtils
      * falling back to UnicodeString::width() for multi-codepoint graphemes
      * (ZWJ emoji sequences, skin tone modifiers, decomposed combining chars)
      * where mb_strwidth() overcounts by summing component widths.
+     *
+     * Malformed UTF-8 is measured on what is left once the invalid bytes are
+     * dropped, so it never throws.
      */
     public static function graphemeWidth(string $grapheme): int
     {
         if (1 === mb_strlen($grapheme, 'UTF-8')) {
             return mb_strwidth($grapheme, 'UTF-8');
+        }
+
+        if (!preg_match('//u', $grapheme)) {
+            // UnicodeString rejects malformed UTF-8. Drop the invalid bytes the
+            // way visibleWidth() does, so text that reaches a measure unscrubbed
+            // comes out as a wrong glyph instead of aborting the render.
+            $grapheme = @iconv('UTF-8', 'UTF-8//IGNORE', $grapheme) ?: '';
+
+            if (1 >= mb_strlen($grapheme, 'UTF-8')) {
+                return mb_strwidth($grapheme, 'UTF-8');
+            }
         }
 
         return new UnicodeString($grapheme)->width(false);

--- a/src/Symfony/Component/Tui/Tests/Ansi/AnsiUtilsTest.php
+++ b/src/Symfony/Component/Tui/Tests/Ansi/AnsiUtilsTest.php
@@ -622,4 +622,32 @@ class AnsiUtilsTest extends TestCase
             $this->assertLessThanOrEqual(8, AnsiUtils::visibleWidth($chunk));
         }
     }
+
+    public function testGraphemeWidthOfMalformedUtf8()
+    {
+        $this->assertSame(1, AnsiUtils::graphemeWidth("\xC3\u{0301}"));
+    }
+
+    public function testGraphemeWidthOfBytesThatCarryNoCharacterIsZero()
+    {
+        $this->assertSame(0, AnsiUtils::graphemeWidth("\xC3\xC3"));
+    }
+
+    public function testSliceByColumnKeepsSlicingMalformedUtf8()
+    {
+        $line = "ab\xC3\u{0301}cdef";
+
+        $this->assertSame('ab', AnsiUtils::sliceByColumn($line, 0, 2));
+        $this->assertSame('cdef', AnsiUtils::sliceByColumn($line, 3, 4));
+        $this->assertLessThanOrEqual(4, AnsiUtils::visibleWidth(AnsiUtils::sliceByColumn($line, 0, 4)));
+    }
+
+    public function testTruncateToWidthKeepsTruncatingMalformedUtf8()
+    {
+        $truncated = AnsiUtils::truncateToWidth("ab\xC3\u{0301}cdefghij", 6);
+
+        $this->assertStringStartsWith("ab\xC3\u{0301}", $truncated);
+        $this->assertStringEndsWith('...', $truncated);
+        $this->assertLessThanOrEqual(6, AnsiUtils::visibleWidth($truncated));
+    }
 }

--- a/src/Symfony/Component/Tui/Tests/Ansi/TextWrapperTest.php
+++ b/src/Symfony/Component/Tui/Tests/Ansi/TextWrapperTest.php
@@ -289,4 +289,16 @@ class TextWrapperTest extends TestCase
         $this->assertSame('Hello', $lines[0]);
         $this->assertSame('World', $lines[1]);
     }
+
+    public function testBreakingALongWordThatCarriesMalformedUtf8()
+    {
+        $word = "aaaaa\xC3\u{0301}aaaaaaaaaa";
+        $lines = TextWrapper::wrapTextWithAnsi($word, 5);
+
+        $this->assertSame($word, implode('', $lines));
+
+        foreach ($lines as $line) {
+            $this->assertLessThanOrEqual(5, AnsiUtils::visibleWidth($line));
+        }
+    }
 }

--- a/src/Symfony/Component/Tui/composer.json
+++ b/src/Symfony/Component/Tui/composer.json
@@ -19,6 +19,7 @@
         "php": ">=8.4.1",
         "revolt/event-loop": "^1.0",
         "symfony/event-dispatcher": "^8.0",
+        "symfony/polyfill-intl-grapheme": "^1.42.1",
         "symfony/string": "^8.0"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | n/a
| License       | MIT

<!--
🛠️ Replace this text with a concise explanation of your change:
- What it does and why it's needed
- A simple example of how it works (include PHP, YAML, etc.)
- If it modifies existing behavior, include a before/after comparison

Contributor guidelines:
- ✅ Add tests and ensure they pass
- 🐞 Bug fixes must target the **lowest maintained** branch where they apply
  https://symfony.com/releases#maintained-symfony-branches
- ✨ New features and deprecations must target the **feature** branch
  and must add an entry to the changelog file of the patched component:
  https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
- 🔒 Do not break backward compatibility:
  https://symfony.com/bc
-->
