### PR TITLE
[DependencyInjection] Name the package to install for a missing component extension

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -53,6 +53,7 @@ use Symfony\Component\DependencyInjection\Compiler\RegisterReverseContainerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Kernel\RequiredBundle;
 use Symfony\Component\DependencyInjection\Kernel\ServicesBundle;
+use Symfony\Component\DependencyInjection\Loader\UndefinedExtensionHandler;
 use Symfony\Component\Dotenv\Dotenv;
 use Symfony\Component\ErrorHandler\ErrorHandler;
 use Symfony\Component\EventDispatcher\DependencyInjection\AddEventAliasesPass;
@@ -181,6 +182,35 @@ class FrameworkBundle extends Bundle
     public function build(ContainerBuilder $container): void
     {
         parent::build($container);
+
+        // so that a missing extension can be reported with the package that provides it;
+        // "cache" is deliberately absent, it is a hard requirement of this bundle and its
+        // bundle is always registered, so suggesting to require it could never help
+        UndefinedExtensionHandler::addPackages($container, [
+            'asset' => 'symfony/asset',
+            'asset_mapper' => 'symfony/asset-mapper',
+            'html_sanitizer' => 'symfony/html-sanitizer',
+            'http_client' => 'symfony/http-client',
+            'json_streamer' => 'symfony/json-streamer',
+            'lock' => 'symfony/lock',
+            'mailer' => 'symfony/mailer',
+            'messenger' => 'symfony/messenger',
+            'notifier' => 'symfony/notifier',
+            'property_access' => 'symfony/property-access',
+            'property_info' => 'symfony/property-info',
+            'rate_limiter' => 'symfony/rate-limiter',
+            'remote_event' => 'symfony/remote-event',
+            'scheduler' => 'symfony/scheduler',
+            'semaphore' => 'symfony/semaphore',
+            'serializer' => 'symfony/serializer',
+            'translation' => 'symfony/translation',
+            'type_info' => 'symfony/type-info',
+            'uid' => 'symfony/uid',
+            'validation' => 'symfony/validator',
+            'web_link' => 'symfony/web-link',
+            'webhook' => 'symfony/webhook',
+            'workflow' => 'symfony/workflow',
+        ]);
 
         $container->addCompilerPass(new AddEventAliasesPass(
             array_merge(

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.2
 ---
 
+ * Name the package to install when an extension is missing, for the configuration keys declared in the `.container.extension_packages` build parameter
  * Add `ContainerBuilder::setExtensionConfig()`
  * Forward the configuration of the nodes declared with `NodeDefinition::aliasOf()` to the extension with that alias in `MergeExtensionConfigurationPass`
  * Allow computing tag attributes per tagged service when using `#[AutoconfigureTag]`, `#[Autoconfigure]` or `_instanceof`: pass a `\Closure` receiving the concrete class-string (requires PHP 8.5), or a `[class-string, method]` callable resolved against each concrete class (works on PHP 8.4)

--- a/src/Symfony/Component/DependencyInjection/Compiler/MergeExtensionConfigurationPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/MergeExtensionConfigurationPass.php
@@ -24,6 +24,7 @@ use Symfony\Component\DependencyInjection\Extension\ConfigurationExtensionInterf
 use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
+use Symfony\Component\DependencyInjection\Loader\UndefinedExtensionHandler;
 use Symfony\Component\DependencyInjection\ParameterBag\EnvPlaceholderParameterBag;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
@@ -179,7 +180,7 @@ class MergeExtensionConfigurationPass implements CompilerPassInterface
                     $alias = $node->getAttribute('alias_of');
 
                     if (!$container->hasExtension($alias)) {
-                        throw new LogicException(\sprintf('The "%s.%s" configuration is handled by the "%s" extension, which is not registered.', $name, $key, $alias));
+                        throw UndefinedExtensionHandler::createUndefinedAliasException($name, $key, $alias, $container);
                     }
 
                     if ($node->isDeprecated()) {

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/ContainerConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/ContainerConfigurator.php
@@ -57,7 +57,7 @@ class ContainerConfigurator extends AbstractConfigurator
 
         if (!$this->container->hasExtension($namespace)) {
             $extensions = array_filter(array_map(static fn (ExtensionInterface $ext) => $ext->getAlias(), $this->container->getExtensions()));
-            throw new InvalidArgumentException(UndefinedExtensionHandler::getErrorMessage($namespace, $this->file, $namespace, $extensions));
+            throw new InvalidArgumentException(UndefinedExtensionHandler::getErrorMessage($namespace, $this->file, $namespace, $extensions, UndefinedExtensionHandler::getPackages($this->container)));
         }
 
         $this->container->loadFromExtension($namespace, static::processValue($config));

--- a/src/Symfony/Component/DependencyInjection/Loader/UndefinedExtensionHandler.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/UndefinedExtensionHandler.php
@@ -11,6 +11,9 @@
 
 namespace Symfony\Component\DependencyInjection\Loader;
 
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\LogicException;
+
 class UndefinedExtensionHandler
 {
     private const BUNDLE_EXTENSIONS = [
@@ -27,7 +30,56 @@ class UndefinedExtensionHandler
         'web_profiler' => 'WebProfilerBundle',
     ];
 
-    public static function getErrorMessage(string $extensionName, ?string $loadingFilePath, string $namespaceOrAlias, array $foundExtensionNamespaces): string
+    /**
+     * The build parameter through which a bundle names the package that provides each
+     * configuration key it knows about, as a map of extension name to package name.
+     */
+    private const PACKAGES_PARAMETER = '.container.extension_packages';
+
+    /**
+     * Declares the package that provides each of the given configuration keys.
+     *
+     * @param array<string, string> $packages A map of extension name to package name
+     */
+    public static function addPackages(ContainerBuilder $container, array $packages): void
+    {
+        $container->setParameter(self::PACKAGES_PARAMETER, [...self::getPackages($container), ...$packages]);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public static function getPackages(ContainerBuilder $container): array
+    {
+        return $container->hasParameter(self::PACKAGES_PARAMETER) ? $container->getParameter(self::PACKAGES_PARAMETER) : [];
+    }
+
+    /**
+     * Reports a configuration node whose value is forwarded to an extension nobody registered.
+     */
+    public static function createUndefinedAliasException(string $extensionName, string $key, string $alias, ContainerBuilder $container): LogicException
+    {
+        return new LogicException(\sprintf('The "%s.%s" configuration is handled by the "%s" extension, which is not registered.', $extensionName, $key, $alias).self::getPackageSuggestion($alias, self::getPackages($container)));
+    }
+
+    /**
+     * Names the package to install for a configuration key a bundle has declared it knows about.
+     *
+     * @param array<string, string> $packages
+     */
+    public static function getPackageSuggestion(string $extensionName, array $packages): string
+    {
+        if (!isset($packages[$extensionName])) {
+            return '';
+        }
+
+        return \sprintf(' Try running "composer require %s".', $packages[$extensionName]);
+    }
+
+    /**
+     * @param array<string, string> $packages
+     */
+    public static function getErrorMessage(string $extensionName, ?string $loadingFilePath, string $namespaceOrAlias, array $foundExtensionNamespaces, array $packages = []): string
     {
         $message = '';
         if (isset(self::BUNDLE_EXTENSIONS[$extensionName])) {
@@ -39,6 +91,8 @@ class UndefinedExtensionHandler
             default => \sprintf('There is no extension able to load the configuration for "%s". ', $extensionName),
         };
 
-        return $message.\sprintf('Looked for namespace "%s", found "%s".', $namespaceOrAlias, $foundExtensionNamespaces ? implode('", "', $foundExtensionNamespaces) : 'none');
+        $message .= \sprintf('Looked for namespace "%s", found "%s".', $namespaceOrAlias, $foundExtensionNamespaces ? implode('", "', $foundExtensionNamespaces) : 'none');
+
+        return $message.self::getPackageSuggestion($extensionName, $packages);
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -129,7 +129,7 @@ class YamlFileLoader extends FileLoader
 
             if (!$this->prepend && !$this->container->hasExtension($namespace)) {
                 $extensionNamespaces = array_filter(array_map(static fn (ExtensionInterface $ext) => $ext->getAlias(), $this->container->getExtensions()));
-                throw new InvalidArgumentException(UndefinedExtensionHandler::getErrorMessage($namespace, $file, $namespace, $extensionNamespaces));
+                throw new InvalidArgumentException(UndefinedExtensionHandler::getErrorMessage($namespace, $file, $namespace, $extensionNamespaces, UndefinedExtensionHandler::getPackages($this->container)));
             }
         }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/MergeExtensionConfigurationPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/MergeExtensionConfigurationPassTest.php
@@ -26,6 +26,7 @@ use Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
+use Symfony\Component\DependencyInjection\Loader\UndefinedExtensionHandler;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
 
@@ -299,6 +300,19 @@ class MergeExtensionConfigurationPassTest extends TestCase
         (new MergeExtensionConfigurationPass())->process($container);
     }
 
+    public function testAnUnregisteredExtensionOwnedByAComponentNamesThePackageToInstall()
+    {
+        $container = new ContainerBuilder();
+        UndefinedExtensionHandler::addPackages($container, ['notifier' => 'symfony/notifier']);
+        $container->registerExtension(new AliasingExtension());
+        $container->loadFromExtension('aliasing', ['notifier' => []]);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('The "aliasing.notifier" configuration is handled by the "notifier" extension, which is not registered. Try running "composer require symfony/notifier".');
+
+        (new MergeExtensionConfigurationPass())->process($container);
+    }
+
     #[Group('legacy')]
     #[IgnoreDeprecations]
     public function testDeprecatedExtensionAliasesTriggerTheirDeprecation()
@@ -431,6 +445,7 @@ final class AliasingConfiguration implements ConfigurationInterface
                 ->variableNode('under_scored')->attribute('alias_of', 'target')->end()
                 ->variableNode('shorthand')->attribute('alias_of', 'target')->beforeNormalization()->ifString()->then(static fn ($v) => ['value' => $v])->end()->end()
                 ->variableNode('legacy')->attribute('alias_of', 'target')->setDeprecated('symfony/test', '1.0', 'The "%path%" configuration is deprecated, use "target" instead.')->end()
+                ->variableNode('notifier')->attribute('alias_of', 'notifier')->end()
             ->end();
 
         return $treeBuilder;

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/UndefinedExtensionHandlerTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/UndefinedExtensionHandlerTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Loader;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\LogicException;
+use Symfony\Component\DependencyInjection\Loader\UndefinedExtensionHandler;
+
+class UndefinedExtensionHandlerTest extends TestCase
+{
+    private const PACKAGES = ['notifier' => 'symfony/notifier', 'html_sanitizer' => 'symfony/html-sanitizer'];
+
+    public function testADeclaredKeyNamesThePackageToInstall()
+    {
+        $this->assertSame(' Try running "composer require symfony/notifier".', UndefinedExtensionHandler::getPackageSuggestion('notifier', self::PACKAGES));
+        $this->assertSame(' Try running "composer require symfony/html-sanitizer".', UndefinedExtensionHandler::getPackageSuggestion('html_sanitizer', self::PACKAGES));
+    }
+
+    public function testAnUndeclaredKeyIsNotGuessedAt()
+    {
+        // guessing "symfony/acme-foo" here would send the reader after a package that does not exist
+        $this->assertSame('', UndefinedExtensionHandler::getPackageSuggestion('acme_foo', self::PACKAGES));
+        $this->assertSame('', UndefinedExtensionHandler::getPackageSuggestion('notifier', []));
+    }
+
+    public function testTheSuggestionIsAppendedToTheErrorMessage()
+    {
+        $message = UndefinedExtensionHandler::getErrorMessage('notifier', '/app/config.yaml', 'notifier', ['framework'], self::PACKAGES);
+
+        $this->assertSame('There is no extension able to load the configuration for "notifier" (in "/app/config.yaml"). Looked for namespace "notifier", found "framework". Try running "composer require symfony/notifier".', $message);
+    }
+
+    public function testTheMessageIsUnchangedWithoutADeclaredPackage()
+    {
+        $message = UndefinedExtensionHandler::getErrorMessage('notifier', '/app/config.yaml', 'notifier', ['framework']);
+
+        $this->assertSame('There is no extension able to load the configuration for "notifier" (in "/app/config.yaml"). Looked for namespace "notifier", found "framework".', $message);
+    }
+
+    public function testPackagesAccumulateSoSeveralBundlesCanDeclareTheirOwn()
+    {
+        $container = new ContainerBuilder();
+        $this->assertSame([], UndefinedExtensionHandler::getPackages($container));
+
+        UndefinedExtensionHandler::addPackages($container, ['notifier' => 'symfony/notifier']);
+        UndefinedExtensionHandler::addPackages($container, ['acme' => 'acme/bundle']);
+
+        $this->assertSame(['notifier' => 'symfony/notifier', 'acme' => 'acme/bundle'], UndefinedExtensionHandler::getPackages($container));
+    }
+
+    public function testTheForwardedAliasExceptionNamesThePackage()
+    {
+        $container = new ContainerBuilder();
+        UndefinedExtensionHandler::addPackages($container, ['notifier' => 'symfony/notifier']);
+
+        $e = UndefinedExtensionHandler::createUndefinedAliasException('framework', 'notifier', 'notifier', $container);
+
+        $this->assertInstanceOf(LogicException::class, $e);
+        $this->assertSame('The "framework.notifier" configuration is handled by the "notifier" extension, which is not registered. Try running "composer require symfony/notifier".', $e->getMessage());
+    }
+
+    public function testTheForwardedAliasExceptionIsUnchangedWithoutADeclaredPackage()
+    {
+        $e = UndefinedExtensionHandler::createUndefinedAliasException('framework', 'acme', 'acme', new ContainerBuilder());
+
+        $this->assertSame('The "framework.acme" configuration is handled by the "acme" extension, which is not registered.', $e->getMessage());
+    }
+
+    public function testAKnownBundleStillReportsItsBundle()
+    {
+        $message = UndefinedExtensionHandler::getErrorMessage('twig', null, 'twig', []);
+
+        $this->assertStringStartsWith('Did you forget to install or enable the TwigBundle? ', $message);
+        $this->assertStringEndsWith('found "none".', $message);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

Moving a section into a component bundle costs the reader the one thing the old error told them: which package to install. Both ways of reaching a missing extension now say it again.

Writing the key at the root, with no bundle providing it:

```
There is no extension able to load the configuration for "notifier" (in "/app/config/packages/notifier.yaml").
Looked for namespace "notifier", found "framework".
+ Try running "composer require symfony/notifier".
```

Setting it under `framework`, where the alias forwards to an extension nobody registered:

```
The "framework.notifier" configuration is handled by the "notifier" extension, which is not registered.
+ Try running "composer require symfony/notifier".
```

The second is what `registerNotifierConfiguration()` and its siblings used to answer with `Notifier support cannot be enabled as the component is not installed. Try running "composer require symfony/notifier".`

## The map is a build parameter, not a constant

Hardcoding the keys in the DependencyInjection component would mean teaching it about Cache, Notifier, Workflow and seventeen others. Instead a bundle declares what it knows through `.container.extension_packages`, a map of configuration key to package name, and both error paths read it back.

`FrameworkBundle::build()` fills it, appending to whatever is already there so another bundle can add its own keys. The ordering works because `prepareContainer()` calls `build()` on every bundle before `registerContainerConfiguration()` loads a single file, so the parameter is in place by the time the loader throws. It starts with a `.`, so `RemoveBuildParametersPass` drops it before the container is dumped.

`UndefinedExtensionHandler::getErrorMessage()` gains an optional trailing argument and keeps its old behaviour when it is omitted.

## Worth reviewing

**`cache` is deliberately absent from the map.** It is the only one of the twenty aliased keys that is a hard `require` of FrameworkBundle rather than a `require-dev`, and the only one whose bundle is registered unconditionally rather than with `ignoreOnInvalid`. So in any application that has FrameworkBundle, `symfony/cache` is installed and `CacheBundle` is registered; the error cannot be reached, and if it somehow were, telling the reader to require a package they already have would not help. The other nineteen are genuinely optional, so the suggestion is actionable.

**Keys are declared, not derived.** The convention does hold for all nineteen, `html_sanitizer` to `symfony/html-sanitizer` and so on, so deriving them would be less code and would cover future keys for free. But it would also answer a typo or a third-party key with `Try running "composer require symfony/acme-foo"`, sending the reader after a package that does not exist. A wrong suggestion in an error message is worse than none. `testAnUndeclaredKeyIsNotGuessedAt` pins that.

**It reads as an addition, not a replacement.** The suggestion is appended, so `Looked for namespace ..., found ...` and the existing bundle hint both survive; `testAKnownBundleStillReportsItsBundle` covers a key present in both maps, and `testTheMessageIsUnchangedWithoutADeclaredPackage` covers a container that declares nothing.

All four cases were checked against a container built the way the kernel builds one, `build()` first and configuration after: the root key and the forwarded key both name the package, while `cache` and an unknown key get no suggestion.

## Checks

DependencyInjection (1896), FrameworkBundle (1424) and Config (637) pass locally. Not run locally: the lowest-dependency jobs, PHPStan and Psalm.

