### PR TITLE
[Security] Do not follow redirects on the OIDC token, UserInfo and JWKS endpoints

### DIFF
--- a/src/Symfony/Component/Security/Http/AccessToken/OAuth2/Oauth2TokenHandler.php
+++ b/src/Symfony/Component/Security/Http/AccessToken/OAuth2/Oauth2TokenHandler.php
@@ -338,7 +338,7 @@ final class Oauth2TokenHandler implements AccessTokenHandlerInterface
      */
     private function computeMetadataKeys(ItemInterface $item): array
     {
-        [$keys, $ttl] = OidcJwks::fromResponse($this->metadataClient->request('GET', $this->metadata->getConfiguration()['jwks_uri']), true);
+        [$keys, $ttl] = OidcJwks::fromResponse($this->metadataClient->request('GET', $this->metadata->getConfiguration()['jwks_uri'], ['max_redirects' => 0]), true);
 
         if (0 < ($ttl ?? -1)) {
             $item->expiresAfter(min($ttl, OidcJwks::MAX_TTL));

--- a/src/Symfony/Component/Security/Http/Authenticator/Oidc/OidcClient.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Oidc/OidcClient.php
@@ -62,6 +62,7 @@ final class OidcClient implements OidcClientInterface
         }
 
         $options = $this->clientAuthentication->authenticate($this->clientId, $tokenEndpoint, ['body' => $body]);
+        $options['max_redirects'] = 0;
 
         try {
             return $this->httpClient->request('POST', $tokenEndpoint, $options)->toArray();
@@ -85,6 +86,7 @@ final class OidcClient implements OidcClientInterface
         }
 
         $options = $this->clientAuthentication->authenticate($this->clientId, $tokenEndpoint, ['body' => $body]);
+        $options['max_redirects'] = 0;
 
         try {
             $response = $this->httpClient->request('POST', $tokenEndpoint, $options);
@@ -111,6 +113,7 @@ final class OidcClient implements OidcClientInterface
         try {
             return $this->httpClient->request('GET', $userInfoEndpoint, [
                 'auth_bearer' => $accessToken,
+                'max_redirects' => 0,
             ])->toArray();
         } catch (HttpClientExceptionInterface $e) {
             throw new AuthenticationException(\sprintf('The OIDC userinfo endpoint request failed: "%s"', $e->getMessage()), previous: $e);

--- a/src/Symfony/Component/Security/Http/Authenticator/Oidc/OidcJwks.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Oidc/OidcJwks.php
@@ -96,7 +96,7 @@ final class OidcJwks
      */
     public static function fetchKeys(HttpClientInterface $httpClient, string $jwksUri, ItemInterface $item, int $defaultTtl = 3600, bool $enforceKeyUsageVerification = true): array
     {
-        [$keys, $ttl] = self::fromResponse($httpClient->request('GET', $jwksUri), $enforceKeyUsageVerification);
+        [$keys, $ttl] = self::fromResponse($httpClient->request('GET', $jwksUri, ['max_redirects' => 0]), $enforceKeyUsageVerification);
 
         $item->expiresAfter(null === $ttl ? $defaultTtl : min($ttl, self::MAX_TTL));
 

--- a/src/Symfony/Component/Security/Http/Tests/AccessToken/OAuth2/OAuth2TokenHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/AccessToken/OAuth2/OAuth2TokenHandlerTest.php
@@ -492,6 +492,41 @@ class OAuth2TokenHandlerTest extends TestCase
         $this->assertContains($metadataUrl, $requested);
     }
 
+    /**
+     * The options are asserted after the call: the handler turns every exception the response
+     * factory raises into a BadCredentialsException, a failed assertion included.
+     */
+    #[RequiresPhpExtension('openssl')]
+    public function testMetadataJwksDoesNotFollowRedirects()
+    {
+        $jwksOptions = [];
+        $client = new MockHttpClient(static function (string $method, string $url, array $options) use (&$jwksOptions): MockResponse {
+            if (str_contains($url, '/.well-known/')) {
+                return new JsonMockResponse(['issuer' => self::ISSUER, 'jwks_uri' => 'https://as.example.com/jwks']);
+            }
+
+            if (str_contains($url, '/jwks')) {
+                $jwksOptions = $options;
+
+                return new MockResponse('', ['http_code' => 301, 'response_headers' => ['location' => 'https://other.example.com/jwks']]);
+            }
+
+            return self::jwtResponse(self::signedResponsePayload(self::activeClaims(['sub' => 'jdoe'])));
+        }, self::ENDPOINT);
+
+        $handler = self::createHandler($client, [self::AUDIENCE], self::ISSUER);
+        $handler->enableSignedResponse(new AlgorithmManager([new ES256()]), null);
+        $handler->enableSignedResponseDiscovery(new ArrayAdapter(), $client, 'metadata.');
+
+        try {
+            $handler->getUserBadgeFrom('a-secret-token');
+            $this->fail('A BadCredentialsException should have been thrown.');
+        } catch (BadCredentialsException) {
+        }
+
+        $this->assertSame(0, $jwksOptions['max_redirects'] ?? null);
+    }
+
     public static function provideIssuersAndMetadataUrls(): iterable
     {
         yield 'a bare origin' => ['https://as.example.com', 'https://as.example.com/.well-known/oauth-authorization-server'];

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/Oidc/OidcClientTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/Oidc/OidcClientTest.php
@@ -60,6 +60,7 @@ class OidcClientTest extends TestCase
                 $this->assertSame('auth-code', $options['body']['code']);
                 $this->assertSame('https://app.example.com/callback', $options['body']['redirect_uri']);
                 $this->assertSame('test-client-id', $options['body']['client_id']);
+                $this->assertSame(0, $options['max_redirects']);
 
                 return true;
             }))
@@ -167,7 +168,7 @@ class OidcClientTest extends TestCase
 
         $this->httpClient->expects($this->once())
             ->method('request')
-            ->with('GET', 'https://provider.example.com/userinfo', ['auth_bearer' => 'access-token'])
+            ->with('GET', 'https://provider.example.com/userinfo', ['auth_bearer' => 'access-token', 'max_redirects' => 0])
             ->willReturn($response);
 
         $claims = $this->createClient($clientAuthentication)->fetchUserInfo('access-token');
@@ -230,6 +231,7 @@ class OidcClientTest extends TestCase
         $this->assertArrayNotHasKey('scope', $body);
         $this->assertSame('access-456', $tokens['access_token']);
         $this->assertSame('refresh-456', $tokens['refresh_token']);
+        $this->assertSame(0, $mockResponse->getRequestOptions()['max_redirects']);
     }
 
     public function testTheRefreshRequestIsMadeWithTheOptionsTheClientAuthenticationReturns()

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/Oidc/OidcJwksTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/Oidc/OidcJwksTest.php
@@ -167,6 +167,23 @@ class OidcJwksTest extends TestCase
         OidcJwks::fetchKeys($httpClient, 'https://provider.example.com/jwks', $item);
     }
 
+    public function testFetchKeysDoesNotFollowRedirects()
+    {
+        $response = new MockResponse('', ['http_code' => 301, 'response_headers' => ['location' => 'https://other.example.com/jwks']]);
+        $httpClient = new MockHttpClient($response);
+
+        $item = $this->createMock(ItemInterface::class);
+        $item->expects($this->never())->method('expiresAfter');
+
+        try {
+            OidcJwks::fetchKeys($httpClient, 'https://provider.example.com/jwks', $item);
+            $this->fail('An AuthenticationException should have been thrown.');
+        } catch (AuthenticationException) {
+        }
+
+        $this->assertSame(0, $response->getRequestOptions()['max_redirects'] ?? null);
+    }
+
     public function testFetchKeysIsUsableAsACacheCallback()
     {
         $httpClient = new MockHttpClient(new JsonMockResponse(['keys' => [['kid' => 'sig-key', 'kty' => 'EC', 'use' => 'sig']]]));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Four requests of the OIDC stack followed redirects:

 * the token endpoint, in `OidcClient::exchangeCode()` and `::refreshToken()`: a 307 or a 308 re-sends the body, so the authorization code, the PKCE verifier, the refresh token and, with `client_secret_post`, the client secret all reach the redirect target. `HttpClient` strips `Authorization` and `Cookie` across origins but never the body, and it follows an `https` to `http` redirect, which is the very downgrade `OidcDiscovery::getSecureEndpoint()` refuses to accept in the announced endpoint;
 * the UserInfo endpoint, in `OidcClient::fetchUserInfo()`: the claims come back from the redirect target. The bearer does not leak, it travels in `Authorization`, but that response is where the user attributes come from;
 * the JWKS of `OidcSignatureVerifier`, through `OidcJwks::fetchKeys()`: the keys an ID token is verified against then come from the redirect target, so a token that target signs verifies;
 * the JWKS the OAuth2 authorization server metadata announces, in `Oauth2TokenHandler`: the same for the signature of a JWT introspection response.

For the GET requests any 3xx does this; the token POST needs a 307 or a 308, since a 301, a 302 and a 303 become a GET without a body.

`max_redirects` is now 0 on the four, as it already was on the discovery request. A redirect surfaces as the `AuthenticationException` any other unreadable answer does.

The handlers that reach further back get the same treatment on their own branches: #65952 on 6.4 for the UserInfo token handler, #65953 on 7.4 for the OIDC JWKS, the OAuth2 introspection and the CAS ticket validation.
