### PR TITLE
[Security] Do not follow redirects on the OIDC UserInfo endpoint

### DIFF
--- a/src/Symfony/Component/Security/Http/AccessToken/Oidc/OidcUserInfoTokenHandler.php
+++ b/src/Symfony/Component/Security/Http/AccessToken/Oidc/OidcUserInfoTokenHandler.php
@@ -40,6 +40,7 @@ final class OidcUserInfoTokenHandler implements AccessTokenHandlerInterface
             // If the token is invalid or expired, the OIDC server will return an error
             $claims = $this->client->request('GET', '', [
                 'auth_bearer' => $accessToken,
+                'max_redirects' => 0,
             ])->toArray();
 
             if (empty($claims[$this->claim])) {

--- a/src/Symfony/Component/Security/Http/Tests/AccessToken/Oidc/OidcUserInfoTokenHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/AccessToken/Oidc/OidcUserInfoTokenHandlerTest.php
@@ -78,7 +78,7 @@ class OidcUserInfoTokenHandlerTest extends TestCase
 
         $clientMock = $this->createMock(HttpClientInterface::class);
         $clientMock->expects($this->once())
-            ->method('request')->with('GET', '', ['auth_bearer' => $accessToken])
+            ->method('request')->with('GET', '', ['auth_bearer' => $accessToken, 'max_redirects' => 0])
             ->willReturn($responseMock);
 
         $userBadge = (new OidcUserInfoTokenHandler($clientMock, null, $claim))->getUserBadgeFrom($accessToken);
@@ -111,7 +111,7 @@ class OidcUserInfoTokenHandlerTest extends TestCase
 
         $clientMock = $this->createMock(HttpClientInterface::class);
         $clientMock->expects($this->once())
-            ->method('request')->with('GET', '', ['auth_bearer' => 'a-secret-token'])
+            ->method('request')->with('GET', '', ['auth_bearer' => 'a-secret-token', 'max_redirects' => 0])
             ->willReturn($responseMock);
 
         $loggerMock = $this->createMock(LoggerInterface::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`OidcUserInfoTokenHandler` capped no redirects, so a UserInfo endpoint answering a 3xx made the handler read the user claims from wherever the redirect pointed. That response is the only source of the identity here: unlike the `oidc_login` authenticator of 8.2 there is no ID token to check the `sub` against, so the authenticated user becomes whoever the redirect target says.

The access token itself does not leak: `HttpClient` drops the `Authorization` header when a redirect leaves the initial scheme and authority. What a redirect gives away is control of the answer.

`max_redirects` is now 0 on that request, as it already is on the discovery request the handler makes on 7.4 and up. A redirect surfaces as the same `BadCredentialsException` any other unreadable answer does.
