### PR TITLE
[Security] Do not follow redirects on the OIDC JWKS, OAuth2 introspection and CAS validation endpoints

### DIFF
--- a/src/Symfony/Component/Security/Http/AccessToken/Cas/Cas2Handler.php
+++ b/src/Symfony/Component/Security/Http/AccessToken/Cas/Cas2Handler.php
@@ -46,7 +46,7 @@ final class Cas2Handler implements AccessTokenHandlerInterface
      */
     public function getUserBadgeFrom(string $accessToken): UserBadge
     {
-        $response = $this->client->request('GET', $this->getValidationUrl($accessToken));
+        $response = $this->client->request('GET', $this->getValidationUrl($accessToken), ['max_redirects' => 0]);
 
         $xml = new \SimpleXMLElement($response->getContent(), 0, false, $this->prefix, true);
 

--- a/src/Symfony/Component/Security/Http/AccessToken/OAuth2/Oauth2TokenHandler.php
+++ b/src/Symfony/Component/Security/Http/AccessToken/OAuth2/Oauth2TokenHandler.php
@@ -55,6 +55,7 @@ final class Oauth2TokenHandler implements AccessTokenHandlerInterface
                     'token' => $accessToken,
                     'token_type_hint' => 'access_token',
                 ],
+                'max_redirects' => 0,
             ])->toArray();
 
             $sub = $claims['sub'] ?? null;

--- a/src/Symfony/Component/Security/Http/AccessToken/Oidc/OidcTokenHandler.php
+++ b/src/Symfony/Component/Security/Http/AccessToken/Oidc/OidcTokenHandler.php
@@ -168,7 +168,7 @@ final class OidcTokenHandler implements AccessTokenHandlerInterface
 
                 $jwksUri = self::checkDiscoveredEndpoint($config['jwks_uri'] ?? null, 'jwks_uri', $response->getInfo('url'));
 
-                $jwkSetResponses[] = $client->request('GET', $jwksUri);
+                $jwkSetResponses[] = $client->request('GET', $jwksUri, ['max_redirects' => 0]);
             }
 
             foreach ($jwkSetResponses as $response) {

--- a/src/Symfony/Component/Security/Http/Tests/AccessToken/Cas/Cas2HandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/AccessToken/Cas/Cas2HandlerTest.php
@@ -155,6 +155,24 @@ final class Cas2HandlerTest extends TestCase
         $this->assertEquals(new UserBadge('lobster'), $cas2Handler->getUserBadgeFrom('ST-1856339'));
     }
 
+    public function testValidationDoesNotFollowRedirects()
+    {
+        $response = new MockResponse('', ['http_code' => 302, 'response_headers' => ['location' => 'https://other.example.com/validate']]);
+
+        $httpClient = new MockHttpClient([$response]);
+        $requestStack = new RequestStack();
+        $requestStack->push(new Request(['ticket' => 'ST-1856339']));
+
+        $cas2Handler = new Cas2Handler($requestStack, 'https://www.example.com/cas', 'cas', $httpClient);
+
+        try {
+            $cas2Handler->getUserBadgeFrom('ST-1856339');
+        } catch (\Throwable) {
+        }
+
+        $this->assertSame(0, $response->getRequestOptions()['max_redirects'] ?? null);
+    }
+
     public function testThrowsWhenNoTrustedHostsConfigured()
     {
         Request::setTrustedHosts([]);

--- a/src/Symfony/Component/Security/Http/Tests/AccessToken/OAuth2/OAuth2TokenHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/AccessToken/OAuth2/OAuth2TokenHandlerTest.php
@@ -94,6 +94,26 @@ class OAuth2TokenHandlerTest extends TestCase
         yield 'anything else' => ['maybe', null];
     }
 
+    public function testIntrospectionDoesNotFollowRedirects()
+    {
+        // the options are asserted after the call: the handler turns every exception the
+        // response factory raises into a BadCredentialsException, a failed assertion included
+        $requestOptions = [];
+        $client = new MockHttpClient(static function (string $method, string $url, array $options) use (&$requestOptions) {
+            $requestOptions = $options;
+
+            return new MockResponse('', ['http_code' => 307, 'response_headers' => ['location' => 'https://other.example.com/introspect']]);
+        });
+
+        try {
+            (new Oauth2TokenHandler($client))->getUserBadgeFrom('a-secret-token');
+            $this->fail('A BadCredentialsException should have been thrown.');
+        } catch (BadCredentialsException) {
+        }
+
+        $this->assertSame(0, $requestOptions['max_redirects'] ?? null);
+    }
+
     public function testGetsUserIdentifierFromOAuth2ServerResponse()
     {
         $accessToken = 'a-secret-token';

--- a/src/Symfony/Component/Security/Http/Tests/AccessToken/Oidc/OidcTokenHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/AccessToken/Oidc/OidcTokenHandlerTest.php
@@ -477,6 +477,43 @@ class OidcTokenHandlerTest extends TestCase
         $this->assertSame(1, $httpClient->getRequestsCount());
     }
 
+    public function testJwksDoesNotFollowRedirects()
+    {
+        // the options are asserted after the call: the handler turns every exception the
+        // response factory raises into a BadCredentialsException, a failed assertion included
+        $jwksOptions = [];
+        $httpClient = new MockHttpClient(static function (string $method, string $url, array $options) use (&$jwksOptions) {
+            if (str_ends_with($url, '/.well-known/openid-configuration')) {
+                return new JsonMockResponse(['jwks_uri' => 'https://www.example.com/jwks.json']);
+            }
+
+            $jwksOptions = $options;
+
+            return new MockResponse('', ['http_code' => 301, 'response_headers' => ['location' => 'https://other.example.com/jwks.json']]);
+        });
+
+        $cache = new ArrayAdapter();
+        $handler = new OidcTokenHandler(
+            new AlgorithmManager([new ES256()]),
+            null,
+            self::AUDIENCE,
+            ['https://www.example.com']
+        );
+        $handler->enableDiscovery($cache, $httpClient, 'oidc_redirected_jwks');
+
+        $item = $this->createMock(ItemInterface::class);
+        $item->expects($this->never())->method('expiresAfter');
+
+        try {
+            $handler->computeDiscoveryKeys($item);
+            $this->fail('A BadCredentialsException should have been thrown.');
+        } catch (BadCredentialsException) {
+        }
+
+        $this->assertSame(0, $jwksOptions['max_redirects'] ?? null);
+        $this->assertSame(2, $httpClient->getRequestsCount());
+    }
+
     public function testDiscoveryRejectsJwksUriDowngradedToHttp()
     {
         $httpClient = new MockHttpClient([


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

Three requests of the access-token handlers followed redirects, while the discovery requests next to them already did not:

 * the JWKS fetch of `OidcTokenHandler`: the keys an ID token is verified against then come from wherever the redirect points, so a token signed by the redirect target verifies;
 * the introspection request of `Oauth2TokenHandler`: a 307 or a 308 re-sends the body, which carries the access token, to the redirect target, and the verdict on that token comes back from there;
 * the ticket validation request of `Cas2Handler`: the CAS response naming the authenticated user comes from the redirect target.

For the two GET requests any 3xx does this; the introspection POST needs a 307 or a 308, since `HttpClient` turns a 301, a 302 and a 303 into a GET without a body. Across origins it strips `Authorization` and `Cookie`, never the body.

`max_redirects` is now 0 on the three. A redirect surfaces as the same `BadCredentialsException` any other unreadable answer does, and as an `AuthenticationException` for CAS.

Merge-up to 8.1: no conflict.

Merge-up to 8.2, three conflicts, all mechanical:

 * `OidcTokenHandler`: keep 8.2's line and add the option, `$this->discoveryClients[$i]->request('GET', $jwksUri, ['max_redirects' => 0])`.
 * `Oauth2TokenHandler`: keep 8.2's `introspect()` split, and add `'max_redirects' => 0` to the request in `requestIntrospection()`.
 * `OAuth2TokenHandlerTest`: keep both sides.

`OidcTokenHandlerTest::testJwksDoesNotFollowRedirects` also needs 8.2's extra constructor arguments (`'sub', null, new Clock(), 0, true`), otherwise it triggers the `$enforceAtJwtType` deprecation.
