### PR TITLE
[FrameworkBundle][HttpClient][Messenger][Notifier][PropertyInfo][Routing][Translation][TypeInfo][Validator] Fix the legs the bundle split left red

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/RemoveMissingTranslatorDependenciesPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/RemoveMissingTranslatorDependenciesPass.php
@@ -33,7 +33,9 @@ class RemoveMissingTranslatorDependenciesPass implements CompilerPassInterface
 
     public function process(ContainerBuilder $container): void
     {
-        if (!$container->hasParameter(TranslationBundle::TRANS_PATHS_PARAMETER)) {
+        // TranslationBundle::class does not autoload, its constants do, and the Translation component
+        // can be older than this bundle or absent altogether
+        if (!class_exists(TranslationBundle::class) || !$container->hasParameter(TranslationBundle::TRANS_PATHS_PARAMETER)) {
             foreach (self::COMMANDS as $id) {
                 $container->removeDefinition($id);
             }

--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -242,8 +242,9 @@ class FrameworkBundle extends Bundle
         $container->addCompilerPass(new FragmentRendererPass());
         $container->addCompilerPass(new ControllerArgumentValueResolverPass());
         $container->addCompilerPass(new DefaultCachePoolsPass());
-        $this->addCompilerPassIfExists($container, FormPass::class);
+        // must run before FormPass, which collects the type extension tags this one can still remove
         $container->addCompilerPass(new RemoveUnusedFormHtmlSanitizerPass());
+        $this->addCompilerPassIfExists($container, FormPass::class);
         $container->addCompilerPass(new RemoveUnusedSerializerPropertyAccessorPass());
         $container->addCompilerPass(new RemoveMissingHttpClientDependenciesPass());
         $container->addCompilerPass(new RemoveMissingRouterDependenciesPass());

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/AddSessionDomainConstraintPassTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/AddSessionDomainConstraintPassTest.php
@@ -22,7 +22,6 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Kernel\ServicesBundle;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Routing\RouterBundle;
 use Symfony\Component\Security\Http\HttpUtils;
 
 class AddSessionDomainConstraintPassTest extends TestCase
@@ -155,11 +154,18 @@ class AddSessionDomainConstraintPassTest extends TestCase
             new ServicesBundle()->getContainerExtension()->load([], $container);
         }
 
-        // the router lives in its own bundle, and loading FrameworkExtension by hand does not forward to it
-        new RouterBundle()->getContainerExtension()->load([['resource' => 'dummy']], $container);
+        $config = ['csrf_protection' => false];
+
+        // the router lives in its own bundle since 8.2, and loading FrameworkExtension by hand does not
+        // forward to it; named as a string so the same file works on the branch before it
+        if (class_exists($routerBundle = 'Symfony\\Component\\Routing\\RouterBundle')) {
+            new $routerBundle()->getContainerExtension()->load([['resource' => 'dummy']], $container);
+        } else {
+            $config['router'] = ['resource' => 'dummy'];
+        }
 
         $ext = new FrameworkExtension();
-        $ext->load([['csrf_protection' => false]], $container);
+        $ext->load([$config], $container);
 
         $config = [
             'security' => [

--- a/src/Symfony/Component/Asset/AssetBundle.php
+++ b/src/Symfony/Component/Asset/AssetBundle.php
@@ -145,7 +145,8 @@ class AssetBundle extends AbstractBundle
                 ->addTag('assets.package', ['package' => $name]);
             $container->setDefinition('assets._package_'.$name, $packageDefinition);
             $container->registerAliasForArgument('assets._package_'.$name, PackageInterface::class, $name.'.package', $name);
-        }    }
+        }
+    }
 
     private function createPackageDefinition(?string $basePath, array $baseUrls, Reference $version): Definition
     {
@@ -161,6 +162,7 @@ class AssetBundle extends AbstractBundle
 
         return $package;
     }
+
     private function createVersion(ContainerBuilder $container, ?string $version, ?string $format, ?string $jsonManifestPath, string $name, bool $strictMode): Reference
     {
         // Configuration prevents $version and $jsonManifestPath from being set

--- a/src/Symfony/Component/HttpClient/HttpClientBundle.php
+++ b/src/Symfony/Component/HttpClient/HttpClientBundle.php
@@ -193,12 +193,12 @@ class HttpClientBundle extends AbstractBundle
         unset($options['vars']);
         $container->getDefinition('http_client.transport')->setArguments([$options, $config['max_host_connections'] ?? 6]);
 
-        if (!$hasPsr18 = ContainerBuilder::willBeAvailable('psr/http-client', ClientInterface::class, ['symfony/http-client'])) {
+        if (!$hasPsr18 = ContainerBuilder::willBeAvailable('psr/http-client', ClientInterface::class, ['symfony/framework-bundle', 'symfony/http-client'])) {
             $container->removeDefinition('psr18.http_client');
             $container->removeAlias(ClientInterface::class);
         }
 
-        if (!$hasHttplug = ContainerBuilder::willBeAvailable('php-http/httplug', HttpAsyncClient::class, ['symfony/http-client'])) {
+        if (!$hasHttplug = ContainerBuilder::willBeAvailable('php-http/httplug', HttpAsyncClient::class, ['symfony/framework-bundle', 'symfony/http-client'])) {
             $container->removeDefinition('httplug.http_client');
             $container->removeAlias(HttpAsyncClient::class);
         }

--- a/src/Symfony/Component/HttpClient/composer.json
+++ b/src/Symfony/Component/HttpClient/composer.json
@@ -35,7 +35,7 @@
         "nyholm/psr7": "^1.0",
         "php-http/httplug": "^1.0|^2.0",
         "psr/http-client": "^1.0",
-        "symfony/config": "^7.4|^8.0",
+        "symfony/config": "^8.2",
         "symfony/dependency-injection": "^8.1",
         "symfony/cache": "^7.4|^8.0",
         "symfony/http-kernel": "^7.4|^8.0",
@@ -47,6 +47,7 @@
     "conflict": {
         "amphp/amp": "<3",
         "php-http/discovery": "<1.15",
+        "symfony/config": "<8.2",
         "symfony/dependency-injection": "<8.1"
     },
     "autoload": {

--- a/src/Symfony/Component/JsonStreamer/Tests/JsonStreamerBundleTest.php
+++ b/src/Symfony/Component/JsonStreamer/Tests/JsonStreamerBundleTest.php
@@ -25,6 +25,7 @@ use Symfony\Component\JsonStreamer\Tests\Fixtures\Model\StreamableDummy;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\Transformer\HeightValueObjectTransformer;
 use Symfony\Component\JsonStreamer\Tests\Fixtures\ValueObject\Height;
 use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\TypeInfoBundle;
 
 class JsonStreamerBundleTest extends TestCase
 {
@@ -32,7 +33,13 @@ class JsonStreamerBundleTest extends TestCase
 
     protected function setUp(): void
     {
+        // tearDown() cleans up whatever setUp() named, so skip only once the path is known
         $this->varDir = sys_get_temp_dir().'/sf_json_streamer_bundle_test';
+
+        if (!class_exists(TypeInfoBundle::class)) {
+            // the streamer needs the type_info configuration, which only TypeInfoBundle provides
+            $this->markTestSkipped('The installed TypeInfo component ships no bundle.');
+        }
     }
 
     protected function tearDown(): void

--- a/src/Symfony/Component/JsonStreamer/composer.json
+++ b/src/Symfony/Component/JsonStreamer/composer.json
@@ -41,12 +41,13 @@
     "require-dev": {
         "nst/json-test-suite": "*",
         "phpstan/phpdoc-parser": "^1.0",
-        "symfony/config": "^7.4|^8.0",
+        "symfony/config": "^8.2",
         "symfony/dependency-injection": "^8.1",
         "symfony/http-kernel": "^7.4|^8.0",
         "symfony/uid": "^7.4|^8.0"
     },
     "conflict": {
+        "symfony/config": "<8.2",
         "symfony/dependency-injection": "<8.1"
     },
     "autoload": {

--- a/src/Symfony/Component/Lock/composer.json
+++ b/src/Symfony/Component/Lock/composer.json
@@ -22,12 +22,13 @@
     "require-dev": {
         "doctrine/dbal": "^4.3",
         "predis/predis": "^1.1|^2.0",
-        "symfony/config": "^7.4|^8.0",
+        "symfony/config": "^8.2",
         "symfony/dependency-injection": "^8.1",
         "symfony/serializer": "^6.4|^7.0"
     },
     "conflict": {
         "doctrine/dbal": "<4.3",
+        "symfony/config": "<8.2",
         "symfony/dependency-injection": "<8.1"
     },
     "autoload": {

--- a/src/Symfony/Component/Mailer/MailerBundle.php
+++ b/src/Symfony/Component/Mailer/MailerBundle.php
@@ -395,7 +395,7 @@ class MailerBundle extends AbstractBundle
         ];
 
         foreach ($classToServices as $class => [$package, $service]) {
-            if (!ContainerBuilder::willBeAvailable($package, $class, ['symfony/mailer'])) {
+            if (!ContainerBuilder::willBeAvailable($package, $class, ['symfony/framework-bundle', 'symfony/mailer'])) {
                 $container->removeDefinition($service);
             }
         }
@@ -528,7 +528,7 @@ class MailerBundle extends AbstractBundle
             ];
 
             foreach ($webhookRequestParsers as $class => [$package, $service]) {
-                if (!ContainerBuilder::willBeAvailable($package, $class, ['symfony/mailer'])) {
+                if (!ContainerBuilder::willBeAvailable($package, $class, ['symfony/framework-bundle', 'symfony/mailer'])) {
                     $container->removeDefinition($service);
                 } elseif ($debug && \defined($class.'::PROVIDER_IPS')) {
                     $container->getDefinition($service)->setArgument('$allowedIPs', [...$class::PROVIDER_IPS, '127.0.0.1']);

--- a/src/Symfony/Component/Mailer/composer.json
+++ b/src/Symfony/Component/Mailer/composer.json
@@ -26,16 +26,18 @@
         "symfony/service-contracts": "^2.5|^3"
     },
     "require-dev": {
-        "symfony/config": "^7.4|^8.0",
+        "symfony/config": "^8.2",
         "symfony/console": "^7.4|^8.0",
         "symfony/dependency-injection": "^8.1",
         "symfony/http-client": "^7.4|^8.0",
         "symfony/messenger": "^7.4|^8.0",
         "symfony/process": "^7.4|^8.0",
         "symfony/rate-limiter": "^7.4|^8.0",
-        "symfony/twig-bridge": "^7.4|^8.0"
+        "symfony/twig-bridge": "^7.4|^8.0",
+        "symfony/webhook": "^8.2"
     },
     "conflict": {
+        "symfony/config": "<8.2",
         "symfony/dependency-injection": "<8.1",
         "symfony/http-client-contracts": "<2.5"
     },

--- a/src/Symfony/Component/Messenger/MessengerBundle.php
+++ b/src/Symfony/Component/Messenger/MessengerBundle.php
@@ -317,27 +317,27 @@ class MessengerBundle extends AbstractBundle
             $container->removeDefinition('serializer.normalizer.flatten_exception');
         }
 
-        if (ContainerBuilder::willBeAvailable('symfony/amqp-messenger', Bridge\Amqp\Transport\AmqpTransportFactory::class, ['symfony/messenger'])) {
+        if (ContainerBuilder::willBeAvailable('symfony/amqp-messenger', Bridge\Amqp\Transport\AmqpTransportFactory::class, ['symfony/framework-bundle', 'symfony/messenger'])) {
             $container->getDefinition('messenger.transport.amqp.factory')->addTag('messenger.transport_factory');
         }
 
-        if (ContainerBuilder::willBeAvailable('symfony/amp-sql-messenger', Bridge\AmpSql\Transport\AmpSqlTransportFactory::class, ['symfony/messenger'])) {
+        if (ContainerBuilder::willBeAvailable('symfony/amp-sql-messenger', Bridge\AmpSql\Transport\AmpSqlTransportFactory::class, ['symfony/framework-bundle', 'symfony/messenger'])) {
             $container->getDefinition('messenger.transport.amp_sql.factory')->addTag('messenger.transport_factory');
         }
 
-        if (ContainerBuilder::willBeAvailable('symfony/redis-messenger', Bridge\Redis\Transport\RedisTransportFactory::class, ['symfony/messenger'])) {
+        if (ContainerBuilder::willBeAvailable('symfony/redis-messenger', Bridge\Redis\Transport\RedisTransportFactory::class, ['symfony/framework-bundle', 'symfony/messenger'])) {
             $container->getDefinition('messenger.transport.redis.factory')->addTag('messenger.transport_factory');
         }
 
-        if (ContainerBuilder::willBeAvailable('symfony/amazon-sqs-messenger', Bridge\AmazonSqs\Transport\AmazonSqsTransportFactory::class, ['symfony/messenger'])) {
+        if (ContainerBuilder::willBeAvailable('symfony/amazon-sqs-messenger', Bridge\AmazonSqs\Transport\AmazonSqsTransportFactory::class, ['symfony/framework-bundle', 'symfony/messenger'])) {
             $container->getDefinition('messenger.transport.sqs.factory')->addTag('messenger.transport_factory');
         }
 
-        if (ContainerBuilder::willBeAvailable('symfony/beanstalkd-messenger', Bridge\Beanstalkd\Transport\BeanstalkdTransportFactory::class, ['symfony/messenger'])) {
+        if (ContainerBuilder::willBeAvailable('symfony/beanstalkd-messenger', Bridge\Beanstalkd\Transport\BeanstalkdTransportFactory::class, ['symfony/framework-bundle', 'symfony/messenger'])) {
             $container->getDefinition('messenger.transport.beanstalkd.factory')->addTag('messenger.transport_factory');
         }
 
-        if (ContainerBuilder::willBeAvailable('symfony/mongodb-messenger', Bridge\MongoDb\Transport\MongoDbTransportFactory::class, ['symfony/messenger'])) {
+        if (ContainerBuilder::willBeAvailable('symfony/mongodb-messenger', Bridge\MongoDb\Transport\MongoDbTransportFactory::class, ['symfony/framework-bundle', 'symfony/messenger'])) {
             $container->getDefinition('messenger.transport.mongodb.factory')->addTag('messenger.transport_factory');
         }
 

--- a/src/Symfony/Component/Notifier/NotifierBundle.php
+++ b/src/Symfony/Component/Notifier/NotifierBundle.php
@@ -220,17 +220,17 @@ class NotifierBundle extends AbstractBundle
         ];
 
         foreach ($classToServices as $class => [$package, $service]) {
-            if (!ContainerBuilder::willBeAvailable($package, $class, ['symfony/notifier'])) {
+            if (!ContainerBuilder::willBeAvailable($package, $class, ['symfony/framework-bundle', 'symfony/notifier'])) {
                 $container->removeDefinition($service);
             }
         }
 
-        if (ContainerBuilder::willBeAvailable('symfony/mercure-notifier', NotifierBridge\Mercure\MercureTransportFactory::class, ['symfony/notifier']) && ContainerBuilder::willBeAvailable('symfony/mercure-bundle', MercureBundle::class, ['symfony/notifier']) && \in_array(MercureBundle::class, $container->getParameter('kernel.bundles'), true)) {
+        if (ContainerBuilder::willBeAvailable('symfony/mercure-notifier', NotifierBridge\Mercure\MercureTransportFactory::class, ['symfony/framework-bundle', 'symfony/notifier']) && ContainerBuilder::willBeAvailable('symfony/mercure-bundle', MercureBundle::class, ['symfony/framework-bundle', 'symfony/notifier']) && \in_array(MercureBundle::class, $container->getParameter('kernel.bundles'), true)) {
             $container->getDefinition('notifier.transport_factory.mercure')
                 ->replaceArgument(0, new Reference(HubRegistry::class))
                 ->replaceArgument(1, new Reference('event_dispatcher', ContainerBuilder::NULL_ON_INVALID_REFERENCE))
                 ->addArgument(new Reference('http_client', ContainerBuilder::NULL_ON_INVALID_REFERENCE));
-        } elseif (ContainerBuilder::willBeAvailable('symfony/mercure-notifier', NotifierBridge\Mercure\MercureTransportFactory::class, ['symfony/notifier'])) {
+        } elseif (ContainerBuilder::willBeAvailable('symfony/mercure-notifier', NotifierBridge\Mercure\MercureTransportFactory::class, ['symfony/framework-bundle', 'symfony/notifier'])) {
             $container->removeDefinition('notifier.transport_factory.mercure');
         }
 
@@ -256,7 +256,7 @@ class NotifierBundle extends AbstractBundle
             $container->removeDefinition('notifier.transport_factory.fake-sms');
         }
 
-        if (ContainerBuilder::willBeAvailable('symfony/bluesky-notifier', NotifierBridge\Bluesky\BlueskyTransportFactory::class, ['symfony/notifier'])) {
+        if (ContainerBuilder::willBeAvailable('symfony/bluesky-notifier', NotifierBridge\Bluesky\BlueskyTransportFactory::class, ['symfony/framework-bundle', 'symfony/notifier'])) {
             $container->getDefinition('notifier.transport_factory.bluesky')
                 ->addArgument(new Reference('logger'))
                 ->addArgument(new Reference('clock', ContainerBuilder::NULL_ON_INVALID_REFERENCE));
@@ -283,9 +283,10 @@ class NotifierBundle extends AbstractBundle
             ];
 
             foreach ($webhookRequestParsers as $class => [$package, $service]) {
-                if (!ContainerBuilder::willBeAvailable($package, $class, ['symfony/notifier'])) {
+                if (!ContainerBuilder::willBeAvailable($package, $class, ['symfony/framework-bundle', 'symfony/notifier'])) {
                     $container->removeDefinition($service);
                 }
             }
-        }    }
+        }
+    }
 }

--- a/src/Symfony/Component/PropertyInfo/PropertyInfoBundle.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyInfoBundle.php
@@ -85,15 +85,15 @@ class PropertyInfoBundle extends AbstractBundle
         }
 
         if (
-            ContainerBuilder::willBeAvailable('phpstan/phpdoc-parser', PhpDocParser::class, ['symfony/property-info'])
-            && ContainerBuilder::willBeAvailable('phpdocumentor/type-resolver', ContextFactory::class, ['symfony/property-info'])
+            ContainerBuilder::willBeAvailable('phpstan/phpdoc-parser', PhpDocParser::class, ['symfony/framework-bundle', 'symfony/property-info'])
+            && ContainerBuilder::willBeAvailable('phpdocumentor/type-resolver', ContextFactory::class, ['symfony/framework-bundle', 'symfony/property-info'])
         ) {
             $container->register('property_info.phpstan_extractor', PhpStanExtractor::class)
                 ->addTag('property_info.type_extractor', ['priority' => -1000])
                 ->addTag('property_info.constructor_extractor', ['priority' => -1000]);
         }
 
-        if (ContainerBuilder::willBeAvailable('phpdocumentor/reflection-docblock', DocBlockFactoryInterface::class, ['symfony/property-info'])) {
+        if (ContainerBuilder::willBeAvailable('phpdocumentor/reflection-docblock', DocBlockFactoryInterface::class, ['symfony/framework-bundle', 'symfony/property-info'])) {
             $container->register('property_info.php_doc_extractor', PhpDocExtractor::class)
                 ->addTag('property_info.description_extractor', ['priority' => -1000])
                 ->addTag('property_info.type_extractor', ['priority' => -1001])

--- a/src/Symfony/Component/Routing/RouterBundle.php
+++ b/src/Symfony/Component/Routing/RouterBundle.php
@@ -113,7 +113,7 @@ class RouterBundle extends AbstractBundle
             $container->getDefinition('routing.loader')->replaceArgument(1, ['utf8' => true]);
         }
 
-        if (!ContainerBuilder::willBeAvailable('symfony/expression-language', ExpressionLanguage::class, ['symfony/routing'])) {
+        if (!ContainerBuilder::willBeAvailable('symfony/expression-language', ExpressionLanguage::class, ['symfony/framework-bundle', 'symfony/routing'])) {
             $container->removeDefinition('router.expression_language_provider');
         }
 

--- a/src/Symfony/Component/Translation/Tests/TranslationBundleTest.php
+++ b/src/Symfony/Component/Translation/Tests/TranslationBundleTest.php
@@ -69,7 +69,8 @@ class TranslationBundleTest extends TestCase
     {
         $options = $this->load(['paths' => [__DIR__.'/Fixtures/translations']])->getDefinition('translator.default')->getArgument(4);
 
-        $this->assertContains(__DIR__.'/Fixtures/translations/messages.en.yaml', $options['resource_files']['en']);
+        // the finder reports the paths with the separator of the platform
+        $this->assertContains(strtr(__DIR__.'/Fixtures/translations/messages.en.yaml', '/', \DIRECTORY_SEPARATOR), $options['resource_files']['en']);
         $this->assertContains(__DIR__.'/Fixtures/translations', $options['scanned_directories']);
     }
 

--- a/src/Symfony/Component/Translation/TranslationBundle.php
+++ b/src/Symfony/Component/Translation/TranslationBundle.php
@@ -229,7 +229,7 @@ class TranslationBundle extends AbstractBundle
             Bridge\PoEditor\PoEditorProviderFactory::class => ['symfony/po-editor-translation-provider', ['translation.provider_factory.poeditor']],
         ];
 
-        $parentPackages = ['symfony/translation', 'symfony/http-client'];
+        $parentPackages = ['symfony/framework-bundle', 'symfony/translation', 'symfony/http-client'];
 
         foreach ($classToServices as $class => [$package, $services]) {
             if (ContainerBuilder::willBeAvailable($package, $class, $parentPackages)) {
@@ -259,17 +259,17 @@ class TranslationBundle extends AbstractBundle
         $transPaths = [];
         $nonExistingDirs = [];
 
-        if (ContainerBuilder::willBeAvailable('symfony/validator', Validation::class, ['symfony/translation'])) {
+        if (ContainerBuilder::willBeAvailable('symfony/validator', Validation::class, ['symfony/framework-bundle', 'symfony/translation'])) {
             $r = new \ReflectionClass(Validation::class);
 
             $dirs[] = $transPaths[] = \dirname($r->getFileName()).'/Resources/translations';
         }
-        if (ContainerBuilder::willBeAvailable('symfony/form', Form::class, ['symfony/translation'])) {
+        if (ContainerBuilder::willBeAvailable('symfony/form', Form::class, ['symfony/framework-bundle', 'symfony/translation'])) {
             $r = new \ReflectionClass(Form::class);
 
             $dirs[] = $transPaths[] = \dirname($r->getFileName()).'/Resources/translations';
         }
-        if (ContainerBuilder::willBeAvailable('symfony/security-core', AuthenticationException::class, ['symfony/translation'])) {
+        if (ContainerBuilder::willBeAvailable('symfony/security-core', AuthenticationException::class, ['symfony/framework-bundle', 'symfony/translation'])) {
             $r = new \ReflectionClass(AuthenticationException::class);
 
             $dirs[] = $transPaths[] = \dirname($r->getFileName(), 2).'/Resources/translations';

--- a/src/Symfony/Component/Translation/composer.json
+++ b/src/Symfony/Component/Translation/composer.json
@@ -23,10 +23,11 @@
     "require-dev": {
         "nikic/php-parser": "^5.0",
         "psr/log": "^1|^2|^3",
-        "symfony/config": "^7.4|^8.0",
+        "symfony/config": "^8.2",
         "symfony/console": "^7.4|^8.0",
         "symfony/dependency-injection": "^8.2",
         "symfony/finder": "^7.4|^8.0",
+        "symfony/framework-bundle": "^8.2",
         "symfony/http-client-contracts": "^2.5|^3.0",
         "symfony/http-kernel": "^7.4|^8.0",
         "symfony/intl": "^7.4|^8.0",
@@ -37,6 +38,7 @@
     },
     "conflict": {
         "nikic/php-parser": "<5.0",
+        "symfony/config": "<8.2",
         "symfony/dependency-injection": "<8.2",
         "symfony/http-client-contracts": "<2.5",
         "symfony/service-contracts": "<2.5"

--- a/src/Symfony/Component/TypeInfo/TypeInfoBundle.php
+++ b/src/Symfony/Component/TypeInfo/TypeInfoBundle.php
@@ -58,7 +58,7 @@ class TypeInfoBundle extends AbstractBundle
 
         $configurator->import('Resources/config/type_info.php');
 
-        if (ContainerBuilder::willBeAvailable('phpstan/phpdoc-parser', PhpDocParser::class, ['symfony/type-info'])) {
+        if (ContainerBuilder::willBeAvailable('phpstan/phpdoc-parser', PhpDocParser::class, ['symfony/framework-bundle', 'symfony/type-info'])) {
             $container->register('type_info.resolver.string', StringTypeResolver::class)
                 ->setArguments([null, null, $config['aliases']]);
 

--- a/src/Symfony/Component/Validator/Tests/ValidationBundleTest.php
+++ b/src/Symfony/Component/Validator/Tests/ValidationBundleTest.php
@@ -149,8 +149,9 @@ class ValidationBundleTest extends TestCase
         $xmlMappings = array_column(array_filter($calls, static fn ($call) => 'addXmlMappings' === $call[0]), 1);
         $yamlMappings = array_column(array_filter($calls, static fn ($call) => 'addYamlMappings' === $call[0]), 1);
 
-        $this->assertSame([[[$dir.'/validation.xml']]], $xmlMappings);
-        $this->assertSame([[[$dir.'/validation.yml']]], $yamlMappings);
+        // the finder reports the paths with the separator of the platform
+        $this->assertSame([[[strtr($dir.'/validation.xml', '/', \DIRECTORY_SEPARATOR)]]], $xmlMappings);
+        $this->assertSame([[[strtr($dir.'/validation.yml', '/', \DIRECTORY_SEPARATOR)]]], $yamlMappings);
     }
 
     public function testAnUnsupportedMappingPathIsRejected()

--- a/src/Symfony/Component/Validator/ValidationBundle.php
+++ b/src/Symfony/Component/Validator/ValidationBundle.php
@@ -236,7 +236,7 @@ class ValidationBundle extends AbstractBundle
             $files['yaml' === $extension ? 'yml' : $extension][] = $path;
         };
 
-        if (!ContainerBuilder::willBeAvailable('symfony/form', Form::class, ['symfony/validator'])) {
+        if (!ContainerBuilder::willBeAvailable('symfony/form', Form::class, ['symfony/framework-bundle', 'symfony/validator'])) {
             $container->removeDefinition('validator.form.attribute_metadata');
         }
 

--- a/src/Symfony/Component/Webhook/Tests/WebhookBundleTest.php
+++ b/src/Symfony/Component/Webhook/Tests/WebhookBundleTest.php
@@ -21,6 +21,7 @@ use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Messenger\MessengerBundle;
 use Symfony\Component\RemoteEvent\RemoteEvent;
 use Symfony\Component\Webhook\Subscriber;
 use Symfony\Component\Webhook\Tests\Fixtures\TestConsumer;
@@ -33,7 +34,13 @@ class WebhookBundleTest extends TestCase
 
     protected function setUp(): void
     {
+        // tearDown() cleans up whatever setUp() named, so skip only once the path is known
         $this->varDir = sys_get_temp_dir().'/sf_webhook_bundle_test';
+
+        if (!class_exists(MessengerBundle::class)) {
+            // the controller dispatches to a message bus, which only MessengerBundle provides
+            $this->markTestSkipped('The installed Messenger component ships no bundle.');
+        }
     }
 
     protected function tearDown(): void

--- a/src/Symfony/Component/Webhook/composer.json
+++ b/src/Symfony/Component/Webhook/composer.json
@@ -24,12 +24,13 @@
     },
     "require-dev": {
         "symfony/clock": "^7.4|^8.0",
-        "symfony/config": "^7.4|^8.0",
+        "symfony/config": "^8.2",
         "symfony/dependency-injection": "^8.1",
         "symfony/http-client": "^7.4|^8.0",
         "symfony/serializer": "^7.4|^8.0"
     },
     "conflict": {
+        "symfony/config": "<8.2",
         "symfony/dependency-injection": "<8.1"
     },
     "autoload": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The 8.2 unit-tests workflow is red on both the low-deps and the high-deps legs since the per-component bundles landed. Six distinct causes, all the same shape: a bundle now needs a neighbour that the leg resolves differently than FrameworkBundle used to.

## A parent package dropped from `willBeAvailable()`

Moving a section into its component rewrote every

```php
ContainerBuilder::willBeAvailable($package, $class, ['symfony/framework-bundle', 'symfony/x'])
```

as `['symfony/x']`. That third argument names the packages that are allowed to carry `$package` as a **dev** dependency, and FrameworkBundle is exactly such a package: it is what require-devs `symfony/expression-language`, the messenger bridges, `phpstan/phpdoc-parser` and the rest. Dropping it makes the call return `false` in every leg whose root package is `symfony/framework-bundle`, so for instance `router.expression_language_provider` disappears and `RoutingConditionServiceTest` returns six 500s.

Eighteen call sites across eight bundles had lost it: HttpClient (2), Messenger (6), Notifier (1), PropertyInfo (3), Routing (1), Translation (3), TypeInfo (1), Validator (1). All restored.

## A pass that autoloads a class it only names

`RemoveMissingTranslatorDependenciesPass` dereferences `TranslationBundle::TRANS_PATHS_PARAMETER`, and a class **constant** autoloads where `::class` does not. Any leg with `symfony/framework-bundle` installed next to an older `symfony/translation` dies with `Class "Symfony\Component\Translation\TranslationBundle" not found`, which is what takes out AssetMapper, WebProfilerBundle and PsrHttpMessage. Guarded with `class_exists()`.

## A pass that runs after the one reading its tag

`RemoveUnusedFormHtmlSanitizerPass` was registered right after `FormPass`, which has already collected the `form.type_extension` tags into `form.extension`, so removing the definition leaves it pointing at a service that no longer exists:

> The service "form.extension" has a dependency on a non-existent service "form.type_extension.form.html_sanitizer".

It only shows when `html_sanitizer` is missing, which on the high-deps leg is every SecurityBundle functional test, about a hundred of them. Registered before `FormPass` now.

## Configuration written against the 8.2 builder

HttpClient, JsonStreamer, Lock and Webhook declare `symfony/config` as `^7.4|^8.0` while their bundles use the 8.2 config builder. HttpClient calls `NodeBuilder::appendFromCallback()`, which does not exist before 8.2; Lock's `acceptAndWrap()` normalization behaves differently. Floor raised to `^8.2` with the matching conflict.

## Tests that need a neighbour bundle

- Mailer's `testTheWebhookRequestParsersAreRegistered` needs the request parsers of `symfony/webhook` 8.2, added to require-dev.
- JsonStreamer configures `type_info` and Webhook dispatches to a message bus, so both need the *bundle* of the neighbouring component rather than only its classes. They skip when it is absent, the way the rest of the suite does.
- Translation's own service file names FrameworkBundle classes (`TranslationsCacheWarmer`, the `Translator` subclass), so testing it needs `symfony/framework-bundle`; added to require-dev. Routing and Serializer have the same shape and no failing test yet.

## Two assertions that pinned a path separator

`TranslationBundleTest::testTranslationResourcesAreDiscovered` and `ValidationBundleTest::testMappingPaths` compare what `Finder` discovered against a path built with `/`, which only matches where that is the separator; the Windows leg says so. Normalised with `strtr()`.

## One test that has to work on both sides of the split

`AddSessionDomainConstraintPassTest` loads `FrameworkExtension` by hand with `framework.router`, which no longer reaches the router. It now goes through `RouterBundle` when that class exists and keeps the old spelling when it does not, so the same file works on the high-deps leg, where 8.1's tests run against the patched components.

## Checks

FrameworkBundle, SecurityBundle, Form, HtmlSanitizer, HttpClient, Messenger, Notifier, PropertyInfo, Routing, Translation, TypeInfo, Validator, JsonStreamer, Webhook, Lock, Mailer and AssetMapper pass locally. The composer floors can only be confirmed by the low-deps leg itself, which is what this is for. AssetMapper's leg installs `symfony/framework-bundle` from the branch rather than from this patch, so its `TranslationBundle not found` clears when this merges, not before.
