### PR TITLE
[Finder] Fix ignoreVCSIgnored() when the search directory is reached through a symlink

### DIFF
--- a/src/Symfony/Component/Finder/Iterator/VcsIgnoredFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/VcsIgnoredFilterIterator.php
@@ -35,7 +35,8 @@ final class VcsIgnoredFilterIterator extends \FilterIterator
      */
     public function __construct(\Iterator $iterator, string $baseDir)
     {
-        $this->baseDir = $this->normalizePath($baseDir);
+        // paths are compared to the real path of each file, so the base directory needs the same treatment
+        $this->baseDir = $this->normalizePath(realpath($baseDir) ?: $baseDir);
 
         foreach ([$this->baseDir, ...$this->parentDirectoriesUpwards($this->baseDir)] as $directory) {
             if (@is_dir("{$directory}/.git")) {

--- a/src/Symfony/Component/Finder/Tests/Iterator/VcsIgnoredFilterIteratorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/VcsIgnoredFilterIteratorTest.php
@@ -445,6 +445,31 @@ class VcsIgnoredFilterIteratorTest extends IteratorTestCase
         $this->assertIterator([__FILE__], $iterator);
     }
 
+    public function testAcceptWithSymlinkedBaseDirectory()
+    {
+        if ('\\' === \DIRECTORY_SEPARATOR) {
+            $this->markTestSkipped('symlinks are not supported on Windows');
+        }
+
+        mkdir("{$this->tmpDir}/a");
+        touch("{$this->tmpDir}/a/file.txt");
+        touch("{$this->tmpDir}/b.txt");
+        file_put_contents("{$this->tmpDir}/.gitignore", "a/\n");
+
+        $link = "{$this->tmpDir}_link";
+        symlink($this->tmpDir, $link);
+
+        try {
+            $inner = new InnerNameIterator(["{$link}/a/file.txt", "{$link}/b.txt"]);
+
+            $iterator = new VcsIgnoredFilterIterator($inner, $link);
+
+            $this->assertIterator(["{$link}/b.txt"], $iterator);
+        } finally {
+            unlink($link);
+        }
+    }
+
     private function toAbsolute(array $files): array
     {
         foreach ($files as &$path) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | n/a
| License       | MIT

`VcsIgnoredFilterIterator` compares each file's `getRealPath()` against a `$baseDir` that is normalized but never resolved. When the search directory is reached through a symlink the prefix check never matches, so no `.gitignore` is ever read and `ignoreVCSIgnored()` silently returns every file, including ignored ones. Resolving `$baseDir` with `realpath()` puts both sides of the comparison in the same terms. The existing tests missed this because `setUp()` calls `realpath(sys_get_temp_dir())`, which normalizes the symlink away.
