### PR TITLE
[Finder] Fix building the gitignore regex for files with many patterns

### DIFF
--- a/src/Symfony/Component/Finder/Gitignore.php
+++ b/src/Symfony/Component/Finder/Gitignore.php
@@ -40,6 +40,7 @@ class Gitignore
         $gitignoreLines = preg_split('~\r\n?|\n~', $gitignoreFileContent);
 
         $res = self::lineToRegex('');
+        $alternatives = [];
         foreach ($gitignoreLines as $line) {
             $line = preg_replace('~(?<!\\\\)[ \t]+$~', '', $line);
 
@@ -52,14 +53,32 @@ class Gitignore
 
             if ('' !== $line) {
                 if ($isNegative xor $inverted) {
-                    $res = '(?!'.self::lineToRegex($line).'$)'.$res;
+                    // a negative pattern only cancels the patterns before it, so it opens a new nesting level
+                    $res = '(?!'.self::lineToRegex($line).'$)'.self::alternate($res, $alternatives);
                 } else {
-                    $res = '(?:'.$res.'|'.self::lineToRegex($line).')';
+                    $alternatives[] = self::lineToRegex($line);
                 }
             }
         }
 
-        return '~^(?:'.$res.')~s';
+        return '~^(?:'.self::alternate($res, $alternatives).')~s';
+    }
+
+    /**
+     * Consecutive patterns share a single group, so deep nesting stays proportional to the number of negative patterns.
+     *
+     * @param list<string> $alternatives
+     */
+    private static function alternate(string $res, array &$alternatives): string
+    {
+        if (!$alternatives) {
+            return $res;
+        }
+
+        $regex = '(?:'.$res.'|'.implode('|', $alternatives).')';
+        $alternatives = [];
+
+        return $regex;
     }
 
     private static function lineToRegex(string $gitignoreLine): string

--- a/src/Symfony/Component/Finder/Tests/GitignoreTest.php
+++ b/src/Symfony/Component/Finder/Tests/GitignoreTest.php
@@ -55,6 +55,19 @@ class GitignoreTest extends TestCase
         }
     }
 
+    public function testToRegexWithMorePatternsThanTheRegexNestingLimit()
+    {
+        $lines = array_map(static fn (int $i): string => "dir{$i}/", range(1, 300));
+
+        $regex = Gitignore::toRegex(implode("\n", $lines));
+        $this->assertMatchesRegularExpression($regex, 'dir300/file.txt');
+        $this->assertDoesNotMatchRegularExpression($regex, 'other/file.txt');
+
+        $negatedRegex = Gitignore::toRegexMatchingNegatedPatterns(implode("\n", array_map(static fn (string $line): string => '!'.$line, $lines)));
+        $this->assertMatchesRegularExpression($negatedRegex, 'dir300/file.txt');
+        $this->assertDoesNotMatchRegularExpression($negatedRegex, 'other/file.txt');
+    }
+
     public static function provider(): array
     {
         $cases = [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | n/a
| License       | MIT

`buildRegex()` wraps the accumulated expression in a new group for every pattern, so a `.gitignore` with around 250 entries produces a regex PCRE refuses to compile with "parentheses are too deeply nested", after which `preg_match()` just returns `false`. Consecutive patterns now share a single alternation, so the nesting depth follows the number of negated patterns instead of the total number of patterns. That moves the practical ceiling from about 250 to about 1500 patterns, where PCRE's overall expression size limit takes over.
