### PR TITLE
 [Finder] Only treat a leading hash as a gitignore comment and strip trailing spaces only

### DIFF
--- a/src/Symfony/Component/Finder/Gitignore.php
+++ b/src/Symfony/Component/Finder/Gitignore.php
@@ -36,13 +36,17 @@ class Gitignore
 
     private static function buildRegex(string $gitignoreFileContent, bool $inverted): string
     {
-        $gitignoreFileContent = preg_replace('~(?<!\\\\)#[^\n\r]*~', '', $gitignoreFileContent);
         $gitignoreLines = preg_split('~\r\n?|\n~', $gitignoreFileContent);
 
         $res = self::lineToRegex('');
         $alternatives = [];
         foreach ($gitignoreLines as $line) {
-            $line = preg_replace('~(?<!\\\\)[ \t]+$~', '', $line);
+            // only a line starting with "#" is a comment, and only trailing spaces are stripped
+            if (str_starts_with($line, '#')) {
+                continue;
+            }
+
+            $line = preg_replace('~(?<!\\\\) +$~', '', $line);
 
             if (str_starts_with($line, '!')) {
                 $line = substr($line, 1);

--- a/src/Symfony/Component/Finder/Iterator/VcsIgnoredFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/VcsIgnoredFilterIterator.php
@@ -162,8 +162,12 @@ final class VcsIgnoredFilterIterator extends \FilterIterator
         $rules = [];
 
         foreach (preg_split('~\r\n?|\n~', file_get_contents($path)) as $line) {
-            $line = preg_replace('~(?<!\\\\)#[^\n\r]*~', '', $line);
-            $line = preg_replace('~(?<!\\\\)[ \t]+$~', '', $line);
+            // only a line starting with "#" is a comment, and only trailing spaces are stripped
+            if (str_starts_with($line, '#')) {
+                continue;
+            }
+
+            $line = preg_replace('~(?<!\\\\) +$~', '', $line);
 
             if ($isNegated = str_starts_with($line, '!')) {
                 $line = substr($line, 1);
@@ -175,6 +179,11 @@ final class VcsIgnoredFilterIterator extends \FilterIterator
 
             if ('' === $line) {
                 continue;
+            }
+
+            if (str_starts_with($line, '#')) {
+                // the leading "!" is already stripped, so a "#" here starts a pattern, not a comment
+                $line = '\\'.$line;
             }
 
             $rules[] = [Gitignore::toRegex($line), $isNegated, $isDirOnly];

--- a/src/Symfony/Component/Finder/Tests/GitignoreTest.php
+++ b/src/Symfony/Component/Finder/Tests/GitignoreTest.php
@@ -133,13 +133,13 @@ class GitignoreTest extends TestCase
             ],
             [
                 ['#', ' #', '/ #', '  #', '/  #', '  \ #', '   \  #', 'a #', 'a  #', 'a  \ #', 'a   \  #'],
-                ['   ', '    ', 'a', 'a   ', 'a    '],
-                [' ', '  ', 'a ', 'a  '],
+                [' #', '  #', '   #', '     #', 'a #', 'a  #', 'a   #', 'a     #'],
+                ['#', '    #', 'a    #', ' ', '  ', '   ', '    ', 'a', 'a ', 'a  ', 'a   '],
             ],
             [
                 ["\t", "\t\\\t", " \t\\\t ", "\t#", "a\t#", "a\t\t#", "a \t#", "a\t\t\\\t#", "a \t\t\\\t\t#"],
-                ["\t\t", " \t\t", 'a', "a\t\t\t", "a \t\t\t"],
-                ["\t", "\t\t ", " \t\t ", "a\t", 'a ', "a \t", "a\t\t"],
+                ["\t", "\t\t", " \t\t", "\t#", "a\t#", "a\t\t#", "a\t\t\t#", "a \t#", "a \t\t\t\t#"],
+                ["\t\t\t", 'a', 'a ', "a\t", " \t", "\t\t#", "a \t\t#"],
             ],
             [
                 [' a', 'b ', '\ ', 'c\ '],
@@ -166,9 +166,14 @@ class GitignoreTest extends TestCase
                 ['bin/bash'],
             ],
             [
-                ['fi#le.txt'],
-                [],
-                ['#file.txt'],
+                ['fi#le.txt', 'a#b'],
+                ['fi#le.txt', 'a#b'],
+                ['#file.txt', 'fi', 'a'],
+            ],
+            [
+                ["y\t", 'z '],
+                ["y\t", 'z'],
+                ['y', 'z '],
             ],
             [
                 [
@@ -568,14 +573,14 @@ class GitignoreTest extends TestCase
 
         yield [
             ['!\#', '! #', '!/ #', '!  #', '!/  #', '!  \ #', '!   \  #', '!a #', '!a  #', '!a  \ #', '!a   \  #'],
-            ['   ', '    ', 'a', 'a   ', 'a    '],
-            [' ', '  ', 'a ', 'a  '],
+            ['#', ' #', '  #', '   #', '     #', 'a #', 'a  #', 'a   #', 'a     #'],
+            ['    #', 'a    #', ' ', '  ', '   ', 'a', 'a ', 'a  '],
         ];
 
         yield [
             ["!\t", "!\t\\\t", "! \t\\\t ", "!\t#", "!a\t#", "!a\t\t#", "!a \t#", "!a\t\t\\\t#", "!a \t\t\\\t\t#"],
-            ["\t\t", " \t\t", 'a', "a\t\t\t", "a \t\t\t"],
-            ["\t", "\t\t ", " \t\t ", "a\t", 'a ', "a \t", "a\t\t"],
+            ["\t", "\t\t", " \t\t", "\t#", "a\t#", "a\t\t#", "a\t\t\t#", "a \t#", "a \t\t\t\t#"],
+            ["\t\t\t", 'a', 'a ', "a\t", " \t", "\t\t#", "a \t\t#"],
         ];
 
         yield [
@@ -607,9 +612,15 @@ class GitignoreTest extends TestCase
         ];
 
         yield [
-            ['!fi#le.txt'],
-            [],
-            ['#file.txt'],
+            ['!fi#le.txt', '!a#b'],
+            ['fi#le.txt', 'a#b'],
+            ['#file.txt', 'fi', 'a'],
+        ];
+
+        yield [
+            ["!y\t", '!z '],
+            ["y\t", 'z'],
+            ['y', 'z '],
         ];
 
         yield [

--- a/src/Symfony/Component/Finder/Tests/Iterator/VcsIgnoredFilterIteratorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/VcsIgnoredFilterIteratorTest.php
@@ -59,6 +59,32 @@ class VcsIgnoredFilterIteratorTest extends IteratorTestCase
 
     public static function getAcceptData(): iterable
     {
+        yield 'a hash in the middle of a line is not a comment' => [
+            [
+                '.gitignore' => "fi#le.txt\n",
+            ],
+            [
+                'fi#le.txt',
+                'fi',
+            ],
+            [
+                'fi',
+            ],
+        ];
+
+        yield 'a negated pattern starting with a hash' => [
+            [
+                '.gitignore' => "*\n!#a.txt\n",
+            ],
+            [
+                '#a.txt',
+                'b.txt',
+            ],
+            [
+                '#a.txt',
+            ],
+        ];
+
         yield 'simple file' => [
             [
                 '.gitignore' => 'a.txt',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | n/a
| License       | MIT

This fixes two deviations from git in how a `.gitignore` line is parsed: `#` was treated as a comment marker anywhere in a line, and trailing tabs were stripped along with trailing spaces. Git only honors `#` at the start of a line and only strips trailing spaces, so `fi#le.txt` was reduced to `fi` and a pattern ending in a tab matched the name without it. Both places that parse lines are fixed, and the whitespace and comment test expectations were regenerated from `git check-ignore` rather than adjusted by hand.

A third case is fixed in `VcsIgnoredFilterIterator`, which strips the leading `!` before handing the line to `Gitignore::toRegex()`: the remainder of `!#a.txt` then looked like a comment, so the negation was silently dropped. Git looks for `#` at the start of the raw line only, so it keeps `#a.txt`.

Measured against `git check-ignore` over 33 pattern files and 168 path checks, the number of disagreements drops from 38 to 1 for both LF and CRLF input, and the remaining one is pre-existing: `lineToRegex()` strips backslashes, so a pattern ending in a lone backslash loses it.
