### PR TITLE
[SecurityBundle] Make two tests survive the FrameworkBundle split of the branch above

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/AddSessionDomainConstraintPassTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/AddSessionDomainConstraintPassTest.php
@@ -150,19 +150,22 @@ class AddSessionDomainConstraintPassTest extends TestCase
         $container->setParameter('request_listener.http_port', 80);
         $container->setParameter('request_listener.https_port', 443);
 
-        $config = [
-            'framework' => [
-                'csrf_protection' => false,
-                'router' => ['resource' => 'dummy'],
-            ],
-        ];
-
         if (class_exists(ServicesBundle::class)) {
             new ServicesBundle()->getContainerExtension()->load([], $container);
         }
 
+        $config = ['csrf_protection' => false];
+
+        // the router lives in its own bundle since 8.2, and loading FrameworkExtension by hand does not
+        // forward to it; named as a string so the same file works on the branch before it
+        if (class_exists($routerBundle = 'Symfony\\Component\\Routing\\RouterBundle')) {
+            new $routerBundle()->getContainerExtension()->load([['resource' => 'dummy']], $container);
+        } else {
+            $config['router'] = ['resource' => 'dummy'];
+        }
+
         $ext = new FrameworkExtension();
-        $ext->load($config, $container);
+        $ext->load([$config], $container);
 
         $config = [
             'security' => [

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -42,6 +42,7 @@
         "symfony/framework-bundle": "^7.4|^8.0",
         "symfony/http-client": "^7.4|^8.0",
         "symfony/ldap": "^7.4|^8.0",
+        "symfony/lock": "^7.4|^8.0",
         "symfony/process": "^7.4|^8.0",
         "symfony/property-info": "^7.4|^8.0",
         "symfony/rate-limiter": "^7.4|^8.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

On the highest branch the `high-deps` job checks out the branch before it and runs **its** tests against the locally patched components, so 8.1's SecurityBundle suite is what meets 8.2's per-component bundles. Two of its tests assume the framework configuration still owns sections that moved, and both take out the whole SecurityBundle leg on 8.2.

**`AddSessionDomainConstraintPassTest`** loads `FrameworkExtension` by hand with `framework.router`, which no longer reaches the router once `RouterBundle` owns it, so `security.http_utils` ends up without a URL generator and every assertion dies on `Call to a member function getContext() on null`. It goes through the bundle when the class is there and keeps the old spelling when it is not, so the same file works on both sides of the split. The class is named as a string rather than imported, since it does not exist on this branch.

**`StandardFormLogin/login_throttling.yml`** sets `framework.lock: ~` while `symfony/lock` is not a dependency of this bundle. That used to configure a section of FrameworkBundle itself and quietly produced nothing usable; it is now forwarded to the `lock` extension, which without the component is not registered, and the forwarding says so:

> The "framework.lock" configuration is handled by the "lock" extension, which is not registered. Try running "composer require symfony/lock".

Declared as a dev dependency, which is what the test has always needed to exercise login throttling.

Both changes are inert on this branch: `RouterBundle` does not exist here, so the test takes the same path it takes today, and the new dev dependency only adds a package the suite already assumed.

## Checks

SecurityBundle passes locally on 8.1 and on 8.2 with the same file. What this is really for is the 8.2 `high-deps` leg, which is where the two failures live.
