### PR TITLE
[Tui] Fix cursor jumps and partial rendering of overheight frames

### DIFF
--- a/src/Symfony/Component/Tui/Render/ScreenWriter.php
+++ b/src/Symfony/Component/Tui/Render/ScreenWriter.php
@@ -186,9 +186,10 @@ final class ScreenWriter
             return;
         }
 
-        // Overflowing content that shrinks moves every visible line up, which
-        // cannot be expressed by erasing the trailing ones.
-        if (!$this->terminal->isVirtual() && \count($this->previousLines) > $rows && $lineCount < \count($this->previousLines)) {
+        // Rows are addressed by relative cursor motion, which clamps at the screen
+        // edges instead of scrolling, so no frame taller than the screen can be
+        // updated that way, in either direction.
+        if (!$this->terminal->isVirtual() && ($lineCount > $rows || \count($this->previousLines) > $rows)) {
             $this->redrawViewport($lines, $cursorPos, $rows);
 
             return;
@@ -242,7 +243,7 @@ final class ScreenWriter
      */
     private function fullRender(array $newLines, ?array $cursorPos, bool $clear): void
     {
-        $buffer = "\x1b[?2026h"; // Begin synchronized output
+        $buffer = "\x1b[?2026h\x1b[?25l"; // Begin synchronized output with the cursor hidden
 
         if ($clear) {
             $buffer .= "\x1b[2J\x1b[3J\x1b[H"; // Clear screen, clear scrollback, and home
@@ -251,8 +252,6 @@ final class ScreenWriter
         if ($newLines) {
             $buffer .= implode("\r\n", $newLines);
         }
-
-        $buffer .= "\x1b[?2026l"; // End synchronized output
 
         $this->terminal->write($buffer);
         $this->cursorRow = max(0, \count($newLines) - 1);
@@ -265,6 +264,7 @@ final class ScreenWriter
         }
 
         $this->positionHardwareCursor($cursorPos, \count($newLines));
+        $this->terminal->write("\x1b[?2026l"); // Publish the content and the restored cursor together
         $this->previousLines = $newLines;
         $this->previousWidth = $this->terminal->getColumns();
     }
@@ -281,9 +281,8 @@ final class ScreenWriter
     {
         $lineCount = \count($newLines);
 
-        $buffer = "\x1b[?2026h\x1b[2J\x1b[H"; // Begin synchronized output, clear screen and home
+        $buffer = "\x1b[?2026h\x1b[?25l\x1b[2J\x1b[H"; // Begin synchronized output with the cursor hidden, clear screen and home
         $buffer .= implode("\r\n", \array_slice($newLines, max(0, $lineCount - $rows), $rows));
-        $buffer .= "\x1b[?2026l"; // End synchronized output
 
         $this->terminal->write($buffer);
         $this->cursorRow = max(0, $lineCount - 1);
@@ -291,6 +290,7 @@ final class ScreenWriter
         $this->maxLinesRendered = $lineCount;
 
         $this->positionHardwareCursor($cursorPos, $lineCount);
+        $this->terminal->write("\x1b[?2026l");
         $this->previousLines = $newLines;
         $this->previousWidth = $this->terminal->getColumns();
     }
@@ -311,7 +311,7 @@ final class ScreenWriter
             return false;
         }
 
-        $buffer = "\x1b[?2026h";
+        $buffer = "\x1b[?2026h\x1b[?25l";
 
         $targetRow = max(0, \count($newLines) - 1);
         $lineDiff = $targetRow - $this->hardwareCursorRow;
@@ -350,13 +350,12 @@ final class ScreenWriter
             $buffer .= "\x1b[{$moveUp}A";
         }
 
-        $buffer .= "\x1b[?2026l";
-
         $this->terminal->write($buffer);
         $this->cursorRow = $targetRow;
         $this->hardwareCursorRow = $targetRow;
 
         $this->positionHardwareCursor($cursorPos, \count($newLines));
+        $this->terminal->write("\x1b[?2026l");
         $this->previousLines = $newLines;
         $this->previousWidth = $this->terminal->getColumns();
 
@@ -369,7 +368,7 @@ final class ScreenWriter
      */
     private function differentialRender(array $newLines, ?array $cursorPos, int $firstChanged, int $lastChanged, int $width): void
     {
-        $buffer = "\x1b[?2026h"; // Begin synchronized output
+        $buffer = "\x1b[?2026h\x1b[?25l"; // Begin synchronized output with the cursor hidden
 
         // Move cursor to first changed line
         $lineDiff = $firstChanged - $this->hardwareCursorRow;
@@ -401,8 +400,11 @@ final class ScreenWriter
             }
 
             if (null !== $lineWidth && $lineWidth > $width) {
-                // End synchronized output before throwing so the terminal
-                // is not left in buffered mode and ScreenWriter state stays consistent
+                // Restore the cursor and end synchronized output before throwing so the
+                // terminal is left neither in buffered mode nor without a cursor
+                if ($this->showHardwareCursor) {
+                    $buffer .= "\x1b[?25h";
+                }
                 $buffer .= "\x1b[?2026l";
                 $this->terminal->write($buffer);
 
@@ -447,8 +449,6 @@ final class ScreenWriter
             }
         }
 
-        $buffer .= "\x1b[?2026l"; // End synchronized output
-
         $this->terminal->write($buffer);
 
         $this->cursorRow = max(0, \count($newLines) - 1);
@@ -456,6 +456,7 @@ final class ScreenWriter
         $this->maxLinesRendered = max($this->maxLinesRendered, \count($newLines));
 
         $this->positionHardwareCursor($cursorPos, \count($newLines));
+        $this->terminal->write("\x1b[?2026l"); // Publish the content and the restored cursor together
         $this->previousLines = $newLines;
         $this->previousWidth = $this->terminal->getColumns();
     }

--- a/src/Symfony/Component/Tui/Tests/Render/ScreenWriterTest.php
+++ b/src/Symfony/Component/Tui/Tests/Render/ScreenWriterTest.php
@@ -394,13 +394,13 @@ class ScreenWriterTest extends TestCase
     {
         $marker = AnsiUtils::cursorMarker();
 
-        yield 'marker present, showHardwareCursor off' => [false, true, self::HIDE_CURSOR, self::SHOW_CURSOR];
-        yield 'marker present, showHardwareCursor on' => [true, true, self::SHOW_CURSOR, self::HIDE_CURSOR];
-        yield 'no marker, showHardwareCursor on' => [true, false, self::HIDE_CURSOR, self::SHOW_CURSOR];
+        yield 'marker present, showHardwareCursor off' => [false, true, self::HIDE_CURSOR];
+        yield 'marker present, showHardwareCursor on' => [true, true, self::SHOW_CURSOR];
+        yield 'no marker, showHardwareCursor on' => [true, false, self::HIDE_CURSOR];
     }
 
     #[DataProvider('cursorVisibilityProvider')]
-    public function testCursorVisibility(bool $showHardwareCursor, bool $hasMarker, string $expectedContains, string $expectedNotContains)
+    public function testCursorVisibility(bool $showHardwareCursor, bool $hasMarker, string $expectedVisibility)
     {
         $terminal = new VirtualTerminal(80, 24);
         $writer = new ScreenWriter($terminal);
@@ -412,8 +412,8 @@ class ScreenWriterTest extends TestCase
 
         $output = $terminal->getOutput();
 
-        $this->assertStringContainsString($expectedContains, $output);
-        $this->assertStringNotContainsString($expectedNotContains, $output);
+        $this->assertStringContainsString(self::SYNC_START.self::HIDE_CURSOR, $output);
+        $this->assertStringEndsWith($expectedVisibility.self::SYNC_END, $output);
     }
 
     public function testDisablingShowHardwareCursorHidesCursorImmediately()
@@ -541,7 +541,7 @@ class ScreenWriterTest extends TestCase
 
     // --- RenderException tests (pre-existing) ---
 
-    public function testRenderExceptionDoesNotCallStopOnTerminal()
+    public function testRenderExceptionLeavesTheTerminalUsable()
     {
         $terminal = new VirtualTerminal(20, 24);
         $screenWriter = new ScreenWriter($terminal);
@@ -561,13 +561,10 @@ class ScreenWriterTest extends TestCase
             $this->assertSame(20, $e->getTerminalWidth());
         }
 
-        // The output should NOT contain showCursor sequence
-        // which would indicate stop()/showCursor() were called
+        // The terminal must be left usable: the cursor restored, since painting hides
+        // it, and synchronized output ended
         $output = $terminal->getOutput();
-        $this->assertStringNotContainsString(self::SHOW_CURSOR, $output, 'showCursor() should not be called');
-
-        // The output should end synchronized output properly
-        $this->assertStringContainsString("\x1b[?2026l", $output, 'Synchronized output should be ended');
+        $this->assertStringEndsWith(self::SHOW_CURSOR.self::SYNC_END, $output);
     }
 
     public function testScreenWriterCanRenderAfterRenderException()
@@ -658,5 +655,61 @@ class ScreenWriterTest extends TestCase
         yield 'three trailing lines removed' => [['A', 'B', 'C', 'D']];
         yield 'two leading lines removed' => [['C', 'D', 'E', 'F', 'G']];
         yield 'all but one line removed' => [['A']];
+    }
+
+    #[DataProvider('renderPathFrames')]
+    public function testRestoresTheCursorBeforeEndingSynchronizedOutput(array $first, array $second)
+    {
+        $marker = AnsiUtils::cursorMarker();
+        $terminal = new VirtualTerminal(20, 5);
+        $writer = new ScreenWriter($terminal);
+        $writer->writeLines($first);
+
+        $terminal->clearOutput();
+        $writer->writeLines($second);
+
+        $output = $terminal->getOutput();
+
+        $this->assertStringStartsWith(self::SYNC_START.self::HIDE_CURSOR, $output);
+        $this->assertStringEndsWith(self::SHOW_CURSOR.self::SYNC_END, $output);
+        $this->assertSame(1, substr_count($output, self::SYNC_END));
+    }
+
+    public static function renderPathFrames(): iterable
+    {
+        $marker = AnsiUtils::cursorMarker();
+
+        yield 'full render' => [[], ["a{$marker}b"]];
+        yield 'differential render' => [['ab', 'cd'], ['ab', "c{$marker}e"]];
+        yield 'trailing lines deleted' => [['ab', 'cd', 'ef'], ["a{$marker}b"]];
+        yield 'overheight redraw' => [['a', 'b', 'c', 'd', 'e', 'f'], ['a', 'b', 'c', 'd', 'e', "f{$marker}g"]];
+    }
+
+    #[DataProvider('overheightFrames')]
+    public function testOverheightFrameKeepsTheViewportInSync(array $previous, array $frame)
+    {
+        $screen = new ScreenBuffer(40, 5);
+        $terminal = $this->createStub(TerminalInterface::class);
+        $terminal->method('getColumns')->willReturn(40);
+        $terminal->method('getRows')->willReturn(5);
+        $terminal->method('isVirtual')->willReturn(false);
+        $terminal->method('write')->willReturnCallback(static fn (string $data) => $screen->write($data));
+
+        $writer = new ScreenWriter($terminal);
+        $writer->writeLines($previous);
+        $writer->writeLines($frame);
+
+        $expected = array_pad(\array_slice($frame, max(0, \count($frame) - 5), 5), 5, '');
+
+        $this->assertSame($expected, array_map(rtrim(...), $screen->getLines()));
+    }
+
+    public static function overheightFrames(): iterable
+    {
+        $six = ['L0', 'L1', 'L2', 'L3', 'L4', 'L5'];
+
+        yield 'one line appended' => [$six, [...$six, 'L6']];
+        yield 'two lines appended' => [$six, [...$six, 'L6', 'L7']];
+        yield 'last line edited' => [[...$six, 'L6'], [...$six, 'L6x']];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65965
| License       | MIT

Fixes the two symptoms reported in #65965, which have separate causes.

**Cursor jumps.** The four repaint paths ended synchronized output before repositioning the cursor, so `ESC[?2026l` published the frame with the hardware cursor still on the last painted row and the move landed outside the atomic window. The cursor is now hidden for the duration of the repaint and restored before the window closes, so content and cursor are published together. The same restore happens on the `RenderException` path, which previously ended synchronized output but left the cursor hidden.

**Partial rendering of overheight frames.** Rows are addressed by relative cursor motion, and `CUD` clamps at the bottom margin instead of scrolling, so a frame taller than the screen cannot be updated that way. The viewport redraw guard only covered overheight content that *shrinks*, so overheight content that *grows*, which is the streaming case in the issue, took the differential path and overwrote the bottom row instead of scrolling. Reproduced against a terminal emulator at 40x5: six lines growing to seven left `["L1","L2","L3","L4","L6"]` on screen, with `L5` destroyed. The guard now covers any overheight frame in either direction.

Merge-up to 8.2: `ScreenWriter.php` conflicts, because 8.2 rewrote it for `LineBufferInterface`. The resolution is to apply the same four edits to 8.2's shape: prefix each `ESC[?2026h` with `ESC[?25l`, drop the `ESC[?2026l` from each buffer and write it after the `positionHardwareCursor()` call, add the `showHardwareCursor` restore before the `RenderException` path's `ESC[?2026l`, and widen the `redrawViewport` guard to `$lineCount > $rows || \count($this->previousLines) > $rows`. The test file merges cleanly.
