### PR TITLE
[Mailer] Reconnect when the server closed the transmission channel

### DIFF
--- a/src/Symfony/Component/Mailer/Tests/Transport/Smtp/SmtpTransportTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/Smtp/SmtpTransportTest.php
@@ -33,6 +33,8 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
  */
 class SmtpTransportTest extends TestCase
 {
+    private const CLOCK_TICK_MICROSECONDS = 1;
+
     public function testToString()
     {
         $t = new SmtpTransport();
@@ -72,6 +74,129 @@ class SmtpTransportTest extends TestCase
             }
         }
         $this->assertSame(2, $heloCommands, 'The transport must reconnect after a read timeout.');
+    }
+
+    public function testConnectionIsResetAfterServiceUnavailableResponse()
+    {
+        $stream = new class extends DummyStream {
+            private array $responses = [];
+            private bool $failNextPing = true;
+
+            public function write(string $bytes, $debug = true): void
+            {
+                parent::write($bytes, $debug);
+
+                if ($this->failNextPing && "NOOP\r\n" === $bytes) {
+                    $this->failNextPing = false;
+                    $this->responses = [
+                        "250 2.0.0 OK\r\n",
+                        "421 4.4.1 Connection timed out.\r\n",
+                    ];
+                }
+            }
+
+            public function readLine(): string
+            {
+                return array_shift($this->responses) ?? parent::readLine();
+            }
+        };
+        $envelope = new Envelope(new Address('sender@example.org'), [new Address('recipient@example.org')]);
+
+        $transport = new SmtpTransport($stream);
+        $transport->setPingThreshold(0);
+        $transport->send(new RawMessage('Message 1'), $envelope);
+        usleep(self::CLOCK_TICK_MICROSECONDS);
+
+        try {
+            $transport->send(new RawMessage('Message 2'), $envelope);
+            $this->fail('The second message is expected to receive a service unavailable response.');
+        } catch (TransportException $e) {
+            $this->assertSame(421, $e->getCode());
+        }
+
+        $this->assertTrue($stream->isClosed(), 'The transport must disconnect when the server closes the transmission channel.');
+
+        // Ensure the next send reconnects because the transport was stopped, not
+        // because the ping path happened to detect the closed stream.
+        $transport->setPingThreshold(\PHP_INT_MAX);
+        $transport->send(new RawMessage('Message 3'), $envelope);
+        $this->assertFalse($stream->isClosed());
+    }
+
+    public function testConnectionIsResetAfterServiceUnavailableGreeting()
+    {
+        $stream = new class extends DummyStream {
+            private bool $failGreeting = true;
+
+            public function readLine(): string
+            {
+                if ($this->failGreeting) {
+                    $this->failGreeting = false;
+
+                    return "421 4.3.2 Service not available\r\n";
+                }
+
+                return parent::readLine();
+            }
+        };
+        $transport = new SmtpTransport($stream);
+
+        try {
+            $transport->start();
+            $this->fail('The server is expected to reject the connection.');
+        } catch (TransportException $e) {
+            $this->assertSame(421, $e->getCode());
+        }
+
+        $this->assertTrue($stream->isClosed(), 'The transport must disconnect after a service unavailable greeting.');
+    }
+
+    public function testPingReconnectsWhenTheServerQueuedAnotherReply()
+    {
+        $stream = new class extends DummyStream {
+            private array $responses = [];
+            private bool $armed = true;
+
+            public function write(string $bytes, $debug = true): void
+            {
+                parent::write($bytes, $debug);
+
+                if ($this->armed && "NOOP\r\n" === $bytes) {
+                    $this->armed = false;
+                    $this->responses = ["250 2.0.0 OK\r\n", "421 4.4.1 Connection timed out.\r\n"];
+                }
+            }
+
+            public function readLine(): string
+            {
+                return array_shift($this->responses) ?? parent::readLine();
+            }
+
+            public function hasPendingData(): bool
+            {
+                return (bool) $this->responses;
+            }
+
+            public function terminate(): void
+            {
+                parent::terminate();
+                $this->responses = [];
+            }
+        };
+        $envelope = new Envelope(new Address('sender@example.org'), [new Address('recipient@example.org')]);
+
+        $transport = new SmtpTransport($stream);
+        $transport->setPingThreshold(-1);
+        $transport->send(new RawMessage('Message 1'), $envelope);
+        $transport->send(new RawMessage('Message 2'), $envelope);
+
+        $heloCommands = 0;
+        foreach ($stream->getCommands() as $command) {
+            if (str_starts_with($command, 'HELO')) {
+                ++$heloCommands;
+            }
+        }
+        $this->assertSame(2, $heloCommands, 'The transport must reconnect when the server queued another reply.');
     }
 
     public function testSendDoesNotPingBelowThreshold()

--- a/src/Symfony/Component/Mailer/Tests/Transport/Smtp/Stream/AbstractStreamTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/Smtp/Stream/AbstractStreamTest.php
@@ -29,6 +29,42 @@ class AbstractStreamTest extends TestCase
         $this->assertSame($expected, $result);
     }
 
+    public function testHasPendingData()
+    {
+        $listener = stream_socket_server('tcp://127.0.0.1:0');
+        $client = stream_socket_client(stream_socket_get_name($listener, false));
+        $server = stream_socket_accept($listener);
+        $stream = new class($client) extends AbstractStream {
+            public function __construct($out)
+            {
+                $this->out = $out;
+            }
+
+            public function initialize(): void
+            {
+            }
+
+            protected function getReadConnectionDescription(): string
+            {
+                return 'pair';
+            }
+        };
+
+        $this->assertFalse($stream->hasPendingData());
+
+        fwrite($server, "250 2.0.0 OK\r\n421 4.4.1 Connection timed out\r\n");
+        usleep(10000);
+
+        $this->assertTrue($stream->hasPendingData());
+        $this->assertSame("250 2.0.0 OK\r\n", $stream->readLine());
+        $this->assertTrue($stream->hasPendingData(), 'The unsolicited reply is still pending.');
+        $this->assertSame("421 4.4.1 Connection timed out\r\n", $stream->readLine());
+
+        fclose($server);
+        fclose($client);
+        fclose($listener);
+    }
+
     public static function provideReplace()
     {
         yield ['ca', 'ab', 'c', ['a', 'b', 'a']];

--- a/src/Symfony/Component/Mailer/Transport/Smtp/SmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/SmtpTransport.php
@@ -142,7 +142,7 @@ class SmtpTransport extends AbstractTransport
             $message = parent::send($message, $envelope);
         } catch (TransportExceptionInterface $e) {
             if ($this->started) {
-                if ($e instanceof UnexpectedResponseException) {
+                if ($e instanceof UnexpectedResponseException && 421 !== $e->getCode()) {
                     // The server replied with an unexpected code: the connection is
                     // still in sync, so it can be reused after resetting the session.
                     try {
@@ -151,7 +151,8 @@ class SmtpTransport extends AbstractTransport
                         // ignore this exception as it probably means that the server error was final
                     }
                 } else {
-                    // Any other failure (timeout, broken pipe, ...) may have left an
+                    // A 421 means the server is closing the channel, and any other
+                    // failure (timeout, broken pipe, ...) may have left an
                     // unread reply in the socket buffer. Reusing the connection would
                     // desync every following command, so close it and reconnect on the
                     // next message.
@@ -277,8 +278,16 @@ class SmtpTransport extends AbstractTransport
         $this->getLogger()->debug(\sprintf('Email transport "%s" starting', __CLASS__));
 
         $this->stream->initialize();
-        $this->assertResponseCode($this->getFullResponse(), [220]);
-        $this->doHeloCommand();
+
+        try {
+            $this->assertResponseCode($this->getFullResponse(), [220]);
+            $this->doHeloCommand();
+        } catch (TransportExceptionInterface $e) {
+            $this->stream->terminate();
+
+            throw $e;
+        }
+
         $this->started = true;
         $this->lastMessageTime = 0;
 
@@ -318,6 +327,12 @@ class SmtpTransport extends AbstractTransport
 
         try {
             $this->executeCommand("NOOP\r\n", [250]);
+
+            if ($this->stream->hasPendingData()) {
+                // The server queued another reply, typically a 421 closing the channel.
+                // The next command would read it as its own reply, so reconnect instead.
+                $this->stop();
+            }
         } catch (TransportExceptionInterface) {
             $this->stop();
         }

--- a/src/Symfony/Component/Mailer/Transport/Smtp/Stream/AbstractStream.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/Stream/AbstractStream.php
@@ -96,6 +96,25 @@ abstract class AbstractStream
         return $line;
     }
 
+    /**
+     * Tells whether the server sent data that has not been read yet.
+     */
+    public function hasPendingData(): bool
+    {
+        if (!\is_resource($this->out)) {
+            return false;
+        }
+
+        if (0 < stream_get_meta_data($this->out)['unread_bytes']) {
+            return true;
+        }
+
+        $read = [$this->out];
+        $write = $except = [];
+
+        return 0 < @stream_select($read, $write, $except, 0);
+    }
+
     public function getDebug(): string
     {
         $debug = $this->debug;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #49744
| License       | MIT

An SMTP server that closes an idle connection can send its `421` reply right after the reply for `NOOP`. `getFullResponse()` stops at `250 2.0.0 OK`, which is correct, because only `250-` marks a continuation line. The ping therefore succeeds while the `421` is still waiting in the buffer. The transport then opens a mail transaction, `MAIL FROM` reads the queued `421` as its own reply, and the message fails. This is what #49744 reports against smtp.office365.com after its ten minute idle timeout.

`ping()` now looks for pending data after `NOOP` and reconnects when it finds any, before the transaction starts. The check itself is `AbstractStream::hasPendingData()`, which reads the stream's unread buffer and then polls the socket. That class is `@internal`, so this adds no public API.

Two related fixes come with it:

 * a `421` received while sending closes the connection instead of resetting it with `RSET`, because the server has announced that it is closing the channel;
 * a handshake that fails at the greeting or at `HELO`/`EHLO` no longer leaves the socket open.

Measured against a local STARTTLS server that queues a `421` on the first `NOOP` and then closes, sending six messages with a ping before each one:

| | before | after |
| --- | --- | --- |
| messages delivered | 5 of 6 | 6 of 6 |
| TCP connections opened | 2 | 2 |

Against a healthy server the same run delivers 6 of 6 over a single connection both before and after, so the check causes no extra reconnects.
