### PR TITLE
[ObjectMapper] Infer nested target class from destination property type

### DIFF
--- a/src/Symfony/Component/ObjectMapper/CHANGELOG.md
+++ b/src/Symfony/Component/ObjectMapper/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Add `ObjectMapperBundle`
  * Add automatic conversion between `BackedEnum` and scalar types (both ways)
  * Add a `MappingAwareTransformCallableInterface` to pass the `Map` attribute being applied to transformers
+ * Add `PropertyTypeMappingMetadataFactory` to map a nested object to the class typing the property it is written into
 
 8.1
 ---

--- a/src/Symfony/Component/ObjectMapper/Metadata/ObjectMapperMetadataFactoryInterface.php
+++ b/src/Symfony/Component/ObjectMapper/Metadata/ObjectMapperMetadataFactoryInterface.php
@@ -19,6 +19,12 @@ namespace Symfony\Component\ObjectMapper\Metadata;
 interface ObjectMapperMetadataFactoryInterface
 {
     /**
+     * The context describes the mapping being computed. The object mapper fills these keys:
+     *
+     *  * "source" and "target": the classes being mapped, when $property is given
+     *  * "target" and "target_property": the class and the property a nested $object is written
+     *    into, set only when the mapper can write that property
+     *
      * @param array<string, mixed> $context
      *
      * @return list<Mapping>

--- a/src/Symfony/Component/ObjectMapper/Metadata/PropertyTypeMappingMetadataFactory.php
+++ b/src/Symfony/Component/ObjectMapper/Metadata/PropertyTypeMappingMetadataFactory.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Metadata;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+use Symfony\Component\ObjectMapper\ClassHierarchyTrait;
+use Symfony\Component\ObjectMapper\Exception\MappingException;
+
+/**
+ * Maps a nested object to the class typing the property it is written into, based on the #[Map]
+ * attributes that class declares.
+ *
+ * It only answers when the decorated factory reports no mapping for the object, and only when the
+ * mapper describes the destination in the context. A property typed with a union, an intersection
+ * or no type at all is left to the decorated factory.
+ *
+ * @author iz-ahmad <n.ahmad.web.cit22@gmail.com>
+ */
+final class PropertyTypeMappingMetadataFactory implements ObjectMapperMetadataFactoryInterface
+{
+    use ClassHierarchyTrait;
+
+    /**
+     * @var array<string, list<Mapping>>
+     */
+    private array $mappingsCache = [];
+
+    public function __construct(
+        private readonly ObjectMapperMetadataFactoryInterface $inner,
+    ) {
+    }
+
+    public function create(object $object, ?string $property = null, array $context = []): array
+    {
+        $mappings = $this->inner->create($object, $property, $context);
+
+        if ($mappings || null !== $property || !isset($context['target'], $context['target_property'])) {
+            return $mappings;
+        }
+
+        $key = $context['target'].'::'.$context['target_property'].'::'.$object::class;
+
+        return $this->mappingsCache[$key] ??= $this->createFromPropertyType($object, $context['target'], $context['target_property']);
+    }
+
+    /**
+     * @return list<Mapping>
+     */
+    private function createFromPropertyType(object $object, string $targetClass, string $targetProperty): array
+    {
+        try {
+            $property = $this->getPropertyFromHierarchy(new \ReflectionClass($targetClass), $targetProperty);
+        } catch (\ReflectionException $e) {
+            throw new MappingException($e->getMessage(), $e->getCode(), $e);
+        }
+
+        $type = $property?->getType();
+
+        if (!$type instanceof \ReflectionNamedType || $type->isBuiltin()) {
+            return [];
+        }
+
+        $propertyClass = $type->getName();
+
+        if ($object instanceof $propertyClass || !class_exists($propertyClass) && !interface_exists($propertyClass)) {
+            return [];
+        }
+
+        $refl = new \ReflectionClass($propertyClass);
+        $mappings = [];
+
+        foreach ($refl->getAttributes(Map::class, \ReflectionAttribute::IS_INSTANCEOF) as $attribute) {
+            $map = $attribute->newInstance();
+
+            if (!$map->source || !is_a($object, $map->source, true)) {
+                continue;
+            }
+
+            // a transform returns the value to store, so the mapper never instantiates the class itself
+            if (!$map->transform && !$refl->isInstantiable()) {
+                throw new MappingException(\sprintf('Cannot infer a mapping target for "%s" from property "%s::$%s": class "%s" is not instantiable.', get_debug_type($object), $targetClass, $targetProperty, $propertyClass));
+            }
+
+            $mappings[] = new Mapping($propertyClass, null, $map->if, $map->transform);
+        }
+
+        return $mappings;
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/ObjectMapper.php
+++ b/src/Symfony/Component/ObjectMapper/ObjectMapper.php
@@ -19,6 +19,7 @@ use Symfony\Component\ObjectMapper\Exception\NoSuchCallableException;
 use Symfony\Component\ObjectMapper\Exception\NoSuchPropertyException;
 use Symfony\Component\ObjectMapper\Metadata\Mapping;
 use Symfony\Component\ObjectMapper\Metadata\ObjectMapperMetadataFactoryInterface;
+use Symfony\Component\ObjectMapper\Metadata\PropertyTypeMappingMetadataFactory;
 use Symfony\Component\ObjectMapper\Metadata\ReflectionObjectMapperMetadataFactory;
 use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException as PropertyAccessorNoSuchPropertyException;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
@@ -39,7 +40,7 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
     private ?\WeakMap $objectMap = null;
 
     public function __construct(
-        private readonly ObjectMapperMetadataFactoryInterface $metadataFactory = new ReflectionObjectMapperMetadataFactory(),
+        private readonly ObjectMapperMetadataFactoryInterface $metadataFactory = new PropertyTypeMappingMetadataFactory(new ReflectionObjectMapperMetadataFactory()),
         private readonly ?PropertyAccessorInterface $propertyAccessor = null,
         private readonly ?ContainerInterface $transformCallableLocator = null,
         private readonly ?ContainerInterface $conditionCallableLocator = null,
@@ -182,7 +183,7 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
                     continue;
                 }
 
-                $value = $this->getSourceValue($source, $mappedTarget, $value, $objectMap, $mapping, $targetPropertyName);
+                $value = $this->getSourceValue($source, $mappedTarget, $value, $objectMap, $mapping, $targetPropertyName, $this->getDestinationContext($mappedTarget, $targetRefl, $targetPropertyName, $ctorArguments));
                 $explicitTargets[$targetPropertyName] = true;
                 $this->storeValue($targetPropertyName, $mapToProperties, $ctorArguments, $value);
             }
@@ -205,7 +206,7 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
                 // target property itself is never surfaced above, so honor its transform here
                 $sameNameMapping = $readMetadataFromTarget ? null : $this->getSameNameTargetMapping($mappedTarget, $propertyName);
 
-                $implicitValues[$propertyName] = $this->getSourceValue($source, $mappedTarget, $this->getRawValue($source, $propertyName), $objectMap, $sameNameMapping, $propertyName);
+                $implicitValues[$propertyName] = $this->getSourceValue($source, $mappedTarget, $this->getRawValue($source, $propertyName), $objectMap, $sameNameMapping, $propertyName, $this->getDestinationContext($mappedTarget, $targetRefl, $propertyName, $ctorArguments));
 
                 continue;
             }
@@ -339,7 +340,10 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
         return null;
     }
 
-    private function getSourceValue(object $source, object $target, mixed $value, \WeakMap $objectMap, ?Mapping $mapping = null, ?string $targetPropertyName = null): mixed
+    /**
+     * @param array<string, mixed> $context
+     */
+    private function getSourceValue(object $source, object $target, mixed $value, \WeakMap $objectMap, ?Mapping $mapping = null, ?string $targetPropertyName = null, array $context = []): mixed
     {
         if ($mapping?->transform) {
             $value = $this->applyTransforms($mapping, $value, $source, $target);
@@ -347,7 +351,7 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
 
         if (
             \is_object($value)
-            && ($innerMetadata = $this->metadataFactory->create($value))
+            && ($innerMetadata = $this->metadataFactory->create($value, null, $context))
             && ($innerMetadata = $this->filterMetadataByPropertyType($innerMetadata, $target, $targetPropertyName))
             && ($mapTo = $this->getMapTarget($innerMetadata, $value, $source, $target, true))
             && (\is_string($mapTo->target) && class_exists($mapTo->target))
@@ -383,6 +387,25 @@ final class ObjectMapper implements ObjectMapperInterface, ObjectMapperAwareInte
         }
 
         return $value;
+    }
+
+    /**
+     * Tells the metadata factory which property the nested value is written into, so that a factory
+     * can resolve a mapping from the type of that property.
+     *
+     * The context is left empty when the mapper cannot write the property: a value that is thrown
+     * away must not report a mapping error.
+     *
+     * @param array<string, mixed> $ctorArguments
+     *
+     * @return array<string, mixed>
+     */
+    private function getDestinationContext(object $target, \ReflectionClass $targetRefl, string $propertyName, array $ctorArguments): array
+    {
+        $writable = \array_key_exists($propertyName, $ctorArguments)
+            || ($this->propertyAccessor ? $this->propertyAccessor->isWritable($target, $propertyName) : $this->propertyIsMappable($targetRefl, $propertyName));
+
+        return $writable ? ['target' => $target::class, 'target_property' => $propertyName] : [];
     }
 
     /**

--- a/src/Symfony/Component/ObjectMapper/Resources/config/object_mapper.php
+++ b/src/Symfony/Component/ObjectMapper/Resources/config/object_mapper.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Symfony\Component\ObjectMapper\Metadata\EnumMappingMetadataFactory;
 use Symfony\Component\ObjectMapper\Metadata\ObjectMapperMetadataFactoryInterface;
+use Symfony\Component\ObjectMapper\Metadata\PropertyTypeMappingMetadataFactory;
 use Symfony\Component\ObjectMapper\Metadata\ReflectionObjectMapperMetadataFactory;
 use Symfony\Component\ObjectMapper\Metadata\ReverseClassObjectMapperMetadataFactory;
 use Symfony\Component\ObjectMapper\ObjectMapper;
@@ -31,6 +32,12 @@ return static function (ContainerConfigurator $container) {
             ])
 
         ->set('object_mapper.metadata_factory.enum', EnumMappingMetadataFactory::class)
+            ->decorate('object_mapper.metadata_factory')
+            ->args([
+                service('.inner'),
+            ])
+
+        ->set('object_mapper.metadata_factory.property_type', PropertyTypeMappingMetadataFactory::class)
             ->decorate('object_mapper.metadata_factory')
             ->args([
                 service('.inner'),

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/InferredFromPropertyType/AbstractTagDto.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/InferredFromPropertyType/AbstractTagDto.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\InferredFromPropertyType;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(source: Tag::class)]
+abstract class AbstractTagDto
+{
+    public string $label = '';
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/InferredFromPropertyType/AbstractTagHolder.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/InferredFromPropertyType/AbstractTagHolder.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\InferredFromPropertyType;
+
+class AbstractTagHolder
+{
+    public ?AbstractTagDto $tag = null;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/InferredFromPropertyType/AmbiguousTagDto.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/InferredFromPropertyType/AmbiguousTagDto.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\InferredFromPropertyType;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(source: Tag::class)]
+#[Map(source: Named::class)]
+class AmbiguousTagDto
+{
+    public string $label = '';
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/InferredFromPropertyType/AmbiguousTagHolder.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/InferredFromPropertyType/AmbiguousTagHolder.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\InferredFromPropertyType;
+
+class AmbiguousTagHolder
+{
+    public ?AmbiguousTagDto $tag = null;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/InferredFromPropertyType/AmbiguousTagHolderWithPrivateProperty.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/InferredFromPropertyType/AmbiguousTagHolderWithPrivateProperty.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\InferredFromPropertyType;
+
+class AmbiguousTagHolderWithPrivateProperty
+{
+    private ?AmbiguousTagDto $tag = null;
+
+    public function getTag(): ?AmbiguousTagDto
+    {
+        return $this->tag;
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/InferredFromPropertyType/InterfaceTagHolder.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/InferredFromPropertyType/InterfaceTagHolder.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\InferredFromPropertyType;
+
+class InterfaceTagHolder
+{
+    public ?TagDtoInterface $tag = null;
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/InferredFromPropertyType/Named.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/InferredFromPropertyType/Named.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\InferredFromPropertyType;
+
+interface Named
+{
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/InferredFromPropertyType/Person.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/InferredFromPropertyType/Person.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\InferredFromPropertyType;
+
+class Person
+{
+    public ?Person $friend = null;
+
+    public function __construct(
+        public string $name = 'alice',
+    ) {
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/InferredFromPropertyType/PersonDto.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/InferredFromPropertyType/PersonDto.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\InferredFromPropertyType;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(source: Person::class)]
+class PersonDto
+{
+    public ?PersonDto $friend = null;
+    public string $name = '';
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/InferredFromPropertyType/PropertyOnlyMetadataFactory.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/InferredFromPropertyType/PropertyOnlyMetadataFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\InferredFromPropertyType;
+
+use Symfony\Component\ObjectMapper\Metadata\ObjectMapperMetadataFactoryInterface;
+use Symfony\Component\ObjectMapper\Metadata\ReflectionObjectMapperMetadataFactory;
+
+/**
+ * Reports the mappings declared on properties, and states that no class maps to another one.
+ */
+final class PropertyOnlyMetadataFactory implements ObjectMapperMetadataFactoryInterface
+{
+    private ObjectMapperMetadataFactoryInterface $inner;
+
+    public function __construct()
+    {
+        $this->inner = new ReflectionObjectMapperMetadataFactory();
+    }
+
+    public function create(object $object, ?string $property = null, array $context = []): array
+    {
+        return $property ? $this->inner->create($object, $property, $context) : [];
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/InferredFromPropertyType/Tag.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/InferredFromPropertyType/Tag.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\InferredFromPropertyType;
+
+class Tag implements Named
+{
+    public function __construct(
+        public string $label = 'php',
+    ) {
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/InferredFromPropertyType/TagDtoInterface.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/InferredFromPropertyType/TagDtoInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\InferredFromPropertyType;
+
+use Symfony\Component\ObjectMapper\Attribute\Map;
+
+#[Map(source: Tag::class)]
+interface TagDtoInterface
+{
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/Fixtures/InferredFromPropertyType/TagHolder.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/Fixtures/InferredFromPropertyType/TagHolder.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ObjectMapper\Tests\Fixtures\InferredFromPropertyType;
+
+class TagHolder
+{
+    public function __construct(
+        public ?Tag $tag = new Tag(),
+    ) {
+    }
+}

--- a/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperBundleTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperBundleTest.php
@@ -99,6 +99,19 @@ class ObjectMapperBundleTest extends TestCase
         $this->assertSame('Electronics', $mapped->nested->name);
     }
 
+    public function testMapNestedObjectWhenNoClassMapIsBuilt()
+    {
+        $kernel = new TestObjectMapperWithoutPropertyAccessorKernel('test', true, $this->varDir);
+        $kernel->boot();
+
+        /** @var ParentEntityResource $mapped */
+        $mapped = $kernel->getContainer()->get('test.object_mapper')->map(new ParentEntity('Laptop', new NestedEntity('Electronics')), ParentEntityResource::class);
+
+        $this->assertSame('Laptop', $mapped->name);
+        $this->assertInstanceOf(NestedEntityResource::class, $mapped->nested);
+        $this->assertSame('Electronics', $mapped->nested->name);
+    }
+
     public function testObjectMapperWorksWithoutPropertyAccessor()
     {
         $kernel = new TestObjectMapperWithoutPropertyAccessorKernel('test', true, $this->varDir);

--- a/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
+++ b/src/Symfony/Component/ObjectMapper/Tests/ObjectMapperTest.php
@@ -29,6 +29,10 @@ use Symfony\Component\ObjectMapper\ObjectMapper;
 use Symfony\Component\ObjectMapper\ObjectMapperInterface;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\A;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\B;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\Bundle\NestedEntity;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\Bundle\NestedEntityResource;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\Bundle\ParentEntity;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\Bundle\ParentEntityResource;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\C;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\Amount;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\ClassMap\AutoNestedFlatTarget;
@@ -92,6 +96,17 @@ use Symfony\Component\ObjectMapper\Tests\Fixtures\Flatten\TargetUser;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\Flatten\User;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\Flatten\UserProfile;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\HydrateObject\SourceOnly;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\InferredFromPropertyType\AbstractTagDto;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\InferredFromPropertyType\AbstractTagHolder;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\InferredFromPropertyType\AmbiguousTagHolder;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\InferredFromPropertyType\AmbiguousTagHolderWithPrivateProperty;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\InferredFromPropertyType\InterfaceTagHolder;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\InferredFromPropertyType\Person;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\InferredFromPropertyType\PersonDto;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\InferredFromPropertyType\PropertyOnlyMetadataFactory;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\InferredFromPropertyType\Tag as InferredTag;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\InferredFromPropertyType\TagDtoInterface;
+use Symfony\Component\ObjectMapper\Tests\Fixtures\InferredFromPropertyType\TagHolder;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\InitializedConstructor\A as InitializedConstructorA;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\InitializedConstructor\B as InitializedConstructorB;
 use Symfony\Component\ObjectMapper\Tests\Fixtures\InitializedConstructor\C as InitializedConstructorC;
@@ -1358,6 +1373,74 @@ final class ObjectMapperTest extends TestCase
 
         $this->assertInstanceOf(Dog::class, $target->pet);
         $this->assertSame('rex', $target->pet->name);
+    }
+
+    public function testNestedObjectIsMappedFromTheClassTypingTheDestinationProperty()
+    {
+        $mapped = (new ObjectMapper())->map(new ParentEntity('Laptop', new NestedEntity('Electronics')), ParentEntityResource::class);
+
+        $this->assertSame('Laptop', $mapped->name);
+        $this->assertInstanceOf(NestedEntityResource::class, $mapped->nested);
+        $this->assertSame('Electronics', $mapped->nested->name);
+    }
+
+    public function testAMetadataFactoryReportingNoClassMappingIsNotOverruled()
+    {
+        $mapper = new ObjectMapper(new PropertyOnlyMetadataFactory());
+
+        $this->expectException(\TypeError::class);
+
+        $mapper->map(new ParentEntity('Laptop', new NestedEntity('Electronics')), ParentEntityResource::class);
+    }
+
+    public function testNestedObjectIsLeftAloneWhenTheDestinationPropertyIsNotPublic()
+    {
+        $mapped = (new ObjectMapper())->map(new TagHolder(), AmbiguousTagHolderWithPrivateProperty::class);
+
+        $this->assertNull($mapped->getTag());
+    }
+
+    public function testDestinationPropertyTypeMatchingSeveralSourcesIsAmbiguous()
+    {
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage(\sprintf('Ambiguous mapping for "%s".', InferredTag::class));
+
+        (new ObjectMapper())->map(new TagHolder(), AmbiguousTagHolder::class);
+    }
+
+    public function testDestinationPropertyTypedWithAnAbstractClassIsRefused()
+    {
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage(\sprintf('Cannot infer a mapping target for "%s" from property "%s::$tag": class "%s" is not instantiable.', InferredTag::class, AbstractTagHolder::class, AbstractTagDto::class));
+
+        (new ObjectMapper())->map(new TagHolder(), AbstractTagHolder::class);
+    }
+
+    public function testDestinationPropertyTypedWithAnInterfaceIsRefused()
+    {
+        $this->expectException(MappingException::class);
+        $this->expectExceptionMessage(\sprintf('Cannot infer a mapping target for "%s" from property "%s::$tag": class "%s" is not instantiable.', InferredTag::class, InterfaceTagHolder::class, TagDtoInterface::class));
+
+        (new ObjectMapper())->map(new TagHolder(), InterfaceTagHolder::class);
+    }
+
+    public function testNullNestedValueIsKept()
+    {
+        $mapped = (new ObjectMapper())->map(new Person(), PersonDto::class);
+
+        $this->assertSame('alice', $mapped->name);
+        $this->assertNull($mapped->friend);
+    }
+
+    public function testSelfReferencingNestedObjectIsMappedIntoTheSameTarget()
+    {
+        $person = new Person();
+        $person->friend = $person;
+
+        $mapped = (new ObjectMapper())->map($person, PersonDto::class);
+
+        $this->assertSame('alice', $mapped->name);
+        $this->assertSame($mapped, $mapped->friend);
     }
 
     public function testExplicitMappingTakesPriorityOverImplicitSameNameProperty()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fixes #65380
| License       | MIT

A class that declares `#[Map(source: ...)]` says how it is built from that source. The mapper used that declaration for the object it maps at the top level, and for a nested object whose target class was listed in a class map, but not for a nested object in the general case. Such a value was copied as it is, so this failed:

```php
final class ParentEntity
{
    public function __construct(public string $name, public NestedEntity $nested) {}
}

#[Map(source: ParentEntity::class)]
final class ParentEntityResource
{
    public function __construct(public string $name = '', public ?NestedEntityResource $nested = null) {}
}

(new ObjectMapper())->map(new ParentEntity('Laptop', new NestedEntity('Electronics')), ParentEntityResource::class);
// TypeError: Argument #2 ($nested) must be of type ?NestedEntityResource, NestedEntity given
```

`NestedEntityResource` declares `#[Map(source: NestedEntity::class)]`, and `$nested` is typed with it, so there is enough information to build it. In a Symfony application this already worked, because the bundle collects every service carrying `#[Map]` into a class map. Standalone, or for a class that is not a service, it did not.

### What this adds

`Symfony\Component\ObjectMapper\Metadata\PropertyTypeMappingMetadataFactory`, a metadata factory that decorates another one:

```php
new ObjectMapper(new PropertyTypeMappingMetadataFactory(new ReflectionObjectMapperMetadataFactory()));
```

It answers only when the factory it decorates reports no mapping for the value. Then it reads the class typing the property the value is written into, and maps the value to that class if it declares a matching `#[Map(source: ...)]`.

It is enabled by default. `new ObjectMapper()` builds it around `ReflectionObjectMapperMetadataFactory`, and `object_mapper.metadata_factory.property_type` decorates `object_mapper.metadata_factory` in the container. In both it is the outermost decorator, so an explicit `#[Map]`, a class map entry and enum conversion all take precedence. Pass your own factory to `ObjectMapper` to leave it out; the factory you pass is then the only authority on mappings.

### When it applies

All of these must hold:

- the value's own class, and every factory in the chain, report no mapping for it;
- the mapper can write the destination property (it is public, or a constructor parameter, or a property accessor can write it);
- the property is typed with a single class or interface, and the value is not already an instance of it;
- that class declares `#[Map(source: S)]` with the value being an `S`.

A property typed with a union, an intersection or nothing at all is left alone, and so is a property whose type the value already satisfies, so `?Animal` receiving a `Dog` still stores the `Dog`.

### How it reports problems

- Several `#[Map(source: ...)]` on the destination property type match the value, for example one naming the class and one naming an interface it implements: `MappingException`, "Ambiguous mapping ... Use the "if" parameter to specify conditions." Add an `if` condition to one of them.
- The destination property type is an abstract class or an interface, and it declares a matching source without a transform: `MappingException`, `Cannot infer a mapping target for "X" from property "Y::$z": class "T" is not instantiable.` Type the property with a concrete class, or give the `#[Map]` a `transform` that returns the instance.
- The destination property cannot be written by the mapper: nothing is resolved and nothing is reported, exactly as before.

### New API

The `$context` argument of `ObjectMapperMetadataFactoryInterface::create()` now carries two keys the mapper fills for a nested value, documented on the interface: `target`, the class the value is written into, and `target_property`, the property it is written into. They are set only when the mapper can write that property. Custom factories may read them; they are optional and absent for other calls.

### Points for the documentation

- The four conditions above, and that this needs no configuration.
- The precedence order: an explicit `#[Map]`, then the class map, then this inference.
- How to opt out, and that passing any factory to `ObjectMapper` opts out unless you compose `PropertyTypeMappingMetadataFactory` yourself. This matters for the common `new ObjectMapper(new ReflectionObjectMapperMetadataFactory(), $propertyAccessor)`.
- The two `MappingException` messages and what to do about each.
- The two new context keys, for anyone writing a metadata factory.
