### PR TITLE
[Security] Improve OIDC secure URL checks

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AccessTokenFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AccessTokenFactory.php
@@ -122,7 +122,7 @@ final class AccessTokenFactory extends AbstractFactory implements StatelessAuthe
                                 // relaxes for the cases that need one, so it is accepted here
                                 return isset($parts['fragment']) || !OidcDiscovery::isSecureUrl((string) $v);
                             })
-                            ->thenInvalid('The protected resource "resource" identifier must be an HTTPS URL without a fragment (got %s), as RFC 9728, Section 1.2 requires. A loopback host (localhost, 127.0.0.1, ::1) or a name reserved for testing (*.localhost, *.test) is accepted over HTTP for local development. It is read when the route is declared, so an environment variable holding the whole value leaves the path unknown: interpolate it into the URL instead, as in "https://%%env(API_HOST)%%/v1".')
+                            ->thenInvalid('The protected resource "resource" identifier must be an HTTPS URL without a fragment (got %s), as RFC 9728, Section 1.2 requires. A loopback host (localhost, 127.0.0.1, ::1, *.localhost) is accepted over HTTP for local development. It is read when the route is declared, so an environment variable holding the whole value leaves the path unknown: interpolate it into the URL instead, as in "https://%%env(API_HOST)%%/v1".')
                         ->end()
                     ->end()
                     ->arrayNode('authorization_servers', 'authorization_server')

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/OidcLoginFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/OidcLoginFactory.php
@@ -58,7 +58,7 @@ class OidcLoginFactory extends AbstractFactory implements FirewallListenerFactor
 
                         return !OidcDiscovery::isSecureUrl((string) $v);
                     })
-                    ->thenInvalid('The OIDC "provider_uri" must use HTTPS (got %s): the authorization code, the PKCE verifier and the tokens it is exchanged for are only confidential over TLS. Use HTTPS, or a loopback host (localhost, 127.0.0.1, ::1) or a name reserved for testing (*.localhost, *.test) for local development.')
+                    ->thenInvalid('The OIDC "provider_uri" must use HTTPS (got %s): the authorization code, the PKCE verifier and the tokens it is exchanged for are only confidential over TLS. Use HTTPS, or a loopback host (localhost, 127.0.0.1, ::1, *.localhost) for local development.')
                 ->end()
                 ->info('The OIDC Issuer URL (e.g. "https://accounts.example.com"). Used for .well-known/openid-configuration discovery.')
             ->end()

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/AccessTokenFactoryTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/AccessTokenFactoryTest.php
@@ -988,6 +988,7 @@ class AccessTokenFactoryTest extends TestCase
         // route is declared, so a value the container cannot parse cannot be served
         yield 'an environment variable used as the whole value' => ['env_2b0d1a_API_RESOURCE_4f8c'];
         yield 'not HTTPS' => ['http://api.example.com'];
+        yield 'a test domain over HTTP' => ['http://api.example.test'];
         yield 'with a fragment' => ['https://api.example.com/v1#api'];
         yield 'no URL at all' => ['https://api.example.com:port/v1'];
     }
@@ -1012,7 +1013,7 @@ class AccessTokenFactoryTest extends TestCase
     {
         yield 'HTTPS' => ['https://api.example.com', '/.well-known/oauth-protected-resource', 'https://api.example.com/.well-known/oauth-protected-resource'];
         yield 'a loopback host over HTTP' => ['http://127.0.0.1:8000/api', '/.well-known/oauth-protected-resource/api', 'http://127.0.0.1:8000/.well-known/oauth-protected-resource/api'];
-        yield 'a host reserved for testing' => ['http://api.example.test', '/.well-known/oauth-protected-resource', 'http://api.example.test/.well-known/oauth-protected-resource'];
+        yield 'a localhost subdomain over HTTP' => ['http://api.localhost', '/.well-known/oauth-protected-resource', 'http://api.localhost/.well-known/oauth-protected-resource'];
         // a query is only a SHOULD NOT, and RFC 9728, Section 3.1 keeps it after the path
         yield 'with a query' => ['https://api.example.com/v1?tenant=acme', '/.well-known/oauth-protected-resource/v1', 'https://api.example.com/.well-known/oauth-protected-resource/v1?tenant=acme'];
         // an environment variable interpolated into the URL still leaves the path readable

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/OidcLoginFactoryTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/OidcLoginFactoryTest.php
@@ -476,7 +476,7 @@ class OidcLoginFactoryTest extends TestCase
     }
 
     /**
-     * @param string $providerUri a loopback host or a name reserved for testing (RFC 2606, RFC 6761)
+     * @param string $providerUri a loopback host or a name RFC 6761, Section 6.3 reserves for the loopback interface
      */
     #[DataProvider('provideLocalDevelopmentProviderUris')]
     public function testAllowsHttpProviderUriForLocalDevelopment(string $providerUri)
@@ -498,7 +498,22 @@ class OidcLoginFactoryTest extends TestCase
         yield 'IPv4 loopback' => ['http://127.0.0.1:8080'];
         yield 'IPv6 loopback' => ['http://[::1]:8080'];
         yield 'localhost subdomain' => ['http://keycloak.localhost'];
-        yield 'test TLD' => ['http://keycloak.test'];
+    }
+
+    public function testRejectsATestDomainProviderUri()
+    {
+        // RFC 6761, Section 6.2 reserves ".test" without tying it to the loopback interface,
+        // so the name resolves like any other and plain HTTP is not confidential there
+        $factory = new OidcLoginFactory();
+
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('The OIDC "provider_uri" must use HTTPS');
+
+        $this->processConfig([
+            'provider_uri' => 'http://keycloak.test',
+            'client_id' => 'my-client-id',
+            'client_authentication' => 'app.client_authentication',
+        ], $factory);
     }
 
     public function testPkceCanBeDisabled()

--- a/src/Symfony/Component/Security/Http/Oidc/OidcDiscovery.php
+++ b/src/Symfony/Component/Security/Http/Oidc/OidcDiscovery.php
@@ -192,11 +192,7 @@ final class OidcDiscovery implements ResetInterface
             throw new AuthenticationException(\sprintf('The OIDC provider does not announce any "%s".', $endpoint));
         }
 
-        // The token endpoint carries the authorization code and the PKCE verifier one way,
-        // and returns the ID and access tokens the other, so its transport must be secure even
-        // for the loopback and test-domain issuers allowed during local development. A public
-        // client sends no secret there, and still needs this.
-        if (!self::isSecureUrl($url) || ('token_endpoint' === $endpoint && 'https' !== strtolower((string) parse_url($url, \PHP_URL_SCHEME)))) {
+        if (!self::isSecureUrl($url)) {
             throw new AuthenticationException(\sprintf('The "%s" announced by the OIDC provider must use HTTPS (got "%s"): the authorization code, the PKCE verifier and the tokens it is exchanged for are only confidential over TLS.', $endpoint, $url));
         }
 
@@ -207,8 +203,7 @@ final class OidcDiscovery implements ResetInterface
      * Tells whether the given URL provides the transport security the OIDC flow relies on.
      *
      * The authorization code, the PKCE verifier and the tokens it is exchanged for are only
-     * confidential over TLS, so HTTPS is mandatory, loopback hosts and the names reserved for
-     * testing excepted, for local development.
+     * confidential over TLS, so HTTPS is mandatory, loopback hosts excepted, for local development.
      */
     public static function isSecureUrl(string $url): bool
     {
@@ -224,8 +219,9 @@ final class OidcDiscovery implements ResetInterface
             return true;
         }
 
-        // special-use domain names reserved for testing: RFC 2606 §2, RFC 6761 §6.2 and §6.3
-        return str_ends_with($host, '.localhost') || str_ends_with($host, '.test');
+        // domain names that can be considered secure because DNS resolvers should always return
+        // the IP loopback address: RFC 6761 §6.3
+        return str_ends_with($host, '.localhost');
     }
 
     private function request(): ResponseInterface

--- a/src/Symfony/Component/Security/Http/Tests/Oidc/OidcDiscoveryTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Oidc/OidcDiscoveryTest.php
@@ -109,7 +109,7 @@ class OidcDiscoveryTest extends TestCase
     }
 
     /**
-     * @param string $issuer a loopback host or a name reserved for testing (RFC 2606, RFC 6761)
+     * @param string $issuer a loopback host or a name RFC 6761, Section 6.3 reserves for the loopback interface
      */
     #[DataProvider('provideLocalDevelopmentIssuers')]
     public function testGetConfigurationAllowsInsecureIssuersForLocalDevelopment(string $issuer)
@@ -127,7 +127,20 @@ class OidcDiscoveryTest extends TestCase
         yield 'IPv4 loopback' => ['http://127.0.0.1:8080'];
         yield 'IPv6 loopback' => ['http://[::1]:8080'];
         yield 'localhost subdomain' => ['http://keycloak.localhost'];
-        yield 'test TLD' => ['http://keycloak.test'];
+    }
+
+    public function testGetConfigurationRejectsATestDomainIssuer()
+    {
+        // RFC 6761, Section 6.2 reserves ".test" without tying it to the loopback interface,
+        // so the name resolves like any other and plain HTTP is not confidential there
+        $httpClient = new MockHttpClient(new JsonMockResponse(['issuer' => 'http://keycloak.test']));
+
+        $discovery = new OidcDiscovery($httpClient, new ArrayAdapter(), 'http://keycloak.test/.well-known/openid-configuration', 'http://keycloak.test');
+
+        $this->expectException(AuthenticationException::class);
+        $this->expectExceptionMessage('must use HTTPS');
+
+        $discovery->getConfiguration();
     }
 
     public function testGetConfigurationSkipsTheIssuerCheckWhenNoIssuerIsExpected()
@@ -242,7 +255,7 @@ class OidcDiscoveryTest extends TestCase
         $discovery->getSecureEndpoint('token_endpoint');
     }
 
-    public function testGetSecureEndpointAllowsALoopbackAuthorizationEndpointForLocalDevelopment()
+    public function testGetSecureEndpointAllowsALoopbackAuthorizationEndpoint()
     {
         $httpClient = new MockHttpClient(new JsonMockResponse([
             'issuer' => 'http://localhost:8080',
@@ -254,7 +267,7 @@ class OidcDiscoveryTest extends TestCase
         $this->assertSame('http://localhost:8080/authorize', $discovery->getSecureEndpoint('authorization_endpoint'));
     }
 
-    public function testGetSecureEndpointRejectsALoopbackTokenEndpoint()
+    public function testGetSecureEndpointAllowsALoopbackTokenEndpoint()
     {
         $httpClient = new MockHttpClient(new JsonMockResponse([
             'issuer' => 'http://localhost:8080',
@@ -263,10 +276,7 @@ class OidcDiscoveryTest extends TestCase
 
         $discovery = new OidcDiscovery($httpClient, new ArrayAdapter(), 'http://localhost:8080/.well-known/openid-configuration', 'http://localhost:8080');
 
-        $this->expectException(AuthenticationException::class);
-        $this->expectExceptionMessage('must use HTTPS');
-
-        $discovery->getSecureEndpoint('token_endpoint');
+        $this->assertSame('http://localhost:8080/token', $discovery->getSecureEndpoint('token_endpoint'));
     }
 
     public function testGetConfigurationAppendsARelativeUrlToTheIssuer()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        |
| License       | MIT

Aligns `OidcDiscovery::isSecureUrl()` with what the loopback interface actually guarantees.

**`.test` is no longer treated as secure.** RFC 6761, Section 6.2 reserves the name so it cannot collide with the public DNS, and says nothing about where it resolves. A `.test` name is answered by whatever resolver the host points at, so plain HTTP is not confidential there.

**`.localhost` is now accepted for the token endpoint too.** RFC 6761, Section 6.3 asks resolvers to return the loopback address for these names, which is the same reason the issuer, the authorization endpoint, the userinfo endpoint and `jwks_uri` already accept them.

**The extra rule that required HTTPS for the token endpoint is removed.** It could not be satisfied together with the loopback exemption, so a `provider_uri: http://localhost:8080` setup passed config validation and discovery, redirected correctly, and then always failed at the code exchange. The case the rule guarded against is already covered elsewhere: `OidcLoginFactory` lists `token_endpoint` in `checkedEndpoints`, and `checkEndpointScheme()` rejects any non-HTTPS endpoint whenever the discovery document itself came over HTTPS, before the document is cached. The rule only ever fired when the document was itself plain HTTP, which is the local development case above.

Note that `isSecureUrl()` also validates the `resource_metadata.resource` identifier of the `access_token` firewall (RFC 9728), so that option stops accepting `.test` URLs as well.

On the browser comparison: the W3C secure contexts algorithm treats `127.0.0.0/8` and `::1` as trustworthy unconditionally, but makes `*.localhost` conditional on the user agent resolving those names itself. Browsers do; a PHP process hands the name to the platform resolver, which does not always honour the RFC. The exemption here therefore rests on the developer's local resolver, which is the same footing the other endpoints were already on.
