### PR TITLE
[FrameworkBundle] Fix the fatal when a cache pool cannot be cleared

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/CachePoolClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CachePoolClearCommand.php
@@ -115,12 +115,12 @@ final class CachePoolClearCommand extends Command
 
             if ($pool instanceof CacheItemPoolInterface) {
                 if (!$pool->clear()) {
-                    $io->warning(\sprintf('Cache pool "%s" could not be cleared.', $pool));
+                    $io->warning(\sprintf('Cache pool "%s" could not be cleared.', $id));
                     $failure = true;
                 }
             } else {
                 if (!$this->poolClearer->clearPool($id)) {
-                    $io->warning(\sprintf('Cache pool "%s" could not be cleared.', $pool));
+                    $io->warning(\sprintf('Cache pool "%s" could not be cleared.', $id));
                     $failure = true;
                 }
             }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CachePoolClearCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CachePoolClearCommandTest.php
@@ -12,11 +12,13 @@
 namespace Symfony\Bundle\FrameworkBundle\Tests\Command;
 
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Bundle\FrameworkBundle\Command\CachePoolClearCommand;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Console\Tester\CommandCompletionTester;
+use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpKernel\CacheClearer\Psr6CacheClearer;
 use Symfony\Component\HttpKernel\KernelInterface;
@@ -35,6 +37,28 @@ class CachePoolClearCommandTest extends TestCase
         $suggestions = $tester->complete($input);
 
         $this->assertSame($expectedSuggestions, $suggestions);
+    }
+
+    public function testTheWarningNamesThePoolThatCouldNotBeCleared()
+    {
+        $pool = $this->createMock(CacheItemPoolInterface::class);
+        $pool->expects($this->once())->method('clear')->willReturn(false);
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container->expects($this->once())->method('get')->with('foo')->willReturn($pool);
+
+        $kernel = $this->createMock(KernelInterface::class);
+        $kernel->method('getContainer')->willReturn($container);
+        $kernel->expects($this->once())->method('getBundles')->willReturn([]);
+
+        $application = new Application($kernel);
+        $application->add(new CachePoolClearCommand(new Psr6CacheClearer()));
+
+        $tester = new CommandTester($application->find('cache:pool:clear'));
+        $tester->execute(['pools' => ['foo']]);
+
+        $this->assertSame(1, $tester->getStatusCode());
+        $this->assertStringContainsString('Cache pool "foo" could not be cleared.', $tester->getDisplay());
     }
 
     public static function provideCompletionSuggestions(): iterable


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

When a cache pool named on the command line fails to clear, `cache:pool:clear` prints a warning naming it. It interpolated the pool **object** instead of its id:

```php
if (!$pool->clear()) {
    $io->warning(\sprintf('Cache pool "%s" could not be cleared.', $pool));
```

`$pools[$id]` holds the pool itself whenever the id was resolved from the container rather than from the pool clearer, and a `CacheItemPoolInterface` has no `__toString()`. So the command dies with `Error: Object of class ... could not be converted to string` on the one path that exists to report the failure, instead of warning and exiting with 1.

The second occurrence, in the branch that clears through the pool clearer, is only correct by accident: `$pools[$id]` is the id itself there. Both say `$id` now.

The added test reproduces the fatal against the code as it stands and passes with the fix.
