### PR TITLE
[FrameworkBundle] Fix the pass order so unwired services are removed before the passes that collect them

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -241,8 +241,8 @@ class FrameworkBundle extends Bundle
         $container->addCompilerPass(new FragmentRendererPass());
         $container->addCompilerPass(new ControllerArgumentValueResolverPass());
         $container->addCompilerPass(new DefaultCachePoolsPass());
+        $container->addCompilerPass(new RemoveUnusedFormHtmlSanitizerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 1);
         $this->addCompilerPassIfExists($container, FormPass::class);
-        $container->addCompilerPass(new RemoveUnusedFormHtmlSanitizerPass());
         $container->addCompilerPass(new RemoveUnusedSerializerPropertyAccessorPass());
         $container->addCompilerPass(new RemoveMissingHttpClientDependenciesPass());
         $container->addCompilerPass(new RemoveMissingRouterDependenciesPass());

--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -241,9 +241,13 @@ class FrameworkBundle extends Bundle
         $container->addCompilerPass(new FragmentRendererPass());
         $container->addCompilerPass(new ControllerArgumentValueResolverPass());
         $container->addCompilerPass(new DefaultCachePoolsPass());
-        $container->addCompilerPass(new RemoveUnusedFormHtmlSanitizerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 1);
+        // FormPass collects the form.type_extension services, so the ones this bundle
+        // cannot wire have to be gone before it runs
+        $container->addCompilerPass(new RemoveUnusedFormHtmlSanitizerPass());
         $this->addCompilerPassIfExists($container, FormPass::class);
-        $container->addCompilerPass(new RemoveUnusedSerializerPropertyAccessorPass());
+        // SerializerPass collects the serializer.normalizer services, and SerializerBundle
+        // registers it while building before this bundle, so ordering here is not enough
+        $container->addCompilerPass(new RemoveUnusedSerializerPropertyAccessorPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 1);
         $container->addCompilerPass(new RemoveMissingHttpClientDependenciesPass());
         $container->addCompilerPass(new RemoveMissingRouterDependenciesPass());
         $container->addCompilerPass(new RemoveMissingSerializerDependenciesPass());

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/RemoveUnusedFormHtmlSanitizerPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/RemoveUnusedFormHtmlSanitizerPassTest.php
@@ -28,7 +28,7 @@ class RemoveUnusedFormHtmlSanitizerPassTest extends TestCase
         $container->register('form.type_extension.form.html_sanitizer', TextType::class);
         $container->register('html_sanitizer', HtmlSanitizer::class);
 
-        (new RemoveUnusedFormHtmlSanitizerPass())->process($container);
+        new RemoveUnusedFormHtmlSanitizerPass()->process($container);
 
         $this->assertTrue($container->hasDefinition('form.type_extension.form.html_sanitizer'));
     }
@@ -38,15 +38,17 @@ class RemoveUnusedFormHtmlSanitizerPassTest extends TestCase
         $container = new ContainerBuilder();
         $container->register('form.type_extension.form.html_sanitizer', TextType::class);
 
-        (new RemoveUnusedFormHtmlSanitizerPass())->process($container);
+        new RemoveUnusedFormHtmlSanitizerPass()->process($container);
 
         $this->assertFalse($container->hasDefinition('form.type_extension.form.html_sanitizer'));
     }
 
     public function testTheTypeExtensionIsRemovedBeforeFormPassCollectsIt()
     {
+        // both passes are registered by this bundle at the same priority, so the order
+        // they are registered in is the order they run in
         $container = new ContainerBuilder(new ParameterBag(['kernel.debug' => false]));
-        (new FrameworkBundle())->build($container);
+        new FrameworkBundle()->build($container);
 
         $order = [];
         foreach ($container->getCompiler()->getPassConfig()->getBeforeOptimizationPasses() as $i => $pass) {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/RemoveUnusedFormHtmlSanitizerPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/RemoveUnusedFormHtmlSanitizerPassTest.php
@@ -13,7 +13,10 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\RemoveUnusedFormHtmlSanitizerPass;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+use Symfony\Component\Form\DependencyInjection\FormPass;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\HtmlSanitizer\HtmlSanitizer;
 
@@ -38,5 +41,20 @@ class RemoveUnusedFormHtmlSanitizerPassTest extends TestCase
         (new RemoveUnusedFormHtmlSanitizerPass())->process($container);
 
         $this->assertFalse($container->hasDefinition('form.type_extension.form.html_sanitizer'));
+    }
+
+    public function testTheTypeExtensionIsRemovedBeforeFormPassCollectsIt()
+    {
+        $container = new ContainerBuilder(new ParameterBag(['kernel.debug' => false]));
+        (new FrameworkBundle())->build($container);
+
+        $order = [];
+        foreach ($container->getCompiler()->getPassConfig()->getBeforeOptimizationPasses() as $i => $pass) {
+            $order[$pass::class] = $i;
+        }
+
+        $this->assertArrayHasKey(FormPass::class, $order);
+        $this->assertArrayHasKey(RemoveUnusedFormHtmlSanitizerPass::class, $order);
+        $this->assertLessThan($order[FormPass::class], $order[RemoveUnusedFormHtmlSanitizerPass::class]);
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/RemoveUnusedSerializerPropertyAccessorPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/RemoveUnusedSerializerPropertyAccessorPassTest.php
@@ -13,10 +13,14 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\RemoveUnusedSerializerPropertyAccessorPass;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
+use Symfony\Component\Serializer\DependencyInjection\SerializerPass;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Symfony\Component\Serializer\Normalizer\UnwrappingDenormalizer;
+use Symfony\Component\Serializer\SerializerBundle;
 
 class RemoveUnusedSerializerPropertyAccessorPassTest extends TestCase
 {
@@ -41,6 +45,24 @@ class RemoveUnusedSerializerPropertyAccessorPassTest extends TestCase
         $this->assertFalse($container->hasAlias('serializer.property_accessor'));
         $this->assertFalse($container->hasDefinition('serializer.normalizer.object'));
         $this->assertFalse($container->hasDefinition('serializer.denormalizer.unwrapping'));
+    }
+
+    public function testTheNormalizersAreRemovedBeforeSerializerPassCollectsThem()
+    {
+        // SerializerBundle is a required bundle, so it is built first and registers
+        // SerializerPass ahead of everything this bundle registers at the default priority
+        $container = new ContainerBuilder(new ParameterBag(['kernel.debug' => false]));
+        new SerializerBundle()->build($container);
+        new FrameworkBundle()->build($container);
+
+        $order = [];
+        foreach ($container->getCompiler()->getPassConfig()->getBeforeOptimizationPasses() as $i => $pass) {
+            $order[$pass::class] = $i;
+        }
+
+        $this->assertArrayHasKey(SerializerPass::class, $order);
+        $this->assertArrayHasKey(RemoveUnusedSerializerPropertyAccessorPass::class, $order);
+        $this->assertLessThan($order[SerializerPass::class], $order[RemoveUnusedSerializerPropertyAccessorPass::class]);
     }
 
     private function createContainer(): ContainerBuilder


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2 
| Bug fix?      | yes
| New feature?  | no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Related to #65931 <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

<!--
🛠️ Replace this text with a concise explanation of your change:
- What it does and why it's needed
- A simple example of how it works (include PHP, YAML, etc.)
- If it modifies existing behavior, include a before/after comparison

Contributor guidelines:
- ✅ Add tests and ensure they pass
- 🐞 Bug fixes must target the **lowest maintained** branch where they apply
  https://symfony.com/releases#maintained-symfony-branches
- ✨ New features and deprecations must target the **feature** branch
  and must add an entry to the changelog file of the patched component:
  https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
- 🔒 Do not break backward compatibility:
  https://symfony.com/bc
-->

Since #65931, `form.type_extension.form.html_sanitizer` is removed by `RemoveUnusedFormHtmlSanitizerPass` instead of `FrameworkExtension`. But that pass is registered right after `FormPass`, which has already injected a reference to it into `form.extension`. The reference is then left dangling, and any app with `framework.form` enabled but no HTML sanitizer available fails to compile:

```
In CheckExceptionOnInvalidReferenceBehaviorPass.php line 116:

  The service "form.extension" has a dependency on a non-existent service
  "form.type_extension.form.html_sanitizer".
```

This registers `RemoveUnusedFormHtmlSanitizerPass` before `FormPass` collects the `form.type_extension` services, and adds a test covering the pass order (the existing tests only cover the pass in isolation, which is why this went unnoticed).

No priority is needed for that one: `PassConfig::addPass()` buckets by priority and `sortPasses()` flattens after `krsort()`, so registration order decides within a priority -- and `FormPass` is registered by this same bundle, in the same method, at the same priority. Moving the line above it is what fixes it.

## The serializer normalizers have the same bug

`RemoveUnusedSerializerPropertyAccessorPass` removes `serializer.normalizer.object` and `serializer.denormalizer.unwrapping`, which carry the `serializer.normalizer` tag that `SerializerPass` collects into the `serializer` service. Measured on 8.2, `SerializerPass` runs at position 9 and the removal at 25:

```
serializer references : serializer.denormalizer.unwrapping, serializer.normalizer.object, serializer.encoder.json
still defined?        : object=false unwrapping=false
DANGLING              : serializer.denormalizer.unwrapping, serializer.normalizer.object
```

Same failure, reached whenever `symfony/property-access` is absent.

Reordering cannot fix this one: `SerializerBundle` is a required bundle, so it is built before FrameworkBundle and its pass lands ahead of everything registered here at the default priority. That removal gets the priority instead, and a test of its own.

The rest of the removals in this bundle are fine, and I checked them: `translation.provider_factory.*` is collected by nothing, the `console.command` and `kernel.event_subscriber` collectors run at `TYPE_BEFORE_REMOVING`, and `ProfilerPass` returns early when there is no `profiler`, which is exactly when the data collectors are removed.

https://github.com/api-platform/core/actions/runs/34416018569/job/102680959461?pr=8520
https://github.com/api-platform/core/actions/runs/34451736760/job/102788785499?pr=8521

