### PR TITLE
[Console] Keep messages containing malformed UTF-8 when wrapping

### DIFF
--- a/src/Symfony/Component/Console/Helper/OutputWrapper.php
+++ b/src/Symfony/Component/Console/Helper/OutputWrapper.php
@@ -68,7 +68,10 @@ final class OutputWrapper
         $patternBlocks[] = '.';
         $blocks = implode('|', $patternBlocks);
         $rowPattern = "(?:$blocks)$limitPattern";
-        $pattern = \sprintf('#(?:((?>(%1$s)((?<=[^\S\r\n])[^\S\r\n]?|(?=\r?\n)|$|[^\S\r\n]))|(%1$s))(?:\r?\n)?|(?:\r?\n|$))#imux', $rowPattern);
+        // the u modifier counts characters instead of bytes, but preg_replace() returns null
+        // on malformed UTF-8, which would empty the text
+        $modifiers = preg_match('//u', $text) ? 'imux' : 'imx';
+        $pattern = \sprintf('#(?:((?>(%1$s)((?<=[^\S\r\n])[^\S\r\n]?|(?=\r?\n)|$|[^\S\r\n]))|(%1$s))(?:\r?\n)?|(?:\r?\n|$))#%2$s', $rowPattern, $modifiers);
         $output = rtrim(preg_replace($pattern, '\\1'.$break, $text), $break);
 
         return str_replace(' '.$break, $break, $output);

--- a/src/Symfony/Component/Console/Tests/Helper/OutputWrapperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/OutputWrapperTest.php
@@ -26,6 +26,32 @@ class OutputWrapperTest extends TestCase
         $this->assertEquals($expected, $result);
     }
 
+    public function testWrapKeepsMalformedUtf8()
+    {
+        $wrapper = new OutputWrapper();
+
+        $this->assertSame("Lorem\n\xB3\nipsum", $wrapper->wrap("Lorem \xB3 ipsum", 5));
+        $this->assertSame("Lorem\n\xF0\x9F", $wrapper->wrap("Lorem \xF0\x9F", 5));
+        $this->assertSame("<info>Lore\nm \xB3</info>\nhttps://example.com/\nipsum ", $wrapper->wrap("<info>Lorem \xB3</info> https://example.com/\nipsum \n", 5));
+    }
+
+    public function testWrapBreaksMalformedUtf8LikeValidText()
+    {
+        $wrapper = new OutputWrapper();
+
+        $this->assertSame($wrapper->wrap('Lorem X ipsum', 5), str_replace("\xB3", 'X', $wrapper->wrap("Lorem \xB3 ipsum", 5)));
+    }
+
+    public function testWrapDoesNotDropBytesOfMalformedUtf8()
+    {
+        $text = "Cannot read the log file: \xB3 check the permissions";
+
+        $wrapped = (new OutputWrapper())->wrap($text, 20);
+
+        $this->assertNotSame($text, $wrapped);
+        $this->assertSame(str_replace(' ', '', $text), str_replace(["\n", ' '], '', $wrapped));
+    }
+
     public static function textProvider(): iterable
     {
         $baseTextWithUtf8AndUrl = 'Árvíztűrőtükörfúrógép https://github.com/symfony/symfony Lorem ipsum <comment>dolor</comment> sit amet, consectetur adipiscing elit. Praesent vestibulum nulla quis urna maximus porttitor. Donec ullamcorper risus at <error>libero ornare</error> efficitur.';

--- a/src/Symfony/Component/Console/Tests/Style/SymfonyStyleTest.php
+++ b/src/Symfony/Component/Console/Tests/Style/SymfonyStyleTest.php
@@ -112,6 +112,24 @@ class SymfonyStyleTest extends TestCase
         $this->assertStringContainsString('Second line.', $display);
     }
 
+    public function testErrorWithMalformedUtf8()
+    {
+        $message = "Cannot read the log file at /var/log/app/deep/path.log: \xB3 check the file permissions, then retry the command and report the result";
+        $this->command->setCode(static function (InputInterface $input, OutputInterface $output) use ($message) {
+            (new SymfonyStyle($input, $output))->error($message);
+        });
+
+        $this->tester->execute([], ['interactive' => false, 'decorated' => false]);
+
+        $display = $this->tester->getDisplay(true);
+        $lines = array_filter(explode("\n", $display), static fn (string $line): bool => '' !== trim($line));
+
+        $this->assertStringContainsString("\xB3", $display);
+        $this->assertSame(str_replace(' ', '', $message), str_replace(' ', '', implode('', array_map(static fn (string $line): string => substr($line, 9), $lines))));
+        $this->assertGreaterThan(1, \count($lines), 'The message is wrapped over several lines.');
+        $this->assertCount(1, array_unique(array_map('strlen', $lines)), 'Every line of the block is padded to the same width.');
+    }
+
     public function testGetErrorStyle()
     {
         $input = $this->createStub(InputInterface::class);


### PR DESCRIPTION
| Q             | A |
| ------------- | --- |
| Branch?       | 6.4 |
| Bug fix?      | yes |
| New feature?  | no |
| Deprecations? | no |
| Issues        | - |
| License       | MIT |

Console messages can carry bytes that are not valid UTF-8, for example when they quote the output of a subprocess or the contents of a file. `OutputWrapper::wrap()` builds its pattern with the `u` modifier, and `preg_replace()` returns `null` for such a subject. `rtrim()` then raised `Passing null to parameter #1 ($string)` and the wrapped text came out empty, so `SymfonyStyle::error()` printed an `[ERROR]` block with no message in it.

The pattern now drops the `u` modifier when the text is not valid UTF-8 and wraps on bytes instead. Nothing changes for valid UTF-8, and a malformed message keeps every one of its bytes while the block still breaks at the right width.

Before:

```
 [ERROR]
```

After:

```
 [ERROR] Cannot read the log file at /var/log/app/deep/path.log: ? check the
         file permissions, then retry the command
```

Returning the text unwrapped instead would keep the message but overflow the block, since the line is then longer than the terminal width and loses its padding. Wrapping on bytes gives a malformed message the same layout a valid one gets: the stray byte occupies one position, exactly as `Helper::width()` already assumes when it falls back to a non-UTF-8 path for the same kind of input.

Merge-up to 7.4: applies as is.

Merge-up to 8.2: conflicts, and must not be resolved by taking either side. `OutputWrapper::wrap()` was rewritten there by #65359 to fold each tag and URL to a private-use codepoint before wrapping. That branch has the same bug one step earlier, in the `preg_replace_callback()` that builds the fold, which also returns `null` on malformed UTF-8. Dropping the `u` modifier is not the fix there, because the placeholders are multi-byte and would each consume four positions of the width budget instead of one. 8.2 needs its own patch.
