### PR TITLE
[Finder] Update PHPDoc with more examples in some methods

### DIFF
--- a/src/Symfony/Component/Finder/Finder.php
+++ b/src/Symfony/Component/Finder/Finder.php
@@ -200,11 +200,13 @@ class Finder implements \IteratorAggregate, \Countable
     }
 
     /**
-     * Adds tests that file contents must match.
+     * Adds tests that file contents must match. If multiple patterns are given,
+     * files only need to match at least one of them.
      *
      * Strings or PCRE patterns can be used:
      *
      *     $finder->contains('Lorem ipsum')
+     *     $finder->contains(['Lorem', 'ipsum']) // matches files containing "Lorem", or "ipsum", or both
      *     $finder->contains('/Lorem ipsum/i')
      *     $finder->contains(['dolor', '/ipsum/i'])
      *
@@ -222,11 +224,13 @@ class Finder implements \IteratorAggregate, \Countable
     }
 
     /**
-     * Adds tests that file contents must not match.
+     * Adds tests that file contents must not match. If multiple patterns are given,
+     * files are excluded as soon as they match any of them.
      *
      * Strings or PCRE patterns can be used:
      *
      *     $finder->notContains('Lorem ipsum')
+     *     $finder->notContains(['Lorem', 'ipsum']) // excludes files containing "Lorem", or "ipsum", or both
      *     $finder->notContains('/Lorem ipsum/i')
      *     $finder->notContains(['lorem', '/dolor/i'])
      *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

When passing several arguments to Finder methods, the behavior (`AND` or `OR`) is trivial for most of them: for `name()` it can only be `OR`, for ranges like date and size it must be `AND`, etc. But for `contains()` and `notContains()`, sometimes I wonder if it's an `AND` or an `OR`. That's why I propose to add this.