### PR TITLE
[Tui] Scroll overheight frames that grow instead of repainting the viewport

### DIFF
--- a/src/Symfony/Component/Tui/Render/ScreenWriter.php
+++ b/src/Symfony/Component/Tui/Render/ScreenWriter.php
@@ -186,10 +186,9 @@ final class ScreenWriter
             return;
         }
 
-        // Rows are addressed by relative cursor motion, which clamps at the screen
-        // edges instead of scrolling, so no frame taller than the screen can be
-        // updated that way, in either direction.
-        if (!$this->terminal->isVirtual() && ($lineCount > $rows || \count($this->previousLines) > $rows)) {
+        // Overflowing content that shrinks moves every visible line up, which
+        // cannot be expressed by erasing the trailing ones.
+        if (!$this->terminal->isVirtual() && \count($this->previousLines) > $rows && $lineCount < \count($this->previousLines)) {
             $this->redrawViewport($lines, $cursorPos, $rows);
 
             return;
@@ -370,10 +369,12 @@ final class ScreenWriter
     {
         $buffer = "\x1b[?2026h\x1b[?25l"; // Begin synchronized output with the cursor hidden
 
-        // Move cursor to first changed line
+        // Move cursor to first changed line. Line feeds instead of downward cursor
+        // motion, which clamps at the last row: on the bottom of the screen they
+        // scroll, which is how content that grew past it reaches the scrollback.
         $lineDiff = $firstChanged - $this->hardwareCursorRow;
         if ($lineDiff > 0) {
-            $buffer .= "\x1b[{$lineDiff}B";
+            $buffer .= str_repeat("\n", $lineDiff);
         } elseif ($lineDiff < 0) {
             $buffer .= "\x1b[".(-$lineDiff).'A';
         }

--- a/src/Symfony/Component/Tui/Terminal/ScreenBuffer.php
+++ b/src/Symfony/Component/Tui/Terminal/ScreenBuffer.php
@@ -28,6 +28,8 @@ final class ScreenBuffer
 {
     /** @var array<int, array<int, array{char: string, style: string}>> */
     private array $cells = [];
+    /** @var list<array<int, array{char: string, style: string}>> */
+    private array $scrollback = [];
     private int $cursorRow = 0;
     private int $cursorCol = 0;
     private int $width;
@@ -210,6 +212,16 @@ final class ScreenBuffer
     }
 
     /**
+     * Get the lines that scrolled off the top of the screen, oldest first.
+     *
+     * @return string[]
+     */
+    public function getScrollback(): array
+    {
+        return array_map($this->renderCells(...), $this->scrollback);
+    }
+
+    /**
      * Get the cell data for external processing (e.g., HTML conversion).
      *
      * @return array<int, array<int, array{char: string, style: string}>>
@@ -232,15 +244,23 @@ final class ScreenBuffer
      */
     private function getLineText(int $row): string
     {
-        if (!isset($this->cells[$row]) || !$this->cells[$row]) {
+        return $this->renderCells($this->cells[$row] ?? []);
+    }
+
+    /**
+     * @param array<int, array{char: string, style: string}> $cells
+     */
+    private function renderCells(array $cells): string
+    {
+        if (!$cells) {
             return '';
         }
 
         $line = '';
-        $maxCol = max(array_keys($this->cells[$row]));
+        $maxCol = max(array_keys($cells));
 
         for ($col = 0; $col <= $maxCol; ++$col) {
-            $char = $this->cells[$row][$col]['char'] ?? ' ';
+            $char = $cells[$col]['char'] ?? ' ';
             // Skip wide character continuation cells (empty string placeholders)
             if ('' === $char) {
                 continue;
@@ -371,7 +391,7 @@ final class ScreenBuffer
      */
     private function scrollUp(): void
     {
-        array_shift($this->cells);
+        $this->scrollback[] = array_shift($this->cells) ?? [];
         $this->cells[] = [];
     }
 
@@ -566,8 +586,10 @@ final class ScreenBuffer
                 $this->eraseInLine(1);
                 break;
 
+            case 3: // Erase the scrollback as well
+                $this->scrollback = [];
+                // no break
             case 2: // Erase entire screen (but don't move cursor)
-            case 3:
                 for ($i = 0; $i < $this->height; ++$i) {
                     $this->cells[$i] = [];
                 }

--- a/src/Symfony/Component/Tui/Tests/Render/ScreenWriterTest.php
+++ b/src/Symfony/Component/Tui/Tests/Render/ScreenWriterTest.php
@@ -712,4 +712,58 @@ class ScreenWriterTest extends TestCase
         yield 'two lines appended' => [$six, [...$six, 'L6', 'L7']];
         yield 'last line edited' => [[...$six, 'L6'], [...$six, 'L6x']];
     }
+
+    #[DataProvider('growingFrames')]
+    public function testGrowingContentScrollsTheLinesLeavingTheViewportIntoTheScrollback(array $frames, array $expectedScrollback, array $expectedScreen)
+    {
+        $screen = new ScreenBuffer(20, 5);
+        $terminal = $this->createStub(TerminalInterface::class);
+        $terminal->method('getColumns')->willReturn(20);
+        $terminal->method('getRows')->willReturn(5);
+        $terminal->method('isVirtual')->willReturn(false);
+        $terminal->method('write')->willReturnCallback(static fn (string $data) => $screen->write($data));
+
+        $writer = new ScreenWriter($terminal);
+        foreach ($frames as $frame) {
+            $writer->writeLines($frame);
+        }
+
+        $this->assertSame($expectedScrollback, array_map(rtrim(...), $screen->getScrollback()));
+        $this->assertSame($expectedScreen, array_map(rtrim(...), $screen->getLines()));
+    }
+
+    public static function growingFrames(): iterable
+    {
+        $lines = static fn (int $from, int $to): array => array_map(static fn (int $i): string => 'L'.$i, range($from, $to));
+
+        yield 'grown past the screen at once' => [
+            [$lines(0, 4), $lines(0, 8)],
+            $lines(0, 3),
+            $lines(4, 8),
+        ];
+
+        yield 'grown one line at a time' => [
+            [$lines(0, 4), $lines(0, 5), $lines(0, 6), $lines(0, 7)],
+            $lines(0, 2),
+            $lines(3, 7),
+        ];
+
+        yield 'grown by more than a screen' => [
+            [$lines(0, 4), $lines(0, 14)],
+            $lines(0, 9),
+            $lines(10, 14),
+        ];
+
+        yield 'last line edited while growing' => [
+            [$lines(0, 4), [...$lines(0, 3), 'L4x', 'L5', 'L6']],
+            ['L0', 'L1'],
+            ['L2', 'L3', 'L4x', 'L5', 'L6'],
+        ];
+
+        yield 'grown while already overflowing' => [
+            [$lines(0, 8), $lines(0, 10)],
+            $lines(0, 5),
+            $lines(6, 10),
+        ];
+    }
 }

--- a/src/Symfony/Component/Tui/Tests/Terminal/ScreenBufferTest.php
+++ b/src/Symfony/Component/Tui/Tests/Terminal/ScreenBufferTest.php
@@ -649,4 +649,23 @@ class ScreenBufferTest extends TestCase
 
         $this->assertStringContainsString("\x1b[31mfghij", $buffer->getStyledScreen());
     }
+
+    public function testScrollbackOfAZeroHeightBuffer()
+    {
+        $buffer = new ScreenBuffer(20, 0);
+        $buffer->write("a\nb\n");
+
+        $this->assertSame(['', ''], $buffer->getScrollback());
+    }
+
+    public function testErasingTheScrollbackDropsTheLinesThatScrolledOff()
+    {
+        $buffer = new ScreenBuffer(20, 2);
+        $buffer->write("a\nb\nc\n");
+        $this->assertSame(['a', 'b'], $buffer->getScrollback());
+
+        $buffer->write("\x1b[3J");
+
+        $this->assertSame([], $buffer->getScrollback());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

#65966 widened the viewport redraw guard to cover any frame taller than the screen. `redrawViewport()` repaints the visible rows in place after an `ESC[2J`, so the terminal never scrolls and no line ever reaches the native scrollback: in an application rendering in the normal screen buffer, a long session can only ever show its last screenful.

The symptom #65966 addressed had a narrower cause, `CUD` clamping at the bottom margin instead of scrolling. Downward motion now uses line feeds, which behave identically inside the screen and scroll at the bottom row, so growing content is rendered differentially again and the lines leaving the viewport land in the scrollback. The guard goes back to covering overflowing content that shrinks. The cursor and synchronized output changes from #65966 are untouched.

`ScreenBuffer` records the lines that scroll off the top so the behaviour can be asserted, and erases them on `ED 3` the way a terminal does, which keeps it consistent with `fullRender()` sending `ESC[2J ESC[3J` while `redrawViewport()` sends only `ESC[2J`.

Merge-up to 8.2: `ScreenWriter.php` conflicts, because 8.2 rewrote `differentialRender()` for line reuse. Apply the same two changes onto 8.2's shape: the guard reverts to the narrow form, and `"\x1b[{$lineDiff}B"` becomes `str_repeat("\n", $lineDiff)`; keep 8.2's `$previousLineCount` line and its `LineBufferInterface` signature. The new test merges cleanly and then fails there, because 8.2 has no `writeLines()`: it becomes `$writer->writeFrame(new ArrayLineBuffer($frame))`.
