### PR TITLE
[DependencyInjection] Deep-clone only the mutable parts of a prototype definition

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
@@ -18,6 +18,7 @@ use Symfony\Component\Config\Loader\FileLoader as BaseFileLoader;
 use Symfony\Component\Config\Loader\Loader;
 use Symfony\Component\Config\Resource\GlobResource;
 use Symfony\Component\DependencyInjection\Alias;
+use Symfony\Component\DependencyInjection\Argument\BoundArgument;
 use Symfony\Component\DependencyInjection\Attribute\AsAlias;
 use Symfony\Component\DependencyInjection\Attribute\Exclude;
 use Symfony\Component\DependencyInjection\Attribute\Target;
@@ -29,6 +30,9 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Exception\LogicException;
+use Symfony\Component\DependencyInjection\Parameter;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\VarExporter\DeepCloner;
 
 /**
@@ -131,7 +135,19 @@ abstract class FileLoader extends BaseFileLoader
         $autoconfigureAttributes = new RegisterAutoconfigureAttributesPass();
         $autoconfigureAttributes = $autoconfigureAttributes->accept($prototype) ? $autoconfigureAttributes : null;
         $classes = $this->findClasses($namespace, $resource, (array) $exclude, $source);
-        $getPrototype = (new DeepCloner($prototype))->clone(...);
+
+        $getPrototype = static fn () => clone $prototype;
+
+        // deep-clone only the parts that hold mutable objects; the other ones
+        // can be shared between all the definitions created from the prototype
+        foreach (['Arguments', 'Properties', 'MethodCalls', 'Configurator', 'Factory', 'Bindings'] as $key) {
+            if (!self::needsDeepClone($value = $prototype->{'get'.$key}())) {
+                continue;
+            }
+
+            $cloner = new DeepCloner($value);
+            $getPrototype = static fn () => $getPrototype()->{'set'.$key}($cloner->clone());
+        }
 
         foreach ($classes as $class => $errorMessage) {
             if (null === $errorMessage && $autoconfigureAttributes) {
@@ -406,5 +422,33 @@ abstract class FileLoader extends BaseFileLoader
         $this->container->register($class, $class)
             ->setAbstract(true)
             ->addTag('container.excluded', null !== $source ? $attributes[$source] : []);
+    }
+
+    /**
+     * Tells whether a part of the prototype holds objects that compiler passes mutate,
+     * in which case each service needs its own copy of them.
+     */
+    private static function needsDeepClone(mixed $value): bool
+    {
+        if ($value instanceof BoundArgument) {
+            // bindings track their usage by identifier, so the very same instance can be shared
+            $value = $value->getValues()[0];
+        }
+
+        if (null === $value || \is_scalar($value) || $value instanceof Reference || $value instanceof Parameter || $value instanceof Expression || $value instanceof \UnitEnum) {
+            return false;
+        }
+
+        if (!\is_array($value)) {
+            return true;
+        }
+
+        foreach ($value as $v) {
+            if (self::needsDeepClone($v)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/FileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/FileLoaderTest.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Loader\LoaderResolver;
 use Symfony\Component\DependencyInjection\Alias;
+use Symfony\Component\DependencyInjection\Argument\BoundArgument;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\RegisterAutoconfigureAttributesPass;
@@ -27,6 +28,7 @@ use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\DependencyInjection\Loader\FileLoader;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\AbstractClass;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\BadClasses\MissingParent;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Foo;
@@ -99,6 +101,55 @@ class FileLoaderTest extends TestCase
             array_keys($container->getDefinitions())
         );
         $this->assertEquals([BarInterface::class], array_keys($container->getAliases()));
+    }
+
+    public function testRegisterClassesSharesImmutablePrototypeParts()
+    {
+        $container = new ContainerBuilder();
+        $loader = new TestFileLoader($container, new FileLocator(self::$fixturesPath.'/Fixtures'));
+        $loader->noAutoRegisterAliasesForSinglyImplementedInterfaces();
+
+        $prototype = new Definition();
+        $prototype->setArguments([new Reference('foo')]);
+        $prototype->setBindings(['string $foo' => new BoundArgument('bar'), 'Bar $baz' => new BoundArgument(new Reference('baz'))]);
+
+        $loader->registerClasses($prototype, 'Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Sub\\', 'Prototype/Sub/*');
+
+        $bar = $container->getDefinition(Bar::class);
+        $barInterface = $container->getDefinition('.abstract.'.BarInterface::class);
+
+        $this->assertSame($prototype->getArguments()[0], $bar->getArguments()[0]);
+        $this->assertSame($bar->getArguments()[0], $barInterface->getArguments()[0]);
+
+        $this->assertSame($prototype->getBindings()['string $foo'], $bar->getBindings()['string $foo']);
+        $this->assertSame($bar->getBindings()['Bar $baz'], $barInterface->getBindings()['Bar $baz']);
+    }
+
+    public function testRegisterClassesDeepClonesMutablePrototypeParts()
+    {
+        $container = new ContainerBuilder();
+        $loader = new TestFileLoader($container, new FileLocator(self::$fixturesPath.'/Fixtures'));
+        $loader->noAutoRegisterAliasesForSinglyImplementedInterfaces();
+
+        $prototype = new Definition();
+        $prototype->setArguments([new Definition(\stdClass::class)]);
+        $prototype->addMethodCall('setFoo', [new TaggedIteratorArgument('foo')]);
+        $prototype->setBindings(['string $foo' => new BoundArgument('bar'), 'iterable $bar' => new BoundArgument(new TaggedIteratorArgument('bar'))]);
+
+        $loader->registerClasses($prototype, 'Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Sub\\', 'Prototype/Sub/*');
+
+        $bar = $container->getDefinition(Bar::class);
+        $barInterface = $container->getDefinition('.abstract.'.BarInterface::class);
+
+        $this->assertNotSame($prototype->getArguments()[0], $bar->getArguments()[0]);
+        $this->assertNotSame($bar->getArguments()[0], $barInterface->getArguments()[0]);
+        $this->assertEquals($prototype->getArguments(), $bar->getArguments());
+
+        $this->assertNotSame($bar->getMethodCalls()[0][1][0], $barInterface->getMethodCalls()[0][1][0]);
+        $this->assertEquals($prototype->getMethodCalls(), $bar->getMethodCalls());
+
+        $this->assertNotSame($bar->getBindings()['string $foo'], $barInterface->getBindings()['string $foo']);
+        $this->assertEquals($prototype->getBindings(), $bar->getBindings());
     }
 
     public function testRegisterClassesWithExclude()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65973
| License       | MIT

Since #63612, `FileLoader::registerClasses()` builds one `DeepCloner` over the whole prototype, so every discovered class gets its own copy of every object the prototype holds. Before that, the prototype was shallow-cloned and only the parts holding a nested `Definition` were copied. On an app that discovers a few thousand classes with a `_defaults` `bind` block, the extra objects are counted in tens of megabytes.

This restores a guard, with a different rule than the one that was there before.

A part of the prototype is deep-cloned when it holds an object that compiler passes rewrite in place: a `Definition`, an `ArgumentInterface` implementation, an `AbstractArgument`, or anything the loader does not recognize. Scalars, arrays, `Reference`, `Parameter`, `Expression` and enums are shared, because nothing mutates them.

`BoundArgument` is unwrapped rather than copied. Bindings track their usage by identifier, and `ResolveBindingsPass` keys `usedBindings` on that identifier, so one shared instance behaves like one instance per service. This is where the memory goes on a large app: 17 bindings times a few thousand classes.

The rule differs from the one used before #63612 on purpose. That one looked for `Definition` and `ChildDefinition` only, so it shared `TaggedIteratorArgument`, `IteratorArgument` and `AbstractArgument` between all the services of a prototype. Those objects are rewritten per service, `ResolveTaggedIteratorArgumentPass` calls `setValues()` on them with an exclude list built from the current service id. The unconditional deep clone had closed that hole, and this keeps it closed.

Measured on a synthetic app with 4000 discovered classes, a `_defaults` block with 17 `bind` entries and 5 `_instanceof` blocks, loading, compiling and dumping the container:

| Setup                                    | Peak    |
| ---------------------------------------- | ------- |
| 8.1                                      | 62.0 MB |
| this patch                               | 52.9 MB |
| 8.1 with the 7.4 `registerClasses` block | 52.9 MB |

Checks run: the full `DependencyInjection` suite (1762 tests, 10 skipped, green), the `Tests/DependencyInjection` suites of FrameworkBundle, HttpKernel and Console (546, 55 and 39 tests, green), and php-cs-fixer on both touched files. `testRegisterClassesSharesImmutablePrototypeParts` fails on the base branch; `testRegisterClassesDeepClonesMutablePrototypeParts` passes there and guards the behavior that must not change.
