### PR TITLE
[Tui] Test that growing overflowing content does not read the unchanged prefix

### DIFF
--- a/src/Symfony/Component/Tui/Tests/Render/ScreenWriterTest.php
+++ b/src/Symfony/Component/Tui/Tests/Render/ScreenWriterTest.php
@@ -698,6 +698,22 @@ class ScreenWriterTest extends TestCase
         $this->assertSame(0, $transcript->getReadCount());
     }
 
+    public function testGrowingOverflowingContentDoesNotReadUnchangedPrefix()
+    {
+        $transcript = new CountingLineBuffer(100);
+        $terminal = $this->createStub(TerminalInterface::class);
+        $terminal->method('getColumns')->willReturn(20);
+        $terminal->method('getRows')->willReturn(5);
+        $terminal->method('isVirtual')->willReturn(false);
+        $writer = new ScreenWriter($terminal);
+
+        $writer->writeFrame(new ConcatenatedLineBuffer([$transcript, new ArrayLineBuffer(['A', 'B', 'C', 'D', 'E', 'F'])]));
+        $transcript->resetReadCount();
+        $writer->writeFrame(new ConcatenatedLineBuffer([$transcript, new ArrayLineBuffer(['A', 'B', 'C', 'D', 'E', 'F', 'G'])]));
+
+        $this->assertSame(0, $transcript->getReadCount());
+    }
+
     public static function provideShrinkingOverflowingContent(): iterable
     {
         yield 'one trailing line removed' => [['A', 'B', 'C', 'D', 'E', 'F']];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| License       | MIT

`testShrinkingOverflowingContentDoesNotReadUnchangedPrefix` covers that shrinking an overflowing frame leaves the unchanged prefix untouched, but nothing covered the growing case, which is the streaming one: a long transcript with a tail that keeps growing. Re-reading that prefix on every frame is what makes rendering cost grow with the length of the session rather than with the size of the change.

The test is the counterpart of the existing one, and it fails with 200 reads instead of 0 when the identity shortcut in `LineBufferDiffer::commonPrefixLength()` is removed.