### PR TITLE
[HttpFoundation][Semaphore] Stop flushing the shared Redis database in tests

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PredisSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PredisSessionHandlerTest.php
@@ -40,7 +40,7 @@ class PredisSessionHandlerTest extends AbstractRedisSessionHandlerTestCase
             $this->assertSame(0, $rawClient->exists('my_session_prefix_my_session_prefix_test_id'));
             $this->assertEquals('test_data', $rawClient->get('my_session_prefix_test_id'));
         } finally {
-            $rawClient->flushdb();
+            $rawClient->del('my_session_prefix_test_id');
         }
     }
 }

--- a/src/Symfony/Component/Semaphore/Tests/Store/AbstractStoreTestCase.php
+++ b/src/Symfony/Component/Semaphore/Tests/Store/AbstractStoreTestCase.php
@@ -29,7 +29,7 @@ abstract class AbstractStoreTestCase extends TestCase
     {
         $store = $this->getStore();
 
-        $key = new Key(__METHOD__, 1);
+        $key = new Key(uniqid(__METHOD__, true), 1);
 
         $this->assertFalse($store->exists($key));
         $store->save($key, 10);
@@ -42,8 +42,8 @@ abstract class AbstractStoreTestCase extends TestCase
     {
         $store = $this->getStore();
 
-        $key1 = new Key(__METHOD__.'1', 1);
-        $key2 = new Key(__METHOD__.'2', 1);
+        $key1 = new Key(uniqid(__METHOD__, true), 1);
+        $key2 = new Key(uniqid(__METHOD__, true), 1);
 
         $store->save($key1, 10);
         $this->assertTrue($store->exists($key1));
@@ -66,7 +66,7 @@ abstract class AbstractStoreTestCase extends TestCase
     {
         $store = $this->getStore();
 
-        $resource = __METHOD__;
+        $resource = uniqid(__METHOD__, true);
         $key1 = new Key($resource, 1);
         $key2 = new Key($resource, 1);
 
@@ -101,7 +101,7 @@ abstract class AbstractStoreTestCase extends TestCase
     {
         $store = $this->getStore();
 
-        $resource = __METHOD__;
+        $resource = uniqid(__METHOD__, true);
         $key1 = new Key($resource, 2);
         $key2 = new Key($resource, 2);
         $key3 = new Key($resource, 2);
@@ -145,7 +145,7 @@ abstract class AbstractStoreTestCase extends TestCase
     {
         $store = $this->getStore();
 
-        $resource = __METHOD__;
+        $resource = uniqid(__METHOD__, true);
         $key1 = new Key($resource, 4, 2);
         $key2 = new Key($resource, 4, 2);
         $key3 = new Key($resource, 4, 2);
@@ -188,7 +188,7 @@ abstract class AbstractStoreTestCase extends TestCase
     public function testPutOffExpiration()
     {
         $store = $this->getStore();
-        $key = new Key(__METHOD__, 4, 2);
+        $key = new Key(uniqid(__METHOD__, true), 4, 2);
         $store->save($key, 20);
 
         $store->putOffExpiration($key, 20);
@@ -213,7 +213,7 @@ abstract class AbstractStoreTestCase extends TestCase
     {
         $store = $this->getStore();
 
-        $key = new Key(__METHOD__, 1);
+        $key = new Key(uniqid(__METHOD__, true), 1);
 
         $store->save($key, 10);
         $store->save($key, 10);

--- a/src/Symfony/Component/Semaphore/Tests/Store/RedisStoreTest.php
+++ b/src/Symfony/Component/Semaphore/Tests/Store/RedisStoreTest.php
@@ -18,11 +18,6 @@ namespace Symfony\Component\Semaphore\Tests\Store;
  */
 class RedisStoreTest extends AbstractRedisStoreTestCase
 {
-    protected function setUp(): void
-    {
-        $this->getRedisConnection()->flushDB();
-    }
-
     public static function setUpBeforeClass(): void
     {
         try {

--- a/src/Symfony/Component/Semaphore/Tests/Store/RelayStoreTest.php
+++ b/src/Symfony/Component/Semaphore/Tests/Store/RelayStoreTest.php
@@ -20,15 +20,6 @@ use Relay\Relay;
  */
 class RelayStoreTest extends AbstractRedisStoreTestCase
 {
-    protected function setUp(): void
-    {
-        try {
-            $this->getRedisConnection()->flushDB();
-        } catch (\Relay\Exception $e) {
-            self::markTestSkipped($e->getMessage());
-        }
-    }
-
     public static function setUpBeforeClass(): void
     {
         try {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

The Windows job runs all components in parallel against one Redis server, and `Semaphore\RedisStoreTest` and `PredisSessionHandlerTest` called `FLUSHDB` on it, which deleted the messages stream under the running Messenger integration tests and raised the `NOGROUP` error. Semaphore tests now use unique resource names like the Lock ones and the session test deletes the single key it wrote. This should fix our flaky test we can see https://github.com/symfony/symfony/actions/runs/34571500900/job/103174390334