### PR TITLE
[Notifier] Support per-message recipient in the LineBot bridge

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/LineBot/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/LineBot/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add the `ssl` DSN option to send requests over plain HTTP
+ * Add the `LineBotOptions` class to set the recipient per message
 
 7.2
 ---

--- a/src/Symfony/Component/Notifier/Bridge/LineBot/LineBotOptions.php
+++ b/src/Symfony/Component/Notifier/Bridge/LineBot/LineBotOptions.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\LineBot;
+
+use Symfony\Component\Notifier\Message\MessageOptionsInterface;
+
+/**
+ * @see https://developers.line.biz/en/reference/messaging-api/#send-push-message-request-body
+ *
+ * @author Yi-Jyun Pan <me@pan93.com>
+ */
+final class LineBotOptions implements MessageOptionsInterface
+{
+    public function __construct(
+        private array $options = [],
+    ) {
+    }
+
+    public function toArray(): array
+    {
+        return $this->options;
+    }
+
+    public function getRecipientId(): ?string
+    {
+        return $this->options['to'] ?? null;
+    }
+
+    /**
+     * Sets the ID of the target recipient.
+     *
+     * @see https://developers.line.biz/en/docs/messaging-api/getting-user-ids/
+     *
+     * @return $this
+     */
+    public function to(string $id): static
+    {
+        $this->options['to'] = $id;
+
+        return $this;
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/LineBot/LineBotTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/LineBot/LineBotTransport.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Notifier\Bridge\LineBot;
 
 use Symfony\Component\Notifier\Exception\TransportException;
 use Symfony\Component\Notifier\Exception\UnsupportedMessageTypeException;
+use Symfony\Component\Notifier\Exception\UnsupportedOptionsException;
 use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SentMessage;
@@ -43,20 +44,25 @@ final class LineBotTransport extends AbstractTransport
             throw new UnsupportedMessageTypeException(__CLASS__, ChatMessage::class, $message);
         }
 
+        if (($options = $message->getOptions()) && !$options instanceof LineBotOptions) {
+            throw new UnsupportedOptionsException(__CLASS__, LineBotOptions::class, $options);
+        }
+
+        $options = $options?->toArray() ?? [];
+        $options['to'] ??= $message->getRecipientId() ?: $this->receiver;
+        $options['messages'] = [
+            [
+                'type' => 'text',
+                'text' => $message->getSubject(),
+            ],
+        ];
+
         $response = $this->client->request(
             'POST',
             \sprintf('%s://%s/v2/bot/message/push', $this->getHttpScheme(), $this->getEndpoint()),
             [
                 'auth_bearer' => $this->accessToken,
-                'json' => [
-                    'to' => $this->receiver,
-                    'messages' => [
-                        [
-                            'type' => 'text',
-                            'text' => $message->getSubject(),
-                        ],
-                    ],
-                ],
+                'json' => $options,
             ],
         );
 
@@ -82,7 +88,7 @@ final class LineBotTransport extends AbstractTransport
 
     public function supports(MessageInterface $message): bool
     {
-        return $message instanceof ChatMessage;
+        return $message instanceof ChatMessage && (null === $message->getOptions() || $message->getOptions() instanceof LineBotOptions);
     }
 
     public function __toString(): string

--- a/src/Symfony/Component/Notifier/Bridge/LineBot/Tests/LineBotOptionsTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/LineBot/Tests/LineBotOptionsTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\LineBot\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Notifier\Bridge\LineBot\LineBotOptions;
+
+final class LineBotOptionsTest extends TestCase
+{
+    public function testEmptyOptions()
+    {
+        $options = new LineBotOptions();
+
+        $this->assertSame([], $options->toArray());
+        $this->assertNull($options->getRecipientId());
+    }
+
+    public function testTo()
+    {
+        $options = new LineBotOptions();
+
+        $returnedOptions = $options->to('testReceiver');
+
+        $this->assertSame($options, $returnedOptions);
+        $this->assertSame(['to' => 'testReceiver'], $options->toArray());
+        $this->assertSame('testReceiver', $options->getRecipientId());
+    }
+
+    public function testConstructWithOptions()
+    {
+        $options = new LineBotOptions(['to' => 'testReceiver']);
+
+        $this->assertSame(['to' => 'testReceiver'], $options->toArray());
+        $this->assertSame('testReceiver', $options->getRecipientId());
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/LineBot/Tests/LineBotTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/LineBot/Tests/LineBotTransportTest.php
@@ -12,14 +12,19 @@
 namespace Symfony\Component\Notifier\Bridge\LineBot\Tests;
 
 use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\JsonMockResponse;
 use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\Notifier\Bridge\LineBot\LineBotOptions;
 use Symfony\Component\Notifier\Bridge\LineBot\LineBotTransport;
 use Symfony\Component\Notifier\Exception\TransportException;
+use Symfony\Component\Notifier\Exception\UnsupportedOptionsException;
 use Symfony\Component\Notifier\Message\ChatMessage;
+use Symfony\Component\Notifier\Message\MessageOptionsInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
 use Symfony\Component\Notifier\Tests\Transport\DummyMessage;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
 
 /**
  * @author Yi-Jyun Pan <me@pan93.com>
@@ -39,6 +44,7 @@ final class LineBotTransportTest extends TransportTestCase
     public static function supportedMessagesProvider(): iterable
     {
         yield [new ChatMessage('Hello!')];
+        yield [new ChatMessage('Hello!', new LineBotOptions())];
     }
 
     public static function unsupportedMessagesProvider(): iterable
@@ -57,5 +63,43 @@ final class LineBotTransportTest extends TransportTestCase
         $this->expectExceptionMessageMatches('/testMessage.+400: "testDescription"/');
 
         $transport->send(new ChatMessage('testMessage'));
+    }
+
+    public function testSendUsesTheReceiverFromTheDsn()
+    {
+        $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
+            $this->assertSame([
+                'to' => 'testReceiver',
+                'messages' => [['type' => 'text', 'text' => 'testMessage']],
+            ], json_decode($options['body'], true));
+
+            return new JsonMockResponse([]);
+        });
+
+        $this->createTransport($client)->send(new ChatMessage('testMessage'));
+    }
+
+    public function testSendUsesTheRecipientFromTheOptions()
+    {
+        $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
+            $this->assertSame([
+                'to' => 'customReceiver',
+                'messages' => [['type' => 'text', 'text' => 'testMessage']],
+            ], json_decode($options['body'], true));
+
+            return new JsonMockResponse([]);
+        });
+
+        $this->createTransport($client)->send(new ChatMessage('testMessage', (new LineBotOptions())->to('customReceiver')));
+    }
+
+    public function testSendWithForeignOptionsThrows()
+    {
+        $options = $this->createStub(MessageOptionsInterface::class);
+
+        $this->expectException(UnsupportedOptionsException::class);
+        $this->expectExceptionMessage(\sprintf('The "%s" transport only supports instances of "%s" for options (instance of "%s" given).', LineBotTransport::class, LineBotOptions::class, get_debug_type($options)));
+
+        $this->createTransport()->send(new ChatMessage('testMessage', $options));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #58568
| License       | MIT

---

`LineBotTransport` hardcodes the `receiver` DSN option as the `to` field of the push endpoint and never reads `$message->getOptions()`, so one configured transport can reach exactly one user id.

This adds a `LineBotOptions` class carrying the target recipient, following the idiom of the other bridges:

```php
$chatMessage = new ChatMessage('Hello!');
$chatMessage->options((new LineBotOptions())->to('U4af4980629...'));

$chatter->send($chatMessage);
```

The `receiver` from the DSN remains the default when the message carries no recipient. Options of another type are now rejected with `UnsupportedOptionsException`, and `supports()` accounts for them, as in `TelegramTransport`.

The `/v2/bot/message/broadcast` endpoint stays out of scope.

The approach comes from #58582 by @pan93412, self-closed after review; @OskarStark offered to finish it. This is a narrower take on the same idea, limited to the recipient, with the points raised there addressed.
