### PR TITLE
[String] Keep the case of a leading acronym in ByteString::camel()

### DIFF
--- a/src/Symfony/Component/String/ByteString.php
+++ b/src/Symfony/Component/String/ByteString.php
@@ -104,8 +104,10 @@ class ByteString extends AbstractString
     {
         $str = clone $this;
 
-        $parts = explode(' ', trim(ucwords(preg_replace('/[^a-zA-Z0-9\x7f-\xff]++/', ' ', $this->string))));
-        $parts[0] = 1 !== \strlen($parts[0]) && ctype_upper($parts[0]) ? $parts[0] : lcfirst($parts[0]);
+        $words = trim(preg_replace('/[^a-zA-Z0-9\x7f-\xff]++/', ' ', $this->string));
+        $parts = explode(' ', ucwords($words));
+        // a leading uppercase letter followed by another one is kept, as in AbstractUnicodeString::camel()
+        $parts[0] = preg_match('/^[A-Z]{2}/', $words) || (1 !== \strlen($parts[0]) && ctype_upper($parts[0])) ? $parts[0] : lcfirst($parts[0]);
         $str->string = implode('', $parts);
 
         return $str;

--- a/src/Symfony/Component/String/Tests/AbstractAsciiTestCase.php
+++ b/src/Symfony/Component/String/Tests/AbstractAsciiTestCase.php
@@ -1056,6 +1056,9 @@ abstract class AbstractAsciiTestCase extends TestCase
             ['symfonyIsAGreatFramework', 'Symfony is a great framework'],
             ['symfonyIsGREAT', '*Symfony* is GREAT!!'],
             ['SYMFONY', 'SYMFONY'],
+            ['XMLHttpRequest', 'XMLHttpRequest'],
+            ['IOError', 'IOError'],
+            ['iPhone', 'iPhone'],
         ];
     }
 
@@ -1093,6 +1096,11 @@ abstract class AbstractAsciiTestCase extends TestCase
             ['symfonyisgreat', 'SYMFONY _ IS _ GREAT'],
             ['symfony_isgreat', 'Symfony IS GREAT!'],
             ['123_customer_with_special_name', '123-customer,with/special#name'],
+            ['xml_http_request', 'XMLHttpRequest'],
+            ['http_response', 'HTTPResponse'],
+            ['url_value', 'URLValue'],
+            ['io_error', 'IOError'],
+            ['symfony5', 'SYMFONY5'],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65993
| License       | MIT

`ByteString::camel()` now keeps a leading uppercase letter when it is followed by another one, which is what the `(?!\p{Lu})` lookahead already does in `AbstractUnicodeString::camel()`. `b()` and `u()` now agree on `XMLHttpRequest`, `HTTPResponse`, `URLValue` and `IOError`, and also on `SYMFONY5` (`s_ymfony5` before).

The check runs on the string before `ucwords()`, so `b('iPhone')->camel()` stays `iPhone`. The `u()` side is untouched, and `ABC Foo` keeps diverging as described in the issue.

Targeting 6.4 since the issue was verified there, happy to retarget to 8.2 if you'd rather ship the `b()` change as a behaviour change.
