### PR TITLE
[Translation] Make `PoEditorProvider` fetch every domain and locale when passed none, and add missing languages

### DIFF
--- a/src/Symfony/Component/Translation/Bridge/PoEditor/PoEditorProvider.php
+++ b/src/Symfony/Component/Translation/Bridge/PoEditor/PoEditorProvider.php
@@ -47,6 +47,8 @@ final class PoEditorProvider implements ProviderInterface
 
     public function write(TranslatorBagInterface $translatorBag): void
     {
+        $languages = $this->addMissingLanguages($translatorBag);
+
         $defaultCatalogue = $translatorBag->getCatalogue($this->defaultLocale);
 
         $terms = $translationsToAdd = [];
@@ -64,10 +66,10 @@ final class PoEditorProvider implements ProviderInterface
         $this->addTerms($terms);
 
         foreach ($translatorBag->getCatalogues() as $catalogue) {
-            $locale = $catalogue->getLocale();
+            $language = self::getPoEditorLocale($catalogue->getLocale(), $languages);
             foreach ($catalogue->all() as $domain => $messages) {
                 foreach ($messages as $id => $message) {
-                    $translationsToAdd[$locale][] = [
+                    $translationsToAdd[$language][] = [
                         'term' => $id,
                         'context' => $domain,
                         'translation' => [
@@ -83,14 +85,20 @@ final class PoEditorProvider implements ProviderInterface
 
     public function read(array $domains, array $locales): TranslatorBag
     {
+        $domains = $domains ?: $this->getDomains();
+        $languages = $this->getLanguages();
+        $locales = $locales
+            ? array_combine($locales, array_map(static fn (string $locale) => self::getPoEditorLocale($locale, $languages), $locales))
+            : array_combine(array_map(self::getSymfonyLocale(...), $languages), $languages);
+
         $translatorBag = new TranslatorBag();
         $exportResponses = $downloadResponses = [];
 
-        foreach ($locales as $locale) {
+        foreach ($locales as $locale => $language) {
             foreach ($domains as $domain) {
                 $response = $this->client->request('POST', 'projects/export', [
                     'body' => [
-                        'language' => $locale,
+                        'language' => $language,
                         'type' => 'xlf',
                         'filters' => json_encode(['translated']),
                         'tags' => json_encode([$domain]),
@@ -198,5 +206,105 @@ final class PoEditorProvider implements ProviderInterface
         if (200 !== $response->getStatusCode() || '200' !== (string) $response->toArray(false)['response']['code']) {
             throw new ProviderException(\sprintf('Unable to delete translation keys on POEditor: "%s".', $response->getContent(false)), $response);
         }
+    }
+
+    /**
+     * POEditor has no endpoint listing the tags, so they are read from the terms.
+     *
+     * @return string[]
+     */
+    private function getDomains(): array
+    {
+        $response = $this->client->request('POST', 'terms/list', [
+            'body' => [],
+        ]);
+
+        if (200 !== $response->getStatusCode() || '200' !== (string) $response->toArray(false)['response']['code']) {
+            throw new ProviderException(\sprintf('Unable to list the translation keys on POEditor: "%s".', $response->getContent(false)), $response);
+        }
+
+        $terms = $response->toArray(false)['result']['terms'] ?? [];
+
+        return array_values(array_unique(array_merge([], ...array_column($terms, 'tags'))));
+    }
+
+    /**
+     * @return string[] the language codes of the project, in POEditor's own spelling
+     */
+    private function getLanguages(): array
+    {
+        $response = $this->client->request('POST', 'languages/list', [
+            'body' => [],
+        ]);
+
+        if (200 !== $response->getStatusCode() || '200' !== (string) $response->toArray(false)['response']['code']) {
+            throw new ProviderException(\sprintf('Unable to list the languages on POEditor: "%s".', $response->getContent(false)), $response);
+        }
+
+        return array_column($response->toArray(false)['result']['languages'] ?? [], 'code');
+    }
+
+    /**
+     * Adding a language POEditor already knows about fails, so only the missing ones are sent.
+     *
+     * @return string[] the language codes of the project, the added ones included
+     */
+    private function addMissingLanguages(TranslatorBagInterface $translatorBag): array
+    {
+        $languages = $this->getLanguages();
+        $responses = [];
+
+        foreach ($translatorBag->getCatalogues() as $catalogue) {
+            if (!\in_array($language = self::getPoEditorLocale($catalogue->getLocale(), $languages), $languages, true)) {
+                $languages[] = $language;
+                $responses[] = [$language, $this->client->request('POST', 'languages/add', [
+                    'body' => ['language' => $language],
+                ])];
+            }
+        }
+
+        foreach ($responses as [$language, $response]) {
+            if (200 !== $response->getStatusCode() || '200' !== (string) $response->toArray(false)['response']['code']) {
+                $this->logger->error(\sprintf('Unable to add the "%s" language to POEditor: "%s".', $language, $response->getContent(false)));
+            }
+        }
+
+        return $languages;
+    }
+
+    /**
+     * POEditor spells most of its codes in lower case, "pt-br", but not all of them, "zh-Hans".
+     * The project's own list is therefore the reference, and lower case is the fallback for a
+     * language that is not in the project yet.
+     *
+     * @param string[] $languages
+     */
+    private static function getPoEditorLocale(string $locale, array $languages): string
+    {
+        $code = str_replace('_', '-', $locale);
+
+        foreach ($languages as $language) {
+            if (0 === strcasecmp($code, $language)) {
+                return $language;
+            }
+        }
+
+        return strtolower($code);
+    }
+
+    private static function getSymfonyLocale(string $code): string
+    {
+        $subtags = explode('-', strtolower($code));
+        $language = array_shift($subtags);
+
+        foreach ($subtags as $i => $subtag) {
+            $subtags[$i] = match (\strlen($subtag)) {
+                2 => strtoupper($subtag),
+                4 => ucfirst($subtag),
+                default => $subtag,
+            };
+        }
+
+        return implode('_', [$language, ...$subtags]);
     }
 }

--- a/src/Symfony/Component/Translation/Bridge/PoEditor/Tests/PoEditorProviderTest.php
+++ b/src/Symfony/Component/Translation/Bridge/PoEditor/Tests/PoEditorProviderTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Translation\Bridge\PoEditor\Tests;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestWith;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Symfony\Component\HttpClient\MockHttpClient;
@@ -19,6 +20,7 @@ use Symfony\Component\HttpClient\Response\JsonMockResponse;
 use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Translation\Bridge\PoEditor\PoEditorHttpClient;
 use Symfony\Component\Translation\Bridge\PoEditor\PoEditorProvider;
+use Symfony\Component\Translation\Exception\ProviderException;
 use Symfony\Component\Translation\Loader\ArrayLoader;
 use Symfony\Component\Translation\Loader\LoaderInterface;
 use Symfony\Component\Translation\Loader\XliffFileLoader;
@@ -68,6 +70,16 @@ class PoEditorProviderTest extends ProviderTestCase
         ]);
 
         $responses = [
+            'listLanguages' => function (string $method, string $url, array $options = []): MockResponse {
+                $this->assertSame('POST', $method);
+                $this->assertSame('https://api.poeditor.com/v2/languages/list', $url);
+                $this->assertSame(http_build_query([
+                    'api_token' => 'API_KEY',
+                    'id' => 'PROJECT_ID',
+                ]), $options['body']);
+
+                return self::createSuccessResponse(['languages' => [['code' => 'en'], ['code' => 'fr']]]);
+            },
             'addTerms' => function (string $method, string $url, array $options = []) use ($successResponse): MockResponse {
                 $this->assertSame('POST', $method);
                 $this->assertSame(http_build_query([
@@ -148,7 +160,7 @@ class PoEditorProviderTest extends ProviderTestCase
         ]));
 
         $provider = self::createProvider(
-            new MockHttpClient($responses, 'https://api.poeditor.com/v2/'),
+            $httpClient = new MockHttpClient($responses, 'https://api.poeditor.com/v2/'),
             $this->getLoader(),
             $this->getLogger(),
             $this->getDefaultLocale(),
@@ -156,6 +168,124 @@ class PoEditorProviderTest extends ProviderTestCase
         );
 
         $provider->write($translatorBag);
+
+        $this->assertSame(\count($responses), $httpClient->getRequestsCount());
+    }
+
+    public function testWriteAddsMissingLanguages()
+    {
+        $addLanguage = fn (string $language) => function (string $method, string $url, array $options = []) use ($language): MockResponse {
+            $this->assertSame('POST', $method);
+            $this->assertSame('https://api.poeditor.com/v2/languages/add', $url);
+            $this->assertSame(http_build_query([
+                'api_token' => 'API_KEY',
+                'id' => 'PROJECT_ID',
+                'language' => $language,
+            ]), $options['body']);
+
+            return self::createSuccessResponse();
+        };
+
+        $responses = [
+            'listLanguages' => self::createSuccessResponse(['languages' => [['code' => 'en']]]),
+            'addLanguageFr' => $addLanguage('fr'),
+            'addLanguageDe' => $addLanguage('de'),
+            'addTerms' => self::createSuccessResponse(),
+            'addTranslationsEn' => self::createSuccessResponse(),
+            'addTranslationsFr' => self::createSuccessResponse(),
+            'addTranslationsDe' => self::createSuccessResponse(),
+        ];
+
+        $translatorBag = new TranslatorBag();
+        $translatorBag->addCatalogue(new MessageCatalogue('en', ['messages' => ['a' => 'trans_en_a']]));
+        $translatorBag->addCatalogue(new MessageCatalogue('fr', ['messages' => ['a' => 'trans_fr_a']]));
+        $translatorBag->addCatalogue(new MessageCatalogue('de', ['messages' => ['a' => 'trans_de_a']]));
+
+        $provider = self::createProvider(
+            $httpClient = new MockHttpClient($responses, 'https://api.poeditor.com/v2/'),
+            $this->getLoader(),
+            $this->getLogger(),
+            $this->getDefaultLocale(),
+            'api.poeditor.com'
+        );
+
+        $provider->write($translatorBag);
+
+        $this->assertSame(\count($responses), $httpClient->getRequestsCount());
+    }
+
+    public function testWriteLogsLanguageThatCannotBeAdded()
+    {
+        $responses = [
+            'listLanguages' => self::createSuccessResponse(['languages' => [['code' => 'en']]]),
+            'addLanguageFr' => new JsonMockResponse([
+                'response' => [
+                    'status' => 'fail',
+                    'code' => '4043',
+                    'message' => 'Wrong language code',
+                ],
+            ]),
+            'addTerms' => self::createSuccessResponse(),
+            'addTranslationsEn' => self::createSuccessResponse(),
+            'addTranslationsFr' => self::createSuccessResponse(),
+        ];
+
+        $translatorBag = new TranslatorBag();
+        $translatorBag->addCatalogue(new MessageCatalogue('en', ['messages' => ['a' => 'trans_en_a']]));
+        $translatorBag->addCatalogue(new MessageCatalogue('fr', ['messages' => ['a' => 'trans_fr_a']]));
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
+            ->method('error')
+            ->with($this->stringStartsWith('Unable to add the "fr" language to POEditor: '));
+
+        $provider = self::createProvider(
+            $httpClient = new MockHttpClient($responses, 'https://api.poeditor.com/v2/'),
+            $this->getLoader(),
+            $logger,
+            $this->getDefaultLocale(),
+            'api.poeditor.com'
+        );
+
+        $provider->write($translatorBag);
+
+        $this->assertSame(\count($responses), $httpClient->getRequestsCount());
+    }
+
+    public function testWriteUsesThePoEditorLanguageCodes()
+    {
+        $requests = [];
+        $client = static function (string $method, string $url, array $options = []) use (&$requests): MockResponse {
+            parse_str($options['body'], $body);
+            $requests[] = rtrim(substr($url, \strlen('https://api.poeditor.com/v2/')).' '.($body['language'] ?? ''));
+
+            return self::createSuccessResponse(['languages' => [['code' => 'en'], ['code' => 'pt-br'], ['code' => 'zh-Hans']]]);
+        };
+
+        $translatorBag = new TranslatorBag();
+        foreach (['en', 'pt_BR', 'zh_Hans', 'de_AT'] as $locale) {
+            $translatorBag->addCatalogue(new MessageCatalogue($locale, ['messages' => ['a' => 'trans_a']]));
+        }
+
+        $provider = self::createProvider(
+            new MockHttpClient($client, 'https://api.poeditor.com/v2/'),
+            $this->getLoader(),
+            $this->getLogger(),
+            $this->getDefaultLocale(),
+            'api.poeditor.com'
+        );
+
+        $provider->write($translatorBag);
+
+        $this->assertSame([
+            'languages/list',
+            'languages/add de-at',
+            'terms/add',
+            'translations/add en',
+            'translations/add pt-br',
+            'translations/add zh-Hans',
+            'translations/add de-at',
+        ], $requests);
     }
 
     #[DataProvider('getResponsesForOneLocaleAndOneDomain')]
@@ -167,6 +297,7 @@ class PoEditorProviderTest extends ProviderTestCase
             ->willReturn((new XliffFileLoader())->load($responseContent, $locale, $domain));
 
         $responses = [
+            self::createSuccessResponse(['languages' => [['code' => $locale]]]),
             new JsonMockResponse([
                 'response' => [
                     'status' => 'success',
@@ -200,6 +331,7 @@ class PoEditorProviderTest extends ProviderTestCase
     #[DataProvider('getResponsesForManyLocalesAndManyDomains')]
     public function testReadForManyLocalesAndManyDomains(array $locales, array $domains, array $responseContents, TranslatorBag $expectedTranslatorBag)
     {
+        $listLanguages = self::createSuccessResponse(['languages' => array_map(static fn (string $locale) => ['code' => $locale], $locales)]);
         $exportResponses = $downloadResponses = [];
         $consecutiveLoadArguments = [];
         $consecutiveLoadReturns = [];
@@ -231,7 +363,7 @@ class PoEditorProviderTest extends ProviderTestCase
             });
 
         $provider = self::createProvider(
-            new MockHttpClient(array_merge($exportResponses, $downloadResponses), 'https://api.poeditor.com/v2/'),
+            new MockHttpClient([$listLanguages, ...$exportResponses, ...$downloadResponses], 'https://api.poeditor.com/v2/'),
             $loader,
             $this->getLogger(),
             $this->getDefaultLocale(),
@@ -245,6 +377,249 @@ class PoEditorProviderTest extends ProviderTestCase
         }
 
         $this->assertEquals($expectedTranslatorBag->getCatalogues(), $translatorBag->getCatalogues());
+    }
+
+    public function testReadWithoutLocales()
+    {
+        $export = fn (string $locale) => function (string $method, string $url, array $options = []) use ($locale): MockResponse {
+            $this->assertSame('POST', $method);
+            $this->assertSame('https://api.poeditor.com/v2/projects/export', $url);
+            $this->assertSame(http_build_query([
+                'api_token' => 'API_KEY',
+                'id' => 'PROJECT_ID',
+                'language' => $locale,
+                'type' => 'xlf',
+                'filters' => json_encode(['translated']),
+                'tags' => json_encode(['messages']),
+            ]), $options['body']);
+
+            return self::createSuccessResponse(['url' => 'https://api.poeditor.com/v2/download/file/'.$locale]);
+        };
+
+        $responses = [
+            'listLanguages' => function (string $method, string $url, array $options = []): MockResponse {
+                $this->assertSame('POST', $method);
+                $this->assertSame('https://api.poeditor.com/v2/languages/list', $url);
+
+                return self::createSuccessResponse(['languages' => [['code' => 'en'], ['code' => 'fr']]]);
+            },
+            'exportEn' => $export('en'),
+            'exportFr' => $export('fr'),
+            'downloadEn' => self::createXliffResponse('en', 'index.hello', 'Hello'),
+            'downloadFr' => self::createXliffResponse('fr', 'index.hello', 'Bonjour'),
+        ];
+
+        $provider = self::createProvider(
+            $httpClient = new MockHttpClient($responses, 'https://api.poeditor.com/v2/'),
+            new XliffFileLoader(),
+            $this->getLogger(),
+            $this->getDefaultLocale(),
+            'api.poeditor.com'
+        );
+
+        $translatorBag = $provider->read(['messages'], []);
+
+        $this->assertSame(['en', 'fr'], array_map(static fn (MessageCatalogue $catalogue) => $catalogue->getLocale(), $translatorBag->getCatalogues()));
+        $this->assertSame(['index.hello' => 'Bonjour'], $translatorBag->getCatalogue('fr')->all('messages'));
+        $this->assertSame(\count($responses), $httpClient->getRequestsCount());
+    }
+
+    public function testReadWithoutLocalesNamesTheCataloguesAfterTheSymfonyLocales()
+    {
+        $export = fn (string $language) => function (string $method, string $url, array $options = []) use ($language): MockResponse {
+            $this->assertSame('https://api.poeditor.com/v2/projects/export', $url);
+            $this->assertStringContainsString('&language='.$language.'&', $options['body']);
+
+            return self::createSuccessResponse(['url' => 'https://api.poeditor.com/v2/download/file/'.$language]);
+        };
+
+        $responses = [
+            'listLanguages' => self::createSuccessResponse(['languages' => [['code' => 'pt-br'], ['code' => 'zh-Hans'], ['code' => 'sr-cyrl']]]),
+            'exportPtBr' => $export('pt-br'),
+            'exportZhHans' => $export('zh-Hans'),
+            'exportSrCyrl' => $export('sr-cyrl'),
+            'downloadPtBr' => self::createXliffResponse('pt-br', 'index.hello', 'Ola'),
+            'downloadZhHans' => self::createXliffResponse('zh-Hans', 'index.hello', 'Nihao'),
+            'downloadSrCyrl' => self::createXliffResponse('sr-cyrl', 'index.hello', 'Zdravo'),
+        ];
+
+        $provider = self::createProvider(
+            $httpClient = new MockHttpClient($responses, 'https://api.poeditor.com/v2/'),
+            new XliffFileLoader(),
+            $this->getLogger(),
+            $this->getDefaultLocale(),
+            'api.poeditor.com'
+        );
+
+        $translatorBag = $provider->read(['messages'], []);
+
+        $this->assertSame(['pt_BR', 'zh_Hans', 'sr_Cyrl'], array_map(static fn (MessageCatalogue $catalogue) => $catalogue->getLocale(), $translatorBag->getCatalogues()));
+        $this->assertSame(['index.hello' => 'Ola'], $translatorBag->getCatalogue('pt_BR')->all('messages'));
+        $this->assertSame(\count($responses), $httpClient->getRequestsCount());
+    }
+
+    public function testReadSendsThePoEditorLanguageCodeAndKeepsTheRequestedLocale()
+    {
+        $requests = [];
+        $client = static function (string $method, string $url, array $options = []) use (&$requests): MockResponse {
+            $endpoint = substr($url, \strlen('https://api.poeditor.com/v2/'));
+
+            if (str_starts_with($endpoint, 'download/')) {
+                return self::createXliffResponse('pt-br', 'index.hello', 'Ola');
+            }
+
+            parse_str($options['body'], $body);
+            $requests[] = rtrim($endpoint.' '.($body['language'] ?? ''));
+
+            return self::createSuccessResponse('languages/list' === $endpoint
+                ? ['languages' => [['code' => 'en'], ['code' => 'pt-br']]]
+                : ['url' => 'https://api.poeditor.com/v2/download/file/pt-br']
+            );
+        };
+
+        $provider = self::createProvider(
+            new MockHttpClient($client, 'https://api.poeditor.com/v2/'),
+            new XliffFileLoader(),
+            $this->getLogger(),
+            $this->getDefaultLocale(),
+            'api.poeditor.com'
+        );
+
+        $translatorBag = $provider->read(['messages'], ['pt_BR']);
+
+        $this->assertSame(['languages/list', 'projects/export pt-br'], $requests);
+        $this->assertSame(['index.hello' => 'Ola'], $translatorBag->getCatalogue('pt_BR')->all('messages'));
+    }
+
+    public function testReadWithoutDomains()
+    {
+        $export = fn (string $domain) => function (string $method, string $url, array $options = []) use ($domain): MockResponse {
+            $this->assertSame('https://api.poeditor.com/v2/projects/export', $url);
+            $this->assertStringEndsWith('&tags='.urlencode(json_encode([$domain])), $options['body']);
+
+            return self::createSuccessResponse(['url' => 'https://api.poeditor.com/v2/download/file/'.$domain]);
+        };
+
+        $responses = [
+            'listTerms' => function (string $method, string $url, array $options = []): MockResponse {
+                $this->assertSame('POST', $method);
+                $this->assertSame('https://api.poeditor.com/v2/terms/list', $url);
+                $this->assertSame(http_build_query([
+                    'api_token' => 'API_KEY',
+                    'id' => 'PROJECT_ID',
+                ]), $options['body']);
+
+                return self::createSuccessResponse(['terms' => [
+                    ['term' => 'index.hello', 'context' => 'messages', 'tags' => ['messages']],
+                    ['term' => 'firstname.error', 'context' => 'validators', 'tags' => ['validators']],
+                    ['term' => 'index.greetings', 'context' => 'messages', 'tags' => ['messages']],
+                    ['term' => 'no.tag', 'context' => 'messages', 'tags' => []],
+                ]]);
+            },
+            'listLanguages' => self::createSuccessResponse(['languages' => [['code' => 'en']]]),
+            'exportMessages' => $export('messages'),
+            'exportValidators' => $export('validators'),
+            'downloadMessages' => self::createXliffResponse('en', 'index.hello', 'Hello'),
+            'downloadValidators' => self::createXliffResponse('en', 'firstname.error', 'Firstname must contains only letters.'),
+        ];
+
+        $provider = self::createProvider(
+            $httpClient = new MockHttpClient($responses, 'https://api.poeditor.com/v2/'),
+            new XliffFileLoader(),
+            $this->getLogger(),
+            $this->getDefaultLocale(),
+            'api.poeditor.com'
+        );
+
+        $translatorBag = $provider->read([], ['en']);
+
+        $this->assertEqualsCanonicalizing(['messages', 'validators'], $translatorBag->getCatalogue('en')->getDomains());
+        $this->assertSame(\count($responses), $httpClient->getRequestsCount());
+    }
+
+    public function testReadWithoutDomainsUsesTheTagsOfTheTerms()
+    {
+        $export = fn (string $domain) => function (string $method, string $url, array $options = []) use ($domain): MockResponse {
+            $this->assertSame('https://api.poeditor.com/v2/projects/export', $url);
+            $this->assertStringEndsWith('&tags='.urlencode(json_encode([$domain])), $options['body']);
+
+            return self::createSuccessResponse(['url' => 'https://api.poeditor.com/v2/download/file/'.$domain]);
+        };
+
+        $responses = [
+            'listTerms' => self::createSuccessResponse(['terms' => [
+                ['term' => 'index.hello', 'context' => '', 'tags' => ['messages']],
+                ['term' => 'firstname.error', 'context' => '', 'tags' => ['validators', 'messages']],
+                ['term' => 'no.tag', 'context' => '', 'tags' => []],
+            ]]),
+            'listLanguages' => self::createSuccessResponse(['languages' => [['code' => 'en']]]),
+            'exportMessages' => $export('messages'),
+            'exportValidators' => $export('validators'),
+            'downloadMessages' => self::createXliffResponse('en', 'index.hello', 'Hello'),
+            'downloadValidators' => self::createXliffResponse('en', 'firstname.error', 'Firstname must contains only letters.'),
+        ];
+
+        $provider = self::createProvider(
+            $httpClient = new MockHttpClient($responses, 'https://api.poeditor.com/v2/'),
+            new XliffFileLoader(),
+            $this->getLogger(),
+            $this->getDefaultLocale(),
+            'api.poeditor.com'
+        );
+
+        $translatorBag = $provider->read([], ['en']);
+
+        $this->assertEqualsCanonicalizing(['messages', 'validators'], $translatorBag->getCatalogue('en')->getDomains());
+        $this->assertSame(\count($responses), $httpClient->getRequestsCount());
+    }
+
+    public function testReadWithoutDomainsAndLocalesFromAnEmptyProject()
+    {
+        $responses = [
+            'listTerms' => self::createSuccessResponse(['terms' => []]),
+            'listLanguages' => self::createSuccessResponse(['languages' => []]),
+        ];
+
+        $provider = self::createProvider(
+            $httpClient = new MockHttpClient($responses, 'https://api.poeditor.com/v2/'),
+            $this->getLoader(),
+            $this->getLogger(),
+            $this->getDefaultLocale(),
+            'api.poeditor.com'
+        );
+
+        $this->assertSame([], $provider->read([], [])->getCatalogues());
+        $this->assertSame(\count($responses), $httpClient->getRequestsCount());
+    }
+
+    #[TestWith(['terms/list', 'Unable to list the translation keys on POEditor: '])]
+    #[TestWith(['languages/list', 'Unable to list the languages on POEditor: '])]
+    public function testReadWithoutDomainsAndLocalesThrowsWhenTheProjectCannotBeListed(string $failingEndpoint, string $expectedMessage)
+    {
+        $provider = self::createProvider(
+            new MockHttpClient(static function (string $method, string $url) use ($failingEndpoint): MockResponse {
+                if (str_ends_with($url, $failingEndpoint)) {
+                    return new JsonMockResponse([
+                        'response' => [
+                            'status' => 'fail',
+                            'code' => '4011',
+                            'message' => 'Invalid API Token',
+                        ],
+                    ]);
+                }
+
+                return self::createSuccessResponse(['terms' => [['term' => 'a', 'tags' => ['messages']]]]);
+            }, 'https://api.poeditor.com/v2/'),
+            $this->getLoader(),
+            $this->getLogger(),
+            $this->getDefaultLocale(),
+            'api.poeditor.com'
+        );
+
+        $this->expectException(ProviderException::class);
+        $this->expectExceptionMessage($expectedMessage);
+
+        $provider->read([], []);
     }
 
     public function testDeleteProcess()
@@ -454,5 +829,39 @@ class PoEditorProviderTest extends ProviderTestCase
             ],
             $expectedTranslatorBag,
         ];
+    }
+
+    private static function createSuccessResponse(array $result = []): JsonMockResponse
+    {
+        $body = [
+            'response' => [
+                'status' => 'success',
+                'code' => '200',
+                'message' => 'OK',
+            ],
+        ];
+
+        if ($result) {
+            $body['result'] = $result;
+        }
+
+        return new JsonMockResponse($body);
+    }
+
+    private static function createXliffResponse(string $locale, string $id, string $translation): MockResponse
+    {
+        return new MockResponse(<<<XLIFF
+            <?xml version="1.0" encoding="UTF-8"?>
+            <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+              <file source-language="en" target-language="$locale" datatype="plaintext" original="ng2.template">
+                <body>
+                  <trans-unit id="$id" resname="$id">
+                    <source>$id</source>
+                    <target>$translation</target>
+                  </trans-unit>
+                </body>
+              </file>
+            </xliff>
+            XLIFF);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Part of #64155
| License       | MIT

This covers the three POEditor items of the checklist in #64155:

- `read()` with no locales lists the project languages (`languages/list`) and reads each of them.
- `read()` with no domains reads them from the context of the terms (`terms/list`), since POEditor has no endpoint listing tags. The bridge writes the domain as both the context and the tag of each term, so exporting by tag keeps working.
- `write()` adds the languages missing from the project (`languages/add`) before pushing translations. A language that cannot be added is logged, like a failed `translations/add`, so the other locales still get written.

Locale codes are compared as-is, like the rest of the bridge does. No CHANGELOG entry since the bridge itself is new in 8.2.


Checked against the documented API with mocked responses only, not against a live POEditor project.
