### PR TITLE
[FrameworkBundle] Add a "configure_container" option to WebTestCase::createClient()

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.2
 ---
 
+ * Add the `configure_container` option to `WebTestCase::createClient()` to configure the container after every kernel reboot
  * Deprecate `Command\RouterMatchCommand`, use the one from the Routing component instead
  * Deprecate `DependencyInjection\Compiler\TranslationLintCommandPass`, `DependencyInjection\Compiler\TranslationUpdateCommandPass`, `DependencyInjection\Compiler\AssetsContextPass` and `DependencyInjection\Compiler\AddValidatorSecurityExpressionLanguageProviderPass`, use the ones from the Translation, Asset and Validator components instead
  * Deprecate `Routing\RouteLoaderInterface`, use the `#[AsRouteLoader]` attribute from the Routing component instead

--- a/src/Symfony/Bundle/FrameworkBundle/KernelBrowser.php
+++ b/src/Symfony/Bundle/FrameworkBundle/KernelBrowser.php
@@ -34,6 +34,7 @@ class KernelBrowser extends HttpKernelBrowser
     private bool $hasPerformedRequest = false;
     private bool $profiler = false;
     private bool $reboot = true;
+    private ?\Closure $containerConfigurator = null;
 
     public function __construct(KernelInterface $kernel, array $server = [], ?History $history = null, ?CookieJar $cookieJar = null)
     {
@@ -125,6 +126,33 @@ class KernelBrowser extends HttpKernelBrowser
     }
 
     /**
+     * Registers a callable to configure the container for the lifetime of this client.
+     *
+     * It is applied right away and then again after each kernel reboot, before the
+     * container has been used to handle a request.
+     *
+     * @internal
+     */
+    public function setContainerConfigurator(\Closure $configurator): void
+    {
+        if ($this->insulated) {
+            throw new \LogicException('Cannot configure the container when requests are insulated, as closures cannot be passed to the insulated process.');
+        }
+
+        $this->containerConfigurator = $configurator;
+        $configurator($this->getContainer());
+    }
+
+    public function insulate(bool $insulated = true): void
+    {
+        if ($insulated && $this->containerConfigurator) {
+            throw new \LogicException('Cannot insulate requests when a container configurator is registered, as closures cannot be passed to the insulated process.');
+        }
+
+        parent::insulate($insulated);
+    }
+
+    /**
      * @param UserInterface        $user
      * @param array<string, mixed> $tokenAttributes
      *
@@ -174,6 +202,11 @@ class KernelBrowser extends HttpKernelBrowser
         if ($this->hasPerformedRequest && $this->reboot) {
             $this->kernel->boot();
             $this->kernel->shutdown();
+
+            if ($this->containerConfigurator) {
+                $this->kernel->boot();
+                ($this->containerConfigurator)($this->getContainer());
+            }
         } else {
             $this->hasPerformedRequest = true;
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
@@ -39,6 +39,11 @@ abstract class WebTestCase extends KernelTestCase
     /**
      * Creates a KernelBrowser.
      *
+     * The "configure_container" option accepts a closure that receives the container
+     * returned by KernelBrowser::getContainer(). It is applied after every kernel boot,
+     * so that services replaced by the closure survive the reboots that happen between
+     * requests. All other options are passed to the createKernel method.
+     *
      * @param array $options An array of options to pass to the createKernel method
      * @param array $server  An array of server parameters
      */
@@ -46,6 +51,13 @@ abstract class WebTestCase extends KernelTestCase
     {
         if (static::$booted) {
             throw new \LogicException(\sprintf('Booting the kernel before calling "%s()" is not supported, the kernel should only be booted once.', __METHOD__));
+        }
+
+        $containerConfigurator = $options['configure_container'] ?? null;
+        unset($options['configure_container']);
+
+        if (null !== $containerConfigurator && !$containerConfigurator instanceof \Closure) {
+            throw new \InvalidArgumentException(\sprintf('The "configure_container" option must be a closure, "%s" given.', get_debug_type($containerConfigurator)));
         }
 
         if (!isset($_SERVER['APP_RUNTIME_MODE'])) {
@@ -65,6 +77,10 @@ abstract class WebTestCase extends KernelTestCase
         }
 
         $client->setServerParameters($server);
+
+        if ($containerConfigurator) {
+            $client->setContainerConfigurator($containerConfigurator);
+        }
 
         return self::getClient($client);
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/ConfigureContainer/Greeter.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/ConfigureContainer/Greeter.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\ConfigureContainer;
+
+class Greeter
+{
+    public function __construct(
+        private string $greeting = 'real',
+    ) {
+    }
+
+    public function greet(): string
+    {
+        return $this->greeting;
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Controller/ConfigureContainerController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Controller/ConfigureContainerController.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\ConfigureContainer\Greeter;
+use Symfony\Component\HttpFoundation\Response;
+
+class ConfigureContainerController
+{
+    public function __construct(
+        private Greeter $greeter,
+    ) {
+    }
+
+    public function __invoke(): Response
+    {
+        return new Response(\sprintf('<html><body><p>%s</p><a href="/configure_container">Next</a></body></html>', $this->greeter->greet()));
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ConfigureContainerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ConfigureContainerTest.php
@@ -1,0 +1,114 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
+
+use Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\ConfigureContainer\Greeter;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+class ConfigureContainerTest extends AbstractWebTestCase
+{
+    private static array $kernelOptions = [];
+
+    public function testTheServiceIsReplacedOnTheFirstRequest()
+    {
+        $calls = 0;
+        $client = $this->createClient(['test_case' => 'ConfigureContainer', 'configure_container' => self::greeterConfigurator('fake', $calls)]);
+
+        $client->request('GET', '/configure_container');
+
+        $this->assertStringContainsString('<p>fake</p>', $client->getResponse()->getContent());
+        $this->assertSame(1, $calls);
+    }
+
+    public function testTheServiceIsStillReplacedAfterAReboot()
+    {
+        $calls = 0;
+        $client = $this->createClient(['test_case' => 'ConfigureContainer', 'configure_container' => self::greeterConfigurator('fake', $calls)]);
+
+        $client->request('GET', '/configure_container');
+        $this->assertStringContainsString('<p>fake</p>', $client->getResponse()->getContent());
+
+        $client->request('GET', '/configure_container');
+        $this->assertStringContainsString('<p>fake</p>', $client->getResponse()->getContent());
+        $this->assertSame(2, $calls);
+    }
+
+    public function testTheServiceIsStillReplacedAfterFollowingALink()
+    {
+        $calls = 0;
+        $client = $this->createClient(['test_case' => 'ConfigureContainer', 'configure_container' => self::greeterConfigurator('fake', $calls)]);
+
+        $crawler = $client->request('GET', '/configure_container');
+        $client->click($crawler->selectLink('Next')->link());
+
+        $this->assertStringContainsString('<p>fake</p>', $client->getResponse()->getContent());
+        $this->assertSame(2, $calls);
+    }
+
+    public function testTheConfiguratorIsNotReappliedWhenRebootIsDisabled()
+    {
+        $calls = 0;
+        $client = $this->createClient(['test_case' => 'ConfigureContainer', 'configure_container' => self::greeterConfigurator('fake', $calls)]);
+        $client->disableReboot();
+
+        $client->request('GET', '/configure_container');
+        $client->request('GET', '/configure_container');
+
+        $this->assertStringContainsString('<p>fake</p>', $client->getResponse()->getContent());
+        $this->assertSame(1, $calls);
+    }
+
+    public function testTheOptionIsNotForwardedToCreateKernel()
+    {
+        $calls = 0;
+        $client = $this->createClient(['test_case' => 'ConfigureContainer', 'configure_container' => self::greeterConfigurator('fake', $calls)]);
+
+        $this->assertArrayNotHasKey('configure_container', self::$kernelOptions);
+        $this->assertSame('ConfigureContainer', self::$kernelOptions['test_case']);
+        $this->assertSame('fake', $client->getContainer()->get(Greeter::class)->greet());
+    }
+
+    public function testANonClosureIsRejected()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "configure_container" option must be a closure, "string" given.');
+
+        $this->createClient(['test_case' => 'ConfigureContainer', 'configure_container' => 'not a closure']);
+    }
+
+    public function testInsulatingRequestsIsRejected()
+    {
+        $calls = 0;
+        $client = $this->createClient(['test_case' => 'ConfigureContainer', 'configure_container' => self::greeterConfigurator('fake', $calls)]);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Cannot insulate requests when a container configurator is registered, as closures cannot be passed to the insulated process.');
+
+        $client->insulate();
+    }
+
+    protected static function createKernel(array $options = []): KernelInterface
+    {
+        self::$kernelOptions = $options;
+
+        return parent::createKernel($options);
+    }
+
+    private static function greeterConfigurator(string $greeting, int &$calls): \Closure
+    {
+        return static function (ContainerInterface $container) use ($greeting, &$calls) {
+            ++$calls;
+            $container->set(Greeter::class, new Greeter($greeting));
+        };
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ConfigureContainer/bundles.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ConfigureContainer/bundles.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\TestBundle;
+
+return [
+    new FrameworkBundle(),
+    new TestBundle(),
+];

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ConfigureContainer/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ConfigureContainer/config.yml
@@ -1,0 +1,3 @@
+imports:
+    - { resource: ../config/default.yml }
+    - { resource: services.yml }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ConfigureContainer/routing.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ConfigureContainer/routing.yml
@@ -1,0 +1,3 @@
+configure_container:
+    path:     /configure_container
+    defaults: { _controller: Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Controller\ConfigureContainerController }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ConfigureContainer/services.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ConfigureContainer/services.yml
@@ -1,0 +1,7 @@
+services:
+    Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\ConfigureContainer\Greeter: ~
+
+    Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Controller\ConfigureContainerController:
+        public: true
+        arguments:
+            - '@Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\ConfigureContainer\Greeter'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #49930
| License       | MIT
| Doc PR        | symfony/symfony-docs#22979

`KernelBrowser::doRequest()` reboots the kernel on every request after the first one. That includes crawler-driven requests: `click()`, `submit()` and redirect following all go through the same code path. So a service replaced with `self::getContainer()->set(...)` survives exactly one request and then silently vanishes: the test gets the real service back, with no error and no warning.

This adds a `configure_container` option to `WebTestCase::createClient()`, holding a closure that is applied to the container after *every* kernel boot, for the lifetime of the client:

```php
$client = self::createClient(['configure_container' => function (ContainerInterface $container) {
    $container->set(ClockInterface::class, $clock);
}]);

$crawler = $client->request('GET', '/');
$clock->sleep(3600);
$client->click($crawler->selectLink('Next')->link()); // reboots, and the closure is applied again
```

The closure receives the container returned by `KernelBrowser::getContainer()`, which resolves `test.service_container` when available, so private services can be replaced. It runs on a freshly booted, untouched container, which is required since `TestContainer::set()` refuses to replace a private service that has already been initialized.

Why `$options` and not a new parameter on `createClient()`: overriding `createClient()` in a project base test case is a very common pattern, and PHP fatals when a child method declares fewer parameters than its parent. Adding a third argument would break every such override. `KernelTestCase::createKernel()` already documents `$options` as an extensible bag and reads only the keys it knows about, so this fits. `createClient()` extracts the key and `unset()`s it before booting, so a user-defined `createKernel()` never sees the closure.

Notes:
* with `disableReboot()` there is no new boot, so the closure is not re-applied (the container simply keeps what was set);
* insulated requests run in a separate process and serialize their state, which a closure cannot cross, so registering a configurator and calling `insulate()` now throws a clear `LogicException` instead of failing obscurely;
* passing a non-closure under the key throws an `InvalidArgumentException`;
* `KernelBrowser::setContainerConfigurator()` is public but `@internal` for now, to keep the public surface minimal. It can be opened up later if re-registering mid-test turns out to be useful.

The documentation is symfony/symfony-docs#22979. Note that `testing.rst` currently recommends `$container->set(...)` under "Mocking Dependencies" with no mention of the reboot, so that PR also adds a warning there.

Thanks to @lyrixx for reporting the issue, and to @nikophil and @benito103e who both volunteered to implement it and never got an answer.

