### PR TITLE
[Routing] Add a test about removing default query params

### DIFF
--- a/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
@@ -1173,6 +1173,20 @@ class UrlGeneratorTest extends TestCase
         $this->assertSame('/app.php/user', $url);
     }
 
+    public function testQueryParametersDefinedAsDefaultsCanBeRemovedByParameters()
+    {
+        $routes = $this->getRoutes('user', new Route('/user', [
+            '_query' => [
+                'page' => 1,
+                'sort' => 'name',
+            ],
+        ]));
+
+        $url = $this->getGenerator($routes)->generate('user', ['sort' => null]);
+
+        $this->assertSame('/app.php/user?page=1', $url);
+    }
+
     public function testQueryParametersDefinedAsDefaultsMustBeAnArray()
     {
         $routes = $this->getRoutes('user', new Route('/user', ['_query' => 'page=1']));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

While merging https://github.com/symfony/symfony-docs/pull/22609 (related to #65073) I realized that there is no test for the condition of removing a default query param directly as `['param' => null]` instead of `['_query' => ['param' => null]]`.