### PR TITLE
[Validator] Add #[WithHttpStatus(422)] to ValidationFailedException

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.2
 ---
 
+ * Add `#[WithHttpStatus(422)]` to `ValidationFailedException`, so that an uncaught one renders as an "Unprocessable Content" response instead of a 500 one
  * Add `ValidationBundle`, which provides the `validation` configuration and the services previously provided by `FrameworkBundle` under `framework.validation`
  * Add `CacheWarmer\ValidatorCacheWarmer` and `DependencyInjection\AddValidatorSecurityExpressionLanguageProviderPass`, which `FrameworkBundle` used to provide
  * Accept the `::class` constant of the annotated class in `GroupSequence` definitions

--- a/src/Symfony/Component/Validator/Exception/ValidationFailedException.php
+++ b/src/Symfony/Component/Validator/Exception/ValidationFailedException.php
@@ -11,11 +11,13 @@
 
 namespace Symfony\Component\Validator\Exception;
 
+use Symfony\Component\HttpKernel\Attribute\WithHttpStatus;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
 
 /**
  * @author Jan Vernieuwe <jan.vernieuwe@phpro.be>
  */
+#[WithHttpStatus(422)]
 class ValidationFailedException extends RuntimeException
 {
     public function __construct(

--- a/src/Symfony/Component/Validator/Tests/Exception/ValidationFailedExceptionTest.php
+++ b/src/Symfony/Component/Validator/Tests/Exception/ValidationFailedExceptionTest.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Exception;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\EventListener\ErrorListener;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\ConstraintViolationList;
+use Symfony\Component\Validator\Exception\ValidationFailedException;
+
+class ValidationFailedExceptionTest extends TestCase
+{
+    public function testItIsRenderedAsUnprocessableEntity()
+    {
+        $exception = $this->createException();
+        $event = $this->createExceptionEvent($exception);
+
+        (new ErrorListener('not used'))->logKernelException($event);
+
+        $throwable = $event->getThrowable();
+
+        $this->assertInstanceOf(HttpExceptionInterface::class, $throwable);
+        $this->assertSame(422, $throwable->getStatusCode());
+    }
+
+    public function testTheViolationsStayReachableFromTheHttpException()
+    {
+        $exception = $this->createException();
+        $event = $this->createExceptionEvent($exception);
+
+        (new ErrorListener('not used'))->logKernelException($event);
+
+        $this->assertSame($exception, $event->getThrowable()->getPrevious());
+    }
+
+    public function testAnExplicitStatusCodeWins()
+    {
+        $exception = $this->createException();
+        $event = $this->createExceptionEvent($exception);
+
+        (new ErrorListener('not used', null, false, [
+            ValidationFailedException::class => ['log_level' => 'warning', 'status_code' => 400],
+        ]))->logKernelException($event);
+
+        $throwable = $event->getThrowable();
+
+        $this->assertInstanceOf(HttpExceptionInterface::class, $throwable);
+        $this->assertSame(400, $throwable->getStatusCode());
+    }
+
+    private function createException(): ValidationFailedException
+    {
+        return new ValidationFailedException('foo', new ConstraintViolationList([
+            new ConstraintViolation('This value should not be blank.', null, [], 'foo', 'name', ''),
+        ]));
+    }
+
+    private function createExceptionEvent(ValidationFailedException $exception): ExceptionEvent
+    {
+        return new ExceptionEvent($this->createStub(HttpKernelInterface::class), new Request(), HttpKernelInterface::MAIN_REQUEST, $exception);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #60234
| License       | MIT

`#[MapRequestPayload]` turns a validation failure into a proper 422 with a `violations` payload, because `RequestPayloadValueResolver` wraps the `ValidationFailedException` in an `HttpException` itself. Nothing else does. A plain `$validator->validate()` failure, or one coming out of `Validation::createCallable()`, reaches `ErrorListener` as a bare `RuntimeException` and renders as a 500 with no violations at all, since `ProblemNormalizer` only looks at `getPrevious()` when the top-level exception implements `HttpExceptionInterface`.

That is the whole gap #60234 described, and it closes with an attribute rather than a new exception class:

```php
#[WithHttpStatus(422)]
class ValidationFailedException extends RuntimeException
```

`ErrorListener::logKernelException()` already reads `WithHttpStatus` through `getInheritedAttribute()`, so this needs no new API and no change to any consumer. The resulting response is the same one `#[MapRequestPayload]` produces today:

```json
{
    "type": "https://symfony.com/errors/validation",
    "title": "Validation Failed",
    "status": 422,
    "detail": "name: This value should not be blank.",
    "violations": [
        {"propertyPath": "name", "title": "This value should not be blank.", "template": "...", "parameters": []}
    ]
}
```

Why not a new `ValidationException`, which is what the two earlier attempts (#61929 and #61942) built: it would have to be thrown explicitly to be useful, so it fixes nothing that already exists, whereas the attribute covers `Validation::createCallable()` and every `throw new ValidationFailedException(...)` already in the wild. A class named `ValidationException` sitting next to `Validator\ValidationFailedException` and `Messenger\ValidationFailedException` would also be a poor thing to name. This is the direction mtarld's review on #61942 was already pointing at.

This follows the existing precedent for exceptions that carry their own status: `Security\Core\Exception\AccessDeniedException` (403), `AuthenticationException` (401), `HttpFoundation\Exception\SignedUriException` (404) and `ExpiredSignedUriException` (403). Like those, it needs no new `require`: `symfony/http-kernel` is already in the Validator's `require-dev` with the same constraint HttpFoundation uses, and a class-level attribute is only resolved when something reflects on it, which only happens when HttpKernel is installed.

Two things worth noting for review:

- This is a behaviour change on a feature branch: an uncaught `ValidationFailedException` that returns 500 today returns 422 after this. That is the point of the issue, and the `framework.exceptions` mapping still wins over the attribute, so anyone who already configured a different status keeps it. There is a test for that.
- `Messenger\Exception\ValidationFailedException` is a separate class extending Messenger's own `RuntimeException`, so it does not inherit this. `ProblemNormalizer` already handles both, and whether the Messenger one should carry a status is a different question.

Reported by @lyrixx, who also asked for exactly this consistency. @momito69 made the two earlier attempts and @thePanz confirmed the need with his own `HttpExceptionBuilder` workaround.
