### PR TITLE
[Messenger] Extract the failed-message logic out of the console commands

### DIFF
--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.2
 ---
 
+ * Add `FailedMessageRepository` and `FailedMessageFilter` to list, inspect, remove and redispatch failed messages outside the console
  * Add `MessengerBundle`, which provides the `messenger` configuration and the services previously provided by `FrameworkBundle` under `framework.messenger`
  * Add claim check support with `ClaimCheckSerializer` and PSR-6 cache pools
  * Add routing and failure transport information and a `--message` option to the `debug:messenger` command

--- a/src/Symfony/Component/Messenger/Command/AbstractFailedMessagesCommand.php
+++ b/src/Symfony/Component/Messenger/Command/AbstractFailedMessagesCommand.php
@@ -23,14 +23,12 @@ use Symfony\Component\ErrorHandler\Exception\FlattenException;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\InvalidArgumentException;
 use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
+use Symfony\Component\Messenger\Failure\FailedMessageFilter;
+use Symfony\Component\Messenger\Failure\FailedMessageRepository;
 use Symfony\Component\Messenger\Stamp\ErrorDetailsStamp;
 use Symfony\Component\Messenger\Stamp\MessageDecodingFailedStamp;
 use Symfony\Component\Messenger\Stamp\RedeliveryStamp;
 use Symfony\Component\Messenger\Stamp\SentToFailureTransportStamp;
-use Symfony\Component\Messenger\Stamp\TransportMessageIdStamp;
-use Symfony\Component\Messenger\Transport\Receiver\ListableReceiverInterface;
-use Symfony\Component\Messenger\Transport\Receiver\MessageCountAwareInterface;
-use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
 use Symfony\Component\Messenger\Transport\Serialization\PhpSerializer;
 use Symfony\Component\VarDumper\Caster\Caster;
 use Symfony\Component\VarDumper\Caster\TraceStub;
@@ -48,27 +46,24 @@ abstract class AbstractFailedMessagesCommand extends Command
 {
     protected const DEFAULT_TRANSPORT_OPTION = 'choose';
 
+    protected FailedMessageRepository $repository;
+
     public function __construct(
-        private ?string $globalFailureReceiverName,
+        ?string $globalFailureReceiverName,
         /**
-         * @var ServiceProviderInterface<ReceiverInterface>
+         * @var ServiceProviderInterface<\Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface>
          */
         protected ServiceProviderInterface $failureTransports,
         protected ?PhpSerializer $phpSerializer = null,
     ) {
         parent::__construct();
+
+        $this->repository = new FailedMessageRepository($failureTransports, $globalFailureReceiverName, $phpSerializer);
     }
 
     protected function getGlobalFailureReceiverName(): ?string
     {
-        return $this->globalFailureReceiverName;
-    }
-
-    protected function getMessageId(Envelope $envelope): mixed
-    {
-        $stamp = $envelope->last(TransportMessageIdStamp::class);
-
-        return $stamp?->getId();
+        return $this->repository->getGlobalTransportName();
     }
 
     protected function displaySingleMessage(Envelope $envelope, SymfonyStyle $io, ?SymfonyStyle $errorIo = null): void
@@ -85,7 +80,7 @@ abstract class AbstractFailedMessagesCommand extends Command
             ['Class', $messageClass],
         ];
 
-        if (null !== $id = $this->getMessageId($envelope)) {
+        if (null !== $id = FailedMessageRepository::getMessageId($envelope)) {
             $rows[] = ['Message Id', $id];
         }
 
@@ -128,85 +123,35 @@ abstract class AbstractFailedMessagesCommand extends Command
         }
     }
 
-    protected function printPendingMessagesMessage(ReceiverInterface $receiver, SymfonyStyle $io): void
+    protected function printPendingMessagesMessage(?string $failureTransportName, SymfonyStyle $io): void
     {
-        if ($receiver instanceof MessageCountAwareInterface) {
-            if (1 === $receiver->getMessageCount()) {
-                $io->writeln('There is <info>1</info> message pending in the failure transport.');
-            } else {
-                $io->writeln(\sprintf('There are <info>%d</info> messages pending in the failure transport.', $receiver->getMessageCount()));
-            }
+        if (null === $count = $this->repository->count($failureTransportName)) {
+            return;
+        }
+
+        if (1 === $count) {
+            $io->writeln('There is <info>1</info> message pending in the failure transport.');
+        } else {
+            $io->writeln(\sprintf('There are <info>%d</info> messages pending in the failure transport.', $count));
         }
     }
 
     /**
      * @param bool $hasIds Whether explicit message ids were given, which the filters cannot be combined with
-     *
-     * @return array{?string, ?\DateTimeImmutable, ?\DateTimeImmutable} The class name, the earliest and the latest failure time to select
      */
-    protected function getFilters(InputInterface $input, bool $hasIds): array
+    protected function getFilter(InputInterface $input, bool $hasIds): FailedMessageFilter
     {
-        $classFilter = $input->getOption('class-filter');
-        $failedAfter = $this->getDateOption($input, 'failed-after');
-        $failedBefore = $this->getDateOption($input, 'failed-before');
+        $filter = new FailedMessageFilter(
+            $input->getOption('class-filter'),
+            $this->getDateOption($input, 'failed-after'),
+            $this->getDateOption($input, 'failed-before'),
+        );
 
-        if ($hasIds && (null !== $classFilter || null !== $failedAfter || null !== $failedBefore)) {
+        if ($hasIds && !$filter->isEmpty()) {
             throw new RuntimeException('You cannot specify message ids when using the "--class-filter", "--failed-after" or "--failed-before" options.');
         }
 
-        return [$classFilter, $failedAfter, $failedBefore];
-    }
-
-    /**
-     * @return list<mixed> The ids of the messages matching every given filter
-     */
-    protected function getMessageIdsByFilter(ListableReceiverInterface $receiver, ?string $classFilter, ?\DateTimeImmutable $failedAfter, ?\DateTimeImmutable $failedBefore): array
-    {
-        $ids = [];
-
-        $this->phpSerializer?->acceptPhpIncompleteClass();
-        try {
-            foreach ($receiver->all() as $envelope) {
-                if ($this->matchesFilter($envelope, $classFilter, $failedAfter, $failedBefore)) {
-                    $ids[] = $this->getMessageId($envelope);
-                }
-            }
-        } finally {
-            $this->phpSerializer?->rejectPhpIncompleteClass();
-        }
-
-        return $ids;
-    }
-
-    protected function matchesFilter(Envelope $envelope, ?string $classFilter, ?\DateTimeImmutable $failedAfter, ?\DateTimeImmutable $failedBefore): bool
-    {
-        if (null !== $classFilter && $classFilter !== $envelope->getMessage()::class) {
-            return false;
-        }
-
-        if (null === $failedAfter && null === $failedBefore) {
-            return true;
-        }
-
-        // messages that were never redelivered have no known failure time, so no time window can select them
-        if (null === $failedAt = $envelope->last(RedeliveryStamp::class)?->getRedeliveredAt()) {
-            return false;
-        }
-
-        return (null === $failedAfter || $failedAt >= $failedAfter) && (null === $failedBefore || $failedAt <= $failedBefore);
-    }
-
-    protected function getReceiver(?string $name = null): ReceiverInterface
-    {
-        if (null === $name ??= $this->globalFailureReceiverName) {
-            throw new InvalidArgumentException(\sprintf('No default failure transport is defined. Available transports are: "%s".', implode('", "', array_keys($this->failureTransports->getProvidedServices()))));
-        }
-
-        if (!$this->failureTransports->has($name)) {
-            throw new InvalidArgumentException(\sprintf('The "%s" failure transport was not found. Available transports are: "%s".', $name, implode('", "', array_keys($this->failureTransports->getProvidedServices()))));
-        }
-
-        return $this->failureTransports->get($name);
+        return $filter;
     }
 
     private function getDateOption(InputInterface $input, string $option): ?\DateTimeImmutable
@@ -247,7 +192,7 @@ abstract class AbstractFailedMessagesCommand extends Command
 
     protected function printWarningAvailableFailureTransports(SymfonyStyle $io, ?string $failureTransportName): void
     {
-        $failureTransports = array_keys($this->failureTransports->getProvidedServices());
+        $failureTransports = $this->repository->getTransportNames();
         $failureTransportsCount = \count($failureTransports);
         if ($failureTransportsCount > 1) {
             $io->writeln([
@@ -261,7 +206,7 @@ abstract class AbstractFailedMessagesCommand extends Command
 
     protected function interactiveChooseFailureTransport(SymfonyStyle $io): string
     {
-        $failedTransports = array_keys($this->failureTransports->getProvidedServices());
+        $failedTransports = $this->repository->getTransportNames();
         $question = new ChoiceQuestion('Select failed transport:', $failedTransports, 0);
         $question->setMultiselect(false);
 
@@ -271,7 +216,7 @@ abstract class AbstractFailedMessagesCommand extends Command
     public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void
     {
         if ($input->mustSuggestOptionValuesFor('transport')) {
-            $suggestions->suggestValues(array_keys($this->failureTransports->getProvidedServices()));
+            $suggestions->suggestValues($this->repository->getTransportNames());
 
             return;
         }
@@ -279,15 +224,14 @@ abstract class AbstractFailedMessagesCommand extends Command
         if ($input->mustSuggestArgumentValuesFor('id')) {
             $transport = $input->getOption('transport');
             $transport = self::DEFAULT_TRANSPORT_OPTION === $transport ? $this->getGlobalFailureReceiverName() : $transport;
-            $receiver = $this->getReceiver($transport);
 
-            if (!$receiver instanceof ListableReceiverInterface) {
+            if (!$this->repository->supportsListing($transport)) {
                 return;
             }
 
             $ids = [];
-            foreach ($receiver->all(50) as $envelope) {
-                $ids[] = $this->getMessageId($envelope);
+            foreach ($this->repository->all($transport, limit: 50) as $envelope) {
+                $ids[] = FailedMessageRepository::getMessageId($envelope);
             }
             $suggestions->suggestValues($ids);
         }

--- a/src/Symfony/Component/Messenger/Command/FailedMessagesRemoveCommand.php
+++ b/src/Symfony/Component/Messenger/Command/FailedMessagesRemoveCommand.php
@@ -18,8 +18,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use Symfony\Component\Messenger\Transport\Receiver\ListableReceiverInterface;
-use Symfony\Component\Messenger\Transport\Receiver\MessageCountAwareInterface;
+use Symfony\Component\Messenger\Failure\FailedMessageRepository;
 
 /**
  * @author Ryan Weaver <ryan@symfonycasts.com>
@@ -74,22 +73,20 @@ class FailedMessagesRemoveCommand extends AbstractFailedMessagesCommand
         $errorIo = $io->getErrorStyle();
 
         $ids = (array) $input->getArgument('id');
-        [$classFilter, $failedAfter, $failedBefore] = $this->getFilters($input, (bool) $ids);
-        $hasFilters = null !== $classFilter || null !== $failedAfter || null !== $failedBefore;
+        $filter = $this->getFilter($input, (bool) $ids);
+        $hasFilters = !$filter->isEmpty();
 
         $failureTransportName = $input->getOption('transport');
         if (self::DEFAULT_TRANSPORT_OPTION === $failureTransportName) {
             $failureTransportName = $this->getGlobalFailureReceiverName();
         }
 
-        $receiver = $this->getReceiver($failureTransportName);
-
         $shouldForce = $input->getOption('force');
         $shouldDeleteAllMessages = $input->getOption('all');
 
         $idsCount = \count($ids);
 
-        if (!$receiver instanceof ListableReceiverInterface) {
+        if (!$this->repository->supportsListing($failureTransportName)) {
             throw new RuntimeException(\sprintf('The "%s" receiver does not support removing specific messages.', $failureTransportName));
         }
 
@@ -98,7 +95,10 @@ class FailedMessagesRemoveCommand extends AbstractFailedMessagesCommand
         }
 
         if ($hasFilters) {
-            $ids = $this->getMessageIdsByFilter($receiver, $classFilter, $failedAfter, $failedBefore);
+            $ids = [];
+            foreach ($this->repository->all($failureTransportName, $filter) as $envelope) {
+                $ids[] = FailedMessageRepository::getMessageId($envelope);
+            }
             $idsCount = \count($ids);
 
             if (!$idsCount) {
@@ -119,23 +119,18 @@ class FailedMessagesRemoveCommand extends AbstractFailedMessagesCommand
         $shouldDisplayMessages = $input->getOption('show-messages') || 1 === $idsCount;
 
         if ($shouldDeleteAllMessages) {
-            $this->removeAllMessages($receiver, $io, $errorIo, $shouldForce, $shouldDisplayMessages);
+            $this->removeAllMessages($failureTransportName, $io, $errorIo, $shouldForce, $shouldDisplayMessages);
         } else {
-            $this->removeMessagesById($ids, $receiver, $io, $errorIo, $shouldForce, $shouldDisplayMessages);
+            $this->removeMessagesById($ids, $failureTransportName, $io, $errorIo, $shouldForce, $shouldDisplayMessages);
         }
 
         return 0;
     }
 
-    private function removeMessagesById(array $ids, ListableReceiverInterface $receiver, SymfonyStyle $io, SymfonyStyle $errorIo, bool $shouldForce, bool $shouldDisplayMessages): void
+    private function removeMessagesById(array $ids, string $failureTransportName, SymfonyStyle $io, SymfonyStyle $errorIo, bool $shouldForce, bool $shouldDisplayMessages): void
     {
         foreach ($ids as $id) {
-            $this->phpSerializer?->acceptPhpIncompleteClass();
-            try {
-                $envelope = $receiver->find($id);
-            } finally {
-                $this->phpSerializer?->rejectPhpIncompleteClass();
-            }
+            $envelope = $this->repository->find($id, $failureTransportName);
 
             if (null === $envelope) {
                 $errorIo->error(\sprintf('The message with id "%s" was not found.', $id));
@@ -147,7 +142,7 @@ class FailedMessagesRemoveCommand extends AbstractFailedMessagesCommand
             }
 
             if ($shouldForce || $errorIo->confirm('Do you want to permanently remove this message?', false)) {
-                $receiver->reject($envelope);
+                $this->repository->remove($envelope, $failureTransportName);
 
                 $io->success(\sprintf('Message with id %s removed.', $id));
             } else {
@@ -156,11 +151,11 @@ class FailedMessagesRemoveCommand extends AbstractFailedMessagesCommand
         }
     }
 
-    private function removeAllMessages(ListableReceiverInterface $receiver, SymfonyStyle $io, SymfonyStyle $errorIo, bool $shouldForce, bool $shouldDisplayMessages): void
+    private function removeAllMessages(string $failureTransportName, SymfonyStyle $io, SymfonyStyle $errorIo, bool $shouldForce, bool $shouldDisplayMessages): void
     {
         if (!$shouldForce) {
-            if ($receiver instanceof MessageCountAwareInterface) {
-                $question = \sprintf('Do you want to permanently remove all (%d) messages?', $receiver->getMessageCount());
+            if (null !== $pending = $this->repository->count($failureTransportName)) {
+                $question = \sprintf('Do you want to permanently remove all (%d) messages?', $pending);
             } else {
                 $question = 'Do you want to permanently remove all failed messages?';
             }
@@ -171,12 +166,12 @@ class FailedMessagesRemoveCommand extends AbstractFailedMessagesCommand
         }
 
         $count = 0;
-        foreach ($receiver->all() as $envelope) {
+        foreach ($this->repository->all($failureTransportName) as $envelope) {
             if ($shouldDisplayMessages) {
                 $this->displaySingleMessage($envelope, $io, $errorIo);
             }
 
-            $receiver->reject($envelope);
+            $this->repository->remove($envelope, $failureTransportName);
             ++$count;
         }
 

--- a/src/Symfony/Component/Messenger/Command/FailedMessagesRetryCommand.php
+++ b/src/Symfony/Component/Messenger/Command/FailedMessagesRetryCommand.php
@@ -24,10 +24,9 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Messenger\Event\WorkerMessageReceivedEvent;
 use Symfony\Component\Messenger\Event\WorkerMessageSkipEvent;
 use Symfony\Component\Messenger\EventListener\StopWorkerOnMessageLimitListener;
+use Symfony\Component\Messenger\Failure\FailedMessageRepository;
 use Symfony\Component\Messenger\MessageBusInterface;
-use Symfony\Component\Messenger\Stamp\NonSendableStampInterface;
 use Symfony\Component\Messenger\Stamp\SentToFailureTransportStamp;
-use Symfony\Component\Messenger\Stamp\TransportMessageIdStamp;
 use Symfony\Component\Messenger\Transport\Receiver\ListableReceiverInterface;
 use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
 use Symfony\Component\Messenger\Transport\Receiver\SingleMessageReceiver;
@@ -123,7 +122,7 @@ class FailedMessagesRetryCommand extends AbstractFailedMessagesCommand implement
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $ids = $input->getArgument('id');
-        [$classFilter, $failedAfter, $failedBefore] = $this->getFilters($input, (bool) $ids);
+        $filter = $this->getFilter($input, (bool) $ids);
 
         $this->eventDispatcher->addSubscriber(new StopWorkerOnMessageLimitListener(1));
 
@@ -143,20 +142,22 @@ class FailedMessagesRetryCommand extends AbstractFailedMessagesCommand implement
         }
         $failureTransportName = self::DEFAULT_TRANSPORT_OPTION === $failureTransportName ? $this->getGlobalFailureReceiverName() : $failureTransportName;
 
-        $receiver = $this->getReceiver($failureTransportName);
-        $this->printPendingMessagesMessage($receiver, $io);
+        $this->printPendingMessagesMessage($failureTransportName, $io);
 
         $io->writeln(\sprintf('To retry all the messages, run <comment>messenger:consume %s</comment>', $failureTransportName));
 
         $shouldForce = $input->getOption('force');
         $shouldRedispatch = $input->getOption('redispatch');
 
-        if (null !== $classFilter || null !== $failedAfter || null !== $failedBefore) {
-            if (!$receiver instanceof ListableReceiverInterface) {
+        if (!$filter->isEmpty()) {
+            if (!$this->repository->supportsListing($failureTransportName)) {
                 throw new RuntimeException(\sprintf('The "%s" receiver does not support filtering messages.', $failureTransportName));
             }
 
-            $ids = $this->getMessageIdsByFilter($receiver, $classFilter, $failedAfter, $failedBefore);
+            $ids = [];
+            foreach ($this->repository->all($failureTransportName, $filter) as $envelope) {
+                $ids[] = FailedMessageRepository::getMessageId($envelope);
+            }
 
             if (!$ids) {
                 throw new RuntimeException('No failed messages were found with this filter.');
@@ -217,7 +218,7 @@ class FailedMessagesRetryCommand extends AbstractFailedMessagesCommand implement
 
     private function runInteractive(string $failureTransportName, SymfonyStyle $io, SymfonyStyle $errorIo, bool $shouldForce, bool $shouldRedispatch): void
     {
-        $receiver = $this->failureTransports->get($failureTransportName);
+        $receiver = $this->repository->getReceiver($failureTransportName);
         $count = 0;
         if ($receiver instanceof ListableReceiverInterface) {
             // for listable receivers, find the messages one-by-one
@@ -227,14 +228,9 @@ class FailedMessagesRetryCommand extends AbstractFailedMessagesCommand implement
             // handling the message
             while (!$this->shouldStop) {
                 $envelopes = [];
-                $this->phpSerializer?->acceptPhpIncompleteClass();
-                try {
-                    foreach ($receiver->all(1) as $envelope) {
-                        ++$count;
-                        $envelopes[] = $envelope;
-                    }
-                } finally {
-                    $this->phpSerializer?->rejectPhpIncompleteClass();
+                foreach ($this->repository->all($failureTransportName, limit: 1) as $envelope) {
+                    ++$count;
+                    $envelopes[] = $envelope;
                 }
 
                 // break the loop if all messages are consumed
@@ -277,11 +273,7 @@ class FailedMessagesRetryCommand extends AbstractFailedMessagesCommand implement
                     $messageReceivedEvent->shouldHandle(false);
 
                     try {
-                        $this->messageBus->dispatch($envelope
-                            ->withoutStampsOfType(NonSendableStampInterface::class)
-                            ->withoutAll(SentToFailureTransportStamp::class)
-                            ->withoutAll(TransportMessageIdStamp::class)
-                        );
+                        $this->messageBus->dispatch(FailedMessageRepository::prepareForRedispatch($envelope));
                     } catch (\Throwable $e) {
                         // the message is left on the failure transport so that
                         // it can be redispatched once the cause is fixed
@@ -327,19 +319,14 @@ class FailedMessagesRetryCommand extends AbstractFailedMessagesCommand implement
 
     private function retrySpecificIds(string $failureTransportName, array $ids, SymfonyStyle $io, SymfonyStyle $errorIo, bool $shouldForce, bool $shouldRedispatch): void
     {
-        $receiver = $this->getReceiver($failureTransportName);
+        $receiver = $this->repository->getReceiver($failureTransportName);
 
         if (!$receiver instanceof ListableReceiverInterface) {
             throw new RuntimeException(\sprintf('The "%s" receiver does not support retrying messages by id.', $failureTransportName));
         }
 
         foreach ($ids as $id) {
-            $this->phpSerializer?->acceptPhpIncompleteClass();
-            try {
-                $envelope = $receiver->find($id);
-            } finally {
-                $this->phpSerializer?->rejectPhpIncompleteClass();
-            }
+            $envelope = $this->repository->find($id, $failureTransportName);
             if (null === $envelope) {
                 throw new RuntimeException(\sprintf('The message "%s" was not found.', $id));
             }
@@ -355,7 +342,7 @@ class FailedMessagesRetryCommand extends AbstractFailedMessagesCommand implement
 
     private function retrySpecificEnvelopes(array $envelopes, string $failureTransportName, SymfonyStyle $io, SymfonyStyle $errorIo, bool $shouldForce, bool $shouldRedispatch): void
     {
-        $receiver = $this->getReceiver($failureTransportName);
+        $receiver = $this->repository->getReceiver($failureTransportName);
 
         foreach ($envelopes as $envelope) {
             $singleReceiver = new SingleMessageReceiver($receiver, $envelope);

--- a/src/Symfony/Component/Messenger/Command/FailedMessagesShowCommand.php
+++ b/src/Symfony/Component/Messenger/Command/FailedMessagesShowCommand.php
@@ -18,9 +18,10 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Messenger\Failure\FailedMessageFilter;
+use Symfony\Component\Messenger\Failure\FailedMessageRepository;
 use Symfony\Component\Messenger\Stamp\ErrorDetailsStamp;
 use Symfony\Component\Messenger\Stamp\RedeliveryStamp;
-use Symfony\Component\Messenger\Transport\Receiver\ListableReceiverInterface;
 
 /**
  * @author Ryan Weaver <ryan@symfonycasts.com>
@@ -70,7 +71,7 @@ class FailedMessagesShowCommand extends AbstractFailedMessagesCommand
         $errorIo = $io->getErrorStyle();
 
         $id = $input->getArgument('id');
-        [$classFilter, $failedAfter, $failedBefore] = $this->getFilters($input, null !== $id);
+        $filter = $this->getFilter($input, null !== $id);
 
         $failureTransportName = $input->getOption('transport');
         if (self::DEFAULT_TRANSPORT_OPTION === $failureTransportName) {
@@ -81,61 +82,48 @@ class FailedMessagesShowCommand extends AbstractFailedMessagesCommand
         }
         $failureTransportName = self::DEFAULT_TRANSPORT_OPTION === $failureTransportName ? $this->getGlobalFailureReceiverName() : $failureTransportName;
 
-        $receiver = $this->getReceiver($failureTransportName);
+        $this->printPendingMessagesMessage($failureTransportName, $io);
 
-        $this->printPendingMessagesMessage($receiver, $io);
-
-        if (!$receiver instanceof ListableReceiverInterface) {
+        if (!$this->repository->supportsListing($failureTransportName)) {
             throw new RuntimeException(\sprintf('The "%s" receiver does not support listing or showing specific messages.', $failureTransportName));
         }
 
         if ($input->getOption('stats')) {
             $max = $input->hasParameterOption(['--max'], true) ? $input->getOption('max') : null;
-            $this->listMessagesPerClass($receiver, $io, $max, $classFilter, $failedAfter, $failedBefore);
+            $this->listMessagesPerClass($failureTransportName, $io, $max, $filter);
         } elseif (null === $id) {
-            $this->listMessages($receiver, $failureTransportName, $io, $errorIo, $input->getOption('max'), $classFilter, $failedAfter, $failedBefore);
+            $this->listMessages($failureTransportName, $io, $errorIo, $input->getOption('max'), $filter);
         } else {
-            $this->showMessage($receiver, $failureTransportName, $id, $io, $errorIo);
+            $this->showMessage($failureTransportName, $id, $io, $errorIo);
         }
 
         return 0;
     }
 
-    private function listMessages(ListableReceiverInterface $receiver, string $failedTransportName, SymfonyStyle $io, SymfonyStyle $errorIo, int $max, ?string $classFilter, ?\DateTimeImmutable $failedAfter, ?\DateTimeImmutable $failedBefore): void
+    private function listMessages(string $failedTransportName, SymfonyStyle $io, SymfonyStyle $errorIo, int $max, FailedMessageFilter $filter): void
     {
-        $envelopes = $receiver->all($max);
-
         $rows = [];
 
-        if ($classFilter) {
-            $errorIo->comment(\sprintf('Displaying only \'%s\' messages', $classFilter));
+        if ($filter->class) {
+            $errorIo->comment(\sprintf('Displaying only \'%s\' messages', $filter->class));
         }
-        if ($failedAfter) {
-            $errorIo->comment(\sprintf('Displaying only messages that failed after %s', $failedAfter->format('Y-m-d H:i:s')));
+        if ($filter->failedAfter) {
+            $errorIo->comment(\sprintf('Displaying only messages that failed after %s', $filter->failedAfter->format('Y-m-d H:i:s')));
         }
-        if ($failedBefore) {
-            $errorIo->comment(\sprintf('Displaying only messages that failed before %s', $failedBefore->format('Y-m-d H:i:s')));
+        if ($filter->failedBefore) {
+            $errorIo->comment(\sprintf('Displaying only messages that failed before %s', $filter->failedBefore->format('Y-m-d H:i:s')));
         }
 
-        $this->phpSerializer?->acceptPhpIncompleteClass();
-        try {
-            foreach ($envelopes as $envelope) {
-                if (!$this->matchesFilter($envelope, $classFilter, $failedAfter, $failedBefore)) {
-                    continue;
-                }
+        foreach ($this->repository->all($failedTransportName, $filter, $max) as $envelope) {
+            $lastRedeliveryStamp = $envelope->last(RedeliveryStamp::class);
+            $lastErrorDetailsStamp = $envelope->last(ErrorDetailsStamp::class);
 
-                $lastRedeliveryStamp = $envelope->last(RedeliveryStamp::class);
-                $lastErrorDetailsStamp = $envelope->last(ErrorDetailsStamp::class);
-
-                $rows[] = [
-                    $this->getMessageId($envelope),
-                    $envelope->getMessage()::class,
-                    null === $lastRedeliveryStamp ? '' : $lastRedeliveryStamp->getRedeliveredAt()->format('Y-m-d H:i:s'),
-                    $lastErrorDetailsStamp?->getExceptionMessage() ?? '',
-                ];
-            }
-        } finally {
-            $this->phpSerializer?->rejectPhpIncompleteClass();
+            $rows[] = [
+                FailedMessageRepository::getMessageId($envelope),
+                $envelope->getMessage()::class,
+                null === $lastRedeliveryStamp ? '' : $lastRedeliveryStamp->getRedeliveredAt()->format('Y-m-d H:i:s'),
+                $lastErrorDetailsStamp?->getExceptionMessage() ?? '',
+            ];
         }
 
         $rowsCount = \count($rows);
@@ -150,36 +138,25 @@ class FailedMessagesShowCommand extends AbstractFailedMessagesCommand
 
         if ($rowsCount === $max) {
             $errorIo->comment(\sprintf('Showing first %d messages.', $max));
-        } elseif ($classFilter || $failedAfter || $failedBefore) {
+        } elseif (!$filter->isEmpty()) {
             $errorIo->comment(\sprintf('Showing %d message(s).', $rowsCount));
         }
 
         $errorIo->comment(\sprintf('Run <comment>messenger:failed:show {id} --transport=%s -vv</comment> to see message details.', $failedTransportName));
     }
 
-    private function listMessagesPerClass(ListableReceiverInterface $receiver, SymfonyStyle $io, ?int $max, ?string $classFilter, ?\DateTimeImmutable $failedAfter, ?\DateTimeImmutable $failedBefore): void
+    private function listMessagesPerClass(string $failedTransportName, SymfonyStyle $io, ?int $max, FailedMessageFilter $filter): void
     {
-        $envelopes = $receiver->all($max);
-
         $countPerClass = [];
 
-        $this->phpSerializer?->acceptPhpIncompleteClass();
-        try {
-            foreach ($envelopes as $envelope) {
-                if (!$this->matchesFilter($envelope, $classFilter, $failedAfter, $failedBefore)) {
-                    continue;
-                }
+        foreach ($this->repository->all($failedTransportName, $filter, $max) as $envelope) {
+            $c = $envelope->getMessage()::class;
 
-                $c = $envelope->getMessage()::class;
-
-                if (!isset($countPerClass[$c])) {
-                    $countPerClass[$c] = [$c, 0];
-                }
-
-                ++$countPerClass[$c][1];
+            if (!isset($countPerClass[$c])) {
+                $countPerClass[$c] = [$c, 0];
             }
-        } finally {
-            $this->phpSerializer?->rejectPhpIncompleteClass();
+
+            ++$countPerClass[$c][1];
         }
 
         if (!$countPerClass) {
@@ -191,15 +168,9 @@ class FailedMessagesShowCommand extends AbstractFailedMessagesCommand
         $io->table(['Class', 'Count'], $countPerClass);
     }
 
-    private function showMessage(ListableReceiverInterface $receiver, string $failedTransportName, string $id, SymfonyStyle $io, SymfonyStyle $errorIo): void
+    private function showMessage(string $failedTransportName, string $id, SymfonyStyle $io, SymfonyStyle $errorIo): void
     {
-        $this->phpSerializer?->acceptPhpIncompleteClass();
-        try {
-            $envelope = $receiver->find($id);
-        } finally {
-            $this->phpSerializer?->rejectPhpIncompleteClass();
-        }
-        if (null === $envelope) {
+        if (null === $envelope = $this->repository->find($id, $failedTransportName)) {
             throw new RuntimeException(\sprintf('The message "%s" was not found.', $id));
         }
 

--- a/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
+++ b/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
@@ -388,6 +388,11 @@ class MessengerPass implements CompilerPassInterface
                 $definition->replaceArgument(1, $failureTransportsLocator);
             }
         }
+
+        if ($container->hasDefinition('messenger.failed_message_repository')) {
+            $container->getDefinition('messenger.failed_message_repository')
+                ->replaceArgument(0, $failureTransportsLocator);
+        }
     }
 
     private function registerBusToCollector(ContainerBuilder $container, string $busId): void

--- a/src/Symfony/Component/Messenger/Failure/FailedMessageFilter.php
+++ b/src/Symfony/Component/Messenger/Failure/FailedMessageFilter.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Failure;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Stamp\RedeliveryStamp;
+
+/**
+ * Selects failed messages by class name and by the time they failed.
+ *
+ * Both bounds of the time window are inclusive.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+final class FailedMessageFilter
+{
+    public function __construct(
+        public readonly ?string $class = null,
+        public readonly ?\DateTimeImmutable $failedAfter = null,
+        public readonly ?\DateTimeImmutable $failedBefore = null,
+    ) {
+    }
+
+    public function isEmpty(): bool
+    {
+        return null === $this->class && null === $this->failedAfter && null === $this->failedBefore;
+    }
+
+    public function matches(Envelope $envelope): bool
+    {
+        if (null !== $this->class && $this->class !== $envelope->getMessage()::class) {
+            return false;
+        }
+
+        if (null === $this->failedAfter && null === $this->failedBefore) {
+            return true;
+        }
+
+        // messages that were never redelivered have no known failure time, so no time window can select them
+        if (null === $failedAt = $envelope->last(RedeliveryStamp::class)?->getRedeliveredAt()) {
+            return false;
+        }
+
+        return (null === $this->failedAfter || $failedAt >= $this->failedAfter)
+            && (null === $this->failedBefore || $failedAt <= $this->failedBefore);
+    }
+}

--- a/src/Symfony/Component/Messenger/Failure/FailedMessageRepository.php
+++ b/src/Symfony/Component/Messenger/Failure/FailedMessageRepository.php
@@ -1,0 +1,177 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Failure;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\InvalidArgumentException;
+use Symfony\Component\Messenger\Exception\LogicException;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\NonSendableStampInterface;
+use Symfony\Component\Messenger\Stamp\SentToFailureTransportStamp;
+use Symfony\Component\Messenger\Stamp\TransportMessageIdStamp;
+use Symfony\Component\Messenger\Transport\Receiver\ListableReceiverInterface;
+use Symfony\Component\Messenger\Transport\Receiver\MessageCountAwareInterface;
+use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
+use Symfony\Component\Messenger\Transport\Serialization\PhpSerializer;
+use Symfony\Contracts\Service\ServiceProviderInterface;
+
+/**
+ * Reads and removes the messages pending in the failure transports.
+ *
+ * This is what the "messenger:failed:*" commands are built on, so that listing,
+ * inspecting, removing and redispatching a failed message can also be done from
+ * outside the console.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+final class FailedMessageRepository
+{
+    public function __construct(
+        /**
+         * @var ServiceProviderInterface<ReceiverInterface>
+         */
+        private ServiceProviderInterface $failureTransports,
+        private ?string $globalFailureTransportName = null,
+        private ?PhpSerializer $phpSerializer = null,
+        private ?MessageBusInterface $messageBus = null,
+    ) {
+    }
+
+    public static function getMessageId(Envelope $envelope): mixed
+    {
+        return $envelope->last(TransportMessageIdStamp::class)?->getId();
+    }
+
+    /**
+     * Strips the stamps that must not survive a redispatch.
+     */
+    public static function prepareForRedispatch(Envelope $envelope): Envelope
+    {
+        return $envelope
+            ->withoutStampsOfType(NonSendableStampInterface::class)
+            ->withoutAll(SentToFailureTransportStamp::class)
+            ->withoutAll(TransportMessageIdStamp::class);
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getTransportNames(): array
+    {
+        return array_keys($this->failureTransports->getProvidedServices());
+    }
+
+    public function getGlobalTransportName(): ?string
+    {
+        return $this->globalFailureTransportName;
+    }
+
+    public function supportsListing(?string $transport = null): bool
+    {
+        return $this->getReceiver($transport) instanceof ListableReceiverInterface;
+    }
+
+    /**
+     * @return int|null The number of pending messages, or null when the transport cannot count them
+     */
+    public function count(?string $transport = null): ?int
+    {
+        $receiver = $this->getReceiver($transport);
+
+        return $receiver instanceof MessageCountAwareInterface ? $receiver->getMessageCount() : null;
+    }
+
+    public function find(mixed $id, ?string $transport = null): ?Envelope
+    {
+        $receiver = $this->getListableReceiver($transport);
+
+        $this->phpSerializer?->acceptPhpIncompleteClass();
+        try {
+            return $receiver->find($id);
+        } finally {
+            $this->phpSerializer?->rejectPhpIncompleteClass();
+        }
+    }
+
+    /**
+     * The limit bounds what is read from the transport, before the filter is applied.
+     *
+     * @return iterable<Envelope>
+     */
+    public function all(?string $transport = null, ?FailedMessageFilter $filter = null, ?int $limit = null): iterable
+    {
+        // resolve the receiver now so that an unusable transport is reported by
+        // this call rather than by the first iteration of the returned generator
+        $receiver = $this->getListableReceiver($transport);
+
+        return $this->iterate($receiver, $filter, $limit);
+    }
+
+    public function remove(Envelope $envelope, ?string $transport = null): void
+    {
+        $this->getReceiver($transport)->reject($envelope);
+    }
+
+    /**
+     * Dispatches the message again and drops it from the failure transport.
+     */
+    public function redispatch(Envelope $envelope, ?string $transport = null): void
+    {
+        if (!$this->messageBus) {
+            throw new LogicException('Cannot redispatch a failed message without a message bus.');
+        }
+
+        $this->messageBus->dispatch(self::prepareForRedispatch($envelope));
+
+        // ack rather than reject: the failure transport is done with this message
+        $this->getReceiver($transport)->ack($envelope);
+    }
+
+    public function getReceiver(?string $transport = null): ReceiverInterface
+    {
+        if (null === $transport ??= $this->globalFailureTransportName) {
+            throw new InvalidArgumentException(\sprintf('No default failure transport is defined. Available transports are: "%s".', implode('", "', $this->getTransportNames())));
+        }
+
+        if (!$this->failureTransports->has($transport)) {
+            throw new InvalidArgumentException(\sprintf('The "%s" failure transport was not found. Available transports are: "%s".', $transport, implode('", "', $this->getTransportNames())));
+        }
+
+        return $this->failureTransports->get($transport);
+    }
+
+    private function getListableReceiver(?string $transport): ListableReceiverInterface
+    {
+        if (!($receiver = $this->getReceiver($transport)) instanceof ListableReceiverInterface) {
+            throw new InvalidArgumentException(\sprintf('The "%s" failure transport does not support listing messages.', $transport ?? $this->globalFailureTransportName));
+        }
+
+        return $receiver;
+    }
+
+    /**
+     * @return \Generator<Envelope>
+     */
+    private function iterate(ListableReceiverInterface $receiver, ?FailedMessageFilter $filter, ?int $limit): \Generator
+    {
+        $this->phpSerializer?->acceptPhpIncompleteClass();
+        try {
+            foreach ($receiver->all($limit) as $envelope) {
+                if (!$filter || $filter->matches($envelope)) {
+                    yield $envelope;
+                }
+            }
+        } finally {
+            $this->phpSerializer?->rejectPhpIncompleteClass();
+        }
+    }
+}

--- a/src/Symfony/Component/Messenger/MessengerBundle.php
+++ b/src/Symfony/Component/Messenger/MessengerBundle.php
@@ -31,6 +31,7 @@ use Symfony\Component\Messenger\Attribute\AsMessage;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\DependencyInjection\MessengerPass;
 use Symfony\Component\Messenger\DependencyInjection\RemoveMissingDependenciesPass;
+use Symfony\Component\Messenger\Failure\FailedMessageRepository;
 use Symfony\Component\Messenger\Handler\BatchHandlerInterface;
 use Symfony\Component\Messenger\Transport\Serialization\ClaimCheckSerializer;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
@@ -597,11 +598,16 @@ class MessengerBundle extends AbstractBundle
                     ->replaceArgument(0, $config['failure_transport']);
             }
 
+            $container->getDefinition('messenger.failed_message_repository')
+                ->replaceArgument(1, $config['failure_transport']);
+
             $failureTransportsByTransportNameServiceLocator = ServiceLocatorTagPass::register($container, $failureTransportReferencesByTransportName);
             $container->getDefinition('messenger.failure.send_failed_message_to_failure_transport_listener')
                 ->replaceArgument(0, $failureTransportsByTransportNameServiceLocator)
                 ->replaceArgument(2, $failureTransportsByName);
         } else {
+            $container->removeDefinition('messenger.failed_message_repository');
+            $container->removeAlias(FailedMessageRepository::class);
             $container->removeDefinition('messenger.failure.send_failed_message_to_failure_transport_listener');
             $container->removeDefinition('console.command.messenger_failed_messages_retry');
             $container->removeDefinition('console.command.messenger_failed_messages_show');

--- a/src/Symfony/Component/Messenger/Resources/config/messenger.php
+++ b/src/Symfony/Component/Messenger/Resources/config/messenger.php
@@ -28,6 +28,7 @@ use Symfony\Component\Messenger\EventListener\SendFailedMessageForRetryListener;
 use Symfony\Component\Messenger\EventListener\SendFailedMessageToFailureTransportListener;
 use Symfony\Component\Messenger\EventListener\StopWorkerOnCustomStopExceptionListener;
 use Symfony\Component\Messenger\EventListener\StopWorkerOnRestartSignalListener;
+use Symfony\Component\Messenger\Failure\FailedMessageRepository;
 use Symfony\Component\Messenger\Handler\RedispatchMessageHandler;
 use Symfony\Component\Messenger\Middleware\AddBusNameStampMiddleware;
 use Symfony\Component\Messenger\Middleware\AddDefaultStampsMiddleware;
@@ -304,5 +305,15 @@ return static function (ContainerConfigurator $container) {
                 service('messenger.default_bus'),
             ])
             ->tag('messenger.message_handler')
+
+        ->set('messenger.failed_message_repository', FailedMessageRepository::class)
+            ->args([
+                abstract_arg('Failure transports'),
+                abstract_arg('Default failure transport name'),
+                service('.messenger.transport.native_php_serializer')->nullOnInvalid(),
+                service('messenger.routable_message_bus'),
+            ])
+
+        ->alias(FailedMessageRepository::class, 'messenger.failed_message_repository')
     ;
 };

--- a/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerBundleExtensionTest.php
+++ b/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerBundleExtensionTest.php
@@ -34,6 +34,7 @@ use Symfony\Component\Messenger\Bridge\Beanstalkd\Transport\BeanstalkdTransportF
 use Symfony\Component\Messenger\Bridge\MongoDb\Transport\MongoDbTransportFactory;
 use Symfony\Component\Messenger\Bridge\Redis\Transport\RedisTransportFactory;
 use Symfony\Component\Messenger\DependencyInjection\MessengerPass;
+use Symfony\Component\Messenger\Failure\FailedMessageRepository;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Messenger\MessengerBundle;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
@@ -209,6 +210,33 @@ class MessengerBundleExtensionTest extends TestCase
             'transport_1' => 'failure_transport_1',
             'transport_3' => 'failure_transport_3',
         ], $container->getDefinition('console.command.messenger_debug')->getArgument(4));
+    }
+
+    public function testItRegistersTheFailedMessageRepository()
+    {
+        $container = $this->createContainerFromFile('messenger_multiple_failure_transports_global', false);
+        $container->addCompilerPass(new MessengerPass());
+        $container->compile();
+
+        $definition = $container->getDefinition('messenger.failed_message_repository');
+
+        $this->assertSame('failure_transport_global', $definition->getArgument(1));
+
+        $locator = $container->getDefinition((string) $definition->getArgument(0));
+        $this->assertSame(
+            ['failure_transport_global', 'failure_transport_1', 'failure_transport_3'],
+            array_keys($locator->getArgument(0))
+        );
+    }
+
+    public function testTheFailedMessageRepositoryIsRemovedWithoutAnyFailureTransport()
+    {
+        $container = $this->createContainerFromFile('messenger', false);
+        $container->addCompilerPass(new MessengerPass());
+        $container->compile();
+
+        $this->assertFalse($container->has('messenger.failed_message_repository'));
+        $this->assertFalse($container->has(FailedMessageRepository::class));
     }
 
     public function testMessengerMultipleFailureTransportsWithGlobalFailureTransport()

--- a/src/Symfony/Component/Messenger/Tests/Failure/FailedMessageFilterTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Failure/FailedMessageFilterTest.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Failure;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Failure\FailedMessageFilter;
+use Symfony\Component\Messenger\Stamp\RedeliveryStamp;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
+
+class FailedMessageFilterTest extends TestCase
+{
+    public function testAnEmptyFilterMatchesEverything()
+    {
+        $filter = new FailedMessageFilter();
+
+        $this->assertTrue($filter->isEmpty());
+        $this->assertTrue($filter->matches(new Envelope(new DummyMessage('a'))));
+    }
+
+    public function testClassFilter()
+    {
+        $filter = new FailedMessageFilter(DummyMessage::class);
+
+        $this->assertFalse($filter->isEmpty());
+        $this->assertTrue($filter->matches(new Envelope(new DummyMessage('a'))));
+        $this->assertFalse($filter->matches(new Envelope(new \stdClass())));
+    }
+
+    public function testTimeWindowNeverSelectsAMessageWithNoKnownFailureTime()
+    {
+        $filter = new FailedMessageFilter(failedAfter: new \DateTimeImmutable('2024-05-01 08:00'));
+
+        $this->assertFalse($filter->matches(new Envelope(new DummyMessage('a'))));
+    }
+
+    #[DataProvider('timeWindowProvider')]
+    public function testTimeWindowBoundsAreInclusive(?string $after, ?string $before, bool $expected)
+    {
+        $envelope = new Envelope(new DummyMessage('a'), [
+            new RedeliveryStamp(0, redeliveredAt: new \DateTimeImmutable('2024-05-01 09:00')),
+        ]);
+
+        $filter = new FailedMessageFilter(
+            failedAfter: $after ? new \DateTimeImmutable($after) : null,
+            failedBefore: $before ? new \DateTimeImmutable($before) : null,
+        );
+
+        $this->assertSame($expected, $filter->matches($envelope));
+    }
+
+    public static function timeWindowProvider(): iterable
+    {
+        yield 'after, before the failure' => ['2024-05-01 08:00', null, true];
+        yield 'after, exactly at the failure' => ['2024-05-01 09:00', null, true];
+        yield 'after, past the failure' => ['2024-05-01 10:00', null, false];
+        yield 'before, past the failure' => [null, '2024-05-01 10:00', true];
+        yield 'before, exactly at the failure' => [null, '2024-05-01 09:00', true];
+        yield 'before, ahead of the failure' => [null, '2024-05-01 08:00', false];
+        yield 'both, surrounding' => ['2024-05-01 08:00', '2024-05-01 10:00', true];
+        yield 'both, excluding' => ['2024-05-01 10:00', '2024-05-01 11:00', false];
+    }
+
+    public function testClassAndTimeWindowAreCombined()
+    {
+        $envelope = new Envelope(new DummyMessage('a'), [
+            new RedeliveryStamp(0, redeliveredAt: new \DateTimeImmutable('2024-05-01 09:00')),
+        ]);
+
+        $this->assertFalse((new FailedMessageFilter(\stdClass::class, new \DateTimeImmutable('2024-05-01 08:00')))->matches($envelope));
+        $this->assertTrue((new FailedMessageFilter(DummyMessage::class, new \DateTimeImmutable('2024-05-01 08:00')))->matches($envelope));
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/Failure/FailedMessageRepositoryTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Failure/FailedMessageRepositoryTest.php
@@ -1,0 +1,224 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Failure;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ServiceLocator;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\InvalidArgumentException;
+use Symfony\Component\Messenger\Exception\LogicException;
+use Symfony\Component\Messenger\Failure\FailedMessageFilter;
+use Symfony\Component\Messenger\Failure\FailedMessageRepository;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\BusNameStamp;
+use Symfony\Component\Messenger\Stamp\ReceivedStamp;
+use Symfony\Component\Messenger\Stamp\RedeliveryStamp;
+use Symfony\Component\Messenger\Stamp\SentToFailureTransportStamp;
+use Symfony\Component\Messenger\Stamp\TransportMessageIdStamp;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Messenger\Transport\Receiver\ListableReceiverInterface;
+use Symfony\Component\Messenger\Transport\Receiver\MessageCountAwareInterface;
+use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
+
+class FailedMessageRepositoryTest extends TestCase
+{
+    public function testGetTransportNames()
+    {
+        $repository = new FailedMessageRepository(new ServiceLocator([
+            'failure_receiver' => fn () => $this->createStub(ListableReceiverInterface::class),
+            'failure_receiver_another' => fn () => $this->createStub(ListableReceiverInterface::class),
+        ]), 'failure_receiver');
+
+        $this->assertSame(['failure_receiver', 'failure_receiver_another'], $repository->getTransportNames());
+        $this->assertSame('failure_receiver', $repository->getGlobalTransportName());
+    }
+
+    public function testTheGlobalTransportIsUsedWhenNoneIsGiven()
+    {
+        $envelope = new Envelope(new DummyMessage('a'));
+        $receiver = $this->createMock(ListableReceiverInterface::class);
+        $receiver->expects($this->once())->method('find')->with(42)->willReturn($envelope);
+
+        $repository = new FailedMessageRepository(new ServiceLocator([
+            'global' => static fn () => $receiver,
+            'other' => fn () => $this->createStub(ListableReceiverInterface::class),
+        ]), 'global');
+
+        $this->assertSame($envelope, $repository->find(42));
+    }
+
+    public function testAnUnknownTransportIsRejected()
+    {
+        $repository = new FailedMessageRepository(new ServiceLocator([
+            'global' => fn () => $this->createStub(ListableReceiverInterface::class),
+        ]), 'global');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "nope" failure transport was not found. Available transports are: "global".');
+
+        $repository->getReceiver('nope');
+    }
+
+    public function testAMissingGlobalTransportIsRejected()
+    {
+        $repository = new FailedMessageRepository(new ServiceLocator([
+            'global' => fn () => $this->createStub(ListableReceiverInterface::class),
+        ]));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('No default failure transport is defined. Available transports are: "global".');
+
+        $repository->getReceiver();
+    }
+
+    public function testAllAppliesTheFilter()
+    {
+        $matching = new Envelope(new DummyMessage('a'), [new TransportMessageIdStamp(1)]);
+        $other = new Envelope(new \stdClass(), [new TransportMessageIdStamp(2)]);
+
+        $receiver = $this->createMock(ListableReceiverInterface::class);
+        $receiver->expects($this->once())->method('all')->with(null)->willReturn([$matching, $other]);
+
+        $repository = new FailedMessageRepository(new ServiceLocator(['global' => static fn () => $receiver]), 'global');
+
+        $envelopes = iterator_to_array($repository->all(null, new FailedMessageFilter(DummyMessage::class)), false);
+
+        $this->assertSame([$matching], $envelopes);
+    }
+
+    public function testAllPassesTheLimitToTheReceiver()
+    {
+        $receiver = $this->createMock(ListableReceiverInterface::class);
+        $receiver->expects($this->once())->method('all')->with(10)->willReturn([]);
+
+        $repository = new FailedMessageRepository(new ServiceLocator(['global' => static fn () => $receiver]), 'global');
+
+        $this->assertSame([], iterator_to_array($repository->all(null, null, 10), false));
+    }
+
+    public function testAllRejectsANonListableTransportEagerly()
+    {
+        $repository = new FailedMessageRepository(new ServiceLocator([
+            'global' => fn () => $this->createStub(ReceiverInterface::class),
+        ]), 'global');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "global" failure transport does not support listing messages.');
+
+        // the exception must not wait for the first iteration
+        $repository->all();
+    }
+
+    public function testCountReturnsNullWhenTheTransportCannotCount()
+    {
+        $counting = $this->createMock(CountableListableReceiver::class);
+        $counting->expects($this->once())->method('getMessageCount')->willReturn(3);
+
+        $repository = new FailedMessageRepository(new ServiceLocator([
+            'counting' => static fn () => $counting,
+            'plain' => fn () => $this->createStub(ListableReceiverInterface::class),
+        ]), 'counting');
+
+        $this->assertSame(3, $repository->count());
+        $this->assertNull($repository->count('plain'));
+    }
+
+    public function testSupportsListing()
+    {
+        $repository = new FailedMessageRepository(new ServiceLocator([
+            'listable' => fn () => $this->createStub(ListableReceiverInterface::class),
+            'plain' => fn () => $this->createStub(ReceiverInterface::class),
+        ]), 'listable');
+
+        $this->assertTrue($repository->supportsListing());
+        $this->assertFalse($repository->supportsListing('plain'));
+    }
+
+    public function testRemoveRejectsTheEnvelope()
+    {
+        $envelope = new Envelope(new DummyMessage('a'));
+
+        $receiver = $this->createMock(ListableReceiverInterface::class);
+        $receiver->expects($this->once())->method('reject')->with($envelope);
+
+        $repository = new FailedMessageRepository(new ServiceLocator(['global' => static fn () => $receiver]), 'global');
+        $repository->remove($envelope);
+    }
+
+    public function testGetMessageId()
+    {
+        $this->assertSame(15, FailedMessageRepository::getMessageId(new Envelope(new DummyMessage('a'), [new TransportMessageIdStamp(15)])));
+        $this->assertNull(FailedMessageRepository::getMessageId(new Envelope(new DummyMessage('a'))));
+    }
+
+    public function testPrepareForRedispatchStripsTheTransportStamps()
+    {
+        $envelope = new Envelope(new DummyMessage('a'), [
+            new TransportMessageIdStamp(15),
+            new SentToFailureTransportStamp('async'),
+            new ReceivedStamp('failed'),
+            new RedeliveryStamp(1),
+            new BusNameStamp('the_bus'),
+        ]);
+
+        $prepared = FailedMessageRepository::prepareForRedispatch($envelope);
+
+        $this->assertSame([], $prepared->all(TransportMessageIdStamp::class));
+        $this->assertSame([], $prepared->all(SentToFailureTransportStamp::class));
+        $this->assertSame([], $prepared->all(ReceivedStamp::class));
+        // sendable stamps are kept, so the redispatched message keeps its history
+        $this->assertCount(1, $prepared->all(RedeliveryStamp::class));
+        $this->assertCount(1, $prepared->all(BusNameStamp::class));
+    }
+
+    public function testRedispatchDispatchesTheStrippedEnvelopeThenAcksTheOriginal()
+    {
+        $envelope = new Envelope(new DummyMessage('a'), [
+            new TransportMessageIdStamp(15),
+            new SentToFailureTransportStamp('async'),
+        ]);
+
+        $dispatched = null;
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects($this->once())->method('dispatch')->willReturnCallback(static function (Envelope $e) use (&$dispatched) {
+            $dispatched = $e;
+
+            return $e;
+        });
+
+        $receiver = $this->createMock(ListableReceiverInterface::class);
+        $receiver->expects($this->once())->method('ack')->with($envelope);
+        $receiver->expects($this->never())->method('reject');
+
+        $repository = new FailedMessageRepository(new ServiceLocator(['global' => static fn () => $receiver]), 'global', messageBus: $bus);
+        $repository->redispatch($envelope);
+
+        $this->assertSame([], $dispatched->all(SentToFailureTransportStamp::class));
+        $this->assertSame($envelope->getMessage(), $dispatched->getMessage());
+    }
+
+    public function testRedispatchWithoutABusIsRejected()
+    {
+        $repository = new FailedMessageRepository(new ServiceLocator([
+            'global' => fn () => $this->createStub(ListableReceiverInterface::class),
+        ]), 'global');
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Cannot redispatch a failed message without a message bus.');
+
+        $repository->redispatch(new Envelope(new DummyMessage('a')));
+    }
+}
+
+interface CountableListableReceiver extends ListableReceiverInterface, MessageCountAwareInterface
+{
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #60151
| License       | MIT

`AbstractFailedMessagesCommand` mixes three concerns: transport-facing logic that has nothing to do with the console, console input parsing, and rendering. Only the first is what a web UI or any other non-console caller needs, and today it can only be reached by extending an `@internal` command.

This extracts that first group:

* `FailedMessageRepository` resolves the failure transports and exposes `getTransportNames()`, `count()`, `supportsListing()`, `find()`, `all()`, `remove()` and `redispatch()`. It is registered as `messenger.failed_message_repository` and aliased for autowiring, so a controller can inject it directly. It is removed from the container when no failure transport is configured.
* `FailedMessageFilter` is the class-name and failure-time selection that `matchesFilter()` used to implement, as a value object with a `matches()` method.

The commands keep their options, their rendering, their confirmations and their exact output. The net effect on the existing files is 206 lines removed for 154 added.

Answers to the three questions raised in the issue:

**Retry stays out.** `messenger:failed:retry` does not simply redispatch: it builds a real `Worker`, wires event listeners and handles signals, and for the by-id path it wraps each envelope in a `SingleMessageReceiver` so the ack goes to the wrapper rather than to the failure transport. Extracting that means deciding what a non-console caller gets in place of the worker loop, which is a design question of its own. `FailedMessageRepository::redispatch()` does exist, because for a listable transport it is a dispatch plus an ack and needs no worker, but the command keeps its own flow and both paths now share `prepareForRedispatch()` so the stamp stripping has a single definition.

**No delegation shims.** `AbstractFailedMessagesCommand` is marked `@internal`, so the methods that moved (`getMessageIdsByFilter()`, `matchesFilter()`, `getReceiver()`, `getMessageId()`) are removed rather than kept as delegations, and `getFilters()` becomes `getFilter()` returning the value object. Constructor signatures are untouched, so anything instantiating the concrete commands keeps working.

**Location.** A new `Symfony\Component\Messenger\Failure\` namespace, alongside the existing `Retry\` and `Execution\`.

The API is michaelthieulin's proposal from the issue thread, with `remove()` taking an `Envelope` rather than an id so that removing every message does not re-`find()` each one.
