### PR TITLE
[DoctrineBridge][FrameworkBundle][HttpKernel][TwigBundle] Escape percent signs in kernel path parameters

### DIFF
--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/AbstractDoctrineExtension.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/AbstractDoctrineExtension.php
@@ -56,6 +56,8 @@ abstract class AbstractDoctrineExtension extends Extension
             }
         }
 
+        $parameterBag = $container->getParameterBag();
+
         foreach ($objectManager['mappings'] as $mappingName => $mappingConfig) {
             if (null !== $mappingConfig && false === $mappingConfig['mapping']) {
                 continue;
@@ -67,7 +69,8 @@ abstract class AbstractDoctrineExtension extends Extension
                 'prefix' => false,
             ], (array) $mappingConfig);
 
-            $mappingConfig['dir'] = $container->getParameterBag()->resolveValue($mappingConfig['dir']);
+            // the parameter bag returns paths in their escaped form, the filesystem needs the literal one
+            $mappingConfig['dir'] = $parameterBag->unescapeValue($parameterBag->resolveValue($mappingConfig['dir']));
             // a bundle configuration is detected by realizing that the specified dir is not absolute and existing
             if (!isset($mappingConfig['is_bundle'])) {
                 $mappingConfig['is_bundle'] = !is_dir($mappingConfig['dir']);
@@ -191,6 +194,8 @@ abstract class AbstractDoctrineExtension extends Extension
         }
 
         foreach ($this->drivers as $driverType => $driverPaths) {
+            // the paths are literals, they go back to the container in their escaped form
+            $driverPaths = $container->getParameterBag()->escapeValue($driverPaths);
             $mappingService = $this->getObjectManagerElementName($objectManager['name'].'_'.$driverType.'_metadata_driver');
             if ($container->hasDefinition($mappingService)) {
                 $mappingDriverDef = $container->getDefinition($mappingService);

--- a/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/DoctrineExtensionTest.php
@@ -188,6 +188,28 @@ class DoctrineExtensionTest extends TestCase
         ], $expectedEm2));
     }
 
+    public function testMappingPathsContainingAPercentSignAreEscaped()
+    {
+        // two percent signs are required: "%2Fother%" is what the parameter bag reads as a reference
+        $path = '/tmp/sf_doctrine_my%2Fother%2Fbranch/Entity';
+
+        $this->extension
+            ->method('getMetadataDriverClass')
+            ->willReturn(SimplifiedXmlDriverStub::class);
+
+        $container = new ContainerBuilder(new ParameterBag());
+
+        $reflection = new \ReflectionClass(AbstractDoctrineExtension::class);
+        $drivers = $reflection->getProperty('drivers');
+        $drivers->setValue($this->extension, ['xml' => ['Prefix' => $path]]);
+
+        $reflection->getMethod('registerMappingDrivers')->invoke($this->extension, ['name' => 'default'], $container);
+
+        $arguments = $container->getDefinition('doctrine.orm.default_xml_metadata_driver')->getArguments();
+
+        $this->assertSame(['/tmp/sf_doctrine_my%%2Fother%%2Fbranch/Entity' => 'Prefix'], $arguments[0]);
+    }
+
     public function testMappingTypeDetection()
     {
         $container = $this->createContainer();
@@ -370,4 +392,8 @@ class DoctrineExtensionTest extends TestCase
             'kernel.project_dir' => __DIR__,
         ], $data)));
     }
+}
+
+class SimplifiedXmlDriverStub
+{
 }

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1369,14 +1369,15 @@ class FrameworkExtension extends Extension
         $container->getDefinition('asset_mapper.public_assets_path_resolver')
             ->setArgument(0, $config['public_prefix']);
 
+        $parameterBag = $container->getParameterBag();
         $publicDirectory = $this->getPublicDirectory($container);
         $publicAssetsDirectory = rtrim($publicDirectory.'/'.ltrim($config['public_prefix'], '/'), '/');
         $container->getDefinition('asset_mapper.local_public_assets_filesystem')
-            ->setArgument(0, $publicDirectory)
+            ->setArgument(0, $parameterBag->escapeValue($publicDirectory))
         ;
 
         $container->getDefinition('asset_mapper.compiled_asset_mapper_config_reader')
-            ->setArgument(0, $publicAssetsDirectory);
+            ->setArgument(0, $parameterBag->escapeValue($publicAssetsDirectory));
 
         if (!$config['server']) {
             $container->removeDefinition('asset_mapper.dev_server_subscriber');
@@ -1516,9 +1517,12 @@ class FrameworkExtension extends Extension
 
             $dirs[] = $transPaths[] = \dirname($r->getFileName(), 2).'/Resources/translations';
         }
-        $defaultDir = $container->getParameterBag()->resolveValue($config['default_path']);
+        $parameterBag = $container->getParameterBag();
+        // the parameter bag returns paths in their escaped form, the filesystem needs the literal one
+        $defaultDir = $parameterBag->unescapeValue($parameterBag->resolveValue($config['default_path']));
         foreach ($container->getParameter('kernel.bundles_metadata') as $name => $bundle) {
-            if ($container->fileExists($dir = $bundle['path'].'/Resources/translations') || $container->fileExists($dir = $bundle['path'].'/translations')) {
+            $bundlePath = $parameterBag->unescapeValue($bundle['path']);
+            if ($container->fileExists($dir = $bundlePath.'/Resources/translations') || $container->fileExists($dir = $bundlePath.'/translations')) {
                 $dirs[] = $transPaths[] = $dir;
             } else {
                 $nonExistingDirs[] = $dir;
@@ -1534,11 +1538,11 @@ class FrameworkExtension extends Extension
         }
 
         if ($container->hasDefinition('console.command.translation_debug')) {
-            $container->getDefinition('console.command.translation_debug')->replaceArgument(5, $transPaths);
+            $container->getDefinition('console.command.translation_debug')->replaceArgument(5, $parameterBag->escapeValue($transPaths));
         }
 
         if ($container->hasDefinition('console.command.translation_extract')) {
-            $container->getDefinition('console.command.translation_extract')->replaceArgument(6, $transPaths);
+            $container->getDefinition('console.command.translation_extract')->replaceArgument(6, $parameterBag->escapeValue($transPaths));
         }
 
         if (null === $defaultDir) {
@@ -1572,15 +1576,15 @@ class FrameworkExtension extends Extension
                 }
             }
 
-            $projectDir = $container->getParameter('kernel.project_dir');
+            $projectDir = $parameterBag->unescapeValue($container->getParameter('kernel.project_dir'));
 
             $options = array_merge(
                 $translator->getArgument(4),
                 [
-                    'resource_files' => $files,
-                    'scanned_directories' => $scannedDirectories = array_merge($dirs, $nonExistingDirs),
+                    'resource_files' => $parameterBag->escapeValue($files),
+                    'scanned_directories' => $parameterBag->escapeValue($scannedDirectories = array_merge($dirs, $nonExistingDirs)),
                     'cache_vary' => [
-                        'scanned_directories' => array_map(static fn ($dir) => str_starts_with($dir, $projectDir.'/') ? substr($dir, 1 + \strlen($projectDir)) : $dir, $scannedDirectories),
+                        'scanned_directories' => $parameterBag->escapeValue(array_map(static fn ($dir) => str_starts_with($dir, $projectDir.'/') ? substr($dir, 1 + \strlen($projectDir)) : $dir, $scannedDirectories)),
                     ],
                 ]
             );
@@ -1723,8 +1727,10 @@ class FrameworkExtension extends Extension
 
     private function registerValidatorMapping(ContainerBuilder $container, array $config, array &$files): void
     {
-        $fileRecorder = static function ($extension, $path) use (&$files) {
-            $files['yaml' === $extension ? 'yml' : $extension][] = $path;
+        $parameterBag = $container->getParameterBag();
+        // mapping files are collected from the filesystem as literals and handed back to the container
+        $fileRecorder = static function ($extension, $path) use (&$files, $parameterBag) {
+            $files['yaml' === $extension ? 'yml' : $extension][] = $parameterBag->escapeValue($path);
         };
 
         if (ContainerBuilder::willBeAvailable('symfony/form', Form::class, ['symfony/framework-bundle', 'symfony/validator'])) {
@@ -1733,7 +1739,8 @@ class FrameworkExtension extends Extension
         }
 
         foreach ($container->getParameter('kernel.bundles_metadata') as $bundle) {
-            $configDir = is_dir($bundle['path'].'/Resources/config') ? $bundle['path'].'/Resources/config' : $bundle['path'].'/config';
+            $bundlePath = $parameterBag->unescapeValue($bundle['path']);
+            $configDir = is_dir($bundlePath.'/Resources/config') ? $bundlePath.'/Resources/config' : $bundlePath.'/config';
 
             if (
                 $container->fileExists($file = $configDir.'/validation.yaml', false)
@@ -1751,7 +1758,7 @@ class FrameworkExtension extends Extension
             }
         }
 
-        $projectDir = $container->getParameter('kernel.project_dir');
+        $projectDir = $parameterBag->unescapeValue($container->getParameter('kernel.project_dir'));
         if ($container->fileExists($dir = $projectDir.'/config/validator', '/^$/')) {
             $this->registerMappingFilesFromDir($dir, $fileRecorder);
         }
@@ -1768,7 +1775,7 @@ class FrameworkExtension extends Extension
 
     private function registerMappingFilesFromConfig(ContainerBuilder $container, array $config, callable $fileRecorder): void
     {
-        foreach ($config['mapping']['paths'] as $path) {
+        foreach ($container->getParameterBag()->unescapeValue($config['mapping']['paths']) as $path) {
             if (is_dir($path)) {
                 $this->registerMappingFilesFromDir($path, $fileRecorder);
                 $container->addResource(new DirectoryResource($path, '/^$/'));
@@ -1811,7 +1818,8 @@ class FrameworkExtension extends Extension
             $definition->addTag('kernel.cache_warmer');
         } else {
             $cacheService = 'annotations.filesystem_cache_adapter';
-            $cacheDir = $container->getParameterBag()->resolveValue($config['file_cache_dir']);
+            $parameterBag = $container->getParameterBag();
+            $cacheDir = $parameterBag->unescapeValue($parameterBag->resolveValue($config['file_cache_dir']));
 
             if (!is_dir($cacheDir) && false === @mkdir($cacheDir, 0o777, true) && !is_dir($cacheDir)) {
                 throw new \RuntimeException(\sprintf('Could not create cache directory "%s".', $cacheDir));
@@ -1819,7 +1827,7 @@ class FrameworkExtension extends Extension
 
             $container
                 ->getDefinition('annotations.filesystem_cache_adapter')
-                ->replaceArgument(2, $cacheDir)
+                ->replaceArgument(2, $parameterBag->escapeValue($cacheDir))
             ;
         }
 
@@ -1964,13 +1972,16 @@ class FrameworkExtension extends Extension
             $serializerLoaders[] = $annotationLoader;
         }
 
-        $fileRecorder = static function ($extension, $path) use (&$serializerLoaders) {
-            $definition = new Definition(\in_array($extension, ['yaml', 'yml']) ? YamlFileLoader::class : XmlFileLoader::class, [$path]);
+        $parameterBag = $container->getParameterBag();
+        // mapping files are collected from the filesystem as literals and handed back to the container
+        $fileRecorder = static function ($extension, $path) use (&$serializerLoaders, $parameterBag) {
+            $definition = new Definition(\in_array($extension, ['yaml', 'yml']) ? YamlFileLoader::class : XmlFileLoader::class, [$parameterBag->escapeValue($path)]);
             $serializerLoaders[] = $definition;
         };
 
         foreach ($container->getParameter('kernel.bundles_metadata') as $bundle) {
-            $configDir = is_dir($bundle['path'].'/Resources/config') ? $bundle['path'].'/Resources/config' : $bundle['path'].'/config';
+            $bundlePath = $parameterBag->unescapeValue($bundle['path']);
+            $configDir = is_dir($bundlePath.'/Resources/config') ? $bundlePath.'/Resources/config' : $bundlePath.'/config';
 
             if ($container->fileExists($file = $configDir.'/serialization.xml', false)) {
                 $fileRecorder('xml', $file);
@@ -1988,7 +1999,7 @@ class FrameworkExtension extends Extension
             }
         }
 
-        $projectDir = $container->getParameter('kernel.project_dir');
+        $projectDir = $parameterBag->unescapeValue($container->getParameter('kernel.project_dir'));
         if ($container->fileExists($dir = $projectDir.'/config/serializer', '/^$/')) {
             $this->registerMappingFilesFromDir($dir, $fileRecorder);
         }
@@ -3228,7 +3239,7 @@ class FrameworkExtension extends Extension
 
     private function getPublicDirectory(ContainerBuilder $container): string
     {
-        $projectDir = $container->getParameter('kernel.project_dir');
+        $projectDir = $container->getParameterBag()->unescapeValue($container->getParameter('kernel.project_dir'));
         $defaultPublicDir = $projectDir.'/public';
 
         $composerFilePath = $projectDir.'/composer.json';

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -47,6 +47,7 @@ use Symfony\Component\DependencyInjection\Loader\ClosureLoader;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\DependencyInjection\ParameterBag\EnvPlaceholderParameterBag;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Form\Form;
@@ -2555,6 +2556,33 @@ abstract class FrameworkExtensionTestCase extends TestCase
         });
 
         $this->assertSame($expectedPrefix, $container->getDefinition('asset_mapper.asset_package')->getArgument(3));
+    }
+
+    public function testTranslatorDefaultPathContainingAPercentSign()
+    {
+        // two percent signs are required: "%2Fother%" is what the parameter bag reads as a reference
+        $projectDir = sys_get_temp_dir().'/sf_fwb_my%2Fother%2Fbranch_'.substr(md5(__METHOD__), 0, 8);
+        @mkdir($projectDir.'/translations', 0o777, true);
+        file_put_contents($projectDir.'/translations/messages.en.yaml', "hello: Hello there\n");
+
+        try {
+            $container = $this->createContainerFromClosure(static function ($container) {
+                $container->loadFromExtension('framework', [
+                    'annotations' => false,
+                    'http_method_override' => false,
+                    'handle_all_throwables' => true,
+                    'php_errors' => ['log' => true],
+                    'translator' => ['default_path' => '%kernel.project_dir%/translations'],
+                ]);
+            }, ['kernel.project_dir' => str_replace('%', '%%', $projectDir)]);
+
+            $options = $container->getDefinition('translator.default')->getArgument(4);
+            $files = array_map(static fn ($file) => str_replace('%%', '%', $file), $options['resource_files']['en']);
+
+            $this->assertContains($projectDir.'/translations/messages.en.yaml', $files);
+        } finally {
+            (new Filesystem())->remove($projectDir);
+        }
     }
 
     public function testDefaultLock()

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
@@ -103,7 +103,9 @@ class TwigExtension extends Extension
 
         $container->setParameter('twig.form.resources', $config['form_themes']);
         $container->setParameter('twig.default_path', $config['default_path']);
-        $defaultTwigPath = $container->getParameterBag()->resolveValue($config['default_path']);
+        $parameterBag = $container->getParameterBag();
+        // the parameter bag returns paths in their escaped form, the filesystem needs the literal one
+        $defaultTwigPath = $parameterBag->unescapeValue($parameterBag->resolveValue($config['default_path']));
 
         $envConfiguratorDefinition = $container->getDefinition('twig.configurator.environment');
         $envConfiguratorDefinition->replaceArgument(0, $config['date']['format']);
@@ -146,7 +148,7 @@ class TwigExtension extends Extension
         }
 
         if (file_exists($defaultTwigPath)) {
-            $twigFilesystemLoaderDefinition->addMethodCall('addPath', [$defaultTwigPath]);
+            $twigFilesystemLoaderDefinition->addMethodCall('addPath', [$parameterBag->escapeValue($defaultTwigPath)]);
         }
         $container->addResource(new FileExistenceResource($defaultTwigPath));
 
@@ -190,16 +192,20 @@ class TwigExtension extends Extension
     private function getBundleTemplatePaths(ContainerBuilder $container, array $config): array
     {
         $bundleHierarchy = [];
+        $parameterBag = $container->getParameterBag();
+        $defaultPath = $parameterBag->unescapeValue($parameterBag->resolveValue($config['default_path']));
+
         foreach ($container->getParameter('kernel.bundles_metadata') as $name => $bundle) {
-            $defaultOverrideBundlePath = $container->getParameterBag()->resolveValue($config['default_path']).'/bundles/'.$name;
+            $bundlePath = $parameterBag->unescapeValue($bundle['path']);
+            $defaultOverrideBundlePath = $defaultPath.'/bundles/'.$name;
 
             if (file_exists($defaultOverrideBundlePath)) {
-                $bundleHierarchy[$name][] = $defaultOverrideBundlePath;
+                $bundleHierarchy[$name][] = $parameterBag->escapeValue($defaultOverrideBundlePath);
             }
             $container->addResource(new FileExistenceResource($defaultOverrideBundlePath));
 
-            if (file_exists($dir = $bundle['path'].'/Resources/views') || file_exists($dir = $bundle['path'].'/templates')) {
-                $bundleHierarchy[$name][] = $dir;
+            if (file_exists($dir = $bundlePath.'/Resources/views') || file_exists($dir = $bundlePath.'/templates')) {
+                $bundleHierarchy[$name][] = $parameterBag->escapeValue($dir);
             }
             $container->addResource(new FileExistenceResource($dir));
         }

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/TwigExtensionTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/TwigExtensionTest.php
@@ -18,6 +18,7 @@ use Symfony\Bundle\TwigBundle\Tests\TestCase;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
@@ -290,11 +291,37 @@ class TwigExtensionTest extends TestCase
         $this->assertEquals(new Reference('my_converter'), $bodyRenderer->getArgument('$converter'));
     }
 
-    private function createContainer()
+    public function testDefaultPathContainingAPercentSign()
     {
+        // two percent signs are required: "%2Fother%" is what the parameter bag reads as a reference
+        $projectDir = sys_get_temp_dir().'/sf_twig_my%2Fother%2Fbranch_'.substr(md5(__METHOD__), 0, 8);
+        @mkdir($projectDir.'/templates', 0o777, true);
+
+        try {
+            $container = $this->createContainer($projectDir);
+            $container->registerExtension(new TwigExtension());
+            $container->loadFromExtension('twig', ['default_path' => '%kernel.project_dir%/templates']);
+            $this->compileContainer($container);
+
+            $paths = [];
+            foreach ($container->getDefinition('twig.loader.native_filesystem')->getMethodCalls() as $call) {
+                if ('addPath' === $call[0] && 1 === \count($call[1])) {
+                    $paths[] = str_replace('%%', '%', $call[1][0]);
+                }
+            }
+
+            $this->assertContains($projectDir.'/templates', $paths);
+        } finally {
+            (new Filesystem())->remove($projectDir);
+        }
+    }
+
+    private function createContainer(?string $projectDir = null)
+    {
+        $projectDir ??= __DIR__;
         $container = new ContainerBuilder(new ParameterBag([
             'kernel.cache_dir' => __DIR__,
-            'kernel.project_dir' => __DIR__,
+            'kernel.project_dir' => str_replace('%', '%%', $projectDir),
             'kernel.charset' => 'UTF-8',
             'kernel.debug' => false,
             'kernel.bundles' => [

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -580,16 +580,20 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
         $bundles = [];
         $bundlesMetadata = [];
 
+        // filesystem paths are literals: a percent sign in them must be escaped
+        // so that the parameter bag does not read it as a parameter reference
+        $escape = static fn (string $path): string => str_replace('%', '%%', $path);
+
         foreach ($this->bundles as $name => $bundle) {
             $bundles[$name] = $bundle::class;
             $bundlesMetadata[$name] = [
-                'path' => $bundle->getPath(),
+                'path' => $escape($bundle->getPath()),
                 'namespace' => $bundle->getNamespace(),
             ];
         }
 
         return [
-            'kernel.project_dir' => realpath($this->getProjectDir()) ?: $this->getProjectDir(),
+            'kernel.project_dir' => $escape(realpath($this->getProjectDir()) ?: $this->getProjectDir()),
             'kernel.environment' => $this->environment,
             'kernel.runtime_environment' => '%env(default:kernel.environment:APP_RUNTIME_ENV)%',
             'kernel.runtime_mode' => '%env(query_string:default:container.runtime_mode:APP_RUNTIME_MODE)%',
@@ -597,9 +601,9 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
             'kernel.runtime_mode.cli' => '%env(not:default:kernel.runtime_mode.web:)%',
             'kernel.runtime_mode.worker' => '%env(bool:default::key:worker:default:kernel.runtime_mode:)%',
             'kernel.debug' => $this->debug,
-            'kernel.build_dir' => realpath($buildDir = $this->warmupDir ?: $this->getBuildDir()) ?: $buildDir,
-            'kernel.cache_dir' => realpath($cacheDir = ($this->getCacheDir() === $this->getBuildDir() ? ($this->warmupDir ?: $this->getCacheDir()) : $this->getCacheDir())) ?: $cacheDir,
-            'kernel.logs_dir' => realpath($this->getLogDir()) ?: $this->getLogDir(),
+            'kernel.build_dir' => $escape(realpath($buildDir = $this->warmupDir ?: $this->getBuildDir()) ?: $buildDir),
+            'kernel.cache_dir' => $escape(realpath($cacheDir = ($this->getCacheDir() === $this->getBuildDir() ? ($this->warmupDir ?: $this->getCacheDir()) : $this->getCacheDir())) ?: $cacheDir),
+            'kernel.logs_dir' => $escape(realpath($this->getLogDir()) ?: $this->getLogDir()),
             'kernel.bundles' => $bundles,
             'kernel.bundles_metadata' => $bundlesMetadata,
             'kernel.charset' => $this->getCharset(),

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -502,6 +502,25 @@ class KernelTest extends TestCase
         $this->assertSame(__DIR__.\DIRECTORY_SEPARATOR.'Fixtures', $kernel->getContainer()->getParameter('kernel.project_dir'));
     }
 
+    public function testProjectDirContainingAPercentSign()
+    {
+        // two percent signs are required: "%2Fother%" is what the parameter bag reads as a reference
+        $projectDir = sys_get_temp_dir().'/sf_percent_my%2Fother%2Fbranch_'.substr(md5(__METHOD__), 0, 8);
+        @mkdir($projectDir.'/var/cache/percent', 0o777, true);
+        @mkdir($projectDir.'/var/log', 0o777, true);
+
+        try {
+            $kernel = new PercentProjectDirKernel($projectDir);
+            $kernel->boot();
+
+            $container = $kernel->getContainer();
+            $this->assertSame(realpath($projectDir), $container->getParameter('kernel.project_dir'));
+            $this->assertSame(realpath($projectDir).'/config', $container->getParameter('percent.interpolated'));
+        } finally {
+            (new Filesystem())->remove($projectDir);
+        }
+    }
+
     public function testKernelReset()
     {
         $this->tearDown();
@@ -778,6 +797,44 @@ class TestKernel implements HttpKernelInterface
     public function getProjectDir(): string
     {
         return __DIR__.'/Fixtures';
+    }
+}
+
+class PercentProjectDirKernel extends Kernel
+{
+    public function __construct(
+        private readonly string $projectDir,
+    ) {
+        parent::__construct('percent', true);
+    }
+
+    public function registerBundles(): iterable
+    {
+        return [];
+    }
+
+    public function registerContainerConfiguration(LoaderInterface $loader): void
+    {
+    }
+
+    public function getProjectDir(): string
+    {
+        return $this->projectDir;
+    }
+
+    public function getCacheDir(): string
+    {
+        return $this->projectDir.'/var/cache/percent';
+    }
+
+    public function getLogDir(): string
+    {
+        return $this->projectDir.'/var/log';
+    }
+
+    protected function build(ContainerBuilder $container): void
+    {
+        $container->setParameter('percent.interpolated', '%kernel.project_dir%/config');
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #58667
| License       | MIT

---

Checking a project out into a directory whose name contains a percent sign, which Jenkins produces for merge-queue branches (`my%2Fother%2Fbranch`), makes every console command fail with `You have requested a non-existent parameter "2Fother"`.

The container parameter bag holds values in an escaped form, where a literal percent sign is written `%%`. `Kernel::getKernelParameters()` stored raw filesystem paths in it, so `kernel.project_dir` was read as a reference to a parameter named `2Fother`. The same applies to `kernel.build_dir`, `kernel.cache_dir`, `kernel.logs_dir` and every `kernel.bundles_metadata[*]['path']`.

Escaping them is the fix, but it is not sufficient on its own, and that is why this PR is bigger than six lines. Build-time consumers read those parameters back through `ParameterBagInterface::resolveValue()`, which works in the escaped domain, so with only the kernel patched the container builds and then:

- `twig.default_path` fails its `file_exists()` check, no path is registered, and rendering dies with `There are no registered paths for namespace "__main__"`
- `framework.translator.default_path` fails the same way, and `trans('hello')` returns `hello`
- the validator and serializer mapping directories under `config/` are never found

So the loud failure becomes a silent one. Each of those call sites needs both representations: the literal path for `file_exists()`, `is_dir()`, `Finder` and the `FileExistenceResource`/`DirectoryResource` objects, and the escaped path for anything handed back to a definition, since definition arguments are unescaped when the container is dumped or the service is created.

The rule this PR applies is that a path variable holds the literal, and `escapeValue()` is called at the point where it re-enters the container. Both methods are already on `ParameterBagInterface`, so no new API is involved and this is backportable as a plain bug fix.

Worth noting in review: paths discovered from the filesystem also flow the other way. `Finder` results collected into the translator's `resource_files`, the mapping files handed to `$fileRecorder`, the reflection-derived vendor translation directories and the Doctrine `$this->drivers` paths are all literals going into definition arguments, and they are escaped at those boundaries here. Without that, a path containing a percent sign would be read as a parameter reference on the way back in.

### Measured

A `MicroKernel` with FrameworkBundle and TwigBundle, booted from a directory named `proj%2Fother%2Fbranch`, against a control in a plain directory:

| | before | after | control |
| --- | --- | --- | --- |
| boot | `ParameterNotFoundException` | ok | ok |
| `kernel.project_dir` | n/a | literal path | literal path |
| render a template | n/a | ok | ok |
| `trans('hello')` | n/a | `Hello there` | `Hello there` |
| `config/validator` mapping | n/a | loaded | loaded |

The escape is a no-op for a project whose paths hold no percent sign, and the control output is byte for byte unchanged.

One thing this incidentally removes: `CachePoolPass` falls back to `'_'.$container->getParameter('kernel.project_dir')` for its prefix seed, which previously carried a bare percent sign into a definition argument.

### Tests

Four regression tests, each verified to fail without its corresponding fix:

- `KernelTest::testProjectDirContainingAPercentSign`, booting a real container from a percent-containing project directory
- `TwigExtensionTest::testDefaultPathContainingAPercentSign`, asserting the default template path is registered
- `FrameworkExtensionTestCase::testTranslatorDefaultPathContainingAPercentSign`, asserting the default translation file is found
- `DoctrineExtensionTest::testMappingPathsContainingAPercentSignAreEscaped`, asserting mapping paths are escaped on their way into the driver definition

Note that two percent signs are needed to reproduce: `%2Fother%` is what the bag reads as a reference, so a directory with a single percent sign never triggered it.

Full suites green on HttpKernel (1244), FrameworkBundle (1397), TwigBundle (41) and the Doctrine bridge (457).

Thanks @satdeveloping for the report and the reproduction.
