### PR TITLE
[Serializer] Resolve generic template types during denormalization

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -20,6 +20,7 @@ CHANGELOG
  * Add `DiscriminatorMapType` to extend discriminator maps from mapped child classes
  * Make the `mapping` argument of `DiscriminatorMap` optional and validate it together with `defaultType` at metadata loading time
  * Add `LoaderChainAwareInterface` so that loaders in a `LoaderChain` can defer work until all loaders have run; `LoaderChain` then validates discriminator maps declared in any format
+ * Resolve generic template types during denormalization, e.g. `T` in a `Box<Circle>`-typed property is denormalized as `Circle`
 
 8.1
 ---

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Serializer\Normalizer;
 
+use PHPStan\PhpDocParser\Parser\PhpDocParser;
 use Symfony\Component\PropertyAccess\Exception\NoSuchIndexException;
 use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
 use Symfony\Component\PropertyAccess\Exception\UninitializedPropertyException;
@@ -36,14 +37,17 @@ use Symfony\Component\TypeInfo\Exception\LogicException as TypeInfoLogicExceptio
 use Symfony\Component\TypeInfo\Type;
 use Symfony\Component\TypeInfo\Type\BuiltinType;
 use Symfony\Component\TypeInfo\Type\CollectionType;
+use Symfony\Component\TypeInfo\Type\GenericType;
 use Symfony\Component\TypeInfo\Type\IntersectionType;
 use Symfony\Component\TypeInfo\Type\NullableType;
 use Symfony\Component\TypeInfo\Type\ObjectType;
+use Symfony\Component\TypeInfo\Type\TemplateType;
 use Symfony\Component\TypeInfo\Type\UnionType;
 use Symfony\Component\TypeInfo\Type\WrappingTypeInterface;
 use Symfony\Component\TypeInfo\TypeContext\TypeContextFactory;
 use Symfony\Component\TypeInfo\TypeIdentifier;
 use Symfony\Component\TypeInfo\TypeResolver\ReflectionTypeResolver;
+use Symfony\Component\TypeInfo\TypeResolver\StringTypeResolver;
 
 /**
  * Base class for a normalizer dealing with objects.
@@ -136,6 +140,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
     private array $typeCache = [];
     private array $attributesCache = [];
     private array $typePropertiesCache = [];
+    private ?TypeContextFactory $typeContextFactory = null;
     private readonly \Closure $objectClassResolver;
 
     public function __construct(
@@ -340,6 +345,15 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
 
         $mappedClass = $this->getMappedClass($normalizedData, $type, $context);
 
+        // the parent normalizer passes the generic type of this object so that its template types can be resolved
+        $templateTypes = $this->getTemplateTypes($mappedClass, $context['generic_type'] ?? null);
+        unset($context['generic_type']);
+        if ($templateTypes) {
+            $context['template_types'] = $templateTypes;
+        } else {
+            unset($context['template_types']);
+        }
+
         $nestedAttributes = $this->getNestedAttributes($mappedClass, $context);
         $nestedData = $originalNestedData = [];
         $propertyAccessor = PropertyAccess::createPropertyAccessorBuilder()->enableExceptionOnInvalidIndex()->getPropertyAccessor();
@@ -358,6 +372,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
 
         $originalNormalizedData = $normalizedData;
         $object = $this->instantiateObject($normalizedData, $mappedClass, $context, new \ReflectionClass($mappedClass), $allowedAttributes, $format);
+        unset($context['template_types']);
         $resolvedClass = ($this->objectClassResolver)($object);
         $skipInvalidAttributes = $context[self::SKIP_INVALID_ATTRIBUTES] ?? $this->defaultContext[self::SKIP_INVALID_ATTRIBUTES] ?? false;
 
@@ -414,6 +429,10 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
             }
 
             if (null !== $type = $this->getType($resolvedClass, $attribute)) {
+                if ($templateTypes) {
+                    $type = $this->replaceTemplateTypes($type, $templateTypes);
+                }
+
                 try {
                     $value = $this->validateAndDenormalize($type, $resolvedClass, $attribute, $value, $format, $attributeContext);
                 } catch (NotNormalizableValueException $exception) {
@@ -497,6 +516,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                 $isList = $t->isList();
             }
 
+            $genericType = self::findGenericType($t);
             while ($t instanceof WrappingTypeInterface) {
                 $t = $t->getWrappedType();
             }
@@ -596,6 +616,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                         $class = $collectionValueBaseType->getClassName().'[]';
                         $context['key_type'] = $collectionKeyType;
                         $context['value_type'] = $collectionValueType;
+                        $genericType = self::findGenericType($collectionValueType);
                     } elseif ($collectionValueBaseType instanceof UnionType) {
                         if (!\is_array($data)) {
                             throw NotNormalizableValueException::createForUnexpectedDataType(\sprintf('The type of the "%s" attribute for class "%s" must be one of "array" ("%s" given).', $attribute, $currentClass, get_debug_type($data)), $data, [Type::array()], $context['deserialization_path'] ?? null);
@@ -682,6 +703,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                             }
                         }
 
+                        $innerGenericType = self::findGenericType($innerType);
                         while ($innerType instanceof WrappingTypeInterface) {
                             $innerType = $innerType->getWrappedType();
                         }
@@ -692,6 +714,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                             $class = $innerType->getClassName().$dimensions;
                             $context['key_type'] = $collectionKeyType;
                             $context['value_type'] = $collectionValueType;
+                            $genericType = $innerGenericType;
                         } else {
                             // default fallback (keep it as array)
                             if ($t instanceof ObjectType) {
@@ -731,6 +754,9 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                     }
 
                     $childContext = $this->createChildContext($context, $attribute, $format);
+                    if ($genericType) {
+                        $childContext['generic_type'] = $genericType;
+                    }
                     if ($this->serializer->supportsDenormalization($data, $class, $format, $childContext)) {
                         return $this->serializer->denormalize($data, $class, $format, $childContext);
                     }
@@ -831,6 +857,10 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
             return parent::denormalizeParameter($class, $parameter, $parameterName, $parameterData, $context, $format);
         }
 
+        if ($templateTypes = $context['template_types'] ?? []) {
+            $type = $this->replaceTemplateTypes($type, $templateTypes);
+        }
+
         $parameterType = $parameter->getType();
         static $parameterTypeResolver;
         static $parameterTypeContextFactory;
@@ -880,6 +910,100 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
         }
 
         return $collectionValueBaseType instanceof BuiltinType && \in_array($collectionValueBaseType->getTypeIdentifier(), [TypeIdentifier::BOOL, TypeIdentifier::FLOAT, TypeIdentifier::INT, TypeIdentifier::STRING], true);
+    }
+
+    /**
+     * Returns the generic type that declares the variable types of the given type, if any.
+     *
+     * Collections are skipped: their variable types describe keys and values, not templates.
+     */
+    private static function findGenericType(Type $type): ?GenericType
+    {
+        while ($type instanceof WrappingTypeInterface) {
+            if ($type instanceof CollectionType) {
+                return null;
+            }
+
+            if ($type instanceof GenericType) {
+                return $type->getWrappedType() instanceof ObjectType ? $type : null;
+            }
+
+            $type = $type->getWrappedType();
+        }
+
+        return null;
+    }
+
+    /**
+     * Pairs the variable types of a generic type with the templates declared by the generic class.
+     *
+     * Templates that have no variable type are left as is, so that they fall back to their bound.
+     *
+     * @return array<string, Type>
+     */
+    private function getTemplateTypes(string $mappedClass, mixed $genericType): array
+    {
+        if (!$genericType instanceof GenericType
+            || !($variableTypes = $genericType->getVariableTypes())
+            || !($genericClass = $genericType->getWrappedType()) instanceof ObjectType
+            || !is_a($mappedClass, $genericClass->getClassName(), true)
+            || !class_exists(PhpDocParser::class)
+        ) {
+            return [];
+        }
+
+        $this->typeContextFactory ??= new TypeContextFactory(new StringTypeResolver());
+        $templateTypes = [];
+
+        // the templates of the generic class are the ones the variable types are given for, not those of a mapped child class
+        foreach (array_keys($this->typeContextFactory->createFromClassName($genericClass->getClassName())->templates) as $i => $template) {
+            if (isset($variableTypes[$i])) {
+                $templateTypes[$template] = $variableTypes[$i];
+            }
+        }
+
+        return $templateTypes;
+    }
+
+    /**
+     * @param array<string, Type> $templateTypes
+     */
+    private function replaceTemplateTypes(Type $type, array $templateTypes): Type
+    {
+        if ($type instanceof TemplateType) {
+            return $templateTypes[$type->getName()] ?? $type;
+        }
+
+        if ($type instanceof NullableType) {
+            return Type::nullable($this->replaceTemplateTypes($type->getWrappedType(), $templateTypes));
+        }
+
+        if ($type instanceof UnionType) {
+            $types = array_map(fn (Type $t): Type => $this->replaceTemplateTypes($t, $templateTypes), $type->getTypes());
+
+            foreach ($types as $t) {
+                // a union with "mixed" is "mixed", and creating such a union is not allowed
+                if ($t instanceof BuiltinType && TypeIdentifier::MIXED === $t->getTypeIdentifier()) {
+                    return $t;
+                }
+            }
+
+            return Type::union(...$types);
+        }
+
+        if ($type instanceof IntersectionType) {
+            return Type::intersection(...array_map(fn (Type $t): Type => $this->replaceTemplateTypes($t, $templateTypes), $type->getTypes()));
+        }
+
+        if ($type instanceof CollectionType) {
+            return new CollectionType($this->replaceTemplateTypes($type->getWrappedType(), $templateTypes), $type->isList());
+        }
+
+        if ($type instanceof GenericType) {
+            return Type::generic($type->getWrappedType(), ...array_map(fn (Type $t): Type => $this->replaceTemplateTypes($t, $templateTypes), $type->getVariableTypes()));
+        }
+
+        return $type;
     }
 
     private function getType(string $currentClass, string $attribute): ?Type

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
@@ -1831,6 +1831,180 @@ class AbstractObjectNormalizerTest extends TestCase
         $this->assertSame('dummy', $denormalizedData->values[0]->type);
     }
 
+    public function testDenormalizeGenericType()
+    {
+        $serializer = self::createGenericTypeSerializer();
+
+        $drawing = $serializer->denormalize(['box' => ['item' => ['kind' => 'circle', 'radius' => 2.0]]], GenericDrawing::class);
+
+        $this->assertInstanceOf(GenericDrawing::class, $drawing);
+        $this->assertInstanceOf(GenericBox::class, $drawing->box);
+        $this->assertInstanceOf(GenericCircle::class, $drawing->box->item);
+        $this->assertSame('circle', $drawing->box->item->kind);
+        $this->assertSame(2.0, $drawing->box->item->radius);
+    }
+
+    public function testDenormalizeGenericTypeWithUnboundedTemplate()
+    {
+        $serializer = self::createGenericTypeSerializer();
+
+        $drawing = $serializer->denormalize(['unboundedBox' => ['item' => ['kind' => 'circle', 'radius' => 2.0]]], GenericDrawing::class);
+
+        $this->assertInstanceOf(GenericCircle::class, $drawing->unboundedBox->item);
+        $this->assertSame(2.0, $drawing->unboundedBox->item->radius);
+    }
+
+    public function testDenormalizeGenericTypeInCollections()
+    {
+        $serializer = self::createGenericTypeSerializer();
+
+        $drawing = $serializer->denormalize([
+            'box' => ['items' => [['kind' => 'circle', 'radius' => 1.0], ['kind' => 'circle', 'radius' => 2.0]]],
+            'boxes' => [['item' => ['kind' => 'circle', 'radius' => 3.0]], ['item' => ['kind' => 'circle', 'radius' => 4.0]]],
+            'boxesByName' => ['small' => ['item' => ['kind' => 'circle', 'radius' => 5.0]]],
+        ], GenericDrawing::class);
+
+        $this->assertCount(2, $drawing->box->items);
+        $this->assertContainsOnlyInstancesOf(GenericCircle::class, $drawing->box->items);
+        $this->assertSame([1.0, 2.0], array_map(static fn (GenericCircle $circle) => $circle->radius, $drawing->box->items));
+
+        $this->assertCount(2, $drawing->boxes);
+        $this->assertContainsOnlyInstancesOf(GenericBox::class, $drawing->boxes);
+        $this->assertInstanceOf(GenericCircle::class, $drawing->boxes[0]->item);
+        $this->assertInstanceOf(GenericCircle::class, $drawing->boxes[1]->item);
+        $this->assertSame(4.0, $drawing->boxes[1]->item->radius);
+
+        $this->assertInstanceOf(GenericBox::class, $drawing->boxesByName['small']);
+        $this->assertInstanceOf(GenericCircle::class, $drawing->boxesByName['small']->item);
+        $this->assertSame(5.0, $drawing->boxesByName['small']->item->radius);
+    }
+
+    public function testDenormalizeGenericTypeWithNullableTemplate()
+    {
+        $serializer = self::createGenericTypeSerializer();
+
+        $drawing = $serializer->denormalize(['box' => ['optionalItem' => null], 'nullableBox' => null], GenericDrawing::class);
+
+        $this->assertNull($drawing->box->optionalItem);
+        $this->assertNull($drawing->nullableBox);
+
+        $drawing = $serializer->denormalize(['box' => ['optionalItem' => ['kind' => 'circle', 'radius' => 1.0]], 'nullableBox' => ['item' => ['kind' => 'circle', 'radius' => 2.0]]], GenericDrawing::class);
+
+        $this->assertInstanceOf(GenericCircle::class, $drawing->box->optionalItem);
+        $this->assertSame(1.0, $drawing->box->optionalItem->radius);
+        $this->assertInstanceOf(GenericBox::class, $drawing->nullableBox);
+        $this->assertInstanceOf(GenericCircle::class, $drawing->nullableBox->item);
+        $this->assertSame(2.0, $drawing->nullableBox->item->radius);
+    }
+
+    public function testDenormalizeGenericTypeInUnionType()
+    {
+        $serializer = self::createGenericTypeSerializer();
+
+        $drawing = $serializer->denormalize(['unboundedBox' => ['itemOrLabel' => ['kind' => 'circle', 'radius' => 2.0]]], GenericDrawing::class);
+
+        $this->assertInstanceOf(GenericCircle::class, $drawing->unboundedBox->itemOrLabel);
+        $this->assertSame(2.0, $drawing->unboundedBox->itemOrLabel->radius);
+    }
+
+    public function testDenormalizeGenericTypeWithMixedVariableType()
+    {
+        $serializer = self::createGenericTypeSerializer();
+
+        $drawing = $serializer->denormalize(['mixedBox' => ['item' => ['kind' => 'circle'], 'itemOrLabel' => ['kind' => 'circle']]], GenericDrawing::class);
+
+        $this->assertSame(['kind' => 'circle'], $drawing->mixedBox->item);
+        $this->assertSame(['kind' => 'circle'], $drawing->mixedBox->itemOrLabel);
+    }
+
+    public function testDenormalizeNestedGenericType()
+    {
+        $serializer = self::createGenericTypeSerializer();
+
+        $drawing = $serializer->denormalize(['nestedBox' => ['item' => ['item' => ['kind' => 'circle', 'radius' => 2.0]]]], GenericDrawing::class);
+
+        $this->assertInstanceOf(GenericUnboundedBox::class, $drawing->nestedBox);
+        $this->assertInstanceOf(GenericUnboundedBox::class, $drawing->nestedBox->item);
+        $this->assertInstanceOf(GenericCircle::class, $drawing->nestedBox->item->item);
+        $this->assertSame(2.0, $drawing->nestedBox->item->item->radius);
+    }
+
+    public function testDenormalizeGenericTypeWithSeveralTemplates()
+    {
+        $serializer = self::createGenericTypeSerializer();
+
+        $drawing = $serializer->denormalize(['pair' => ['first' => ['kind' => 'circle', 'radius' => 1.0], 'second' => ['kind' => 'square', 'side' => 2.0]]], GenericDrawing::class);
+
+        $this->assertInstanceOf(GenericCircle::class, $drawing->pair->first);
+        $this->assertSame(1.0, $drawing->pair->first->radius);
+        $this->assertInstanceOf(GenericSquare::class, $drawing->pair->second);
+        $this->assertSame(2.0, $drawing->pair->second->side);
+    }
+
+    public function testDenormalizeGenericTypeKeepsTemplatesWithoutVariableType()
+    {
+        $serializer = self::createGenericTypeSerializer();
+
+        $drawing = $serializer->denormalize(['partialPair' => ['first' => ['kind' => 'circle', 'radius' => 1.0], 'second' => ['kind' => 'square', 'side' => 2.0]]], GenericDrawing::class);
+
+        $this->assertInstanceOf(GenericCircle::class, $drawing->partialPair->first);
+        // "V" has no variable type, so it falls back to its bound, which is "mixed"
+        $this->assertSame(['kind' => 'square', 'side' => 2.0], $drawing->partialPair->second);
+    }
+
+    public function testDenormalizeGenericTypeInConstructor()
+    {
+        $serializer = self::createGenericTypeSerializer();
+
+        $drawing = $serializer->denormalize(['constructedBox' => ['item' => ['kind' => 'circle', 'radius' => 2.0], 'label' => 'round']], GenericDrawing::class);
+
+        $this->assertInstanceOf(GenericBoxWithConstructor::class, $drawing->constructedBox);
+        $this->assertInstanceOf(GenericCircle::class, $drawing->constructedBox->item);
+        $this->assertSame(2.0, $drawing->constructedBox->item->radius);
+        $this->assertSame('round', $drawing->constructedBox->label);
+    }
+
+    public function testDenormalizeGenericTypeWithDiscriminatorMap()
+    {
+        $serializer = self::createGenericTypeSerializer();
+
+        $drawing = $serializer->denormalize(['mappedBox' => ['type' => 'gift', 'item' => ['kind' => 'circle', 'radius' => 2.0], 'wrapping' => ['kind' => 'circle']]], GenericDrawing::class);
+
+        $this->assertInstanceOf(GenericGiftBox::class, $drawing->mappedBox);
+        $this->assertInstanceOf(GenericCircle::class, $drawing->mappedBox->item);
+        $this->assertSame(2.0, $drawing->mappedBox->item->radius);
+        // the variable type is given for "T" of the declared class, while "U" belongs to the mapped one
+        $this->assertSame(['kind' => 'circle'], $drawing->mappedBox->wrapping);
+    }
+
+    public function testDenormalizeGenericTypeDoesNotLeakToNestedObjects()
+    {
+        $serializer = self::createGenericTypeSerializer();
+
+        $drawing = $serializer->denormalize(['box' => ['inner' => ['item' => ['kind' => 'circle', 'radius' => 2.0]]]], GenericDrawing::class);
+
+        $this->assertInstanceOf(GenericUnboundedBox::class, $drawing->box->inner);
+        // the inner box is not declared as a generic type, so its template keeps its "mixed" bound
+        $this->assertSame(['kind' => 'circle', 'radius' => 2.0], $drawing->box->inner->item);
+    }
+
+    public function testDenormalizeGenericTypeWithoutVariableTypesFallsBackToBound()
+    {
+        $serializer = self::createGenericTypeSerializer();
+
+        $this->expectException(NotNormalizableValueException::class);
+        $this->expectExceptionMessage('Failed to create object because the class "'.GenericShape::class.'" is not instantiable.');
+
+        $serializer->denormalize(['plainBox' => ['item' => ['kind' => 'circle', 'radius' => 2.0]]], GenericDrawing::class);
+    }
+
+    private static function createGenericTypeSerializer(): Serializer
+    {
+        $normalizer = new ObjectNormalizer(new ClassMetadataFactory(new AttributeLoader()), null, null, new PropertyInfoExtractor(typeExtractors: [new PhpStanExtractor(), new ReflectionExtractor()]));
+
+        return new Serializer([new ArrayDenormalizer(), $normalizer]);
+    }
+
     public function testNotNormalizableValueExceptionCurrentTypeUsesAttributeValue()
     {
         $serializer = new Serializer([new ObjectNormalizer(propertyAccessor: PropertyAccess::createPropertyAccessor())]);
@@ -2597,4 +2771,133 @@ class DummyWithArrayObjectOfDtos
     {
         $this->items = new \ArrayObject(iterator_to_array($items));
     }
+}
+
+abstract class GenericShape
+{
+    public string $kind = '';
+}
+
+class GenericCircle extends GenericShape
+{
+    public float $radius = 0.0;
+}
+
+class GenericSquare extends GenericShape
+{
+    public float $side = 0.0;
+}
+
+/**
+ * @template T of GenericShape
+ */
+class GenericBox
+{
+    /** @var T */
+    public mixed $item = null;
+
+    /** @var ?T */
+    public mixed $optionalItem = null;
+
+    /** @var list<T> */
+    public array $items = [];
+
+    public ?GenericUnboundedBox $inner = null;
+}
+
+/**
+ * @template T
+ */
+class GenericUnboundedBox
+{
+    /** @var T */
+    public mixed $item = null;
+
+    /** @var T|string */
+    public mixed $itemOrLabel = null;
+}
+
+/**
+ * @template T of GenericShape
+ */
+class GenericBoxWithConstructor
+{
+    /**
+     * @param T $item
+     */
+    public function __construct(
+        public mixed $item,
+        public string $label = '',
+    ) {
+    }
+}
+
+/**
+ * @template K
+ * @template V
+ */
+class GenericPair
+{
+    /** @var K */
+    public mixed $first = null;
+
+    /** @var V */
+    public mixed $second = null;
+}
+
+/**
+ * @template T of GenericShape
+ */
+#[DiscriminatorMap('type', ['gift' => GenericGiftBox::class])]
+abstract class AbstractGenericBox
+{
+    /** @var T */
+    public mixed $item = null;
+}
+
+/**
+ * @template U
+ */
+class GenericGiftBox extends AbstractGenericBox
+{
+    /** @var U */
+    public mixed $wrapping = null;
+}
+
+class GenericDrawing
+{
+    /** @var GenericBox<GenericCircle> */
+    public GenericBox $box;
+
+    /** @var GenericUnboundedBox<GenericCircle> */
+    public GenericUnboundedBox $unboundedBox;
+
+    /** @var ?GenericBox<GenericCircle> */
+    public ?GenericBox $nullableBox = null;
+
+    /** @var list<GenericBox<GenericCircle>> */
+    public array $boxes = [];
+
+    /** @var array<string, GenericBox<GenericCircle>> */
+    public array $boxesByName = [];
+
+    /** @var GenericUnboundedBox<mixed> */
+    public GenericUnboundedBox $mixedBox;
+
+    /** @var GenericUnboundedBox<GenericUnboundedBox<GenericCircle>> */
+    public GenericUnboundedBox $nestedBox;
+
+    /** @var GenericPair<GenericCircle, GenericSquare> */
+    public GenericPair $pair;
+
+    /** @var GenericPair<GenericCircle> */
+    public GenericPair $partialPair;
+
+    /** @var GenericBoxWithConstructor<GenericCircle> */
+    public GenericBoxWithConstructor $constructedBox;
+
+    /** @var AbstractGenericBox<GenericCircle> */
+    public AbstractGenericBox $mappedBox;
+
+    public GenericBox $plainBox;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #65991 
| License       | MIT

PropertyInfo returns a `GenericType` for `Box<Circle>` and a `TemplateType` for `T`. The Serializer dropped both while unwrapping the type, so `T` was denormalized as its bound, or kept as an array when unbounded.

This PR carries the variable types of the outer `GenericType` into the child context and resolves each `TemplateType` against them, the same way JsonStreamer's `GenericTypePropertyMetadataLoader` does. Templates without a variable type keep their bound, so existing behavior is unchanged. Traversable generics like `Collection<Foo>` are resolved as collections by TypeInfo and are not affected.

>Only denormalization is affected: normalization already works with generics, including collections.

## Supported variants

```php
abstract class Shape 
{ 
    public string $kind = ''; 
}
class Circle extends Shape 
{ 
    public float $radius = 0.0; 
}
class Square extends Shape 
{ 
    public float $side = 0.0; 
}
```

**Bounded template**

```php
/** @template T of Shape */
class Box
{
    /** @var T */
    public mixed $item = null;
}

/** @var Box<Circle> */
public Box $box;

// $box->item is a Circle
```

**Unbounded template**

```php
/** @template T */
class Wrapper
{
    /** @var T */
    public mixed $value = null;
}

/** @var Wrapper<Circle> */
public Wrapper $wrapper;

// $wrapper->value is a Circle (was kept as an array before)
```

**Collections of `T`**

```php
/** @template T of Shape */
class Box
{
    /** @var list<T> */
    public array $items = [];
}

/** @var Box<Circle> */
public Box $box;

// $box->items is a list of Circle
```

**Collections of generics**

```php
/** @var list<Box<Circle>> */
public array $boxes = [];

/** @var array<string, Box<Circle>> */
public array $boxesByName = [];

// every Box holds a Circle
```

**Nullable template and nullable generic**

```php
/** @template T of Shape */
class Box
{
    /** @var ?T */
    public mixed $optionalItem = null;
}

/** @var ?Box<Circle> */
public ?Box $box = null;

// null stays null, data becomes a Circle
```

**Nested generics**

```php
/** @var Wrapper<Wrapper<Circle>> */
public Wrapper $nested;

// $nested->value->value is a Circle
```

**Several templates**

```php
/**
 * @template K
 * @template V
 */
class Pair
{
    /** @var K */
    public mixed $first = null;

    /** @var V */
    public mixed $second = null;
}

/** @var Pair<Circle, Square> */
public Pair $pair;

// $pair->first is a Circle, $pair->second is a Square

/** @var Pair<Circle> */
public Pair $partial;

// $partial->first is a Circle, $partial->second keeps the bound of V
```

**Template in a union**

```php
/** @template T */
class Wrapper
{
    /** @var T|string */
    public mixed $valueOrLabel = null;
}

/** @var Wrapper<Circle> */
public Wrapper $wrapper;

// object data becomes a Circle, a string stays a string

/** @var Wrapper<mixed> */
public Wrapper $anything;

// T|string collapses to mixed, so the data is kept as is
```

**Constructor arguments**

```php
/** @template T of Shape */
class Gift
{
    /** @param T $item */
    public function __construct(public mixed $item) {}
}

/** @var Gift<Circle> */
public Gift $gift;

// $gift->item is a Circle
```

**Discriminator map**

```php
/** @template T of Shape */
#[DiscriminatorMap('type', ['gift' => GiftBox::class])]
abstract class AbstractBox
{
    /** @var T */
    public mixed $item = null;
}

class GiftBox extends AbstractBox {}

/** @var AbstractBox<Circle> */
public AbstractBox $box;

// $box is a GiftBox and $box->item is a Circle
```

**No variable types**

```php
public Box $plainBox;

// T falls back to its bound, as before
```

A variable type of mixed is supported too: a union that would contain it collapses to mixed, since TypeInfo does not allow such a union. Template types never leak into nested objects that are not declared as generic. 

## Not covered

**A child class that extends a generic parent.** The variable types have to be on the property. A class that binds them with `@extends` is seen as a plain object, so its inherited templates keep their bound:

```php
/** @extends Box<Circle> */
class CircleBox extends Box {}

public CircleBox $box;

// $box->item stays an array
```

**Templates declared by a class a discriminator map resolves to.** The variable types are given for the templates of the declared class. A mapped child that declares templates of its own keeps their bound:

```php
/** @template T of Shape */
#[DiscriminatorMap('type', ['gift' => GiftBox::class])]
abstract class AbstractBox
{
    /** @var T */
    public mixed $item = null;
}

/** @template U */
class GiftBox extends AbstractBox
{
    /** @var U */
    public mixed $wrapping = null;
}

/** @var AbstractBox<Circle> */
public AbstractBox $box;

// $box->item is a Circle, $box->wrapping stays an array
```

**A generic at the root of a payload.** `denormalize()` takes a class name, which cannot carry variable types. Declare the generic on a property of a wrapper class instead.

## For the documentation

- Denormalization resolves `@template` types when the property that holds the object is declared with its variable types, as `Box<Circle>`. Normalization needs nothing.
- It needs `PhpStanExtractor` from PropertyInfo, so `phpstan/phpdoc-parser` has to be installed. `PhpDocExtractor` reads `@var T` as a class literally named `T`, which fails today and is left untouched.
- A template with no variable type falls back to its bound, and to `mixed` when it has none. That is the same result as before this change, so nothing that works today starts failing.
- The three shapes above are not covered, and the workaround for the third one is a wrapper class.
