### PR TITLE
[Translation] Make `PhraseProvider::read()` fetch every domain and locale when passed none

### DIFF
--- a/src/Symfony/Component/Translation/Bridge/Phrase/CHANGELOG.md
+++ b/src/Symfony/Component/Translation/Bridge/Phrase/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Make `PhraseProvider::read()` fetch every locale when passed none
+ * Make `PhraseProvider::read()` fetch every domain when passed none
+
 6.4
 ---
 

--- a/src/Symfony/Component/Translation/Bridge/Phrase/PhraseProvider.php
+++ b/src/Symfony/Component/Translation/Bridge/Phrase/PhraseProvider.php
@@ -89,6 +89,18 @@ class PhraseProvider implements ProviderInterface
     {
         $translatorBag = new TranslatorBag();
 
+        if (!$locales) {
+            if (!$this->phraseLocales) {
+                $this->initLocales();
+            }
+
+            // getLocale() looks locales up by name, so reading them all goes through their names too
+            $locales = str_replace('-', '_', array_keys($this->phraseLocales));
+        }
+
+        // domains are the tags write() attaches to the keys it uploads
+        $domains = $domains ?: $this->getTags();
+
         foreach ($locales as $locale) {
             $phraseLocale = $this->getLocale($locale);
 
@@ -241,6 +253,39 @@ class PhraseProvider implements ProviderInterface
             $pagination = $response->getHeaders()['pagination'][0] ?? '{}';
             $page = json_decode($pagination, true)['next_page'] ?? null;
         } while (null !== $page);
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getTags(): array
+    {
+        $tags = [];
+        $page = 1;
+
+        do {
+            $response = $this->client->request('GET', 'tags', [
+                'query' => [
+                    'per_page' => 100,
+                    'page' => $page,
+                ],
+            ]);
+
+            if (200 !== $statusCode = $response->getStatusCode()) {
+                $this->logger->error(\sprintf('Unable to get tags from phrase: "%s".', $response->getContent(false)));
+
+                $this->throwProviderException($statusCode, $response, 'Unable to get tags from phrase.');
+            }
+
+            foreach ($response->toArray() as $tag) {
+                $tags[] = $tag['name'];
+            }
+
+            $pagination = $response->getHeaders()['pagination'][0] ?? '{}';
+            $page = json_decode($pagination, true)['next_page'] ?? null;
+        } while (null !== $page);
+
+        return $tags;
     }
 
     private function throwProviderException(int $statusCode, ResponseInterface $response, string $message): void

--- a/src/Symfony/Component/Translation/Bridge/Phrase/Tests/PhraseProviderTest.php
+++ b/src/Symfony/Component/Translation/Bridge/Phrase/Tests/PhraseProviderTest.php
@@ -257,6 +257,63 @@ class PhraseProviderTest extends TestCase
         $provider->read([$domain], [$locale]);
     }
 
+    public function testReadWithoutLocales()
+    {
+        $this->getLoader()
+            ->method('load')
+            ->willReturnCallback(static fn (string $content, string $locale, string $domain) => new MessageCatalogue($locale, [$domain => ['a' => $content]]));
+
+        $responses = [
+            'init locales' => $this->getInitLocaleResponseMock(),
+            'download de' => $this->getDownloadLocaleResponseMock('messages', '5fea6ed5c21767730918a9400e420832', 'trans_de_a'),
+            'download en-GB' => $this->getDownloadLocaleResponseMock('messages', '13604ec993beefcdaba732812cdb828c', 'trans_en_GB_a'),
+        ];
+
+        $provider = $this->createProvider(httpClient: $httpClient = (new MockHttpClient($responses))->withOptions([
+            'base_uri' => 'https://api.phrase.com/api/v2/projects/1/',
+            'headers' => [
+                'Authorization' => 'token API_TOKEN',
+                'User-Agent' => 'myProject',
+            ],
+        ]), endpoint: 'api.phrase.com/api/v2');
+
+        $translatorBag = $provider->read(['messages'], []);
+
+        $this->assertSame(['de', 'en_GB'], array_map(static fn (MessageCatalogue $catalogue) => $catalogue->getLocale(), $translatorBag->getCatalogues()));
+        $this->assertSame(['a' => 'trans_en_GB_a'], $translatorBag->getCatalogue('en_GB')->all('messages'));
+        // no locale is created on the way
+        $this->assertSame(\count($responses), $httpClient->getRequestsCount());
+    }
+
+    public function testReadWithoutDomains()
+    {
+        $this->getLoader()
+            ->method('load')
+            ->willReturnCallback(static fn (string $content, string $locale, string $domain) => new MessageCatalogue($locale, [$domain => ['a' => $content]]));
+
+        $responses = [
+            'list tags' => $this->getTagsResponseMock(),
+            'init locales' => $this->getInitLocaleResponseMock(),
+            'download messages' => $this->getDownloadLocaleResponseMock('messages', '5fea6ed5c21767730918a9400e420832', 'trans_de_messages_a'),
+            'download validators' => $this->getDownloadLocaleResponseMock('validators', '5fea6ed5c21767730918a9400e420832', 'trans_de_validators_a'),
+        ];
+
+        $provider = $this->createProvider(httpClient: $httpClient = (new MockHttpClient($responses))->withOptions([
+            'base_uri' => 'https://api.phrase.com/api/v2/projects/1/',
+            'headers' => [
+                'Authorization' => 'token API_TOKEN',
+                'User-Agent' => 'myProject',
+            ],
+        ]), endpoint: 'api.phrase.com/api/v2');
+
+        $translatorBag = $provider->read([], ['de']);
+
+        // the tags of the project are the domains, under their own names
+        $this->assertSame(['a' => 'trans_de_messages_a'], $translatorBag->getCatalogue('de')->all('messages'));
+        $this->assertSame(['a' => 'trans_de_validators_a'], $translatorBag->getCatalogue('de')->all('validators'));
+        $this->assertSame(\count($responses), $httpClient->getRequestsCount());
+    }
+
     #[DataProvider('cacheKeyProvider')]
     public function testCacheKeyOptionsSort(array $options, string $expectedKey)
     {
@@ -1059,6 +1116,27 @@ class PhraseProviderTest extends TestCase
                 'ETag' => 'W/"625d11cf081b1697cbc216edf6ebb13c"',
                 'Last-Modified' => 'Wed, 28 Dec 2022 13:16:45 GMT',
             ]]);
+        };
+    }
+
+    private function getTagsResponseMock(): \Closure
+    {
+        return function (string $method, string $url): ResponseInterface {
+            $this->assertSame('GET', $method);
+            $this->assertSame('https://api.phrase.com/api/v2/projects/1/tags?per_page=100&page=1', $url);
+
+            return new JsonMockResponse([
+                [
+                    'name' => 'messages',
+                    'keys_count' => 2,
+                    'system_tag' => false,
+                ],
+                [
+                    'name' => 'validators',
+                    'keys_count' => 1,
+                    'system_tag' => false,
+                ],
+            ]);
         };
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Part of #64155
| License       | MIT

This covers both Phrase `read()` items of the checklist in #64155.

With no locales, `read()` reads every locale of the project, taken from the paginated list `initLocales()` already fetches. They are read under their names, since `getLocale()` looks them up by name, so no locale gets created on the way.

With no domains, it reads the tags of the project, one request per page like the locales, and reads one domain per tag. Domains come back under their real names, which is what the contract in the issue asks for.

### The one thing worth a look

Phrase marks some tags as its own: every tag carries a `system_tag` flag, and the listing endpoint takes `exclude_system_tags`, documented as excluding "tags generated by the system, e.g. job, upload or figma tags". Our domains are attached through the `uploads` endpoint by `write()`, so whether they count as system tags decides what the default should be:

- listing every tag, as this PR does, always returns the domains `write()` created, at the cost of surfacing a `job` or `figma` tag as a domain on projects that have them;
- excluding system tags is quieter, but if the tags set at upload are system tags, `read()` returns an empty bag again, which is the bug this issue is about.

I went for the first, since a missing domain is silent and an extra one is not. Checked with mocked responses only, so if someone has a project at hand, the question is whether a tag set through an upload comes back with `system_tag` true or false.