### PR TITLE
[TypeInfo] Collect templates in declaration order

### DIFF
--- a/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyWithMixedTemplates.php
+++ b/src/Symfony/Component/TypeInfo/Tests/Fixtures/DummyWithMixedTemplates.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\TypeInfo\Tests\Fixtures;
+
+/**
+ * @template-covariant T
+ *
+ * @template U
+ *
+ * @phpstan-template V
+ *
+ * @psalm-template W
+ */
+final class DummyWithMixedTemplates
+{
+}

--- a/src/Symfony/Component/TypeInfo/Tests/TypeContext/TypeContextFactoryTest.php
+++ b/src/Symfony/Component/TypeInfo/Tests/TypeContext/TypeContextFactoryTest.php
@@ -22,6 +22,7 @@ use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithCovariantTemplates;
 use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithImportedOnlyTypeAliases;
 use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithInvalidTypeAlias;
 use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithInvalidTypeAliasImport;
+use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithMixedTemplates;
 use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithPhpstanCovariantTemplates;
 use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithPhpstanTemplates;
 use Symfony\Component\TypeInfo\Tests\Fixtures\DummyWithPsalmCovariantTemplates;
@@ -171,6 +172,11 @@ class TypeContextFactoryTest extends TestCase
         yield [DummyWithCovariantTemplates::class];
         yield [DummyWithPsalmCovariantTemplates::class];
         yield [DummyWithPhpstanCovariantTemplates::class];
+    }
+
+    public function testCollectTemplatesInDeclarationOrder()
+    {
+        $this->assertSame(['T', 'U', 'V', 'W'], array_keys($this->typeContextFactory->createFromClassName(DummyWithMixedTemplates::class)->templates));
     }
 
     public function testCollectTemplatesWithParent()

--- a/src/Symfony/Component/TypeInfo/TypeContext/TypeContextFactory.php
+++ b/src/Symfony/Component/TypeInfo/TypeContext/TypeContextFactory.php
@@ -260,14 +260,9 @@ final class TypeContextFactory
             '@phpstan-template-covariant',
         ];
 
-        $tags = [];
-        foreach ($templateTags as $tagName) {
-            $tags = [...$tags, ...$docNode->getTagsByName($tagName)];
-        }
-
         $templates = [];
-        foreach ($tags as $tag) {
-            if (!$tag->value instanceof TemplateTagValueNode) {
+        foreach ($docNode->getTags() as $tag) {
+            if (!$tag->value instanceof TemplateTagValueNode || !\in_array($tag->name, $templateTags, true)) {
                 continue;
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`TypeContextFactory::collectTemplates()` builds its tag list by calling `getTagsByName()` once per accepted tag name and concatenating the results. A class that mixes tag spellings therefore gets its templates back grouped by tag name instead of in declaration order:

```php
/**
 * @template-covariant K
 * @template V
 */
class Pair {}

$typeContextFactory->createFromClassName(Pair::class)->templates; // ['V' => ..., 'K' => ...]
```

Consumers pair the variable types of a `GenericType` with that list by position, so the wrong type is bound to each template. `JsonStreamer` reads `Pair<A, B>` as if it were `Pair<B, A>`:

```php
$reader->read('{"first":{...},"second":{...}}', Type::generic(Type::object(Pair::class), Type::object(A::class), Type::object(B::class)));
// $pair->first is a B, $pair->second is an A
```

The fix walks `$docNode->getTags()` once, in the order the tags appear in the doc block, and keeps the ones whose name is a template tag.

Covariant templates were added in #64130, so the swap only exists on 8.2. Older branches do not collect `@template-covariant` at all, and they can still mis-order a class that mixes `@template` with `@psalm-template` or `@phpstan-template`.

`StringTypeResolver` looks templates up by name, so it is unaffected. `JsonStreamer` is the only consumer that reads the order today; `Serializer` becomes a second one with #66005.
