### PR TITLE
[Notifier] Deprecate the LineNotify bridge

### DIFF
--- a/UPGRADE-8.2.md
+++ b/UPGRADE-8.2.md
@@ -254,6 +254,7 @@ Notifier
  * Deprecate declaring `getAdminRecipients()` on a `NotifierInterface` implementation without implementing `AdminRecipientsProviderInterface`
  * Deprecate reading a value that is not a boolean with `Dsn::getBooleanOption()`; it will throw in 9.0. The
    boolean values it accepts are `1`/`0`, `true`/`false`, `on`/`off`, `yes`/`no` and the empty string, which reads as `false`
+ * Deprecate the `LineNotify` transport as LINE Notify was shut down, use `LineBot` instead
 
 RateLimiter
 -----------

--- a/src/Symfony/Component/Notifier/Bridge/LineNotify/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/LineNotify/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add the `ssl` DSN option to send requests over plain HTTP
+ * Deprecate the bridge as LINE Notify was shut down, use the LineBot bridge instead
 
 6.3
 ---

--- a/src/Symfony/Component/Notifier/Bridge/LineNotify/LineNotifyTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/LineNotify/LineNotifyTransport.php
@@ -22,6 +22,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
  * @author Akira Kurozumi <info@a-zumi.net>
+ *
+ * @deprecated since Symfony 8.2, use the LineBot bridge instead
  */
 final class LineNotifyTransport extends AbstractTransport
 {

--- a/src/Symfony/Component/Notifier/Bridge/LineNotify/LineNotifyTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/LineNotify/LineNotifyTransportFactory.php
@@ -17,6 +17,8 @@ use Symfony\Component\Notifier\Transport\Dsn;
 
 /**
  * @author Akira Kurozumi <info@a-zumi.net>
+ *
+ * @deprecated since Symfony 8.2, use the LineBot bridge instead
  */
 final class LineNotifyTransportFactory extends AbstractTransportFactory
 {
@@ -29,6 +31,8 @@ final class LineNotifyTransportFactory extends AbstractTransportFactory
 
     public function create(Dsn $dsn): LineNotifyTransport
     {
+        trigger_deprecation('symfony/line-notify-notifier', '8.2', 'The "symfony/line-notify-notifier" package is deprecated as LINE Notify was shut down, use "symfony/line-bot-notifier" instead.');
+
         if (self::SCHEME !== $dsn->getScheme()) {
             throw new UnsupportedSchemeException($dsn, self::SCHEME, $this->getSupportedSchemes());
         }

--- a/src/Symfony/Component/Notifier/Bridge/LineNotify/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/LineNotify/README.md
@@ -1,7 +1,8 @@
 LINE Notifier
 =============
 
-Provides [LINE Notify](https://notify-bot.line.me/) integration for Symfony Notifier.
+The LINE Notify bridge is deprecated as LINE Notify was shut down on 2025-03-31,
+use the LineBot bridge instead.
 
 DSN example
 -----------

--- a/src/Symfony/Component/Notifier/Bridge/LineNotify/Tests/LineNotifyTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/LineNotify/Tests/LineNotifyTransportFactoryTest.php
@@ -11,20 +11,34 @@
 
 namespace Symfony\Component\Notifier\Bridge\LineNotify\Tests;
 
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
+use Symfony\Bridge\PhpUnit\ExpectUserDeprecationMessageTrait;
 use Symfony\Component\Notifier\Bridge\LineNotify\LineNotifyTransportFactory;
 use Symfony\Component\Notifier\Test\AbstractTransportFactoryTestCase;
 use Symfony\Component\Notifier\Test\IncompleteDsnTestTrait;
+use Symfony\Component\Notifier\Transport\Dsn;
 
 /**
  * @author Akira Kurozumi <info@a-zumi.net>
  */
+#[Group('legacy')]
+#[IgnoreDeprecations]
 final class LineNotifyTransportFactoryTest extends AbstractTransportFactoryTestCase
 {
+    use ExpectUserDeprecationMessageTrait;
     use IncompleteDsnTestTrait;
 
     public function createFactory(): LineNotifyTransportFactory
     {
         return new LineNotifyTransportFactory();
+    }
+
+    public function testCreateIsDeprecated()
+    {
+        $this->expectUserDeprecationMessage('Since symfony/line-notify-notifier 8.2: The "symfony/line-notify-notifier" package is deprecated as LINE Notify was shut down, use "symfony/line-bot-notifier" instead.');
+
+        $this->createFactory()->create(new Dsn('linenotify://token@default'));
     }
 
     public static function supportsProvider(): iterable

--- a/src/Symfony/Component/Notifier/Bridge/LineNotify/Tests/LineNotifyTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/LineNotify/Tests/LineNotifyTransportTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Notifier\Bridge\LineNotify\Tests;
 
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Notifier\Bridge\LineNotify\LineNotifyTransport;
@@ -24,6 +26,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Akira Kurozumi <info@a-zumi.net>
  */
+#[Group('legacy')]
+#[IgnoreDeprecations]
 final class LineNotifyTransportTest extends TransportTestCase
 {
     public static function createTransport(?HttpClientInterface $client = null): LineNotifyTransport

--- a/src/Symfony/Component/Notifier/Bridge/LineNotify/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/LineNotify/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=8.4.1",
+        "symfony/deprecation-contracts": "^2.5|^3",
         "symfony/http-client": "^7.4|^8.0",
         "symfony/notifier": "^8.2"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Issues        | Fix #65992
| License       | MIT

LINE Notify was shut down on 2025-03-31, so this bridge points at an API that no longer answers. This deprecates it on 8.2, for removal in 9.0, and points to the LineBot bridge instead.

The deprecation is triggered in `LineNotifyTransportFactory::create()` rather than when the class is loaded, as #58200 did for the sms77 bridge: the factory is listed in `Transport::FACTORY_CLASSES`, the `NotifierBundle` and `UnsupportedSchemeException`, so only applications actually using a `linenotify://` DSN get the notice.
