### PR TITLE
[Console] Autowire the lock factory named "console" in LockableTrait

### DIFF
--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.2
 ---
 
+ * Add `LockableTrait::setLockFactory()`, autowired with the lock factory of the resource named `console` when the app declares one
  * Allow `#[AsCommand]` to list `InputOption`s to add after the ones the parameters of the command declare
  * Register a class-level `#[AsCommand]` without `__invoke()` as the command grouping its method-level ones
  * Resolve spaced sub-command invocations through the tree derived from registered command names, with per-level options and `--` binding the remaining tokens to the current command

--- a/src/Symfony/Component/Console/Command/LockableTrait.php
+++ b/src/Symfony/Component/Console/Command/LockableTrait.php
@@ -13,10 +13,12 @@ namespace Symfony\Component\Console\Command;
 
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Exception\LogicException;
+use Symfony\Component\DependencyInjection\Attribute\Target;
 use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\Lock\LockInterface;
 use Symfony\Component\Lock\Store\FlockStore;
 use Symfony\Component\Lock\Store\SemaphoreStore;
+use Symfony\Contracts\Service\Attribute\Required;
 
 /**
  * Basic lock feature for commands.
@@ -28,6 +30,18 @@ trait LockableTrait
     private ?LockInterface $lock = null;
 
     private ?LockFactory $lockFactory = null;
+
+    /**
+     * Sets the lock factory, unless the command set one for itself already.
+     *
+     * The argument is nullable so that autowiring is a no-op for apps that
+     * declare no lock resource named "console".
+     */
+    #[Required]
+    public function setLockFactory(#[Target('console')] ?LockFactory $lockFactory = null): void
+    {
+        $this->lockFactory ??= $lockFactory;
+    }
 
     /**
      * Locks a command.

--- a/src/Symfony/Component/Console/Tests/Command/LockableTraitTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/LockableTraitTest.php
@@ -14,6 +14,10 @@ namespace Symfony\Component\Console\Tests\Command;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\DependencyInjection\Alias;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ParameterBag\EnvPlaceholderParameterBag;
+use Symfony\Component\Lock\LockBundle;
 use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\Lock\SharedLockInterface;
 use Symfony\Component\Lock\Store\FlockStore;
@@ -81,6 +85,110 @@ class LockableTraitTest extends TestCase
 
         $lockFactory->expects(static::once())->method('createLock')->willReturn($lock);
         $this->assertSame(1, $tester->execute([]));
+    }
+
+    public function testLockFactoryIsInjectedBySetter()
+    {
+        $lockFactory = $this->createMock(LockFactory::class);
+        $command = new \FooLockCommand();
+        $command->setLockFactory($lockFactory);
+
+        $lock = $this->createStub(SharedLockInterface::class);
+        $lock->method('acquire')->willReturn(false);
+        $lockFactory->expects($this->once())->method('createLock')->willReturn($lock);
+
+        $tester = new CommandTester($command);
+        $this->assertSame(1, $tester->execute([]));
+    }
+
+    public function testInjectedLockFactoryDoesNotOverrideTheCommandOne()
+    {
+        $commandFactory = $this->createMock(LockFactory::class);
+        $injectedFactory = $this->createMock(LockFactory::class);
+        $injectedFactory->expects($this->never())->method('createLock');
+
+        $command = new \FooLock3Command($commandFactory);
+        $command->setLockFactory($injectedFactory);
+
+        $lock = $this->createStub(SharedLockInterface::class);
+        $lock->method('acquire')->willReturn(false);
+        $commandFactory->expects($this->once())->method('createLock')->willReturn($lock);
+
+        $tester = new CommandTester($command);
+        $this->assertSame(1, $tester->execute([]));
+    }
+
+    public function testNoLockFactoryToInjectKeepsTheDefaultOne()
+    {
+        $command = new \FooLockCommand();
+        $command->setLockFactory();
+
+        $tester = new CommandTester($command);
+        $this->assertSame(2, $tester->execute([]));
+    }
+
+    public function testNothingIsInjectedWithoutLockServices()
+    {
+        $container = $this->createContainer(null);
+
+        $this->assertNull($container->get('command')->getLockFactory());
+        $this->assertSame(2, new CommandTester($container->get('command'))->execute([]));
+    }
+
+    public function testTheDefaultLockResourceIsNotInjected()
+    {
+        $container = $this->createContainer(['default' => 'flock'], 'lock.default.factory');
+
+        $this->assertInstanceOf(LockFactory::class, $container->get('lock_factory'));
+        $this->assertNull($container->get('command')->getLockFactory());
+    }
+
+    public function testTheConsoleLockResourceIsInjected()
+    {
+        $container = $this->createContainer(['console' => 'flock'], 'lock.console.factory');
+
+        $this->assertSame($container->get('lock_factory'), $container->get('command')->getLockFactory());
+    }
+
+    public function testTheConsoleLockResourceRegistersTheTargetAlias()
+    {
+        $container = $this->createContainer(['console' => 'flock'], null, false);
+
+        $this->assertSame(LockFactory::class.' $consoleLockFactory', (string) $container->getAlias('.'.LockFactory::class.' $console'));
+        $this->assertSame('lock.console.factory', (string) $container->getAlias(LockFactory::class.' $consoleLockFactory'));
+        $this->assertFalse($container->hasAlias(LockFactory::class));
+    }
+
+    private function createContainer(?array $resources, ?string $factoryId = null, bool $compileFully = true): ContainerBuilder
+    {
+        if (null !== $resources && !class_exists(LockBundle::class)) {
+            $this->markTestSkipped('The installed version of symfony/lock has no LockBundle.');
+        }
+
+        $container = new ContainerBuilder(new EnvPlaceholderParameterBag(['kernel.debug' => false, 'kernel.project_dir' => __DIR__]));
+
+        if (null !== $resources) {
+            $container->registerExtension(new LockBundle()->getContainerExtension());
+            $container->loadFromExtension('lock', $resources);
+        }
+
+        if (null !== $factoryId) {
+            $container->setAlias('lock_factory', new Alias($factoryId, true));
+        }
+
+        $container->register('command', \FooLockCommand::class)
+            ->setAutowired(true)
+            ->setPublic(true);
+
+        if (!$compileFully) {
+            $container->getCompilerPassConfig()->setOptimizationPasses([]);
+            $container->getCompilerPassConfig()->setRemovingPasses([]);
+            $container->getCompilerPassConfig()->setAfterRemovingPasses([]);
+        }
+
+        $container->compile();
+
+        return $container;
     }
 
     public function testLockInvokableCommandReturnsFalseIfAlreadyLockedByAnotherCommand()

--- a/src/Symfony/Component/Console/Tests/Fixtures/FooLockCommand.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/FooLockCommand.php
@@ -4,10 +4,16 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Command\LockableTrait;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Lock\LockFactory;
 
 class FooLockCommand extends Command
 {
     use LockableTrait;
+
+    public function getLockFactory(): ?LockFactory
+    {
+        return $this->lockFactory;
+    }
 
     protected function configure(): void
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #63966
| License       | MIT

`LockableTrait` builds its own store and never looks at the container:

```php
if (null === $this->lockFactory) {
    $store = SemaphoreStore::isSupported() ? new SemaphoreStore() : new FlockStore();
    $this->lockFactory = new LockFactory($store);
}
```

Both stores are built with no arguments, so both are unscoped: `FlockStore` falls back to `sys_get_temp_dir()` and `SemaphoreStore` to the empty project id. The lock a command takes is keyed on the command name and nothing else, machine-wide. Two ParaTest workers sharing `/tmp` collide on `sf.app-my-command.*.lock` and one of them reports the command as already running. Two checkouts of the same project on one machine collide the same way.

There is no public API to point the trait somewhere else. The property is assignable from the using class, which is what #54135 shipped in 7.1, but that means touching all 30 commands of the reporting app, and it does not help with a test env at all.

## The contract

Declare a lock resource named `console` and every command using `LockableTrait` locks with it:

```yaml
# config/packages/lock.yaml
lock:
    console: '%env(LOCK_DSN)%'
```

`framework.lock` is an alias of the same extension, so `framework: { lock: { console: ... } }` is equivalent.

Declare nothing and nothing changes: the trait keeps building the store it builds today. That is the whole design. The setter is

```php
#[Required]
public function setLockFactory(#[Target('console')] ?LockFactory $lockFactory = null): void
{
    $this->lockFactory ??= $lockFactory;
}
```

and the two halves of it do the two things that keep this free of surprises.

**`#[Target('console')]` means an existing app is untouched.** Picking up the plain `LockFactory` service would have taken whatever `framework.lock` already points at, and an app whose `default` resource is Redis or PDO would have seen every lockable command silently move from a machine-local lock to a cluster-wide one. Addressing a dedicated name instead makes the whole thing opt-in. `LockBundle` gives the `default` resource a bare `LockFactory` alias and gives every other resource a target alias only, so with `default` alone there is nothing for `#[Target('console')]` to resolve and the parameter takes its default. Compiled and asserted, three ways:

| lock configuration | injected |
| --- | --- |
| no lock services at all | `null` |
| `lock: { default: flock }` | `null` |
| `lock: { console: flock }` | `lock.console.factory` |

The mechanism is `AutowirePass::getAutowiredReference()` returning null for a target it cannot resolve, which short-circuits the bare-alias fallback below it, and then the nullable-with-default branch supplying the default. Nothing in DependencyInjection or in `#[Target]` needed changing.

**`??=` means a command that picked a factory keeps it.** `#[Required]` setters run after the constructor, so a plain assignment would silently overwrite the factory a command chose for itself, which is exactly the idiom #54135 added the property for and `FooLock3Command` tests:

```php
public function __construct(LockFactory $lockFactory)
{
    parent::__construct();
    $this->lockFactory = $lockFactory;
}
```

With `??=` that command keeps its own factory and the injection is skipped. There is a test for it.

## Why `console` and not `command`

In a CQRS application `lock: { command: ... }` plausibly already exists and means the command bus. Those apps would have handed that store to every console command without asking. `console` has no such reading.

## Answering the two objections on record

@VincentLanglet wrote in the #54135 description: "I'm not sure if I have a way to provide autowire to the `setLockFactory` method without introducing a BC break for people who rely on the fact that the `LockableTrait` use a different `LockFactory` than the one configured the `framework.lock` dsn." Nobody answered him. This is the answer: address a resource by name rather than taking the configured default, and the BC break he was worried about does not exist. An app relying on the trait's own store keeps it unless it declares a `console` resource, and an app relying on a factory it assigns itself keeps that too.

#31914 proposed `setStore()` on the trait and was closed with "No need to add a setter, named autowiring aliases can be used instead." That was 2019, about `StoreInterface`, five years before `$lockFactory` existed. Named aliases bind constructor arguments, and `LockableTrait` is a trait: it has no constructor to bind, and not having to declare one is the point of using it. A `#[Required]` setter is how a trait reaches the container, which is why `ClockAwareTrait` uses one.

## Two notes on the implementation

`#[Target]` lives in `symfony/dependency-injection`, which Console only dev-requires. Attribute classes are resolved lazily: PHP records the name and loads the class only when something calls `newInstance()`, which only `AutowirePass` does, and that only runs where the component is installed. Probed with the attribute class absent entirely: the class loads, the setter runs, reflection on the parameter works. The precedent is `Messenger\EventListener\ResetServicesListener`, which uses `#[Autowire]` with DependencyInjection dev-required, and `Dotenv\Command\DotenvDumpCommand`, which uses `#[Autoconfigure]` with DependencyInjection not required at all.

The nullable-with-default parameter is also what lets `symfony/lock` stay a dev requirement of Console. `AutowirePass` prefers a parameter default over nullability over throwing, then unsets trailing default-only arguments, so the dumped container emits `$instance->setLockFactory();` and PHP applies the default. That holds even when `LockFactory` does not exist at all.

## What this does not do

The trait's own fallback store stays unscoped, because it cannot be scoped. The container scopes its stores by `%kernel.project_dir%`, but the trait lives in Console and has no kernel, and nothing reachable from there identifies the project reliably. `getcwd()` varies with how the command was invoked. `$_SERVER['SCRIPT_FILENAME']` is whatever was typed, `scope.php` and `./scope.php` and the absolute path all reach PHP verbatim, and normalising it would split a project with two entry scripts into two scopes that stop excluding each other. `$_composer_autoload_path` is defined only inside Composer's `vendor/bin` proxies, never in a project's `bin/console`. `Composer\InstalledVersions::getRootPackage()` is process-global and follows autoloader registration order, so registering any second Composer autoloader flips the root package, which is the bundled-tool and ParaTest situation precisely. Reflecting on the command's own file is per-class rather than per-project and would break two commands that deliberately share one lock name.

So the way to get a scoped or isolated lock is to declare the resource and let this setter pick it up, which is also the answer for the reported ParaTest case: the test env points `console` at a per-worker store and no command changes.

## Tests

Twelve in `LockableTraitTest`, six of them new, covering the setter directly, a command whose own factory wins, and the three container scenarios in the table above. The container ones drive the real `LockBundle` rather than a hand-registered alias, so they prove that `lock: { console: ... }` actually emits the aliases `#[Target('console')]` resolves through, and one of them asserts those alias ids. They skip on an installed `symfony/lock` older than 8.2, which has no `LockBundle`.

`src/Symfony/Component/Console` and `src/Symfony/Component/Lock/Tests/DependencyInjection` pass locally. `QuestionHelperTest::testAskTimeout` and `::testAskThrowsExceptionOnMissingInputForChoiceQuestion` fail on this machine, identically on the base branch, for unrelated reasons.
