### PR TITLE
[DependencyInjection] Pass top-level extension values that are not arrays to the extension

### DIFF
--- a/UPGRADE-8.2.md
+++ b/UPGRADE-8.2.md
@@ -35,6 +35,10 @@ Crowdin Translation Provider
 DependencyInjection
 -------------------
 
+ * [BC BREAK] A top-level extension key that holds a value which is not an array is now passed to that
+   extension instead of being replaced by an empty array. `lock: 'redis://example.com'` configures the lock,
+   where it used to be ignored. An extension whose configuration tree does not accept the value now reports
+   an `InvalidTypeException` instead of ignoring it
  * Bundles that declare no constructor and inherit `boot()`, `shutdown()` and `setContainer()` from
    `AbstractBundle` are now instantiated on demand instead of on every boot. The `$bundles` property of
    the kernel holds only the bundles that have been instantiated, call `getBundles()` to get them all

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.2
 ---
 
+ * Pass top-level extension values that are not arrays to the extension instead of replacing them with an empty array, so that a configuration tree can accept a scalar at its root
  * Name the package to install when an extension is missing, for the configuration keys declared in the `.container.extension_packages` build parameter
  * Add the `container.remove_if_missing` tag to drop a definition when a service, a class or a package it needs is not there
  * Add `ContainerBuilder::setExtensionConfig()`

--- a/src/Symfony/Component/DependencyInjection/Compiler/MergeExtensionConfigurationPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/MergeExtensionConfigurationPass.php
@@ -160,6 +160,10 @@ class MergeExtensionConfigurationPass implements CompilerPassInterface
 
             $forwarded = [];
             foreach ($configs as $i => $config) {
+                if (!\is_array($config)) {
+                    continue;
+                }
+
                 foreach ($tree->getXmlRemappings() as [$singular, $plural]) {
                     if (isset($aliases[$plural]) && isset($config[$singular])) {
                         $config[$plural] = Processor::normalizeConfig($config, $singular, $plural);

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -738,9 +738,12 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
     }
 
     /**
-     * Returns the configuration array for the given extension.
+     * Returns the list of configs for the given extension.
      *
-     * @return array<array<string, mixed>>
+     * An element is usually an array, but it can hold any value the configuration
+     * tree of the extension accepts at its root.
+     *
+     * @return list<mixed>
      */
     public function getExtensionConfig(string $name): array
     {
@@ -766,9 +769,12 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
     }
 
     /**
-     * Replaces the configuration arrays of the given extension.
+     * Replaces the list of configs of the given extension.
      *
-     * @param array<array<string, mixed>> $configs
+     * An element is usually an array, but it can hold any value the configuration
+     * tree of the extension accepts at its root.
+     *
+     * @param list<mixed> $configs
      */
     public function setExtensionConfig(string $name, array $configs): void
     {

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/ContainerConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/ContainerConfigurator.php
@@ -47,10 +47,20 @@ class ContainerConfigurator extends AbstractConfigurator
         $this->instanceof = &$instanceof;
     }
 
-    final public function extension(string $namespace, array $config, bool $prepend = false): void
+    final public function extension(string $namespace, mixed $config, bool $prepend = false): void
     {
+        $config = static::processValue($config) ?? [];
+
         if ($prepend) {
-            $this->container->prependExtensionConfig($namespace, static::processValue($config));
+            if (\is_array($config)) {
+                $this->container->prependExtensionConfig($namespace, $config);
+
+                return;
+            }
+
+            $configs = $this->container->getExtensionConfig($namespace);
+            array_unshift($configs, $config);
+            $this->container->setExtensionConfig($namespace, $configs);
 
             return;
         }
@@ -60,7 +70,19 @@ class ContainerConfigurator extends AbstractConfigurator
             throw new InvalidArgumentException(UndefinedExtensionHandler::getErrorMessage($namespace, $this->file, $namespace, $extensions, UndefinedExtensionHandler::getPackages($this->container)));
         }
 
-        $this->container->loadFromExtension($namespace, static::processValue($config));
+        if (\is_array($config)) {
+            $this->container->loadFromExtension($namespace, $config);
+
+            return;
+        }
+
+        // loadFromExtension() takes an array; let it check the container and resolve the
+        // extension, then swap the empty config it appended for the value it cannot take
+        $this->container->loadFromExtension($namespace);
+        $namespace = $this->container->getExtension($namespace)->getAlias();
+        $configs = $this->container->getExtensionConfig($namespace);
+        $configs[array_key_last($configs)] = $config;
+        $this->container->setExtensionConfig($namespace, $configs);
     }
 
     final public function import(string $resource, ?string $type = null, bool|string $ignoreErrors = false, string|array|null $exclude = null): void

--- a/src/Symfony/Component/DependencyInjection/Loader/ContentLoaderTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/ContentLoaderTrait.php
@@ -967,10 +967,6 @@ trait ContentLoaderTrait
                 continue;
             }
 
-            if (!\is_array($values)) {
-                $values = [];
-            }
-
             $this->loadExtensionConfig($namespace, $values);
         }
 

--- a/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
@@ -273,10 +273,12 @@ abstract class FileLoader extends BaseFileLoader
         $this->interfaces = $this->singlyImplemented = $this->aliases = $this->aliasedTargets = [];
     }
 
-    final protected function loadExtensionConfig(string $namespace, array $config, string $file = '?'): void
+    final protected function loadExtensionConfig(string $namespace, mixed $config, string $file = '?'): void
     {
+        $config ??= [];
+
         if (!$this->prepend) {
-            $this->container->loadFromExtension($namespace, $config);
+            $this->appendExtensionConfig($namespace, $config);
 
             return;
         }
@@ -290,7 +292,7 @@ abstract class FileLoader extends BaseFileLoader
             return;
         }
 
-        $this->container->prependExtensionConfig($namespace, $config);
+        $this->unshiftExtensionConfig($namespace, $config);
     }
 
     final protected function loadExtensionConfigs(): void
@@ -301,7 +303,7 @@ abstract class FileLoader extends BaseFileLoader
 
         foreach ($this->extensionConfigs as $namespace => $configs) {
             foreach ($configs as $config) {
-                $this->container->prependExtensionConfig($namespace, $config);
+                $this->unshiftExtensionConfig($namespace, $config);
             }
         }
 
@@ -422,6 +424,36 @@ abstract class FileLoader extends BaseFileLoader
         $this->container->register($class, $class)
             ->setAbstract(true)
             ->addTag('container.excluded', null !== $source ? $attributes[$source] : []);
+    }
+
+    private function appendExtensionConfig(string $namespace, mixed $config): void
+    {
+        if (\is_array($config)) {
+            $this->container->loadFromExtension($namespace, $config);
+
+            return;
+        }
+
+        // loadFromExtension() takes an array; let it check the container and resolve the
+        // extension, then swap the empty config it appended for the value it cannot take
+        $this->container->loadFromExtension($namespace);
+        $namespace = $this->container->getExtension($namespace)->getAlias();
+        $configs = $this->container->getExtensionConfig($namespace);
+        $configs[array_key_last($configs)] = $config;
+        $this->container->setExtensionConfig($namespace, $configs);
+    }
+
+    private function unshiftExtensionConfig(string $namespace, mixed $config): void
+    {
+        if (\is_array($config)) {
+            $this->container->prependExtensionConfig($namespace, $config);
+
+            return;
+        }
+
+        $configs = $this->container->getExtensionConfig($namespace);
+        array_unshift($configs, $config);
+        $this->container->setExtensionConfig($namespace, $configs);
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Loader/PhpFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/PhpFileLoader.php
@@ -77,13 +77,13 @@ class PhpFileLoader extends FileLoader
                     ], $path);
 
                     foreach ($result as $namespace => $config) {
-                        if (!\is_array($config)) {
-                            throw new InvalidArgumentException(\sprintf('The "%s" key should contain an array in "%s".', $namespace, $path));
-                        }
                         if (\in_array($namespace, ['imports', 'parameters', 'services'], true)) {
                             continue;
                         }
                         if (str_starts_with($namespace, 'when@')) {
+                            if (!\is_array($config)) {
+                                throw new InvalidArgumentException(\sprintf('The "%s" key should contain an array in "%s".', $namespace, $path));
+                            }
                             $knownEnvs = $this->container->hasParameter('.container.known_envs') ? array_flip($this->container->getParameter('.container.known_envs')) : [];
                             $this->container->setParameter('.container.known_envs', array_keys($knownEnvs + [substr($namespace, 5) => true]));
                             continue;
@@ -104,9 +104,6 @@ class PhpFileLoader extends FileLoader
                         ], $path);
 
                         foreach ($result[$when] as $namespace => $config) {
-                            if (!\is_array($config)) {
-                                throw new InvalidArgumentException(\sprintf('The "%s" key should contain an array in "%s".', $namespace, $path));
-                            }
                             if (!\in_array($namespace, ['imports', 'parameters', 'services'], true) && !str_starts_with($namespace, 'when@')) {
                                 $this->loadExtensionConfig($namespace, ContainerConfigurator::processValue($config));
                             }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/MergeExtensionConfigurationPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/MergeExtensionConfigurationPassTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\Config\Definition\Exception\InvalidTypeException;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\DependencyInjection\Compiler\MergeExtensionConfigurationContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\MergeExtensionConfigurationPass;
@@ -313,6 +314,43 @@ class MergeExtensionConfigurationPassTest extends TestCase
         (new MergeExtensionConfigurationPass())->process($container);
     }
 
+    public function testRootScalarConfigIsWrappedByTheConfigurationTree()
+    {
+        $container = new ContainerBuilder();
+        $container->registerExtension(new ShorthandExtension());
+        $container->setExtensionConfig('shorthand', ['redis://localhost', ['value' => 'explicit']]);
+
+        (new MergeExtensionConfigurationPass())->process($container);
+
+        $this->assertSame(['value' => 'explicit'], $container->getParameter('shorthand.config'));
+        $this->assertSame(['redis://localhost', ['value' => 'explicit']], $container->getParameter('shorthand.configs'));
+    }
+
+    public function testRootScalarConfigIsRejectedWhenTheConfigurationTreeExpectsAnArray()
+    {
+        $container = new ContainerBuilder();
+        $container->registerExtension(new FooExtension());
+        $container->setExtensionConfig('foo', ['not an array']);
+
+        $this->expectException(InvalidTypeException::class);
+        $this->expectExceptionMessage('Invalid type for path "foo". Expected "array", but got "string"');
+
+        (new MergeExtensionConfigurationPass())->process($container);
+    }
+
+    public function testExtensionAliasesLeaveRootValuesThatAreNotArraysAlone()
+    {
+        $container = new ContainerBuilder();
+        $container->registerExtension(new AliasingExtension());
+        $container->registerExtension(new TargetExtension());
+        $container->setExtensionConfig('aliasing', ['not an array', ['target' => ['value' => 'forwarded']]]);
+
+        (new MergeExtensionConfigurationPass())->process($container);
+
+        $this->assertSame(['not an array', []], $container->getParameter('aliasing.configs'));
+        $this->assertSame([['value' => 'forwarded']], $container->getParameter('target.configs'));
+    }
+
     #[Group('legacy')]
     #[IgnoreDeprecations]
     public function testDeprecatedExtensionAliasesTriggerTheirDeprecation()
@@ -428,6 +466,40 @@ final class TestCccExtension extends Extension
     {
         $configuration = $this->getConfiguration($configs, $container);
         $this->processConfiguration($configuration, $configs);
+    }
+}
+
+final class ShorthandConfiguration implements ConfigurationInterface
+{
+    public function getConfigTreeBuilder(): TreeBuilder
+    {
+        $treeBuilder = new TreeBuilder('shorthand');
+        $treeBuilder->getRootNode()
+            ->acceptAndWrap(['string'], 'value')
+            ->children()
+                ->scalarNode('value')->end()
+            ->end();
+
+        return $treeBuilder;
+    }
+}
+
+final class ShorthandExtension extends Extension
+{
+    public function getAlias(): string
+    {
+        return 'shorthand';
+    }
+
+    public function getConfiguration(array $config, ContainerBuilder $container): ?ConfigurationInterface
+    {
+        return new ShorthandConfiguration();
+    }
+
+    public function load(array $configs, ContainerBuilder $container): void
+    {
+        $container->setParameter('shorthand.configs', $configs);
+        $container->setParameter('shorthand.config', $this->processConfiguration(new ShorthandConfiguration(), $configs));
     }
 }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/scalar_extension_config.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/scalar_extension_config.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+return static function (ContainerConfigurator $container) {
+    $container->extension('acme', 'from the DSL');
+};

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/scalar_extension_config_returned.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/scalar_extension_config_returned.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'acme' => 'from a returned array',
+];

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/scalar_config.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/scalar_config.yml
@@ -1,0 +1,1 @@
+project: 'a scalar'

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
@@ -87,6 +87,17 @@ class PhpFileLoaderTest extends TestCase
         $this->assertSame($expected, $container->getExtensionConfig('acme'));
     }
 
+    public function testExtensionWithScalarConfig()
+    {
+        $container = new ContainerBuilder();
+        $container->registerExtension(new \AcmeExtension());
+        $loader = new PhpFileLoader($container, new FileLocator(\dirname(__DIR__).'/Fixtures/config'));
+        $loader->load('scalar_extension_config.php');
+        $loader->load('scalar_extension_config_returned.php');
+
+        $this->assertSame(['from the DSL', 'from a returned array'], $container->getExtensionConfig('acme'));
+    }
+
     public function testConfigServices()
     {
         $fixtures = realpath(__DIR__.'/../Fixtures');

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -374,6 +374,26 @@ class YamlFileLoaderTest extends TestCase
         $this->assertSame($expected, $container->getExtensionConfig('project'));
     }
 
+    public function testExtensionWithScalarConfig()
+    {
+        $container = new ContainerBuilder();
+        $container->registerExtension(new \ProjectExtension());
+        $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
+        $loader->load('scalar_config.yml');
+
+        $this->assertSame(['a scalar'], $container->getExtensionConfig('project'));
+    }
+
+    public function testPrependExtensionConfigWithScalarConfig()
+    {
+        $container = new ContainerBuilder();
+        $container->prependExtensionConfig('project', ['foo' => 'bar']);
+        $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'), prepend: true);
+        $loader->load('scalar_config.yml');
+
+        $this->assertSame(['a scalar', ['foo' => 'bar']], $container->getExtensionConfig('project'));
+    }
+
     public function testExtensionWithNullConfig()
     {
         $container = new ContainerBuilder();

--- a/src/Symfony/Component/Lock/Tests/DependencyInjection/Fixtures/lock_dsn.php
+++ b/src/Symfony/Component/Lock/Tests/DependencyInjection/Fixtures/lock_dsn.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+return static function (ContainerConfigurator $container) {
+    $container->extension('lock', 'redis://example.com');
+};

--- a/src/Symfony/Component/Lock/Tests/DependencyInjection/LockBundleExtensionTest.php
+++ b/src/Symfony/Component/Lock/Tests/DependencyInjection/LockBundleExtensionTest.php
@@ -50,6 +50,15 @@ class LockBundleExtensionTest extends TestCase
         $this->assertSame('lock.factory', (string) $container->getAlias(LockFactory::class));
     }
 
+    public function testLockFromARootLevelDsn()
+    {
+        $container = $this->createContainerFromFile('lock_dsn');
+
+        $this->assertTrue($container->hasDefinition('lock.default.factory'));
+        $storeDef = $container->getDefinition($container->getDefinition('lock.default.factory')->getArgument(0));
+        $this->assertSame('redis://example.com', $storeDef->getArgument(0));
+    }
+
     public function testNamedLocks()
     {
         $container = $this->createContainerFromFile('lock_named');

--- a/src/Symfony/Component/Semaphore/Tests/DependencyInjection/Fixtures/semaphore_dsn.php
+++ b/src/Symfony/Component/Semaphore/Tests/DependencyInjection/Fixtures/semaphore_dsn.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+return static function (ContainerConfigurator $container) {
+    $container->extension('semaphore', 'redis://example.com');
+};

--- a/src/Symfony/Component/Semaphore/Tests/DependencyInjection/SemaphoreBundleExtensionTest.php
+++ b/src/Symfony/Component/Semaphore/Tests/DependencyInjection/SemaphoreBundleExtensionTest.php
@@ -35,6 +35,16 @@ class SemaphoreBundleExtensionTest extends TestCase
         $this->assertSame('semaphore.factory', (string) $container->getAlias(SemaphoreFactory::class));
     }
 
+    public function testSemaphoreFromARootLevelDsn()
+    {
+        $container = $this->createContainerFromFile('semaphore_dsn');
+
+        $this->assertTrue($container->hasDefinition('semaphore.default.factory'));
+        $storeDef = $container->getDefinition($container->getDefinition('semaphore.default.factory')->getArgument(0));
+        $this->assertSame([StoreFactory::class, 'createStore'], $storeDef->getFactory());
+        $this->assertSame('redis://example.com', $storeDef->getArgument(0));
+    }
+
     public function testNamedSemaphores()
     {
         $container = $this->createContainerFromFile('semaphore_named');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #28923
| License       | MIT

A top-level extension key whose value is not an array was replaced by an empty array before the extension saw it. The value was dropped with no error and no log line.

```yaml
# config/packages/lock.yaml
lock: 'redis://example.com'
```

`LockBundle` declares `->acceptAndWrap(['string'], 'resources')` on its root node, so this is exactly the form it asks for. What you got was a `SemaphoreStore` pointing at `%kernel.project_dir%`, because the loader replaced the string with `[]` and the bundle fell back to its defaults. A production lock silently became a local semaphore.

`SemaphoreBundle` declares the same shorthand and had the same problem. Those two are the only bundles in the tree whose root node accepts a string: I built every `*Bundle` in `src/` and ran a root string through its tree, and only `lock` and `semaphore` took it. Every other `acceptAndWrap()` call sits on a child node, where the value was never touched.

## The cause

`ContentLoaderTrait::loadFromExtensions()` did this before handing the value over:

```php
if (!\is_array($values)) {
    $values = [];
}
```

It had to, because `ContainerBuilder::loadFromExtension()` takes `?array $values` and `prependExtensionConfig()` takes `array $config`. The PHP-DSL `ContainerConfigurator::extension()` took `array $config` too, so it threw a `TypeError` where YAML stayed silent.

The Config component was never the blocker. `Processor::process()` normalizes each element of `$configs` on its own, so a string element reaches `BaseNode::normalize()` and the `beforeNormalization()` closures fire, which is what `acceptAndWrap()` registers. That is also what the linked issue asks for, with a hand-written `->beforeNormalization()->ifString()` instead of the 8.2 shorthand.

## The change

The loaders stop replacing the value. `loadFromExtension()` and `prependExtensionConfig()` keep their signatures: the value goes in through the pair that takes the whole list of configs instead.

```php
public function getExtensionConfig(string $name): array
public function setExtensionConfig(string $name, array $configs): void
```

Their `array` type constrains the list, not its elements, and an element is all `Processor::process()` reads. So a loader holding a value that `loadFromExtension()` cannot take calls it with nothing, which keeps the `isCompiled()` guard, the unknown-extension error and the alias resolution, then swaps the empty config it appended for the real one:

```php
$this->container->loadFromExtension($namespace);
$namespace = $this->container->getExtension($namespace)->getAlias();
$configs = $this->container->getExtensionConfig($namespace);
$configs[array_key_last($configs)] = $config;
$this->container->setExtensionConfig($namespace, $configs);
```

The prepend side is the same read, `array_unshift`, write. `setExtensionConfig()` is itself new in 8.2, so nothing can be overriding it.

Widened, both `final`, so no subclass can be narrowing them:

- `FileLoader::loadExtensionConfig()`, argument `$config`
- `ContainerConfigurator::extension()`, argument `$config`

`null` still becomes `[]`, so `lock: ~` is unchanged.

`MergeExtensionConfigurationPass::forwardExtensionAliases()` now skips a config that is not an array. It reads keys with `array_key_exists()`, which is a `TypeError` on a string. This only concerns `framework`, the one tree with `aliasOf()` nodes.

## Why not a deprecation

stof proposed on the issue that the loaders deprecate the drop and throw in the next major. That was the right call in 2018. It is the wrong one now: telling a user their value is ignored, when the bundle has explicitly declared that it accepts that value, describes a bug rather than fixing it. The deprecation also leaves `lock:` and `semaphore:` unusable in their documented short form until 9.0.

Passing the value through gives the loud behavior anyway, and with a better message. An extension whose tree does not accept the value now reports where it came from:

```
Invalid type for path "framework". Expected "array", but got "string"
```

## What changes for a config that already builds

Only values that were being discarded. Measured against the real trees:

| config | before | after |
| --- | --- | --- |
| `lock: 'redis://…'` | ignored, semaphore store | Redis store |
| `semaphore: 'redis://…'` | ignored, no store | Redis store |
| `lock: false` | ignored, lock enabled | lock disabled, as `canBeDisabled()` says |
| `framework: 'a string'` | ignored | `InvalidTypeException` |
| `twig: false` | ignored | `InvalidTypeException` |
| `framework: true` | ignored | accepted, same result as before |
| `framework: ~` | defaults | unchanged |

So a typo that used to build now fails to build, which is the point. That is the one `[BC BREAK]` entry in `UPGRADE-8.2.md`.

No signature on `ContainerBuilder` changes, so a class extending it and redeclaring `loadFromExtension(string $extension, ?array $values = null)` keeps loading, and its override still runs on this path. The two widened arguments are on `final` methods, where the backward compatibility promise allows it.

## Checks

DependencyInjection (1923), Config (637), Lock (584), Semaphore (125), FrameworkBundle (1131), SecurityBundle (632) and HttpKernel (1801) pass locally. php-cs-fixer is clean on the touched files. PHPStan over DependencyInjection, `FrameworkBundle/Command` and `SecurityBundle/DependencyInjection` reports no error the base does not, and one fewer.

Six of the eight new tests fail on the base branch, with a `TypeError` or with the dropped value. The two in `MergeExtensionConfigurationPassTest` that put the value straight into the list with `setExtensionConfig()` pass on both: they record what the compiler pass and the configuration tree already did with a scalar element, which is what makes this fix possible, rather than what the loaders now do.

## Documentation

`lock:` and `semaphore:` accept a DSN at the top level from now on. That form is worth a line in the Lock and Semaphore pages, next to the `resources` key.
