### PR TITLE
[EventDispatcher] Allow getSubscribedEvents() to name its keys

### DIFF
--- a/src/Symfony/Component/EventDispatcher/CHANGELOG.md
+++ b/src/Symfony/Component/EventDispatcher/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.2
+---
+
+ * Allow `getSubscribedEvents()` to name its keys: `['method' => 'onEvent', 'priority' => 10]`
+
 8.1
 ---
 

--- a/src/Symfony/Component/EventDispatcher/EventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/EventDispatcher.php
@@ -189,11 +189,13 @@ class EventDispatcher implements EventDispatcherInterface
         foreach ($subscriber->getSubscribedEvents() as $eventName => $params) {
             if (\is_string($params)) {
                 $this->addListener($eventName, [$subscriber, $params]);
+            } elseif (isset($params['method'])) {
+                $this->addListener($eventName, [$subscriber, $params['method']], $params['priority'] ?? 0);
             } elseif (\is_string($params[0])) {
                 $this->addListener($eventName, [$subscriber, $params[0]], $params[1] ?? 0);
             } else {
                 foreach ($params as $listener) {
-                    $this->addListener($eventName, [$subscriber, $listener[0]], $listener[1] ?? 0);
+                    $this->addListener($eventName, [$subscriber, $listener['method'] ?? $listener[0]], $listener['priority'] ?? $listener[1] ?? 0);
                 }
             }
         }
@@ -202,12 +204,12 @@ class EventDispatcher implements EventDispatcherInterface
     public function removeSubscriber(EventSubscriberInterface $subscriber): void
     {
         foreach ($subscriber->getSubscribedEvents() as $eventName => $params) {
-            if (\is_array($params) && \is_array($params[0])) {
+            if (\is_array($params) && !isset($params['method']) && \is_array($params[0])) {
                 foreach ($params as $listener) {
-                    $this->removeListener($eventName, [$subscriber, $listener[0]]);
+                    $this->removeListener($eventName, [$subscriber, $listener['method'] ?? $listener[0]]);
                 }
             } else {
-                $this->removeListener($eventName, [$subscriber, \is_string($params) ? $params : $params[0]]);
+                $this->removeListener($eventName, [$subscriber, \is_string($params) ? $params : ($params['method'] ?? $params[0])]);
             }
         }
     }

--- a/src/Symfony/Component/EventDispatcher/EventSubscriberInterface.php
+++ b/src/Symfony/Component/EventDispatcher/EventSubscriberInterface.php
@@ -31,19 +31,22 @@ interface EventSubscriberInterface
      *
      *  * The method name to call (priority defaults to 0)
      *  * An array composed of the method name to call and the priority
-     *  * An array of arrays composed of the method names to call and respective
-     *    priorities, or 0 if unset
+     *  * An array with a "method" key and an optional "priority" one
+     *  * An array of any of the two array forms above, to register several
+     *    listeners for the same event
      *
      * For instance:
      *
      *  * ['eventName' => 'methodName']
      *  * ['eventName' => ['methodName', $priority]]
+     *  * ['eventName' => ['method' => 'methodName', 'priority' => $priority]]
      *  * ['eventName' => [['methodName1', $priority], ['methodName2']]]
+     *  * ['eventName' => [['method' => 'methodName1'], ['method' => 'methodName2', 'priority' => $priority]]]
      *
      * The code must not depend on runtime state as it will only be called at compile time.
      * All logic depending on runtime state must be put into the individual methods handling the events.
      *
-     * @return array<string, string|array{0: string, 1: int}|list<array{0: string, 1?: int}>>
+     * @return array<string, string|array{0: string, 1?: int}|array{method: string, priority?: int}|list<array{0: string, 1?: int}|array{method: string, priority?: int}>>
      */
     public static function getSubscribedEvents(): array;
 }

--- a/src/Symfony/Component/EventDispatcher/Tests/EventDispatcherTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/EventDispatcherTest.php
@@ -196,6 +196,49 @@ class EventDispatcherTest extends TestCase
         $this->assertTrue($this->dispatcher->hasListeners(self::postFoo));
     }
 
+    public function testAddSubscriberWithNamedKeys()
+    {
+        $eventSubscriber = new TestEventSubscriberWithNamedKeys();
+        $this->dispatcher->addSubscriber($eventSubscriber);
+
+        $this->assertTrue($this->dispatcher->hasListeners('pre.foo'));
+        $this->assertTrue($this->dispatcher->hasListeners('post.foo'));
+        $this->assertSame(10, $this->dispatcher->getListenerPriority('pre.foo', [$eventSubscriber, 'preFoo']));
+        $this->assertSame(0, $this->dispatcher->getListenerPriority('post.foo', [$eventSubscriber, 'postFoo']));
+    }
+
+    public function testAddSubscriberWithNamedKeysAndMultipleListeners()
+    {
+        $this->dispatcher->addSubscriber(new TestEventSubscriberWithNamedKeysAndMultipleListeners());
+
+        $listeners = $this->dispatcher->getListeners('pre.foo');
+        $this->assertCount(3, $listeners);
+        $this->assertSame('preFoo3', $listeners[0][1]);
+        $this->assertSame('preFoo2', $listeners[1][1]);
+        $this->assertSame('preFoo1', $listeners[2][1]);
+    }
+
+    public function testRemoveSubscriberWithNamedKeys()
+    {
+        $eventSubscriber = new TestEventSubscriberWithNamedKeys();
+        $this->dispatcher->addSubscriber($eventSubscriber);
+        $this->assertTrue($this->dispatcher->hasListeners('pre.foo'));
+
+        $this->dispatcher->removeSubscriber($eventSubscriber);
+        $this->assertFalse($this->dispatcher->hasListeners('pre.foo'));
+        $this->assertFalse($this->dispatcher->hasListeners('post.foo'));
+    }
+
+    public function testRemoveSubscriberWithNamedKeysAndMultipleListeners()
+    {
+        $eventSubscriber = new TestEventSubscriberWithNamedKeysAndMultipleListeners();
+        $this->dispatcher->addSubscriber($eventSubscriber);
+        $this->assertCount(3, $this->dispatcher->getListeners('pre.foo'));
+
+        $this->dispatcher->removeSubscriber($eventSubscriber);
+        $this->assertFalse($this->dispatcher->hasListeners('pre.foo'));
+    }
+
     public function testAddSubscriberWithPriorities()
     {
         $eventSubscriber = new TestEventSubscriber();
@@ -638,6 +681,29 @@ class TestEventSubscriberWithMultipleListeners implements EventSubscriberInterfa
         return ['pre.foo' => [
             ['preFoo1'],
             ['preFoo2', 10],
+        ]];
+    }
+}
+
+class TestEventSubscriberWithNamedKeys implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            'pre.foo' => ['method' => 'preFoo', 'priority' => 10],
+            'post.foo' => ['method' => 'postFoo'],
+        ];
+    }
+}
+
+class TestEventSubscriberWithNamedKeysAndMultipleListeners implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return ['pre.foo' => [
+            ['method' => 'preFoo1'],
+            ['method' => 'preFoo2', 'priority' => 10],
+            ['preFoo3', 20],
         ]];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | -
| License       | MIT

`getSubscribedEvents()` has three positional shapes and none of them says what the slots mean. `['onFoo', 10]` reads as a pair of unrelated values until you go and check, and the nested variant compounds it.

This accepts a named form wherever a positional listener is accepted:

```php
public static function getSubscribedEvents(): array
{
    return [
        KernelEvents::REQUEST => ['method' => 'onRequest', 'priority' => 10],
        KernelEvents::RESPONSE => [
            ['method' => 'onEarlyResponse', 'priority' => 100],
            ['method' => 'onLateResponse', 'priority' => -100],
        ],
    ];
}
```

`priority` is optional and defaults to 0, the same as the positional form. Both spellings can be mixed inside one list, since each entry is resolved on its own. The three existing shapes keep working untouched.

### Notes for review

The named form has to be checked **before** the positional one: reading `$params[0]` on a named array warns, so the order of the branches is load bearing rather than stylistic. `removeSubscriber()` needed the same treatment, for the same reason.

`EventDispatcher` is the only thing in the tree that parses the return value of `getSubscribedEvents()`, so it is the only place to change. The container path inherits it for free, because `ExtractingEventDispatcher` extends `EventDispatcher` and only overrides `addListener()`.

### Relation to #66012

Independent, and deliberately so. #66012 adds `before`/`after` ordering constraints and leaves subscribers able to be targeted by a constraint but unable to declare one, because `getSubscribedEvents()` has no slot to put one in. This adds the slot, without adding the constraints.

Either can merge first. Whichever lands second gets rebased, and wiring `before`/`after` into the named form is then a small follow-up rather than something bolted onto either PR.
