### PR TITLE
[Lock][Semaphore] Skip the root-level DSN tests when dependency-injection is too old

### DIFF
--- a/src/Symfony/Component/Lock/Tests/DependencyInjection/LockBundleExtensionTest.php
+++ b/src/Symfony/Component/Lock/Tests/DependencyInjection/LockBundleExtensionTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Compiler\ResolveChildDefinitionsPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\DependencyInjection\ParameterBag\EnvPlaceholderParameterBag;
 use Symfony\Component\DependencyInjection\Reference;
@@ -52,6 +53,12 @@ class LockBundleExtensionTest extends TestCase
 
     public function testLockFromARootLevelDsn()
     {
+        $config = (new \ReflectionMethod(ContainerConfigurator::class, 'extension'))->getParameters()[1]->getType();
+
+        if ($config instanceof \ReflectionNamedType && 'array' === $config->getName()) {
+            $this->markTestSkipped('symfony/dependency-injection >= 8.2 is required to pass a value that is not an array to an extension.');
+        }
+
         $container = $this->createContainerFromFile('lock_dsn');
 
         $this->assertTrue($container->hasDefinition('lock.default.factory'));

--- a/src/Symfony/Component/Semaphore/Tests/DependencyInjection/SemaphoreBundleExtensionTest.php
+++ b/src/Symfony/Component/Semaphore/Tests/DependencyInjection/SemaphoreBundleExtensionTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Semaphore\Tests\DependencyInjection;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Semaphore\SemaphoreBundle;
@@ -37,6 +38,12 @@ class SemaphoreBundleExtensionTest extends TestCase
 
     public function testSemaphoreFromARootLevelDsn()
     {
+        $config = (new \ReflectionMethod(ContainerConfigurator::class, 'extension'))->getParameters()[1]->getType();
+
+        if ($config instanceof \ReflectionNamedType && 'array' === $config->getName()) {
+            $this->markTestSkipped('symfony/dependency-injection >= 8.2 is required to pass a value that is not an array to an extension.');
+        }
+
         $container = $this->createContainerFromFile('semaphore_dsn');
 
         $this->assertTrue($container->hasDefinition('semaphore.default.factory'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

`LockBundleExtensionTest::testLockFromARootLevelDsn()` and `SemaphoreBundleExtensionTest::testSemaphoreFromARootLevelDsn()`, added in #66021, drive a fixture that calls `$container->extension('lock', 'redis://example.com')`. Passing a value that is not an array to `ContainerConfigurator::extension()` needs the widened signature from that same PR.

Both components allow `symfony/dependency-injection: ^8.1` in `require-dev`, so the `low-deps` job installs the released 8.1, where the second argument is still typed `array`, and the tests fatal:

```
TypeError: Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator::extension():
Argument #2 ($config) must be of type array, string given,
called in src/Symfony/Component/Lock/Tests/DependencyInjection/Fixtures/lock_dsn.php on line 6
```

That is the only thing left red on `low-deps`; every other job is green.

This skips the two tests when the installed `ContainerConfigurator::extension()` still declares `array`, rather than raising the `require-dev` constraint, since nothing but these two tests needs the newer component.
