### PR TITLE
[Form] Guess "empty_data" from the type of the mapped property

### DIFF
--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.2
 ---
 
+ * Guess the `empty_data` option from the type of the mapped property when that type refuses `null`
  * Add `#[AsFormType]` and `#[FormField]` attributes to derive a form type from the properties of a data class
  * Add the `allow_array_submission` option to let `PRE_SUBMIT` listeners turn a submitted array into data the form accepts
  * Add support for grouping and nested steps in `FormFlowType`

--- a/src/Symfony/Component/Form/FormFactory.php
+++ b/src/Symfony/Component/Form/FormFactory.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Form;
 
 use Symfony\Component\Form\Extension\Core\Type\ColorType;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\MoneyType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Extension\Core\Type\PercentType;
@@ -21,9 +22,13 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\Flow\FormFlowBuilderInterface;
 use Symfony\Component\Form\Flow\FormFlowInterface;
 use Symfony\Component\Form\Flow\FormFlowTypeInterface;
+use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
+use Symfony\Component\PropertyInfo\PropertyWriteInfo;
 
 class FormFactory implements FormFactoryInterface
 {
+    private ?ReflectionExtractor $writeInfoExtractor = null;
+
     public function __construct(
         private FormRegistryInterface $registry,
     ) {
@@ -85,6 +90,8 @@ class FormFactory implements FormFactoryInterface
     public function createBuilderForProperty(string $class, string $property, mixed $data = null, array $options = []): FormBuilderInterface
     {
         if (null === $guesser = $this->registry->getTypeGuesser()) {
+            $options = $this->addEmptyDataGuess($class, $property, TextType::class, $options);
+
             return $this->createNamedBuilder($property, TextType::class, $data, $options);
         }
 
@@ -121,16 +128,107 @@ class FormFactory implements FormFactoryInterface
             $options = array_merge($typeGuessOptions, $options, $attrs);
         }
 
+        $options = $this->addEmptyDataGuess($class, $property, $type, $options);
+
         return $this->createNamedBuilder($property, $type, $data, $options);
+    }
+
+    /**
+     * Derives "empty_data" from the type of the mapped property when it refuses null.
+     *
+     * Since "empty_data" is view data, the guess is expressed in view space and is
+     * restricted to types that map a scalar to a single control.
+     */
+    private function addEmptyDataGuess(string $class, string $property, string $type, array $options): array
+    {
+        if (\array_key_exists('empty_data', $options) || !($options['mapped'] ?? true) || isset($options['property_path'])) {
+            return $options;
+        }
+
+        if (!$this->isScalarInput($type)) {
+            return $options;
+        }
+
+        $writeTargetType = $this->getWriteTargetType($class, $property);
+
+        if (!$writeTargetType instanceof \ReflectionNamedType || $writeTargetType->allowsNull()) {
+            return $options;
+        }
+
+        $emptyData = match ($writeTargetType->getName()) {
+            'string' => '',
+            'int', 'float' => '0',
+            'bool' => false,
+            default => null,
+        };
+
+        if (null !== $emptyData) {
+            $options['empty_data'] = $emptyData;
+        }
+
+        return $options;
+    }
+
+    /**
+     * Resolves the type of the target that PropertyAccessor writes the mapped value to.
+     *
+     * Only a publicly writable mutator method or property is a write target. The type of an accessor
+     * or of a constructor argument says nothing about what the value is written through.
+     */
+    private function getWriteTargetType(string $class, string $property): ?\ReflectionType
+    {
+        $this->writeInfoExtractor ??= new ReflectionExtractor();
+
+        $writeInfo = $this->writeInfoExtractor->getWriteInfo($class, $property, [
+            'enable_getter_setter_extraction' => true,
+            'enable_constructor_extraction' => false,
+            'enable_adder_remover_extraction' => false,
+        ]);
+
+        if (null === $writeInfo) {
+            return null;
+        }
+
+        try {
+            // PropertyWriteInfo names the target without describing it, so the target is reflected here
+            $target = match ($writeInfo->getType()) {
+                PropertyWriteInfo::TYPE_METHOD => (new \ReflectionMethod($class, $writeInfo->getName()))->getParameters()[0] ?? null,
+                PropertyWriteInfo::TYPE_PROPERTY => new \ReflectionProperty($class, $writeInfo->getName()),
+                default => null,
+            };
+        } catch (\ReflectionException) {
+            return null;
+        }
+
+        // the visibility is carried by the write info only, the target does not tell whether it can be written to
+        if (null === $target || PropertyWriteInfo::VISIBILITY_PUBLIC !== $writeInfo->getVisibility()) {
+            return null;
+        }
+
+        if ($target instanceof \ReflectionProperty) {
+            $target = $target->getHook(\PropertyHookType::Set)?->getParameters()[0] ?? $target;
+        }
+
+        return $target->getType();
+    }
+
+    /**
+     * Tells whether the type maps a scalar to a single control, so that a scalar "empty_data" is meaningful for it.
+     */
+    private function isScalarInput(string $type): bool
+    {
+        foreach ($this->getInnerTypes($type) as $innerType) {
+            if ($innerType instanceof TextType || $innerType instanceof IntegerType || $innerType instanceof NumberType || $innerType instanceof MoneyType || $innerType instanceof PercentType) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function isTextInput(string $type): bool
     {
-        $resolvedType = $this->registry->getType($type);
-
-        do {
-            $innerType = $resolvedType->getInnerType();
-
+        foreach ($this->getInnerTypes($type) as $innerType) {
             // both descend from TextType but render their own input types
             if ($innerType instanceof RangeType || $innerType instanceof ColorType) {
                 return false;
@@ -139,8 +237,20 @@ class FormFactory implements FormFactoryInterface
             if ($innerType instanceof TextType || $innerType instanceof NumberType || $innerType instanceof MoneyType || $innerType instanceof PercentType) {
                 return true;
             }
-        } while ($resolvedType = $resolvedType->getParent());
+        }
 
         return false;
+    }
+
+    /**
+     * @return iterable<FormTypeInterface>
+     */
+    private function getInnerTypes(string $type): iterable
+    {
+        $resolvedType = $this->registry->getType($type);
+
+        do {
+            yield $resolvedType->getInnerType();
+        } while ($resolvedType = $resolvedType->getParent());
     }
 }

--- a/src/Symfony/Component/Form/Tests/EmptyDataGuessingTest.php
+++ b/src/Symfony/Component/Form/Tests/EmptyDataGuessingTest.php
@@ -1,0 +1,266 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormTypeGuesserInterface;
+use Symfony\Component\Form\Guess\Guess;
+use Symfony\Component\Form\Guess\TypeGuess;
+use Symfony\Component\Form\Guess\ValueGuess;
+use Symfony\Component\Form\Test\FormIntegrationTestCase;
+use Symfony\Component\Form\Tests\Fixtures\TypedProperties;
+use Symfony\Component\Form\Tests\Fixtures\WriteTargetTypedProperties;
+
+class EmptyDataGuessingTest extends FormIntegrationTestCase
+{
+    public array $typeGuesses = [];
+
+    public function testSubmitEmptyStringOnNonNullableProperty()
+    {
+        $data = new TypedProperties();
+        $form = $this->createForm($data, 'name');
+
+        $form->submit(['name' => '']);
+
+        $this->assertSame('', $data->name);
+    }
+
+    public function testSubmitMissingFieldOnNonNullableProperty()
+    {
+        $data = new TypedProperties();
+        $form = $this->createForm($data, 'name');
+
+        $form->submit([]);
+
+        $this->assertSame('', $data->name);
+    }
+
+    #[DataProvider('provideGuessedEmptyData')]
+    public function testGuessedEmptyData(string $property, mixed $expected)
+    {
+        $form = $this->createForm(new TypedProperties(), $property);
+
+        $this->assertSame($expected, $form->get($property)->getConfig()->getEmptyData());
+    }
+
+    public static function provideGuessedEmptyData(): iterable
+    {
+        yield 'string' => ['name', ''];
+        yield 'int' => ['age', '0'];
+        yield 'float' => ['height', '0'];
+        yield 'bool' => ['active', false];
+    }
+
+    #[DataProvider('provideNotGuessedEmptyData')]
+    public function testNotGuessedEmptyData(string $property)
+    {
+        $form = $this->createForm(new TypedProperties(), $property);
+
+        $this->assertInstanceOf(\Closure::class, $form->get($property)->getConfig()->getEmptyData());
+    }
+
+    public static function provideNotGuessedEmptyData(): iterable
+    {
+        yield 'nullable' => ['nickname'];
+        yield 'nullable mutator' => ['slug'];
+        yield 'array' => ['tags'];
+        yield 'mixed' => ['extra'];
+        yield 'union' => ['identifier'];
+    }
+
+    public function testExplicitEmptyDataWins()
+    {
+        $data = new TypedProperties();
+        $form = $this->createForm($data, 'name', options: ['empty_data' => 'default']);
+
+        $form->submit(['name' => '']);
+
+        $this->assertSame('default', $data->name);
+    }
+
+    public function testUnmappedFieldsAreNotGuessed()
+    {
+        $form = $this->createForm(new TypedProperties(), 'name', options: ['mapped' => false]);
+
+        $this->assertInstanceOf(\Closure::class, $form->get('name')->getConfig()->getEmptyData());
+    }
+
+    public function testFieldsWithAPropertyPathAreNotGuessed()
+    {
+        $form = $this->createForm(new TypedProperties(), 'name', options: ['property_path' => 'name']);
+
+        $this->assertInstanceOf(\Closure::class, $form->get('name')->getConfig()->getEmptyData());
+    }
+
+    public function testExplicitlyTypedFieldsAreNotGuessed()
+    {
+        $form = $this->createForm(new TypedProperties(), 'name', TextType::class);
+
+        $this->assertInstanceOf(\Closure::class, $form->get('name')->getConfig()->getEmptyData());
+    }
+
+    public function testGuessedIntegerTypeIsSubmittedAsZero()
+    {
+        $this->typeGuesses['age'] = new TypeGuess(IntegerType::class, [], Guess::HIGH_CONFIDENCE);
+
+        $data = new TypedProperties();
+        $form = $this->createForm($data, 'age');
+
+        $form->submit(['age' => '']);
+
+        $this->assertTrue($form->isSynchronized());
+        $this->assertSame(0, $data->age);
+    }
+
+    public function testUncheckedCheckboxKeepsReturningFalse()
+    {
+        $this->typeGuesses['active'] = new TypeGuess(CheckboxType::class, [], Guess::HIGH_CONFIDENCE);
+
+        $data = new TypedProperties();
+        $data->active = true;
+        $form = $this->createForm($data, 'active');
+
+        $form->submit([]);
+
+        $this->assertTrue($form->isSynchronized());
+        $this->assertFalse($data->active);
+    }
+
+    public function testConstructorArgumentIsNotAWriteTarget()
+    {
+        $data = new WriteTargetTypedProperties();
+        $form = $this->createForm($data, 'qty');
+
+        $form->submit(['qty' => '']);
+
+        $this->assertTrue($form->isSynchronized());
+        $this->assertNull($data->qty);
+    }
+
+    public function testAccessorIsNotAWriteTarget()
+    {
+        $data = new WriteTargetTypedProperties();
+        $data->name = 'foo';
+        $form = $this->createForm($data, 'name');
+
+        $form->submit(['name' => '']);
+
+        $this->assertNull($data->name);
+    }
+
+    public function testMutatorWinsOverProperty()
+    {
+        $data = new WriteTargetTypedProperties();
+        $form = $this->createForm($data, 'label');
+
+        $this->assertInstanceOf(\Closure::class, $form->get('label')->getConfig()->getEmptyData());
+
+        $data->label = 'foo';
+        $form->submit(['label' => '']);
+
+        $this->assertSame('', $data->label);
+    }
+
+    public function testMutatorOfANullablePropertyIsGuessed()
+    {
+        $data = new WriteTargetTypedProperties();
+        $form = $this->createForm($data, 'title');
+
+        $this->assertSame('', $form->get('title')->getConfig()->getEmptyData());
+
+        $form->submit(['title' => '']);
+
+        $this->assertSame('', $data->getTitle());
+    }
+
+    public function testSetHookIsTheWriteTarget()
+    {
+        $data = new WriteTargetTypedProperties();
+        $form = $this->createForm($data, 'comment');
+
+        $this->assertInstanceOf(\Closure::class, $form->get('comment')->getConfig()->getEmptyData());
+
+        $form->submit(['comment' => '']);
+
+        $this->assertSame('none', $data->comment);
+    }
+
+    #[DataProvider('provideNonPublicWriteTargets')]
+    public function testNonPublicWriteTargetsAreNotGuessed(string $property)
+    {
+        $form = $this->createForm(new WriteTargetTypedProperties(), $property);
+
+        $this->assertInstanceOf(\Closure::class, $form->get($property)->getConfig()->getEmptyData());
+    }
+
+    public static function provideNonPublicWriteTargets(): iterable
+    {
+        yield 'private(set) property' => ['slug'];
+        yield 'protected(set) property' => ['tone'];
+        yield 'readonly property' => ['ref'];
+        yield 'virtual property without a set hook' => ['alias'];
+        yield 'non-public mutator' => ['thing'];
+    }
+
+    public function testPublicWriteTargetIsStillGuessed()
+    {
+        $data = new WriteTargetTypedProperties();
+        $form = $this->createForm($data, 'heading');
+
+        $this->assertSame('', $form->get('heading')->getConfig()->getEmptyData());
+
+        $form->submit(['heading' => '']);
+
+        $this->assertSame('', $data->heading);
+    }
+
+    protected function getTypeGuessers(): array
+    {
+        return [new class($this) implements FormTypeGuesserInterface {
+            public function __construct(private EmptyDataGuessingTest $test)
+            {
+            }
+
+            public function guessType(string $class, string $property): ?TypeGuess
+            {
+                return $this->test->typeGuesses[$property] ?? null;
+            }
+
+            public function guessRequired(string $class, string $property): ?ValueGuess
+            {
+                return null;
+            }
+
+            public function guessMaxLength(string $class, string $property): ?ValueGuess
+            {
+                return null;
+            }
+
+            public function guessPattern(string $class, string $property): ?ValueGuess
+            {
+                return null;
+            }
+        }];
+    }
+
+    private function createForm(object $data, string $property, ?string $type = null, array $options = []): FormInterface
+    {
+        return $this->factory
+            ->createBuilder(options: ['data_class' => $data::class, 'data' => $data])
+            ->add($property, $type, $options)
+            ->getForm();
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Fixtures/TypedProperties.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/TypedProperties.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Fixtures;
+
+class TypedProperties
+{
+    public string $name = '';
+    public ?string $nickname = null;
+    public int $age = 0;
+    public float $height = 0.0;
+    public bool $active = false;
+    public array $tags = [];
+    public mixed $extra = null;
+    public string|int $identifier = '';
+
+    private string $slug = '';
+
+    public function getSlug(): string
+    {
+        return $this->slug;
+    }
+
+    public function setSlug(?string $slug): void
+    {
+        $this->slug = $slug ?? '';
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Fixtures/WriteTargetTypedProperties.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/WriteTargetTypedProperties.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Fixtures;
+
+class WriteTargetTypedProperties
+{
+    public ?int $qty = null;
+    public ?string $name = null;
+    public string $label = '';
+
+    public string $comment = '' {
+        set(?string $value) => $value ?? 'none';
+    }
+
+    public string $heading = 'foo';
+
+    public private(set) string $slug = '';
+
+    public protected(set) string $tone = '';
+
+    public readonly string $ref;
+
+    public string $alias {
+        get => $this->heading;
+    }
+
+    private ?string $title = null;
+
+    private ?string $thing = null;
+
+    public function __construct(int $qty = 0)
+    {
+        $this->qty = $qty;
+        $this->ref = 'bar';
+    }
+
+    public function getName(): string
+    {
+        return $this->name ?? '';
+    }
+
+    public function setLabel(?string $label): void
+    {
+        $this->label = $label ?? '';
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(string $title): void
+    {
+        $this->title = $title;
+    }
+
+    public function getThing(): ?string
+    {
+        return $this->thing;
+    }
+
+    private function setThing(string $thing): void
+    {
+        $this->thing = $thing;
+    }
+}

--- a/src/Symfony/Component/Form/composer.json
+++ b/src/Symfony/Component/Form/composer.json
@@ -24,6 +24,7 @@
         "symfony/polyfill-intl-icu": "^1.21",
         "symfony/polyfill-mbstring": "^1.0",
         "symfony/property-access": "^7.4|^8.0",
+        "symfony/property-info": "^7.4|^8.0",
         "symfony/service-contracts": "^2.5|^3",
         "symfony/var-exporter": "^8.1"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Fix #25977
| License       | MIT

Reported by @soullivaneuh in #25977: submitting an empty scalar field that is mapped to a non-nullable typed property writes `null` and blows up with

```
Symfony\Component\PropertyAccess\Exception\InvalidTypeException:
Expected argument of type "string", "null" given at property path "name".
```

Today the only cure is to repeat `'empty_data' => ''` on every such field. This PR derives it from the type of the property instead.

### The mechanism

Three pieces have to line up:

1. `FormType` resolves `empty_data` to a **closure**, `static fn (FormInterface $form) => $form->getConfig()->getCompound() ? [] : ''` for a non-compound field.
2. `TextType::buildForm()` registers its identity view transformer only when `'' === $options['empty_data']`, a literal comparison. Against a closure it never fires.
3. `Form::submit()` applies `empty_data` to the **view** data and only then calls `viewToNorm()`, which without any transformer does `return '' === $value ? null : $value;`.

So the closure returns `''`, `viewToNorm()` turns it straight back into `null`, and the property writer gets `null`. Setting `empty_data` to the literal `''` is what makes `TextType` add the transformer and the `null` disappear. That is also why the guessed value is expressed in **view** space rather than model space: `'0'` for a number, not `0`, because `IntegerType` and `NumberType` reverse-transform a string and reject anything else.

### Scope

Deliberately narrow, so that the only behaviour that changes is behaviour that throws today:

* the guess only runs when `empty_data` was **not** set by the user;
* the guess only runs when the resolved writable type of the property **refuses null**: `ReflectionExtractor::getType()` reads the mutator argument first, then the accessor, the constructor and finally the property, so a setter widened to `?string` suppresses the guess;
* only `string` (`''`), `int` and `float` (`'0'`) and `bool` (`false`) are guessed, nothing else, and only when the type is a plain builtin, so nullables, unions, `mixed`, arrays and objects are left alone;
* only types that map a scalar to a single control take the guess. `CheckboxType` brings its own `empty_data` semantics and already returns `false` for a non-nullable `bool`, so forcing a value on it would have broken unchecked checkboxes;
* fields with `mapped: false` or an explicit `property_path` are skipped, since the guess is read from the field name and would otherwise be read off the wrong property.

#41516 was closed because changing the global `empty_data` default would have been an upgrade step for everybody. This is different: every case it touches currently ends in an uncaught `InvalidTypeException`, so there is nothing working today that starts behaving differently.

### Where it hooks, and what it does not cover yet

The guess is applied in `FormFactory::createBuilderForProperty()`, next to the `required`, `maxlength` and `pattern` guesses. That is the only place in the chain that has both the class and the property name **and** still owns the options array before the type resolves them. Since `empty_data` must be a literal at option-resolution time (point 2 above), a value produced any later is useless.

The two alternatives were rejected:

* **A form type extension on `FormType`.** `configureOptions()` sees neither the parent's `data_class` nor the child's name, and an extension's `buildForm()` runs after `TextType::buildForm()` has already tested the resolved option. It can only install a closure, which is exactly the shape that fails.
* **Passing property context through `FormBuilder::create()` into `createNamedBuilder()`.** This is the one that would matter, and it is honestly not covered here. `->add('name')` gets the guess; `->add('name', TextType::class)` does not, because that branch of `FormBuilder::create()` calls `createNamedBuilder()` and drops the property context on the floor, even though the builder knows its own `data_class` and the child name. Carrying it across needs either a signature change on `FormFactoryInterface::createNamedBuilder()`, which is a BC break, or a new optional factory interface that `FormBuilder` feature-checks. I did not want to add public API to a first pass, and `FormBuilder` must not learn about PropertyInfo itself. Worth doing as a follow-up, since the explicit-type form is the more common idiom.

A second follow-up would be to let guessers contribute the value, so that Doctrine could answer from column metadata. That needs a separate optional interface: adding a fifth method to `FormTypeGuesserInterface` would break every third-party guesser.

### Dependency note

The premise that PropertyInfo is optional for the Form component no longer holds: `symfony/property-access`, which Form requires, has required `symfony/property-info` since 7.4.4/8.0.4, and property-info requires type-info. Both are therefore always installed. Since `FormFactory` now uses them directly and unconditionally, they are declared in `require` rather than `require-dev` plus `suggest`, and there is no `class_exists()` dance guarding an unreachable branch.
