### PR TITLE
[AssetMapper][FrameworkBundle] Stop versioning the assets the mapper already resolved

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1313,6 +1313,9 @@ class FrameworkExtension extends Extension
         $defaultPackage = $this->createPackageDefinition($config['base_path'], $config['base_urls'], $defaultVersion);
         $container->setDefinition('assets._default_package', $defaultPackage);
 
+        // used by the asset mapper for the assets it resolves itself, which already carry a content hash
+        $container->setDefinition('assets._default_package_without_version', $this->createPackageDefinition($config['base_path'], $config['base_urls'], new Reference('assets.empty_version_strategy')));
+
         foreach ($config['packages'] as $name => $package) {
             if (null !== $package['version_strategy']) {
                 $version = new Reference($package['version_strategy']);
@@ -1341,7 +1344,8 @@ class FrameworkExtension extends Extension
             $container->removeDefinition('asset_mapper.asset_package');
         } else {
             $container->getDefinition('asset_mapper.asset_package')
-                ->replaceArgument(3, $config['server'] ? $config['public_prefix'] : null);
+                ->replaceArgument(3, $config['server'] ? $config['public_prefix'] : null)
+                ->replaceArgument(5, $config['public_prefix']);
         }
 
         if (!$httpClientEnabled) {

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/asset_mapper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/asset_mapper.php
@@ -103,6 +103,8 @@ return static function (ContainerConfigurator $container) {
                 service('asset_mapper'),
                 service('request_stack'),
                 abstract_arg('dev server public prefix'),
+                service('assets._default_package_without_version')->nullOnInvalid(),
+                abstract_arg('asset public prefix'),
             ])
 
         ->set('asset_mapper.dev_server_subscriber', AssetMapperDevServerSubscriber::class)

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTestCase.php
@@ -47,8 +47,8 @@ use Symfony\Component\DependencyInjection\Loader\ClosureLoader;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\DependencyInjection\ParameterBag\EnvPlaceholderParameterBag;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Form\Form;
 use Symfony\Component\HtmlSanitizer\HtmlSanitizer;
@@ -2523,6 +2523,17 @@ abstract class FrameworkExtensionTestCase extends TestCase
         );
     }
 
+    public function testAssetsPackageWithoutVersionKeepsTheBaseUrls()
+    {
+        $container = $this->createContainerFromFile('assets');
+
+        $package = $container->getDefinition('assets._default_package_without_version');
+
+        $this->assertSame('assets.url_package', $package->getParent());
+        $this->assertSame(['http://cdn.example.com'], $package->getArgument(0));
+        $this->assertEquals(new Reference('assets.empty_version_strategy'), $package->getArgument(1));
+    }
+
     public function testAssetMapperWithoutAssets()
     {
         $container = $this->createContainerFromFile('asset_mapper_without_assets');
@@ -2556,6 +2567,30 @@ abstract class FrameworkExtensionTestCase extends TestCase
         });
 
         $this->assertSame($expectedPrefix, $container->getDefinition('asset_mapper.asset_package')->getArgument(3));
+    }
+
+    public function testAssetMapperAssetPackageSkipsTheVersionOfMappedAssets()
+    {
+        $container = $this->createContainerFromClosure(static function ($container) {
+            $container->loadFromExtension('framework', [
+                'annotations' => false,
+                'http_method_override' => false,
+                'handle_all_throwables' => true,
+                'php_errors' => ['log' => true],
+                'assets' => null,
+                'asset_mapper' => [
+                    'server' => false,
+                    'public_prefix' => '/assets_path/',
+                    'paths' => ['assets/'],
+                ],
+            ]);
+        });
+
+        $definition = $container->getDefinition('asset_mapper.asset_package');
+
+        $this->assertEquals(new Reference('assets._default_package_without_version', ContainerInterface::NULL_ON_INVALID_REFERENCE), $definition->getArgument(4));
+        // unlike the dev server prefix, this one is passed whether the server runs or not
+        $this->assertSame('/assets_path/', $definition->getArgument(5));
     }
 
     public function testTranslatorDefaultPathContainingAPercentSign()

--- a/src/Symfony/Component/AssetMapper/MapperAwareAssetPackage.php
+++ b/src/Symfony/Component/AssetMapper/MapperAwareAssetPackage.php
@@ -22,17 +22,23 @@ use Symfony\Component\HttpFoundation\RequestStack;
 final class MapperAwareAssetPackage implements PackageInterface
 {
     private readonly ?string $devServerPrefix;
+    private readonly ?string $publicPrefix;
 
     /**
-     * @param string|null $devServerPublicPrefix The public prefix served by AssetMapperDevServerSubscriber, null when it is disabled
+     * @param string|null           $devServerPublicPrefix      The public prefix served by AssetMapperDevServerSubscriber, null when it is disabled
+     * @param PackageInterface|null $innerPackageWithoutVersion The decorated package without its version strategy, null when the Asset component is not configured
+     * @param string|null           $publicPrefix               The public prefix of the mapped assets, used to recognize a path the mapper already resolved
      */
     public function __construct(
         private readonly PackageInterface $innerPackage,
         private readonly AssetMapperInterface $assetMapper,
         private readonly ?RequestStack $requestStack = null,
         ?string $devServerPublicPrefix = null,
+        private readonly ?PackageInterface $innerPackageWithoutVersion = null,
+        ?string $publicPrefix = null,
     ) {
         $this->devServerPrefix = null === $devServerPublicPrefix ? null : '/'.trim($devServerPublicPrefix, '/').'/';
+        $this->publicPrefix = null === $publicPrefix ? null : '/'.trim($publicPrefix, '/').'/';
     }
 
     public function getVersion(string $path): string
@@ -43,6 +49,14 @@ final class MapperAwareAssetPackage implements PackageInterface
     public function getUrl(string $path): string
     {
         $publicPath = $this->assetMapper->getPublicPath($path);
+
+        // the content hash is the version, so the configured strategy must not add a second one.
+        // The import map renders public paths, which the mapper does not resolve again, hence the prefix test.
+        // The package must be picked before the block below prepends the front controller.
+        $package = $publicPath || (null !== $this->publicPrefix && str_starts_with('/'.$path, $this->publicPrefix))
+            ? $this->innerPackageWithoutVersion ?? $this->innerPackage
+            : $this->innerPackage;
+
         if ($publicPath) {
             $path = ltrim($publicPath, '/');
         }
@@ -57,6 +71,6 @@ final class MapperAwareAssetPackage implements PackageInterface
             }
         }
 
-        return $this->innerPackage->getUrl($path);
+        return $package->getUrl($path);
     }
 }

--- a/src/Symfony/Component/AssetMapper/Tests/MapperAwareAssetPackageTest.php
+++ b/src/Symfony/Component/AssetMapper/Tests/MapperAwareAssetPackageTest.php
@@ -15,7 +15,9 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Asset\Context\RequestStackContext;
 use Symfony\Component\Asset\PackageInterface;
 use Symfony\Component\Asset\PathPackage;
+use Symfony\Component\Asset\UrlPackage;
 use Symfony\Component\Asset\VersionStrategy\EmptyVersionStrategy;
+use Symfony\Component\Asset\VersionStrategy\StaticVersionStrategy;
 use Symfony\Component\AssetMapper\AssetMapperInterface;
 use Symfony\Component\AssetMapper\MapperAwareAssetPackage;
 use Symfony\Component\HttpFoundation\Request;
@@ -149,6 +151,85 @@ class MapperAwareAssetPackageTest extends TestCase
         );
 
         $this->assertSame('/assets/images/foo.123456.png', $assetMapperPackage->getUrl('images/foo.png'));
+    }
+
+    public function testGetUrlSkipsTheVersionOfAssetsResolvedByTheMapper()
+    {
+        $assetMapperPackage = new MapperAwareAssetPackage(
+            new PathPackage('/', new StaticVersionStrategy('v1')),
+            $this->createAssetMapper(),
+            null,
+            null,
+            new PathPackage('/', new EmptyVersionStrategy()),
+            '/assets/',
+        );
+
+        // the content hash is the version, a second one would point at a file that does not exist
+        $this->assertSame('/assets/images/foo.123456.png', $assetMapperPackage->getUrl('images/foo.png'));
+        // assets the mapper knows nothing about keep the configured version
+        $this->assertSame('/legacy.css?v1', $assetMapperPackage->getUrl('legacy.css'));
+    }
+
+    public function testGetUrlKeepsTheBaseUrlOfAssetsResolvedByTheMapper()
+    {
+        $assetMapperPackage = new MapperAwareAssetPackage(
+            new UrlPackage(['https://cdn.example.com'], new StaticVersionStrategy('v1')),
+            $this->createAssetMapper(),
+            null,
+            null,
+            new UrlPackage(['https://cdn.example.com'], new EmptyVersionStrategy()),
+            '/assets/',
+        );
+
+        $this->assertSame('https://cdn.example.com/assets/images/foo.123456.png', $assetMapperPackage->getUrl('images/foo.png'));
+    }
+
+    public function testGetUrlSkipsTheVersionOfAPublicPathTheMapperDoesNotResolve()
+    {
+        // the import map renders the keys of its entries, which are public paths without a digest
+        $assetMapperPackage = new MapperAwareAssetPackage(
+            new PathPackage('/', new StaticVersionStrategy('v1')),
+            $this->createAssetMapper(),
+            null,
+            null,
+            new PathPackage('/', new EmptyVersionStrategy()),
+            '/assets/',
+        );
+
+        $this->assertSame('/assets/app.js', $assetMapperPackage->getUrl('assets/app.js'));
+        $this->assertSame('/legacy.css?v1', $assetMapperPackage->getUrl('legacy.css'));
+    }
+
+    public function testGetUrlSkipsTheVersionWithACustomPublicPrefix()
+    {
+        $assetMapperPackage = new MapperAwareAssetPackage(
+            new PathPackage('/', new StaticVersionStrategy('v1')),
+            $this->createAssetMapper(),
+            null,
+            null,
+            new PathPackage('/', new EmptyVersionStrategy()),
+            '/static/',
+        );
+
+        $this->assertSame('/static/app.js', $assetMapperPackage->getUrl('static/app.js'));
+        // the default prefix has nothing special about it, it is versioned like any other path
+        $this->assertSame('/assets/app.js?v1', $assetMapperPackage->getUrl('assets/app.js'));
+    }
+
+    public function testGetUrlSkipsTheVersionWithTheDevServer()
+    {
+        $requestStack = $this->createRequestStack('/index.php/blog', '/index.php');
+        $assetMapperPackage = new MapperAwareAssetPackage(
+            new PathPackage('', new StaticVersionStrategy('v1'), new RequestStackContext($requestStack)),
+            $this->createAssetMapper(),
+            $requestStack,
+            '/assets/',
+            new PathPackage('', new EmptyVersionStrategy(), new RequestStackContext($requestStack)),
+            '/assets/',
+        );
+
+        // the front controller is still added, and the version is still skipped
+        $this->assertSame('/index.php/assets/images/foo.123456.png', $assetMapperPackage->getUrl('images/foo.png'));
     }
 
     public static function getUrlTests(): iterable


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65911
| License       | MIT

`MapperAwareAssetPackage` asks the mapper for the public path of an asset, which already carries a content hash, then hands it to the decorated package, which applies the configured version on top of it:

```yaml
framework:
    assets:
        version: 'v1'
    asset_mapper:
        paths: ['assets/']
```

| | before | after |
| --- | --- | --- |
| `{{ asset('app.js') }}` | `/assets/app-abc123.js?v1` | `/assets/app-abc123.js` |
| import map key | `/assets/dep.js?v1` | `/assets/dep.js` |
| asset outside the mapper | `/legacy.css?v1` | unchanged |

Returning the public path directly would also drop the base path and the base URLs, since `getUrl()` applies them together with the version. So the decorator now receives a second package, built from the same `base_path` and `base_urls` but with `assets.empty_version_strategy`, and uses it only for the paths the mapper handles. Anything the mapper does not know keeps the configured version, so a setup that mixes mapped and unmapped assets still works.

The import map half needs the public prefix. `ImportMapRenderer::render()` also runs the `/assets/...` keys through the package, and those are already resolved, so `getPublicPath()` returns null for them and the version is applied anyway. `JavaScriptImportPathCompiler` writes that same unversioned path as the specifier in the compiled JavaScript, so a versioned key no longer matches its specifier: the browser ignores the entry and fetches the undigested path, which is the 404 of the report. The package is chosen before the dev server block, which prepends the front controller and would make the prefix test fail.

Tests: five cases on `MapperAwareAssetPackage` (a logical path the mapper resolves with `PathPackage`, the same with `UrlPackage` so the base URL survives, an already public path without a digest, a custom `public_prefix`, and the dev server case), plus the wiring in `FrameworkExtensionTestCase`. The five fail without the fix.

The same problem was reported earlier in #57584.
