### PR TITLE
[HttpFoundation] Compare packed bytes to detect IPv4-mapped addresses in anonymize()

### DIFF
--- a/src/Symfony/Component/HttpFoundation/IpUtils.php
+++ b/src/Symfony/Component/HttpFoundation/IpUtils.php
@@ -213,9 +213,9 @@ class IpUtils
         $packedAddress = inet_pton($ip);
         if (4 === \strlen($packedAddress)) {
             $mask = '255.255.255.0';
-        } elseif ($ip === inet_ntop($packedAddress & inet_pton('::ffff:ffff:ffff'))) {
+        } elseif ($packedAddress === ($packedAddress & inet_pton('::ffff:ffff:ffff'))) {
             $mask = '::ffff:ffff:ff00';
-        } elseif ($ip === inet_ntop($packedAddress & inet_pton('::ffff:ffff'))) {
+        } elseif ($packedAddress === ($packedAddress & inet_pton('::ffff:ffff'))) {
             $mask = '::ffff:ff00';
         } else {
             $mask = 'ffff:ffff:ffff:ffff:0000:0000:0000:0000';

--- a/src/Symfony/Component/HttpFoundation/Tests/IpUtilsTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/IpUtilsTest.php
@@ -146,6 +146,9 @@ class IpUtilsTest extends TestCase
             ['[0:0:603:50:396e:4789:8e99:0001]', '[0:0:603:50::]'],
             ['[2a01:198::3]', '[2a01:198::]'],
             ['::ffff:123.234.235.236', '::ffff:123.234.235.0'], // IPv4-mapped IPv6 addresses
+            ['::FFFF:123.234.235.236', '::ffff:123.234.235.0'], // same address, upper case
+            ['::ffff:7bea:ebec', '::ffff:123.234.235.0'], // same address, IPv4 part in hexadecimal
+            ['0000:0000:0000:0000:0000:ffff:7bea:ebec', '::ffff:123.234.235.0'], // same address, fully expanded
             ['::123.234.235.236', '::123.234.235.0'], // deprecated IPv4-compatible IPv6 address
             ['fe80::1fc4:15d8:78db:2319%enp4s0', 'fe80::'], // IPv6 link-local with RFC4007 scoping
         ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #65999
| License       | MIT

`anonymize()` detects IPv4-mapped and IPv4-compatible addresses by comparing the address as it was written with the canonical form returned by `inet_ntop()`. Equivalent spellings of the same address fail that comparison, fall through to the generic IPv6 mask and come back as `::`.

On 6.4, with the default arguments:

| input | before | after |
|---|---|---|
| `::ffff:123.234.235.236` | `::ffff:123.234.235.0` | unchanged |
| `::FFFF:123.234.235.236` | `::` | `::ffff:123.234.235.0` |
| `::ffff:7bea:ebec` | `::` | `::ffff:123.234.235.0` |
| `0000:0000:0000:0000:0000:ffff:7bea:ebec` | `::` | `::ffff:123.234.235.0` |

The four are the same 16 bytes. Comparing the packed address against itself masked keeps the detection independent of the notation.

It matters beyond the odd output: an address that reaches the generic branch loses its last 8 bytes, so a caller storing the result believes it kept a mapped address while it kept nothing. Given what this method is for, the reverse mistake would be worse, but silently turning an address into `::` also breaks any per-network aggregation built on it.

The same two comparisons are present unchanged up to 8.2, so the fix applies as is.

One thing I noticed and left alone: after this change the `::ffff:ffff` branch is unreachable, since its condition is strictly stronger than the one above it. The outcome is the same either way for an IPv4-compatible address, both masks clear the same last byte, so removing it would be a separate cleanup rather than part of this fix. Happy to do it here if you prefer.

Tests: the three spellings above are added to `anonymizedIpData`. They fail on 6.4 without the change, each returning `::`. `IpUtilsTest` goes from 86 to 89 tests, all passing.
