### PR TITLE
[Console] Report a validation error instead of a TypeError on numeric arguments and options

### DIFF
--- a/src/Symfony/Component/Console/Attribute/Argument.php
+++ b/src/Symfony/Component/Console/Attribute/Argument.php
@@ -126,6 +126,10 @@ class Argument
             return $this->typeName::tryFrom($value) ?? throw InvalidArgumentException::fromEnumValue($this->name, $value, $this->suggestedValues);
         }
 
+        if (\is_string($value) && \in_array($this->typeName, ['int', 'float'], true) && !is_numeric($value)) {
+            throw InvalidArgumentException::fromInvalidType($this->name, $value, $this->typeName);
+        }
+
         return $value;
     }
 

--- a/src/Symfony/Component/Console/Attribute/Option.php
+++ b/src/Symfony/Component/Console/Attribute/Option.php
@@ -153,6 +153,10 @@ class Option
             return $this->typeName::tryFrom($value) ?? throw InvalidOptionException::fromEnumValue($this->name, $value, $this->suggestedValues);
         }
 
+        if (\is_string($value) && \in_array($this->typeName, ['int', 'float'], true) && !is_numeric($value)) {
+            throw InvalidOptionException::fromInvalidType($this->name, $value, $this->typeName);
+        }
+
         if ('array' === $this->typeName && $this->allowNull && [] === $value) {
             return null;
         }

--- a/src/Symfony/Component/Console/Exception/InvalidArgumentException.php
+++ b/src/Symfony/Component/Console/Exception/InvalidArgumentException.php
@@ -29,4 +29,12 @@ class InvalidArgumentException extends \InvalidArgumentException implements Exce
 
         return new self($error);
     }
+
+    /**
+     * @internal
+     */
+    public static function fromInvalidType(string $name, string $value, string $type): self
+    {
+        return new self(\sprintf('The value "%s" is not valid for the "%s" argument. Expected a value of type "%s".', $value, $name, $type));
+    }
 }

--- a/src/Symfony/Component/Console/Exception/InvalidOptionException.php
+++ b/src/Symfony/Component/Console/Exception/InvalidOptionException.php
@@ -31,4 +31,12 @@ class InvalidOptionException extends \InvalidArgumentException implements Except
 
         return new self($error);
     }
+
+    /**
+     * @internal
+     */
+    public static function fromInvalidType(string $name, string $value, string $type): self
+    {
+        return new self(\sprintf('The value "%s" is not valid for the "%s" option. Expected a value of type "%s".', $value, $name, $type));
+    }
 }

--- a/src/Symfony/Component/Console/Tests/Command/InvokableCommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/InvokableCommandTest.php
@@ -231,6 +231,48 @@ class InvokableCommandTest extends TestCase
         $command->run(new ArrayInput(['--enum' => 'incorrect']), new NullOutput());
     }
 
+    public function testNumericArgumentIsConvertedOrRejected()
+    {
+        $command = new Command('foo');
+        $command->setCode(static function (#[Argument] int $count, #[Argument] float $ratio = 1.0) use (&$received): int {
+            $received = [$count, $ratio];
+
+            return Command::SUCCESS;
+        });
+
+        $command->run(new ArrayInput(['count' => '3', 'ratio' => '1.5']), new NullOutput());
+
+        self::assertSame([3, 1.5], $received);
+
+        $command->run(new ArrayInput(['count' => '007', 'ratio' => '1e3']), new NullOutput());
+
+        self::assertSame([7, 1000.0], $received);
+
+        self::expectException(InvalidArgumentException::class);
+        self::expectExceptionMessage('The value "abc" is not valid for the "count" argument. Expected a value of type "int".');
+
+        $command->run(new ArrayInput(['count' => 'abc']), new NullOutput());
+    }
+
+    public function testNumericOptionIsConvertedOrRejected()
+    {
+        $command = new Command('foo');
+        $command->setCode(static function (#[Option] float $ratio = 1.0) use (&$received): int {
+            $received = $ratio;
+
+            return Command::SUCCESS;
+        });
+
+        $command->run(new ArrayInput(['--ratio' => '1.5']), new NullOutput());
+
+        self::assertSame(1.5, $received);
+
+        self::expectException(InvalidOptionException::class);
+        self::expectExceptionMessage('The value "half" is not valid for the "ratio" option. Expected a value of type "float".');
+
+        $command->run(new ArrayInput(['--ratio' => 'half']), new NullOutput());
+    }
+
     public function testInvalidArgumentType()
     {
         $command = new Command('foo');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #66029
| License       | MIT

An invokable command with an `int` or `float` argument or option crashes with a raw `TypeError` when the value typed in the terminal cannot be converted. The person running the command gets a trace naming a PHP parameter instead of a message naming the input they got wrong.

Reproduced on 7.4 with @GromNaN's command:

```
$ bin/console app:foo Hello
PHP Fatal error:  Uncaught TypeError: FooCommand::__invoke(): Argument #1 ($fun) must be of type int, string given
```

After:

```
  The value "Hello" is not valid for the "fun" argument. Expected a value of
  type "int".

  app:foo [--foo FOO] [--] <fun>
```

Same for an option, with `InvalidOptionException`.

## The change

`Argument::resolveValue()` and `Option::resolveValue()` already turn an unrecognised value into a readable error for backed enums, through `InvalidArgumentException::fromEnumValue()`. Numeric types now get the same treatment, and following @GromNaN's review the value is converted with `filter_var` rather than left to the implicit conversion that happens when the parameter is bound.

Measured against the implicit conversion, over `'12'`, `'12.0'`, `'12.5'`, `'1e3'`, `'0'`, `''`, `' 12'`, `'12 '`, `'abc'`, `'12abc'`, `'0x1A'`, `'-3'`, `'+3'`, `'.5'`, `'NaN'`, `'INF'`, `'007'`:

- `float`: `FILTER_VALIDATE_FLOAT` accepts exactly what the implicit conversion accepted and rejects exactly what raised a `TypeError`. Nothing moves.
- `int`: `FILTER_VALIDATE_INT` is stricter on `12.0`, `12.5`, `.5`, `1e3` and `007`. The first four used to arrive silently altered, `.5` becoming `0` being the worst of them. `007` is discussed in the review thread.

Only `int` and `float` are concerned. `string` and `array` receive what the input already holds, `bool` options are flags, and enums already had their own path.

The exception message check asked for the placeholders of the messages already present in `Argument.php` and `Option.php` to be quoted, since this PR touches those files. That is in the same commit.

## Verification

`InvokableCommandTest` gains two tests, one for the argument and one for the option. Each one first runs the command with valid input and asserts the values arrive already typed, `[3, 1.5]` and `1.5`, then asserts the message on invalid input. Both fail on 7.4 without the change, with the raw `TypeError`.

Full Console suite: **1478 tests**. The 1 error and 2 failures left are in `QuestionHelperTest` and `DumperNativeFallbackTest`, and they are identical on 7.4 without this change, verified by stashing. They come from running without a terminal.

`php-cs-fixer` clean on the five files with your configuration.

One thing to decide, and it is yours: someone catching `\TypeError` around a command run would now see `InvalidArgumentException` or `InvalidOptionException`. I read the current behaviour as the defect rather than as contract, which is why this targets 7.4. Tell me if you would rather have it on 8.2.
