### PR TITLE
[Messenger] Drop the messages queued by a failed nested dispatch

### DIFF
--- a/src/Symfony/Component/Messenger/Middleware/DispatchAfterCurrentBusMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/DispatchAfterCurrentBusMiddleware.php
@@ -58,7 +58,15 @@ class DispatchAfterCurrentBusMiddleware implements MiddlewareInterface
              * A call to MessageBusInterface::dispatch() was made from inside the main bus handling,
              * but the message does not have the stamp. So, process it like normal.
              */
-            return $stack->next()->handle($envelope, $stack);
+            $queueLengthBefore = \count($this->queue);
+            try {
+                return $stack->next()->handle($envelope, $stack);
+            } catch (\Throwable $e) {
+                // drop the messages queued by the failed dispatch, they were likely dependent on it
+                $this->queue = \array_slice($this->queue, 0, $queueLengthBefore);
+
+                throw $e;
+            }
         }
 
         // First time we get here, mark as inside a "root dispatch" call:

--- a/src/Symfony/Component/Messenger/Tests/Middleware/DispatchAfterCurrentBusMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/DispatchAfterCurrentBusMiddlewareTest.php
@@ -289,6 +289,54 @@ class DispatchAfterCurrentBusMiddlewareTest extends TestCase
         self::assertNull($envelope->last(DispatchAfterCurrentBusStamp::class));
     }
 
+    public function testMessagesQueuedByAFailedNestedDispatchAreDropped()
+    {
+        $message = new DummyMessage('Hello');
+        $nestedMessage = new DummyMessage('Nested');
+        $event = new DummyEvent('Event queued by the failed nested dispatch');
+
+        $middleware = new DispatchAfterCurrentBusMiddleware();
+        $handlingMiddleware = $this->createMock(MiddlewareInterface::class);
+
+        $eventBus = new MessageBus([
+            $middleware,
+            $handlingMiddleware,
+        ]);
+
+        $nestedBus = new MessageBus([
+            $middleware,
+            new DispatchingMiddleware($eventBus, [
+                new Envelope($event, [new DispatchAfterCurrentBusStamp()]),
+            ]),
+            $handlingMiddleware,
+        ]);
+
+        $messageBus = new MessageBus([
+            $middleware,
+            new FailingDispatchingMiddleware($nestedBus, $nestedMessage),
+            $handlingMiddleware,
+        ]);
+
+        // the nested message fails after queueing the event, then the main message is
+        // handled: the event queued by the failed dispatch must not be handled
+        $series = [$nestedMessage, $message];
+
+        $handlingMiddleware->expects($this->exactly(2))
+            ->method('handle')
+            ->with($this->callback(static function (Envelope $envelope) use (&$series) {
+                return $envelope->getMessage() === array_shift($series);
+            }))
+            ->willReturnCallback(static function (Envelope $envelope, StackInterface $stack) use ($nestedMessage) {
+                if ($envelope->getMessage() === $nestedMessage) {
+                    throw new \RuntimeException('Some exception while handling the nested message');
+                }
+
+                return $stack->next()->handle($envelope, $stack);
+            });
+
+        $messageBus->dispatch($message);
+    }
+
     private function expectHandledMessage($message): Callback
     {
         return $this->callback(static fn (Envelope $envelope) => $envelope->getMessage() === $message);
@@ -330,6 +378,28 @@ class DispatchingMiddleware implements MiddlewareInterface
     {
         foreach ($this->messages as $event) {
             $this->bus->dispatch($event);
+        }
+
+        return $stack->next()->handle($envelope, $stack);
+    }
+}
+
+class FailingDispatchingMiddleware implements MiddlewareInterface
+{
+    private MessageBusInterface $bus;
+    private object $message;
+
+    public function __construct(MessageBusInterface $bus, object $message)
+    {
+        $this->bus = $bus;
+        $this->message = $message;
+    }
+
+    public function handle(Envelope $envelope, StackInterface $stack): Envelope
+    {
+        try {
+            $this->bus->dispatch($this->message);
+        } catch (\RuntimeException $e) {
         }
 
         return $stack->next()->handle($envelope, $stack);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

A message dispatched with a `DispatchAfterCurrentBusStamp` from inside a handler is queued and dispatched once the root dispatch is over. When the nested dispatch that queued it fails, the queued messages are dispatched anyway, although the work that queued them never completed.

The root dispatch already drops its queue when handling throws, with the reasoning that the queued messages were likely dependent on the work that queued them. The nested path did not, so the two halves of the same middleware disagreed.

```php
public function __invoke(RegisterUser $command): void
{
    try {
        // this dispatch queues UserRegistered, then throws
        $this->bus->dispatch(new CreateProfile($command->getUuid()));
    } catch (\Throwable) {
        // the caller decides to carry on
    }

    // UserRegistered was dispatched anyway, for a profile that was never created
}
```

Found while working on #65902, which turns each attempt of a synchronous retry into a nested dispatch and therefore meets this on every failed attempt. It is a bug of its own, so it is proposed here separately for the lowest maintained branch.

## Checks

- `./phpunit src/Symfony/Component/Messenger/Tests` on 6.4: 425 tests, green.
- `testMessagesQueuedByAFailedNestedDispatchAreDropped` errors without the fix, because the event queued by the failed nested dispatch reaches the handling middleware a third time.
