### PR TITLE
[Config][DependencyInjection] Add NodeDefinition::inlineEnvVars() to inline env vars while the container is compiled

### DIFF
--- a/UPGRADE-8.2.md
+++ b/UPGRADE-8.2.md
@@ -13,6 +13,14 @@ AssetMapper
 
  * Add argument `$useEsm` to `ImportMapConfigReader::createRemoteEntry()`
 
+Config
+------
+
+ * [BC BREAK] The `enabled` node of the sections declared with `canBeEnabled()` or `canBeDisabled()` reads the
+   env vars it references while the container is compiled, where the extension used to get a placeholder that
+   was always truthy. A section configured with `enabled: '%env(bool:FOO)%'` is now really disabled when `FOO`
+   is false, and compiling fails when `FOO` has no value at that point
+
 Console
 -------
 

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.2
 ---
 
+ * Add an "Inlined" column to `debug:container --env-vars`, telling which env vars are read while the container is compiled
  * Deprecate `Command\RouterMatchCommand`, use the one from the Routing component instead
  * Deprecate `DependencyInjection\Compiler\TranslationLintCommandPass`, `DependencyInjection\Compiler\TranslationUpdateCommandPass`, `DependencyInjection\Compiler\AssetsContextPass` and `DependencyInjection\Compiler\AddValidatorSecurityExpressionLanguageProviderPass`, use the ones from the Translation, Asset and Validator components instead
  * Deprecate `Routing\RouteLoaderInterface`, use the `#[AsRouteLoader]` attribute from the Routing component instead

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/Descriptor.php
@@ -362,6 +362,8 @@ abstract class Descriptor implements DescriptorInterface
             }
         }
 
+        $inlined = $container->hasParameter('.debug.container.inlined_env_vars') ? array_flip($container->getParameter('.debug.container.inlined_env_vars')) : [];
+
         $bag = $container->getParameterBag();
         $getDefaultParameter = fn (string $name) => parent::get($name);
         $getDefaultParameter = $getDefaultParameter->bindTo($bag, $bag::class);
@@ -387,6 +389,7 @@ abstract class Descriptor implements DescriptorInterface
                 'runtime_value' => $runtimeValue,
                 'processed_value' => $processedValue,
                 'used' => isset($used[$name]),
+                'inlined' => isset($inlined[$env]),
             ];
         }
         ksort($envs);

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
@@ -533,6 +533,7 @@ class TextDescriptor extends Descriptor
                         ['<info>Real value</>', $env['runtime_available'] ? $dump($env['runtime_value']) : 'n/a'],
                         ['<info>Processed value</>', $env['default_available'] || $env['runtime_available'] ? $dump($env['processed_value']) : 'n/a'],
                         ['<info>Used</>', $env['used'] ? 'yes' : 'no'],
+                        ['<info>Inlined</>', $env['inlined'] ? 'yes' : 'no'],
                     ]);
                 }
             }
@@ -557,6 +558,8 @@ class TextDescriptor extends Descriptor
         foreach ($envs as $env) {
             if (isset($rows[$env['name']])) {
                 $rows[$env['name']][3] = $rows[$env['name']][3] || $env['used'];
+                // one spelling that is still read at runtime keeps the variable dynamic
+                $rows[$env['name']][4] = $rows[$env['name']][4] && $env['inlined'];
                 continue;
             }
 
@@ -565,6 +568,7 @@ class TextDescriptor extends Descriptor
                 $env['default_available'] ? $dump($env['default_value']) : 'n/a',
                 $env['runtime_available'] ? $dump($env['runtime_value']) : 'n/a',
                 $env['used'],
+                $env['inlined'],
             ];
             // the "default" processor carries the fallback, so an unset variable is not missing
             if (!$env['default_available'] && !$env['runtime_available'] && !\in_array('default', explode(':', $env['processor']), true)) {
@@ -572,14 +576,21 @@ class TextDescriptor extends Descriptor
             }
         }
 
-        $rows = array_map(static function ($row) {
+        $hasInlined = false;
+        $rows = array_map(static function ($row) use (&$hasInlined) {
+            $hasInlined = $hasInlined || $row[4];
             $row[3] = $row[3] ? 'yes' : 'no';
+            $row[4] = $row[4] ? 'yes' : 'no';
 
             return $row;
         }, $rows);
 
-        $options['output']->table(['Name', 'Default value', 'Real value', 'Used'], $rows);
+        $options['output']->table(['Name', 'Default value', 'Real value', 'Used', 'Inlined'], $rows);
         $options['output']->comment('Note real values might be different between web and CLI.');
+
+        if ($hasInlined) {
+            $options['output']->comment('Inlined variables were read when the container was compiled, so the container must be rebuilt for a new value to apply.');
+        }
 
         if ($missing) {
             $options['output']->warning('The following variables are missing:');

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/ContainerBuilderDebugDumpPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/ContainerBuilderDebugDumpPass.php
@@ -35,9 +35,40 @@ class ContainerBuilderDebugDumpPass implements CompilerPassInterface
             return;
         }
 
+        $bag = $container->getParameterBag();
+        $envVars = array_keys($container->getEnvCounters());
+        $dump = $dumpParameters = null;
+        $readAtRuntime = null;
+
+        try {
+            $dump = new ContainerBuilder($bag);
+            $dump->setDefinitions($container->getDefinitions());
+            $dump->setAliases($container->getAliases());
+
+            if ($bag instanceof EnvPlaceholderParameterBag) {
+                $dump = DeepCloner::deepClone($dump);
+                (new ResolveEnvPlaceholdersPass(null))->process($dump);
+
+                // resolving the placeholders of a copy reports the variables the container still
+                // reads when it runs, which the bag cannot tell: it counts a variable as read when
+                // the processed configuration holds it, even when no definition does
+                $usedInParameters = [];
+                $dumpParameters = $container->resolveEnvPlaceholders($this->escapeParameters($bag->all()), null, $usedInParameters);
+                $readAtRuntime = array_unique(array_merge(array_keys(array_filter($dump->getEnvCounters())), array_keys($usedInParameters)));
+            }
+        } catch (\Throwable $e) {
+            $container->getCompiler()->log($this, $e->getMessage());
+            $dump = null;
+        }
+
         // the compiler knows which variables are referenced; the dumps below cannot be asked,
         // since the serialized one has its placeholders already resolved
-        $container->setParameter('.debug.container.env_vars', array_keys($container->getEnvCounters()));
+        $container->setParameter('.debug.container.env_vars', $envVars);
+
+        // the ones nothing reads at runtime were read while the container was compiled, so a new
+        // value only applies once it is rebuilt
+        $readAtRuntime ??= $bag instanceof EnvPlaceholderParameterBag ? array_keys($bag->getEnvPlaceholders()) : $envVars;
+        $container->setParameter('.debug.container.inlined_env_vars', array_values(array_diff($envVars, $readAtRuntime)));
 
         $file = $container->getParameter('debug.container.dump');
         $cache = new ConfigCache($file, true);
@@ -46,22 +77,15 @@ class ContainerBuilderDebugDumpPass implements CompilerPassInterface
         }
         $cache->write((new XmlDumper($container))->dump(), $container->getResources());
 
-        if (!str_ends_with($file, '.xml')) {
+        if (!str_ends_with($file, '.xml') || null === $dump) {
             return;
         }
 
         $file = substr_replace($file, '.ser', -4);
 
         try {
-            $bag = $container->getParameterBag();
-            $dump = new ContainerBuilder($bag);
-            $dump->setDefinitions($container->getDefinitions());
-            $dump->setAliases($container->getAliases());
-
-            if ($bag instanceof EnvPlaceholderParameterBag) {
-                $dump = DeepCloner::deepClone($dump);
-                (new ResolveEnvPlaceholdersPass(null))->process($dump);
-                $dump->__construct(new EnvPlaceholderParameterBag($container->resolveEnvPlaceholders($this->escapeParameters($bag->all()))));
+            if (null !== $dumpParameters) {
+                $dump->__construct(new EnvPlaceholderParameterBag($dumpParameters));
             }
 
             $fs = new Filesystem();

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/ContainerBuilderDebugDumpPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/ContainerBuilderDebugDumpPassTest.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ContainerBuilderDebugDumpPass;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
+use Symfony\Component\Filesystem\Filesystem;
+
+class ContainerBuilderDebugDumpPassTest extends TestCase
+{
+    public function testEnvVarsThatNothingReadsAtRuntimeAreReportedAsInlined()
+    {
+        $_ENV['DUMP_NODE'] = 'a';
+        $_ENV['DUMP_EXT'] = 'b';
+        $_ENV['DUMP_DYNAMIC'] = 'c';
+
+        $dir = sys_get_temp_dir().'/sf_debug_dump_'.bin2hex(random_bytes(6));
+        $container = new ContainerBuilder();
+        $container->setParameter('debug.container.dump', $dir.'/container.xml');
+        $container->registerExtension(new DebugDumpExtension());
+        $container->loadFromExtension('debug_dump', [
+            'node_inlined' => '%env(DUMP_NODE)%',
+            'ext_inlined' => '%env(DUMP_EXT)%',
+            'dynamic' => '%env(DUMP_DYNAMIC)%',
+        ]);
+        $container->addCompilerPass(new ContainerBuilderDebugDumpPass(), PassConfig::TYPE_BEFORE_REMOVING, -255);
+
+        try {
+            $container->compile();
+
+            $referenced = $container->getParameter('.debug.container.env_vars');
+            $inlined = $container->getParameter('.debug.container.inlined_env_vars');
+        } finally {
+            unset($_ENV['DUMP_NODE'], $_ENV['DUMP_EXT'], $_ENV['DUMP_DYNAMIC']);
+            (new Filesystem())->remove($dir);
+        }
+
+        sort($referenced);
+        sort($inlined);
+
+        $this->assertSame(['DUMP_DYNAMIC', 'DUMP_EXT', 'DUMP_NODE'], $referenced);
+        // the node declares it, and the extension resolves the other one itself; only the third
+        // one is still read when the container runs
+        $this->assertSame(['DUMP_EXT', 'DUMP_NODE'], $inlined);
+    }
+}
+
+class DebugDumpConfiguration implements ConfigurationInterface
+{
+    public function getConfigTreeBuilder(): TreeBuilder
+    {
+        $treeBuilder = new TreeBuilder('debug_dump');
+        $treeBuilder->getRootNode()
+            ->children()
+                ->scalarNode('node_inlined')->attribute('inline_env_vars', true)->end()
+                ->scalarNode('ext_inlined')->end()
+                ->scalarNode('dynamic')->end()
+            ->end();
+
+        return $treeBuilder;
+    }
+}
+
+class DebugDumpExtension extends Extension
+{
+    public function getAlias(): string
+    {
+        return 'debug_dump';
+    }
+
+    public function getConfiguration(array $config, ContainerBuilder $container): ?ConfigurationInterface
+    {
+        return new DebugDumpConfiguration();
+    }
+
+    public function load(array $configs, ContainerBuilder $container): void
+    {
+        $config = $this->processConfiguration($this->getConfiguration($configs, $container), $configs);
+
+        $container->setParameter('debug_dump.node', $config['node_inlined']);
+        $container->setParameter('debug_dump.ext', strtoupper($container->resolveEnvPlaceholders($config['ext_inlined'], true)));
+        $container->register('debug_dump.service', \stdClass::class)->setArguments([$config['dynamic']])->setPublic(true);
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ContainerDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ContainerDebugCommandTest.php
@@ -258,24 +258,29 @@ class ContainerDebugCommandTest extends AbstractWebTestCase
         try {
             $display = $this->runEnvVarsCommand()->getDisplay(true);
 
-            $this->assertMatchesRegularExpression('/Name\s+Default value\s+Real value\s+Used/', $display);
+            $this->assertMatchesRegularExpression('/Name\s+Default value\s+Real value\s+Used\s+Inlined/', $display);
 
             // APP_FOO has a container default and APP_BAR has nothing, but no service reads either,
             // so both are unused; APP_BAZ is in .env and read by a service, so it is used
-            $this->assertMatchesRegularExpression('/^  APP_BAR\s+n\/a\s+"bar"\s+no\s*$/m', $display);
-            $this->assertMatchesRegularExpression('/^  APP_BAZ\s+n\/a\s+"baz"\s+yes\s*$/m', $display);
-            $this->assertMatchesRegularExpression('/^  APP_FOO\s+"foo"\s+"foo"\s+no\s*$/m', $display);
-            $this->assertMatchesRegularExpression('/^  JSON\s+"\[1, "2.5", 3\]"\s+n\/a\s+yes\s*$/m', $display);
-            $this->assertMatchesRegularExpression('/^  REAL\s+n\/a\s+"value"\s+yes\s*$/m', $display);
-            $this->assertMatchesRegularExpression('/^  UNKNOWN\s+n\/a\s+n\/a\s+yes\s*$/m', $display);
+            $this->assertMatchesRegularExpression('/^  APP_BAR\s+n\/a\s+"bar"\s+no\s+no\s*$/m', $display);
+            $this->assertMatchesRegularExpression('/^  APP_BAZ\s+n\/a\s+"baz"\s+yes\s+no\s*$/m', $display);
+            $this->assertMatchesRegularExpression('/^  APP_FOO\s+"foo"\s+"foo"\s+no\s+no\s*$/m', $display);
+            $this->assertMatchesRegularExpression('/^  JSON\s+"\[1, "2.5", 3\]"\s+n\/a\s+yes\s+no\s*$/m', $display);
+            $this->assertMatchesRegularExpression('/^  REAL\s+n\/a\s+"value"\s+yes\s+no\s*$/m', $display);
+            $this->assertMatchesRegularExpression('/^  UNKNOWN\s+n\/a\s+n\/a\s+yes\s+no\s*$/m', $display);
 
             // variables the framework itself reads are listed, and are not reported as missing
             // because their placeholder carries a "default" fallback
-            $this->assertMatchesRegularExpression('/^  SYMFONY_TRUSTED_HOSTS\s+n\/a\s+\S+\s+yes\s*$/m', $display);
+            $this->assertMatchesRegularExpression('/^  SYMFONY_TRUSTED_HOSTS\s+n\/a\s+\S+\s+yes\s+no\s*$/m', $display);
             $this->assertStringContainsString('The following variables are missing:', $display);
             $this->assertStringContainsString('* UNKNOWN', $display);
             $this->assertStringNotContainsString('* SYMFONY_TRUSTED_HOSTS', $display);
             $this->assertStringNotContainsString('* APP_RUNTIME_ENV', $display);
+
+            // "framework.form.enabled" reads FORM_ENABLED while the container is compiled,
+            // so nothing reads it at runtime anymore
+            $this->assertMatchesRegularExpression('/^  FORM_ENABLED\s+"true"\s+n\/a\s+yes\s+yes\s*$/m', $display);
+            $this->assertStringContainsString('Inlined variables were read when the container was compiled', $display);
         } finally {
             putenv('REAL');
             putenv('APP_FOO');
@@ -293,9 +298,9 @@ class ContainerDebugCommandTest extends AbstractWebTestCase
             $display = $this->runEnvVarsCommand()->getDisplay(true);
 
             // an absent SYMFONY_DOTENV_VARS used to add a row with no name and a count of its own
-            $this->assertDoesNotMatchRegularExpression('/^\s+n\/a\s+n\/a\s+(yes|no)\s*$/m', $display);
+            $this->assertDoesNotMatchRegularExpression('/^\s+n\/a\s+n\/a\s+(yes|no)\s+(yes|no)\s*$/m', $display);
             $this->assertStringNotContainsString('* '.\PHP_EOL, $display);
-            $this->assertMatchesRegularExpression('/^  REAL\s+n\/a\s+"value"\s+yes\s*$/m', $display);
+            $this->assertMatchesRegularExpression('/^  REAL\s+n\/a\s+"value"\s+yes\s+no\s*$/m', $display);
             $this->assertStringNotContainsString('APP_BAR', $display);
         } finally {
             putenv('REAL');

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Fixtures/describe_env_vars.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Fixtures/describe_env_vars.txt
@@ -6,6 +6,7 @@
   Real value        n/a              
   Processed value   3.0              
   Used              yes              
+  Inlined           no               
  ----------------- ----------------- 
 
 %env(int:key:2:json:JSON)%
@@ -16,4 +17,5 @@
   Real value        n/a              
   Processed value   3                
   Used              yes              
+  Inlined           no               
  ----------------- ----------------- 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ContainerDebug/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ContainerDebug/config.yml
@@ -4,6 +4,11 @@ imports:
 parameters:
     env(JSON): '[1, "2.5", 3]'
     env(APP_FOO): 'foo'
+    env(FORM_ENABLED): 'true'
+
+framework:
+    form:
+        enabled: '%env(bool:FORM_ENABLED)%'
 
 services:
     _defaults: { public: true }

--- a/src/Symfony/Component/Config/CHANGELOG.md
+++ b/src/Symfony/Component/Config/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add `NodeDefinition::inlineEnvVars()` to replace the env vars referenced by a node with their value while the configuration is processed
+ * Inline the env vars referenced by the `enabled` node of the sections declared with `canBeEnabled()` or `canBeDisabled()`
  * Add `NodeDefinition::aliasOf()` to declare that the value of a node belongs to the configuration rooted at another name
  * Add argument `$resolveAlias` to `ArrayShapeGenerator::generate()` and to the constructor of `JsonSchemaDumper` to dump the nodes declared with `NodeDefinition::aliasOf()` as references
  * Add `JsonSchemaDumper` to dump JSON Schema from configuration node definitions

--- a/src/Symfony/Component/Config/CHANGELOG.md
+++ b/src/Symfony/Component/Config/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.2
 ---
 
+ * Add `NodeDefinition::inlineEnvVars()` to replace the env vars referenced by a node with their value while the configuration is processed
  * Add `NodeDefinition::aliasOf()` to declare that the value of a node belongs to the configuration rooted at another name
  * Add argument `$resolveAlias` to `ArrayShapeGenerator::generate()` and to the constructor of `JsonSchemaDumper` to dump the nodes declared with `NodeDefinition::aliasOf()` as references
  * Add `JsonSchemaDumper` to dump JSON Schema from configuration node definitions

--- a/src/Symfony/Component/Config/Definition/BaseNode.php
+++ b/src/Symfony/Component/Config/Definition/BaseNode.php
@@ -30,6 +30,7 @@ abstract class BaseNode implements NodeInterface
 
     private static array $placeholderUniquePrefixes = [];
     private static array $placeholders = [];
+    private static ?\Closure $placeholderResolver = null;
 
     protected string $name;
     protected array $normalizationClosures = [];
@@ -89,6 +90,19 @@ abstract class BaseNode implements NodeInterface
     }
 
     /**
+     * Registers the resolver that gives the actual value of a dynamic placeholder.
+     *
+     * Nodes that declare their dynamic values must be inlined use it to replace placeholders
+     * by their actual value, before the value is normalized.
+     *
+     * @internal
+     */
+    public static function setPlaceholderResolver(?\Closure $resolver): void
+    {
+        self::$placeholderResolver = $resolver;
+    }
+
+    /**
      * Resets all current placeholders available.
      *
      * @internal
@@ -97,6 +111,7 @@ abstract class BaseNode implements NodeInterface
     {
         self::$placeholderUniquePrefixes = [];
         self::$placeholders = [];
+        self::$placeholderResolver = null;
     }
 
     public function setAttribute(string $key, mixed $value): void
@@ -378,6 +393,10 @@ abstract class BaseNode implements NodeInterface
 
     final public function normalize(mixed $value): mixed
     {
+        if (null !== self::$placeholderResolver && $this->getAttribute('inline_env_vars', false)) {
+            $value = (self::$placeholderResolver)($value, $this->getPath());
+        }
+
         $value = $this->preNormalize($value);
 
         // run custom normalization closures
@@ -532,6 +551,11 @@ abstract class BaseNode implements NodeInterface
 
     private function doValidateType(mixed $value): void
     {
+        if (null !== $this->handlingPlaceholder && $this->getAttribute('inline_env_vars', false)) {
+            // the value is inlined before it is used, so there is no dynamic value to validate
+            return;
+        }
+
         if (null !== $this->handlingPlaceholder && !$this->allowPlaceholders()) {
             $e = new InvalidTypeException(\sprintf('A dynamic value is not compatible with a "%s" node type at path "%s".', static::class, $this->getPath()));
             $e->setPath($this->getPath());

--- a/src/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.php
@@ -364,6 +364,7 @@ class ArrayNodeDefinition extends NodeDefinition implements ParentNodeDefinition
             ->children()
                 ->booleanNode('enabled')
                     ->defaultFalse()
+                    ->inlineEnvVars()
         ;
 
         if ($info) {
@@ -393,6 +394,7 @@ class ArrayNodeDefinition extends NodeDefinition implements ParentNodeDefinition
             ->children()
                 ->booleanNode('enabled')
                     ->defaultTrue()
+                    ->inlineEnvVars()
         ;
 
         if ($info) {

--- a/src/Symfony/Component/Config/Definition/Builder/NodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/NodeDefinition.php
@@ -134,6 +134,20 @@ abstract class NodeDefinition implements NodeParentInterface
     }
 
     /**
+     * Replaces the env vars referenced by this node with their value instead of passing along placeholders.
+     *
+     * Use it when the value is needed while the configuration is processed, for example to decide
+     * which services to register. The env vars are read once, so the container must be rebuilt when
+     * their value changes.
+     *
+     * @return $this
+     */
+    public function inlineEnvVars(bool $inlineEnvVars = true): static
+    {
+        return $this->attribute('inline_env_vars', $inlineEnvVars);
+    }
+
+    /**
      * Sets an attribute on the node.
      *
      * @return $this

--- a/src/Symfony/Component/Config/Tests/Definition/BaseNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/BaseNodeTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Config\Tests\Definition;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\BaseNode;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\NodeInterface;
 
 class BaseNodeTest extends TestCase
@@ -77,5 +78,70 @@ class BaseNodeTest extends TestCase
             'name and separator' => ['foo', ['foo', null, '/']],
             'name, parent and separator' => ['foo.bar/baz/bim', ['bim', 'foo.bar/baz', '/']],
         ];
+    }
+
+    public function testEnvVarsAreInlined()
+    {
+        $tree = (new TreeBuilder('root'))
+            ->getRootNode()
+                ->children()
+                    ->scalarNode('static')->inlineEnvVars()->end()
+                    ->scalarNode('dynamic')->end()
+                ->end()
+            ->end()
+            ->buildTree()
+        ;
+
+        BaseNode::setPlaceholderUniquePrefix('env_test');
+        BaseNode::setPlaceholderResolver(static fn (mixed $value): mixed => 'env_test_FOO' === $value ? 'resolved' : $value);
+
+        try {
+            $normalized = $tree->normalize(['static' => 'env_test_FOO', 'dynamic' => 'env_test_FOO']);
+        } finally {
+            BaseNode::resetPlaceholders();
+        }
+
+        $this->assertSame(['static' => 'resolved', 'dynamic' => 'env_test_FOO'], $normalized);
+    }
+
+    public function testInlinedEnvVarsCanBeArrays()
+    {
+        $tree = (new TreeBuilder('root'))
+            ->getRootNode()
+                ->children()
+                    ->arrayNode('locales')->inlineEnvVars()->scalarPrototype()->end()->end()
+                ->end()
+            ->end()
+            ->buildTree()
+        ;
+
+        BaseNode::setPlaceholderUniquePrefix('env_test');
+        BaseNode::setPlaceholderResolver(static fn (mixed $value): mixed => 'env_test_FOO' === $value ? ['en', 'fr'] : $value);
+
+        try {
+            $normalized = $tree->normalize(['locales' => 'env_test_FOO']);
+        } finally {
+            BaseNode::resetPlaceholders();
+        }
+
+        $this->assertSame(['locales' => ['en', 'fr']], $normalized);
+    }
+
+    public function testResetPlaceholdersDropsTheResolver()
+    {
+        $tree = (new TreeBuilder('root'))
+            ->getRootNode()
+                ->children()
+                    ->scalarNode('static')->inlineEnvVars()->end()
+                ->end()
+            ->end()
+            ->buildTree()
+        ;
+
+        BaseNode::setPlaceholderUniquePrefix('env_test');
+        BaseNode::setPlaceholderResolver(static fn (mixed $value): mixed => 'resolved');
+        BaseNode::resetPlaceholders();
+
+        $this->assertSame(['static' => 'env_test_FOO'], $tree->normalize(['static' => 'env_test_FOO']));
     }
 }

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 8.2
 ---
 
+ * Inline env vars while the container is compiled for the configuration nodes declared with `NodeDefinition::inlineEnvVars()`
  * Pass top-level extension values that are not arrays to the extension instead of replacing them with an empty array, so that a configuration tree can accept a scalar at its root
  * Name the package to install when an extension is missing, for the configuration keys declared in the `.container.extension_packages` build parameter
  * Add the `container.remove_if_missing` tag to drop a definition when a service, a class or a package it needs is not there

--- a/src/Symfony/Component/DependencyInjection/Compiler/MergeExtensionConfigurationPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/MergeExtensionConfigurationPass.php
@@ -16,6 +16,7 @@ use Symfony\Component\Config\Definition\BaseNode;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\ExceptionInterface;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException;
@@ -103,6 +104,16 @@ class MergeExtensionConfigurationPass implements CompilerPassInterface
                     $tmpContainer->addExpressionLanguageProvider($provider);
                 }
 
+                if ($configAvailable) {
+                    BaseNode::setPlaceholderResolver(static function (mixed $value, string $path) use ($tmpContainer): mixed {
+                        try {
+                            return $tmpContainer->resolveStaticValue($value);
+                        } catch (ExceptionInterface $e) {
+                            throw new RuntimeException(\sprintf('The value of the configuration option "%s" must be known when the container is compiled: %s', $path, $e->getMessage()), 0, $e);
+                        }
+                    });
+                }
+
                 $extension->load($config, $tmpContainer);
             } catch (\Exception $e) {
                 if ($resolvingBag instanceof MergeExtensionConfigurationParameterBag) {
@@ -110,6 +121,10 @@ class MergeExtensionConfigurationPass implements CompilerPassInterface
                 }
 
                 throw $e;
+            } finally {
+                if ($configAvailable) {
+                    BaseNode::setPlaceholderResolver(null);
+                }
             }
 
             if ($resolvingBag instanceof MergeExtensionConfigurationParameterBag) {
@@ -310,6 +325,14 @@ class MergeExtensionConfigurationContainerBuilder extends ContainerBuilder
     public function compile(bool $resolveEnvPlaceholders = false): void
     {
         throw new LogicException(\sprintf('Cannot compile the container in extension "%s".', $this->extensionClass));
+    }
+
+    /**
+     * Resolves the env vars referenced by $value, ignoring the restriction that applies to extensions.
+     */
+    public function resolveStaticValue(mixed $value): mixed
+    {
+        return parent::resolveEnvPlaceholders($value, true);
     }
 
     public function resolveEnvPlaceholders(mixed $value, string|bool|null $format = null, ?array &$usedEnvs = null): mixed

--- a/src/Symfony/Component/DependencyInjection/Compiler/ValidateEnvPlaceholdersPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ValidateEnvPlaceholdersPass.php
@@ -74,6 +74,19 @@ class ValidateEnvPlaceholdersPass implements CompilerPassInterface
             $this->extensionConfig[$name] = $processor->processConfiguration($configuration, $config);
         }
 
+        // placeholders that no definition references are about to be dropped, while the configuration
+        // can still hold the ones that were inlined, so name their env var before they become unknown
+        $names = [];
+        foreach ($resolvingBag->getUnusedEnvPlaceholders() as $env => $placeholders) {
+            foreach ($placeholders as $placeholder) {
+                $names[$placeholder] = \sprintf('%%env(%s)%%', $env);
+            }
+        }
+
+        if ($names) {
+            $this->extensionConfig = $this->nameEnvPlaceholders($this->extensionConfig, $names);
+        }
+
         $resolvingBag->clearUnusedEnvPlaceholders();
     }
 
@@ -133,5 +146,22 @@ class ValidateEnvPlaceholdersPass implements CompilerPassInterface
         $defaultType = null !== $default ? get_debug_type($default) : 'string';
 
         return [$default, $defaultType];
+    }
+
+    /**
+     * @param array<string, string> $names
+     */
+    private function nameEnvPlaceholders(mixed $value, array $names): mixed
+    {
+        if (\is_array($value)) {
+            $result = [];
+            foreach ($value as $k => $v) {
+                $result[\is_string($k) ? strtr($k, $names) : $k] = $this->nameEnvPlaceholders($v, $names);
+            }
+
+            return $result;
+        }
+
+        return \is_string($value) ? strtr($value, $names) : $value;
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ValidateEnvPlaceholdersPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ValidateEnvPlaceholdersPassTest.php
@@ -314,6 +314,90 @@ class ValidateEnvPlaceholdersPassTest extends TestCase
         $this->assertSame('1', $container->getParameter('boolish'));
     }
 
+    public function testEnvVarsAreInlinedBeforeTheExtensionIsLoaded()
+    {
+        $_ENV['STATIC_LEVEL'] = 'notice';
+
+        $container = new ContainerBuilder();
+        $container->registerExtension($ext = new EnvExtension(new ConfigurationWithInlinedEnvVars()));
+        $container->prependExtensionConfig('env_extension', [
+            'level' => '%env(STATIC_LEVEL)%',
+            'dynamic' => '%env(STATIC_LEVEL)%',
+        ]);
+
+        try {
+            (new MergeExtensionConfigurationPass())->process($container);
+        } finally {
+            unset($_ENV['STATIC_LEVEL']);
+        }
+
+        $config = $ext->getConfig();
+
+        $this->assertSame('notice', $config['level']);
+        $this->assertStringStartsWith('env_', $config['dynamic']);
+    }
+
+    public function testInlinedEnvVarsCanUseACast()
+    {
+        $_ENV['STATIC_LOCALES'] = 'en,fr';
+
+        $container = new ContainerBuilder();
+        $container->registerExtension($ext = new EnvExtension(new ConfigurationWithInlinedEnvVars()));
+        $container->prependExtensionConfig('env_extension', [
+            'locales' => '%env(csv:STATIC_LOCALES)%',
+        ]);
+
+        try {
+            $this->doProcess($container);
+        } finally {
+            unset($_ENV['STATIC_LOCALES']);
+        }
+
+        $this->assertSame(['en', 'fr'], $ext->getConfig()['locales']);
+    }
+
+    public function testInliningAnUndefinedEnvVarReportsTheOption()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The value of the configuration option "env_extension.level" must be known when the container is compiled: Environment variable not found: "UNDEFINED_STATIC".');
+
+        $container = new ContainerBuilder();
+        $container->registerExtension(new EnvExtension(new ConfigurationWithInlinedEnvVars()));
+        $container->prependExtensionConfig('env_extension', [
+            'level' => '%env(UNDEFINED_STATIC)%',
+        ]);
+
+        $this->doProcess($container);
+    }
+
+    public function testInlinedEnvVarsAreReportedByTheirNameInTheProcessedConfig()
+    {
+        $_ENV['REPORTED_LEVEL'] = 'notice';
+        $_ENV['REPORTED_DYNAMIC'] = 'whatever';
+
+        $container = new ContainerBuilder();
+        $container->registerExtension(new EnvExtension(new ConfigurationWithInlinedEnvVars()));
+        $container->prependExtensionConfig('env_extension', [
+            'level' => '%env(REPORTED_LEVEL)%',
+            'dynamic' => '%env(REPORTED_DYNAMIC)%',
+        ]);
+
+        $pass = new ValidateEnvPlaceholdersPass();
+
+        try {
+            (new MergeExtensionConfigurationPass())->process($container);
+            (new RegisterEnvVarProcessorsPass())->process($container);
+            $pass->process($container);
+        } finally {
+            unset($_ENV['REPORTED_LEVEL'], $_ENV['REPORTED_DYNAMIC']);
+        }
+
+        $config = $container->resolveEnvPlaceholders($pass->getExtensionConfig()['env_extension']);
+
+        $this->assertSame('%env(REPORTED_LEVEL)%', $config['level']);
+        $this->assertSame('%env(REPORTED_DYNAMIC)%', $config['dynamic']);
+    }
+
     private function doProcess(ContainerBuilder $container): void
     {
         (new MergeExtensionConfigurationPass())->process($container);
@@ -391,6 +475,25 @@ class ConfigurationWithArrayNodeRequiringOneElement implements ConfigurationInte
                 ->arrayNode('nodes')
                     ->isRequired()
                     ->requiresAtLeastOneElement()
+                    ->scalarPrototype()->end()
+                ->end()
+            ->end();
+
+        return $treeBuilder;
+    }
+}
+
+class ConfigurationWithInlinedEnvVars implements ConfigurationInterface
+{
+    public function getConfigTreeBuilder(): TreeBuilder
+    {
+        $treeBuilder = new TreeBuilder('env_extension');
+        $treeBuilder->getRootNode()
+            ->children()
+                ->scalarNode('level')->attribute('inline_env_vars', true)->end()
+                ->scalarNode('dynamic')->end()
+                ->arrayNode('locales')
+                    ->attribute('inline_env_vars', true)
                     ->scalarPrototype()->end()
                 ->end()
             ->end();

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ValidateEnvPlaceholdersPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ValidateEnvPlaceholdersPassTest.php
@@ -398,6 +398,25 @@ class ValidateEnvPlaceholdersPassTest extends TestCase
         $this->assertSame('%env(REPORTED_DYNAMIC)%', $config['dynamic']);
     }
 
+    public function testTheEnabledNodeOfAnEnableableSectionInlinesItsEnvVar()
+    {
+        $_ENV['SECTION_ENABLED'] = 'false';
+
+        $container = new ContainerBuilder();
+        $container->registerExtension($ext = new EnvExtension(new EnableableConfiguration()));
+        $container->prependExtensionConfig('env_extension', [
+            'section' => ['enabled' => '%env(bool:SECTION_ENABLED)%'],
+        ]);
+
+        try {
+            $this->doProcess($container);
+        } finally {
+            unset($_ENV['SECTION_ENABLED']);
+        }
+
+        $this->assertFalse($ext->getConfig()['section']['enabled']);
+    }
+
     private function doProcess(ContainerBuilder $container): void
     {
         (new MergeExtensionConfigurationPass())->process($container);
@@ -477,6 +496,20 @@ class ConfigurationWithArrayNodeRequiringOneElement implements ConfigurationInte
                     ->requiresAtLeastOneElement()
                     ->scalarPrototype()->end()
                 ->end()
+            ->end();
+
+        return $treeBuilder;
+    }
+}
+
+class EnableableConfiguration implements ConfigurationInterface
+{
+    public function getConfigTreeBuilder(): TreeBuilder
+    {
+        $treeBuilder = new TreeBuilder('env_extension');
+        $treeBuilder->getRootNode()
+            ->children()
+                ->arrayNode('section')->canBeEnabled()->end()
             ->end();
 
         return $treeBuilder;

--- a/src/Symfony/Component/DependencyInjection/composer.json
+++ b/src/Symfony/Component/DependencyInjection/composer.json
@@ -29,6 +29,7 @@
     },
     "conflict": {
         "ext-psr": "<1.1|>=2",
+        "symfony/config": "<8.2",
         "symfony/http-kernel": "<8.2"
     },
     "provide": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Issues        | Ref #40794
| License       | MIT

Some configuration options need their value while the container is built: to decide which services to register, to turn a log level into a constant, or to fill an array node. An env var cannot be used there, because what reaches the extension is a placeholder string. That is the half of #40794 that is still open. The other half, the schema rejecting placeholders, `ValidateEnvPlaceholdersPass` already handles when a cast prefix is used.

A node can say so now:

```php
->booleanNode('enabled')->inlineEnvVars()->end()
->scalarNode('level')->inlineEnvVars()->end()
->arrayNode('enabled_locales')->inlineEnvVars()->scalarPrototype()->end()->end()
```

The env vars such a node references are replaced by their value before the extension is loaded, so `$config['enabled']` is a real `false` and `$config['enabled_locales']` a real array. The value is inlined in the compiled container, so no `getEnv()` call is left for it and changing the variable needs a new build. Nodes without the flag are untouched. When the value is not known at that point, compiling fails and names the option:

> The value of the configuration option "env_extension.level" must be known when the container is compiled: Environment variable not found: "UNDEFINED_STATIC".

**The node declares it, not the host.** #40794 looked for an app-wide or host-wide switch, `SYMFONY_DYNAMIC_ENV_VARS`, listing the variables that stay dynamic. But almost every `%env()%` reference lands on a configuration node, and the node is the only thing that knows whether the value is needed at build time. Nothing ships in `.env`, and no recipe is involved. A switch stays possible on top of this, and is orthogonal to it.

**The second commit flags the `enabled` node.** `canBeEnabled()` and `canBeDisabled()` generate a boolean node that every extension reads to decide what to register, which is the case the feature exists for. It is a behavior change, `[BC BREAK]` in `UPGRADE-8.2.md`: `enabled: '%env(bool:PROFILER)%'` used to hand the extension a placeholder, which is truthy, so the section was enabled whatever `PROFILER` held. Sibling options are untouched, so `dsn: '%env(PROFILER_DSN)%'` in the same section still resolves at runtime. FrameworkBundle and SecurityBundle, which carry the most enableable sections, pass unchanged.

The part worth weighing is the new failure. An app naming a variable that has no value at compile time used to compile and silently enable the section, and now fails. Defining it in `.env`, or writing `%env(bool:default:some_param:PROFILER)%`, is the fix.

**The third commit answers "can I still change this one at runtime?"** That is the question `debug:container --env-vars` exists for, and the one #40794 keeps coming back to, but the listing showed an inlined variable exactly like any other. A new column reports it, and it covers an extension that resolves a variable itself as well as a node that declares it, which is what valtzu asked for in [#1632998562](https://github.com/symfony/symfony/issues/40794#issuecomment-1632998562).

```
  Name           Default value   Real value   Used   Inlined
  FORM_ENABLED   "true"          n/a          yes    yes
  REAL           n/a             "value"      yes    no
```

A note under the table says that changing an inlined variable needs a rebuild. `debug:container --env-var=NAME` gains the same line.

### Notes for review

`BaseNode::normalize()` asks a resolver, which `MergeExtensionConfigurationPass` registers for the duration of `Extension::load()`. It goes through `ContainerBuilder::resolveEnvPlaceholders($value, true)`, so core processors and variables present in the real environment resolve, while env var loaders and custom processors, which are not registered that early, do not. A variable that comes from a vault therefore stays dynamic.

`MergeExtensionConfigurationContainerBuilder::resolveEnvPlaceholders()` refuses compile-time resolution of a cast env var, which is the guard against an extension doing this behind the framework's back. It stays. The new path calls `parent::` and skips it, because here the node declared the requirement rather than the extension taking it.

`ValidateEnvPlaceholdersPass` runs later and re-processes the raw configuration, and by then the placeholder has been dropped from the parameter bag as unused, so it can no longer be resolved there. It does not need to be: the merge pass either settled the value or failed, so `doValidateType()` skips dynamic-value validation for these nodes. Registering a second resolver in that pass was the first attempt, and it silently resolved nothing.

That same reclassification is what the debug commands trip on. Once the placeholder counts as unused, the pass clears it, and `debug:config` has nothing left to map it back with, so it printed the raw internal id. The pass now names those placeholders back to their `%env(NAME)%` spelling before clearing them: `debug:config` prints `%env(bool:PROFILER)%` as it does for any other option, and `--resolve-env` prints the value that was compiled in.

The `Inlined` column cannot be read off the parameter bag, which counts a variable as read when the processed configuration holds it, even when no definition does. That misses an extension resolving a variable itself, the Monolog pattern. The pass already resolves the placeholders of a copy of the container in order to serialize it, so doing that first answers the question exactly, for both the node path and the extension path. Placeholders that live in parameters rather than in definitions are counted too, otherwise `kernel.trusted_hosts` and the other `SYMFONY_TRUSTED_*` variables read as inlined when they are not.

The scalar shorthand of an enableable section, `profiler: '%env(bool:PROFILER)%'`, is not covered. The placeholder lands on the array node, which rejects it with `A dynamic value is not compatible with an "ArrayNode" node type`, as it already does. Flagging the section instead of the child would cover it, but `resolveEnvPlaceholders()` walks arrays, so the flag would then inline every variable in the subtree.

Config, DependencyInjection, FrameworkBundle and SecurityBundle all pass, and each of the new tests fails on the base with the error it is there to catch. Nothing outside those four packages was run locally.

### Left for later

No adoption beyond the `enabled` node. Each option is its own call, and `framework.enabled_locales` and the monolog handler level are the obvious next ones.

No inference either. A node that can never hold a placeholder, any `ArrayNode` or an `EnumNode`, could carry the flag implicitly, since the only outcome today is an exception, and that is what #50323 is. It deserves its own pull request.

### The open design point

The flag is read per node, so one variable can be inlined for one option and stay dynamic for another. #40794 argued that static versus dynamic is a property of the variable rather than of the reference. The counter-argument is that a node states a requirement about its own value, not a preference, and another option may legitimately read the same variable at runtime. Pinning the variable everywhere as soon as one node carries the flag is a small change on top of this.

The node-level declaration was first proposed in #40794 by @alexander-schranz, with the polarity @webmozart argued for there: flag the exception, not the rule, so that nothing breaks by not adopting it.
