### PR TITLE
[Doctrine][Messenger] Do not lose the signals raised while fetching

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrineReceiverTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrineReceiverTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Messenger\Bridge\Doctrine\Tests\Transport;
 
 use Doctrine\DBAL\Driver\PDO\Exception;
 use Doctrine\DBAL\Exception\DeadlockException;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Bridge\Doctrine\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Messenger\Bridge\Doctrine\Transport\Connection;
@@ -395,6 +396,64 @@ class DoctrineReceiverTest extends TestCase
                 'Content-Type' => 'application/json',
             ],
         ];
+    }
+
+    #[RequiresPhpExtension('pcntl')]
+    #[RequiresPhpExtension('posix')]
+    public function testItDispatchesTheSignalsRaisedWhileFetching()
+    {
+        $received = false;
+        $previousHandler = pcntl_signal_get_handler(\SIGUSR1);
+        $previousAsync = pcntl_async_signals(true);
+        pcntl_signal(\SIGUSR1, static function () use (&$received) { $received = true; });
+
+        try {
+            $connection = $this->createMock(Connection::class);
+            $connection->expects($this->once())->method('get')->willReturnCallback(function () use (&$received) {
+                posix_kill(posix_getpid(), \SIGUSR1);
+
+                // the transport holds the signal back until it is done talking to the database
+                $this->assertFalse($received);
+
+                return null;
+            });
+
+            $receiver = new DoctrineReceiver($connection, $this->createSerializer());
+
+            $this->assertSame([], $receiver->get());
+            $this->assertTrue($received);
+            $this->assertTrue(pcntl_async_signals());
+        } finally {
+            pcntl_signal(\SIGUSR1, $previousHandler);
+            pcntl_async_signals($previousAsync);
+        }
+    }
+
+    #[RequiresPhpExtension('pcntl')]
+    public function testItRestoresSignalDispatchingWhenFetchingThrows()
+    {
+        $previousAsync = pcntl_async_signals(true);
+
+        try {
+            $connection = $this->createStub(Connection::class);
+            $connection->method('get')->willThrowException(new DeadlockException(Exception::new(new \PDOException('Deadlock', 40001)), null));
+
+            $receiver = new DoctrineReceiver($connection, $this->createSerializer());
+
+            // the first calls are swallowed as retryable, the last one throws
+            $this->assertSame([], $receiver->get());
+            $this->assertSame([], $receiver->get());
+
+            try {
+                $receiver->get();
+                $this->fail('TransportException expected.');
+            } catch (TransportException) {
+            }
+
+            $this->assertTrue(pcntl_async_signals());
+        } finally {
+            pcntl_async_signals($previousAsync);
+        }
     }
 
     private function createSerializer(): Serializer

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineReceiver.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineReceiver.php
@@ -42,6 +42,12 @@ class DoctrineReceiver implements ListableReceiverInterface, MessageCountAwareIn
 
     public function get(): iterable
     {
+        // Signals that reach the process while the driver waits on the database are dropped by
+        // the engine when that wait ends by throwing, which is what a lock timeout does. Holding
+        // them here and dispatching them once the call is over keeps the keepalive alarm armed,
+        // since it is rescheduled by its own handler, and keeps workers stoppable.
+        $asyncSignals = \function_exists('pcntl_async_signals') && pcntl_async_signals(false);
+
         try {
             $doctrineEnvelope = $this->connection->get();
             $this->retryingSafetyCounter = 0; // reset counter
@@ -57,6 +63,11 @@ class DoctrineReceiver implements ListableReceiverInterface, MessageCountAwareIn
             return [];
         } catch (DBALException $exception) {
             throw new TransportException($exception->getMessage(), 0, $exception);
+        } finally {
+            if ($asyncSignals) {
+                pcntl_async_signals(true);
+                pcntl_signal_dispatch();
+            }
         }
 
         if (null === $doctrineEnvelope) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

A signal that arrives while the driver is waiting on the database is lost, not delayed, when that wait ends by throwing. The engine runs its interrupt check with the exception already pending, `call_user_function()` does nothing in that state, and the queued signal is recycled: the handler never runs, and an explicit `pcntl_signal_dispatch()` afterwards finds nothing left either.

That is reachable from the worker's normal polling loop: another process holds the write lock, `beginTransaction()` blocks until the lock timeout expires, the driver throws, and whatever arrived in the meantime is gone.

Two consequences, and the first one is the reason for this patch:

* The keepalive alarm is a one-shot `pcntl_alarm()` rescheduled by its own handler (`Application::run()` calls `scheduleAlarm()` on `SIGALRM`). Losing a single `SIGALRM` therefore stops the keepalive for the rest of the process's life, silently. The messages being handled keep running while the transport is no longer told about them, so they are redelivered as soon as their `redeliver_timeout` expires and end up handled twice.
* A lost `SIGTERM` leaves the worker running until it is killed.

So the fetch now holds signals for the duration of the call and dispatches them once the driver is done. The window is exactly the database call, which is why this sits in the receiver rather than around the worker loop: the fetch is lazy and interleaved with `handleMessage()` there, so wrapping the loop would hold signals across message handling too and delay `SIGTERM` by the length of a handler.

The AMQP bridge does the same thing on 8.2, where push consumption made it unavoidable.

Reported upstream against php-src (PR 23624) with a fix pending for 8.4 and up. It cannot reach the versions this branch supports, and it only covers the engine side, so the workaround is worth having regardless.

The first test fails without the patch: the mocked connection signals the process and asserts, from inside the call, that the handler has not run yet, which is what proves dispatch is actually suspended. The second one drives the retry path through to the `TransportException` and checks dispatch is restored on the throwing path.
